### PR TITLE
test: stabilize timing-flaky macOS reconnect-stats + monitor-close-race (Issue #2205)

### DIFF
--- a/features/steward/steward_test.go
+++ b/features/steward/steward_test.go
@@ -343,13 +343,27 @@ func TestMonitorCloseRace(t *testing.T) {
 	// platforms: on Linux/macOS it sits below internal/poll.runtime_pollWait; on
 	// Windows it sits below syscall.syscalln via Start.func2.
 	goleak.VerifyNone(t, existingGoroutines,
-		// os/exec pipe-reader goroutines spawned by DNA collection in sibling tests.
-		// goleak.HasFunction checks allFunctions which excludes the "created by"
-		// frame, so IgnoreAnyFunction("os/exec.(*Cmd).Start") is a no-op.
-		// writerDescriptor.func1 IS a regular call-stack frame on all platforms:
-		// on Linux/macOS it appears below internal/poll.runtime_pollWait; on Windows
-		// it appears below syscall.syscalln via Start.func2.
+		// os/exec goroutines spawned by DNA collection commands in sibling tests.
+		//
+		// goleak.IgnoreAnyFunction uses exact function-name matching against every
+		// non-"created-by" frame in the goroutine's stack (allFunctions map).
+		//
+		// writerDescriptor.func1 — the closure that copies a command's stdout/stderr
+		// pipe to an io.Writer. It IS a regular call-stack frame (not a creator),
+		// so IgnoreAnyFunction matches any goroutine whose stack passes through it,
+		// including the Start.func2 wrapper goroutine it runs inside.
 		goleak.IgnoreAnyFunction("os/exec.(*Cmd).writerDescriptor.func1"),
+		// watchCtx — the context-watching goroutine spawned by exec.CommandContext
+		// for every command that has a non-nil context. It blocks on a select between
+		// the process exiting and the context being cancelled. On slow macOS CI,
+		// background DNA goroutines start new exec commands AFTER IgnoreCurrent()
+		// snapshots (commands execute sequentially within collectSoftwareInfo /
+		// collectSecurityInfo). Each new command creates a new watchCtx goroutine
+		// that is NOT captured by IgnoreCurrent() and can still be blocking when
+		// VerifyNone() runs if the command takes > 0.5s (brew list, find, dscl,
+		// security, etc. all can). Without this ignore the leak check fails with
+		// "os/exec.(*Cmd).watchCtx" as the unexpected goroutine.
+		goleak.IgnoreAnyFunction("os/exec.(*Cmd).watchCtx"),
 		// DNA background collection goroutine tree from sibling tests. Each goroutine
 		// is ignored by its OWN function name (top-level closure) so it is caught
 		// regardless of which frame it is currently executing — in particular when the

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -329,7 +329,10 @@ func TestReconnectStatsTracking(t *testing.T) {
 	// Kill server to trigger reconnection attempts
 	server.ForceStop()
 
-	// Wait for at least one reconnect attempt
+	// Wait for all reconnect stats to be populated. Capture them in one atomic
+	// snapshot inside the closure to eliminate the TOCTOU window that existed
+	// when a separate GetStats call followed the Eventually condition check.
+	var capturedStats *types.ControlPlaneStats
 	require.Eventually(t, func() bool {
 		stats, err := client.GetStats(context.Background())
 		if err != nil {
@@ -340,16 +343,27 @@ func TestReconnectStatsTracking(t *testing.T) {
 			return false
 		}
 		attempts, ok := v.(int64)
-		return ok && attempts >= 1
-	}, 10*time.Second, 50*time.Millisecond)
+		if !ok || attempts < 1 {
+			return false
+		}
+		if stats.ProviderMetrics["last_connected_at"] == nil {
+			return false
+		}
+		if stats.ProviderMetrics["last_disconnected_at"] == nil {
+			return false
+		}
+		if stats.ProviderMetrics["connection_state"] == "connected" {
+			return false
+		}
+		capturedStats = stats
+		return true
+	}, 10*time.Second, 50*time.Millisecond,
+		"reconnect stats must be fully populated after server kill")
 
-	// Verify stats include reconnect info
-	stats, err := client.GetStats(context.Background())
-	require.NoError(t, err)
-	assert.Greater(t, stats.ProviderMetrics["reconnect_attempts"].(int64), int64(0))
-	assert.NotNil(t, stats.ProviderMetrics["last_connected_at"])
-	assert.NotNil(t, stats.ProviderMetrics["last_disconnected_at"])
-	assert.NotEqual(t, "connected", stats.ProviderMetrics["connection_state"])
+	assert.Greater(t, capturedStats.ProviderMetrics["reconnect_attempts"].(int64), int64(0))
+	assert.NotNil(t, capturedStats.ProviderMetrics["last_connected_at"])
+	assert.NotNil(t, capturedStats.ProviderMetrics["last_disconnected_at"])
+	assert.NotEqual(t, "connected", capturedStats.ProviderMetrics["connection_state"])
 
 	// Restart server so cleanup reconnection stops
 	_ = restartServerAndRepoint(t, client, tc, reg)


### PR DESCRIPTION
## Summary

- **`TestReconnectStatsTracking`**: Replaced the two-step check (separate `require.Eventually` + second `GetStats()` call) with a single atomic closure. The prior pattern had a TOCTOU window: after `Eventually` confirmed `reconnect_attempts >= 1`, a separate `GetStats` call could observe transitional state, producing spurious assertion failures on slow macOS runners.

- **`TestMonitorCloseRace`**: Added `goleak.IgnoreAnyFunction("os/exec.(*Cmd).watchCtx")` to the leak-check ignore list. Background DNA goroutines from sibling tests (captured by `IgnoreCurrent`) continue running after the snapshot and start new exec commands — each spawning a `watchCtx` goroutine (Go 1.20+ context watcher) **after** the snapshot. On macOS CI, `brew list` / `find` / `dscl` / `security` can take 10–60s; `watchCtx` stays alive for the full command duration and trips `VerifyNone`. The exact function name was confirmed via `runtime.Stack` on Go 1.26.

No production code changes. Both tests are deterministic under `go test -race`.

## Test plan

- [x] `go test -race -run TestReconnectStatsTracking ./pkg/controlplane/providers/grpc/` — PASS
- [x] `go test -race -run TestMonitorCloseRace ./features/steward/` — PASS
- [x] `go test -race ./pkg/controlplane/providers/grpc/` — PASS (full suite)
- [x] `go test -race ./features/steward` — PASS (full suite)
- [x] `make test-agent-complete` — PASS (all gates including cross-platform compilation)
- [x] QA code reviewer — PASS
- [x] Security engineer — PASS

Fixes #2205

🤖 Generated with [Claude Code](https://claude.com/claude-code)