### PR TITLE
controller/api: auth-tier constants + requireTier() middleware (Issue #2222)

### DIFF
--- a/features/controller/api/auth_tiers.go
+++ b/features/controller/api/auth_tiers.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http"
+	"time"
+)
+
+// authTier defines the authentication strength an endpoint requires.
+type authTier int
+
+const (
+	TierPublic   authTier = 0 // No authentication (registered on the base router, not the api subrouter)
+	TierAny      authTier = 1 // Any valid credential: API key OR mTLS admin cert
+	TierElevated authTier = 2 // Reserved for future use
+	TierMTLSOnly authTier = 3 // mTLS admin cert required; API-key callers rejected even with matching permissions
+)
+
+// tier3Permissions is the authoritative set of permission IDs whose REST endpoints
+// require mTLS (Issue #1419). It is the one place that declares the Tier-3 surface;
+// S3 wraps exactly these routes and S4's startup scan reports keys holding any of them.
+var tier3Permissions = map[string]struct{}{
+	"certificate:provision":        {}, // POST /certificates/provision
+	"certificate:rotate":           {}, // POST /certificates/signing/rotate
+	"rbac:create-role":             {}, // POST /rbac/roles
+	"rbac:update-role":             {}, // PUT /rbac/roles/{id}
+	"rbac:delete-role":             {}, // DELETE /rbac/roles/{id}
+	"api-key:create":               {}, // POST /api-keys
+	"api-key:delete":               {}, // DELETE /api-keys/{id}
+	"registration:create-token":    {}, // POST /registration/tokens
+	"registration:delete-token":    {}, // DELETE /registration/tokens/{token}
+	"registration:revoke-token":    {}, // POST /registration/tokens/{token}/revoke
+	"registration:rotate-token":    {}, // POST /registration/tokens/{tenant_id}/rotate
+	"registration:approve":         {}, // POST /registration/{id}/approve, /approve-all, /approve-by-cidr
+	"registration:manage-ip-trust": {}, // POST + DELETE /registration/ip-trust
+	"tenant:create":                {}, // POST /tenants
+}
+
+// requireTier returns middleware that enforces the given authentication tier.
+// Tiers below TierMTLSOnly are a no-op passthrough — zero enforcement overhead.
+// TierMTLSOnly rejects any caller that is not an mTLS admin principal (principal.IsAdmin
+// is the sole discriminator; the permission set is never consulted). On rejection an
+// audit event is emitted via auditAuthorizationDecision before writing the 403 response.
+func (s *Server) requireTier(tier authTier) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if tier < TierMTLSOnly {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			principal, _ := r.Context().Value(principalContextKey).(*Principal)
+			if principal == nil || !principal.IsAdmin {
+				subjectID := ""
+				tenantID := ""
+				if principal != nil {
+					subjectID = principal.ID
+					tenantID = principal.TenantID
+				}
+				decision := &AuthorizationDecision{
+					Granted:   false,
+					Action:    r.Method,
+					Decision:  "DENY",
+					Reason:    "mTLS required (Tier-3 endpoint)",
+					CheckedAt: time.Now(),
+					SubjectID: subjectID,
+					TenantID:  tenantID,
+				}
+				s.auditAuthorizationDecision(r, decision)
+				s.writeErrorResponse(w, http.StatusForbidden, "mTLS admin certificate required for this endpoint", "MTLS_REQUIRED")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/features/controller/api/auth_tiers_test.go
+++ b/features/controller/api/auth_tiers_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequireTierMTLSOnly_RejectsAPIKeyPrincipal verifies that a caller with an API-key
+// principal (IsAdmin: false) is rejected with HTTP 403 and MTLS_REQUIRED error code,
+// and that the inner handler is never invoked.
+func TestRequireTierMTLSOnly_RejectsAPIKeyPrincipal(t *testing.T) {
+	server := setupTestServer(t)
+
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierMTLSOnly)(probe)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", nil)
+	req = req.WithContext(context.WithValue(req.Context(), principalContextKey, &Principal{
+		IsAdmin:     false,
+		Permissions: []string{"api-key:create", "rbac:create-role"},
+	}))
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, handlerCalled, "inner handler must not be called for API-key principal")
+
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	require.NotNil(t, errResp.Error)
+	assert.Equal(t, "MTLS_REQUIRED", errResp.Error.Code)
+}
+
+// TestRequireTierMTLSOnly_AcceptsAdminCertPrincipal verifies that an mTLS admin principal
+// passes through the TierMTLSOnly middleware and the inner handler is called.
+func TestRequireTierMTLSOnly_AcceptsAdminCertPrincipal(t *testing.T) {
+	server := setupTestServer(t)
+
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierMTLSOnly)(probe)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", nil)
+	req = req.WithContext(context.WithValue(req.Context(), principalContextKey, &Principal{
+		IsAdmin:    true,
+		CertSerial: "abc123",
+	}))
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "admin cert principal must receive 200 from probe handler")
+	assert.True(t, handlerCalled, "inner handler must be called for admin cert principal")
+}
+
+// TestRequireTierMTLSOnly_AuditsDenial verifies that a Tier-3 rejection emits an
+// authorization audit event with decision=DENY and auth_method=api_key via
+// auditAuthorizationDecision.
+func TestRequireTierMTLSOnly_AuditsDenial(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierMTLSOnly)(probe)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", nil)
+	req = req.WithContext(context.WithValue(req.Context(), principalContextKey, &Principal{
+		IsAdmin:     false,
+		Permissions: []string{"api-key:create"},
+	}))
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	output := capLog.formattedOutput()
+	assert.Contains(t, output, "decision=DENY", "audit log must record DENY decision")
+	assert.Contains(t, output, "auth_method=api_key", "audit log must record api_key auth method")
+	assert.True(t, capLog.hasLevel("WARN"), "denial must be logged at WARN level")
+}
+
+// TestRequireTier_PassesThrough_TierPublic verifies TierPublic is a no-op passthrough.
+func TestRequireTier_PassesThrough_TierPublic(t *testing.T) {
+	server := setupTestServer(t)
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierPublic)(probe)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.True(t, handlerCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestRequireTier_PassesThrough_TierAny verifies TierAny is a no-op passthrough.
+func TestRequireTier_PassesThrough_TierAny(t *testing.T) {
+	server := setupTestServer(t)
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierAny)(probe)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.True(t, handlerCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestRequireTier_PassesThrough_TierElevated verifies TierElevated is a no-op passthrough.
+func TestRequireTier_PassesThrough_TierElevated(t *testing.T) {
+	server := setupTestServer(t)
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierElevated)(probe)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.True(t, handlerCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestRequireTierMTLSOnly_RejectsNilPrincipal verifies that a request with no principal
+// in context is also rejected with 403 MTLS_REQUIRED and emits a denial audit event.
+func TestRequireTierMTLSOnly_RejectsNilPrincipal(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierMTLSOnly)(probe)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", nil)
+	// no principal in context
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, handlerCalled, "inner handler must not be called when no principal in context")
+
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	require.NotNil(t, errResp.Error)
+	assert.Equal(t, "MTLS_REQUIRED", errResp.Error.Code)
+
+	// Nil-principal denials must also be audited.
+	output := capLog.formattedOutput()
+	assert.Contains(t, output, "decision=DENY", "nil-principal denial must be audited as DENY")
+	assert.True(t, capLog.hasLevel("WARN"), "nil-principal denial must be logged at WARN level")
+}
+
+// TestTier3Permissions_SourceOfTruth validates that the canonical Tier-3 permission set
+// is non-empty and that every entry is a non-empty string in the expected "resource:action"
+// format. This test is the compile-time anchor for the S3/S4 consumers of this map.
+func TestTier3Permissions_SourceOfTruth(t *testing.T) {
+	require.NotEmpty(t, tier3Permissions, "tier3Permissions must declare at least one Tier-3 permission")
+	for perm := range tier3Permissions {
+		assert.NotEmpty(t, perm, "tier3Permissions must not contain empty permission IDs")
+		assert.Contains(t, perm, ":", "permission ID %q must use resource:action format", perm)
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `authTier` type with four constants (TierPublic=0, TierAny=1, TierElevated=2, TierMTLSOnly=3) as the canonical auth-strength vocabulary for the mTLS-gate epic (#1419)
- Declares `tier3Permissions` as the single authoritative set of permission IDs whose REST endpoints require mTLS — the one place S3 (route wrapping) and S4 (startup key scan) will consume
- Adds `requireTier()` middleware factory: sub-TierMTLSOnly tiers are zero-overhead passthroughs; TierMTLSOnly gates on `principal.IsAdmin` only (never inspects permissions), rejects API-key callers with HTTP 403 `MTLS_REQUIRED`, and emits a `decision=DENY` audit event via the existing `auditAuthorizationDecision` sink

No routes are changed in this story — it provides the building blocks for S2/S3.

## Test plan

- [ ] `TestRequireTierMTLSOnly_RejectsAPIKeyPrincipal` — API-key principal with `api-key:create`+`rbac:create-role` gets 403 MTLS_REQUIRED, inner handler not called
- [ ] `TestRequireTierMTLSOnly_AcceptsAdminCertPrincipal` — mTLS admin principal gets 200, inner handler called
- [ ] `TestRequireTierMTLSOnly_AuditsDenial` — rejection emits WARN audit log with `decision=DENY` and `auth_method=api_key`
- [ ] `TestRequireTierMTLSOnly_RejectsNilPrincipal` — nil-principal also rejected + audited as DENY at WARN
- [ ] `TestRequireTier_PassesThrough_Tier{Public,Any,Elevated}` — all sub-TierMTLSOnly tiers pass through with no 403
- [ ] `TestTier3Permissions_SourceOfTruth` — canonical map is non-empty, all keys match `resource:action` format

## Specialist review results

- **QA test runner**: PASS — `make test-agent-complete` clean (all packages, lint, cross-platform builds)
- **QA code reviewer**: PASS — no mocks, error paths covered, weak-assertion fixed, nil-principal audit verified, `IsAdmin`-only invariant confirmed
- **Security engineer**: PASS — `IsAdmin`-only discriminator confirmed at `auth_tiers.go:52`, no log injection (all values flow through existing `auditAuthorizationDecision` sanitization), no information disclosure, no new dependencies

Fixes #2222

🤖 Generated with [Claude Code](https://claude.com/claude-code)