### PR TITLE
feat(credential,session): foundational contract skeletons for cfg zero-standing-privilege sessions (Issue #2220)

### DIFF
--- a/pkg/credential/unlocker.go
+++ b/pkg/credential/unlocker.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package credential defines the CredentialUnlocker interface for pluggable credential access.
+//
+// Credential access for cfg admin sessions goes through CredentialUnlocker. The default
+// implementation (Story #3 of epic #2213) wraps pkg/secrets/providers/steward's platform
+// encryptor (DPAPI on Windows, machine-key AES-256-GCM on Linux/macOS). Additional unlock
+// methods (OS-native keychain, hardware token, passphrase) slot in additively via the same
+// seam without rework.
+//
+// This package defines contracts only; it imports no crypto/* packages directly.
+// See ADR-014 §4 for the rationale.
+package credential
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrLocked is returned when the credential exists but is currently locked and cannot be read.
+var ErrLocked = errors.New("credential: credential is locked")
+
+// ErrNoUnlocker is returned when no unlocker is configured for the requested connection.
+var ErrNoUnlocker = errors.New("credential: no unlocker configured for this connection")
+
+// CredentialUnlocker provides access to the machine-bound encrypted admin credential for a
+// named connection. Implementations are selectable per-connection via ConnectionEntry.UnlockMethod
+// (default "machine"). The seam is mandatory; there is no code path that reads the credential
+// without going through an unlocker.
+//
+// Unlock returns the raw credential bytes (the mTLS bundle) for a single connect operation.
+// The caller is responsible for zeroing the returned slice when done.
+//
+// Lock re-seals the credential. For the machine-bound default implementation this is a no-op
+// (the encrypted file is already sealed at rest); for interactive implementations it discards
+// any cached key material.
+type CredentialUnlocker interface {
+	Unlock(ctx context.Context, name string) ([]byte, error)
+	Lock(ctx context.Context, name string) error
+}

--- a/pkg/credential/unlocker_test.go
+++ b/pkg/credential/unlocker_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package credential_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/credential"
+)
+
+// stubUnlocker satisfies CredentialUnlocker for compile-time interface verification.
+type stubUnlocker struct{}
+
+func (s *stubUnlocker) Unlock(_ context.Context, _ string) ([]byte, error) { return nil, nil }
+func (s *stubUnlocker) Lock(_ context.Context, _ string) error             { return nil }
+
+// TestCredentialUnlockerInterfaceSatisfied verifies the interface can be satisfied by a concrete type.
+func TestCredentialUnlockerInterfaceSatisfied(t *testing.T) {
+	var _ credential.CredentialUnlocker = (*stubUnlocker)(nil)
+}
+
+// TestSentinelsAreDistinctErrors verifies ErrLocked and ErrNoUnlocker are separate sentinel values.
+func TestSentinelsAreDistinctErrors(t *testing.T) {
+	if credential.ErrLocked == nil {
+		t.Fatal("ErrLocked must not be nil")
+	}
+	if credential.ErrNoUnlocker == nil {
+		t.Fatal("ErrNoUnlocker must not be nil")
+	}
+	if errors.Is(credential.ErrLocked, credential.ErrNoUnlocker) {
+		t.Fatal("ErrLocked and ErrNoUnlocker must be distinct error values")
+	}
+	if errors.Is(credential.ErrNoUnlocker, credential.ErrLocked) {
+		t.Fatal("ErrNoUnlocker and ErrLocked must be distinct error values")
+	}
+}
+
+// TestSentinelWrapping verifies sentinels are identifiable via errors.Is when wrapped.
+func TestSentinelWrapping(t *testing.T) {
+	wrapped := errors.Join(credential.ErrLocked, errors.New("additional context"))
+	if !errors.Is(wrapped, credential.ErrLocked) {
+		t.Fatal("wrapped ErrLocked must be identifiable via errors.Is")
+	}
+}

--- a/pkg/session/contract.go
+++ b/pkg/session/contract.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package session defines the foundational contracts for cfg admin sessions
+// (zero-standing-privilege model, ADR-014).
+//
+// This package is a Direct Provider (no interfaces/ subdirectory). Manager and Store
+// are defined here; their implementations land in Story #4 of epic #2213.
+package session
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNotAdmin is returned when the caller presents credentials that are not admin-level mTLS.
+var ErrNotAdmin = errors.New("session: caller is not an admin principal")
+
+// ErrSessionExpired is returned when the session has exceeded its idle or absolute timeout.
+var ErrSessionExpired = errors.New("session: session has expired")
+
+// ErrSessionRevoked is returned when the session has been explicitly revoked.
+var ErrSessionRevoked = errors.New("session: session has been revoked")
+
+// ErrSessionNotFound is returned when the requested session does not exist in the store.
+var ErrSessionNotFound = errors.New("session: session not found")
+
+// Session is the runtime record for a cfg admin session (ADR-014 §2).
+// ID holds the opaque session identifier (not the bearer token; that is never stored).
+// AbsoluteExpiresAt is measured from the original connect, capping even continuously-active sessions.
+type Session struct {
+	ID                string
+	ConnectionName    string
+	PrincipalID       string
+	TenantID          string
+	IssuedAt          time.Time
+	LastActivity      time.Time
+	AbsoluteExpiresAt time.Time
+}
+
+// Config holds the lifecycle tunables for cfg admin sessions (ADR-014 §3).
+// Use DefaultConfig() to obtain the ratified defaults.
+type Config struct {
+	// IdleTimeout is the maximum idle gap before the session lapses.
+	IdleTimeout time.Duration
+	// AbsoluteTimeout is the hard cap measured from the original connect.
+	AbsoluteTimeout time.Duration
+	// GraceWindow is the time-only window during which the prior token remains valid
+	// after a renewal (tolerates racing requests from a stateless CLI; see ADR-014 §3).
+	GraceWindow time.Duration
+}
+
+// DefaultConfig returns the ratified ADR-014 tunables: idle 15m, absolute 8h, grace 30s.
+// Tests lock these values so implementation stories cannot silently drift them.
+func DefaultConfig() Config {
+	return Config{
+		IdleTimeout:     15 * time.Minute,
+		AbsoluteTimeout: 8 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+}
+
+// Manager is the runtime interface for cfg admin session lifecycle (ADR-014 §2).
+// The implementation lives in Story #4 of epic #2213; this definition is the contract
+// that all callers in this epic build against.
+//
+// Issue mints a new session for the given principal + connection (admin mTLS gated by
+// the controller). It returns the Session record and an opaque bearer token (32 bytes from
+// crypto/rand, base64url). The caller writes the token to the OS-native secret store via
+// pkg/secrets/providers/oskeychain; the controller stores only SHA-256(token).
+//
+// Validate authenticates an incoming request token and returns the live Session, updating
+// LastActivity. It returns ErrSessionExpired or ErrSessionRevoked on failure.
+//
+// Renew re-issues a fresh TTL'd token for an active session (rolling token model). The
+// prior token remains valid for the GraceWindow after renewal.
+//
+// Revoke invalidates a session by ID. Accepts a valid session token or an admin mTLS cert
+// so a client holding an expired token can still clean up server-side.
+type Manager interface {
+	Issue(ctx context.Context, principalID, connectionName, tenantID string) (*Session, string, error)
+	Validate(ctx context.Context, token string) (*Session, error)
+	Renew(ctx context.Context, token string) (*Session, string, error)
+	Revoke(ctx context.Context, id string) error
+}
+
+// Store is the in-memory backing store for the session Manager (ADR-014 §2, v1).
+// The key for Set/Get is SHA-256(token) encoded as hex — the controller never persists
+// the raw token. Delete removes by session ID. A controller restart drops all sessions
+// (re-auth required); durable/shared store is deferred to the SaaS cluster story (#2051).
+//
+// The implementation lives in Story #4 of epic #2213.
+type Store interface {
+	Set(ctx context.Context, tokenHash string, session *Session) error
+	Get(ctx context.Context, tokenHash string) (*Session, error)
+	Delete(ctx context.Context, id string) error
+	ListAll(ctx context.Context) ([]*Session, error)
+}

--- a/pkg/session/contract_test.go
+++ b/pkg/session/contract_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// TestDefaultConfig locks the ADR-014 tunables so later stories cannot silently drift them.
+func TestDefaultConfig(t *testing.T) {
+	cfg := session.DefaultConfig()
+
+	if cfg.IdleTimeout != 15*time.Minute {
+		t.Errorf("IdleTimeout = %v, want 15m", cfg.IdleTimeout)
+	}
+	if cfg.AbsoluteTimeout != 8*time.Hour {
+		t.Errorf("AbsoluteTimeout = %v, want 8h", cfg.AbsoluteTimeout)
+	}
+	if cfg.GraceWindow != 30*time.Second {
+		t.Errorf("GraceWindow = %v, want 30s", cfg.GraceWindow)
+	}
+}
+
+// stubManager satisfies Manager for compile-time interface verification.
+type stubManager struct{}
+
+func (s *stubManager) Issue(_ context.Context, _, _, _ string) (*session.Session, string, error) {
+	return nil, "", nil
+}
+func (s *stubManager) Validate(_ context.Context, _ string) (*session.Session, error) {
+	return nil, nil
+}
+func (s *stubManager) Renew(_ context.Context, _ string) (*session.Session, string, error) {
+	return nil, "", nil
+}
+func (s *stubManager) Revoke(_ context.Context, _ string) error { return nil }
+
+// stubStore satisfies Store for compile-time interface verification.
+type stubStore struct{}
+
+func (s *stubStore) Set(_ context.Context, _ string, _ *session.Session) error { return nil }
+func (s *stubStore) Get(_ context.Context, _ string) (*session.Session, error) { return nil, nil }
+func (s *stubStore) Delete(_ context.Context, _ string) error                  { return nil }
+func (s *stubStore) ListAll(_ context.Context) ([]*session.Session, error)     { return nil, nil }
+
+// TestManagerInterfaceSatisfied verifies Manager can be satisfied by a concrete type.
+func TestManagerInterfaceSatisfied(t *testing.T) {
+	var _ session.Manager = (*stubManager)(nil)
+}
+
+// TestStoreInterfaceSatisfied verifies Store can be satisfied by a concrete type.
+func TestStoreInterfaceSatisfied(t *testing.T) {
+	var _ session.Store = (*stubStore)(nil)
+}
+
+// TestSentinelsAreDistinctErrors verifies all error sentinels are distinct non-nil values.
+func TestSentinelsAreDistinctErrors(t *testing.T) {
+	sentinels := map[string]error{
+		"ErrNotAdmin":        session.ErrNotAdmin,
+		"ErrSessionExpired":  session.ErrSessionExpired,
+		"ErrSessionRevoked":  session.ErrSessionRevoked,
+		"ErrSessionNotFound": session.ErrSessionNotFound,
+	}
+
+	for name, err := range sentinels {
+		if err == nil {
+			t.Errorf("%s must not be nil", name)
+		}
+	}
+
+	// Verify each sentinel is distinct from every other.
+	names := []string{"ErrNotAdmin", "ErrSessionExpired", "ErrSessionRevoked", "ErrSessionNotFound"}
+	errs := []error{session.ErrNotAdmin, session.ErrSessionExpired, session.ErrSessionRevoked, session.ErrSessionNotFound}
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				continue
+			}
+			if errors.Is(errs[i], errs[j]) {
+				t.Errorf("%s and %s must be distinct error values", names[i], names[j])
+			}
+		}
+	}
+}
+
+// TestSessionStruct verifies the Session struct has the required fields with correct zero values.
+func TestSessionStruct(t *testing.T) {
+	s := session.Session{}
+	// Verify string fields exist and are zero-valued
+	if s.ID != "" || s.ConnectionName != "" || s.PrincipalID != "" || s.TenantID != "" {
+		t.Error("Session string fields must be empty by default")
+	}
+	// Verify time fields exist and are zero-valued
+	if !s.IssuedAt.IsZero() || !s.LastActivity.IsZero() || !s.AbsoluteExpiresAt.IsZero() {
+		t.Error("Session time fields must be zero by default")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/credential` package with `CredentialUnlocker` interface and `ErrLocked`/`ErrNoUnlocker` sentinels (ADR-014 §4). No implementation, no `crypto/*` imports — the seam is mandatory.
- Adds `pkg/session` package with `Session` struct, `Config`/`DefaultConfig()` (idle 15m, absolute 8h, grace 30s), `Manager` and `Store` interfaces, and `ErrNotAdmin`/`ErrSessionExpired`/`ErrSessionRevoked`/`ErrSessionNotFound` sentinels (ADR-014 §2–§3).
- Tests lock the ADR-014 tunables (`TestDefaultConfig`) and verify interface satisfiability and sentinel distinctness.

## Specialist Review Results

**QA Test Runner:** PASS — all unit tests, lint, license headers, production-critical tests, and cross-platform compilation (5 platforms) passed.

**QA Code Reviewer:** PASS — no blocking issues. Stub types in contract tests are the standard Go compile-time interface verification idiom; no mock frameworks used.

**Security Engineer:** PASS — no crypto/* imports in pkg/credential (verified); no hardcoded secrets; no central provider violations; gosec 0 issues; gitleaks/truffleHog clean.

## Test Plan

- [ ] `go test ./pkg/credential/... ./pkg/session/...` — all tests pass
- [ ] `make check-architecture` — no violations
- [ ] `make test-agent-complete` — full suite passes

Fixes #2220

🤖 Generated with [Claude Code](https://claude.com/claude-code)