### PR TITLE
fix(steward/dna): WaitDelay-protect all macOS network-collection commands to stop CI hang

### DIFF
--- a/features/steward/dna/network_darwin.go
+++ b/features/steward/dna/network_darwin.go
@@ -30,18 +30,14 @@ func (d *DarwinNetworkCollector) CollectInterfaces(ctx context.Context, attribut
 	}
 
 	// Enhanced interface information using ifconfig
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "ifconfig").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "ifconfig"); output != nil {
 		d.parseIfconfigOutput(string(output), attributes)
 	}
-	cancel()
 
 	// Network service information using networksetup
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "networksetup", "-listallnetworkservices").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "networksetup", "-listallnetworkservices"); output != nil {
 		d.parseNetworkServices(string(output), attributes)
 	}
-	cancel2()
 
 	// Wi-Fi information if available
 	d.collectWiFiInfo(ctx, attributes)
@@ -87,11 +83,9 @@ func (d *DarwinNetworkCollector) CollectRouting(ctx context.Context, attributes 
 // CollectDNS gathers DNS configuration on macOS
 func (d *DarwinNetworkCollector) CollectDNS(ctx context.Context, attributes map[string]string) error {
 	// DNS configuration using scutil
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "scutil", "--dns").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "scutil", "--dns"); output != nil {
 		d.parseDNSConfig(string(output), attributes)
 	}
-	cancel()
 
 	// System DNS servers using networksetup
 	d.collectDNSServers(ctx, attributes)
@@ -100,14 +94,12 @@ func (d *DarwinNetworkCollector) CollectDNS(ctx context.Context, attributes map[
 	d.collectSearchDomains(ctx, attributes)
 
 	// /etc/hosts file information
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "wc", "-l", "/etc/hosts").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "wc", "-l", "/etc/hosts"); output != nil {
 		hostsLines := strings.TrimSpace(string(output))
 		if lines := strings.Fields(hostsLines); len(lines) > 0 {
 			attributes["hosts_file_lines"] = lines[0]
 		}
 	}
-	cancel2()
 
 	return nil
 }
@@ -115,8 +107,7 @@ func (d *DarwinNetworkCollector) CollectDNS(ctx context.Context, attributes map[
 // CollectFirewall gathers firewall configuration on macOS
 func (d *DarwinNetworkCollector) CollectFirewall(ctx context.Context, attributes map[string]string) error {
 	// macOS firewall status using defaults
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "defaults", "read", "/Library/Preferences/com.apple.alf", "globalstate").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "defaults", "read", "/Library/Preferences/com.apple.alf", "globalstate"); output != nil {
 		firewallState := strings.TrimSpace(string(output))
 		switch firewallState {
 		case "0":
@@ -129,11 +120,9 @@ func (d *DarwinNetworkCollector) CollectFirewall(ctx context.Context, attributes
 			attributes["macos_firewall_state"] = "unknown_" + firewallState
 		}
 	}
-	cancel()
 
 	// pfctl firewall rules (if enabled and accessible)
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "pfctl", "-s", "rules").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "pfctl", "-s", "rules"); output != nil {
 		lines := strings.Split(string(output), "\n")
 		var ruleCount int
 		for _, line := range lines {
@@ -146,21 +135,16 @@ func (d *DarwinNetworkCollector) CollectFirewall(ctx context.Context, attributes
 			attributes["pfctl_rule_count"] = fmt.Sprintf("%d", ruleCount)
 		}
 	}
-	cancel2()
 
 	// Stealth mode status
-	cmdCtx3, cancel3 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx3, "defaults", "read", "/Library/Preferences/com.apple.alf", "stealthenabled").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "defaults", "read", "/Library/Preferences/com.apple.alf", "stealthenabled"); output != nil {
 		attributes["macos_firewall_stealth"] = strings.TrimSpace(string(output))
 	}
-	cancel3()
 
 	// Logging enabled status
-	cmdCtx4, cancel4 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx4, "defaults", "read", "/Library/Preferences/com.apple.alf", "loggingenabled").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "defaults", "read", "/Library/Preferences/com.apple.alf", "loggingenabled"); output != nil {
 		attributes["macos_firewall_logging"] = strings.TrimSpace(string(output))
 	}
-	cancel4()
 
 	return nil
 }
@@ -250,8 +234,7 @@ func (d *DarwinNetworkCollector) parseNetworkServices(output string, attributes 
 // collectWiFiInfo collects Wi-Fi specific information
 func (d *DarwinNetworkCollector) collectWiFiInfo(ctx context.Context, attributes map[string]string) {
 	// Current Wi-Fi SSID
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "networksetup", "-getairportnetwork", "en0").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "networksetup", "-getairportnetwork", "en0"); output != nil {
 		ssidLine := strings.TrimSpace(string(output))
 		if strings.Contains(ssidLine, ":") {
 			parts := strings.SplitN(ssidLine, ":", 2)
@@ -263,11 +246,9 @@ func (d *DarwinNetworkCollector) collectWiFiInfo(ctx context.Context, attributes
 			}
 		}
 	}
-	cancel()
 
 	// Wi-Fi power status
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "networksetup", "-getairportpower", "en0").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "networksetup", "-getairportpower", "en0"); output != nil {
 		powerStatus := strings.TrimSpace(string(output))
 		if strings.Contains(powerStatus, ":") {
 			parts := strings.SplitN(powerStatus, ":", 2)
@@ -276,7 +257,6 @@ func (d *DarwinNetworkCollector) collectWiFiInfo(ctx context.Context, attributes
 			}
 		}
 	}
-	cancel2()
 }
 
 // parseRoutingTable parses netstat routing table output
@@ -372,8 +352,7 @@ func (d *DarwinNetworkCollector) collectDNSServers(ctx context.Context, attribut
 	services := []string{"Wi-Fi", "Ethernet", "USB 10/100/1000 LAN"}
 
 	for _, service := range services {
-		cmdCtx, cancel := context.WithTimeout(ctx, darwinNetCmdTimeout)
-		if output, err := exec.CommandContext(cmdCtx, "networksetup", "-getdnsservers", service).Output(); err == nil {
+		if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "networksetup", "-getdnsservers", service); output != nil {
 			dnsOutput := strings.TrimSpace(string(output))
 			if dnsOutput != "" && !strings.Contains(dnsOutput, "There aren't any DNS Servers") {
 				servers := strings.Split(dnsOutput, "\n")
@@ -390,7 +369,6 @@ func (d *DarwinNetworkCollector) collectDNSServers(ctx context.Context, attribut
 				}
 			}
 		}
-		cancel()
 	}
 }
 
@@ -399,8 +377,7 @@ func (d *DarwinNetworkCollector) collectSearchDomains(ctx context.Context, attri
 	services := []string{"Wi-Fi", "Ethernet"}
 
 	for _, service := range services {
-		cmdCtx, cancel := context.WithTimeout(ctx, darwinNetCmdTimeout)
-		if output, err := exec.CommandContext(cmdCtx, "networksetup", "-getsearchdomains", service).Output(); err == nil {
+		if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "networksetup", "-getsearchdomains", service); output != nil {
 			searchOutput := strings.TrimSpace(string(output))
 			if searchOutput != "" && !strings.Contains(searchOutput, "There aren't any Search Domains") {
 				domains := strings.Split(searchOutput, "\n")
@@ -417,6 +394,5 @@ func (d *DarwinNetworkCollector) collectSearchDomains(ctx context.Context, attri
 				}
 			}
 		}
-		cancel()
 	}
 }


### PR DESCRIPTION
## Root cause (from #2187's macos-latest goroutine dump)
`TestRunConvergenceDetectsDNADriftOnSecondRun` blocks 4+ min in `DarwinNetworkCollector.CollectFirewall` → `exec.Cmd.Output` → `Cmd.Wait` → `awaitGoroutines`. On macOS CI runners the spawned command (`pfctl`/`defaults`) leaves its stdout pipe open after its context kills it, so `Cmd.Wait()` never returns → 5-min test timeout → **Build Gate red** on every steward-touching PR (this is what's been blocking #1517/#2187).

## Fix
#2098 added `darwinRunNetCmd` (sets `cmd.WaitDelay` so `Output()` returns even when the process is killed with its pipe open) but only converted `CollectRouting`. This converts **all** remaining bare `exec.CommandContext(...).Output()` calls in `network_darwin.go` to the helper:
- `CollectInterfaces` (ifconfig, networksetup), `CollectDNS` (scutil, wc), `CollectFirewall` (defaults×3, pfctl), `collectWiFiInfo` (×2), `collectDNSServers`/`collectSearchDomains` (×2).

Net −24 lines (drops per-call context+cancel boilerplate). Healthy-run behavior unchanged; a stuck command now returns `nil` after `WaitDelay` instead of hanging the test binary.

## Validation
Cross-compiles for darwin (`GOOS=darwin go build`). The actual hang-fix can only be confirmed on macOS CI — **this PR's `Native Build (macos-latest)` is the test.** If green, it confirms the fix and unblocks #1517 (+#2143/#2145) once that rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)