### PR TITLE
cfg: add install-to-PATH targets for Linux/macOS/Windows (Issue #2216)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-unit test-integration-factory test-watch test-commit test-complete test-e2e-local test-e2e-parallel test-e2e-ci test-e2e-controller test-e2e-scenarios test-e2e-fleet test-ci test-integration test-security test-performance test-performance-baseline test-data-consistency test-docker test-cross-feature-integration test-failure-propagation proto proto-gen proto-gen-modules lint lint-log-injection clean security-trivy security-deps security-scan security-check security-precommit check-architecture check-license-headers generate-test-certificates build-msi-windows build-pkg-darwin test-install-sh
+.PHONY: build test test-unit test-integration-factory test-watch test-commit test-complete test-e2e-local test-e2e-parallel test-e2e-ci test-e2e-controller test-e2e-scenarios test-e2e-fleet test-ci test-integration test-security test-performance test-performance-baseline test-data-consistency test-docker test-cross-feature-integration test-failure-propagation proto proto-gen proto-gen-modules lint lint-log-injection clean security-trivy security-deps security-scan security-check security-precommit check-architecture check-license-headers generate-test-certificates build-msi-windows build-pkg-darwin test-install-sh install-cfg uninstall-cfg test-install-cfg
 
 # Use bash for all recipe commands (required for credential loading scripts)
 SHELL := /bin/bash
@@ -270,6 +270,68 @@ test-install-sh:
 	@echo "=================================="
 	@bash build/linux/install_test.sh
 	@echo "✅ Linux install.sh tests passed"
+
+# Install cfg CLI binary onto PATH (Issue #2216)
+# Depends on build-cli so the installed binary is always current.
+# Linux/macOS: delegates to scripts/install-cfg.sh (root → /usr/local/bin, non-root → ~/.local/bin).
+# Windows: copies bin/cfg.exe to %GOPATH%/bin.
+install-cfg: build-cli
+	@DETECTED_OS="$$(go env GOOS)"; \
+	if [ "$$DETECTED_OS" = "windows" ]; then \
+		GOPATH_BIN="$$(go env GOPATH | tr '\\' '/')/bin"; \
+		mkdir -p "$$GOPATH_BIN"; \
+		cp bin/cfg.exe "$$GOPATH_BIN/cfg.exe"; \
+		echo "cfg installed to $$GOPATH_BIN/cfg.exe"; \
+		case ":$$PATH:" in \
+			*":$$GOPATH_BIN:"*) ;; \
+			*) \
+				echo ""; \
+				echo "Note: $$GOPATH_BIN is not on your PATH."; \
+				echo "To add it permanently, run in PowerShell:"; \
+				echo "  setx PATH \"%PATH%;$$GOPATH_BIN\""; \
+				;; \
+		esac; \
+	else \
+		bash scripts/install-cfg.sh; \
+	fi
+
+# Remove the cfg CLI binary installed by install-cfg (Issue #2216)
+# Accepts an optional PREFIX= override: make uninstall-cfg PREFIX=/opt/cfgms/bin
+# Without PREFIX, removes from /usr/local/bin and ~/.local/bin (the two defaults).
+uninstall-cfg:
+	@DETECTED_OS="$$(go env GOOS)"; \
+	if [ "$$DETECTED_OS" = "windows" ]; then \
+		GOPATH_BIN="$$(go env GOPATH | tr '\\' '/')/bin"; \
+		TARGET="$$GOPATH_BIN/cfg.exe"; \
+		rm -f "$$TARGET"; \
+		echo "cfg uninstalled from $$GOPATH_BIN"; \
+	elif [ -n "$(PREFIX)" ]; then \
+		TARGET="$(PREFIX)/cfg"; \
+		rm -f "$$TARGET"; \
+		echo "cfg uninstalled from $(PREFIX)"; \
+	else \
+		REMOVED=""; \
+		if [ -f "/usr/local/bin/cfg" ]; then \
+			rm -f /usr/local/bin/cfg; \
+			REMOVED="$${REMOVED:+$$REMOVED, }/usr/local/bin/cfg"; \
+		fi; \
+		if [ -f "$$HOME/.local/bin/cfg" ]; then \
+			rm -f "$$HOME/.local/bin/cfg"; \
+			REMOVED="$${REMOVED:+$$REMOVED, }$$HOME/.local/bin/cfg"; \
+		fi; \
+		if [ -n "$$REMOVED" ]; then \
+			echo "cfg uninstalled from: $$REMOVED"; \
+		else \
+			echo "cfg not found in /usr/local/bin or $$HOME/.local/bin (nothing removed)"; \
+		fi; \
+	fi
+
+# Run cfg install script integration tests (Issue #2216)
+test-install-cfg: build-cli
+	@echo "🧪 Testing scripts/install-cfg.sh"
+	@echo "=================================="
+	@bash scripts/install-cfg-test.sh
+	@echo "✅ cfg install tests passed"
 
 # Smart test - core modules + changed modules only
 test: fix-git-bare

--- a/docs/deployment/cfg-install.md
+++ b/docs/deployment/cfg-install.md
@@ -1,0 +1,113 @@
+# cfg CLI Install Guide
+
+This guide covers installing the `cfg` CLI binary on Linux, macOS, and Windows.
+
+## Linux and macOS
+
+### Quick install (system-wide, requires root)
+
+```bash
+make build-cli && sudo bash scripts/install-cfg.sh
+```
+
+Installs `cfg` to `/usr/local/bin/cfg`. Verify:
+
+```bash
+which cfg
+cfg version
+```
+
+### Install without root (user-local)
+
+```bash
+make build-cli && bash scripts/install-cfg.sh
+```
+
+Without root, the script installs to `~/.local/bin/cfg`. If that directory is not on your `PATH`, the script prints a hint:
+
+```
+Note: /home/<user>/.local/bin is not on your PATH.
+Add it by running:
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
+```
+
+After adding it to your PATH, verify:
+
+```bash
+which cfg
+cfg version
+```
+
+### Custom install prefix
+
+```bash
+make build-cli && bash scripts/install-cfg.sh --prefix /opt/cfgms/bin
+```
+
+The script creates the prefix directory if it does not exist.
+
+### Re-install
+
+Re-running the install command over an existing binary exits 0 (idempotent).
+
+### Uninstall
+
+For the two default locations (`/usr/local/bin` and `~/.local/bin`):
+
+```bash
+make uninstall-cfg
+```
+
+For a custom prefix install:
+
+```bash
+make uninstall-cfg PREFIX=/opt/cfgms/bin
+```
+
+Or manually:
+
+```bash
+rm -f /usr/local/bin/cfg
+# or, for user-local install:
+rm -f ~/.local/bin/cfg
+# or, for a custom prefix:
+rm -f /opt/cfgms/bin/cfg
+```
+
+---
+
+## Windows
+
+On Windows, `make install-cfg` copies `bin\cfg.exe` to `%GOPATH%\bin`.
+
+```
+make build-cli && make install-cfg
+```
+
+Verify the install:
+
+```powershell
+Get-Command cfg
+cfg version
+```
+
+### PATH setup
+
+`%GOPATH%\bin` must be on your `PATH`. If `Get-Command cfg` fails, add it permanently:
+
+```powershell
+setx PATH "%PATH%;%GOPATH%\bin"
+```
+
+Then restart your terminal and verify again with `Get-Command cfg`.
+
+---
+
+## Running tests
+
+```bash
+make test-install-cfg
+```
+
+Runs `scripts/install-cfg-test.sh`, which installs `cfg` to a temporary directory,
+verifies `cfg version` exits 0, and confirms that re-install is idempotent.

--- a/scripts/install-cfg-test.sh
+++ b/scripts/install-cfg-test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# install-cfg-test.sh — Integration tests for scripts/install-cfg.sh.
+#
+# Tests install to a temp prefix, verifies cfg runs, and re-installs
+# idempotently. Does not require root. Requires a pre-built bin/cfg binary.
+#
+# Usage:
+#   bash scripts/install-cfg-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SCRIPT="$SCRIPT_DIR/install-cfg.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; ((PASS++)) || true; }
+fail() { echo "FAIL: $1"; ((FAIL++)) || true; }
+
+# ── Centralized cleanup ───────────────────────────────────────────────────────
+
+# All temp dirs and backup paths registered here are cleaned up on EXIT.
+CLEANUP_PATHS=()
+
+cleanup() {
+    local p
+    for p in "${CLEANUP_PATHS[@]:-}"; do
+        [[ -z "$p" ]] && continue
+        rm -rf "$p" 2>/dev/null || true
+    done
+}
+
+trap cleanup EXIT
+
+# ── Preflight: ensure bin/cfg exists ─────────────────────────────────────────
+
+if [[ ! -f "$REPO_ROOT/bin/cfg" ]]; then
+    echo "Error: bin/cfg not found. Run 'make build-cli' before running this test." >&2
+    exit 1
+fi
+
+# ── Test 1: Install to temp prefix, binary is executable and runs ─────────────
+
+T1_PREFIX="$(mktemp -d)"
+CLEANUP_PATHS+=("$T1_PREFIX")
+
+EXIT_CODE=0
+OUTPUT="$(bash "$INSTALL_SCRIPT" --prefix "$T1_PREFIX" 2>&1)" || EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]] && [[ -x "$T1_PREFIX/cfg" ]]; then
+    pass "test1: install exits 0 and places executable cfg binary in prefix"
+else
+    fail "test1: expected exit 0 and executable $T1_PREFIX/cfg (exit=$EXIT_CODE output='$OUTPUT')"
+fi
+
+# cfg version must exit 0
+VERSION_EXIT=0
+VERSION_OUT="$("$T1_PREFIX/cfg" version 2>&1)" || VERSION_EXIT=$?
+
+if [[ $VERSION_EXIT -eq 0 ]]; then
+    pass "test1: $T1_PREFIX/cfg version exits 0"
+else
+    fail "test1: $T1_PREFIX/cfg version should exit 0 (exit=$VERSION_EXIT output='$VERSION_OUT')"
+fi
+
+# ── Test 2: Re-install over existing binary is idempotent (exits 0) ───────────
+
+EXIT_CODE=0
+OUTPUT="$(bash "$INSTALL_SCRIPT" --prefix "$T1_PREFIX" 2>&1)" || EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]] && [[ -x "$T1_PREFIX/cfg" ]]; then
+    pass "test2: re-install exits 0 (idempotent)"
+else
+    fail "test2: re-install should exit 0 (exit=$EXIT_CODE output='$OUTPUT')"
+fi
+
+# cfg version must still work after re-install
+VERSION_EXIT=0
+VERSION_OUT="$("$T1_PREFIX/cfg" version 2>&1)" || VERSION_EXIT=$?
+
+if [[ $VERSION_EXIT -eq 0 ]]; then
+    pass "test2: cfg version exits 0 after re-install"
+else
+    fail "test2: cfg version should exit 0 after re-install (exit=$VERSION_EXIT output='$VERSION_OUT')"
+fi
+
+# ── Test 3: install creates prefix directory when absent ──────────────────────
+
+T3_BASE="$(mktemp -d)"
+CLEANUP_PATHS+=("$T3_BASE")
+T3_PREFIX="$T3_BASE/nonexistent/subdir"
+
+EXIT_CODE=0
+OUTPUT="$(bash "$INSTALL_SCRIPT" --prefix "$T3_PREFIX" 2>&1)" || EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]] && [[ -x "$T3_PREFIX/cfg" ]]; then
+    pass "test3: install creates absent prefix directory and installs binary"
+else
+    fail "test3: expected exit 0 and binary at $T3_PREFIX/cfg (exit=$EXIT_CODE output='$OUTPUT')"
+fi
+
+# ── Test 4: missing binary exits 1 with error message ────────────────────────
+
+T4_PREFIX="$(mktemp -d)"
+CLEANUP_PATHS+=("$T4_PREFIX")
+
+ORIGINAL_BIN="$REPO_ROOT/bin/cfg"
+BACKUP_BIN="$REPO_ROOT/bin/cfg.bak.$$"
+CLEANUP_PATHS+=("$BACKUP_BIN")
+
+# Move aside; restore is guaranteed by the EXIT trap registering BACKUP_BIN
+# and by the explicit mv below (whichever fires first).
+mv "$ORIGINAL_BIN" "$BACKUP_BIN"
+
+EXIT_CODE=0
+OUTPUT="$(bash "$INSTALL_SCRIPT" --prefix "$T4_PREFIX" 2>&1)" || EXIT_CODE=$?
+
+# Restore immediately so subsequent tests work
+mv "$BACKUP_BIN" "$ORIGINAL_BIN"
+# Remove from cleanup so the EXIT trap does not try to rm the restored binary
+CLEANUP_PATHS=("${CLEANUP_PATHS[@]/$BACKUP_BIN/}")
+
+if [[ $EXIT_CODE -ne 0 ]] && echo "$OUTPUT" | grep -q "not found"; then
+    pass "test4: missing bin/cfg exits non-zero with 'not found' message"
+else
+    fail "test4: expected non-zero exit and 'not found' in output (exit=$EXIT_CODE output='$OUTPUT')"
+fi
+
+# ── Test 5: unknown argument exits non-zero with error message ────────────────
+
+EXIT_CODE=0
+OUTPUT="$(bash "$INSTALL_SCRIPT" --unknown-flag 2>&1)" || EXIT_CODE=$?
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+    pass "test5: unknown argument exits non-zero"
+else
+    fail "test5: expected non-zero exit for unknown argument (exit=$EXIT_CODE)"
+fi
+
+if echo "$OUTPUT" | grep -q "Unknown argument"; then
+    pass "test5: unknown argument emits 'Unknown argument' error message"
+else
+    fail "test5: expected 'Unknown argument' in output (exit=$EXIT_CODE output='$OUTPUT')"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/install-cfg.sh
+++ b/scripts/install-cfg.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# install-cfg.sh — Install the cfg CLI binary on Linux and macOS.
+#
+# Copies the cfg binary to a directory on PATH. Defaults to /usr/local/bin when
+# running as root; falls back to ~/.local/bin for non-root callers. If the
+# fallback directory is not already on PATH, a hint is printed.
+#
+# Usage:
+#   bash scripts/install-cfg.sh [--prefix <dir>]
+#
+# Flags:
+#   --prefix <dir>   Install directory (default: /usr/local/bin or ~/.local/bin)
+#
+# Examples:
+#   sudo bash scripts/install-cfg.sh
+#   bash scripts/install-cfg.sh --prefix ~/.local/bin
+#   bash scripts/install-cfg.sh --prefix /opt/homebrew/bin
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_SRC="$REPO_ROOT/bin/cfg"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+PREFIX=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prefix) PREFIX="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ── Resolve install prefix ────────────────────────────────────────────────────
+
+if [[ -z "$PREFIX" ]]; then
+    if [[ "$EUID" -eq 0 ]]; then
+        PREFIX="/usr/local/bin"
+    else
+        PREFIX="$HOME/.local/bin"
+    fi
+fi
+
+# ── Validate source binary ────────────────────────────────────────────────────
+
+if [[ ! -f "$BIN_SRC" ]]; then
+    echo "Error: cfg binary not found at $BIN_SRC" >&2
+    echo "Run 'make build-cli' first." >&2
+    exit 1
+fi
+
+# ── Create prefix directory if absent ────────────────────────────────────────
+
+if [[ ! -d "$PREFIX" ]]; then
+    install -d "$PREFIX"
+fi
+
+# ── Install binary ────────────────────────────────────────────────────────────
+
+install -m 755 "$BIN_SRC" "$PREFIX/cfg"
+
+echo "cfg installed to $PREFIX/cfg"
+
+# ── PATH hint for ~/.local/bin ────────────────────────────────────────────────
+
+if [[ "$PREFIX" == "$HOME/.local/bin" ]]; then
+    case ":${PATH}:" in
+        *":$PREFIX:"*) ;;
+        *)
+            echo ""
+            echo "Note: $PREFIX is not on your PATH."
+            echo "Add it by running:"
+            echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+            echo "Or for zsh:"
+            echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+            ;;
+    esac
+fi


### PR DESCRIPTION
## Summary

- Adds `make install-cfg` that builds `cfg` via `build-cli` and installs the binary to PATH on Linux/macOS (root → `/usr/local/bin`, non-root → `~/.local/bin`) and Windows (`%GOPATH%\bin`)
- Adds `scripts/install-cfg.sh` with `--prefix <dir>` flag, idempotent re-install, and PATH hint when the fallback directory is not on `$PATH`
- Adds `make uninstall-cfg` (accepts `PREFIX=` override for custom-prefix installs) and `make test-install-cfg` that runs an 8-assertion integration test suite
- Adds `docs/deployment/cfg-install.md` with one-liner install commands for Linux, macOS, and Windows plus PATH verification steps

Fixes #2216

## Specialist Review Results

**QA Test Runner**: PASS — `make test-agent-complete` passed. All Go unit tests, script syntax validation, production-critical tests, and cross-platform compilation (5 platforms) passed. `make test-install-cfg` ran 8 tests: 8 passed, 0 failed.

**QA Code Reviewer**: PASS (after fixes) — Initial review found 6 blocking issues (trap cleanup, bin/cfg restore safety, Test 5 missing assertion, uninstall not handling custom prefix, docs missing verification block in non-root section). All 6 resolved. Re-review: 0 blocking issues.

**Security Engineer**: PASS — No shell injection, path traversal risks, or hardcoded secrets. Binary installs from the locally-built `bin/cfg` (no external download). All automated scans (gitleaks, gosec, staticcheck, check-architecture) passed. Pre-existing Makefile gitleaks finding is env-var based and outside this story's diff.

## Test plan

- [ ] `make test-install-cfg` — 8 tests pass (install, cfg version, re-install, creates prefix dir, missing binary error, unknown-arg error)
- [ ] `which cfg` resolves after `sudo bash scripts/install-cfg.sh` on Linux/macOS
- [ ] `bash scripts/install-cfg.sh` without root installs to `~/.local/bin/cfg`
- [ ] `bash scripts/install-cfg.sh --prefix /tmp/testdir` creates `/tmp/testdir/cfg`
- [ ] `make uninstall-cfg` removes binary from default locations
- [ ] `make uninstall-cfg PREFIX=/opt/cfgms/bin` removes from custom prefix
- [ ] `make test-agent-complete` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)