### PR TITLE
launcher: health-gated rollback — never demote a proven binary (Issue #2033)

### DIFF
--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -124,6 +124,18 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			return fmt.Errorf("launcher: steward exe %q for version %q is missing: %w", exe, current, statErr)
 		}
 
+		// Compute the binary hash and determine known-good status before each
+		// exec. Rechecking every iteration catches on-disk replacements that
+		// happen between the initial mark and a subsequent restart.
+		exeHash, hashErr := computeBinaryHash(exe)
+		if hashErr != nil {
+			return fmt.Errorf("launcher: hash steward exe for version %q: %w", current, hashErr)
+		}
+		isKnownGood := false
+		if kgPS, kgErr := s.Layout.loadState(); kgErr == nil {
+			isKnownGood = kgPS.KnownGood == current && kgPS.KnownGoodHash == exeHash
+		}
+
 		started := s.clock.Now()
 		exitErr := s.execOnce(ctx, exe)
 		ranFor := s.clock.Since(started)
@@ -150,6 +162,13 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			if !failedStartupOnCancel {
 				return nil
 			}
+			// A known-good version that fast-exits coinciding with a
+			// context cancel is an environmental fault (e.g. WMI race on
+			// boot), not an upgrade failure. Return clean shutdown rather
+			// than rolling back or looping on a cancelled context.
+			if isKnownGood {
+				return nil
+			}
 			// Fall through to the rollback logic below — this looks
 			// like a real upgrade failure that happened to coincide
 			// with a cancel. The operator (or the next startup) will
@@ -170,11 +189,14 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 
 		if !failedStartup && !nonZeroExit {
 			// Child stayed up past the startup window then exited cleanly.
-			// Reset the failure counter and prune old version directories,
-			// then write the committed flag file last so its presence is a
-			// reliable completion signal for tests and the steward process.
+			// Reset the failure counter, persist the known-good marker, and
+			// prune old version directories. Write the committed flag file
+			// last so its presence is a reliable completion signal for tests
+			// and the steward process.
 			if ps, loadErr := s.Layout.loadState(); loadErr == nil {
 				ps.ConsecutiveFailures = 0
+				ps.KnownGood = current
+				ps.KnownGoodHash = exeHash
 				if saveErr := s.Layout.saveState(ps); saveErr != nil {
 					_, _ = fmt.Fprintf(s.Stderr, "launcher: save state after commit: %v\n", saveErr)
 				}
@@ -200,6 +222,16 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			}
 		} else {
 			_, _ = fmt.Fprintf(s.Stderr, "launcher: load state for failure counter: %v\n", loadErr)
+		}
+
+		// Known-good fast-exit: a proven binary that exits inside the startup
+		// window is suffering a transient environmental fault (e.g. a boot-time
+		// dependency race), not an upgrade regression. Restart it in place so
+		// SCM recovery and the OS backoff handle persistence — never roll back
+		// a binary that has already proven healthy (Issue #2033).
+		if isKnownGood && failedStartup {
+			_, _ = fmt.Fprintf(s.Stderr, "launcher: version %q is known-good — restarting in place after fast exit (ran %s); rollback suppressed\n", current, ranFor)
+			continue
 		}
 
 		// Attempt rollback if we have a previous version AND budget.

--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -124,21 +124,29 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			return fmt.Errorf("launcher: steward exe %q for version %q is missing: %w", exe, current, statErr)
 		}
 
-		// Compute the binary hash and determine known-good status before each
-		// exec. Rechecking every iteration catches on-disk replacements that
-		// happen between the initial mark and a subsequent restart.
-		exeHash, hashErr := computeBinaryHash(exe)
-		if hashErr != nil {
-			return fmt.Errorf("launcher: hash steward exe for version %q: %w", current, hashErr)
-		}
-		isKnownGood := false
-		if kgPS, kgErr := s.Layout.loadState(); kgErr == nil {
-			isKnownGood = kgPS.KnownGood == current && kgPS.KnownGoodHash == exeHash
-		}
-
 		started := s.clock.Now()
 		exitErr := s.execOnce(ctx, exe)
 		ranFor := s.clock.Since(started)
+
+		// Compute the binary hash AFTER the child exits. Hashing before exec
+		// would delay the child launch on every restart — for a large binary
+		// the I/O adds hundreds of milliseconds, creating a window where a
+		// caller that checks connection state may observe stale "connected"
+		// from the previous process and dispatch a command to the dead
+		// connection. Hashing after exec still catches on-disk replacements:
+		// if the binary was swapped while the child ran, the new hash differs
+		// from the stored known-good hash and probation rules apply correctly.
+		exeHash, hashErr := computeBinaryHash(exe)
+		isKnownGood := false
+		if hashErr == nil {
+			if kgPS, kgErr := s.Layout.loadState(); kgErr == nil {
+				isKnownGood = kgPS.KnownGood == current && kgPS.KnownGoodHash == exeHash
+			}
+		}
+		// If the binary cannot be hashed (deleted, permission error), isKnownGood
+		// stays false — conservative treatment applies probation rules. This does
+		// not abort supervision; the stat check at the top of the next iteration
+		// will surface a missing-binary error if the file is truly gone.
 
 		// Context cancelled → service manager is shutting us down.
 		// Distinguish two sub-cases:
@@ -195,8 +203,13 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			// and the steward process.
 			if ps, loadErr := s.Layout.loadState(); loadErr == nil {
 				ps.ConsecutiveFailures = 0
-				ps.KnownGood = current
-				ps.KnownGoodHash = exeHash
+				// Only update the known-good marker if the post-exec hash
+				// succeeded; if it failed (binary deleted/unreadable after
+				// run) leave any existing marker untouched.
+				if hashErr == nil {
+					ps.KnownGood = current
+					ps.KnownGoodHash = exeHash
+				}
 				if saveErr := s.Layout.saveState(ps); saveErr != nil {
 					_, _ = fmt.Fprintf(s.Stderr, "launcher: save state after commit: %v\n", saveErr)
 				}

--- a/cmd/cfgms-steward-launcher/lifecycle_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_test.go
@@ -1243,3 +1243,179 @@ func TestSupervise_KnownGood_MarkedAfterHealthyRun(t *testing.T) {
 		t.Error("KnownGoodHash must be non-empty after healthy run")
 	}
 }
+
+// TestSupervise_HashFailureAfterCleanRun_SkipsKnownGoodUpdate verifies the
+// post-exec hash-failure code path for a clean (past-startup-window) child exit:
+//  1. Supervision does NOT abort — the loop continues.
+//  2. The upgrade-committed flag is still written (counter-reset path completes).
+//  3. The pre-existing KnownGood marker in state.json is left untouched, not
+//     cleared, when the hash of the just-exited binary cannot be computed.
+//
+// The hash failure is induced by chmod-ing the binary to 0o000 after the child
+// has started (the in-memory child is unaffected) but before it exits. This
+// causes computeBinaryHash to return an error without ever aborting the child.
+func TestSupervise_HashFailureAfterCleanRun_SkipsKnownGoodUpdate(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	// Pre-seed a known-good marker to verify it survives the hash failure.
+	premarkKnownGood(t, l, "v1")
+	psInit, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState before test: %v", err)
+	}
+	existingHash := psInit.KnownGoodHash
+	if existingHash == "" {
+		t.Fatal("premarkKnownGood must set a non-empty hash for this test to be meaningful")
+	}
+
+	markerFile := filepath.Join(t.TempDir(), "started")
+	certStoreDir := t.TempDir()
+	// Child sleeps long enough for the test goroutine to chmod the binary
+	// before the child exits. After the sleep it exits cleanly (code 0).
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE":   "0",
+		"FAKE_STEWARD_SLEEP_MS":    "300",
+		"FAKE_STEWARD_MARKER_FILE": markerFile,
+	})
+
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 0,
+		CertStoreDir:      certStoreDir,
+		clock:             &fakeClock{sinceResult: time.Minute}, // past startup window → clean exit
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Supervise(ctx) }()
+
+	// Wait for the child to start, then make the binary unreadable so
+	// computeBinaryHash fails on the post-exec hash call.
+	if !waitForFile(markerFile, 5*time.Second) {
+		t.Fatal("child never started (marker absent within 5s)")
+	}
+	exe, exeErr := l.StewardExeFor("v1")
+	if exeErr != nil {
+		t.Fatalf("StewardExeFor v1: %v", exeErr)
+	}
+	if chErr := os.Chmod(exe, 0o000); chErr != nil {
+		t.Fatalf("chmod 000 binary: %v", chErr)
+	}
+	// Restore permissions so t.TempDir cleanup can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(exe, 0o755) })
+
+	// upgrade-committed must be written even when the post-exec hash fails.
+	// It is written at the END of the clean-startup branch, so its presence
+	// proves that the entire clean-startup path (counter reset, prune, flag)
+	// ran to completion.
+	flagPath := filepath.Join(certStoreDir, "upgrade-committed")
+	if !waitForFile(flagPath, 5*time.Second) {
+		t.Fatal("upgrade-committed flag not written after clean run with hash failure (post-exec hash failure must not skip the committed branch)")
+	}
+	cancel()
+	<-done // supervisor exits (nil or error — both are acceptable here)
+
+	// The pre-existing KnownGood marker must be completely untouched.
+	ps, loadErr := l.loadState()
+	if loadErr != nil {
+		t.Fatalf("loadState after hash-failure clean run: %v", loadErr)
+	}
+	if ps.KnownGood != "v1" {
+		t.Errorf("KnownGood = %q, want v1 — pre-existing marker must survive post-exec hash failure", ps.KnownGood)
+	}
+	if ps.KnownGoodHash != existingHash {
+		t.Errorf("KnownGoodHash = %q, want %q — pre-existing hash must survive post-exec hash failure", ps.KnownGoodHash, existingHash)
+	}
+}
+
+// TestSupervise_HashFailureAfterFailedStartup_TreatsAsNotKnownGood verifies that
+// when computeBinaryHash fails (binary unreadable) after a known-good binary
+// fast-exits, the launcher does NOT restart in place. Without the hash the
+// launcher cannot confirm the binary is the proven one — isKnownGood stays false
+// and probation rules apply (rollback fires).
+//
+// Scenario: v1 is known-good; v1 starts, writes a marker, then sleeps. The test
+// goroutine chmod-s the binary to 0o000 after the child is running. When the child
+// exits with code 1 (failed startup), computeBinaryHash fails → isKnownGood=false
+// → rollback to v0 instead of restart-in-place.
+func TestSupervise_HashFailureAfterFailedStartup_TreatsAsNotKnownGood(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v0")
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v0"); err != nil {
+		t.Fatalf("WriteCurrent v0: %v", err)
+	}
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	// State: current=v1, previous=v0. Mark v1 known-good.
+	premarkKnownGood(t, l, "v1")
+
+	markerFile := filepath.Join(t.TempDir(), "started")
+	// Child sleeps long enough for the test to chmod the binary, then exits
+	// with code 1 (simulating a crashed steward). The clock will report 0 for
+	// ranFor (always inside startup window), making this look like a fast exit.
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE":   "1",
+		"FAKE_STEWARD_SLEEP_MS":    "300",
+		"FAKE_STEWARD_MARKER_FILE": markerFile,
+	})
+
+	exe, exeErr := l.StewardExeFor("v1")
+	if exeErr != nil {
+		t.Fatalf("StewardExeFor v1: %v", exeErr)
+	}
+
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 1,
+		clock:             &fakeClock{sinceResult: 0}, // always inside startup window → failedStartup=true
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Supervise(ctx) }()
+
+	// Wait for v1 to start, then make its binary unreadable.
+	if !waitForFile(markerFile, 5*time.Second) {
+		t.Fatal("child never started (marker absent within 5s)")
+	}
+	if chErr := os.Chmod(exe, 0o000); chErr != nil {
+		t.Fatalf("chmod 000 v1 binary: %v", chErr)
+	}
+	t.Cleanup(func() { _ = os.Chmod(exe, 0o755) })
+
+	// Supervise must return an error: v1 rolls back to v0 (hash failure → not
+	// known-good → probation), then v0 also fails and budget is exhausted.
+	var superviseErr error
+	select {
+	case superviseErr = <-done:
+	case <-ctx.Done():
+		t.Fatal("Supervise did not exit within 15s — rollback to v0 must have stalled")
+	}
+	if superviseErr == nil {
+		t.Error("Supervise returned nil after hash-failure rollback with exhausted budget; want non-nil error")
+	}
+
+	// current must be v0 — rollback must have fired (not restart-in-place).
+	cur, readErr := l.ReadCurrent()
+	if readErr != nil {
+		t.Fatalf("ReadCurrent after hash-failure rollback: %v", readErr)
+	}
+	if cur != "v0" {
+		t.Errorf("current = %q after v1 hash-failure fast-exit, want v0 (rollback must fire; v1 must NOT restart in place when hash fails)", cur)
+	}
+}

--- a/cmd/cfgms-steward-launcher/lifecycle_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_test.go
@@ -935,3 +935,311 @@ func TestSupervise_UpgradeSelfExit_AdvancesToNewVersion(t *testing.T) {
 		t.Errorf("current = %q, want v2 (no rollback must have occurred)", cur)
 	}
 }
+
+// premarkKnownGood pre-seeds the known-good marker in state.json using the
+// actual hash of the installed binary at the given version. This simulates the
+// launcher having previously run the binary past its startup window.
+func premarkKnownGood(t *testing.T, l Layout, version string) {
+	t.Helper()
+	exe, err := l.StewardExeFor(version)
+	if err != nil {
+		t.Fatalf("StewardExeFor %q: %v", version, err)
+	}
+	hash, err := computeBinaryHash(exe)
+	if err != nil {
+		t.Fatalf("computeBinaryHash for %q: %v", version, err)
+	}
+	ps, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState before premarkKnownGood: %v", err)
+	}
+	ps.KnownGood = version
+	ps.KnownGoodHash = hash
+	if err := l.saveState(ps); err != nil {
+		t.Fatalf("saveState with known-good marker: %v", err)
+	}
+}
+
+// TestSupervise_KnownGood_FastExitRestartsInPlace verifies AC2: a version
+// already marked known-good that exits inside StartupWindow is restarted in
+// place — Rollback() is NOT called and state.json current is unchanged.
+func TestSupervise_KnownGood_FastExitRestartsInPlace(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	installFakeSteward(t, l, "v0") // previous version (must NOT become current)
+	if err := l.WriteCurrent("v0"); err != nil {
+		t.Fatalf("WriteCurrent v0: %v", err)
+	}
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	// State: current=v1, previous=v0. Mark v1 as known-good.
+	premarkKnownGood(t, l, "v1")
+
+	// All children exit immediately with non-zero code — inside startup window.
+	markerFile := filepath.Join(t.TempDir(), "ran")
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE":   "1",
+		"FAKE_STEWARD_SLEEP_MS":    "0",
+		"FAKE_STEWARD_MARKER_FILE": markerFile,
+	})
+
+	stderr := &bytes.Buffer{}
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 1,
+		clock:             &fakeClock{sinceResult: 0}, // always inside startup window
+		Stdout:            &bytes.Buffer{},
+		Stderr:            stderr,
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	// Run with a short timeout; the known-good loop must not return an error.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := s.Supervise(ctx)
+	// Context timeout is a clean cancel — Supervise must return nil.
+	if err != nil {
+		t.Errorf("Supervise returned %v on known-good fast-exit; want nil (restart in place, not terminal failure)", err)
+	}
+
+	// current must still be v1 — Rollback must NOT have been called.
+	cur, curErr := l.ReadCurrent()
+	if curErr != nil {
+		t.Fatalf("ReadCurrent after known-good fast-exit: %v", curErr)
+	}
+	if cur != "v1" {
+		t.Errorf("current = %q after known-good fast-exit, want v1 (rollback must be suppressed)", cur)
+	}
+
+	// The child must have run at least once (marker file written).
+	if _, statErr := os.Stat(markerFile); statErr != nil {
+		t.Errorf("child never ran (marker absent): %v", statErr)
+	}
+
+	// Stderr must mention the restart-in-place decision.
+	if !bytes.Contains(stderr.Bytes(), []byte("known-good")) {
+		t.Errorf("stderr did not mention known-good restart:\n%s", stderr.String())
+	}
+}
+
+// TestSupervise_Probation_FastExitRollsBack verifies AC3: a freshly staged
+// (not-yet-known-good) version that exits inside StartupWindow still rolls
+// back to the previous version (existing probation behavior preserved).
+func TestSupervise_Probation_FastExitRollsBack(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	installFakeSteward(t, l, "v2")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	if err := l.WriteCurrent("v2"); err != nil {
+		t.Fatalf("WriteCurrent v2: %v", err)
+	}
+	// State: current=v2, previous=v1. v2 has NO known-good marker (probation).
+
+	marker := filepath.Join(t.TempDir(), "ran")
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE":   "1",
+		"FAKE_STEWARD_SLEEP_MS":    "0",
+		"FAKE_STEWARD_MARKER_FILE": marker,
+	})
+
+	stderr := &bytes.Buffer{}
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 1,
+		clock:             &fakeClock{sinceResult: 0}, // always inside startup window
+		Stdout:            &bytes.Buffer{},
+		Stderr:            stderr,
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	err := runSupervisor(t, s, 10*time.Second)
+	if err == nil {
+		t.Fatal("Supervise must return error when non-known-good v2 fails and v1 also fails")
+	}
+
+	// Rollback must have fired: current must be v1 after the rollback.
+	cur, curErr := l.ReadCurrent()
+	if curErr != nil {
+		t.Fatalf("ReadCurrent after probation rollback: %v", curErr)
+	}
+	if cur != "v1" {
+		t.Errorf("current = %q after probation rollback, want v1", cur)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte(`rolled back to version "v1"`)) {
+		t.Errorf("stderr did not mention rollback:\n%s", stderr.String())
+	}
+}
+
+// TestSupervise_IncidentReplay_KnownGoodNotDemoted verifies AC4: replaying
+// the 2026-06-16 incident. Known-good vA is current; a forced fast-exit on
+// first start does NOT demote to vB. The launcher keeps vA current and retries.
+func TestSupervise_IncidentReplay_KnownGoodNotDemoted(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v0-5-12") // old version — must NOT become current
+	installFakeSteward(t, l, "v0-5-13") // known-good current
+	if err := l.WriteCurrent("v0-5-12"); err != nil {
+		t.Fatalf("WriteCurrent v0-5-12: %v", err)
+	}
+	if err := l.WriteCurrent("v0-5-13"); err != nil {
+		t.Fatalf("WriteCurrent v0-5-13: %v", err)
+	}
+	// Mark v0-5-13 known-good (it was running fine before the reboot).
+	premarkKnownGood(t, l, "v0-5-13")
+
+	// Simulate the boot-time race: v0-5-13 exits in under 2s (0-byte logs).
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE": "1",
+		"FAKE_STEWARD_SLEEP_MS":  "0",
+	})
+
+	stderr := &bytes.Buffer{}
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     30 * time.Second,
+		MaxRollbackCycles: 1,
+		clock:             &fakeClock{sinceResult: time.Millisecond}, // fast exit inside 30s window
+		Stdout:            &bytes.Buffer{},
+		Stderr:            stderr,
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := s.Supervise(ctx)
+	if err != nil {
+		t.Errorf("Supervise returned %v in incident replay; want nil (known-good v0-5-13 never demoted)", err)
+	}
+
+	// v0-5-13 must remain current — no demotion to v0-5-12.
+	cur, curErr := l.ReadCurrent()
+	if curErr != nil {
+		t.Fatalf("ReadCurrent after incident replay: %v", curErr)
+	}
+	if cur != "v0-5-13" {
+		t.Errorf("current = %q after incident replay, want v0-5-13 (not demoted)", cur)
+	}
+	if bytes.Contains(stderr.Bytes(), []byte("rolled back")) {
+		t.Errorf("rollback must not fire for known-good v0-5-13:\n%s", stderr.String())
+	}
+}
+
+// TestSupervise_KnownGoodCutover_NewVersionEntersProbation verifies AC6 (lifecycle
+// side): after a controller cutover to a new version (vB), a vB fast-exit follows
+// probation rules and rolls back to known-good vA — the known-good marker for vA
+// cannot protect vB from rollback.
+func TestSupervise_KnownGoodCutover_NewVersionEntersProbation(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "vA")
+	installFakeSteward(t, l, "vB")
+	if err := l.WriteCurrent("vA"); err != nil {
+		t.Fatalf("WriteCurrent vA: %v", err)
+	}
+	// Mark vA known-good (security-patch pre-condition).
+	premarkKnownGood(t, l, "vA")
+
+	// Controller pushes vB (security patch) via WriteCurrent. This must clear
+	// vA's known-good marker and enter vB into probation.
+	if err := l.WriteCurrent("vB"); err != nil {
+		t.Fatalf("WriteCurrent vB: %v", err)
+	}
+
+	// Verify marker was cleared by cutover.
+	ps, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	if ps.KnownGood != "" || ps.KnownGoodHash != "" {
+		t.Fatalf("cutover to vB must clear known-good marker; got KnownGood=%q KnownGoodHash=%q",
+			ps.KnownGood, ps.KnownGoodHash)
+	}
+
+	// vB fast-exits → must roll back to vA (probation rules apply).
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE": "1",
+		"FAKE_STEWARD_SLEEP_MS":  "0",
+	})
+
+	stderr := &bytes.Buffer{}
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 1,
+		clock:             &fakeClock{sinceResult: 0}, // fast exit inside startup window
+		Stdout:            &bytes.Buffer{},
+		Stderr:            stderr,
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	// Both vA and vB fail (same env), so supervise exhausts rollback budget and errors.
+	if err := runSupervisor(t, s, 10*time.Second); err == nil {
+		t.Fatal("Supervise must return error after vB fails and vA also fails")
+	}
+
+	// The rollback to vA must have fired (vB was in probation, not known-good).
+	cur, curErr := l.ReadCurrent()
+	if curErr != nil {
+		t.Fatalf("ReadCurrent after vB probation rollback: %v", curErr)
+	}
+	if cur != "vA" {
+		t.Errorf("current = %q after vB probation rollback, want vA", cur)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte(`rolled back to version "vA"`)) {
+		t.Errorf("stderr must mention rollback to vA:\n%s", stderr.String())
+	}
+}
+
+// TestSupervise_KnownGood_MarkedAfterHealthyRun verifies that a version which
+// runs past StartupWindow and exits cleanly has the known-good marker written to
+// state.json, and that marker survives a subsequent loadState (AC1 via lifecycle).
+func TestSupervise_KnownGood_MarkedAfterHealthyRun(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	certStoreDir := t.TempDir()
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE": "0",
+		"FAKE_STEWARD_SLEEP_MS":  "0",
+	})
+
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 0,
+		CertStoreDir:      certStoreDir,
+		clock:             &fakeClock{sinceResult: time.Minute}, // past startup window → clean
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Supervise(ctx) }()
+
+	// Wait for upgrade-committed flag (written after mark-known-good).
+	flagPath := filepath.Join(certStoreDir, "upgrade-committed")
+	if !waitForFile(flagPath, 5*time.Second) {
+		t.Fatal("upgrade-committed flag never appeared")
+	}
+	cancel()
+	<-done
+
+	ps, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState after healthy run: %v", err)
+	}
+	if ps.KnownGood != "v1" {
+		t.Errorf("KnownGood = %q, want v1 — must be set after binary survived StartupWindow", ps.KnownGood)
+	}
+	if ps.KnownGoodHash == "" {
+		t.Error("KnownGoodHash must be non-empty after healthy run")
+	}
+}

--- a/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
@@ -15,7 +15,120 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/svc"
 )
+
+// TestWindowsServiceHandler_TerminalFailure_ReportsServiceSpecificExitCode
+// verifies AC5: when the supervise loop exits on its own (terminal failure —
+// no rollback available), Execute must return svcSpecificEC=true with a
+// non-zero exit code so that Win32_Service.ExitCode is non-zero and the SCM
+// applies its configured RESTART recovery actions.
+//
+// The three independent self-heal caps are:
+//   - SCM's OS-configured reset period (sc failure reset=86400)
+//   - launcher MaxRollbackCycles (default 1): governs how many times the
+//     launcher itself will roll back before giving up and surfacing a terminal
+//     failure to the SCM.
+//   - Known-good restart-in-place loop: a proven binary is retried
+//     indefinitely; SCM recovery fires only when a non-known-good binary
+//     exhausts rollback budget and the launcher process exits.
+//
+// Expected Win32_Service state after terminal failure:
+//   ExitCode:        ERROR_SERVICE_SPECIFIC_ERROR (1066)
+//   ServiceExitCode: the launcher's own exit code (1 for supervise error)
+func TestWindowsServiceHandler_TerminalFailure_ReportsServiceSpecificExitCode(t *testing.T) {
+	// Empty root with no current version: Supervise returns an error immediately.
+	root := t.TempDir()
+
+	r := make(chan svc.ChangeRequest)
+	status := make(chan svc.Status, 10)
+
+	h := &windowsServiceHandler{
+		// --max-rollbacks 0: no rollback budget → terminal failure on first child error.
+		args: []string{"--root", root, "--max-rollbacks", "0"},
+	}
+
+	svcSpecific, exitCode := h.Execute(nil, r, status)
+
+	if !svcSpecific {
+		t.Errorf("Execute returned svcSpecificEC=false on terminal failure; want true so SCM "+
+			"records ERROR_SERVICE_SPECIFIC_ERROR and applies recovery actions (AC5)")
+	}
+	if exitCode == 0 {
+		t.Errorf("Execute returned exitCode=0 on terminal failure; want non-zero so "+
+			"Win32_Service.ExitCode is non-zero and SCM recovery fires (AC5)")
+	}
+}
+
+// TestWindowsServiceHandler_AdminStop_DoesNotTriggerRecovery verifies AC5
+// (negative case): an SCM-initiated Stop must NOT trigger recovery — it must
+// return svcSpecificEC=false so Win32_Service.ExitCode stays 0 (clean stop).
+func TestWindowsServiceHandler_AdminStop_DoesNotTriggerRecovery(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	// Child sleeps long. Use a 10ms startup window so the child is considered
+	// past it before Stop arrives (~100ms after Running is reported).
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("FAKE_STEWARD_SLEEP_MS", "60000")
+	t.Setenv("FAKE_STEWARD_EXIT_CODE", "0")
+
+	r := make(chan svc.ChangeRequest, 1)
+	status := make(chan svc.Status, 20)
+
+	h := &windowsServiceHandler{
+		args: []string{
+			"--root", l.Root,
+			"--startup-window", "10ms",
+			"--child-args", "-test.run=TestHelperProcess",
+		},
+	}
+
+	type execResult struct {
+		svcSpecific bool
+		code        uint32
+	}
+	resultCh := make(chan execResult, 1)
+	go func() {
+		s, c := h.Execute(nil, r, status)
+		resultCh <- execResult{s, c}
+	}()
+
+	// Drain status until Running, then wait for the startup window to elapse,
+	// then send Stop.
+	deadline := time.Now().Add(15 * time.Second)
+	var runningStatus svc.Status
+	for {
+		select {
+		case st := <-status:
+			if st.State == svc.Running {
+				runningStatus = st
+				goto sendStop
+			}
+		case <-time.After(time.Until(deadline)):
+			t.Fatal("service did not reach Running state within 15s")
+		}
+	}
+sendStop:
+	// Give the startup window (10ms) time to elapse so ranFor > StartupWindow
+	// when the child is killed. This ensures ctx cancel is seen as a clean
+	// shutdown rather than a startup failure.
+	time.Sleep(100 * time.Millisecond)
+	r <- svc.ChangeRequest{Cmd: svc.Stop, CurrentStatus: runningStatus}
+
+	select {
+	case res := <-resultCh:
+		if res.svcSpecific {
+			t.Errorf("Execute returned svcSpecificEC=true on admin Stop; "+
+				"must be false (clean stop, no SCM recovery) (AC5)")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Execute did not return after Stop within 15s")
+	}
+}
 
 // TestAttachChildToJobObject_KillsChildOnLauncherExit covers the #1928
 // guarantee: an abnormal launcher exit must take the supervised steward

--- a/cmd/cfgms-steward-launcher/service_windows.go
+++ b/cmd/cfgms-steward-launcher/service_windows.go
@@ -110,12 +110,18 @@ func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, 
 				return false, uint32(code)
 			}
 		case code := <-done:
-			// Supervise exited on its own (e.g. broken child, no
-			// rollback available). Report Stopped with the actual
-			// exit code so the SCM can log + apply recovery actions.
+			// Supervise exited on its own (terminal failure — broken child
+			// with no rollback available). A non-zero code is reported as a
+			// service-specific exit so Win32_Service.ExitCode is non-zero and
+			// the SCM applies its configured recovery actions (RESTART).
+			// A zero code (unexpected clean supervise exit) is reported as a
+			// clean stop — no recovery needed.
 			cancel()
 			status <- svc.Status{State: svc.Stopped}
-			return false, uint32(code)
+			if code != 0 {
+				return true, uint32(code)
+			}
+			return false, 0
 		}
 	}
 }

--- a/cmd/cfgms-steward-launcher/state.go
+++ b/cmd/cfgms-steward-launcher/state.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,6 +61,14 @@ type pointerState struct {
 	Current             string `json:"current"`
 	Previous            string `json:"previous,omitempty"`
 	ConsecutiveFailures int    `json:"consecutive_failures,omitempty"`
+	// KnownGood and KnownGoodHash record the version and SHA-256 content
+	// hash of the last binary that survived StartupWindow. Both fields
+	// must match the live binary for the marker to be considered valid —
+	// a version-tag reuse or an on-disk replacement voids it.
+	// The marker gates auto-rollback policy only; it is not a security
+	// control (see security note in Issue #2033).
+	KnownGood     string `json:"known_good,omitempty"`
+	KnownGoodHash string `json:"known_good_hash,omitempty"`
 }
 
 // StatePath returns the path of the single JSON document that records
@@ -108,6 +118,23 @@ func validateVersion(v string) error {
 		return fmt.Errorf("launcher: version name must not contain path separators or dot sequences: %q", v)
 	}
 	return nil
+}
+
+// computeBinaryHash returns the hex-encoded SHA-256 digest of the file at path.
+// The hash is paired with the version tag in the known-good marker so that a
+// tag reused for different binary content cannot suppress rollback for that
+// new content.
+func computeBinaryHash(path string) (string, error) {
+	f, err := os.Open(path) //#nosec G304 -- path comes from Layout.StewardExeFor which validates the version tag
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 // loadState reads the combined pointer state. If state.json exists it
@@ -227,6 +254,12 @@ func (l Layout) WriteCurrent(version string) error {
 	}
 	if ps.Current != "" && ps.Current != version {
 		ps.Previous = ps.Current
+		// Changing to a new version: the incoming binary enters probation
+		// regardless of any prior known-good marker. Clearing here ensures
+		// a controller-pushed security patch (vB) cannot be rolled back to
+		// a known-good-but-vulnerable vA if vB fast-exits (Issue #2033 AC6).
+		ps.KnownGood = ""
+		ps.KnownGoodHash = ""
 	}
 	ps.Current = version
 	return l.saveState(ps)

--- a/cmd/cfgms-steward-launcher/state_test.go
+++ b/cmd/cfgms-steward-launcher/state_test.go
@@ -9,6 +9,129 @@ import (
 	"testing"
 )
 
+// TestKnownGood_PersistsAndReloads verifies AC1: the known-good marker
+// (version tag + binary hash) is written atomically and survives a process
+// restart / reboot (read back from state.json by a new process).
+func TestKnownGood_PersistsAndReloads(t *testing.T) {
+	l := newLayout(t)
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	ps, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	ps.KnownGood = "v1"
+	ps.KnownGoodHash = "deadbeefcafe0123456789abcdef"
+	if err := l.saveState(ps); err != nil {
+		t.Fatalf("saveState with known-good: %v", err)
+	}
+
+	// Simulate process restart: create a fresh Layout over the same Root.
+	l2 := Layout{Root: l.Root, StewardBinaryName: l.StewardBinaryName}
+	ps2, err := l2.loadState()
+	if err != nil {
+		t.Fatalf("loadState after simulated restart: %v", err)
+	}
+	if ps2.KnownGood != "v1" {
+		t.Errorf("KnownGood = %q, want v1 — marker must survive reboot", ps2.KnownGood)
+	}
+	if ps2.KnownGoodHash != "deadbeefcafe0123456789abcdef" {
+		t.Errorf("KnownGoodHash = %q, want original hash", ps2.KnownGoodHash)
+	}
+	// Other fields must be intact.
+	if ps2.Current != "v1" {
+		t.Errorf("Current = %q, want v1", ps2.Current)
+	}
+}
+
+// TestWriteCurrent_ClearsKnownGoodOnVersionChange verifies AC6 (state side):
+// a cutover to a new version clears the known-good marker so the incoming
+// binary enters probation.
+func TestWriteCurrent_ClearsKnownGoodOnVersionChange(t *testing.T) {
+	l := newLayout(t)
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	// Pre-mark v1 as known-good.
+	ps, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	ps.KnownGood = "v1"
+	ps.KnownGoodHash = "abc123"
+	if err := l.saveState(ps); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	// Cutover to v2 (new version).
+	if err := l.WriteCurrent("v2"); err != nil {
+		t.Fatalf("WriteCurrent v2: %v", err)
+	}
+
+	ps2, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState after cutover: %v", err)
+	}
+	if ps2.KnownGood != "" {
+		t.Errorf("KnownGood = %q after cutover, want empty — new version must enter probation", ps2.KnownGood)
+	}
+	if ps2.KnownGoodHash != "" {
+		t.Errorf("KnownGoodHash = %q after cutover, want empty", ps2.KnownGoodHash)
+	}
+	if ps2.Current != "v2" {
+		t.Errorf("Current = %q, want v2", ps2.Current)
+	}
+	if ps2.Previous != "v1" {
+		t.Errorf("Previous = %q, want v1", ps2.Previous)
+	}
+}
+
+// TestComputeBinaryHash_MissingFileReturnsError verifies the error path of
+// computeBinaryHash: a missing file must return a non-nil error (not a zero hash).
+func TestComputeBinaryHash_MissingFileReturnsError(t *testing.T) {
+	_, err := computeBinaryHash(filepath.Join(t.TempDir(), "nonexistent-binary"))
+	if err == nil {
+		t.Fatal("computeBinaryHash of nonexistent file returned nil error, want error")
+	}
+}
+
+// TestWriteCurrent_PreservesKnownGoodOnNoOp verifies that re-writing the same
+// version does not clear the known-good marker (idempotent no-op).
+func TestWriteCurrent_PreservesKnownGoodOnNoOp(t *testing.T) {
+	l := newLayout(t)
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	ps, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	ps.KnownGood = "v1"
+	ps.KnownGoodHash = "abc123"
+	if err := l.saveState(ps); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	// Re-write same version — must not clear marker.
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1 again: %v", err)
+	}
+
+	ps2, err := l.loadState()
+	if err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	if ps2.KnownGood != "v1" {
+		t.Errorf("KnownGood = %q after no-op WriteCurrent, want v1 — must not clear marker", ps2.KnownGood)
+	}
+	if ps2.KnownGoodHash != "abc123" {
+		t.Errorf("KnownGoodHash = %q, want abc123", ps2.KnownGoodHash)
+	}
+}
+
 func newLayout(t *testing.T) Layout {
 	t.Helper()
 	return Layout{


### PR DESCRIPTION
## Summary

- Persists a `known_good` marker (version tag + SHA-256 hash) in `state.json` once a binary survives `StartupWindow`; marker survives reboots via the existing atomic temp-file+rename
- Known-good binary that fast-exits is **restarted in place** (transient environmental fault) — `Rollback()` is never called for a proven binary
- `WriteCurrent` cutover **clears the marker** so a controller-pushed security patch enters probation and cannot be rolled back to a known-good-but-vulnerable predecessor (AC6)
- Windows SCM handler now returns `(true, code)` on terminal failure so `Win32_Service.ExitCode` is non-zero and configured RESTART recovery actions fire

## Root cause fixed

On `steward-1780659937223058807` (2026-06-16): v0.5.13 (running fine for hours) lost a boot-time WMI race and exited in under 2 s; the launcher demoted it to v0.5.12, which lost the same race, exhausted `MaxRollbackCycles`, and left the service stopped 9 minutes. Same binary ran fine when started manually — rollback was spurious.

## Acceptance criteria

- [x] AC1 — Known-good marker persists to `state.json` and reloads after restart (`TestKnownGood_PersistsAndReloads`)
- [x] AC2 — Known-good fast-exit → restart in place, `Rollback()` not called (`TestSupervise_KnownGood_FastExitRestartsInPlace`)
- [x] AC3 — Non-known-good fast-exit → still rolls back (`TestSupervise_Probation_FastExitRollsBack`)
- [x] AC4 — Incident replay: known-good vA not demoted on fast-exit (`TestSupervise_IncidentReplay_KnownGoodNotDemoted`)
- [x] AC5 — Terminal failure returns service-specific exit code; admin Stop returns clean exit (`TestWindowsServiceHandler_TerminalFailure_ReportsServiceSpecificExitCode`, `TestWindowsServiceHandler_AdminStop_DoesNotTriggerRecovery`)
- [x] AC6 — Cutover to new version clears known-good; vB fast-exit rolls back to vA (`TestSupervise_KnownGoodCutover_NewVersionEntersProbation`, `TestWriteCurrent_ClearsKnownGoodOnVersionChange`)
- [x] AC7 — `make test-complete` passes

## Specialist review results

| Reviewer | Result |
|----------|--------|
| QA test runner | **PASS** — all packages, cross-platform builds, linting |
| QA code reviewer | **PASS** — no mocks, no t.Skip(), all new code has error-path tests |
| Security engineer | **PASS** — known-good marker confirmed as liveness-only, not a security control; hash-binding and cutover invalidation verified |

## Files changed

- `cmd/cfgms-steward-launcher/state.go` — `KnownGood`/`KnownGoodHash` fields, `computeBinaryHash`, cutover invalidation in `WriteCurrent`
- `cmd/cfgms-steward-launcher/lifecycle.go` — hash probe per iteration, mark-known-good after startup window, restart-in-place for known-good fast exits
- `cmd/cfgms-steward-launcher/service_windows.go` — service-specific exit code on terminal failure
- `cmd/cfgms-steward-launcher/state_test.go` — AC1, AC6 state tests, `computeBinaryHash` error path
- `cmd/cfgms-steward-launcher/lifecycle_test.go` — AC2, AC3, AC4, AC6 lifecycle tests
- `cmd/cfgms-steward-launcher/lifecycle_windows_test.go` — AC5 SCM exit-code tests

Fixes #2033