### PR TITLE
pipeline: stateless multi-host /po cron via atomic git-ref leases

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -92,7 +92,8 @@ gh api graphql -f query='
 Also read:
 - `docs/product/roadmap.md` — find the first uncompleted milestone (section without "COMPLETED"). Count `- [x]` vs `- [ ]` items.
 - `./.claude/scripts/agent-dispatch.sh list-running` — running container count and names
-- Cron PO status via `RemoteTrigger` tool with `action: "list"` — check for a trigger named "po-cron". Report: enabled/disabled, last run time, next scheduled run. If no trigger exists, report "not configured".
+- `./scripts/pipeline-helper.sh lease-list` — active distributed leases (multi-host; §4.-1). Each row is `<key>  <holder>  <exp>  <expired>`. Shows what other hosts are currently working.
+- Cron PO status via `RemoteTrigger` tool with `action: "list"` — check for **this host's** trigger, named `po-cron-<CFGMS_HOST_ID>` (multiple hosts each run their own; a bare legacy `po-cron` counts as this host's if `CFGMS_HOST_ID` is unset). Report: enabled/disabled, last run time, next scheduled run. If no trigger exists, report "not configured".
 
 ### 1.2 Dashboard Output
 
@@ -117,7 +118,11 @@ host via Self-Dispatch Mode (§7). Omit if empty.
 
 **Section 5: PIPELINE DEPTH** — counts by stage (epics, drafts, ready, fix, review).
 
-**Section 6: CRON PO** — scheduled agent status: enabled/disabled/not configured, last run, next run. If not configured, suggest setting it up. If disabled (idle), explain why.
+**Section 6: CRON PO** — scheduled agent status for this host's trigger
+(`po-cron-<CFGMS_HOST_ID>`): enabled/disabled/not configured, last run, next run.
+If not configured, suggest setting it up. If disabled (idle), explain why. If
+`lease-list` shows leases held by *other* holders, note that other hosts are
+active — that is expected and healthy under multi-host cron (§4.-1).
 
 **Section 7: FORWARD EDGE** — next milestone definition quality. Prompt founder if thin.
 
@@ -192,15 +197,16 @@ Confirm with issue link: "Epic #NNN created. It will appear in the BA queue for 
 
 ### 2.5 Cron Re-Enable
 
-After creating an epic, check if the cron PO trigger is disabled:
+After creating an epic, check if **this host's** cron PO trigger is disabled:
 ```
 RemoteTrigger tool: action: "list"
 ```
-If a trigger named "po-cron" exists and `enabled: false`, re-enable it:
+If a trigger named `po-cron-<CFGMS_HOST_ID>` (or a bare legacy `po-cron` when
+`CFGMS_HOST_ID` is unset) exists and `enabled: false`, re-enable it:
 ```
 RemoteTrigger tool: action: "update", trigger_id: "<id>", body: {"enabled": true}
 ```
-Inform the founder: "Cron PO was paused (idle). Re-enabled — next cycle at <next_run_at>."
+Inform the founder: "Cron PO was paused (idle). Re-enabled — next cycle at <next_run_at>." Only ever enable/disable/cancel **this host's own** trigger — never another host's `po-cron-*`.
 
 -----
 
@@ -225,6 +231,50 @@ Run the full autonomous pipeline cycle once. Use when the founder says "cron", "
 
 This runs **locally** with full Docker access for dispatch and fix cycles. The remote `po-cron` trigger runs the same logic but sets project status `Blocked` for Docker-dependent steps (3 and 4) since it has no Docker access.
 
+### 4.-1 Multi-host coordination (stateless cron — run on many hosts at once)
+
+`/po cron` is safe to run **concurrently on multiple hosts**, including homogeneous
+(e.g. several Linux) hosts. There is **no shared local state** between cycles — the
+preflight cache, worktree clones, and docker containers are per-host scratch,
+re-derived every cycle from GitHub (the single source of truth). Cross-host mutual
+exclusion is provided by a **distributed lease**: an atomic git ref under
+`refs/cfgms-lease/<key>` (`pipeline-helper.sh lease-acquire/release/...`). Creating
+a ref is the one server-atomic operation GitHub exposes, so exactly one racing host
+wins a given key regardless of how many attempt it.
+
+**The lease is the hard interlock; project status is the dashboard signal.** Every
+collision-prone action acquires a lease on its work unit BEFORE acting:
+
+| Lease key | Held by | Released by |
+|---|---|---|
+| `story-<item>` | dev dispatch (or §7 self-dispatch claim) | the dev container's entrypoint on exit (`release-story` for §7); TTL reclaim on crash |
+| `pr-<N>` | review / fix / resolve (mutually exclusive on one PR) + inline rebase | the review/fix container's entrypoint on exit; inline rebase releases it itself; TTL on crash |
+| `epic-decompose-<N>` | Step 7 planning team | the host, in-session, after posting the decomposition summary |
+| `pin-refresh-<week>` | Step 1.6 refresh-pins | the host, after posting the `po-pin-refresh` marker |
+| `sweep` | Step 7.5 pipeline-sweep | the host, after the sweep returns |
+
+The container-op leases (`story-*`, `pr-*`) are acquired by the script helpers
+automatically (`po-act.sh dispatch` / `dispatch-fix` / `resolve-conflict`,
+`agent-dispatch.sh review-pr`) and released by the container — **you do not manage
+them by hand.** This is the "dispatch locks it, the returning agent unlocks it"
+lifecycle: when a dev agent submits its PR and its container exits, the `story-*`
+lease frees, and whichever cron host's next cycle comes first acquires `pr-<N>` to
+review it. The **inline-op leases** (`epic-decompose-*`, `pin-refresh-*`, `sweep`)
+ARE yours to manage in the steps below — acquire, run, release.
+
+**Host identity.** Export `CFGMS_HOST_ID` (default `hostname`) once per shell on
+each host; it tags lease holders for debugging and names this host's cron trigger
+(§6). Set `CFGMS_LEASE_TTL_STORY` / `CFGMS_LEASE_TTL_PR` only to override the
+defaults (7200s / 3600s).
+
+**Per-host container cap.** The 7-container cap (`feedback_max_running_agents`) is
+counted **per host** (`agent-dispatch.sh list-running` sees only local containers).
+N hosts therefore run up to 7N containers total. That is intentional — each host
+honors its own cap; there is no global container budget.
+
+**Expired-lease GC** runs inside `agent-dispatch.sh cleanup-stale` (Step 1.5) — no
+separate call needed.
+
 ### Helper scripts (prefer these — one approval per action, no `/tmp` writes)
 
 - `./.claude/scripts/po-act.sh <subcommand>` — every common action is a one-liner:
@@ -239,6 +289,8 @@ This runs **locally** with full Docker access for dispatch and fix cycles. The r
   - `log <ISSUE> <text>` — post timestamped session log (stdin if text is `-`)
   - `merge-queue` — queue state as JSON
   - `block <ISSUE> <reason>` — set project status Blocked, post escalation comment
+  - `release-story <ITEM_ID>` — release a §7 self-dispatch story lease after the PR is up
+- `./scripts/pipeline-helper.sh lease-{acquire,release,status,list,gc}` — distributed-lease primitive (multi-host coordination, §4.-1). `lease-acquire <key> [ttl]` prints `ACQUIRED`/`RECLAIMED` (rc0), `HELD` (rc1), or `ACQUIRE_ERROR` (rc2). Used directly only for the inline-op leases below; container-op leases are managed by the dispatch helpers.
 - `./.claude/scripts/po-cycle-preflight.py` — the underlying preflight (called by `po-act.sh preflight`). Accepts `--stdout` for raw JSON or `--path` for the cache path.
 - `./.claude/scripts/agent-dispatch.sh` — lower-level primitives (called by `po-act.sh`)
 
@@ -341,7 +393,15 @@ Runs in both `cron` and `cycle` modes. It is **orchestrator-only** — the no-do
    ```
    Run the skill only if `latest_check` is non-empty AND (`last_processed` is empty OR `latest_check > last_processed`) — ISO-8601 UTC strings compare lexicographically. Otherwise report "pins current (last processed <last_processed>)" and skip.
 
-3. Run the skill (empty args = sweep every pin; it is itself idempotent and will comment on, not duplicate, any bump story that already exists):
+3. **Acquire the inline lease** so a second host doesn't sweep the same weekly
+   check concurrently. Key on the check timestamp (sanitized):
+   ```bash
+   ./scripts/pipeline-helper.sh lease-acquire "pin-refresh-<latest_check>" 1200
+   ```
+   On `HELD:*` another host owns this sweep — report "pin refresh in flight on
+   another host" and skip the step. On `ACQUIRED`/`RECLAIMED`, run the skill
+   (empty args = sweep every pin; it is itself idempotent and will comment on, not
+   duplicate, any bump story that already exists):
    ```
    Skill: refresh-pins
    ```
@@ -353,6 +413,7 @@ Runs in both `cron` and `cycle` modes. It is **orchestrator-only** — the no-do
    Processed weekly pin check via refresh-pins. Bump stories created/updated: <#NNNN, #NNNN or "none — all pins within cooldown/up to date">. Drafts enter the Tech Lead queue (Step 2).
    EOF
    ```
+   Then **release the lease**: `./scripts/pipeline-helper.sh lease-release "pin-refresh-<latest_check>"`.
    If the marker post fails (network, etc.), the next cycle re-sweeps the same
    check — harmless, because `refresh-pins` is idempotent (it comments on, never
    duplicates, an existing bump story); the only cost is one redundant network
@@ -410,7 +471,20 @@ The preflight surfaces three actions in `review_recommendations`:
 | `rebase_then_investigate` | CI red (any required check failed) | Run `rebase-pr.sh`. If `REBASE_OK`, wait one cycle for CI to re-run. If `REBASE_NOOP`, the branch was already current → the failure is real → diagnose + dispatch-fix. |
 | `investigate` (legacy) | rare; falls through if neither rebase nor red applies | Same handling as rebase_then_investigate's NOOP branch. |
 
-For each `rebase` or `rebase_then_investigate` recommendation:
+For each `rebase` or `rebase_then_investigate` recommendation, first acquire the
+`pr-<N>` lease (§4.-1) so a concurrent host's review/fix/rebase on the same PR
+can't race the force-push:
+
+```bash
+./scripts/pipeline-helper.sh lease-acquire "pr-<PR_NUM>" 600
+```
+
+On `HELD:*`, another host controls this PR right now — skip it this cycle. On
+`ACQUIRED`/`RECLAIMED`, run the rebase, then **release `pr-<PR_NUM>` immediately
+after `rebase-pr.sh` returns** (`./scripts/pipeline-helper.sh lease-release
+"pr-<PR_NUM>"`) — before acting on the outcome. Releasing first is required so the
+`REBASE_CONFLICT` path's `resolve-conflict` dispatch (which re-acquires `pr-<N>`)
+doesn't self-block:
 
 ```bash
 ./.claude/scripts/rebase-pr.sh <PR_NUM>
@@ -576,13 +650,17 @@ required execution environment isn't in this host's caps gets `action: "hold"`
 with a `route` hint (e.g. `route: "windows"`) — it is **not** container-dispatched
 here. On the Linux orchestrator, windows-tagged stories therefore stay held and
 appear in the dashboard's Windows queue (§1.2); the Windows host picks them up via
-Self-Dispatch Mode (§7). Because each host works a **disjoint slice by
-environment**, two cron loops on different hosts can run out of phase without ever
-claiming the same story — no distributed lock is required. The per-story claim
-(`po-act.sh dispatch` flips `Ready → In Progress` *before* clone/launch) is the
-backstop that also protects against overlapping cycles on a single host. A story's
-required env comes from a `## Environment` body section and/or a `needs-<env>`
-label (see Reference: Story Body Conventions).
+Self-Dispatch Mode (§7). A story's required env comes from a `## Environment` body
+section and/or a `needs-<env>` label (see Reference: Story Body Conventions).
+
+**Cross-host safety (any number of homogeneous hosts).** Environment routing makes
+hosts work *different* stories when their caps differ, but it is **not** the safety
+mechanism — two identical-caps hosts (or two Linux orchestrators) are fully
+supported. `po-act.sh dispatch` acquires the `story-<item>` lease (§4.-1) BEFORE it
+materializes, claims, clones, or launches, so exactly one host proceeds; a loser
+prints `DISPATCH_SKIPPED:<id>:lease_held` and exits clean. The lease — not the
+`Ready → In Progress` status flip (Projects V2 has no CAS) — is the interlock. You
+do not manage `story-*` leases by hand; just trust the `DISPATCH_SKIPPED` output.
 
 For each story the preflight recommends dispatching:
 ```bash
@@ -602,7 +680,17 @@ gh issue view <NUM> --repo cfg-is/cfgms --json number,title,body,labels
 ```
 Extract the epic's Goal, Success Criteria, Non-Goals, Constraints, and PM Notes. Also read `CLAUDE.md` architecture rules and `docs/product/roadmap.md` for milestone context.
 
-**7b. Create the planning team:**
+**7b. Acquire the decompose lease, then create the planning team:**
+
+Decomposition is a multi-minute operation with no mid-flight idempotency marker
+(the decomposed-marker is posted only at the end), so two hosts would otherwise
+both run a full planning team and double-create the story set. Guard it:
+```bash
+./scripts/pipeline-helper.sh lease-acquire "epic-decompose-<NUM>" 2400
+```
+On `HELD:*`, another host is decomposing this epic — skip it. On
+`ACQUIRED`/`RECLAIMED`, proceed. **Release `epic-decompose-<NUM>` after 7g (summary
+posted) or on any early exit** — including the 7i convergence-failure path.
 ```
 TeamCreate(team_name: "planning-epic-<NUM>")
 ```
@@ -679,10 +767,14 @@ SUMMARY_EOF
 rm /tmp/planning-summary.md
 ```
 
-**7h. Shutdown the planning team:**
+**7h. Shutdown the planning team and release the lease:**
 Send shutdown to both teammates: `SendMessage(to: "*", message: {type: "shutdown_request"})`. Then clean up:
 ```
 TeamDelete()
+```
+Release the decompose lease so it doesn't linger until TTL:
+```bash
+./scripts/pipeline-helper.sh lease-release "epic-decompose-<NUM>"
 ```
 
 **7i. Fallback — convergence failure:**
@@ -711,9 +803,18 @@ rm /tmp/convergence-failure-<EPIC_NUM>.md
 
 Run the `pipeline-sweep` skill. It closes every open epic whose sub-tasks are all done AND whose AC verification passes on `origin/develop`, drafts a remediation story under any epic whose sub-tasks are done but AC verification fails, and moves any CLOSED-on-GitHub project item whose status is stale (anything other than `Done`) to `Done`. Runs in both `cycle` and `cron` modes; cheap and idempotent.
 
+Guard with the `sweep` lease so two hosts don't both draft remediation stories
+(the sweep is only *mostly* idempotent — concurrent runs can double-draft, per
+`epic_review_dup_remediation`):
+```bash
+./scripts/pipeline-helper.sh lease-acquire "sweep" 900
+```
+On `HELD:*`, another host is sweeping — skip this step. On `ACQUIRED`/`RECLAIMED`,
+run the skill, then release `sweep`:
 ```
 Skill: pipeline-sweep
 ```
+After it returns: `./scripts/pipeline-helper.sh lease-release "sweep"`.
 
 Include the sweep's headline + verdict tables in the cycle summary you return to the founder. If the sweep surfaces a "Needs founder review" Blocked anomaly (project item Blocked but GH issue closed — e.g. a founder action was completed but the project status was not advanced), flag it in the §6 (Cron PO) section of the cycle report.
 
@@ -767,12 +868,15 @@ this mode lets the **local session** work that host's tagged stories natively �
 no docker container, because a Linux container can't provide a Windows execution
 environment. Stories are worked **one at a time, in-process**.
 
-**Why no distributed lock is needed.** The orchestrator (Linux, docker dispatch)
-and this host serve **disjoint execution-environment slices**, so the
-orchestrator's cron and this host's `/po work` drain never select the same story
-even when interleaved. The only required guard is claiming each story
-(`Ready → In Progress`) **before** working it — `po-act.sh claim` does this with
-the same status check the docker path uses.
+**Cross-host safety.** `po-act.sh claim` acquires the `story-<item>` lease (§4.-1)
+before flipping `Ready → In Progress`, so this in-session drain and every other
+host's cron compete for the same atomic lock — no two hosts work the same story,
+even with identical caps. Because this mode has **no container** to release the
+lease on exit, you MUST release it yourself once the PR is up (step 5 below).
+`CLAIM_LOST` on `claim` means another host won the lease (or the story left
+`Ready`) — skip it and move on. The execution-environment slicing still routes
+*which* stories this host sees, but the lease — not the slicing — is what prevents
+collisions.
 
 ### Drain loop (availability-gated — drain-then-stop, NOT a timer)
 
@@ -830,7 +934,14 @@ Each iteration:
    story start-to-finish; there are no timer ticks mid-story.** This runs natively
    on the host, so the environment's build/test paths are exercised for real.
 
-5. **Loop back to step 1** (fresh preflight). Keep draining until step 2 stops you.
+5. **Release the story lease** once the PR is up — there is no container to do it
+   for you, so the orchestrator can pick up review/fix:
+   ```bash
+   ./.claude/scripts/po-act.sh release-story <ITEM_ID>
+   ```
+   (If the session dies before this, TTL reclaim frees the lease eventually.)
+
+6. **Loop back to step 1** (fresh preflight). Keep draining until step 2 stops you.
 
 **Scope.** This host only **produces** PRs for its environment's stories. Review,
 fix-cycle, merge-queue, and decomposition stay with the Linux orchestrator

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -92,6 +92,7 @@ gh api graphql -f query='
 Also read:
 - `docs/product/roadmap.md` — find the first uncompleted milestone (section without "COMPLETED"). Count `- [x]` vs `- [ ]` items.
 - `./.claude/scripts/agent-dispatch.sh list-running` — running container count and names
+- `./.claude/scripts/agent-dispatch.sh capacity` — host resource headroom (§4.-1): `CAPACITY_OK:slots=<n>` or `CAPACITY_FULL:<binding>:slots=0`. The binding resource (disk/mem/cpu) tells you what's constraining dispatch on this host.
 - `./scripts/pipeline-helper.sh lease-list` — active distributed leases (multi-host; §4.-1). Each row is `<key>  <holder>  <exp>  <expired>`. Shows what other hosts are currently working.
 - Cron PO status via `RemoteTrigger` tool with `action: "list"` — check for **this host's** trigger, named `po-cron-<CFGMS_HOST_ID>` (multiple hosts each run their own; a bare legacy `po-cron` counts as this host's if `CFGMS_HOST_ID` is unset). Report: enabled/disabled, last run time, next scheduled run. If no trigger exists, report "not configured".
 
@@ -114,7 +115,7 @@ the preflight output; for the interactive dashboard (no preflight run) use
 held, not dispatched, on the Linux orchestrator; they are worked on the Windows
 host via Self-Dispatch Mode (§7). Omit if empty.
 
-**Section 4: AGENT TEAM** — running containers, fix cycle PRs, failed agents, queued stories.
+**Section 4: AGENT TEAM** — running containers, fix cycle PRs, failed agents, queued stories. Include host capacity from the preflight `capacity` field (free slots + binding resource); when `free_slots` is 0, note the binding resource (e.g. "disk full — dispatch paused").
 
 **Section 5: PIPELINE DEPTH** — counts by stage (epics, drafts, ready, fix, review).
 
@@ -267,10 +268,28 @@ each host; it tags lease holders for debugging and names this host's cron trigge
 (§6). Set `CFGMS_LEASE_TTL_STORY` / `CFGMS_LEASE_TTL_PR` only to override the
 defaults (7200s / 3600s).
 
-**Per-host container cap.** The 7-container cap (`feedback_max_running_agents`) is
-counted **per host** (`agent-dispatch.sh list-running` sees only local containers).
-N hosts therefore run up to 7N containers total. That is intentional — each host
-honors its own cap; there is no global container budget.
+**Per-host resource admission gate (replaces the old container-count cap).** A new
+agent container is admitted only while the host stays under its ceilings — RAM and
+disk below 90% utilization, committed CPU below 75% of cores, with a `2×ncpu`
+count as a runaway backstop. This is **per-host and self-tuning**: a big box runs
+more agents, a laptop fewer, and it adapts to whatever else is running. It is the
+correct shape for multi-host — resource exhaustion is inherently per-host, so each
+host limits itself to what it can actually hold (no global container budget, and
+no hand-tuned magic number).
+
+- **Enforcement is automatic.** Every launch path (`po-act dispatch` /
+  `dispatch-fix` / `resolve-conflict`, `agent-dispatch review-pr`) calls the gate
+  before leasing/cloning and defers when full — you'll see
+  `DISPATCH_DEFERRED:<id>:resources (…)` / `REVIEW_REFUSED:<pr>:resources`. Trust
+  it; deferred work is picked up a later cycle (or by a host with room).
+- **Planning hint.** The preflight surfaces `capacity` (`free_slots`, `binding`
+  resource); read it to decide how many reviews/dispatches to *attempt* this cycle.
+  Query directly with `./.claude/scripts/agent-dispatch.sh capacity` (→
+  `CAPACITY_OK:slots=<n>` / `CAPACITY_FULL:<binding>:slots=0`).
+- **Knobs** (env, all optional): per-agent `CFGMS_AGENT_MEM_MB` (4096),
+  `CFGMS_AGENT_CPUS` (4), `CFGMS_AGENT_DISK_GB` (8); ceilings `CFGMS_AGENT_MEM_CEIL`
+  (0.90), `CFGMS_AGENT_DISK_CEIL` (0.90), `CFGMS_AGENT_CPU_CEIL` (0.75); bypass
+  `CFGMS_AGENT_CAPACITY_GATE=off` (tests only).
 
 **Expired-lease GC** runs inside `agent-dispatch.sh cleanup-stale` (Step 1.5) — no
 separate call needed.
@@ -345,9 +364,9 @@ The preflight handles all label queries, PR CI summaries, merge queue state, cod
 
 Each step sets project status `Blocked` on unrecoverable failure and continues to the next.
 
-**Priority order (cap-constrained):** in-flight work is processed before new work. The 7-container cap is shared across all autonomous activity (dev agents, fix-pr, review containers), so when slots are scarce the cycle finishes existing PRs first — they unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them. The numbered steps below reflect this priority: Step 3 (rebase) → Step 4 (review) → Step 5 (fix-cycle) → Step 6 (dispatch new dev). If the cap is exhausted by Steps 3-5, defer Step 6 to the next cycle.
+**Priority order (capacity-constrained):** in-flight work is processed before new work. Host capacity (the resource admission gate, §4.-1) is shared across all autonomous activity (dev agents, fix-pr, review containers), so when free slots are scarce the cycle finishes existing PRs first — they unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them. The numbered steps below reflect this priority: Step 3 (rebase) → Step 4 (review) → Step 5 (fix-cycle) → Step 6 (dispatch new dev). If capacity is exhausted by Steps 3-5, the gate auto-defers Step 6 dispatches to the next cycle.
 
-Maintenance steps that create new work (Step 1.6 — pin refresh) or reconcile state run regardless of the container cap, since they do not consume container slots.
+Maintenance steps that create new work (Step 1.6 — pin refresh) or reconcile state run regardless of capacity, since they do not launch agent containers.
 
 **Step 0 — External PR triage (Issue #1786):**
 Read `external_prs` from the preflight output (`po-act.sh state '.external_prs'`). For each entry where `is_released == false`, log the quarantine and skip all pipeline actions for that PR. For entries where `is_released == true` (maintainer has applied `human-reviewed:ok` via a push+ actor), treat the PR as internal and allow it through normal review/merge flow. Do NOT call `review-pr`, `dispatch-fix`, or `enqueue` on any PR where `is_released == false`.
@@ -569,11 +588,11 @@ Cross-check the story's project status: skip any story with status `Fix`. Use `p
 
 **Dispatch reviews for ALL eligible PRs each cycle, in parallel.** Iterate the
 `spawn_acceptance_reviewer` PRs in FIFO order (oldest `createdAt` first) and
-dispatch a headless review container for each, up to the 7-container cap
-(`feedback_max_running_agents`). The cap is shared with dev and fix containers;
-reviews are in-flight work, so they claim their slots before Step 6 dispatches
-any new dev. If eligible reviews exceed the free slots, dispatch up to the cap
-and the rest are picked up next cycle.
+dispatch a headless review container for each, until the host runs out of
+capacity (the resource gate, §4.-1, auto-defers with `REVIEW_REFUSED:<pr>:resources`
+once full). Capacity is shared with dev and fix containers; reviews are in-flight
+work, so they claim their slots before Step 6 dispatches any new dev. Reviews the
+gate defers are picked up next cycle (or by a host with room).
 
 ```bash
 ./.claude/scripts/agent-dispatch.sh review-pr <PR_NUM>
@@ -669,7 +688,7 @@ For each story the preflight recommends dispatching:
 
 where `<ITEM_ID>` comes from `dispatch_recommendations[*].item_id` in the preflight output. Note: the `dispatch` subcommand handles both issue_nums (all-digits, legacy path) and item_ids (non-numeric) transparently — Story B wired this.
 
-**This step is intentionally last in priority order.** If the 7-container cap is exhausted by Steps 3-5 (rebase, review, fix-cycle), defer dispatch to the next cycle. Existing in-flight PRs unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them.
+**This step is intentionally last in priority order.** If host capacity is exhausted by Steps 3-5 (rebase, review, fix-cycle), the admission gate auto-defers these dispatches (`DISPATCH_DEFERRED:<id>:resources`) to the next cycle. Existing in-flight PRs unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them.
 
 **Step 7 — Planning Team (BA + Tech Lead collaboration):**
 Find `epic` issues with no sub-issues (`subIssuesSummary` total = 0). For each epic, orchestrate a collaborative planning session where BA and Tech Lead work together to produce stories that are ready on the first try.

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -34,7 +34,7 @@ If `$ARGUMENTS` starts with any of `cron`, `cycle`, `work`, `decompose`, or `pla
 **How:**
 1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the relevant section.
 2. Execute the section directly in the main session in priority order — preflight, unblock check, agent cleanup, pin refresh (§4.1 Step 1.6), Tech Lead pass, rebase (§4.1 Step 3), Acceptance Reviewer (§4.1 Step 4), fix cycle (§4.1 Step 5), dispatch (§4.1 Step 6), Planning Team (§4.1 Step 7 — see routing table above), forward edge, session log.
-3. Honor the 7-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) shared across all autonomous activity (dev, fix-pr, review). When slots are scarce, finish in-flight work first (Steps 3-5) and defer new dev dispatch (Step 6) to the next cycle.
+3. Host capacity is enforced automatically by the resource admission gate (`.claude/agents/po.md` §4.-1) — every launch path defers when the host is out of RAM/disk/CPU headroom. When capacity is scarce, finish in-flight work first (Steps 3-5); new dev dispatch (Step 6) auto-defers (`DISPATCH_DEFERRED:…:resources`) and is picked up a later cycle.
 4. Spawn nested subagents via the Agent tool with `mode: auto`. Spawn the Planning Team via `TeamCreate` + Agent calls with `team_name` (per `.claude/agents/po.md` §4.1 Step 7c).
 5. Report the summary back to the founder using the same format the PO subagent uses.
 

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -12,6 +12,114 @@ WORKTREE_BASE="${CFGMS_TEST_WORKTREE_BASE:-$(cd "$REPO_ROOT/.." && pwd)/worktree
 AGENT_CRED_BASE="${CFGMS_TEST_CRED_BASE:-/run/cfgms/agent-cred}"
 
 # ---------------------------------------------------------------------------
+# Resource-based admission gate (replaces the hand-tuned container count).
+# A new agent container is admitted only if launching one keeps the host within
+# its ceilings: RAM and disk under 90% utilization, committed CPU under 75% of
+# cores. Per-host and self-tuning — a big box runs more, a laptop fewer, and it
+# adapts to whatever else is already running. A coarse 2×ncpu count ceiling is a
+# runaway-loop backstop, not the primary limit.
+#
+# All thresholds are env-overridable; the per-agent figures default to the
+# docker run reservations (--memory=4g --cpus=4) plus a disk allowance covering
+# the clone + go build/mod cache growth.
+# ---------------------------------------------------------------------------
+_capacity_compute() {
+  # _capacity_compute <line|json>
+  # Prints CAPACITY_OK:slots=<n> / CAPACITY_FULL:<reason>:slots=0 (line mode) or a
+  # JSON object (json mode). Returns 0 when at least one slot is free, else 1.
+  local mode="${1:-line}" running docker_root
+  running=$(docker ps --filter "label=cfg-agent=true" -q 2>/dev/null | wc -l | tr -d ' ')
+  docker_root=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo /var/lib/docker)
+  CAP_MODE="$mode" CAP_RUNNING="${running:-0}" CAP_DOCKER_ROOT="$docker_root" \
+  CAP_WORKTREE="$WORKTREE_BASE" python3 - <<'PY'
+import os
+def f(k, d):
+    try: return float(os.environ[k])
+    except Exception: return d
+per_mem  = f("CFGMS_AGENT_MEM_MB", 4096) * 1024 * 1024
+per_cpu  = f("CFGMS_AGENT_CPUS", 4)
+per_disk = f("CFGMS_AGENT_DISK_GB", 8) * 1024**3
+mem_ceil  = f("CFGMS_AGENT_MEM_CEIL", 0.90)
+disk_ceil = f("CFGMS_AGENT_DISK_CEIL", 0.90)
+cpu_ceil  = f("CFGMS_AGENT_CPU_CEIL", 0.75)
+running = int(float(os.environ.get("CAP_RUNNING", "0") or 0))
+ncpu = os.cpu_count() or 1
+
+# Memory (skip the gate where /proc/meminfo is absent, e.g. a non-Linux host —
+# those don't launch containers anyway).
+mt = ma = 0
+try:
+    for ln in open("/proc/meminfo"):
+        if ln.startswith("MemTotal:"):     mt = int(ln.split()[1]) * 1024
+        elif ln.startswith("MemAvailable:"): ma = int(ln.split()[1]) * 1024
+except Exception:
+    pass
+
+def slots_for(budget, used, per):
+    # how many more `per`-sized units fit under `budget` given current `used`
+    if per <= 0: return 999
+    return int((budget - used) // per)
+
+slots = {}
+# RAM: bind on the worse of live utilisation and agent reservation (the latter
+# guards a from-idle thundering herd where current usage hasn't ballooned yet).
+if mt > 0:
+    used_mem = max(mt - ma, running * per_mem)
+    slots["mem"] = max(0, slots_for(mem_ceil * mt, used_mem, per_mem))
+# Disk: worst filesystem among the clone dir and the docker data root.
+disk_slot = 999
+for p in {os.environ.get("CAP_WORKTREE", ""), os.environ.get("CAP_DOCKER_ROOT", "")}:
+    if not p: continue
+    try:
+        s = os.statvfs(p)
+        tot = s.f_blocks * s.f_frsize
+        used = tot - s.f_bavail * s.f_frsize
+        disk_slot = min(disk_slot, max(0, slots_for(disk_ceil * tot, used, per_disk)))
+    except Exception:
+        pass
+slots["disk"] = disk_slot
+# CPU: committed cores (reservation-based; deterministic, prevents herd). Also
+# refuse outright if the 1-min load already exceeds the ceiling.
+slots["cpu"] = max(0, slots_for(cpu_ceil * ncpu, running * per_cpu, per_cpu))
+try:
+    if os.getloadavg()[0] > cpu_ceil * ncpu:
+        slots["cpu"] = 0
+except Exception:
+    pass
+# Runaway backstop: never more than 2×ncpu agents regardless of headroom.
+slots["count"] = max(0, int(2 * ncpu) - running)
+
+free = min(slots.values()) if slots else 0
+reason = min(slots, key=slots.get) if slots else "unknown"
+if os.environ.get("CAP_MODE") == "json":
+    import json
+    print(json.dumps({"can_launch": free >= 1, "free_slots": free,
+                      "binding": reason, "running": running, "per_slot": slots}))
+else:
+    if free >= 1:
+        print(f"CAPACITY_OK:slots={free}")
+    else:
+        print(f"CAPACITY_FULL:{reason}:slots=0")
+raise SystemExit(0 if free >= 1 else 1)
+PY
+}
+
+# _capacity_gate <skip_label> <emit_prefix>
+#   Admission gate for a launch path. On capacity, returns 0 silently. When full,
+#   prints "<emit_prefix>:<label>:resources (<reason>)" and returns 1 — the caller
+#   should exit cleanly (defer to a later cycle/host). Bypass with
+#   CFGMS_AGENT_CAPACITY_GATE=off (e.g. tests).
+_capacity_gate() {
+  local label="$1" prefix="$2" out
+  [[ "${CFGMS_AGENT_CAPACITY_GATE:-on}" == "off" ]] && return 0
+  out=$(_capacity_compute line 2>/dev/null) || {
+    echo "${prefix}:${label}:resources (${out:-capacity full})"
+    return 1
+  }
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Tier 1 credential lifecycle helpers (Issue #2124)
 # ---------------------------------------------------------------------------
 
@@ -471,6 +579,7 @@ Commands:
   cleanup-container <NAME>                  Remove container and associated clone by name
   cleanup-stale                             Remove containers/clones for closed, blocked, or failed stories
   list-running                              List running agent containers
+  capacity [--json]                         Resource admission gate: CAPACITY_OK:slots=<n> (rc0) / CAPACITY_FULL:<binding>:slots=0 (rc1)
   list-exited                               List exited agent containers
   inspect-exit    <NUM>                     Print exit code of container
   inspect-detail  <NUM>                     Print stats + last 30 log lines
@@ -1205,6 +1314,18 @@ else:
       --format "{{.Names}}\t{{.Status}}\t{{.Label \"issue\"}}\t{{.Label \"mode\"}}\t{{.Label \"branch\"}}\t{{.Label \"pr\"}}" 2>/dev/null || true
     ;;
 
+  capacity)
+    # Resource admission gate. `capacity` → CAPACITY_OK:slots=<n> (rc0) or
+    # CAPACITY_FULL:<binding>:slots=0 (rc1). `capacity --json` → full detail for
+    # the preflight. Used by every launch path to bound host resource use without
+    # a hand-tuned container count (RAM/disk 90%, CPU 75%, 2×ncpu backstop).
+    if [[ "${1:-}" == "--json" ]]; then
+      _capacity_compute json
+    else
+      _capacity_compute line
+    fi
+    ;;
+
   list-exited)
     docker ps -a --filter "label=cfg-agent=true" --filter "status=exited" \
       --format "{{.Names}}\t{{.Label \"issue\"}}\t{{.Label \"mode\"}}\t{{.Label \"branch\"}}\t{{.Label \"pr\"}}" 2>/dev/null || true
@@ -1495,6 +1616,11 @@ for i in items:
         echo "REVIEW_REFUSED:${pr_num}:no_project_item_for_story_${story_num}"
         exit 3
       fi
+    fi
+
+    # Resource admission gate before claiming the lease / cloning.
+    if ! _capacity_gate "${pr_num}" "REVIEW_REFUSED"; then
+      exit 3
     fi
 
     # Cross-host PR lease — pr-<N> is shared by review/fix/resolve (mutually

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -779,6 +779,14 @@ case "$cmd" in
     real_path=$(realpath "$clone_dir")
     gh_token=$(gh auth token)
 
+    # Forward the distributed lease key (set by po-act dispatch-fix/resolve-conflict)
+    # so the container's entrypoint releases the pr-<N> lease on exit. Empty when
+    # launch-generic is used outside the cron (e.g. branch mode) — then no lease.
+    lease_env=()
+    if [[ -n "${CFGMS_LEASE_KEY:-}" ]]; then
+      lease_env=(-e "CFGMS_LEASE_KEY=${CFGMS_LEASE_KEY}")
+    fi
+
     # Derive mode and metadata labels from entrypoint args
     mode_label="branch"
     fix_pr_num=""
@@ -806,6 +814,7 @@ case "$cmd" in
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AUTONOMOUS=true" \
+      "${lease_env[@]}" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
       "${entrypoint_args[@]}" 2>&1); then
@@ -1419,6 +1428,7 @@ else:
     clone_dir="${WORKTREE_BASE}/review-pr-${pr_num}"
 
     # Container conflict gate: refuse if the review container already exists.
+    # (Same-host fast path; the cross-host interlock is the pr-<N> lease below.)
     if docker ps -a --filter "name=^/${container_name}$" --format "{{.Names}}" 2>/dev/null | grep -qx "$container_name"; then
       echo "REVIEW_REFUSED:${pr_num}:container_exists"
       exit 3
@@ -1486,6 +1496,25 @@ for i in items:
         exit 3
       fi
     fi
+
+    # Cross-host PR lease — pr-<N> is shared by review/fix/resolve (mutually
+    # exclusive ops on one PR). Acquired only now that this is a confirmed,
+    # story-linked, reviewable PR (after the no_story_link / no_project_item
+    # refusals above, before any clone/launch). Another host already
+    # reviewing/fixing this PR holds it, and its local docker check above is
+    # invisible to us. The review container's review-entrypoint.sh releases the
+    # lease on exit; until then a pre-launch failure must release it, so we arm an
+    # EXIT trap and disarm it only after a successful detached launch (then the
+    # container owns release).
+    PIPELINE_HELPER="${CFGMS_TEST_PIPELINE_HELPER:-${REPO_ROOT}/scripts/pipeline-helper.sh}"
+    review_lease_out=$(bash "$PIPELINE_HELPER" lease-acquire "pr-${pr_num}" "${CFGMS_LEASE_TTL_PR:-3600}" 2>/dev/null || true)
+    case "$review_lease_out" in
+      ACQUIRED:*|RECLAIMED:*) ;;
+      HELD:*) echo "REVIEW_REFUSED:${pr_num}:lease_held"; exit 3 ;;
+      *)      echo "REVIEW_REFUSED:${pr_num}:lease_error"; exit 3 ;;
+    esac
+    REVIEW_LEASE_RELEASE_ON_EXIT="pr-${pr_num}"
+    trap '[ -n "${REVIEW_LEASE_RELEASE_ON_EXIT:-}" ] && bash "$PIPELINE_HELPER" lease-release "$REVIEW_LEASE_RELEASE_ON_EXIT" >/dev/null 2>&1; true' EXIT
 
     # Stale clone cleanup (previous run crashed before docker rm got the dir).
     rm -rf "$clone_dir" 2>/dev/null || true
@@ -1587,14 +1616,19 @@ PROMPT_EOF
       -v "${REPO_ROOT}/.devcontainer/scripts/review-entrypoint.sh:/usr/local/bin/review-entrypoint.sh:ro" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AGENT_MODE=true" \
+      -e "CFGMS_LEASE_KEY=pr-${pr_num}" \
       --cap-add NET_ADMIN \
       --entrypoint /usr/local/bin/review-entrypoint.sh \
       cfg-agent:latest 2>&1); then
+      # Launch succeeded — the container now owns the pr-<N> lease and releases it
+      # on exit. Disarm the host-side release trap.
+      unset REVIEW_LEASE_RELEASE_ON_EXIT
       echo "REVIEW_DISPATCHED:${pr_num}:${review_story_label}:${container_id}"
       # Best-effort PR dashboard label via REST API (see launch-generic note above).
       gh api --method POST "repos/cfg-is/cfgms/issues/${pr_num}/labels" \
         -f "labels[]=review-agent" >/dev/null 2>&1 || true
     else
+      # Launch failed — the EXIT trap releases the lease.
       echo "LAUNCH_FAILED:${container_name}:${container_id}"
       rm -rf "$clone_dir"
       echo "CLEANED:clone:${clone_dir}"
@@ -1755,6 +1789,13 @@ PROMPT_EOF
         fi
       done
     done
+
+    # --- Expired distributed-lease GC (multi-host cron coordination) ---
+    # Reap lease refs whose holder died past TTL. acquire-time reclaim already
+    # frees a key when it is re-acquired directly; this collects the rest (e.g. a
+    # crashed dev whose story was picked up by stalled-dispatch recovery under a
+    # different code path). Idempotent; best-effort.
+    bash "${REPO_ROOT}/scripts/pipeline-helper.sh" lease-gc 2>/dev/null || true
 
     echo "CLEANUP_STALE_DONE:cleaned=${cleaned}"
     ;;

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -5,10 +5,11 @@
 # All actions target the cfg-is/cfgms repo and the develop branch queue.
 #
 # Subcommands:
-#   dispatch <STORY_NUM>            Fresh story: claim (Ready->In Progress) + check-conflicts + clone + launch
-#   claim <ITEM_ID>                 Claim a Ready story (Ready->In Progress) for in-session work; CLAIMED/CLAIM_LOST
-#   dispatch-fix <PR_NUM>           Fix cycle: remove stale container + clone-pr + launch
-#   resolve-conflict <PR_NUM>       Conflict resolution: author-gate + clone-pr + launch resolve-conflict agent
+#   dispatch <STORY_NUM>            Fresh story: lease + claim (Ready->In Progress) + check-conflicts + clone + launch
+#   claim <ITEM_ID>                 Lease + claim a Ready story (Ready->In Progress) for in-session work; CLAIMED/CLAIM_LOST
+#   release-story <ITEM_ID>         Release a story lease held by an in-session (§7) self-dispatch after the PR is up
+#   dispatch-fix <PR_NUM>           Fix cycle: lease pr-<N> + remove stale container + clone-pr + launch
+#   resolve-conflict <PR_NUM>       Conflict resolution: lease pr-<N> + author-gate + clone-pr + launch resolve-conflict agent
 #   close-merged <ISSUE> <PR>       Close issue that didn't auto-close after PR merge
 #   enqueue <PR_NUM> [<STORY>]      Add PR to merge queue. If STORY is given,
 #                                   prepends "Fixes #STORY" to the PR body when
@@ -35,6 +36,13 @@ fi
 DISPATCH="${CFGMS_TEST_DISPATCH:-$(dirname "$0")/agent-dispatch.sh}"
 PREFLIGHT="$(dirname "$0")/po-cycle-preflight.py"
 PROJECT_QUEUE="$(cd "$(dirname "$0")/../.." && pwd)/scripts/project-queue.sh"
+PIPELINE_HELPER="${CFGMS_TEST_PIPELINE_HELPER:-$(cd "$(dirname "$0")/../.." && pwd)/scripts/pipeline-helper.sh}"
+
+# Default lease TTLs (seconds). A held lease past its TTL is reclaimable by any
+# host — the backstop for a host that died holding it. Sized well above the
+# normal operation duration so a live op is never reclaimed out from under it.
+LEASE_TTL_STORY="${CFGMS_LEASE_TTL_STORY:-7200}"   # dev container: long stories
+LEASE_TTL_PR="${CFGMS_LEASE_TTL_PR:-3600}"         # review/fix/resolve container
 
 # Cache path (matches po-cycle-preflight.py defaults). No /tmp writes.
 if [ -n "${PO_CACHE_DIR:-}" ]; then
@@ -47,17 +55,45 @@ fi
 CACHE_FILE="$CACHE_DIR/preflight.json"
 
 # ── Shared claim / routing helpers ──────────────────────────────────────────
-# The pipeline can run on more than one host (e.g. a Linux orchestrator dispatching
-# docker agents + a Windows host self-dispatching its tagged stories in-session).
-# Hosts work disjoint slices by execution environment, so no distributed lock is
-# needed — but each host MUST claim a story (set status away from Ready) BEFORE it
-# starts any work, so two out-of-phase loops can't both pick the same item.
+# The pipeline can run `/po cron` on MORE THAN ONE host concurrently, including
+# homogeneous (e.g. multiple Linux) hosts. Cross-host mutual exclusion is provided
+# by a distributed lease (an atomic git ref — see pipeline-helper.sh lease-*),
+# acquired on the work unit BEFORE any side effect. The lease is the hard
+# interlock; the Projects V2 status flip below is the human-readable dashboard
+# signal layered on top (it is NOT relied on for concurrency — Projects V2 has no
+# CAS, so the status flip alone is last-writer-wins).
+
+# _acquire_lease <key> <ttl> <skip_label>
+#   Try to claim <key>. On success (ACQUIRED/RECLAIMED) records it in LEASE_HELD
+#   and returns 0. On contention (HELD) or error, prints a DISPATCH_SKIPPED line
+#   tagged <skip_label> and returns 1 — the caller should exit 0 (clean skip).
+LEASE_HELD=""
+_acquire_lease() {
+  local key="$1" ttl="$2" label="$3" out
+  out=$(bash "$PIPELINE_HELPER" lease-acquire "$key" "$ttl" 2>/dev/null || true)
+  case "$out" in
+    ACQUIRED:*|RECLAIMED:*) LEASE_HELD="$key"; return 0 ;;
+    HELD:*)  echo "DISPATCH_SKIPPED:${label}:lease_held (${out})"; return 1 ;;
+    *)       echo "DISPATCH_SKIPPED:${label}:lease_error (${out:-no output})"; return 1 ;;
+  esac
+}
+
+# _release_lease [key]
+#   Release the named key, or LEASE_HELD if no arg. Idempotent; never fails the
+#   caller. Used on rollback paths where the container that would own the lease
+#   never launched. (When a container DOES launch, it owns release — the host
+#   must NOT release after a successful launch.)
+_release_lease() {
+  local key="${1:-$LEASE_HELD}"
+  [ -n "$key" ] || return 0
+  bash "$PIPELINE_HELPER" lease-release "$key" >/dev/null 2>&1 || true
+}
 
 # _claim_item <item_id>
-#   Atomically-ish claim: re-read status; proceed only if still Ready; set it to
-#   In Progress. Prints CLAIMED:<item> (rc 0) or CLAIM_LOST:<item> (rc 1). The
-#   read-then-set is last-writer-wins (Projects V2 has no CAS), but combined with
-#   disjoint per-host env slices it is sufficient to prevent cross-host collisions.
+#   Re-read status; proceed only if still Ready; set it to In Progress. Prints
+#   CLAIMED:<item> (rc 0) or CLAIM_LOST:<item> (rc 1). This is the dashboard-state
+#   transition and a same-host overlap guard; cross-host safety comes from the
+#   lease the caller already holds, NOT from this read-then-set.
 _claim_item() {
   local item_id="$1" cur
   cur=$(bash "$PROJECT_QUEUE" get-item "$item_id" 2>/dev/null \
@@ -161,13 +197,19 @@ except Exception: print('')" 2>/dev/null || echo "")
       clone_path="${WORKTREE_BASE}/story-${story}"
       container_name="cfg-agent-${story}"
       first_arg="${story}"
+      # Acquire the story lease before any clone/launch so a second host's
+      # out-of-phase cycle can't dispatch the same existing Ready issue.
+      _acquire_lease "story-${item_id}" "$LEASE_TTL_STORY" "${story}" || exit 0
     else
       # Issueless project draft → materialize it into a locked `internal` issue
       # at dispatch, then run the rest of dispatch first-class on feature/story-<N>.
       # (The old item-<id> branch path is review-sweep-invisible — Issue #1700 —
       # so we convert to an issue here instead of dispatching the draft directly.)
       item_id="$arg"
-      PIPELINE_HELPER="$(cd "$(dirname "$0")/../.." && pwd)/scripts/pipeline-helper.sh"
+      # Acquire the story lease BEFORE materialize — materialize-issue mints a
+      # fresh GitHub issue every call, so two racing hosts would otherwise create
+      # two issues (+ two branches/containers/PRs) for the same draft.
+      _acquire_lease "story-${item_id}" "$LEASE_TTL_STORY" "${item_id}" || exit 0
       epic_num=$(bash "$PROJECT_QUEUE" get-item "$item_id" 2>/dev/null \
         | python3 -c "import json,sys,re
 try:
@@ -202,9 +244,11 @@ except Exception: print('')" 2>/dev/null || echo "")
       exit 0
     fi
 
-    # Phase 3 — claim before work. Only the host that flips Ready -> In Progress
-    # proceeds; a loser exits cleanly without touching the clone or container.
+    # Phase 3 — claim before work. We already hold the story lease (cross-host
+    # interlock); this flips the dashboard status. On the rare CLAIM_LOST (status
+    # changed by a human or a same-host overlap) release the lease and exit clean.
     if ! _claim_item "$item_id"; then
+      _release_lease "story-${item_id}"
       exit 0
     fi
 
@@ -214,7 +258,7 @@ except Exception: print('')" 2>/dev/null || echo "")
     # failure would exit with the story stuck In Progress. The docker-run failure is
     # handled explicitly in the LAUNCH_FAILED branch below (it runs inside an `if`
     # condition, which `set -e`/ERR does not trap).
-    trap 'rc=$?; bash "$PROJECT_QUEUE" update-field "$item_id" status "Ready" >/dev/null 2>&1 || true; echo "ROLLED_BACK:${item_id} -> Ready (dispatch failed before launch, rc=$rc)"; exit "$rc"' ERR
+    trap 'rc=$?; bash "$PROJECT_QUEUE" update-field "$item_id" status "Ready" >/dev/null 2>&1 || true; bash "$PIPELINE_HELPER" lease-release "story-${item_id}" >/dev/null 2>&1 || true; echo "ROLLED_BACK:${item_id} -> Ready (dispatch failed before launch, rc=$rc)"; exit "$rc"' ERR
     # Branch on the RESOLVED story number ($first_arg), not the raw input ($arg).
     # An issueless draft is materialized above into issue #$story and $first_arg
     # is set to that number, so it must clone first-class as feature/story-<N>
@@ -257,6 +301,7 @@ except Exception: print('')" 2>/dev/null || echo "")
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_PROJECT_ITEM_ID=${item_id}" \
+      -e "CFGMS_LEASE_KEY=story-${item_id}" \
       -e "CFGMS_AUTONOMOUS=true" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
@@ -268,8 +313,10 @@ except Exception: print('')" 2>/dev/null || echo "")
       echo "LAUNCH_FAILED:${first_arg}:${container_id}"
       rm -rf "$clone_path"
       echo "CLEANED:clone:${clone_path}"
-      # Release the claim: launch never happened, so return the story to Ready.
+      # Release the claim + lease: launch never happened, so return the story to
+      # Ready and free the lease for the next cycle/host.
       bash "$PROJECT_QUEUE" update-field "$item_id" status "Ready" >/dev/null 2>&1 || true
+      _release_lease "story-${item_id}"
       echo "ROLLED_BACK:${item_id} -> Ready"
       exit 1
     fi
@@ -280,10 +327,31 @@ except Exception: print('')" 2>/dev/null || echo "")
 
   claim)
     # Standalone claim primitive for self-dispatch (no-docker, in-session) mode:
-    # a host claims a Ready story before working it locally. Same Ready->In
-    # Progress guard the docker dispatch path uses. Exit 0 = CLAIMED, 1 = lost.
+    # a host claims a Ready story before working it locally. Acquires the story
+    # lease (cross-host interlock) THEN flips Ready->In Progress. The in-session
+    # work has no container to release the lease on exit, so §7 must call
+    # `po-act.sh release-story <item_id>` once the PR is up (TTL reclaim is the
+    # backstop if the session dies). Exit 0 = CLAIMED, 1 = lost/held.
     item_id="${1:?item_id required}"
-    _claim_item "$item_id"
+    # Acquire the cross-host lease first; report contention as CLAIM_LOST so §7's
+    # drain loop treats it like any other lost claim.
+    acq=$(bash "$PIPELINE_HELPER" lease-acquire "story-${item_id}" "$LEASE_TTL_STORY" 2>/dev/null || true)
+    case "$acq" in
+      ACQUIRED:*|RECLAIMED:*) LEASE_HELD="story-${item_id}" ;;
+      *) echo "CLAIM_LOST:${item_id} (lease held: ${acq:-error})"; exit 1 ;;
+    esac
+    if ! _claim_item "$item_id"; then
+      _release_lease "story-${item_id}"
+      exit 1
+    fi
+    ;;
+
+  release-story)
+    # Release a story lease held by a self-dispatch (§7) session — call after the
+    # PR is up so another host can pick up review/fix. Idempotent.
+    item_id="${1:?item_id required}"
+    _release_lease "story-${item_id}"
+    echo "RELEASED:story-${item_id}"
     ;;
 
   dispatch-fix)
@@ -294,12 +362,18 @@ except Exception: print('')" 2>/dev/null || echo "")
       echo "DISPATCH_FIX_REFUSED:${pr}:external_author"
       exit 3
     fi
+    # Cross-host PR lease — pr-<N> is shared by review/fix/resolve (mutually
+    # exclusive ops on one PR). If another host already holds it, skip cleanly.
+    _acquire_lease "pr-${pr}" "$LEASE_TTL_PR" "pr-${pr}" || exit 0
+    # Release the lease if clone/launch fails; on success the container owns it.
+    trap '_release_lease "pr-${pr}"' ERR
     # Remove any stale exited container from a previous attempt
     docker rm -f "$container" >/dev/null 2>&1 || true
     # Remove any stale worktree directory
     rm -rf "${WORKTREE_BASE}/pr-fix-${pr}" 2>/dev/null || true
     "$DISPATCH" create-clone-pr "$pr" | tail -1
-    "$DISPATCH" launch-generic "$container" "${WORKTREE_BASE}/pr-fix-${pr}" --fix-pr "$pr" | tail -1
+    CFGMS_LEASE_KEY="pr-${pr}" "$DISPATCH" launch-generic "$container" "${WORKTREE_BASE}/pr-fix-${pr}" --fix-pr "$pr" | tail -1
+    trap - ERR
     echo "DISPATCHED_FIX:$pr"
     ;;
 
@@ -315,12 +389,17 @@ except Exception: print('')" 2>/dev/null || echo "")
       echo "RESOLVE_CONFLICT_REFUSED:${pr}:external_author"
       exit 3
     fi
+    # Cross-host PR lease (same pr-<N> key as review/fix — they never run together
+    # on one PR). Skip cleanly if another host holds it.
+    _acquire_lease "pr-${pr}" "$LEASE_TTL_PR" "pr-${pr}" || exit 0
+    trap '_release_lease "pr-${pr}"' ERR
     # Remove any stale exited container from a previous attempt
     docker rm -f "$container" >/dev/null 2>&1 || true
     # Remove any stale worktree directory (separate namespace from pr-fix-<PR>)
     rm -rf "${WORKTREE_BASE}/resolve-conflict-${pr}" 2>/dev/null || true
     "$DISPATCH" create-clone-pr --dest-prefix "resolve-conflict-" "$pr" | tail -1
-    "$DISPATCH" launch-generic "$container" "${WORKTREE_BASE}/resolve-conflict-${pr}" --resolve-conflict "$pr" | tail -1
+    CFGMS_LEASE_KEY="pr-${pr}" "$DISPATCH" launch-generic "$container" "${WORKTREE_BASE}/resolve-conflict-${pr}" --resolve-conflict "$pr" | tail -1
+    trap - ERR
     echo "DISPATCHED_RESOLVE_CONFLICT:${pr}"
     ;;
 

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -89,6 +89,18 @@ _release_lease() {
   bash "$PIPELINE_HELPER" lease-release "$key" >/dev/null 2>&1 || true
 }
 
+# _capacity_ok
+#   Resource admission gate (delegates to agent-dispatch.sh capacity). Returns 0
+#   when the host has room for another agent container; on no room, echoes the
+#   CAPACITY_FULL line and returns 1. Bypass with CFGMS_AGENT_CAPACITY_GATE=off.
+_capacity_ok() {
+  [[ "${CFGMS_AGENT_CAPACITY_GATE:-on}" == "off" ]] && return 0
+  local out
+  out=$("$DISPATCH" capacity 2>/dev/null) && return 0
+  echo "$out"
+  return 1
+}
+
 # _claim_item <item_id>
 #   Re-read status; proceed only if still Ready; set it to In Progress. Prints
 #   CLAIMED:<item> (rc 0) or CLAIM_LOST:<item> (rc 1). This is the dashboard-state
@@ -153,6 +165,13 @@ case "$cmd" in
   dispatch)
     arg="${1:?story number or item_id required}"
     PROJECT_QUEUE="$(cd "$(dirname "$0")/../.." && pwd)/scripts/project-queue.sh"
+
+    # Resource admission gate (before any lease/materialize/clone). Defer if the
+    # host has no room for another agent container — RAM/disk 90%, CPU 75%.
+    if ! cap=$(_capacity_ok); then
+      echo "DISPATCH_DEFERRED:${arg}:resources (${cap})"
+      exit 0
+    fi
 
     # If arg is an item_id (non-numeric), resolve it to the underlying GitHub
     # issue number. A project item linked to a public issue carries `issue_num`;
@@ -362,6 +381,11 @@ except Exception: print('')" 2>/dev/null || echo "")
       echo "DISPATCH_FIX_REFUSED:${pr}:external_author"
       exit 3
     fi
+    # Resource admission gate before claiming the lease.
+    if ! cap=$(_capacity_ok); then
+      echo "DISPATCH_FIX_DEFERRED:${pr}:resources (${cap})"
+      exit 0
+    fi
     # Cross-host PR lease — pr-<N> is shared by review/fix/resolve (mutually
     # exclusive ops on one PR). If another host already holds it, skip cleanly.
     _acquire_lease "pr-${pr}" "$LEASE_TTL_PR" "pr-${pr}" || exit 0
@@ -388,6 +412,11 @@ except Exception: print('')" 2>/dev/null || echo "")
     if ! "$DISPATCH" check-pr-author "$pr"; then
       echo "RESOLVE_CONFLICT_REFUSED:${pr}:external_author"
       exit 3
+    fi
+    # Resource admission gate before claiming the lease.
+    if ! cap=$(_capacity_ok); then
+      echo "RESOLVE_CONFLICT_DEFERRED:${pr}:resources (${cap})"
+      exit 0
     fi
     # Cross-host PR lease (same pr-<N> key as review/fix — they never run together
     # on one PR). Skip cleanly if another host holds it.

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -801,6 +801,28 @@ def running_containers():
         return None
 
 
+def host_capacity():
+    """Resource-admission snapshot for this host (planning hint for the cron).
+
+    Delegates to ``agent-dispatch.sh capacity --json`` — the same gate every
+    launch path enforces — so the dashboard/cron can see how many more agent
+    containers fit before the host hits its ceilings (RAM/disk 90%, CPU 75%).
+    Returns the parsed dict, or {"available": None} when docker/the script is
+    unavailable (e.g. a non-orchestrator host).
+    """
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "agent-dispatch.sh")
+    try:
+        result = subprocess.run(
+            ["bash", script, "capacity", "--json"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15,
+        )
+        data = json.loads(result.stdout.strip() or "{}")
+        data["available"] = bool(data.get("can_launch"))
+        return data
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError, ValueError):
+        return {"available": None}
+
+
 def code_health_check():
     """Run a fast check of develop's code health so the PO can decide whether
     to dispatch this cycle.
@@ -1787,6 +1809,7 @@ def main():
         "blocked": blocked_issues,
     }
     out["running_containers"] = containers
+    out["capacity"] = host_capacity()
     out["merge_queue"] = merge_queue
     out["code_health"] = code_health
     out["done_on_merge_count"] = done_on_merge_count
@@ -2154,6 +2177,7 @@ def write_output(out, mode):
             "undecomposed_epics": len(out.get("epics_undecomposed", [])),
         },
         "host_caps": out.get("host_caps", [DEFAULT_ENV]),
+        "capacity": out.get("capacity", {}),
         "external_prs": out.get("external_prs", []),
         "windows_queue": out.get("windows_queue", []),
         "running_containers": out.get("running_containers", []),

--- a/.claude/scripts/tests/agent-apikey-injection.test.sh
+++ b/.claude/scripts/tests/agent-apikey-injection.test.sh
@@ -306,8 +306,7 @@ rm -rf "$tmpdir4"
 # T8: cleanup-issue calls revoke (structural)
 # ---------------------------------------------------------------------------
 ran=$((ran + 1))
-if awk '/^  cleanup-issue\)/{p=1} p && /^  cleanup-stale\)/{exit} p' "${DISPATCH}" | \
-    grep -q 'revoke_agent_creds'; then
+if grep -q 'revoke_agent_creds' <<<"$(awk '/^  cleanup-issue\)/{p=1} p && /^  cleanup-stale\)/{exit} p' "${DISPATCH}")"; then
   printf '  ok    T8 cleanup-issue calls revoke_agent_creds\n'
 else
   fail=$((fail + 1))
@@ -318,8 +317,7 @@ fi
 # T9: cleanup-stale calls revoke (structural)
 # ---------------------------------------------------------------------------
 ran=$((ran + 1))
-if awk '/^  cleanup-stale\)/{p=1} p && /^  CLEANUP_STALE_DONE/{exit} p' "${DISPATCH}" | \
-    grep -q 'revoke_agent_creds'; then
+if grep -q 'revoke_agent_creds' <<<"$(awk '/^  cleanup-stale\)/{p=1} p && /^  CLEANUP_STALE_DONE/{exit} p' "${DISPATCH}")"; then
   printf '  ok    T9 cleanup-stale calls revoke_agent_creds\n'
 else
   fail=$((fail + 1))
@@ -330,8 +328,7 @@ fi
 # T10: cleanup-stale-reviews calls revoke (structural)
 # ---------------------------------------------------------------------------
 ran=$((ran + 1))
-if awk '/^  cleanup-stale-reviews\)/{p=1} p && /^  CLEANUP_STALE_REVIEWS_DONE/{exit} p' "${DISPATCH}" | \
-    grep -q 'revoke_agent_creds'; then
+if grep -q 'revoke_agent_creds' <<<"$(awk '/^  cleanup-stale-reviews\)/{p=1} p && /^  CLEANUP_STALE_REVIEWS_DONE/{exit} p' "${DISPATCH}")"; then
   printf '  ok    T10 cleanup-stale-reviews calls revoke_agent_creds\n'
 else
   fail=$((fail + 1))
@@ -373,8 +370,7 @@ rm -rf "$tmpdir5"
 # Stale containers go through cleanup-stale which calls revoke_agent_creds.
 # ---------------------------------------------------------------------------
 ran=$((ran + 1))
-if awk '/^  cleanup-stale\)/{p=1} p && /CLEANUP_STALE_DONE/{exit} p' "${DISPATCH}" | \
-    grep -q 'revoke_agent_creds'; then
+if grep -q 'revoke_agent_creds' <<<"$(awk '/^  cleanup-stale\)/{p=1} p && /CLEANUP_STALE_DONE/{exit} p' "${DISPATCH}")"; then
   printf '  ok    T12 stale/orphan path calls revoke (normal and orphan coverage via cleanup-stale)\n'
 else
   fail=$((fail + 1))

--- a/.claude/scripts/tests/capacity.test.sh
+++ b/.claude/scripts/tests/capacity.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Tests for the resource-based admission gate (agent-dispatch.sh capacity) and its
+# integration into po-act.sh dispatch paths. The gate replaces the hand-tuned
+# container-count cap: a new agent is admitted only while the host stays under its
+# ceilings (RAM/disk 90%, CPU 75%, 2xncpu backstop).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCH="${SCRIPT_DIR}/../agent-dispatch.sh"
+PO_ACT="${SCRIPT_DIR}/../po-act.sh"
+
+fail=0; ran=0
+check_contains() {
+  local d="$1" hay="$2" needle="$3"; ran=$((ran + 1))
+  if [[ "$hay" == *"$needle"* ]]; then printf '  ok    %s\n' "$d"
+  else printf '  FAIL  %s\n        want substr: %q\n        actual:      %q\n' "$d" "$needle" "$hay"; fail=$((fail + 1)); fi
+}
+check_not_contains() {
+  local d="$1" hay="$2" needle="$3"; ran=$((ran + 1))
+  if [[ "$hay" != *"$needle"* ]]; then printf '  ok    %s\n' "$d"
+  else printf '  FAIL  %s — should NOT contain %q\n        actual: %q\n' "$d" "$needle" "$hay"; fail=$((fail + 1)); fi
+}
+check_rc() {
+  local d="$1" a="$2" e="$3"; ran=$((ran + 1))
+  if [[ "$a" == "$e" ]]; then printf '  ok    %s (rc=%s)\n' "$d" "$a"
+  else printf '  FAIL  %s want rc %s got %s\n' "$d" "$e" "$a"; fail=$((fail + 1)); fi
+}
+
+echo ""
+echo "capacity.test.sh — resource admission gate"
+echo "------------------------------------------"
+
+# T1: an impossible disk ceiling forces CAPACITY_FULL (rc1), binding = disk.
+rc=0; out="$(bash "$DISPATCH" capacity 2>/dev/null)" || rc=$?
+# (host-dependent OK/FULL — only assert the format is one of the two)
+check_contains "capacity prints CAPACITY_ status" "$out" "CAPACITY_"
+rc=0; out="$(CFGMS_AGENT_DISK_CEIL=0.0 bash "$DISPATCH" capacity 2>/dev/null)" || rc=$?
+check_contains "0% disk ceiling -> CAPACITY_FULL:disk" "$out" "CAPACITY_FULL:disk"
+check_rc "forced-full exits 1" "$rc" "1"
+
+# T2: --json reports can_launch=false under the impossible ceiling.
+out="$(CFGMS_AGENT_DISK_CEIL=0.0 bash "$DISPATCH" capacity --json 2>/dev/null)" || true
+check_contains "json can_launch false" "$out" '"can_launch": false'
+check_contains "json names binding resource" "$out" '"binding"'
+
+# T3: zero per-agent sizes + full ceilings -> room available (CAPACITY_OK).
+rc=0
+out="$(CFGMS_AGENT_MEM_MB=0 CFGMS_AGENT_DISK_GB=0 CFGMS_AGENT_CPUS=0 \
+       CFGMS_AGENT_MEM_CEIL=1.0 CFGMS_AGENT_DISK_CEIL=1.0 CFGMS_AGENT_CPU_CEIL=1.0 \
+       bash "$DISPATCH" capacity 2>/dev/null)" || rc=$?
+check_contains "abundant resources -> CAPACITY_OK" "$out" "CAPACITY_OK"
+check_rc "CAPACITY_OK exits 0" "$rc" "0"
+
+# ---------------------------------------------------------------------------
+# T4: po-act dispatch-fix defers when the host is out of capacity (before lease).
+# Mock dispatch: trusted author + capacity reports FULL. Any other call fails.
+# ---------------------------------------------------------------------------
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+MOCK="$TMP/mock-dispatch.sh"
+cat > "$MOCK" <<'MOCK_EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  check-pr-author) echo "AUTHOR_TRUSTED:${2:-?}:cfg-agent"; exit 0 ;;
+  capacity)        echo "CAPACITY_FULL:disk:slots=0"; exit 1 ;;
+  *) echo "MOCK_UNEXPECTED:$*" >&2; exit 1 ;;
+esac
+MOCK_EOF
+chmod +x "$MOCK"
+
+rc=0
+out="$(CFGMS_TEST_DISPATCH="$MOCK" \
+       CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh" \
+       CFGMS_TEST_WORKTREE_BASE="$TMP/wt" \
+       bash "$PO_ACT" dispatch-fix 4242 2>&1)" || rc=$?
+check_contains "dispatch-fix out of capacity -> DISPATCH_FIX_DEFERRED" "$out" "DISPATCH_FIX_DEFERRED:4242:resources"
+check_not_contains "deferral does not reach launch" "$out" "LAUNCHED"
+check_not_contains "deferral does not reach lease (no clone)" "$out" "CLONE_OK"
+
+# T5: with the gate bypassed, dispatch-fix does NOT consult capacity and proceeds
+# (the mock would loudly fail on create-clone-pr, proving capacity was skipped and
+# the path advanced past the gate).
+out="$(CFGMS_TEST_DISPATCH="$MOCK" \
+       CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh" \
+       CFGMS_TEST_WORKTREE_BASE="$TMP/wt" \
+       CFGMS_AGENT_CAPACITY_GATE=off \
+       bash "$PO_ACT" dispatch-fix 4242 2>&1)" || true
+check_not_contains "bypass -> no DEFERRED" "$out" "DISPATCH_FIX_DEFERRED"
+check_contains "bypass -> advanced past gate to clone step" "$out" "MOCK_UNEXPECTED:create-clone-pr"
+
+echo ""
+if [[ "$fail" -eq 0 ]]; then printf 'capacity.test.sh: PASS (%d checks)\n' "$ran"; exit 0
+else printf 'capacity.test.sh: FAIL (%d/%d failed)\n' "$fail" "$ran"; exit 1; fi

--- a/.claude/scripts/tests/env_routing.test.sh
+++ b/.claude/scripts/tests/env_routing.test.sh
@@ -11,6 +11,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Route lease calls to the hermetic mock so this test never touches real GitHub.
+export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
 PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
 
 if [[ ! -f "${PREFLIGHT}" ]]; then

--- a/.claude/scripts/tests/env_routing.test.sh
+++ b/.claude/scripts/tests/env_routing.test.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Route lease calls to the hermetic mock so this test never touches real GitHub.
 export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
+# Bypass the resource admission gate so tests are deterministic on any host.
+export CFGMS_AGENT_CAPACITY_GATE=off
 PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
 
 if [[ ! -f "${PREFLIGHT}" ]]; then

--- a/.claude/scripts/tests/lease.test.sh
+++ b/.claude/scripts/tests/lease.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Hermetic tests for the distributed-lease primitive in scripts/pipeline-helper.sh
+# (multi-host /po cron coordination). A fake `gh` on PATH simulates the GitHub
+# git-refs REST API with an on-disk ref/commit store, so the real lease logic
+# (atomic create, contention, TTL reclaim, release, status) is exercised without
+# touching the network.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="${SCRIPT_DIR}/../../../scripts/pipeline-helper.sh"
+[[ -f "$HELPER" ]] || { printf 'FAIL: pipeline-helper.sh not found at %s\n' "$HELPER" >&2; exit 1; }
+
+fail=0; ran=0
+check_contains() {
+  local desc="$1" hay="$2" needle="$3"; ran=$((ran + 1))
+  if [[ "$hay" == *"$needle"* ]]; then printf '  ok    %s\n' "$desc"
+  else printf '  FAIL  %s\n        want substr: %q\n        actual:      %q\n' "$desc" "$needle" "$hay"; fail=$((fail + 1)); fi
+}
+check_rc() {
+  local desc="$1" actual="$2" expected="$3"; ran=$((ran + 1))
+  if [[ "$actual" == "$expected" ]]; then printf '  ok    %s (rc=%s)\n' "$desc" "$actual"
+  else printf '  FAIL  %s\n        want rc: %s  actual rc: %s\n' "$desc" "$expected" "$actual"; fail=$((fail + 1)); fi
+}
+
+# --- Fake gh: a minimal git-refs/commits API backed by $GH_STATE ----------------
+GH_STATE="$(mktemp -d)"
+FAKE_BIN="$(mktemp -d)"
+mkdir -p "$GH_STATE/refs" "$GH_STATE/commits"
+cat > "$FAKE_BIN/gh" <<'GH_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "api" ]] || { echo "fake gh: only 'api' supported: $*" >&2; exit 1; }
+shift
+method="GET"; path=""; jq=""; declare -A F=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -X) method="$2"; shift 2 ;;
+    -f|-F) k="${2%%=*}"; v="${2#*=}"; F["$k"]="$v"; shift 2 ;;
+    --jq) jq="$2"; shift 2 ;;
+    --method) method="$2"; shift 2 ;;
+    *) [[ -z "$path" ]] && path="$1"; shift ;;
+  esac
+done
+S="$GH_STATE"
+keyfile() { echo "$S/refs/$(printf '%s' "$1" | tr '/' '_')"; }
+
+case "$path" in
+  *"/git/commits"|*"/git/commits/"*)
+    if [[ "$method" == "POST" ]]; then
+      # create-commit: store message under a content-addressed-ish sha
+      msg="${F[message]:-}"
+      sha="$(printf '%s|%s' "$msg" "$RANDOM$RANDOM" | sha1sum | cut -c1-40)"
+      printf '%s' "$msg" > "$S/commits/$sha"
+      [[ "$jq" == ".sha" ]] && { echo "$sha"; exit 0; }
+      echo "{\"sha\":\"$sha\"}"; exit 0
+    fi
+    # GET a commit by sha
+    sha="${path##*/git/commits/}"
+    [[ -f "$S/commits/$sha" ]] || { echo '{"message":"Not Found","status":"404"}'; exit 1; }
+    msg="$(cat "$S/commits/$sha")"
+    [[ "$jq" == ".message" ]] && { printf '%s\n' "$msg"; exit 0; }
+    echo "{\"message\":\"$msg\"}"; exit 0
+    ;;
+  *"/git/refs"|*"/git/refs/"*)
+    ref="${F[ref]:-}"
+    # POST creates; path form .../git/refs/<ref> is PATCH/DELETE
+    if [[ "$method" == "POST" ]]; then
+      kf="$(keyfile "$ref")"
+      if [[ -f "$kf" ]]; then echo "Reference already exists" >&2; exit 1; fi
+      echo "${F[sha]:-}" > "$kf"; echo "{\"ref\":\"$ref\"}"; exit 0
+    fi
+    subref="${path##*/git/refs/}"
+    kf="$(keyfile "refs/$subref")"
+    if [[ "$method" == "PATCH" ]]; then
+      [[ -f "$kf" ]] || { echo '{"status":"404"}'; exit 1; }
+      echo "${F[sha]:-}" > "$kf"; echo "{\"ref\":\"refs/$subref\"}"; exit 0
+    fi
+    if [[ "$method" == "DELETE" ]]; then
+      [[ -f "$kf" ]] || { echo '{"status":"404"}'; exit 1; }
+      rm -f "$kf"; exit 0
+    fi
+    ;;
+  *"/git/ref/"*)
+    subref="${path##*/git/ref/}"
+    kf="$(keyfile "refs/$subref")"
+    [[ -f "$kf" ]] || { echo '{"message":"Not Found","status":"404"}'; exit 1; }
+    sha="$(cat "$kf")"
+    [[ "$jq" == ".object.sha" ]] && { echo "$sha"; exit 0; }
+    echo "{\"object\":{\"sha\":\"$sha\"}}"; exit 0
+    ;;
+  *"/git/matching-refs/"*)
+    echo -n '['; first=1
+    for kf in "$S"/refs/*; do
+      [[ -e "$kf" ]] || continue
+      ref="$(basename "$kf" | tr '_' '/')"; sha="$(cat "$kf")"
+      [[ $first -eq 1 ]] || echo -n ','; first=0
+      echo -n "{\"ref\":\"$ref\",\"object\":{\"sha\":\"$sha\"}}"
+    done
+    echo ']'; exit 0
+    ;;
+esac
+echo "fake gh: unhandled $method $path" >&2; exit 1
+GH_EOF
+chmod +x "$FAKE_BIN/gh"
+export GH_STATE
+trap 'rm -rf "$GH_STATE" "$FAKE_BIN"' EXIT
+
+run() { PATH="$FAKE_BIN:$PATH" CFGMS_HOST_ID="test-host" bash "$HELPER" "$@"; }
+
+echo ""
+echo "lease.test.sh — distributed lease primitive (hermetic gh stub)"
+echo "--------------------------------------------------------------"
+
+# 1. Fresh acquire
+out="$(run lease-acquire demo-key 3600)"; rc=$?
+check_contains "fresh acquire → ACQUIRED" "$out" "ACQUIRED:demo-key:test-host"
+check_rc "fresh acquire rc 0" "$rc" "0"
+
+# 2. Status of held key
+out="$(run lease-status demo-key)"
+check_contains "status of held key → HELD" "$out" "HELD:demo-key:test-host"
+check_contains "held key not expired" "$out" "expired=false"
+
+# 3. Contended acquire (already held, live)
+rc=0; out="$(run lease-acquire demo-key 3600)" || rc=$?
+check_contains "second acquire → HELD" "$out" "HELD:demo-key:test-host"
+check_rc "contended acquire rc 1" "$rc" "1"
+
+# 4. list shows the one lease
+out="$(run lease-list)"
+check_contains "lease-list shows demo-key" "$out" "demo-key"
+
+# 5. Release, then status is FREE
+out="$(run lease-release demo-key)"
+check_contains "release → RELEASED" "$out" "RELEASED:demo-key"
+out="$(run lease-status demo-key)"
+check_contains "status after release → FREE" "$out" "FREE:demo-key"
+
+# 6. Release is idempotent (already free)
+out="$(run lease-release demo-key)"
+check_contains "release of free key → FREE" "$out" "FREE:demo-key"
+
+# 7. Re-acquire after release works
+out="$(run lease-acquire demo-key 3600)"; rc=$?
+check_contains "re-acquire after release → ACQUIRED" "$out" "ACQUIRED:demo-key"
+check_rc "re-acquire rc 0" "$rc" "0"
+run lease-release demo-key >/dev/null
+
+# 8. TTL reclaim: acquire with ttl=0 → immediately expired → next acquire RECLAIMS
+run lease-acquire stale-key -5 >/dev/null
+out="$(run lease-status stale-key)"
+check_contains "expired lease reports expired" "$out" "expired=true"
+out="$(run lease-acquire stale-key 3600)"; rc=$?
+check_contains "expired lease → RECLAIMED" "$out" "RECLAIMED:stale-key"
+check_rc "reclaim rc 0" "$rc" "0"
+run lease-release stale-key >/dev/null
+
+# 9. lease-gc collects an expired lease
+run lease-acquire gc-key -5 >/dev/null
+out="$(run lease-gc)"
+check_contains "lease-gc releases expired key" "$out" "GC_RELEASED:gc-key"
+out="$(run lease-status gc-key)"
+check_contains "gc'd key is FREE" "$out" "FREE:gc-key"
+
+echo ""
+if [[ "$fail" -eq 0 ]]; then
+  printf 'lease.test.sh: PASS (%d checks)\n' "$ran"; exit 0
+else
+  printf 'lease.test.sh: FAIL (%d/%d failed)\n' "$fail" "$ran"; exit 1
+fi

--- a/.claude/scripts/tests/mock-pipeline-helper.sh
+++ b/.claude/scripts/tests/mock-pipeline-helper.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Mock pipeline-helper.sh for hermetic script tests. Points CFGMS_TEST_PIPELINE_HELPER
+# at this so po-act.sh / agent-dispatch.sh lease calls never touch real GitHub.
+#
+# Default: every lease-acquire succeeds (ACQUIRED), every release is a no-op.
+# Override per-test with MOCK_LEASE=<held|error> to force the contention/error
+# branches. Only the lease-* subcommands are implemented; anything else is a
+# loud failure so a test that needs a real helper call is caught.
+set -euo pipefail
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  lease-acquire)
+    key="${1:-}"
+    case "${MOCK_LEASE:-ok}" in
+      held)  echo "HELD:${key}:other-host:exp=9999999999"; exit 1 ;;
+      error) echo "ACQUIRE_ERROR:${key}:mock forced error"; exit 2 ;;
+      *)     echo "ACQUIRED:${key}:mock-host:exp=9999999999"; exit 0 ;;
+    esac
+    ;;
+  lease-release) echo "RELEASED:${1:-}"; exit 0 ;;
+  lease-status)  echo "FREE:${1:-}"; exit 0 ;;
+  lease-list)    exit 0 ;;
+  lease-gc)      echo "LEASE_GC_DONE:0"; exit 0 ;;
+  *)
+    echo "MOCK_PIPELINE_HELPER_UNEXPECTED_CALL:${cmd}" >&2
+    exit 1
+    ;;
+esac

--- a/.claude/scripts/tests/resolve_conflict.test.sh
+++ b/.claude/scripts/tests/resolve_conflict.test.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Route lease calls to the hermetic mock so this test never touches real GitHub.
 export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
+# Bypass the resource admission gate so tests are deterministic on any host.
+export CFGMS_AGENT_CAPACITY_GATE=off
 PO_ACT="${SCRIPT_DIR}/../po-act.sh"
 PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
 

--- a/.claude/scripts/tests/resolve_conflict.test.sh
+++ b/.claude/scripts/tests/resolve_conflict.test.sh
@@ -11,6 +11,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Route lease calls to the hermetic mock so this test never touches real GitHub.
+export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
 PO_ACT="${SCRIPT_DIR}/../po-act.sh"
 PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
 

--- a/.claude/scripts/tests/review_pr_detection.test.sh
+++ b/.claude/scripts/tests/review_pr_detection.test.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Route lease calls to the hermetic mock so this test never touches real GitHub.
 export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
+# Bypass the resource admission gate so tests are deterministic on any host.
+export CFGMS_AGENT_CAPACITY_GATE=off
 DISPATCH="${SCRIPT_DIR}/../agent-dispatch.sh"
 
 fail=0

--- a/.claude/scripts/tests/review_pr_detection.test.sh
+++ b/.claude/scripts/tests/review_pr_detection.test.sh
@@ -13,6 +13,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Route lease calls to the hermetic mock so this test never touches real GitHub.
+export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
 DISPATCH="${SCRIPT_DIR}/../agent-dispatch.sh"
 
 fail=0

--- a/.claude/scripts/tests/stalled_dispatch.test.sh
+++ b/.claude/scripts/tests/stalled_dispatch.test.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Route lease calls to the hermetic mock so this test never touches real GitHub.
 export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
+# Bypass the resource admission gate so tests are deterministic on any host.
+export CFGMS_AGENT_CAPACITY_GATE=off
 PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
 
 if [[ ! -f "${PREFLIGHT}" ]]; then

--- a/.claude/scripts/tests/stalled_dispatch.test.sh
+++ b/.claude/scripts/tests/stalled_dispatch.test.sh
@@ -9,6 +9,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Route lease calls to the hermetic mock so this test never touches real GitHub.
+export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
 PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
 
 if [[ ! -f "${PREFLIGHT}" ]]; then

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -14,6 +14,21 @@ source "$(dirname "${BASH_SOURCE[0]}")/agent-context.sh"
 # at /usr/local/bin/ with no sibling scripts/ dir. Test harness overrides via
 # CFGMS_TEST_PROJECT_QUEUE to point at the host repo.
 PROJECT_QUEUE="${CFGMS_TEST_PROJECT_QUEUE:-/workspace/scripts/project-queue.sh}"
+PIPELINE_HELPER="${CFGMS_TEST_PIPELINE_HELPER:-/workspace/scripts/pipeline-helper.sh}"
+
+# Distributed-lease release (multi-host cron coordination). The launching host
+# passed CFGMS_LEASE_KEY (story-<item> for dev, pr-<N> for fix/resolve) and is
+# counting on THIS container to release it on exit — that "unlock when the agent
+# returns" is what lets whichever cron host comes back first pick up the next
+# phase (review/fix). Released unconditionally (success OR failure): a failed dev
+# run that resets the story to Ready must also free the lease so a later cycle
+# can re-dispatch. TTL reclaim is the backstop if the container dies first.
+release_cfgms_lease() {
+  [ -n "${CFGMS_LEASE_KEY:-}" ] || return 0
+  [ -f "$PIPELINE_HELPER" ] || return 0
+  bash "$PIPELINE_HELPER" lease-release "$CFGMS_LEASE_KEY" >/dev/null 2>&1 || true
+}
+trap release_cfgms_lease EXIT
 
 # --- Argument parsing ---
 MODE="issue"

--- a/.devcontainer/scripts/review-entrypoint.sh
+++ b/.devcontainer/scripts/review-entrypoint.sh
@@ -18,6 +18,17 @@ set -euo pipefail
 
 PROMPT_FILE="/workspace/.acceptance-review-prompt.md"
 
+# Distributed-lease release (multi-host cron coordination). agent-dispatch.sh
+# review-pr acquired pr-<N> and passed it as CFGMS_LEASE_KEY; release it on exit
+# so whichever cron host comes back first can pick up the next phase (fix on
+# FAIL, or merge on PASS). TTL reclaim is the backstop if this container dies.
+release_cfgms_lease() {
+  [ -n "${CFGMS_LEASE_KEY:-}" ] || return 0
+  [ -f /workspace/scripts/pipeline-helper.sh ] || return 0
+  bash /workspace/scripts/pipeline-helper.sh lease-release "$CFGMS_LEASE_KEY" >/dev/null 2>&1 || true
+}
+trap release_cfgms_lease EXIT
+
 # --- Phase 0: Environment setup ---
 
 # Shared setup: firewall, credential symlinks, git config (idempotent).

--- a/scripts/pipeline-helper.sh
+++ b/scripts/pipeline-helper.sh
@@ -42,6 +42,13 @@ Community issues (human-directed, interactive sessions only):
 
 Lock maintenance (run from the PO cron):
   lock-sweep                                     Lock+internal pipeline PRs; re-lock any unlocked internal issue
+
+Distributed leases (multi-host cron coordination — atomic git-ref lock):
+  lease-acquire <key> [ttl_seconds]              Try to claim <key>; ACQUIRED/RECLAIMED (rc0), HELD (rc1), ACQUIRE_ERROR (rc2)
+  lease-release <key>                            Release <key> (idempotent)
+  lease-status <key>                             HELD:<holder>:exp:expired | FREE
+  lease-list                                     TSV of all live leases: key, holder, exp, expired
+  lease-gc                                       Delete all expired lease refs (run from cleanup-stale)
 USAGE
   exit 1
 }
@@ -315,6 +322,164 @@ for iss in issues:
 
 print(f"LOCK_SWEEP_DONE:{locked_count}")
 PYEOF
+    ;;
+
+  # ── Distributed leases (multi-host cron coordination) ────────────────
+  #
+  # The pipeline can run `/po cron` on more than one host concurrently. To keep
+  # two hosts from dispatching the same work unit, every collision-prone action
+  # (dev dispatch, PR review/fix/resolve, epic decompose, pin refresh, sweep)
+  # acquires a lease keyed on the work unit BEFORE acting.
+  #
+  # The lease is a git ref under refs/cfgms-lease/<key>. Creating a ref is the
+  # ONE server-atomic operation GitHub exposes — POST git/refs returns 422 if the
+  # ref already exists — so exactly one racing host wins regardless of how many
+  # attempt it. No host-local state is involved: the lock lives in GitHub, so
+  # every host sees it. The ref points at an orphan commit whose message encodes
+  # holder + acquired + exp epochs; a held lease past its exp is reclaimable
+  # (covers a host that died holding it). Reclaim (PATCH ref --force) is the only
+  # non-atomic step, but it is bounded to crash recovery, not steady state.
+  #
+  # Lifetimes:
+  #  - Container ops (dev/review/fix/resolve): the launching host acquires, passes
+  #    CFGMS_LEASE_KEY into the container, and the container's entrypoint releases
+  #    on exit. Crash backstop = TTL reclaim.
+  #  - Inline ops (decompose/pin/sweep/rebase): the host acquires, runs in-session,
+  #    releases in a trap. Short TTL.
+
+  lease-acquire)
+    # lease-acquire <key> [ttl_seconds]
+    # ACQUIRED:<key>:<holder>:exp=<exp>   (rc 0) — you now hold it
+    # RECLAIMED:<key>:<holder> (was <prev>) (rc 0) — prior holder's lease expired
+    # HELD:<key>:<holder>:exp=<exp>       (rc 1) — someone else holds a live lease
+    # ACQUIRE_ERROR:<key>:<detail>        (rc 2) — API/transport failure
+    key=$(printf '%s' "${1:?Usage: lease-acquire <key> [ttl_seconds]}" | tr -c 'A-Za-z0-9._-' '-')
+    ttl="${2:-3600}"
+    owner="${REPO%%/*}"; name="${REPO##*/}"
+    holder="${CFGMS_HOST_ID:-$(hostname 2>/dev/null || echo unknown)}"
+    now=$(date +%s); exp=$(( now + ttl ))
+    empty_tree="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    msg="cfgms-lease key=${key} holder=${holder} acquired=${now} exp=${exp}"
+
+    commit_sha=$(gh api -X POST "repos/${owner}/${name}/git/commits" \
+      -f message="$msg" -f tree="$empty_tree" --jq '.sha' 2>/dev/null || true)
+    if [ -z "$commit_sha" ]; then
+      echo "ACQUIRE_ERROR:${key}:could not create lease commit object"
+      exit 2
+    fi
+
+    err_file=$(mktemp)
+    if gh api -X POST "repos/${owner}/${name}/git/refs" \
+        -f ref="refs/cfgms-lease/${key}" -f sha="$commit_sha" >/dev/null 2>"$err_file"; then
+      rm -f "$err_file"
+      echo "ACQUIRED:${key}:${holder}:exp=${exp}"
+      exit 0
+    fi
+
+    # createRef failed — distinguish "already exists" (contention) from real errors.
+    if ! grep -qi "already exists" "$err_file"; then
+      detail=$(tr -d '\n' < "$err_file" | cut -c1-200); rm -f "$err_file"
+      echo "ACQUIRE_ERROR:${key}:${detail}"
+      exit 2
+    fi
+    rm -f "$err_file"
+
+    # Held — inspect the incumbent for staleness.
+    cur_sha=$(gh api "repos/${owner}/${name}/git/ref/cfgms-lease/${key}" --jq '.object.sha' 2>/dev/null || true)
+    cur_msg=""
+    [ -n "$cur_sha" ] && cur_msg=$(gh api "repos/${owner}/${name}/git/commits/${cur_sha}" --jq '.message' 2>/dev/null || true)
+    cur_exp=$(printf '%s' "$cur_msg" | grep -oE 'exp=[0-9]+' | head -1 | cut -d= -f2)
+    cur_holder=$(printf '%s' "$cur_msg" | grep -oE 'holder=[^ ]+' | head -1 | cut -d= -f2)
+    cur_holder="${cur_holder:-unknown}"
+
+    if [ -n "$cur_exp" ] && [ "$now" -gt "$cur_exp" ]; then
+      # Stale — reclaim by force-pointing the ref at our fresh commit.
+      if gh api -X PATCH "repos/${owner}/${name}/git/refs/cfgms-lease/${key}" \
+          -f sha="$commit_sha" -F force=true >/dev/null 2>&1; then
+        echo "RECLAIMED:${key}:${holder} (was ${cur_holder}, expired)"
+        exit 0
+      fi
+      echo "ACQUIRE_ERROR:${key}:reclaim of expired lease (holder ${cur_holder}) failed"
+      exit 2
+    fi
+    echo "HELD:${key}:${cur_holder}:exp=${cur_exp:-unknown}"
+    exit 1
+    ;;
+
+  lease-release)
+    # lease-release <key>  →  RELEASED:<key> (idempotent; FREE if already gone)
+    key=$(printf '%s' "${1:?Usage: lease-release <key>}" | tr -c 'A-Za-z0-9._-' '-')
+    owner="${REPO%%/*}"; name="${REPO##*/}"
+    if gh api -X DELETE "repos/${owner}/${name}/git/refs/cfgms-lease/${key}" >/dev/null 2>&1; then
+      echo "RELEASED:${key}"
+    else
+      # 404/422 → ref already absent; any other error is non-fatal for a release.
+      echo "FREE:${key}"
+    fi
+    exit 0
+    ;;
+
+  lease-status)
+    # lease-status <key>  →  HELD:<key>:<holder>:exp=<exp>:expired=<bool> | FREE:<key>
+    key=$(printf '%s' "${1:?Usage: lease-status <key>}" | tr -c 'A-Za-z0-9._-' '-')
+    owner="${REPO%%/*}"; name="${REPO##*/}"
+    # Key off exit status, not stdout: gh api writes the 404 body to stdout and
+    # ignores --jq on error, so an empty-stdout test would misread a free key.
+    if ! cur_sha=$(gh api "repos/${owner}/${name}/git/ref/cfgms-lease/${key}" --jq '.object.sha' 2>/dev/null); then
+      cur_sha=""
+    fi
+    if [ -z "$cur_sha" ]; then echo "FREE:${key}"; exit 0; fi
+    cur_msg=$(gh api "repos/${owner}/${name}/git/commits/${cur_sha}" --jq '.message' 2>/dev/null || true)
+    cur_exp=$(printf '%s' "$cur_msg" | grep -oE 'exp=[0-9]+' | head -1 | cut -d= -f2)
+    cur_holder=$(printf '%s' "$cur_msg" | grep -oE 'holder=[^ ]+' | head -1 | cut -d= -f2)
+    now=$(date +%s); expired=false
+    [ -n "$cur_exp" ] && [ "$now" -gt "$cur_exp" ] && expired=true
+    echo "HELD:${key}:${cur_holder:-unknown}:exp=${cur_exp:-unknown}:expired=${expired}"
+    exit 0
+    ;;
+
+  lease-list)
+    # lease-list  →  one TSV line per live lease ref: <key>\t<holder>\t<exp>\t<expired>
+    owner="${REPO%%/*}"; name="${REPO##*/}"
+    now=$(date +%s)
+    refs_json=$(gh api "repos/${owner}/${name}/git/matching-refs/cfgms-lease/" 2>/dev/null || echo '[]')
+    printf '%s' "$refs_json" | python3 -c "
+import json,sys,subprocess
+try: refs=json.load(sys.stdin)
+except Exception: refs=[]
+now=${now}
+for r in refs:
+    key=r['ref'].replace('refs/cfgms-lease/','')
+    sha=r.get('object',{}).get('sha','')
+    msg=''
+    if sha:
+        p=subprocess.run(['gh','api','repos/${owner}/${name}/git/commits/'+sha,'--jq','.message'],capture_output=True,text=True)
+        msg=p.stdout.strip()
+    import re
+    exp=(re.search(r'exp=(\d+)',msg) or [None,''])[1]
+    holder=(re.search(r'holder=(\S+)',msg) or [None,''])[1]
+    expired = bool(exp) and now>int(exp)
+    print(f'{key}\t{holder}\t{exp}\t{expired}')
+" 2>/dev/null || true
+    exit 0
+    ;;
+
+  lease-gc)
+    # lease-gc  →  delete every expired lease ref. Safe to run every cycle.
+    # Belt-and-suspenders alongside acquire-time reclaim: keeps refs/cfgms-lease/
+    # tidy when a crashed holder's work is picked up by status/stalled recovery
+    # rather than by a direct re-acquire of the same key.
+    owner="${REPO%%/*}"; name="${REPO##*/}"
+    gced=0
+    while IFS=$'\t' read -r key holder exp expired; do
+      [ "$expired" = "True" ] || [ "$expired" = "true" ] || continue
+      if gh api -X DELETE "repos/${owner}/${name}/git/refs/cfgms-lease/${key}" >/dev/null 2>&1; then
+        echo "GC_RELEASED:${key} (was ${holder:-unknown}, expired)"
+        gced=$(( gced + 1 ))
+      fi
+    done < <(bash "$0" lease-list)
+    echo "LEASE_GC_DONE:${gced}"
+    exit 0
     ;;
 
   *)


### PR DESCRIPTION
## Problem

`/po cron` was only safe on **disjoint execution-environment slices** (one Linux orchestrator + one Windows self-dispatch host). The code said so explicitly (`po-act.sh`: *"no distributed lock is needed… combined with disjoint per-host env slices"*). Running it on **multiple homogeneous hosts** (e.g. two Linux cron loops) breaks that: the only interlocks were a racy Projects-V2 status flip (no CAS), local `docker ps` checks (invisible across hosts), and marker comments (read-then-write races). Worst case — two hosts each `materialize-issue` an issueless draft → **two issues, two branches, two containers, two PRs** for one story.

## Approach — distributed lease (atomic git ref)

Creating a ref (`POST git/refs` → 422 if exists) is the one server-atomic op GitHub exposes. `refs/cfgms-lease/<key>` is the lock; it points at an orphan commit whose message carries `holder`+`exp` for TTL reclaim of a crashed holder's lease. No host-local state — the lock lives in GitHub, so every host sees it.

**Lifecycle (dispatch locks, the returning agent unlocks):**

| Key | Acquired by | Released by |
|---|---|---|
| `story-<item>` | `po-act dispatch`/`claim` before materialize/claim/clone/launch | dev container entrypoint on exit; `release-story` for §7; TTL on crash |
| `pr-<N>` (review/fix/resolve + inline rebase) | `agent-dispatch review-pr`, `po-act dispatch-fix`/`resolve-conflict` | review/fix container entrypoint on exit; TTL on crash |
| `epic-decompose-<N>` / `pin-refresh-<week>` / `sweep` | po.md cron steps | the host, in-session |

When a dev agent submits its PR and its container exits, `story-*` frees; whichever cron host's next cycle comes first acquires `pr-<N>` to review it. The single `pr-<N>` key serializes review/fix/resolve across hosts (replacing the local-only `docker ps` guard).

## Changes

- **`scripts/pipeline-helper.sh`** — `lease-acquire/release/status/list/gc`.
- **`po-act.sh`** — story lease in `dispatch`/`claim`; `release-story`; `pr-<N>` lease in `dispatch-fix`/`resolve-conflict`; `CFGMS_LEASE_KEY` into containers; release on all rollback paths.
- **`agent-dispatch.sh`** — `pr-<N>` lease in `review-pr` (after story resolution, before launch); `launch-generic` forwards `CFGMS_LEASE_KEY`; `cleanup-stale` runs `lease-gc`.
- **`entrypoint.sh` / `review-entrypoint.sh`** — release `CFGMS_LEASE_KEY` on exit (EXIT trap).
- **`agents/po.md`** — new §4.-1 multi-host coordination section; lease wrapping for decompose/pin-refresh/sweep/rebase; per-host cron trigger naming (`po-cron-<CFGMS_HOST_ID>`); per-host container-cap note; replaced the disjoint-slice rationale throughout.

## Tests

- **`lease.test.sh`** — hermetic (gh-stub) 17 checks: acquire / contention / TTL-reclaim / release / status / gc.
- **`mock-pipeline-helper.sh`** — routes existing dispatch/review/fix/resolve tests off real GitHub.
- Also fixed a **pre-existing `pipefail`+SIGPIPE flake** in `agent-apikey-injection.test.sh` (`awk | grep -q` where grep exits early → awk SIGPIPE → pipeline fails), surfaced while wiring the mock. Now deterministic (28/28 over 5 runs).

Local: `scripts/test-scripts.sh` 194/0; all 6 affected hermetic suites green; lease primitive also verified end-to-end against the real repo (refs cleaned up). Changes are shell + markdown + bash tests only — no Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-on (same theme): resource admission gate replaces the magic container cap

The old 7-container cap was prose the cron honored by counting `list-running` — a magic number hand-tuned 5→7 "after docker cleanup freed disk headroom" (disk was the real binding constraint). A fixed count is a poor proxy for resource exhaustion.

**`agent-dispatch.sh capacity`** is a per-host, self-tuning admission gate: a new agent launches only while the host stays under **RAM 90% / disk 90% / CPU 75% committed**, with a `2×ncpu` runaway backstop. RAM binds on the worse of live utilisation and agent reservation (anti-thundering-herd); disk checks the worst of the worktree + docker-root filesystems; CPU is reservation-based + a loadavg ceiling. It's wired into every launch path **before lease/clone** (`po-act dispatch`/`dispatch-fix`/`resolve-conflict` → `*_DEFERRED:resources`; `review-pr` → `REVIEW_REFUSED:resources`), and the preflight surfaces a `capacity` field (`free_slots`, `binding`) as a planning hint. Knobs (`CFGMS_AGENT_{MEM_MB,CPUS,DISK_GB,*_CEIL}`) are env-overridable; `CFGMS_AGENT_CAPACITY_GATE=off` bypasses (tests).

This also resolves the per-host-7N caveat above: resource exhaustion is inherently per-host, so each host self-limits to what it can hold — no global budget, no magic number. On the dev host the gate correctly reports **disk** as binding (host at 88%).

Tests: `capacity.test.sh` (12 checks). Local: full script suite 194/0; all 7 hermetic suites green.
