### PR TITLE
executor: per-call module timeout with did-not-finish(timeout) outcome (Issue #2142)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -93,7 +93,9 @@ For every resource check that reaches the drift-comparison step, the execution e
 
 **Detection event** — enqueued immediately before `module.Get()`, carrying a newly generated `correlation_id`, the `resource_id`, and the active `drift_mode`. A detection event with no matching outcome event signals that convergence hung inside a module (ADR-012 §2 crash-isolation).
 
-**Outcome event** — enqueued after convergence completes, with the same `correlation_id` and an `action` field: `applied` (convergence succeeded), `drift_reported` (monitor mode), or `error` (Set or Verify failed).
+**Outcome event** — enqueued after convergence completes, with the same `correlation_id` and an `action` field: `applied` (convergence succeeded), `drift_reported` (monitor mode), `error` (Set or Verify failed), or `did-not-finish(timeout)` (per-call deadline exceeded — see below).
+
+**Per-call module timeout (ADR-012 §7)** — each individual `module.Get`, `module.Set`, and `verifyChanges` call runs under its own `context.WithTimeout` (default 120 s, configurable via `ExecutorConfig.ModuleCallTimeoutSec`; there is no "infinite" option). If a module call exceeds its deadline, the executor emits a `did-not-finish(timeout)` outcome event carrying `timeout_ms` (the configured ceiling) and `duration_ms` (actual elapsed), then returns `StatusTimeout` immediately — converting the former silent wedge into two queryable, correlated events. Errors that return before the deadline continue through the existing `handleResourceError` → `ConfigStatusReport` → `StatusError` path unchanged.
 
 ### Error Handling
 

--- a/features/steward/execution/event.go
+++ b/features/steward/execution/event.go
@@ -39,6 +39,30 @@ func (e *Executor) enqueueDetection(correlationID, resourceID, driftModeStr stri
 	})
 }
 
+// enqueueTimeoutOutcome emits an outcome event when a per-resource module call
+// (Get, Set, or verifyChanges) exceeds the configured deadline (ADR-012 §7).
+// The event carries both the configured ceiling (timeout_ms) and the actual
+// elapsed time (duration_ms) so the controller can distinguish timeout outcomes
+// from other outcome types and observe proximity to the limit.
+func (e *Executor) enqueueTimeoutOutcome(correlationID string, timeout, elapsed time.Duration) {
+	if e.eventEmitter == nil {
+		return
+	}
+	e.eventEmitter.Enqueue(&transportpb.LogEntry{
+		StewardId:     e.stewardID,
+		Level:         transportpb.Severity_SEVERITY_WARNING,
+		Message:       "convergence outcome",
+		Timestamp:     timestamppb.Now(),
+		CorrelationId: correlationID,
+		Fields: map[string]string{
+			"event_kind":  "outcome",
+			"action":      "did-not-finish(timeout)",
+			"timeout_ms":  fmt.Sprintf("%d", timeout.Milliseconds()),
+			"duration_ms": fmt.Sprintf("%d", elapsed.Milliseconds()),
+		},
+	})
+}
+
 // enqueueOutcome emits an outcome event when convergence completes, errors, or
 // drift is reported without correction (monitor mode). A nil emitter is a no-op.
 func (e *Executor) enqueueOutcome(correlationID, action string, duration time.Duration) {

--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -86,6 +86,10 @@ const (
 	// StatusNonCompliant indicates drift was detected in monitor mode.
 	// module.Set() and module.Verify() were NOT called; the drift is reported but not corrected.
 	StatusNonCompliant
+	// StatusTimeout indicates a per-resource module call (Get, Set, or verifyChanges)
+	// exceeded the configured per-call timeout. Treated as a failure in all aggregation
+	// paths. The emitted outcome event carries action=did-not-finish(timeout) (ADR-012 §7).
+	StatusTimeout
 )
 
 // NewConfigState creates a ConfigState from a raw configuration map.

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -8,6 +8,7 @@ package execution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -65,6 +66,13 @@ type ExecutorConfig struct {
 	// EventEmitter, when non-nil, receives convergence detection and outcome events.
 	// Enqueue must never block the caller; the concrete implementation drops when full.
 	EventEmitter EventEmitter
+
+	// ModuleCallTimeoutSec is the per-call timeout (in seconds) applied individually
+	// to each module.Get, module.Set, and verifyChanges invocation. Zero or negative
+	// values default to 120 s. There is no "infinite" option — all module calls have
+	// a finite deadline to prevent a hung module from wedging the convergence loop
+	// (ADR-012 §7).
+	ModuleCallTimeoutSec int
 }
 
 // Executor applies configurations using the unified Get→Compare→Set→Verify workflow.
@@ -89,6 +97,11 @@ type Executor struct {
 	// (ADR-012 §2). Enqueue is the only emitter call on the convergence goroutine;
 	// the actual LogStream send runs on the emitter's own goroutine.
 	eventEmitter EventEmitter
+
+	// moduleCallTimeout is the per-call deadline applied to module.Get, module.Set,
+	// and verifyChanges. Derived from ModuleCallTimeoutSec at construction; defaults
+	// to 120 s when the config field is zero or negative (ADR-012 §7).
+	moduleCallTimeout time.Duration
 }
 
 // NewExecutor creates an Executor. When cfg.Factory is nil, an empty registry and
@@ -124,15 +137,21 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 		comp = stewardtesting.NewStateComparator()
 	}
 
+	callTimeout := time.Duration(cfg.ModuleCallTimeoutSec) * time.Second
+	if callTimeout <= 0 {
+		callTimeout = 120 * time.Second
+	}
+
 	return &Executor{
-		factory:      f,
-		comparator:   comp,
-		config:       errCfg,
-		tenantID:     cfg.TenantID,
-		stewardID:    cfg.StewardID,
-		logger:       cfg.Logger,
-		driftMode:    cfg.DriftMode,
-		eventEmitter: cfg.EventEmitter,
+		factory:           f,
+		comparator:        comp,
+		config:            errCfg,
+		tenantID:          cfg.TenantID,
+		stewardID:         cfg.StewardID,
+		logger:            cfg.Logger,
+		driftMode:         cfg.DriftMode,
+		eventEmitter:      cfg.EventEmitter,
+		moduleCallTimeout: callTimeout,
 	}, nil
 }
 
@@ -178,7 +197,7 @@ func (e *Executor) ExecuteConfiguration(ctx context.Context, cfg config.StewardC
 			switch result.Status {
 			case StatusSuccess, StatusNoChange:
 				report.SuccessfulCount++
-			case StatusFailed:
+			case StatusFailed, StatusTimeout:
 				report.FailedCount++
 			case StatusSkipped:
 				report.SkippedCount++
@@ -292,10 +311,25 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 	// the detection observable on the out-of-band channel (ADR-012 §2 crash-isolation).
 	e.enqueueDetection(correlationID, resourceID, driftModeStr)
 
-	currentState, err := module.Get(ctx, resourceID)
+	// module.Get with per-call deadline so a hung module cannot wedge the
+	// convergence loop (ADR-012 §7). The deadline is derived from the ambient ctx
+	// so outer cancellation still propagates.
+	getCtx, getCancel := context.WithTimeout(ctx, e.moduleCallTimeout)
+	defer getCancel()
+	currentState, err := module.Get(getCtx, resourceID)
 	if err != nil {
-		result.Error = fmt.Sprintf("failed to get current state: %v", err)
 		result.ExecutionTime = time.Since(startTime)
+		if errors.Is(err, context.DeadlineExceeded) {
+			result.Status = StatusTimeout
+			result.Error = fmt.Sprintf("module.Get did not finish within %s", e.moduleCallTimeout)
+			e.enqueueTimeoutOutcome(correlationID, e.moduleCallTimeout, result.ExecutionTime)
+			e.logger.Warn("module.Get timeout",
+				"resource", resource.Name,
+				"module", resource.Module,
+				"timeout_ms", e.moduleCallTimeout.Milliseconds())
+			return result
+		}
+		result.Error = fmt.Sprintf("failed to get current state: %v", err)
 		if rerr := e.handleResourceError(resource, err); rerr != nil {
 			result.Error = rerr.Error()
 			return result
@@ -348,9 +382,22 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 		return result
 	}
 
-	if err := module.Set(ctx, resourceID, desiredState); err != nil {
-		result.Error = fmt.Sprintf("failed to apply configuration: %v", err)
+	// module.Set with per-call deadline (ADR-012 §7).
+	setCtx, setCancel := context.WithTimeout(ctx, e.moduleCallTimeout)
+	defer setCancel()
+	if err := module.Set(setCtx, resourceID, desiredState); err != nil {
 		result.ExecutionTime = time.Since(startTime)
+		if errors.Is(err, context.DeadlineExceeded) {
+			result.Status = StatusTimeout
+			result.Error = fmt.Sprintf("module.Set did not finish within %s", e.moduleCallTimeout)
+			e.enqueueTimeoutOutcome(correlationID, e.moduleCallTimeout, result.ExecutionTime)
+			e.logger.Warn("module.Set timeout",
+				"resource", resource.Name,
+				"module", resource.Module,
+				"timeout_ms", e.moduleCallTimeout.Milliseconds())
+			return result
+		}
+		result.Error = fmt.Sprintf("failed to apply configuration: %v", err)
 		// Outcome: Set failed; record before error-handling may continue.
 		e.enqueueOutcome(correlationID, "error", result.ExecutionTime)
 		if rerr := e.handleResourceError(resource, err); rerr != nil {
@@ -362,9 +409,23 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 
 	result.ChangesApplied = true
 
-	if err := e.verifyChanges(ctx, module, resourceID, desiredState); err != nil {
-		result.Error = fmt.Sprintf("verification failed: %v", err)
+	// verifyChanges with per-call deadline (ADR-012 §7). The deadline applies to
+	// the module.Get call inside verifyChanges.
+	verifyCtx, verifyCancel := context.WithTimeout(ctx, e.moduleCallTimeout)
+	defer verifyCancel()
+	if err := e.verifyChanges(verifyCtx, module, resourceID, desiredState); err != nil {
 		result.ExecutionTime = time.Since(startTime)
+		if errors.Is(err, context.DeadlineExceeded) {
+			result.Status = StatusTimeout
+			result.Error = fmt.Sprintf("verifyChanges did not finish within %s", e.moduleCallTimeout)
+			e.enqueueTimeoutOutcome(correlationID, e.moduleCallTimeout, result.ExecutionTime)
+			e.logger.Warn("verifyChanges timeout",
+				"resource", resource.Name,
+				"module", resource.Module,
+				"timeout_ms", e.moduleCallTimeout.Milliseconds())
+			return result
+		}
+		result.Error = fmt.Sprintf("verification failed: %v", err)
 		// Outcome: post-Set verification failed.
 		e.enqueueOutcome(correlationID, "error", result.ExecutionTime)
 		if rerr := e.handleResourceError(resource, err); rerr != nil {
@@ -567,7 +628,7 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 		switch result.Status {
 		case StatusSuccess, StatusNoChange:
 			successCount++
-		case StatusFailed:
+		case StatusFailed, StatusTimeout:
 			errorCount++
 			hasErrors = true
 			moduleStatus.Status = "ERROR"

--- a/features/steward/execution/executor_test.go
+++ b/features/steward/execution/executor_test.go
@@ -15,11 +15,73 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/features/modules"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
 	"github.com/cfgis/cfgms/features/steward/execution"
+	"github.com/cfgis/cfgms/features/steward/factory"
 	stewardtesting "github.com/cfgis/cfgms/features/steward/testing"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// HungModule is a real test module implementation that blocks indefinitely in
+// Get() until the context is cancelled or times out. Placed here for reuse by
+// downstream tests (S7 assertion gate) that verify the controller-side timeout
+// event pipeline.
+type HungModule struct{}
+
+func (h *HungModule) Get(ctx context.Context, _ string) (modules.ConfigState, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (h *HungModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+// Compile-time check: HungModule implements modules.Module.
+var _ modules.Module = (*HungModule)(nil)
+
+// HungSetModule is a real test module that reports drift on Get() and then
+// blocks indefinitely in Set() until the context is cancelled. Used to cover
+// the module.Set timeout path in executor.go.
+type HungSetModule struct{}
+
+func (h *HungSetModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	// Return drifted state so the comparator detects drift and the executor calls Set.
+	return &mapConfigState{data: map[string]interface{}{"state": "drifted"}}, nil
+}
+
+func (h *HungSetModule) Set(ctx context.Context, _ string, _ modules.ConfigState) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+var _ modules.Module = (*HungSetModule)(nil)
+
+// HungVerifyModule is a real test module that reports drift on the first Get()
+// call, succeeds on Set(), then blocks indefinitely in the second Get() (the
+// post-Set verification call). Used to cover the verifyChanges timeout path.
+type HungVerifyModule struct {
+	getCalls int
+}
+
+func (h *HungVerifyModule) Get(ctx context.Context, _ string) (modules.ConfigState, error) {
+	h.getCalls++
+	if h.getCalls == 1 {
+		// First call: return drifted state so the executor proceeds to Set().
+		return &mapConfigState{data: map[string]interface{}{"state": "drifted"}}, nil
+	}
+	// Second call (inside verifyChanges): block until timeout.
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (h *HungVerifyModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+var _ modules.Module = (*HungVerifyModule)(nil)
 
 // testFileConfig returns a file resource config appropriate for the current platform.
 // On Unix, includes permissions (0644 = 420 decimal). On Windows, omits permissions
@@ -580,4 +642,173 @@ func TestApplyConfiguration_ApplyMode_ModeAliasConfigVerifiesClean(t *testing.T)
 	require.NoError(t, readErr)
 	assert.Equal(t, "fleet-managed-content\n", string(got),
 		"drifted resource declared with the mode alias must be re-applied to desired state")
+}
+
+// TestExecuteResource_HungModule_ProducesTimeoutOutcomeEvent verifies that a
+// module whose Get() blocks past the per-call deadline causes ExecuteResource
+// to return (not wedge) and emits a detection+outcome pair where the outcome
+// action is "did-not-finish(timeout)" with the detection event's correlation_id.
+// The HungModule helper defined in this file is placed for reuse by S7 tests.
+func TestExecuteResource_HungModule_ProducesTimeoutOutcomeEvent(t *testing.T) {
+	emitter := &recordingEmitter{}
+
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	f.RegisterModule("hung", &HungModule{})
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:               logging.ForModule("executor_test"),
+		StewardID:            "test-steward-timeout",
+		EventEmitter:         emitter,
+		Factory:              f,
+		ErrorHandling:        errCfg,
+		ModuleCallTimeoutSec: 1, // 1 s for test speed
+	})
+	require.NoError(t, err)
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "hung-resource",
+		Module: "hung",
+		Config: map[string]interface{}{
+			"state": "present",
+		},
+	}
+
+	result := executor.ExecuteResource(context.Background(), resource)
+
+	// ExecuteResource must return rather than wedging.
+	assert.Equal(t, execution.StatusTimeout, result.Status,
+		"a hung module must produce StatusTimeout")
+	assert.NotEmpty(t, result.Error,
+		"timeout result must carry an error description")
+
+	entries := emitter.Entries()
+	require.Len(t, entries, 2,
+		"a hung module must emit exactly detection + timeout outcome")
+
+	detection := entries[0]
+	assert.Equal(t, "detection", detection.Fields["event_kind"],
+		"first entry must be the detection event")
+	assert.NotEmpty(t, detection.CorrelationId,
+		"detection must carry a non-empty correlation_id")
+
+	outcome := entries[1]
+	assert.Equal(t, "outcome", outcome.Fields["event_kind"],
+		"second entry must be the outcome event")
+	assert.Equal(t, "did-not-finish(timeout)", outcome.Fields["action"],
+		"timeout outcome action must be 'did-not-finish(timeout)'")
+	assert.NotEmpty(t, outcome.Fields["timeout_ms"],
+		"timeout outcome must carry timeout_ms")
+	assert.Equal(t, detection.CorrelationId, outcome.CorrelationId,
+		"detection and timeout outcome must share the same correlation_id")
+}
+
+// TestExecuteResource_HungSetModule_ProducesTimeoutOutcomeEvent verifies that a
+// module whose Set() blocks past the per-call deadline yields a timeout outcome
+// event and returns StatusTimeout without wedging.
+func TestExecuteResource_HungSetModule_ProducesTimeoutOutcomeEvent(t *testing.T) {
+	emitter := &recordingEmitter{}
+
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	f.RegisterModule("hung-set", &HungSetModule{})
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:               logging.ForModule("executor_test"),
+		StewardID:            "test-steward-set-timeout",
+		EventEmitter:         emitter,
+		Factory:              f,
+		ErrorHandling:        errCfg,
+		ModuleCallTimeoutSec: 1,
+	})
+	require.NoError(t, err)
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "hung-set-resource",
+		Module: "hung-set",
+		Config: map[string]interface{}{
+			"state": "desired",
+		},
+	}
+
+	result := executor.ExecuteResource(context.Background(), resource)
+
+	assert.Equal(t, execution.StatusTimeout, result.Status,
+		"a module whose Set() hangs must produce StatusTimeout")
+	assert.NotEmpty(t, result.Error)
+
+	entries := emitter.Entries()
+	require.Len(t, entries, 2, "hung Set must emit detection + timeout outcome")
+
+	detection := entries[0]
+	assert.Equal(t, "detection", detection.Fields["event_kind"])
+	assert.NotEmpty(t, detection.CorrelationId)
+
+	outcome := entries[1]
+	assert.Equal(t, "outcome", outcome.Fields["event_kind"])
+	assert.Equal(t, "did-not-finish(timeout)", outcome.Fields["action"],
+		"Set timeout must emit did-not-finish(timeout)")
+	assert.Equal(t, detection.CorrelationId, outcome.CorrelationId,
+		"detection and Set-timeout outcome must share correlation_id")
+}
+
+// TestExecuteResource_HungVerifyModule_ProducesTimeoutOutcomeEvent verifies that
+// a module whose post-Set Get() (inside verifyChanges) blocks past the deadline
+// yields a timeout outcome event and returns StatusTimeout without wedging.
+func TestExecuteResource_HungVerifyModule_ProducesTimeoutOutcomeEvent(t *testing.T) {
+	emitter := &recordingEmitter{}
+
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	f.RegisterModule("hung-verify", &HungVerifyModule{})
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:               logging.ForModule("executor_test"),
+		StewardID:            "test-steward-verify-timeout",
+		EventEmitter:         emitter,
+		Factory:              f,
+		ErrorHandling:        errCfg,
+		ModuleCallTimeoutSec: 1,
+	})
+	require.NoError(t, err)
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "hung-verify-resource",
+		Module: "hung-verify",
+		Config: map[string]interface{}{
+			"state": "desired",
+		},
+	}
+
+	result := executor.ExecuteResource(context.Background(), resource)
+
+	assert.Equal(t, execution.StatusTimeout, result.Status,
+		"a module whose verifyChanges Get() hangs must produce StatusTimeout")
+	assert.NotEmpty(t, result.Error)
+
+	entries := emitter.Entries()
+	require.Len(t, entries, 2, "hung verifyChanges must emit detection + timeout outcome")
+
+	detection := entries[0]
+	assert.Equal(t, "detection", detection.Fields["event_kind"])
+	assert.NotEmpty(t, detection.CorrelationId)
+
+	outcome := entries[1]
+	assert.Equal(t, "outcome", outcome.Fields["event_kind"])
+	assert.Equal(t, "did-not-finish(timeout)", outcome.Fields["action"],
+		"verifyChanges timeout must emit did-not-finish(timeout)")
+	assert.Equal(t, detection.CorrelationId, outcome.CorrelationId,
+		"detection and verify-timeout outcome must share correlation_id")
 }


### PR DESCRIPTION
## Summary

A hung module in `module.Get`, `module.Set`, or `verifyChanges` previously wedged the entire convergence loop silently — no event, no error, just a stalled goroutine. This PR implements ADR-012 §7: finite per-call deadlines that convert silent wedges into two queryable correlated events (detection + `did-not-finish(timeout)` outcome).

## Problem Context

`executor.ExecuteResource` passed the ambient context to all three module calls without any deadline. A module that blocks indefinitely in `Get`, `Set`, or the post-Set verification `Get` caused the convergence loop to stall permanently on that resource, never emitting a `ConfigStatusReport` and producing no observable telemetry. This was the worst failure mode with zero diagnostic signal.

ADR-012 §7 addresses this directly: wrap each call in `context.WithTimeout`, and on `DeadlineExceeded` emit an outcome event with `action=did-not-finish(timeout)` correlated to the detection event already on the out-of-band channel. The controller can then detect "detection with no matching outcome" or an explicit timeout outcome.

## Changes

- **`ExecutorConfig.ModuleCallTimeoutSec int`** — per-call ceiling (default 120 s; ≤0 uses default; no "infinite" option; all module calls are finite)
- **`enqueueTimeoutOutcome`** in `event.go` — emits `action=did-not-finish(timeout)` with `timeout_ms` (configured ceiling) and `duration_ms` (actual elapsed), severity WARNING
- **`StatusTimeout`** constant in `execution.go` — distinct from `StatusFailed`; aggregated as failure in both `ExecuteConfiguration` and `ApplyConfiguration`
- **`executor.go`**: three `context.WithTimeout` wraps around `module.Get`, `module.Set`, and `verifyChanges`; `errors.Is(err, context.DeadlineExceeded)` gate; existing non-timeout error paths unchanged
- **`executor_test.go`**: `HungModule`, `HungSetModule`, `HungVerifyModule` real-component test helpers covering all three timeout paths; placed for S7 reuse
- **`steward-operating-model.md`**: per-call timeout and `did-not-finish(timeout)` outcome documented alongside convergence-loop description

## Measured Impact

| Test | Duration | Result |
|------|----------|--------|
| `TestExecuteResource_HungModule_ProducesTimeoutOutcomeEvent` | 1.00 s | PASS |
| `TestExecuteResource_HungSetModule_ProducesTimeoutOutcomeEvent` | 1.00 s | PASS |
| `TestExecuteResource_HungVerifyModule_ProducesTimeoutOutcomeEvent` | 1.00 s | PASS |
| Full `features/steward/execution` suite (34 tests) | 4.2 s | PASS |
| `make test-agent-complete` (all packages, cross-platform builds, lint) | — | PASS |

## Specialist Review

- **QA Test Runner**: PASS — all unit tests, cross-platform builds (5 targets), linting, license headers
- **QA Code Reviewer**: PASS — real components only, no mocks, all three timeout branches tested
- **Security Engineer**: PASS — no CVEs, no central provider violations, security-precommit/check-architecture/security-scan all clean

Fixes #2142