### PR TITLE
connections: add connection registry and cfg connections list (Issue #2217)

### DIFF
--- a/cmd/cfg/cmd/connection_registry.go
+++ b/cmd/cfg/cmd/connection_registry.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ConnectionEntry stores non-secret metadata about a known controller connection.
+// Credential and token material is never written to this file.
+type ConnectionEntry struct {
+	Name          string    `json:"name"`
+	ControllerURL string    `json:"controller_url"`
+	AdminIdentity string    `json:"admin_identity"`
+	LastUsed      time.Time `json:"last_used"`
+	UnlockMethod  string    `json:"unlock_method,omitempty"`
+}
+
+// ConnectionRegistry manages non-secret connection metadata persisted to connections.json.
+type ConnectionRegistry struct {
+	path string
+}
+
+// newConnectionRegistry creates a ConnectionRegistry backed by the cfgms user config directory.
+// The cfgms directory is created at mode 0700 if it does not exist.
+func newConnectionRegistry() (*ConnectionRegistry, error) {
+	configDir, err := userConfigDirFn()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine user config directory: %w", err)
+	}
+	cfgmsDir := filepath.Join(configDir, "cfgms")
+	// #nosec G301 - 0700 is intentional; traversable but private config directory
+	if err := os.MkdirAll(cfgmsDir, 0700); err != nil {
+		return nil, fmt.Errorf("cannot create cfgms config directory: %w", err)
+	}
+	return &ConnectionRegistry{path: filepath.Join(cfgmsDir, "connections.json")}, nil
+}
+
+// load reads existing entries from disk, returning an empty slice when the file does not exist.
+func (r *ConnectionRegistry) load() ([]ConnectionEntry, error) {
+	// #nosec G304 - path is constructed from userConfigDir + known subpath, never from user input
+	data, err := os.ReadFile(r.path)
+	if os.IsNotExist(err) {
+		return []ConnectionEntry{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("cannot read connections file: %w", err)
+	}
+	var entries []ConnectionEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("cannot parse connections file: %w", err)
+	}
+	return entries, nil
+}
+
+// save writes entries to disk at mode 0600.
+func (r *ConnectionRegistry) save(entries []ConnectionEntry) error {
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal connections: %w", err)
+	}
+	// 0600: owner read/write only — this file sits next to the admin bundle
+	if err := os.WriteFile(r.path, data, 0600); err != nil {
+		return fmt.Errorf("cannot write connections file: %w", err)
+	}
+	return nil
+}
+
+// Register adds a new entry or overwrites an existing entry with the same name.
+func (r *ConnectionRegistry) Register(entry ConnectionEntry) error {
+	entries, err := r.load()
+	if err != nil {
+		return err
+	}
+	for i, e := range entries {
+		if e.Name == entry.Name {
+			entries[i] = entry
+			return r.save(entries)
+		}
+	}
+	return r.save(append(entries, entry))
+}
+
+// Get returns the entry for the given name, or (nil, nil) when not found.
+func (r *ConnectionRegistry) Get(name string) (*ConnectionEntry, error) {
+	entries, err := r.load()
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.Name == name {
+			cp := e
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+// List returns all registered connection entries.
+func (r *ConnectionRegistry) List() ([]ConnectionEntry, error) {
+	return r.load()
+}
+
+// UpdateLastUsed updates the LastUsed timestamp for a named connection.
+func (r *ConnectionRegistry) UpdateLastUsed(name string, t time.Time) error {
+	entries, err := r.load()
+	if err != nil {
+		return err
+	}
+	for i, e := range entries {
+		if e.Name == name {
+			entries[i].LastUsed = t
+			return r.save(entries)
+		}
+	}
+	return fmt.Errorf("connection %q not found", name)
+}
+
+// Delete removes the named connection entry. Returns an error if the name does not exist.
+func (r *ConnectionRegistry) Delete(name string) error {
+	entries, err := r.load()
+	if err != nil {
+		return err
+	}
+	filtered := entries[:0]
+	found := false
+	for _, e := range entries {
+		if e.Name == name {
+			found = true
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	if !found {
+		return fmt.Errorf("connection %q not found", name)
+	}
+	return r.save(filtered)
+}

--- a/cmd/cfg/cmd/connection_registry_test.go
+++ b/cmd/cfg/cmd/connection_registry_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withTempConfigDir overrides userConfigDirFn to use t.TempDir() and restores it via t.Cleanup.
+// Returns the temp directory path for use in per-test assertions.
+func withTempConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := userConfigDirFn
+	t.Cleanup(func() { userConfigDirFn = orig })
+	userConfigDirFn = func() (string, error) { return dir, nil }
+	return dir
+}
+
+// TestConnectionRegistry_RoundTrip exercises the full register → list → update-last-used → delete
+// lifecycle and asserts the written JSON contains no credential, key, cert, or token field name.
+func TestConnectionRegistry_RoundTrip(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	entry := ConnectionEntry{
+		Name:          "prod",
+		ControllerURL: "https://ctrl.example.com:9090",
+		AdminIdentity: "admin@example.com",
+	}
+
+	// Register — writes new entry
+	require.NoError(t, reg.Register(entry))
+
+	// List returns the registered entry
+	list, err := reg.List()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "prod", list[0].Name)
+	assert.Equal(t, "https://ctrl.example.com:9090", list[0].ControllerURL)
+	assert.Equal(t, "admin@example.com", list[0].AdminIdentity)
+
+	// Assert written JSON contains no sensitive field names
+	raw, err := os.ReadFile(reg.path)
+	require.NoError(t, err)
+	var parsed []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	sensitivePatterns := []string{"credential", "key", "cert", "token", "secret", "password"}
+	for _, e := range parsed {
+		for fieldName := range e {
+			lower := strings.ToLower(fieldName)
+			for _, pattern := range sensitivePatterns {
+				assert.NotContainsf(t, lower, pattern,
+					"JSON field %q matches sensitive pattern %q — no credentials may appear in connections.json",
+					fieldName, pattern)
+			}
+		}
+	}
+
+	// UpdateLastUsed
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, reg.UpdateLastUsed("prod", now))
+
+	list, err = reg.List()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, now, list[0].LastUsed.UTC().Truncate(time.Second))
+
+	// Delete
+	require.NoError(t, reg.Delete("prod"))
+
+	list, err = reg.List()
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestConnectionRegistry_FilePermissions(t *testing.T) {
+	dir := withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	// Write at least one entry so the file is created
+	require.NoError(t, reg.Register(ConnectionEntry{
+		Name:          "perm-test",
+		ControllerURL: "https://ctrl.example.com:9090",
+		AdminIdentity: "admin@example.com",
+	}))
+
+	// Config directory must be 0700
+	cfgmsDir := dir + "/cfgms"
+	dirInfo, err := os.Stat(cfgmsDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), dirInfo.Mode().Perm(),
+		"cfgms config directory must have mode 0700")
+
+	// connections.json must be 0600
+	fileInfo, err := os.Stat(reg.path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), fileInfo.Mode().Perm(),
+		"connections.json must have mode 0600")
+}
+
+func TestConnectionRegistry_EmptyListWhenNoFile(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	list, err := reg.List()
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestConnectionRegistry_RegisterOverwritesSameName(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	first := ConnectionEntry{Name: "staging", ControllerURL: "https://old.example.com:9090", AdminIdentity: "old-admin"}
+	require.NoError(t, reg.Register(first))
+
+	updated := ConnectionEntry{Name: "staging", ControllerURL: "https://new.example.com:9090", AdminIdentity: "new-admin"}
+	require.NoError(t, reg.Register(updated))
+
+	list, err := reg.List()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "https://new.example.com:9090", list[0].ControllerURL)
+	assert.Equal(t, "new-admin", list[0].AdminIdentity)
+}
+
+func TestConnectionRegistry_MultipleEntries(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	names := []string{"prod", "staging", "dev"}
+	for _, name := range names {
+		require.NoError(t, reg.Register(ConnectionEntry{
+			Name:          name,
+			ControllerURL: "https://" + name + ".example.com:9090",
+			AdminIdentity: name + "-admin",
+		}))
+	}
+
+	list, err := reg.List()
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+
+	got := make(map[string]bool)
+	for _, e := range list {
+		got[e.Name] = true
+	}
+	for _, name := range names {
+		assert.True(t, got[name], "expected entry %q in list", name)
+	}
+}
+
+func TestConnectionRegistry_Get(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Register(ConnectionEntry{
+		Name:          "prod",
+		ControllerURL: "https://ctrl.example.com:9090",
+		AdminIdentity: "admin@example.com",
+	}))
+
+	got, err := reg.Get("prod")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "prod", got.Name)
+	assert.Equal(t, "https://ctrl.example.com:9090", got.ControllerURL)
+}
+
+func TestConnectionRegistry_GetNonExistent(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	got, err := reg.Get("nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestConnectionRegistry_DeleteNonExistent(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	err = reg.Delete("nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestConnectionRegistry_UpdateLastUsedNonExistent(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	err = reg.UpdateLastUsed("nonexistent", time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}

--- a/cmd/cfg/cmd/connections.go
+++ b/cmd/cfg/cmd/connections.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var connectionsListJSON bool
+
+var connectionsCmd = &cobra.Command{
+	Use:   "connections",
+	Short: "Manage known controller connections",
+	Long: `Commands for managing the local registry of known controller connections.
+
+The connection registry stores non-secret metadata (name, controller URL, admin
+identity, last used, unlock method) in the cfgms user config directory:
+
+  Linux:   $XDG_CONFIG_HOME/cfgms/connections.json
+  macOS:   ~/Library/Application Support/cfgms/connections.json
+  Windows: %APPDATA%\cfgms\connections.json
+
+No credential or token material is ever written to this file.`,
+}
+
+var connectionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered controller connections",
+	Long: `List all registered controller connections from the local registry.
+
+Prints a table with name, URL, admin identity, and last-used timestamp for each
+registered connection. Use --json to emit a JSON array instead.
+
+Examples:
+  cfg connections list
+  cfg connections list --json`,
+	RunE: runConnectionsList,
+}
+
+func init() {
+	connectionsListCmd.Flags().BoolVar(&connectionsListJSON, "json", false, "Emit JSON array instead of human-readable table")
+	connectionsCmd.AddCommand(connectionsListCmd)
+}
+
+func runConnectionsList(cmd *cobra.Command, args []string) error {
+	reg, err := newConnectionRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to open connection registry: %w", err)
+	}
+
+	entries, err := reg.List()
+	if err != nil {
+		return fmt.Errorf("failed to list connections: %w", err)
+	}
+
+	if connectionsListJSON {
+		return json.NewEncoder(os.Stdout).Encode(entries)
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No connections configured.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "NAME\tURL\tIDENTITY\tLAST USED"); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		lastUsed := "-"
+		if !e.LastUsed.IsZero() {
+			lastUsed = e.LastUsed.Format(time.RFC3339)
+		}
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			e.Name,
+			e.ControllerURL,
+			e.AdminIdentity,
+			lastUsed,
+		); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}

--- a/cmd/cfg/cmd/connections_test.go
+++ b/cmd/cfg/cmd/connections_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionsList_Empty(t *testing.T) {
+	withTempConfigDir(t)
+
+	orig := connectionsListJSON
+	t.Cleanup(func() { connectionsListJSON = orig })
+	connectionsListJSON = false
+
+	output := captureStdout(t, func() {
+		err := runConnectionsList(connectionsListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No connections configured.")
+}
+
+func TestConnectionsList_Table(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, reg.Register(ConnectionEntry{
+		Name:          "prod",
+		ControllerURL: "https://ctrl.example.com:9090",
+		AdminIdentity: "admin@example.com",
+		LastUsed:      ts,
+	}))
+
+	orig := connectionsListJSON
+	t.Cleanup(func() { connectionsListJSON = orig })
+	connectionsListJSON = false
+
+	output := captureStdout(t, func() {
+		err := runConnectionsList(connectionsListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "prod")
+	assert.Contains(t, output, "https://ctrl.example.com:9090")
+	assert.Contains(t, output, "admin@example.com")
+	assert.Contains(t, output, "2026-06-01T12:00:00Z")
+	assert.Contains(t, output, "NAME")
+	assert.Contains(t, output, "URL")
+	assert.Contains(t, output, "IDENTITY")
+	assert.Contains(t, output, "LAST USED")
+}
+
+func TestConnectionsList_JSON(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Register(ConnectionEntry{
+		Name:          "staging",
+		ControllerURL: "https://staging.example.com:9090",
+		AdminIdentity: "staging-admin",
+	}))
+
+	orig := connectionsListJSON
+	t.Cleanup(func() { connectionsListJSON = orig })
+	connectionsListJSON = true
+
+	output := captureStdout(t, func() {
+		err := runConnectionsList(connectionsListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	var entries []ConnectionEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries))
+	require.Len(t, entries, 1)
+	assert.Equal(t, "staging", entries[0].Name)
+	assert.Equal(t, "https://staging.example.com:9090", entries[0].ControllerURL)
+}
+
+func TestConnectionsList_NoLastUsed(t *testing.T) {
+	withTempConfigDir(t)
+
+	reg, err := newConnectionRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Register(ConnectionEntry{
+		Name:          "dev",
+		ControllerURL: "https://dev.example.com:9090",
+		AdminIdentity: "dev-admin",
+	}))
+
+	orig := connectionsListJSON
+	t.Cleanup(func() { connectionsListJSON = orig })
+	connectionsListJSON = false
+
+	output := captureStdout(t, func() {
+		err := runConnectionsList(connectionsListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "dev")
+	assert.Contains(t, output, "-")
+}

--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -60,6 +60,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(installerCmd)
 	rootCmd.AddCommand(moduleCmd)
+	rootCmd.AddCommand(connectionsCmd)
 }
 
 // versionCmd represents the version command

--- a/docs/development/commands-reference.md
+++ b/docs/development/commands-reference.md
@@ -376,3 +376,41 @@ make security-scan           # Security validation
 ```
 
 For automation of these commands, use the CFGMS slash commands: `/story-start`, `/story-commit`, `/story-complete`.
+
+## Connection Management
+
+The `cfg connections` commands manage the local registry of known controller connections. The registry stores non-secret metadata only — no credentials, tokens, or keys are ever written to this file.
+
+Registry location:
+
+| Platform | Path |
+|----------|------|
+| Linux | `$XDG_CONFIG_HOME/cfgms/connections.json` |
+| macOS | `~/Library/Application Support/cfgms/connections.json` |
+| Windows | `%APPDATA%\cfgms\connections.json` |
+
+File permissions: directory at `0700`, `connections.json` at `0600`.
+
+### cfg connections list
+
+List all registered controller connections.
+
+```bash
+# Print a table of known connections (name, URL, identity, last-used)
+cfg connections list
+
+# Emit a JSON array
+cfg connections list --json
+```
+
+When no connections are registered, exits 0 and prints:
+
+```
+No connections configured.
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit a JSON array instead of a human-readable table |


### PR DESCRIPTION
## Summary

- Adds `ConnectionRegistry` type backed by `os.UserConfigDir()/cfgms/connections.json` with `Register`, `Get`, `List`, `UpdateLastUsed`, and `Delete` operations
- Adds `cfg connections list` command with tabwriter table output and `--json` flag
- No credential, key, cert, or token material is ever written to the connections file; round-trip test asserts this by inspecting raw JSON field names

Fixes #2217

## Implementation Details

The registry is created at mode `0700` (directory) / `0600` (file), following the same `userConfigDirFn` override pattern from `client_helpers.go` for test isolation. The cobra command style matches `token.go` (`--json` flag) and `config.go` (tabwriter table).

## Test Coverage

- `TestConnectionRegistry_RoundTrip` — required test: register → list → update-last-used → delete with JSON field name assertion
- `TestConnectionRegistry_FilePermissions` — asserts `0700` directory and `0600` file via `os.Stat`
- 7 additional registry tests covering empty list, overwrite, multiple entries, Get, and error paths (DeleteNonExistent, UpdateLastUsedNonExistent, GetNonExistent)
- 4 command tests: empty output, table output, JSON output, zero last-used display

## Specialist Review Results

**QA Test Runner**: PASS — All 168 packages pass, lint clean, cross-platform builds verified, security scans clean.

**QA Code Reviewer**: PASS — No blocking issues. 3 non-blocking warnings (missing edge-case tests for corrupt JSON, failing `userConfigDirFn`, and registry-open failure in the list command — all edge cases, not operational paths).

**Security Engineer**: PASS — No blocking issues. `security-precommit`, `check-architecture`, and `security-scan` all pass. File permissions correct and tested. No sensitive field names in `ConnectionEntry`. `#nosec` annotations have valid justifications.