### PR TITLE
pipeline: resolve-conflict agent mode for DIRTY PRs (Issue #1977)

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -423,11 +423,23 @@ Outcomes:
   ./.claude/scripts/po-act.sh diagnose <PR>
   ./scripts/project-queue.sh update-field <ITEM_ID> status Fix
   ```
-- `REBASE_CONFLICT:<PR>` — real conflicts that need code changes. Set status to Fix and post a comment on the PR with the conflicting files (the script prints them):
+- `REBASE_CONFLICT:<PR>` — real conflicts requiring code understanding. **Immediately** (in this same Step 3 execution, without waiting for the next cycle) dispatch a resolve-conflict agent:
   ```bash
-  ./scripts/project-queue.sh update-field <ITEM_ID> status Fix
+  ./.claude/scripts/po-act.sh resolve-conflict <PR>
   ```
-  Step 5 will pick it up next cycle for dispatch-fix.
+  The resolve-conflict agent: rebases onto `origin/develop`, resolves conflict markers (understanding both sides' intent, deduplicating helpers, preserving both stories' logic), validates (`go build ./...` + affected tests), and force-pushes with `--force-with-lease` to the PR's own branch. **One attempt per PR per cycle** — the inline call here is the only dispatch; the preflight never emits a separate `resolve-conflict` action type.
+
+  After a successful dispatch (`DISPATCHED_RESOLVE_CONFLICT:<PR>`):
+  - The next cycle will see the PR with a new commit (from the rebase). Because the new commit's `committedDate` is newer than any prior review comment, the preflight routes the PR to **`spawn_acceptance_reviewer`** (AC4 re-review) before enqueue — this applies to prior-PASS, prior-FAIL, and never-reviewed PRs alike. No additional status change is needed.
+
+  If the resolve-conflict dispatch fails (author gate refused, validation failure inside the container):
+  - The agent will have posted the conflict files + failure summary on the PR
+  - Set status Fix for human triage:
+    ```bash
+    ./scripts/project-queue.sh update-field <ITEM_ID> status Fix
+    ```
+
+  **Do NOT re-dispatch** if the PR is still DIRTY in the next cycle after a successful push — surface for human triage instead (the resolve-conflict guard in `active_fix_pr_nums` in the preflight suppresses dispatch while the container is in flight, and after that you get at most one attempt per cycle because Step 3 runs once per PR per cycle).
 - `REBASE_REFUSED:<PR>:<reason>` — PR closed/merged/from a fork. Skip; next cycle will resync.
 
 This step is REQUIRED before Step 4 because:
@@ -533,6 +545,8 @@ For each story with project status `Fix`, find its PR and dispatch the fix agent
 ./.claude/scripts/po-act.sh dispatch-fix <PR_NUM>
 ```
 This cleans any stale container from a prior failed attempt, re-clones, and launches.
+
+`dispatch-fix` and `resolve-conflict` are sibling modes: `dispatch-fix` addresses review/CI failures on an otherwise-rebased branch; `resolve-conflict` (Step 3) addresses rebase conflicts. The two never run on the same PR simultaneously — the `active_fix_pr_nums` suppression guard in the preflight recognizes both `cfg-agent-pr-fix-<PR>` and `cfg-agent-resolve-conflict-<PR>` containers.
 
 **Step 6 — Dispatch:**
 

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -655,9 +655,20 @@ case "$cmd" in
     ;;
 
   create-clone-pr)
+    # Optional --dest-prefix <PREFIX> flag (default: "pr-fix-") lets callers
+    # land the clone in a distinct namespace (e.g. "resolve-conflict-" for the
+    # resolve-conflict agent so it never collides with a simultaneous fix-pr
+    # container on the same PR).
+    dest_prefix="pr-fix-"
+    while [[ $# -gt 0 && "$1" == --* ]]; do
+      case "$1" in
+        --dest-prefix) dest_prefix="${2:?--dest-prefix requires a value}"; shift 2 ;;
+        *) echo "Unknown flag for create-clone-pr: $1"; exit 1 ;;
+      esac
+    done
     [[ $# -eq 1 ]] || { echo "create-clone-pr requires exactly one PR number"; exit 1; }
     pr_num="$1"
-    dest="${WORKTREE_BASE}/pr-fix-${pr_num}"
+    dest="${WORKTREE_BASE}/${dest_prefix}${pr_num}"
     github_url=$(git -C "$REPO_ROOT" remote get-url origin)
 
     # Fetch all PR metadata in one call (author gate + branch + body).
@@ -699,7 +710,7 @@ case "$cmd" in
     git checkout "$pr_branch"
     trap - ERR
 
-    echo "CLONE_OK:pr-fix-${pr_num}:${pr_branch}:issue=${issue_num:-none}"
+    echo "CLONE_OK:${dest_prefix}${pr_num}:${pr_branch}:issue=${issue_num:-none}"
     ;;
 
   launch)
@@ -774,9 +785,10 @@ case "$cmd" in
     extra_labels=()
     for i in "${!entrypoint_args[@]}"; do
       case "${entrypoint_args[$i]}" in
-        --fix-pr) mode_label="fix-pr"; fix_pr_num="${entrypoint_args[$((i+1))]}"; extra_labels+=(--label "pr=${entrypoint_args[$((i+1))]}") ;;
-        --branch) extra_labels+=(--label "branch=${entrypoint_args[$((i+1))]}") ;;
-        --issue)  extra_labels+=(--label "issue=${entrypoint_args[$((i+1))]}") ;;
+        --fix-pr)          mode_label="fix-pr";          fix_pr_num="${entrypoint_args[$((i+1))]}"; extra_labels+=(--label "pr=${entrypoint_args[$((i+1))]}") ;;
+        --resolve-conflict) mode_label="resolve-conflict";                                           extra_labels+=(--label "pr=${entrypoint_args[$((i+1))]}") ;;
+        --branch)          extra_labels+=(--label "branch=${entrypoint_args[$((i+1))]}") ;;
+        --issue)           extra_labels+=(--label "issue=${entrypoint_args[$((i+1))]}") ;;
       esac
     done
 
@@ -1163,6 +1175,8 @@ else:
     clone_dir=""
     if [[ "$container_name" =~ ^cfg-agent-pr-fix-(.+)$ ]]; then
       clone_dir="${WORKTREE_BASE}/pr-fix-${BASH_REMATCH[1]}"
+    elif [[ "$container_name" =~ ^cfg-agent-resolve-conflict-(.+)$ ]]; then
+      clone_dir="${WORKTREE_BASE}/resolve-conflict-${BASH_REMATCH[1]}"
     elif [[ "$container_name" =~ ^cfg-agent-branch-(.+)$ ]]; then
       clone_dir="${WORKTREE_BASE}/${BASH_REMATCH[1]}"
     elif [[ "$container_name" =~ ^cfg-agent-interactive-(.+)$ ]]; then

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -8,6 +8,7 @@
 #   dispatch <STORY_NUM>            Fresh story: claim (Ready->In Progress) + check-conflicts + clone + launch
 #   claim <ITEM_ID>                 Claim a Ready story (Ready->In Progress) for in-session work; CLAIMED/CLAIM_LOST
 #   dispatch-fix <PR_NUM>           Fix cycle: remove stale container + clone-pr + launch
+#   resolve-conflict <PR_NUM>       Conflict resolution: author-gate + clone-pr + launch resolve-conflict agent
 #   close-merged <ISSUE> <PR>       Close issue that didn't auto-close after PR merge
 #   enqueue <PR_NUM> [<STORY>]      Add PR to merge queue. If STORY is given,
 #                                   prepends "Fixes #STORY" to the PR body when
@@ -300,6 +301,27 @@ except Exception: print('')" 2>/dev/null || echo "")
     "$DISPATCH" create-clone-pr "$pr" | tail -1
     "$DISPATCH" launch-generic "$container" "${WORKTREE_BASE}/pr-fix-${pr}" --fix-pr "$pr" | tail -1
     echo "DISPATCHED_FIX:$pr"
+    ;;
+
+  resolve-conflict)
+    pr="${1:?PR number required}"
+    [[ "$pr" =~ ^[0-9]+$ ]] || { echo "ERROR: PR number must be numeric, got: ${pr}"; exit 1; }
+    container="cfg-agent-resolve-conflict-${pr}"
+    # Subcommand-level author gate (defense in depth — must run before any
+    # clone/fetch/checkout/launch). Uses #1786's permission-level helper
+    # (push/maintain/admin). The interim authorAssociation check was replaced
+    # once #1786 landed; this subcommand-level assertion stays regardless.
+    if ! "$DISPATCH" check-pr-author "$pr"; then
+      echo "RESOLVE_CONFLICT_REFUSED:${pr}:external_author"
+      exit 3
+    fi
+    # Remove any stale exited container from a previous attempt
+    docker rm -f "$container" >/dev/null 2>&1 || true
+    # Remove any stale worktree directory (separate namespace from pr-fix-<PR>)
+    rm -rf "${WORKTREE_BASE}/resolve-conflict-${pr}" 2>/dev/null || true
+    "$DISPATCH" create-clone-pr --dest-prefix "resolve-conflict-" "$pr" | tail -1
+    "$DISPATCH" launch-generic "$container" "${WORKTREE_BASE}/resolve-conflict-${pr}" --resolve-conflict "$pr" | tail -1
+    echo "DISPATCHED_RESOLVE_CONFLICT:${pr}"
     ;;
 
   close-merged)

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -1272,7 +1272,7 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
         if pr.get("is_external") and not pr.get("is_released"):
             recs.append({
                 "pr": pr["pr"],
-                "story": pr["story_number"],  # always None for external PRs (AC4)
+                "story": pr["story_number"],  # always None for external PRs (#1786 AC4)
                 "action": "skip",
                 "reason": (
                     f"external-author PR quarantined (author: {pr.get('author_login') or 'unknown'}) — "
@@ -1317,7 +1317,7 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
                 "pr": pr["pr"],
                 "story": pr["story_number"],
                 "action": "rebase",
-                "reason": "mergeStateStatus=DIRTY (conflicts with develop) — run `./.claude/scripts/rebase-pr.sh <PR>`; if it returns REBASE_CONFLICT, escalate to dispatch-fix",
+                "reason": "mergeStateStatus=DIRTY (conflicts with develop) — run `./.claude/scripts/rebase-pr.sh <PR>`; if it returns REBASE_CONFLICT, escalate to resolve-conflict",
             })
             continue
         if not in_queue and ms == "BEHIND" and pr.get("auto_merge_enabled"):
@@ -1376,6 +1376,36 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
             continue
 
         if pr["has_acceptance_review_comment"]:
+            # AC4 (Issue #1977): a new commit landed AFTER a passing review invalidates
+            # the verdict — the reviewer has not seen the new code (e.g. a
+            # resolve-conflict rebase). Route to re-review so the trust chain is
+            # closed. This check runs before the enqueue_merge path so a
+            # prior-PASS PR is never enqueued without a re-review of the new head.
+            if verdict == "pass" and fix_landed_after_review(pr):
+                if overall == "green":
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "spawn_acceptance_reviewer",
+                        "reason": "commit landed after review PASS — prior verdict invalidated; re-review required before enqueue",
+                    })
+                elif overall == "pending":
+                    pending = pr["ci_summary"]["pending_checks"][:3]
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "defer",
+                        "reason": f"commit landed after review PASS; CI re-running: {', '.join(pending)} — re-review once CI completes",
+                    })
+                else:
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "skip",
+                        "reason": "commit landed after review PASS but CI is red — fix cycle owns this before re-review",
+                    })
+                continue
+
             # Review passed (or verdict unparseable). Flag as stuck if CI green
             # + mergeable but not in queue and not already auto-merge-enabled.
             if (
@@ -2032,11 +2062,18 @@ def main():
     )
     # Pull the active fix-agent set out of running_containers so the review
     # recommender can skip rebase/dispatch-fix work for any PR with an
-    # in-flight fix container. Container name pattern: cfg-agent-pr-fix-<PR>.
+    # in-flight fix or resolve-conflict container. Container name patterns:
+    #   cfg-agent-pr-fix-<PR>         — fix-pr agent (Issue #1786)
+    #   cfg-agent-resolve-conflict-<PR> — conflict-resolution agent (Issue #1977)
+    # Both push to the PR branch and must not race with a rebase or second dispatch.
     active_fix_pr_nums = set()
     for name in containers or []:
         if name.startswith("cfg-agent-pr-fix-"):
             tail = name.removeprefix("cfg-agent-pr-fix-")
+            if tail.isdigit():
+                active_fix_pr_nums.add(int(tail))
+        elif name.startswith("cfg-agent-resolve-conflict-"):
+            tail = name.removeprefix("cfg-agent-resolve-conflict-")
             if tail.isdigit():
                 active_fix_pr_nums.add(int(tail))
     # Story numbers with project status Blocked — their PRs are fenced off from

--- a/.claude/scripts/tests/resolve_conflict.test.sh
+++ b/.claude/scripts/tests/resolve_conflict.test.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# Tests for resolve-conflict agent mode (Issue #1977).
+#
+# Covers:
+#   AC1  — author gate refuses non-member PR before any clone/fetch/checkout/launch
+#   AC4  — preflight routes prior-PASS PR to spawn_acceptance_reviewer after a
+#           commit lands post-review (Python unit test)
+#   AC6  — rebase-pr.sh exit 2 triggers DISPATCHED_RESOLVE_CONFLICT:<PR>;
+#           author gate refuses external PR before any clone
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PO_ACT="${SCRIPT_DIR}/../po-act.sh"
+PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
+
+if [[ ! -f "$PO_ACT" ]]; then
+  printf 'FAIL: po-act.sh not found at %s\n' "$PO_ACT" >&2
+  exit 1
+fi
+if [[ ! -f "$PREFLIGHT" ]]; then
+  printf 'FAIL: po-cycle-preflight.py not found at %s\n' "$PREFLIGHT" >&2
+  exit 1
+fi
+
+fail=0
+ran=0
+
+check() {
+  local description="$1" result="$2" expected="$3"
+  ran=$((ran + 1))
+  if [[ "$result" == "$expected" ]]; then
+    printf '  ok    %s\n' "$description"
+  else
+    printf '  FAIL  %s\n        expected: %q\n        actual:   %q\n' \
+      "$description" "$expected" "$result"
+    fail=$((fail + 1))
+  fi
+}
+
+check_contains() {
+  local description="$1" haystack="$2" needle="$3"
+  ran=$((ran + 1))
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf '  ok    %s\n' "$description"
+  else
+    printf '  FAIL  %s\n        expected to contain: %q\n        actual: %q\n' \
+      "$description" "$needle" "$haystack"
+    fail=$((fail + 1))
+  fi
+}
+
+check_not_contains() {
+  local description="$1" haystack="$2" needle="$3"
+  ran=$((ran + 1))
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf '  ok    %s\n' "$description"
+  else
+    printf '  FAIL  %s — output should NOT contain %q\n        actual: %q\n' \
+      "$description" "$needle" "$haystack"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Shared: temp worktree dir (rm -rf target; Docker calls are silenced || true)
+# ---------------------------------------------------------------------------
+TMPWT="$(mktemp -d)"
+trap 'rm -rf "$TMPWT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Build a mock dispatch script that records calls and fakes success.
+# Accepts two modes controlled by MOCK_AUTHOR_GATE:
+#   "trusted"  — check-pr-author exits 0 (AUTHOR_TRUSTED)
+#   "external" — check-pr-author exits 3 (AUTHOR_EXTERNAL)
+# ---------------------------------------------------------------------------
+MOCK_DISPATCH="$(mktemp)"
+chmod +x "$MOCK_DISPATCH"
+cat > "$MOCK_DISPATCH" <<'MOCK_EOF'
+#!/usr/bin/env bash
+# Minimal mock for agent-dispatch.sh used in resolve-conflict tests.
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  check-pr-author)
+    pr="${1:-0}"
+    if [[ "${MOCK_AUTHOR_GATE:-trusted}" == "external" ]]; then
+      echo "AUTHOR_EXTERNAL:${pr}:cfg-agent:external:push_absent"
+      exit 3
+    fi
+    echo "AUTHOR_TRUSTED:${pr}:cfg-agent"
+    exit 0
+    ;;
+  create-clone-pr)
+    # Accept optional --dest-prefix flag
+    dest_prefix="pr-fix-"
+    while [[ $# -gt 0 && "$1" == --* ]]; do
+      case "$1" in
+        --dest-prefix) dest_prefix="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    pr="${1:-0}"
+    echo "CLONE_OK:${dest_prefix}${pr}:feature/story-${pr}-agent"
+    exit 0
+    ;;
+  launch-generic)
+    # Args: <container_name> <clone_dir> [entrypoint_args...]
+    container="${1:-}"; shift || true
+    clone_dir="${1:-}"; shift || true
+    echo "LAUNCHED:${container}:mock-container-id"
+    exit 0
+    ;;
+  *)
+    # Any unexpected call fails loudly so tests catch "should not be called" paths.
+    echo "MOCK_UNEXPECTED_CALL:${cmd}" >&2
+    exit 1
+    ;;
+esac
+MOCK_EOF
+
+# ---------------------------------------------------------------------------
+# AC1 / AC6b — author gate: refuse external PR before any clone
+# ---------------------------------------------------------------------------
+echo ""
+echo "resolve_conflict.test.sh — AC1 / AC6b: author gate"
+echo "---------------------------------------------------"
+
+out=$(MOCK_AUTHOR_GATE=external \
+      CFGMS_TEST_WORKTREE_BASE="$TMPWT" \
+      CFGMS_TEST_DISPATCH="$MOCK_DISPATCH" \
+      bash "$PO_ACT" resolve-conflict 9999 2>&1) || rc=$?
+
+check_contains "AC1: output contains RESOLVE_CONFLICT_REFUSED" "$out" "RESOLVE_CONFLICT_REFUSED:9999"
+
+# clone / launch must NOT be called when the author gate fires
+check_not_contains "AC1: CLONE_OK not emitted before gate" "$out" "CLONE_OK"
+check_not_contains "AC1: LAUNCHED not emitted before gate" "$out" "LAUNCHED"
+check_not_contains "AC1: DISPATCHED_RESOLVE_CONFLICT not emitted" "$out" "DISPATCHED_RESOLVE_CONFLICT"
+
+rc=0
+MOCK_AUTHOR_GATE=external \
+  CFGMS_TEST_WORKTREE_BASE="$TMPWT" \
+  CFGMS_TEST_DISPATCH="$MOCK_DISPATCH" \
+  bash "$PO_ACT" resolve-conflict 9999 >/dev/null 2>&1 && rc=0 || rc=$?
+check "AC1: exits non-zero for external author" "$rc" "3"
+
+# ---------------------------------------------------------------------------
+# AC6a — trusted PR: exit-2 path dispatches resolve-conflict
+# (Simulates: rebase-pr.sh exits 2 → po-act.sh resolve-conflict called)
+# ---------------------------------------------------------------------------
+echo ""
+echo "resolve_conflict.test.sh — AC6a: trusted dispatch"
+echo "--------------------------------------------------"
+
+rc=0
+out=$(MOCK_AUTHOR_GATE=trusted \
+      CFGMS_TEST_WORKTREE_BASE="$TMPWT" \
+      CFGMS_TEST_DISPATCH="$MOCK_DISPATCH" \
+      bash "$PO_ACT" resolve-conflict 1234 2>&1) || rc=$?
+check "AC6a: exits 0 for trusted PR" "$rc" "0"
+
+check_contains "AC6a: CLONE_OK emitted"                     "$out" "CLONE_OK"
+check_contains "AC6a: LAUNCHED emitted"                     "$out" "LAUNCHED"
+check_contains "AC6a: DISPATCHED_RESOLVE_CONFLICT emitted"  "$out" "DISPATCHED_RESOLVE_CONFLICT:1234"
+
+# Verify the resolve-conflict namespace (not pr-fix)
+check_contains "AC6a: clone uses resolve-conflict- prefix"  "$out" "CLONE_OK:resolve-conflict-1234"
+check_contains "AC6a: container name is resolve-conflict"   "$out" "LAUNCHED:cfg-agent-resolve-conflict-1234"
+
+# ---------------------------------------------------------------------------
+# Error paths — launch failure and missing argument guard
+# ---------------------------------------------------------------------------
+echo ""
+echo "resolve_conflict.test.sh — error paths"
+echo "---------------------------------------"
+
+# Missing PR argument: ${1:?} guard exits 1 before any dispatch call
+rc=0
+bash "$PO_ACT" resolve-conflict 2>/dev/null || rc=$?
+check "error: missing PR arg exits non-zero" "$rc" "1"
+
+# launch-generic infra failure → DISPATCHED_RESOLVE_CONFLICT must NOT be emitted
+MOCK_DISPATCH_FAIL="${TMPWT}/mock_dispatch_fail.sh"
+cat > "$MOCK_DISPATCH_FAIL" <<'MOCK_FAIL_EOF'
+#!/usr/bin/env bash
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  check-pr-author)
+    echo "AUTHOR_TRUSTED:${1:-0}:cfg-agent"; exit 0 ;;
+  create-clone-pr)
+    dest_prefix="pr-fix-"
+    while [[ $# -gt 0 && "$1" == --* ]]; do
+      case "$1" in
+        --dest-prefix) dest_prefix="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    echo "CLONE_OK:${dest_prefix}${1:-0}:feature/story-test"; exit 0 ;;
+  launch-generic)
+    echo "LAUNCH_FAILED: simulated infra error" >&2; exit 1 ;;
+  *)
+    echo "MOCK_UNEXPECTED_CALL:${cmd}" >&2; exit 1 ;;
+esac
+MOCK_FAIL_EOF
+chmod +x "$MOCK_DISPATCH_FAIL"
+
+rc=0
+out=$(MOCK_AUTHOR_GATE=trusted \
+      CFGMS_TEST_WORKTREE_BASE="$TMPWT" \
+      CFGMS_TEST_DISPATCH="$MOCK_DISPATCH_FAIL" \
+      bash "$PO_ACT" resolve-conflict 5678 2>&1) || rc=$?
+check "error: launch failure exits non-zero" "$rc" "1"
+check_not_contains "error: DISPATCHED_RESOLVE_CONFLICT not emitted on launch failure" \
+  "$out" "DISPATCHED_RESOLVE_CONFLICT"
+
+# ---------------------------------------------------------------------------
+# AC4 (Python) — preflight routes prior-PASS PR with post-review commit to
+#                spawn_acceptance_reviewer instead of enqueue_merge.
+#
+# This exercises the exact path described in AC4: "prior-PASS" case.
+# ---------------------------------------------------------------------------
+echo ""
+echo "resolve_conflict.test.sh — AC4: preflight re-review routing"
+echo "------------------------------------------------------------"
+
+PREFLIGHT_PATH="$PREFLIGHT" python3 - <<'PY'
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("preflight", os.environ["PREFLIGHT_PATH"])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+ran = 0
+fail = 0
+
+def check(desc, got, want):
+    global ran, fail
+    ran += 1
+    if got == want:
+        print(f"  ok    {desc}")
+    else:
+        fail += 1
+        print(f"  FAIL  {desc}\n         expected: {want!r}\n         actual:   {got!r}")
+
+def mk_pr(pr_num, overall, merge_state, has_review, verdict, commit_date, review_date,
+          auto_merge=False, mergeable="MERGEABLE", in_queue=False, comments=None):
+    """Build a minimal pr_summary dict for compute_review_recommendations."""
+    story_num = 1000 + pr_num
+    c = []
+    if has_review and verdict:
+        c.append({
+            "body": f"<!-- cfgms-acceptance-review -->\n## Acceptance Review — {verdict.upper()}\nDetails.",
+            "createdAt": review_date,
+        })
+    if comments:
+        c.extend(comments)
+    return {
+        "pr": pr_num,
+        "story_number": story_num,
+        "ci_summary": {
+            "overall": overall,
+            "pending_checks": [],
+            "failing_checks": [],
+        },
+        "merge_state_status": merge_state,
+        "has_acceptance_review_comment": has_review,
+        "latest_review_verdict": verdict,
+        "latest_review_comment_date": review_date,
+        "latest_commit_date": commit_date,
+        "auto_merge_enabled": auto_merge,
+        "mergeable": mergeable,
+        "is_draft": False,
+        "wip_session_failed": False,
+        "is_external": False,
+        "is_released": True,
+        "comments": c,
+    }
+
+# ── AC4 case 1: prior-PASS PR, new commit after review (force-pushed by resolve-conflict)
+# Expected: spawn_acceptance_reviewer (not enqueue_merge)
+pr = mk_pr(
+    pr_num=1961,
+    overall="green",
+    merge_state="CLEAN",
+    has_review=True,
+    verdict="pass",
+    commit_date="2026-06-10T12:00:00Z",   # commit AFTER review (force-push)
+    review_date="2026-06-09T15:00:00Z",   # old passing review
+    auto_merge=False,
+    mergeable="MERGEABLE",
+)
+recs = m.compute_review_recommendations([pr], queued_pr_numbers=set())
+actions = [r["action"] for r in recs]
+check(
+    "AC4 prior-PASS + post-review commit → spawn_acceptance_reviewer",
+    actions,
+    ["spawn_acceptance_reviewer"],
+)
+
+# ── AC4 case 2: prior-PASS PR, NO new commit after review (commit predates review)
+# Expected: enqueue_merge (normal happy path — commit is older than the review)
+pr2 = mk_pr(
+    pr_num=1962,
+    overall="green",
+    merge_state="CLEAN",
+    has_review=True,
+    verdict="pass",
+    commit_date="2026-06-09T10:00:00Z",   # commit BEFORE review
+    review_date="2026-06-09T15:00:00Z",   # review after commit
+    auto_merge=False,
+    mergeable="MERGEABLE",
+)
+recs2 = m.compute_review_recommendations([pr2], queued_pr_numbers=set())
+actions2 = [r["action"] for r in recs2]
+check(
+    "AC4 prior-PASS + no post-review commit → enqueue_merge (normal path)",
+    actions2,
+    ["enqueue_merge"],
+)
+
+# ── AC4 case 3: never-reviewed PR, CI green → spawn_acceptance_reviewer (existing behavior)
+pr3 = mk_pr(
+    pr_num=1963,
+    overall="green",
+    merge_state="CLEAN",
+    has_review=False,
+    verdict=None,
+    commit_date="2026-06-10T12:00:00Z",
+    review_date=None,
+    auto_merge=False,
+    mergeable="MERGEABLE",
+)
+recs3 = m.compute_review_recommendations([pr3], queued_pr_numbers=set())
+actions3 = [r["action"] for r in recs3]
+check(
+    "AC4 never-reviewed + CI green → spawn_acceptance_reviewer (baseline unchanged)",
+    actions3,
+    ["spawn_acceptance_reviewer"],
+)
+
+# ── AC4 case 4: prior-PASS PR + post-review commit but CI pending
+# Expected: defer (not spawn yet — wait for CI)
+pr4 = mk_pr(
+    pr_num=1964,
+    overall="pending",
+    merge_state="CLEAN",
+    has_review=True,
+    verdict="pass",
+    commit_date="2026-06-10T12:00:00Z",
+    review_date="2026-06-09T15:00:00Z",
+    auto_merge=False,
+    mergeable="MERGEABLE",
+)
+pr4["ci_summary"]["pending_checks"] = ["unit-tests"]
+recs4 = m.compute_review_recommendations([pr4], queued_pr_numbers=set())
+actions4 = [r["action"] for r in recs4]
+check(
+    "AC4 prior-PASS + post-review commit + CI pending → defer",
+    actions4,
+    ["defer"],
+)
+
+# ── AC4 case 5: prior-PASS PR + post-review commit but CI red
+# Expected: skip (not spawn — wait for fix cycle)
+pr5 = mk_pr(
+    pr_num=1965,
+    overall="red",
+    merge_state="CLEAN",
+    has_review=True,
+    verdict="pass",
+    commit_date="2026-06-10T12:00:00Z",
+    review_date="2026-06-09T15:00:00Z",
+    auto_merge=False,
+    mergeable="MERGEABLE",
+)
+recs5 = m.compute_review_recommendations([pr5], queued_pr_numbers=set())
+actions5 = [r["action"] for r in recs5]
+check(
+    "AC4 prior-PASS + post-review commit + CI red → skip",
+    actions5,
+    ["skip"],
+)
+
+# ── AC4 case 6: prior-PASS PR + post-review commit, PR in merge queue
+# Force-push dequeues in practice; if in_queue somehow remains True, re-review still fires
+# because the AC4 block runs before any in_queue guard on the enqueue_merge path.
+pr6 = mk_pr(
+    pr_num=1966,
+    overall="green",
+    merge_state="CLEAN",
+    has_review=True,
+    verdict="pass",
+    commit_date="2026-06-10T12:00:00Z",
+    review_date="2026-06-09T15:00:00Z",
+    auto_merge=False,
+    mergeable="MERGEABLE",
+)
+recs6 = m.compute_review_recommendations([pr6], queued_pr_numbers={1966})
+actions6 = [r["action"] for r in recs6]
+check(
+    "AC4 prior-PASS + post-review commit + in_queue → spawn_acceptance_reviewer (re-review before merge)",
+    actions6,
+    ["spawn_acceptance_reviewer"],
+)
+
+# ── AC4 case 7: prior-PASS PR + post-review commit, auto_merge enabled
+# AC4 fires before the auto_merge skip path; unreviewed head requires re-review regardless.
+pr7 = mk_pr(
+    pr_num=1967,
+    overall="green",
+    merge_state="CLEAN",
+    has_review=True,
+    verdict="pass",
+    commit_date="2026-06-10T12:00:00Z",
+    review_date="2026-06-09T15:00:00Z",
+    auto_merge=True,
+    mergeable="MERGEABLE",
+)
+recs7 = m.compute_review_recommendations([pr7], queued_pr_numbers=set())
+actions7 = [r["action"] for r in recs7]
+check(
+    "AC4 prior-PASS + post-review commit + auto_merge → spawn_acceptance_reviewer (not skipped)",
+    actions7,
+    ["spawn_acceptance_reviewer"],
+)
+
+print(f"\nran={ran}  fail={fail}")
+sys.exit(1 if fail else 0)
+PY
+py_exit=$?
+ran=$((ran + 7))    # 7 Python assertions
+if [[ $py_exit -ne 0 ]]; then
+  fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "resolve_conflict.test.sh — ran=${ran}  fail=${fail}"
+[[ $fail -eq 0 ]] && exit 0 || exit 1

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Agent container entrypoint: restore creds, fetch issue, run Claude, update labels.
-# Supports three modes: issue (default), branch, and pr-fix.
+# Supports four modes: issue (default), branch, pr-fix, and resolve-conflict.
 set -euo pipefail
 
 # Helper library for prompt context assembly (fetch_* / render_* / no-op detection).
@@ -26,10 +26,11 @@ DRY_RUN=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --branch)  [[ $# -ge 2 ]] || { echo "ERROR: --branch requires a value"; exit 1; }; MODE="branch"; BRANCH="$2"; shift 2 ;;
-        --issue)   [[ $# -ge 2 ]] || { echo "ERROR: --issue requires a value"; exit 1; }; ISSUE_NUM="$2"; shift 2 ;;
-        --fix-pr)  [[ $# -ge 2 ]] || { echo "ERROR: --fix-pr requires a value"; exit 1; }; MODE="fix-pr"; PR_NUM="$2"; shift 2 ;;
-        --dry-run) DRY_RUN="true"; shift ;;
+        --branch)           [[ $# -ge 2 ]] || { echo "ERROR: --branch requires a value"; exit 1; }; MODE="branch"; BRANCH="$2"; shift 2 ;;
+        --issue)            [[ $# -ge 2 ]] || { echo "ERROR: --issue requires a value"; exit 1; }; ISSUE_NUM="$2"; shift 2 ;;
+        --fix-pr)           [[ $# -ge 2 ]] || { echo "ERROR: --fix-pr requires a value"; exit 1; }; MODE="fix-pr"; PR_NUM="$2"; shift 2 ;;
+        --resolve-conflict) [[ $# -ge 2 ]] || { echo "ERROR: --resolve-conflict requires a value"; exit 1; }; MODE="resolve-conflict"; PR_NUM="$2"; shift 2 ;;
+        --dry-run)          DRY_RUN="true"; shift ;;
         *)
             if [[ "$1" =~ ^[0-9]+$ ]]; then
                 ISSUE_NUM="$1"; shift
@@ -73,6 +74,13 @@ case "$MODE" in
             echo "ERROR: PR-fix mode requires --fix-pr <PR_NUM>"
             exit 1
         fi
+        ;;
+    resolve-conflict)
+        if [[ -z "$PR_NUM" ]]; then
+            echo "ERROR: Resolve-conflict mode requires --resolve-conflict <PR_NUM>"
+            exit 1
+        fi
+        [[ "$PR_NUM" =~ ^[0-9]+$ ]] || { echo "ERROR: PR number must be numeric, got: ${PR_NUM}"; exit 1; }
         ;;
 esac
 
@@ -589,18 +597,127 @@ PROMPT_EOF
     printf '%s\n' "$FOLLOW_UP_ISSUES_SECTION" >> "$PROMPT_FILE"
 }
 
+compose_resolve_conflict_prompt() {
+    echo "Fetching PR #${PR_NUM} metadata for conflict resolution..."
+    local pr_json
+    pr_json=$(gh_api_with_retry "fetch PR #${PR_NUM}" gh pr view "$PR_NUM" \
+        --repo cfg-is/cfgms \
+        --json number,title,headRefName,body,headRepositoryOwner 2>/dev/null) || {
+        echo "ERROR: Cannot fetch PR #${PR_NUM} for conflict resolution"
+        exit 1
+    }
+
+    local pr_title pr_branch
+    pr_title=$(echo "$pr_json" | jq -r '.title // ""')
+    pr_branch=$(echo "$pr_json" | jq -r '.headRefName // ""')
+
+    if [[ -z "$pr_branch" ]]; then
+        echo "ERROR: Could not determine PR branch from PR #${PR_NUM}"
+        exit 1
+    fi
+    BRANCH="$pr_branch"
+
+    PROMPT_FILE=$(mktemp)
+    printf 'You are resolving a rebase conflict on PR #%s: %s\n\n' "$PR_NUM" "$pr_title" > "$PROMPT_FILE"
+    cat >> "$PROMPT_FILE" <<PROMPT_EOF
+## PR Branch
+
+Branch: \`${pr_branch}\`
+
+## Context
+
+This PR's branch has merge conflicts with \`origin/develop\`. A plain
+\`rebase-pr.sh\` run returned \`REBASE_CONFLICT:${PR_NUM}\`. Your job is to
+resolve the conflict markers intelligently, validate the result, and push.
+
+## Instructions
+
+You are running inside an isolated container with --dangerously-skip-permissions.
+Branch \`${pr_branch}\` is already checked out. Follow CLAUDE.md conventions.
+CFGMS_AGENT_MODE=true is set.
+
+## Phase 1: Rebase and Resolve
+
+1. Run: \`git fetch origin develop\`
+2. Run: \`git rebase origin/develop\`
+3. For each conflict:
+   - Read BOTH sides carefully using \`git diff\` or the conflict markers
+   - Preserve ALL functionality from BOTH sides — do NOT silently drop any
+     test functions, validation checks, auth filters, or tenant guards
+   - Deduplicate helper functions that both sides added (keep one copy)
+   - Understand the intent of each side before merging
+4. After each file resolved: \`git add <resolved-file>\`
+5. Continue the rebase: \`git rebase --continue\`
+6. Repeat steps 3-5 until \`git rebase --continue\` completes without conflict
+
+## Phase 2: Validation (REQUIRED — do NOT skip)
+
+After rebase completes, run ALL of the following:
+
+\`\`\`bash
+go build ./...           # must exit 0
+go vet ./...             # must exit 0
+make test-commit         # runs tests + security + lint
+\`\`\`
+
+If ANY command fails:
+1. Abort the rebase: \`git rebase --abort\` (if still in progress)
+2. Post a comment on PR #${PR_NUM} with:
+   - The conflicting files
+   - The failure output (truncated to the first 50 lines)
+   - Why manual resolution is needed
+3. Exit WITHOUT pushing anything
+
+Example comment:
+\`\`\`bash
+gh pr comment ${PR_NUM} --repo cfg-is/cfgms --body "..."
+\`\`\`
+
+## Phase 3: Push (only after Phase 2 fully passes)
+
+\`\`\`bash
+git fetch origin ${pr_branch}   # refresh the lease reference
+git push --force-with-lease origin ${pr_branch}
+\`\`\`
+
+**Security constraints (enforced):**
+- ONLY push to \`${pr_branch}\` — never to \`develop\` or any other shared branch
+- Use \`--force-with-lease\`, never bare \`--force\`
+- \`git fetch origin ${pr_branch}\` immediately before the push (refreshes the lease)
+- One attempt only — do NOT loop on failure
+
+## Phase 4: Report
+
+Post a comment on PR #${PR_NUM} summarizing:
+- Which files had conflicts and how they were resolved
+- What validation was run and that it passed
+- That the branch has been force-pushed and is ready for re-review
+
+## Failure Handling
+
+If rebase fails (e.g., the conflict is too complex to resolve safely):
+- Abort: \`git rebase --abort\`
+- Post the failure summary on PR #${PR_NUM} explaining what failed
+- Exit non-zero (the PO cycle will surface this for human triage)
+- Do NOT push partial or unvalidated changes
+
+PROMPT_EOF
+    printf '%s\n\n' "$SCOPE_CONSTRAINTS_SECTION" >> "$PROMPT_FILE"
+}
+
 # Hard refusal: issue and branch modes must source content from Projects V2.
-# fix-pr reads PR review comments gated by repo write access — a separate surface.
-if [[ "$MODE" != "fix-pr" ]] && [[ -z "${CFGMS_PROJECT_ITEM_ID:-}" ]]; then
+# fix-pr and resolve-conflict read PR content gated by repo write access — separate surfaces.
+if [[ "$MODE" != "fix-pr" ]] && [[ "$MODE" != "resolve-conflict" ]] && [[ -z "${CFGMS_PROJECT_ITEM_ID:-}" ]]; then
     echo "ERROR: CFGMS_PROJECT_ITEM_ID must be set — no fallback to gh issue view" >&2
     exit 1
 fi
 
 # Compose prompt based on mode
 case "$MODE" in
-    issue)    compose_issue_prompt ;;
-    branch)   compose_branch_prompt ;;
-    fix-pr)   compose_pr_fix_prompt ;;
+    issue)             compose_issue_prompt ;;
+    branch)            compose_branch_prompt ;;
+    fix-pr)            compose_pr_fix_prompt ;;
+    resolve-conflict)  compose_resolve_conflict_prompt ;;
 esac
 
 if [ "$DRY_RUN" = "true" ]; then
@@ -658,8 +775,8 @@ fi
 # In fix-pr mode, a run that exits 0 but never advanced HEAD is a silent no-op.
 # The make test-agent-complete fallback would pass trivially on unchanged code,
 # masking the failure. Detect the no-op first and skip the fallback entirely.
-if [[ "$MODE" == "fix-pr" ]] && [ "$EXIT_CODE" -eq 0 ] && [ "$HEAD_ADVANCED" != "true" ]; then
-    echo "ERROR: fix-pr agent ran but made no commits (HEAD unchanged at ${PRE_FIX_HEAD})"
+if [[ "$MODE" == "fix-pr" || "$MODE" == "resolve-conflict" ]] && [ "$EXIT_CODE" -eq 0 ] && [ "$HEAD_ADVANCED" != "true" ]; then
+    echo "ERROR: ${MODE} agent ran but made no commits (HEAD unchanged at ${PRE_FIX_HEAD})"
     echo "Skipping make test-agent-complete fallback (would pass trivially on unchanged code)."
     EXIT_CODE=1
     # Best-effort idempotent breadcrumb on the PR.
@@ -751,7 +868,7 @@ if [ "$EXIT_CODE" -eq 0 ]; then
 else
     echo "Agent failed with exit code ${EXIT_CODE}"
 
-    if [[ "$MODE" != "fix-pr" ]] && [ -z "$PR_URL" ]; then
+    if [[ "$MODE" != "fix-pr" ]] && [[ "$MODE" != "resolve-conflict" ]] && [ -z "$PR_URL" ]; then
         if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
             # Agent produced work but failed — capture it as a draft PR so the
             # cron's resume_failed_session path can pick it up.

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -2978,8 +2978,10 @@ else:
     print(f"FAIL_B2: review FAIL + no fix got action={action!r}, expected skip")
     sys.exit(1)
 
-# Part C: review PASS + CI green + mergeable -> enqueue_merge (unchanged)
-pr_pass_green = dict(pr_fail_green, pr=2002, latest_review_verdict="pass")
+# Part C: review PASS + CI green + mergeable + no new commit -> enqueue_merge (unchanged)
+# latest_commit_date must predate REVIEW_TS so AC4 (Issue #1977) does not fire.
+pr_pass_green = dict(pr_fail_green, pr=2002, latest_review_verdict="pass",
+                     latest_commit_date="2026-05-21T11:00:00Z")
 recs = mod.compute_review_recommendations([pr_pass_green], set(), set())
 action = recs[0].get("action") if recs else None
 if action == "enqueue_merge":


### PR DESCRIPTION
## Summary

- **`po-act.sh resolve-conflict <PR>`** — new subcommand (mirrors `dispatch-fix` shape) with author gate as the first action before any clone/fetch/checkout/launch
- **`agent-dispatch.sh`** — `--dest-prefix` flag for `create-clone-pr` (distinct worktree namespace `resolve-conflict-<PR>`); `--resolve-conflict` launch mode; `cleanup-container` extended for new pattern
- **`po-cycle-preflight.py`** — DIRTY reason string updated; `active_fix_pr_nums` extended to suppress `cfg-agent-resolve-conflict-*` containers; **AC4 re-review route**: when a commit lands after a PASS review (e.g. the rebase force-push), the prior verdict is invalidated and the PR routes to `spawn_acceptance_reviewer` before any enqueue
- **`entrypoint.sh`** — `--resolve-conflict` mode: Phase 1 rebase+resolve, Phase 2 validation (`go build/vet` + `make test-commit`, required), Phase 3 `git push --force-with-lease` to PR's own head branch only (fetch before push to refresh lease), Phase 4 comment report; abort + post comment on failure, never push invalid state
- **`po.md`** — Step 3 documents inline dispatch on `REBASE_CONFLICT` exit 2; Step 5 notes distinguish `dispatch-fix` vs `resolve-conflict` modes
- **`scripts/test-scripts.sh`** — pre-existing `pr_pass_green` fixture patched to set `latest_commit_date` before the review timestamp (AC4 would otherwise fire on the existing test)

## Security properties

| Property | Enforcement |
|---|---|
| Author gate first | `check-pr-author` before any clone/fetch/checkout/launch in po-act.sh; `agent-dispatch.sh` re-gates independently |
| Force-push safety | `git push --force-with-lease` only; `git fetch` to refresh lease immediately before; target is PR's own head branch, never `develop` |
| Validate before push | Phase 2 build+test required; abort without push on any failure |
| No loop | `active_fix_pr_nums` suppression + one-dispatch-per-cycle in Step 3 |

## Test plan

- [ ] `bash .claude/scripts/tests/resolve_conflict.test.sh` — 21 assertions (AC1, AC6a/b, error paths, AC4×7) all pass
- [ ] `make test-agent-complete` — 194 script tests pass, all Go packages pass, all 5 platforms compile
- [ ] Security scan: PASS (no critical/high; architecture check clean)

Fixes #1977

🤖 Generated with [Claude Code](https://claude.com/claude-code)