### PR TITLE
hyperv: cluster resource — Set with CNO-gated create + destructive gate (Issue #2202)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -426,7 +426,7 @@ resource ID string built by the steward executor:
 |----------|-----------------|----------------------|-----------|
 | `hyperv.vm` | `name: web-01` | `vm:web-01` | Virtual machine management (create, start, stop, remove) |
 | `hyperv.vswitch` | `name: External-Switch` | `vswitch:External-Switch` | Virtual switch management (create External/Internal/Private, remove) |
-| `hyperv.cluster` | `name: lab-hv` | `cluster:lab-hv` | Failover-cluster state (read-only `Get`): member nodes, CNO owner, per-role owners, CSV paths |
+| `hyperv.cluster` | `name: lab-hv` | `cluster:lab-hv` | Failover-cluster state: `Get` (read-only) member nodes, CNO owner, per-role owners, CSV paths; `Set` clustered VM roles (CNO-gated create + `allow_destructive` removal) |
 
 ### VM networking (declarative, multi-NIC)
 
@@ -468,14 +468,17 @@ model is the replacement for the removed standalone `vmattach` resource
 module leaves the VM's existing adapters untouched (it never implicitly strips a
 VM down to zero NICs).
 
-## Failover cluster (read-only)
+## Failover cluster
 
-`hyperv.cluster` exposes the state of a Windows Server **failover cluster** the
-host is a member of. In S1 this resource is **read-only** — `Get` only; there is
-no `Set` (cluster formation, role placement, and live migration are later
-stories). The module reads cluster state by invoking the host-native
-Failover-Clustering cmdlets through the in-host `psHostTransport`; every cluster
-name travels via `ArgumentList`, never composed into PowerShell text.
+`hyperv.cluster` exposes and manages the state of a Windows Server **failover
+cluster** the host is a member of. `Get` is read-only (member nodes, CNO owner,
+per-role owners, CSV paths); `Set` manages **clustered VM roles** — clustering an
+existing VM as a highly-available role and (gated) removing one. Cluster
+**formation** (`New-Cluster`, `Add-ClusterNode`, `Remove-ClusterNode`, quorum)
+remains out of scope. The module reads and writes cluster state by invoking the
+host-native Failover-Clustering cmdlets through the in-host `psHostTransport`;
+every cluster and role name travels via `ArgumentList`, never composed into
+PowerShell text.
 
 `Get("cluster:<name>")` returns a `ClusterStatus` whose observed fields are:
 
@@ -488,9 +491,38 @@ name travels via `ArgumentList`, never composed into PowerShell text.
 | `csv_paths` | Cluster Shared Volume friendly volume paths (`Get-ClusterSharedVolume`). |
 
 The four read-only cmdlets the module invokes — `Get-Cluster`,
-`Get-ClusterNode`, `Get-ClusterGroup`, and
-`Get-ClusterSharedVolume` — are declared in `module.yaml`'s
-`behavioral_envelope`. No write cmdlet (`Add-*`/`Remove-*`/`New-*`) is declared.
+`Get-ClusterNode`, `Get-ClusterGroup`, and `Get-ClusterSharedVolume` — plus the
+two write cmdlets `Add-ClusterVirtualMachineRole` and `Remove-ClusterResource`
+(S2) are declared in `module.yaml`'s `behavioral_envelope`. No cluster-formation
+cmdlet (`New-Cluster`/`Add-ClusterNode`/`Remove-ClusterNode`/quorum) is declared.
+
+### Managing clustered VM roles (`Set`)
+
+`Set("cluster:<name>", config)` reconciles the **declared** clustered-VM-role set
+(`role_names`). Its decision order is:
+
+| Step | Behaviour |
+|------|-----------|
+| **Scope cap (S5)** | An out-of-scope `<name>` returns `ErrClusterNotDeclared` **before** any cmdlet runs. |
+| **CNO gate (S1)** | Only the **CNO-owner** node mutates. A non-owner records an *ownership-gated-skip* audit event and returns `nil` (coordination, not authorization — never an error, never a PS write). |
+| **Existence check (idempotency)** | Before clustering a role, the owner checks the live per-role owner map (the same `Get-ClusterGroup` read the ownership gate already performs — no extra PS function). An already-clustered role is a no-op. |
+| **Create** | An absent declared role is clustered with `Add-ClusterVirtualMachineRole`. If the cmdlet still reports *already configured / already exists* (a post-failover existence-check↔Add race), that error is normalised to `nil`. **Only** that error class is treated as idempotent — every other PS error surfaces. |
+| **Destructive gate (S6)** | `state: absent` removes the role with `Remove-ClusterResource`, but **only** when `allow_destructive: true`. With the default `allow_destructive: false` it returns `ErrDestructiveOpBlocked` **without** invoking any write cmdlet. |
+| **Drift-not-adopted (S1)** | Only roles named in `role_names` are ever passed to Add/Remove. A role present on the cluster but absent from the config is **never** created, removed, or adopted — even with `allow_destructive: true`. |
+
+Every `Set` path (create / gated-skip / idempotent no-op / destructive / drift)
+records a `pkg/audit` event via the same audit path as `Get`, carrying the node
+identity, the CNO-owner decision, the role, and before/after state maps, with a
+Go receipt-time `Timestamp` (S8).
+
+```yaml
+- name: lab-hv
+  module: hyperv.cluster
+  config:
+    role_names: [web-01, db-01]   # cluster these existing VMs as HA roles
+    # state: absent                # opt into teardown of the named roles, AND:
+    # allow_destructive: true      # ...required for any role removal (default false)
+```
 
 ### Ownership gate (coordination, not authorization)
 
@@ -523,9 +555,15 @@ host can never be steered into reading a cluster it was not declared against.
 ### Module trust: strict
 
 The `hyperv.cluster` surface requires `module_trust.required_mode: strict` (set
-in `module.yaml`). A module that reads failover-cluster ownership and topology
-must be **independently verified by the steward** — the steward must not rely on
-the controller's word alone for it.
+in `module.yaml`). A module that reads failover-cluster ownership and topology —
+and (S2) **writes** clustered VM roles — must be **independently verified by the
+steward**; the steward must not rely on the controller's word alone for it.
+
+Because S2 extends the `behavioral_envelope` with two write cmdlets
+(`Add-ClusterVirtualMachineRole`, `Remove-ClusterResource`), the module bundle
+must be **re-signed by the publisher and re-approved** (ADR-006) before
+`module_trust: strict` stewards will accept the updated module — a strict steward
+re-verifies the signature over the changed manifest independently.
 
 ```yaml
 - name: lab-hv

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -28,6 +28,14 @@ var ErrClusterNotDeclared = errors.New("hyperv: cluster not in declared cluster_
 // misconfiguration apart from an out-of-scope cluster name.
 var ErrTransportNotConfigured = errors.New("hyperv: cluster transport not configured")
 
+// ErrDestructiveOpBlocked is returned by setCluster when a destructive cluster
+// operation (state: absent — role removal) is requested without the operator
+// opting in via allow_destructive: true (S6). It is returned WITHOUT invoking
+// any PowerShell write cmdlet — the destructive gate is checked before the
+// transport is touched, so a default-off config can never delete a clustered
+// role even if the steward owns the CNO.
+var ErrDestructiveOpBlocked = errors.New("hyperv: destructive cluster operation blocked — set allow_destructive: true to proceed")
+
 // ClusterConfig is the DESIRED state of a Hyper-V failover cluster as declared
 // by an operator. S1 manages no cluster mutation; the desired-state struct
 // exists so the executor and DNA layers have a stable ConfigState shape (Set /
@@ -157,6 +165,20 @@ const psGetClusterOwnerNode = `$g = Get-ClusterGroup -Cluster $ClusterName -Name
 // psGetClusterResourceOwner reads the current owner node of every clustered VM
 // role group (GroupType -eq 'VirtualMachine'). It emits {"owners":{name:owner}}.
 const psGetClusterResourceOwner = `$owners = @{}; Get-ClusterGroup -Cluster $ClusterName -ErrorAction SilentlyContinue | Where-Object { $_.GroupType -eq 'VirtualMachine' } | ForEach-Object { $owners[$_.Name] = if ($_.OwnerNode) { $_.OwnerNode.Name } else { '' } }; ConvertTo-Json @{ owners=$owners } -Compress -Depth 4`
+
+// psAddClusterVMRole clusters an existing Hyper-V VM as a highly-available role
+// (S2 create). $ClusterName and $VMName travel via ArgumentList — never
+// interpolated. Add-ClusterVirtualMachineRole is the write cmdlet; only the
+// CNO-owner node invokes it (the ownership gate ensures exactly-once across the
+// members). The Go caller normalises an "already exists"/"already registered"
+// error to nil (idempotency).
+const psAddClusterVMRole = `Add-ClusterVirtualMachineRole -Cluster $ClusterName -VirtualMachine $VMName | Out-Null`
+
+// psRemoveClusterResource removes a clustered role group (S2 destructive teardown,
+// gated behind allow_destructive: true). $Name travels via ArgumentList — never
+// interpolated. Remove-ClusterResource -Force is reached only after the Go
+// destructive gate has confirmed the operator opted in.
+const psRemoveClusterResource = `Remove-ClusterResource -Name $Name -Force`
 
 // getCluster returns the observed state of a failover cluster on the host.
 //
@@ -313,6 +335,197 @@ func (m *hypervModule) readResourceOwners(ctx context.Context, clusterName strin
 		parsed.Owners = map[string]string{}
 	}
 	return parsed.Owners, nil
+}
+
+// setCluster reconciles the declared clustered-VM-role set on a failover
+// cluster (S2). It is the Set("cluster:<name>", config) write path.
+//
+// Decision order (each step short-circuits BEFORE any transport call where it
+// can):
+//
+//  1. Scope cap (S5): an out-of-scope clusterName returns ErrClusterNotDeclared
+//     WITHOUT touching the transport.
+//  2. Transport wired: a nil transport returns ErrTransportNotConfigured.
+//  3. CNO gate (S1): clusterOwnershipHelper decides which node acts. A NON-owner
+//     records an ownership-gated-skip audit event and returns nil — ownership is
+//     coordination, not authorization, so a non-owner never errors or blocks.
+//  4. On the owner, for each role NAMED in the declared RoleNames set
+//     (drift-not-adopted, S1 — roles absent from cfg are never mutated):
+//     - state: absent + allow_destructive=false → ErrDestructiveOpBlocked,
+//     with NO PS write cmdlet (S6 destructive gate, default off).
+//     - state: absent + allow_destructive=true  → Remove-ClusterResource.
+//     - present (default): existence check via the helper's resource-owner
+//     map (reuses S1's readResourceOwners output — no 4th PS function). If
+//     the role already exists → idempotent no-op. Otherwise
+//     Add-ClusterVirtualMachineRole; an "already"/"exists" error is
+//     normalised to nil (post-failover existence-check↔Add race).
+//
+// Every path (create / gated-skip / idempotent no-op / destructive / drift)
+// records a pkg/audit event via recordHypervOp with the node identity
+// (m.nodeHostname), the CNO-owner decision, and before/after state maps;
+// timestamps are Go receipt-time (S8).
+func (m *hypervModule) setCluster(ctx context.Context, resourceID string, config modules.ConfigState) error {
+	_, name, _ := splitResourceID(resourceID)
+
+	cfg := parseClusterConfig(name, config)
+
+	// (1) Scope cap (S5): reject an out-of-scope cluster name before the transport.
+	if m.clusterName != "" && cfg.Name != m.clusterName {
+		if logger, ok := m.GetLogger(); ok {
+			logger.Warn("hyperv: declining cluster Set — not in declared cluster_name scope",
+				"requested", logging.SanitizeLogValue(cfg.Name),
+				"declared", logging.SanitizeLogValue(m.clusterName))
+		}
+		return fmt.Errorf("hyperv: set cluster %q: %w", cfg.Name, ErrClusterNotDeclared)
+	}
+
+	// (2) Transport wired.
+	if m.transport == nil {
+		return fmt.Errorf("hyperv: set cluster %q: %w", cfg.Name, ErrTransportNotConfigured)
+	}
+
+	// (3) CNO gate (S1). The helper enforces the scope cap again, audits the
+	// ownership decision, and returns the per-role owner map (its readResourceOwners
+	// output) which doubles as the existence-check oracle below — no 4th PS function.
+	ownsCNO, resourceOwners, err := m.clusterOwnershipHelper(ctx, cfg.Name)
+	if err != nil {
+		return fmt.Errorf("hyperv: set cluster %q: %w", cfg.Name, err)
+	}
+
+	cnoOwner := m.readCNOOwner(ctx, cfg.Name)
+
+	if !ownsCNO {
+		// Non-owner: record an ownership-gated-skip and return nil. Coordination,
+		// not authorization (S1) — never an error, never a PS mutation here.
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-skip", "cluster:"+cfg.Name, nil,
+			map[string]interface{}{
+				"owns_cno":  false,
+				"cno_owner": cnoOwner,
+				"skipped":   true,
+				"roles":     append([]string(nil), cfg.RoleNames...),
+			}, nil)
+		return nil
+	}
+
+	if resourceOwners == nil {
+		resourceOwners = map[string]string{}
+	}
+
+	// (4) Owner path. Mutate ONLY roles named in cfg (drift-not-adopted, S1).
+	for _, role := range cfg.RoleNames {
+		if strings.TrimSpace(role) == "" {
+			continue
+		}
+		_, exists := resourceOwners[role]
+
+		if strings.EqualFold(strings.TrimSpace(cfg.State), "absent") {
+			// S6 destructive gate. Default off: NO PS write cmdlet is issued.
+			if !cfg.AllowDestructive {
+				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+					"cluster-set-remove-blocked", "cluster:"+cfg.Name,
+					map[string]interface{}{"role": role, "exists": exists},
+					map[string]interface{}{"allow_destructive": false, "blocked": true}, ErrDestructiveOpBlocked)
+				return fmt.Errorf("hyperv: set cluster %q role %q: %w", cfg.Name, role, ErrDestructiveOpBlocked)
+			}
+			if !exists {
+				// Already gone — idempotent no-op for the destructive path.
+				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+					"cluster-set-remove-noop", "cluster:"+cfg.Name,
+					map[string]interface{}{"role": role, "exists": false},
+					map[string]interface{}{"removed": false, "cno_owner": cnoOwner}, nil)
+				continue
+			}
+			if _, rmErr := m.transport.ExecutePS(ctx, psRemoveClusterResource, map[string]string{"Name": role}); rmErr != nil {
+				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+					"cluster-set-remove", "cluster:"+cfg.Name,
+					map[string]interface{}{"role": role, "exists": true},
+					map[string]interface{}{"removed": false}, rmErr)
+				return fmt.Errorf("hyperv: set cluster %q remove role %q: %w", cfg.Name, role, rmErr)
+			}
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-set-remove", "cluster:"+cfg.Name,
+				map[string]interface{}{"role": role, "exists": true},
+				map[string]interface{}{"removed": true, "cno_owner": cnoOwner}, nil)
+			continue
+		}
+
+		// Present (default): existence check BEFORE the Add (idempotency).
+		if exists {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-set-noop", "cluster:"+cfg.Name,
+				map[string]interface{}{"role": role, "exists": true},
+				map[string]interface{}{"created": false, "cno_owner": cnoOwner}, nil)
+			continue
+		}
+
+		_, addErr := m.transport.ExecutePS(ctx, psAddClusterVMRole, map[string]string{
+			"ClusterName": cfg.Name,
+			"VMName":      role,
+		})
+		if addErr != nil {
+			// Idempotency: an "already registered"/"already exists" error means a
+			// concurrent owner (or a stale existence read post-failover) created the
+			// role — normalise to nil. Only this specific text class is treated as
+			// idempotent; any other PS error is fatal (do NOT swallow).
+			if isAlreadyRegistered(addErr) {
+				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+					"cluster-set-noop", "cluster:"+cfg.Name,
+					map[string]interface{}{"role": role, "exists": false},
+					map[string]interface{}{"created": false, "already_registered": true, "cno_owner": cnoOwner}, nil)
+				continue
+			}
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-set-create", "cluster:"+cfg.Name,
+				map[string]interface{}{"role": role, "exists": false},
+				map[string]interface{}{"created": false}, addErr)
+			return fmt.Errorf("hyperv: set cluster %q add role %q: %w", cfg.Name, role, addErr)
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-create", "cluster:"+cfg.Name,
+			map[string]interface{}{"role": role, "exists": false},
+			map[string]interface{}{"created": true, "cno_owner": cnoOwner}, nil)
+	}
+
+	return nil
+}
+
+// parseClusterConfig builds a *ClusterConfig from the executor-supplied generic
+// config map (config.AsMap), or copies a *ClusterConfig passed directly. The
+// resource-id name is authoritative for Name so the scope cap always compares
+// the addressed cluster.
+func parseClusterConfig(name string, config modules.ConfigState) *ClusterConfig {
+	cfg := &ClusterConfig{Name: name}
+	if config == nil {
+		return cfg
+	}
+	if cc, ok := config.(*ClusterConfig); ok {
+		*cfg = *cc
+		cfg.Name = name
+		return cfg
+	}
+	cm := config.AsMap()
+	cfg.RoleNames = parseStringList(cm["role_names"])
+	if v, ok := cm["allow_destructive"].(bool); ok {
+		cfg.AllowDestructive = v
+	}
+	if v, ok := cm["state"].(string); ok {
+		cfg.State = v
+	}
+	return cfg
+}
+
+// isAlreadyRegistered reports whether a PS error indicates the clustered role
+// already exists. Matched case-insensitively on "already" or "exists" — the two
+// stable fragments Failover Clustering emits when a VM is already an HA role
+// ("already configured for high availability", "already exists"). Any OTHER
+// error is NOT idempotent and must surface (no blanket swallow).
+func isAlreadyRegistered(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already") || strings.Contains(msg, "exists")
 }
 
 // firstNonEmpty returns a if non-empty, else b.

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -516,16 +516,17 @@ func parseClusterConfig(name string, config modules.ConfigState) *ClusterConfig 
 }
 
 // isAlreadyRegistered reports whether a PS error indicates the clustered role
-// already exists. Matched case-insensitively on "already" or "exists" — the two
-// stable fragments Failover Clustering emits when a VM is already an HA role
-// ("already configured for high availability", "already exists"). Any OTHER
-// error is NOT idempotent and must surface (no blanket swallow).
+// already exists. Matched case-insensitively on "already" ONLY — the stable
+// fragments Failover Clustering emits when a VM is already an HA role both carry
+// it ("already configured for high availability", "already exists"). A bare
+// "exists" match is deliberately NOT used: it would swallow non-idempotent
+// errors such as "The virtual machine 'web-01' does not exist". Any error
+// without "already" is NOT idempotent and must surface (no blanket swallow).
 func isAlreadyRegistered(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "already") || strings.Contains(msg, "exists")
+	return strings.Contains(strings.ToLower(err.Error()), "already")
 }
 
 // firstNonEmpty returns a if non-empty, else b.

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -405,6 +405,43 @@ func countCmd(tr *testWinRMTransport, psCommand string) int {
 	return n
 }
 
+// psArgsForCmd reconstructs the psArgs key→value map for the first recorded
+// call to psCommand. winRMCall stores args as []interface{} in SORTED key order
+// (see testWinRMTransport.ExecutePS), so the caller-known sorted key list for
+// each cluster verb is zipped back against the recorded values. Returns nil if
+// the command was never invoked. Used by W2 to positively assert that the
+// user-supplied names travelled via ArgumentList.
+func psArgsForCmd(tr *testWinRMTransport, psCommand string) map[string]string {
+	// Sorted key order per cluster write verb (matches the dispatch psArgs maps
+	// in setCluster).
+	var keys []string
+	switch psCommand {
+	case psAddClusterVMRole:
+		keys = []string{"ClusterName", "VMName"} // sorted
+	case psRemoveClusterResource:
+		keys = []string{"Name"}
+	default:
+		return nil
+	}
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	for _, c := range tr.calls {
+		if c.scriptBlock != psCommand {
+			continue
+		}
+		out := make(map[string]string, len(keys))
+		for i, k := range keys {
+			if i < len(c.args) {
+				if s, ok := c.args[i].(string); ok {
+					out[k] = s
+				}
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // TestClusterSet_CNOOwner_Create verifies the AC: the CNO-owner node calls
 // Cfgms-AddClusterVMRole (psAddClusterVMRole) exactly once when the named role
 // is absent, and records a create audit event with the owner node identity and
@@ -437,6 +474,17 @@ func TestClusterSet_CNOOwner_Create(t *testing.T) {
 		assert.NotContains(t, sb, "lab-hv",
 			"cluster names must travel via ArgumentList, never composed into the scriptBlock")
 	}
+
+	// W2: positive assertion — the recorded Add call carries the cluster + role
+	// names via psArgs (ClusterName/VMName), complementing the negative
+	// "names absent from scriptBlock text" assertion above. args is sorted by
+	// key: ClusterName before VMName.
+	addArgs := psArgsForCmd(transport, psAddClusterVMRole)
+	require.NotNil(t, addArgs, "the Add call's psArgs must be recorded")
+	assert.Equal(t, "lab-hv", addArgs["ClusterName"],
+		"Add must carry the cluster name in the ClusterName psArg")
+	assert.Equal(t, "web-01", addArgs["VMName"],
+		"Add must carry the role name in the VMName psArg")
 
 	require.NoError(t, m.auditMgr.Flush(context.Background()))
 	var createEvt *business.AuditEntry
@@ -633,4 +681,200 @@ func TestClusterSet_DriftNotAdopted(t *testing.T) {
 			}
 		}
 	}
+}
+
+// ─── B2: setCluster destructive REMOVE success path (state: absent + allow_destructive) ─
+
+// TestClusterSet_Remove_Success verifies B2(a): on the CNO-owner node, a
+// declared role that EXISTS, with state: absent + allow_destructive: true,
+// triggers Remove-ClusterResource exactly once and records a
+// cluster-set-remove audit event with removed: true.
+func TestClusterSet_Remove_Success(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`,             // helper CNO owner → this node (NODE1) owns it
+			`{"owners":{"web-01":"NODE1"}}`, // helper resource owners → role present
+			`{"owner":"NODE1"}`,             // setCluster cnoOwner re-read
+			``,                              // Remove-ClusterResource → success
+		},
+	}
+	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{
+		Name:             "lab-hv",
+		RoleNames:        []string{"web-01"},
+		State:            "absent",
+		AllowDestructive: true,
+	}
+
+	start := time.Now()
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.NoError(t, err, "removing an existing role with allow_destructive must succeed")
+
+	// (a) Exactly one Remove cmdlet; zero Adds.
+	assert.Equal(t, 1, countCmd(transport, psRemoveClusterResource),
+		"an existing declared role must be Removed exactly once")
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"the destructive path must issue no Add")
+
+	// The Remove carries the role via the Name psArg (never the scriptBlock).
+	rmArgs := psArgsForCmd(transport, psRemoveClusterResource)
+	require.NotNil(t, rmArgs, "the Remove call's psArgs must be recorded")
+	assert.Equal(t, "web-01", rmArgs["Name"],
+		"Remove must carry the role name in the Name psArg")
+	for _, sb := range scriptBlocks(transport) {
+		assert.NotContains(t, sb, "web-01",
+			"role names must travel via ArgumentList, never composed into the scriptBlock")
+	}
+
+	// Audit: a cluster-set-remove event with removed: true and the owner identity.
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var removeEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-set-remove" {
+			removeEvt = e
+		}
+	}
+	require.NotNil(t, removeEvt, "a cluster-set-remove audit event must be recorded")
+	assert.WithinDuration(t, start, removeEvt.Timestamp, 5*time.Second,
+		"remove audit Timestamp must be Go receipt-time")
+	host, _ := removeEvt.Details["host"].(string)
+	assert.Equal(t, "NODE1", host, "remove audit must carry the owner node identity")
+	require.NotNil(t, removeEvt.Changes)
+	assert.Equal(t, true, removeEvt.Changes.After["removed"],
+		"the remove audit must record removed: true")
+}
+
+// TestClusterSet_Remove_TransportError verifies B2(b): when the
+// Remove-ClusterResource transport call FAILS, setCluster wraps and returns the
+// error (it does NOT swallow it) — isAlreadyRegistered must NOT be applied to
+// the remove path, so even an "already"-bearing error surfaces.
+func TestClusterSet_Remove_TransportError(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`,             // helper CNO owner (this node owns it)
+			`{"owners":{"web-01":"NODE1"}}`, // role present
+			`{"owner":"NODE1"}`,             // cnoOwner re-read
+			``,                              // Remove call (error supplied below)
+		},
+		perCallErrors: []error{
+			nil, nil, nil,
+			// Note the literal "already" substring: the remove path must STILL
+			// surface this, proving isAlreadyRegistered is not applied here.
+			errors.New("Remove-ClusterResource : The cluster resource could not be deleted; it is already in a pending state."),
+		},
+	}
+	m, store := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{
+		Name:             "lab-hv",
+		RoleNames:        []string{"web-01"},
+		State:            "absent",
+		AllowDestructive: true,
+	}
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.Error(t, err, "a failed Remove must surface, never be swallowed")
+	assert.Contains(t, err.Error(), "could not be deleted",
+		"the underlying Remove error must be wrapped, not normalised away")
+
+	assert.Equal(t, 1, countCmd(transport, psRemoveClusterResource),
+		"the Remove was attempted once before the error surfaced")
+
+	// The remove failure is audited with removed: false.
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var removeEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-set-remove" {
+			removeEvt = e
+		}
+	}
+	require.NotNil(t, removeEvt, "a cluster-set-remove audit event must be recorded for the failure")
+	require.NotNil(t, removeEvt.Changes)
+	assert.Equal(t, false, removeEvt.Changes.After["removed"],
+		"a failed remove must record removed: false")
+}
+
+// TestClusterSet_Remove_AlreadyGone verifies B2(c): a declared role that is NOT
+// present in the resource-owner map, with state: absent + allow_destructive:
+// true, is an idempotent no-op — zero Remove-ClusterResource calls, a
+// cluster-set-remove-noop audit event, and no error.
+func TestClusterSet_Remove_AlreadyGone(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`, // helper CNO owner (this node owns it)
+			`{"owners":{}}`,     // resource owners → role already gone
+			`{"owner":"NODE1"}`, // cnoOwner re-read
+		},
+	}
+	m, store := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{
+		Name:             "lab-hv",
+		RoleNames:        []string{"web-01"},
+		State:            "absent",
+		AllowDestructive: true,
+	}
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.NoError(t, err, "removing an already-absent role is an idempotent no-op")
+
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),
+		"an already-gone role must issue zero Remove-ClusterResource calls")
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"the destructive no-op path must issue no Add")
+
+	// Audit: a cluster-set-remove-noop event with removed: false.
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var noopEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-set-remove-noop" {
+			noopEvt = e
+		}
+	}
+	require.NotNil(t, noopEvt, "an idempotent remove-noop audit event must be recorded")
+	require.NotNil(t, noopEvt.Changes)
+	assert.Equal(t, false, noopEvt.Changes.After["removed"],
+		"the remove-noop audit must record removed: false")
+}
+
+// ─── B3: setCluster scope-cap + nil-transport guards ───────────────────────────
+
+// TestClusterSet_ScopeCap_Undeclared verifies B3: setCluster addressed to a
+// cluster name != the configured cluster_name returns ErrClusterNotDeclared and
+// makes ZERO transport calls — the scope cap rejects BEFORE the transport, even
+// for the write path.
+func TestClusterSet_ScopeCap_Undeclared(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m, _ := clusterTestModule(t, transport) // m.clusterName == "lab-hv"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{Name: "other-cluster", RoleNames: []string{"web-01"}, State: "present"}
+	err := m.setCluster(context.Background(), "cluster:other-cluster", cfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrClusterNotDeclared,
+		"an out-of-scope cluster name must return the scope-cap sentinel on the write path")
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	assert.Len(t, transport.calls, 0,
+		"the scope cap must reject BEFORE touching the transport — zero PS calls")
+}
+
+// TestClusterSet_NilTransport verifies B3: setCluster with no transport wired
+// returns the distinct ErrTransportNotConfigured sentinel (a misconfiguration),
+// NOT the ErrClusterNotDeclared scope-cap sentinel.
+func TestClusterSet_NilTransport(t *testing.T) {
+	m, _ := clusterTestModule(t, &testWinRMTransport{})
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+	m.transport = nil
+
+	cfg := &ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"}
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTransportNotConfigured,
+		"a nil transport is a misconfiguration, not an out-of-scope cluster")
+	assert.NotErrorIs(t, err, ErrClusterNotDeclared,
+		"the nil-transport path must not masquerade as the scope-cap sentinel")
 }

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -377,3 +377,260 @@ func TestClusterOwnershipHelper_NilTransport(t *testing.T) {
 	assert.NotErrorIs(t, err, ErrClusterNotDeclared,
 		"the nil-transport path must not masquerade as the scope-cap sentinel")
 }
+
+// ─── S2: setCluster (create / skip / idempotency / destructive / drift) ────────
+
+// scriptBlocks returns the psCommand (scriptBlock) const string recorded for
+// every transport call, in call order. The cluster tests assert on this to
+// prove which PS verb was (or was NOT) invoked — the user-supplied role/cluster
+// names only ever travel via psArgs, never the scriptBlock text (S3).
+func scriptBlocks(tr *testWinRMTransport) []string {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	out := make([]string, len(tr.calls))
+	for i, c := range tr.calls {
+		out[i] = c.scriptBlock
+	}
+	return out
+}
+
+// countCmd returns how many recorded calls used the given psCommand const.
+func countCmd(tr *testWinRMTransport, psCommand string) int {
+	n := 0
+	for _, sb := range scriptBlocks(tr) {
+		if sb == psCommand {
+			n++
+		}
+	}
+	return n
+}
+
+// TestClusterSet_CNOOwner_Create verifies the AC: the CNO-owner node calls
+// Cfgms-AddClusterVMRole (psAddClusterVMRole) exactly once when the named role
+// is absent, and records a create audit event with the owner node identity and
+// a Go receipt-time Timestamp (S8).
+func TestClusterSet_CNOOwner_Create(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`, // helper: CNO owner read → this node (NODE1) owns it
+			`{"owners":{}}`,     // helper: resource owners → role absent
+			`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read
+			``,                  // Add-ClusterVirtualMachineRole → success (empty output)
+		},
+	}
+	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1", clusterName == "lab-hv"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"}
+
+	start := time.Now()
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.NoError(t, err)
+
+	// Exactly one Add cmdlet, and the user-supplied role name never appears in the
+	// scriptBlock text — only in psArgs (S3 no string composition).
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"the CNO owner must call Add-ClusterVirtualMachineRole exactly once for an absent role")
+	for _, sb := range scriptBlocks(transport) {
+		assert.NotContains(t, sb, "web-01",
+			"role names must travel via ArgumentList, never composed into the scriptBlock")
+		assert.NotContains(t, sb, "lab-hv",
+			"cluster names must travel via ArgumentList, never composed into the scriptBlock")
+	}
+
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var createEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-set-create" {
+			createEvt = e
+		}
+	}
+	require.NotNil(t, createEvt, "a create audit event must be recorded")
+	assert.WithinDuration(t, start, createEvt.Timestamp, 5*time.Second,
+		"create audit Timestamp must be Go receipt-time")
+	host, _ := createEvt.Details["host"].(string)
+	assert.Equal(t, "NODE1", host, "create audit must carry the owner node identity")
+	require.NotNil(t, createEvt.Changes)
+	assert.Equal(t, true, createEvt.Changes.After["created"])
+}
+
+// TestClusterSet_NonOwner_Skip verifies S1/S8: a non-owner node issues no PS
+// mutation (no Add/Remove cmdlet) and records an ownership-gated-skip audit
+// event. Set returns nil — coordination, not authorization.
+func TestClusterSet_NonOwner_Skip(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE2"}`,             // helper: CNO owner is NODE2, not this node (NODE1)
+			`{"owners":{"web-01":"NODE2"}}`, // helper: resource owners
+			`{"owner":"NODE2"}`,             // setCluster: cnoOwner re-read
+		},
+	}
+	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"}
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.NoError(t, err, "a non-owner must return nil — coordination, not authorization")
+
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"a non-owner must issue no Add-ClusterVirtualMachineRole")
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),
+		"a non-owner must issue no Remove-ClusterResource")
+
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var skipEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-set-skip" {
+			skipEvt = e
+		}
+	}
+	require.NotNil(t, skipEvt, "an ownership-gated-skip audit event must be recorded")
+	require.NotNil(t, skipEvt.Changes)
+	assert.Equal(t, true, skipEvt.Changes.After["skipped"])
+	assert.Equal(t, false, skipEvt.Changes.After["owns_cno"])
+}
+
+// TestClusterSet_Idempotent verifies the idempotency Technical Decision two ways:
+// (a) when the role already exists, the existence check short-circuits the Add
+// (no PS mutation), and (b) when the existence read missed it but Add returns an
+// "already registered" error, that error is normalised to nil. Both converges
+// succeed and leave no error.
+func TestClusterSet_Idempotent(t *testing.T) {
+	// (a) Existence-check short-circuit: role already present in the owners map.
+	t.Run("existence-check short-circuit", func(t *testing.T) {
+		transport := &testWinRMTransport{
+			perCallOutputs: []string{
+				`{"owner":"NODE1"}`,             // helper CNO owner (this node)
+				`{"owners":{"web-01":"NODE1"}}`, // role already exists
+				`{"owner":"NODE1"}`,             // cnoOwner re-read
+			},
+		}
+		m, _ := clusterTestModule(t, transport)
+		defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+		err := m.setCluster(context.Background(), "cluster:lab-hv",
+			&ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"})
+		require.NoError(t, err)
+		assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+			"an already-existing role must short-circuit BEFORE the Add (no PS mutation)")
+	})
+
+	// (b) Add error normalised: existence read empty, but Add reports already-registered.
+	t.Run("already-registered error normalised", func(t *testing.T) {
+		transport := &testWinRMTransport{
+			perCallOutputs: []string{
+				`{"owner":"NODE1"}`, // helper CNO owner (this node)
+				`{"owners":{}}`,     // existence read: role absent
+				`{"owner":"NODE1"}`, // cnoOwner re-read
+				``,                  // Add call (output ignored; error supplied below)
+			},
+			perCallErrors: []error{
+				nil, nil, nil,
+				errors.New("Add-ClusterVirtualMachineRole : The resource is already configured for high availability."),
+			},
+		}
+		m, _ := clusterTestModule(t, transport)
+		defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+		err := m.setCluster(context.Background(), "cluster:lab-hv",
+			&ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"})
+		require.NoError(t, err,
+			"an 'already configured' error from Add must be normalised to nil (idempotent)")
+		assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+			"the Add was attempted once before the error was normalised")
+	})
+
+	// (c) A genuine non-idempotent error is NOT swallowed.
+	t.Run("non-idempotent error surfaces", func(t *testing.T) {
+		transport := &testWinRMTransport{
+			perCallOutputs: []string{
+				`{"owner":"NODE1"}`,
+				`{"owners":{}}`,
+				`{"owner":"NODE1"}`,
+				``,
+			},
+			perCallErrors: []error{
+				nil, nil, nil,
+				errors.New("Add-ClusterVirtualMachineRole : Access is denied."),
+			},
+		}
+		m, _ := clusterTestModule(t, transport)
+		defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+		err := m.setCluster(context.Background(), "cluster:lab-hv",
+			&ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"})
+		require.Error(t, err, "a non-idempotent PS error must surface, not be swallowed")
+		assert.Contains(t, err.Error(), "Access is denied")
+	})
+}
+
+// TestClusterSet_DestructiveGate verifies S6: state: absent with
+// allow_destructive: false returns ErrDestructiveOpBlocked WITHOUT invoking any
+// PS write cmdlet (zero Add/Remove calls).
+func TestClusterSet_DestructiveGate(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`,             // helper CNO owner (this node owns it)
+			`{"owners":{"web-01":"NODE1"}}`, // role present
+			`{"owner":"NODE1"}`,             // cnoOwner re-read
+		},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{
+		Name:             "lab-hv",
+		RoleNames:        []string{"web-01"},
+		State:            "absent",
+		AllowDestructive: false,
+	}
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDestructiveOpBlocked,
+		"state: absent without allow_destructive must return ErrDestructiveOpBlocked")
+
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),
+		"the destructive gate must block BEFORE any Remove-ClusterResource")
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"the destructive gate must issue no Add either")
+}
+
+// TestClusterSet_DriftNotAdopted verifies S1: Set on a cfg naming only role A,
+// with an undeclared role B also present on the cluster, issues no Add or Remove
+// targeting B — only declared roles are mutated. Here role A ("web-01") is
+// absent (gets created) while role B ("db-99") is present but undeclared and
+// must be left untouched, even though state is the default "present".
+func TestClusterSet_DriftNotAdopted(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`,            // helper CNO owner (this node)
+			`{"owners":{"db-99":"NODE1"}}`, // undeclared role db-99 present; declared web-01 absent
+			`{"owner":"NODE1"}`,            // cnoOwner re-read
+			``,                             // Add web-01 → success
+		},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"}
+	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	require.NoError(t, err)
+
+	// Exactly one Add (for the declared web-01); zero Removes (db-99 is never adopted).
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"only the declared role is created")
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),
+		"an undeclared, present role must never be Removed (drift-not-adopted)")
+
+	// The undeclared role name must never appear in any Add psArgs.
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	for _, c := range transport.calls {
+		if c.scriptBlock == psAddClusterVMRole {
+			for _, a := range c.args {
+				assert.NotEqual(t, "db-99", a,
+					"the undeclared role must never be passed to Add-ClusterVirtualMachineRole")
+			}
+		}
+	}
+}

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -381,6 +381,9 @@ func parseStringList(v interface{}) []string {
 // Supported resource ID prefixes:
 //   - "vm:<name>": create, update, or delete the named virtual machine
 //   - "vswitch:<name>": create or delete the named virtual switch
+//   - "cluster:<name>": create / remove clustered VM roles on the named
+//     failover cluster (S2). Only the CNO-owner node mutates (coordination, not
+//     authorization); role removal is gated behind allow_destructive (S6).
 //
 // VM network connectivity is declarative on the VM via switch_name (single
 // switch — the common case). Multi-NIC reconciliation is tracked in #2021.
@@ -409,6 +412,11 @@ func (m *hypervModule) Set(ctx context.Context, resourceID string, config module
 			return modules.ErrNotImplemented
 		}
 		return m.setVSwitch(ctx, resourceID, config)
+	case "cluster":
+		if config == nil {
+			return modules.ErrNotImplemented
+		}
+		return m.setCluster(ctx, resourceID, config)
 	default:
 		return modules.ErrNotImplemented
 	}

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -32,17 +32,31 @@ security:
     required_mode: strict
 
 # behavioral_envelope documents the runtime behaviour of the module for the
-# signing/approval workflow. The hyperv module shells out to powershell.exe; the
-# read-only failover-cluster surface added in #2199 S1 invokes ONLY the four
-# Get-Cluster* cmdlets below — no Add-*/Remove-*/New-* (cluster mutation is S2).
+# signing/approval workflow. The hyperv module shells out to powershell.exe. The
+# read-only failover-cluster surface (#2199 S1) invokes the four Get-Cluster*
+# cmdlets; #2202 S2 adds the two cluster WRITE cmdlets below
+# (Add-ClusterVirtualMachineRole, Remove-ClusterResource) — clustered-VM-role
+# create + destructive teardown. Cluster FORMATION (New-Cluster, Add-ClusterNode,
+# Remove-ClusterNode, quorum cmdlets) is NOT declared and out of scope.
+#
+# ADR-006 re-sign: this envelope change (adding the two write cmdlets) is a
+# material change to the module's behavioural contract. The bundle MUST be
+# re-signed by the publisher and re-approved before module_trust: strict stewards
+# will accept the updated module — strict stewards verify the signature
+# independently of the controller.
 behavioral_envelope:
   shells_out_to:
     - powershell.exe
   lolbin_usage_justification: >-
     Hyper-V and Failover Clustering are managed exclusively through their
-    PowerShell modules; there is no in-process managed API. The ONLY
-    failover-cluster cmdlets the module invokes (#2199 S1, all read-only) are:
-    Get-Cluster, Get-ClusterNode, Get-ClusterGroup,
-    Get-ClusterSharedVolume. All arguments travel via ArgumentList (never
-    string-composed). No write cmdlet (Add-*/Remove-*/New-*) is declared —
-    cluster mutation is a separate, later story.
+    PowerShell modules; there is no in-process managed API. The read-only
+    failover-cluster cmdlets (#2199 S1) are: Get-Cluster, Get-ClusterNode,
+    Get-ClusterGroup, Get-ClusterSharedVolume. The failover-cluster WRITE
+    cmdlets (#2202 S2) are: Add-ClusterVirtualMachineRole (cluster an existing
+    VM as a highly-available role — invoked only by the CNO-owner node, gated
+    exactly-once) and Remove-ClusterResource (remove a clustered role group —
+    gated behind allow_destructive: true, default off). All arguments travel via
+    ArgumentList (never string-composed). Cluster FORMATION cmdlets
+    (New-Cluster, Add-ClusterNode, Remove-ClusterNode, quorum) are NOT declared
+    and out of scope. This envelope change requires ADR-006 module re-signing
+    before module_trust: strict stewards accept the updated module.

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -174,6 +174,14 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 		return t.run(ctx, "Cfgms-GetClusterOwnerNode -ClusterName "+quoteArg(psArgs, "ClusterName"))
 	case psGetClusterResourceOwner:
 		return t.run(ctx, "Cfgms-GetClusterResourceOwner -ClusterName "+quoteArg(psArgs, "ClusterName"))
+
+	// ── Failover cluster (write, #2202 S2) ──────────────────────────
+	case psAddClusterVMRole:
+		return t.run(ctx,
+			"Cfgms-AddClusterVMRole -ClusterName "+quoteArg(psArgs, "ClusterName")+
+				" -VMName "+quoteArg(psArgs, "VMName"))
+	case psRemoveClusterResource:
+		return t.run(ctx, "Cfgms-RemoveClusterResource -Name "+quoteArg(psArgs, "Name"))
 	}
 
 	return "", fmt.Errorf("hyperv-ps-host: unknown psCommand (not in dispatch table); add a Cfgms-* function and a case here")

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -355,6 +355,67 @@ func TestPSDispatch_VSwitchVerbs(t *testing.T) {
 	}
 }
 
+// TestPSDispatch_ClusterVerbs covers all FIVE failover-cluster psXxx constants
+// (three read-only + two write) and asserts the EXACT synthesised Cfgms-*
+// invocation string for each, mirroring TestPSDispatch_VMVerbs /
+// TestPSDispatch_VSwitchVerbs. The wrapper parameter names asserted here
+// (-ClusterName / -VMName / -Name) must match the param(...) declarations of the
+// corresponding Cfgms-* functions in pstransport_preamble_windows.go: notably
+// Cfgms-AddClusterVMRole takes -ClusterName/-VMName and internally maps to
+// Add-ClusterVirtualMachineRole -Cluster $ClusterName -VirtualMachine $VMName,
+// so the wrapper param is -ClusterName (NOT the real cmdlet's -Cluster).
+func TestPSDispatch_ClusterVerbs(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		psCommand string
+		psArgs    map[string]string
+		want      string
+	}{
+		{
+			name:      "Get-Cluster",
+			psCommand: psGetCluster,
+			psArgs:    map[string]string{"ClusterName": "lab-hv"},
+			want:      "Cfgms-GetCluster -ClusterName 'lab-hv'",
+		},
+		{
+			name:      "Get-ClusterOwnerNode",
+			psCommand: psGetClusterOwnerNode,
+			psArgs:    map[string]string{"ClusterName": "lab-hv"},
+			want:      "Cfgms-GetClusterOwnerNode -ClusterName 'lab-hv'",
+		},
+		{
+			name:      "Get-ClusterResourceOwner",
+			psCommand: psGetClusterResourceOwner,
+			psArgs:    map[string]string{"ClusterName": "lab-hv"},
+			want:      "Cfgms-GetClusterResourceOwner -ClusterName 'lab-hv'",
+		},
+		{
+			name:      "Add-ClusterVMRole",
+			psCommand: psAddClusterVMRole,
+			psArgs:    map[string]string{"ClusterName": "lab-hv", "VMName": "web-01"},
+			want:      "Cfgms-AddClusterVMRole -ClusterName 'lab-hv' -VMName 'web-01'",
+		},
+		{
+			name:      "Remove-ClusterResource",
+			psCommand: psRemoveClusterResource,
+			psArgs:    map[string]string{"Name": "web-01"},
+			want:      "Cfgms-RemoveClusterResource -Name 'web-01'",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &recordingPSTransport{}
+			_, err := tr.ExecutePS(ctx, tc.psCommand, tc.psArgs)
+			require.NoError(t, err)
+			require.Len(t, tr.calls, 1)
+			assert.Equal(t, tc.want, tr.calls[0])
+		})
+	}
+}
+
 // TestDispatch_AllKnownCommands verifies that dispatchForTest handles every
 // psXxx constant defined in vm.go and vswitch.go without silently returning
 // an empty expression. This guards against the production dispatch switch

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -144,6 +144,11 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 		return emit("Cfgms-GetClusterOwnerNode -ClusterName " + quoteArg(psArgs, "ClusterName"))
 	case psGetClusterResourceOwner:
 		return emit("Cfgms-GetClusterResourceOwner -ClusterName " + quoteArg(psArgs, "ClusterName"))
+	case psAddClusterVMRole:
+		return emit("Cfgms-AddClusterVMRole -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -VMName " + quoteArg(psArgs, "VMName"))
+	case psRemoveClusterResource:
+		return emit("Cfgms-RemoveClusterResource -Name " + quoteArg(psArgs, "Name"))
 	}
 	// Mirror production ExecutePS: an unknown psCommand is an error, not a
 	// silent success — keeps this test mirror honest to the production contract.
@@ -404,6 +409,9 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psGetCluster", psGetCluster, map[string]string{"ClusterName": "lab-hv"}},
 		{"psGetClusterOwnerNode", psGetClusterOwnerNode, map[string]string{"ClusterName": "lab-hv"}},
 		{"psGetClusterResourceOwner", psGetClusterResourceOwner, map[string]string{"ClusterName": "lab-hv"}},
+		// Failover cluster write verbs (cluster.go, #2202 S2)
+		{"psAddClusterVMRole", psAddClusterVMRole, map[string]string{"ClusterName": "lab-hv", "VMName": "web-01"}},
+		{"psRemoveClusterResource", psRemoveClusterResource, map[string]string{"Name": "web-01"}},
 	}
 
 	for _, tc := range commands {

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -542,4 +542,28 @@ function Cfgms-GetClusterResourceOwner {
         ForEach-Object { $owners[$_.Name] = if ($_.OwnerNode) { $_.OwnerNode.Name } else { '' } }
     ConvertTo-Json @{ owners = $owners } -Compress -Depth 4
 }
+
+# ── Failover cluster write (#2202 S2) ─────────────────────────────────
+# Each function wraps a single write cmdlet; the exactly-once coordination
+# (only the CNO-owner node calls these), the existence/idempotency check, and
+# the allow_destructive gate all live in Go (setCluster). $ClusterName/$VMName/
+# $Name travel via ArgumentList — never interpolated. Both are dispatched on the
+# persistent host: Add-ClusterVirtualMachineRole / Remove-ClusterResource are
+# synchronous and do not hit the async-VHD deadlock the seed disk ops do.
+
+# Cfgms-AddClusterVMRole mirrors psAddClusterVMRole: cluster an existing Hyper-V
+# VM as a highly-available role. The Go caller normalises an "already
+# registered"/"already exists" error to a no-op (idempotency).
+function Cfgms-AddClusterVMRole {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$VMName)
+    Add-ClusterVirtualMachineRole -Cluster $ClusterName -VirtualMachine $VMName | Out-Null
+}
+
+# Cfgms-RemoveClusterResource mirrors psRemoveClusterResource: remove a clustered
+# role group. Reached only after the Go destructive gate (allow_destructive:
+# true) has confirmed the operator opted in.
+function Cfgms-RemoveClusterResource {
+    param([Parameter(Mandatory)][string]$Name)
+    Remove-ClusterResource -Name $Name -Force
+}
 `


### PR DESCRIPTION
## Summary

S2 of epic #2198 (cluster-aware HA resource management), building on S1 (#2199, merged). Adds the **cluster `Set`/create path**: `Set("cluster:<name>", config)` creates a clustered VM role **exactly once** — the Cluster-Core-Group (CNO) owner node issues `Add-ClusterVirtualMachineRole`; every other node is a read-only no-op. Idempotent, scope-capped, and gated against destructive operations by default.

## Decision order in `setCluster`

scope-cap (S5) → transport check → **CNO gate** (`clusterOwnershipHelper`; non-owner records a gated-skip audit and returns nil — coordination, not authorization, S1) → per-declared-role **existence check** (reuses S1's `readResourceOwners` map — no extra PS query) → **destructive gate** (S6: `state: absent` + `allow_destructive: false` → `ErrDestructiveOpBlocked`, zero PS writes) → `Add-ClusterVirtualMachineRole` with `already`-bearing errors normalized to nil (idempotency). **Drift-not-adopted**: only roles named in `cfg.RoleNames` are ever mutated.

## Changes

- `cluster.go`: `ErrDestructiveOpBlocked` sentinel; `setCluster`; write consts `psAddClusterVMRole`/`psRemoveClusterResource` (`$ClusterName`/`$VMName`/`$Name` via ArgumentList); `isAlreadyRegistered` (matches only `already`, case-insensitive — never swallows `does not exist`).
- `module.go`: `cluster:` case in `Set()`.
- `module.yaml`: `behavioral_envelope` adds the 2 write cmdlets (+ ADR-006 re-sign note); `module_trust: strict` retained; no cluster-formation cmdlets.
- pstransport preamble/dispatch (+ drift-guard mirror): `Cfgms-AddClusterVMRole` / `Cfgms-RemoveClusterResource`.
- `cluster_test.go`: the 5 required `TestClusterSet_*` tests + destructive-remove success/failure/no-op + scope-cap/nil-transport guards + exact-expression `TestPSDispatch_ClusterVerbs`.

## Test results (qa-test-runner: PASS)

`go build ./...`, `go vet` (host + GOOS=windows), full `hyperv` + `modules` package tests, `-run Cluster -race`, cross-compile linux/windows, `GOOS=windows go test -c` (windows-tagged dispatch/preamble + drift-guard compile), `make check-architecture` — all green. Lint + SAST deferred to CI.

## QA code review (qa-code-reviewer: PASS after fixes)

First pass found 4 blocking; all fixed and re-verified: a real correctness bug — `isAlreadyRegistered` matched bare `"exists"` and would have swallowed `"does not exist"` errors (narrowed to `"already"` only); plus coverage gaps closed (destructive-remove success/failure/no-op, `setCluster`'s own scope-cap + nil-transport guards, and exact-expression dispatch assertions for all five cluster verbs).

## Security review (security-engineer: PASS)

0 blocking. On this first **mutating** cluster path, verified: **S1** ownership is coordination not authorization (non-owner no-ops; owner mutates only declared roles — `Remove-ClusterResource -Force` can't break out, names go via `quoteForPS`/ArgumentList); **S3** no command-string composition / no banned patterns; **S5** scope-cap before any transport call; **S6** destructive gate default-off, unbypassable; **S8** audit on every path with receipt-time + node identity, sanitized logging. Envelope honestly declares only the cmdlets called; no cluster-formation cmdlets.

## Environment

`windows`: live cluster create/failover behavior validates on the Hyper-V lab (S5); the cross-platform unit tests (recording transport) run on Linux CI; the windows-tagged dispatch/preamble + drift-guard tests run on CI's Windows runner.

Fixes #2202

Co-Authored-By: Claude <noreply@anthropic.com>
