### PR TITLE
credential: encrypted-at-rest admin credential + CredentialUnlocker seam (Issue #2231)

### DIFF
--- a/cmd/cfg/cmd/credential_store.go
+++ b/cmd/cfg/cmd/credential_store.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cfgis/cfgms/pkg/credential"
+	"github.com/cfgis/cfgms/pkg/secrets/providers/steward"
+)
+
+// credentialsDirFn is overridable in tests to avoid touching real user config directories.
+var credentialsDirFn = defaultCredentialsDir
+
+func defaultCredentialsDir() (string, error) {
+	configDir, err := userConfigDirFn()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine user config directory: %w", err)
+	}
+	return filepath.Join(configDir, "cfgms", "credentials"), nil
+}
+
+// CredentialStore manages encrypted-at-rest admin credentials stored under
+// os.UserConfigDir()/cfgms/credentials/<name>.enc.
+// All cryptographic operations are delegated to pkg/secrets/providers/steward;
+// no crypto package is used directly.
+type CredentialStore struct {
+	dir      string
+	enc      steward.Encryptor
+	unlocker credential.CredentialUnlocker
+}
+
+// newCredentialStore returns a CredentialStore using the default machine-bound unlocker.
+// The credentials directory is created at mode 0700 if it does not exist.
+func newCredentialStore() (*CredentialStore, error) {
+	dir, err := credentialsDirFn()
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G301 - 0700: traversable but private to the user
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("cannot create credentials directory: %w", err)
+	}
+	enc, err := steward.NewPlatformEncryptor(dir)
+	if err != nil {
+		return nil, fmt.Errorf("credential store: init encryptor: %w", err)
+	}
+	unlocker, err := credential.NewMachineUnlocker(dir)
+	if err != nil {
+		return nil, fmt.Errorf("credential store: init unlocker: %w", err)
+	}
+	return &CredentialStore{dir: dir, enc: enc, unlocker: unlocker}, nil
+}
+
+// Store encrypts bundleBytes and writes them to <dir>/<name>.enc (mode 0600).
+// No plaintext credential material appears on disk after this call.
+func (s *CredentialStore) Store(_ context.Context, name string, bundleBytes []byte) error {
+	if err := credential.ValidateCredentialName(name); err != nil {
+		return err
+	}
+	ciphertext, err := s.enc.Encrypt(bundleBytes)
+	if err != nil {
+		return fmt.Errorf("credential store: encrypt %q: %w", name, err)
+	}
+	path := filepath.Join(s.dir, name+".enc")
+	// #nosec G306 - 0600: owner read/write only; encrypted credential material
+	if err := os.WriteFile(path, ciphertext, 0600); err != nil {
+		return fmt.Errorf("credential store: write %q: %w", name, err)
+	}
+	return nil
+}
+
+// Load decrypts and returns the credential bytes for the named connection.
+// Returns a wrapped credential.ErrLocked on decrypt failure or when the credential is absent.
+func (s *CredentialStore) Load(ctx context.Context, name string) ([]byte, error) {
+	plain, err := s.unlocker.Unlock(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("credential store: load %q: %w", name, err)
+	}
+	return plain, nil
+}
+
+// Lock discards any in-memory reference to decrypted credential material for name.
+// For the default machine-bound unlocker this is a no-op; interactive unlocker
+// implementations use this to clear cached key material.
+func (s *CredentialStore) Lock(ctx context.Context, name string) error {
+	return s.unlocker.Lock(ctx, name)
+}

--- a/cmd/cfg/cmd/credential_store_test.go
+++ b/cmd/cfg/cmd/credential_store_test.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/credential"
+)
+
+// overrideCredentialsDir replaces credentialsDirFn for the duration of the test and
+// restores it on cleanup.
+func overrideCredentialsDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := credentialsDirFn
+	credentialsDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { credentialsDirFn = orig })
+}
+
+func TestCredentialStore_StoreAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	bundle := []byte("test-bundle-content")
+
+	require.NoError(t, store.Store(ctx, "my-controller", bundle))
+
+	got, err := store.Load(ctx, "my-controller")
+	require.NoError(t, err)
+	assert.Equal(t, bundle, got)
+}
+
+// TestCredentialStore_NoPlaintextOnDisk is a required acceptance test: it reads back
+// the raw .enc file and asserts that no PEM header from the original bundle survives
+// unencrypted on disk.
+func TestCredentialStore_NoPlaintextOnDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	bundle := []byte("-----BEGIN CERTIFICATE-----\nABCDEFGHIJKLMNOP\n-----END CERTIFICATE-----\n" +
+		"-----BEGIN PRIVATE KEY-----\nXYZABCDEFG\n-----END PRIVATE KEY-----")
+
+	ctx := context.Background()
+	require.NoError(t, store.Store(ctx, "ctrl", bundle))
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "ctrl.enc"))
+	require.NoError(t, err)
+
+	assert.False(t, bytes.Contains(raw, []byte("-----BEGIN")),
+		"raw .enc file must not contain plaintext PEM header '-----BEGIN'")
+}
+
+// TestCredentialStore_NoBespokeCrypto is a required acceptance test: it asserts that
+// pkg/credential source files do not import any crypto packages directly.
+// All encryption must be delegated to pkg/secrets/providers/steward.
+func TestCredentialStore_NoBespokeCrypto(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// cmd/cfg/cmd/ is 3 levels deep; pkg/credential is at workspace root.
+	pkgCredDir := filepath.Join(wd, "..", "..", "..", "pkg", "credential")
+
+	forbidden := []string{
+		`"crypto/aes"`,
+		`"crypto/cipher"`,
+		`"crypto/des"`,
+		`"crypto/rc4"`,
+		`"golang.org/x/crypto/`,
+	}
+
+	entries, err := os.ReadDir(pkgCredDir)
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(pkgCredDir, entry.Name()))
+		require.NoError(t, err)
+
+		for _, pkg := range forbidden {
+			assert.False(t, bytes.Contains(content, []byte(pkg)),
+				"pkg/credential/%s must not import forbidden crypto package %s",
+				entry.Name(), pkg)
+		}
+	}
+}
+
+func TestCredentialStore_DirectoryCreatedAt0700(t *testing.T) {
+	tmpDir := t.TempDir()
+	credDir := filepath.Join(tmpDir, "credentials")
+	overrideCredentialsDir(t, credDir)
+
+	_, err := newCredentialStore()
+	require.NoError(t, err)
+
+	info, err := os.Stat(credDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+	if os.Getenv("GOOS") != "windows" {
+		assert.Equal(t, os.FileMode(0700), info.Mode().Perm(),
+			"credentials directory must be created at mode 0700")
+	}
+}
+
+func TestCredentialStore_EncFileCreatedAt0600(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	require.NoError(t, store.Store(context.Background(), "ctrl", []byte("data")))
+
+	info, err := os.Stat(filepath.Join(tmpDir, "ctrl.enc"))
+	require.NoError(t, err)
+	if os.Getenv("GOOS") != "windows" {
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm(),
+			".enc file must be created at mode 0600")
+	}
+}
+
+func TestCredentialStore_LoadMissingReturnsErrLocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	_, err = store.Load(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrLocked)
+}
+
+func TestCredentialStore_LockIsNoop(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	// Lock on a stored credential must not return an error.
+	require.NoError(t, store.Store(context.Background(), "ctrl", []byte("data")))
+	assert.NoError(t, store.Lock(context.Background(), "ctrl"))
+}
+
+func TestCredentialStore_MultipleCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	pairs := map[string][]byte{
+		"controller-a": []byte("bundle-a"),
+		"controller-b": []byte("bundle-b"),
+		"controller-c": []byte("bundle-c"),
+	}
+
+	for name, data := range pairs {
+		require.NoError(t, store.Store(ctx, name, data))
+	}
+	for name, want := range pairs {
+		got, err := store.Load(ctx, name)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "credential %s round-trip mismatch", name)
+	}
+}
+
+func TestCredentialStore_ConstructorErrorOnBadDir(t *testing.T) {
+	orig := credentialsDirFn
+	credentialsDirFn = func() (string, error) {
+		return "", os.ErrPermission
+	}
+	t.Cleanup(func() { credentialsDirFn = orig })
+
+	_, err := newCredentialStore()
+	require.Error(t, err, "newCredentialStore must fail when credentialsDirFn returns an error")
+}
+
+func TestCredentialStore_StoreRejectsTraversalName(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	traversalNames := []string{"../evil", "foo/bar", "", "..", "."}
+	for _, name := range traversalNames {
+		err := store.Store(context.Background(), name, []byte("data"))
+		require.Error(t, err, "Store should reject name %q", name)
+	}
+}
+
+func TestCredentialStore_LoadRejectsTraversalName(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	traversalNames := []string{"../evil", "foo/bar", "", "..", "."}
+	for _, name := range traversalNames {
+		_, err := store.Load(context.Background(), name)
+		require.Error(t, err, "Load should reject name %q", name)
+	}
+}
+
+func TestCredentialStore_OverwriteExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	overrideCredentialsDir(t, tmpDir)
+
+	store, err := newCredentialStore()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, store.Store(ctx, "ctrl", []byte("first")))
+	require.NoError(t, store.Store(ctx, "ctrl", []byte("second")))
+
+	got, err := store.Load(ctx, "ctrl")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("second"), got)
+}

--- a/pkg/credential/unlocker.go
+++ b/pkg/credential/unlocker.go
@@ -15,6 +15,12 @@ package credential
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
 // ErrLocked is returned when the credential exists but is currently locked and cannot be read.
@@ -37,4 +43,70 @@ var ErrNoUnlocker = errors.New("credential: no unlocker configured for this conn
 type CredentialUnlocker interface {
 	Unlock(ctx context.Context, name string) ([]byte, error)
 	Lock(ctx context.Context, name string) error
+}
+
+// ValidateCredentialName rejects names that could cause path traversal or contain
+// reserved characters. A name must be a simple filename with no directory components.
+func ValidateCredentialName(name string) error {
+	if name == "" {
+		return errors.New("credential: name must not be empty")
+	}
+	// Reject bare dot-references that are special in every filesystem.
+	if name == "." || name == ".." {
+		return fmt.Errorf("credential: name %q is reserved", name)
+	}
+	// filepath.Base cleans path separators and ".." components; if the result differs
+	// from the original, the name contained a traversal attempt.
+	if filepath.Base(name) != name || strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("credential: name %q contains invalid path characters", name)
+	}
+	return nil
+}
+
+// NewMachineUnlocker creates a machine-bound CredentialUnlocker backed by the platform
+// encryptor (DPAPI on Windows, AES-256-GCM with HKDF on Linux/macOS).
+// dir is the credentials directory where <name>.enc files reside; a salt file for key
+// derivation is also maintained within dir.
+func NewMachineUnlocker(dir string) (CredentialUnlocker, error) {
+	enc, err := steward.NewPlatformEncryptor(dir)
+	if err != nil {
+		return nil, fmt.Errorf("credential: init platform encryptor: %w", err)
+	}
+	return &machineUnlocker{dir: dir, enc: enc}, nil
+}
+
+// machineUnlocker implements CredentialUnlocker using the machine-bound platform encryptor.
+// No crypto package is imported directly — all encryption is delegated to
+// pkg/secrets/providers/steward.
+type machineUnlocker struct {
+	dir string
+	enc steward.Encryptor
+}
+
+// Unlock reads <dir>/<name>.enc, decrypts it with the machine-bound key, and returns
+// the plaintext bundle bytes. Returns ErrLocked when the file is missing or decryption fails.
+func (m *machineUnlocker) Unlock(_ context.Context, name string) ([]byte, error) {
+	if err := ValidateCredentialName(name); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(m.dir, name+".enc")
+	// #nosec G304 - path is constructed from the configured credentials directory; name is validated above
+	ciphertext, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: credential %q not found", ErrLocked, name)
+		}
+		return nil, fmt.Errorf("credential: read %s.enc: %w", name, err)
+	}
+	plain, err := m.enc.Decrypt(ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decrypt failed for %q: %w", ErrLocked, name, err)
+	}
+	return plain, nil
+}
+
+// Lock is a no-op for the machine-bound implementation: the encrypted file is already sealed
+// at rest; there is no in-memory key material to discard.
+func (m *machineUnlocker) Lock(_ context.Context, _ string) error {
+	return nil
 }

--- a/pkg/credential/unlocker_test.go
+++ b/pkg/credential/unlocker_test.go
@@ -5,20 +5,27 @@ package credential_test
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cfgis/cfgms/pkg/credential"
+	"github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
-// stubUnlocker satisfies CredentialUnlocker for compile-time interface verification.
-type stubUnlocker struct{}
-
-func (s *stubUnlocker) Unlock(_ context.Context, _ string) ([]byte, error) { return nil, nil }
-func (s *stubUnlocker) Lock(_ context.Context, _ string) error             { return nil }
-
-// TestCredentialUnlockerInterfaceSatisfied verifies the interface can be satisfied by a concrete type.
+// TestCredentialUnlockerInterfaceSatisfied verifies NewMachineUnlocker returns a non-nil
+// CredentialUnlocker; the compiler enforces the interface satisfaction via the return type.
 func TestCredentialUnlockerInterfaceSatisfied(t *testing.T) {
-	var _ credential.CredentialUnlocker = (*stubUnlocker)(nil)
+	unlocker, err := credential.NewMachineUnlocker(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewMachineUnlocker must not fail: %v", err)
+	}
+	if unlocker == nil {
+		t.Fatal("NewMachineUnlocker must return a non-nil CredentialUnlocker")
+	}
 }
 
 // TestSentinelsAreDistinctErrors verifies ErrLocked and ErrNoUnlocker are separate sentinel values.
@@ -43,4 +50,137 @@ func TestSentinelWrapping(t *testing.T) {
 	if !errors.Is(wrapped, credential.ErrLocked) {
 		t.Fatal("wrapped ErrLocked must be identifiable via errors.Is")
 	}
+}
+
+// TestMachineUnlocker_RoundTrip verifies that a credential encrypted by the platform
+// encryptor for the same directory is correctly decrypted by machineUnlocker.Unlock.
+func TestMachineUnlocker_RoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Pre-write an .enc file using the same dir (same salt → same HKDF key).
+	enc, err := steward.NewPlatformEncryptor(tmpDir)
+	require.NoError(t, err)
+
+	plaintext := []byte("test-bundle-bytes")
+	ciphertext, err := enc.Encrypt(plaintext)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "my-ctrl.enc"), ciphertext, 0600))
+
+	unlocker, err := credential.NewMachineUnlocker(tmpDir)
+	require.NoError(t, err)
+
+	got, err := unlocker.Unlock(context.Background(), "my-ctrl")
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, got)
+}
+
+// TestMachineUnlocker_LockIsNoop verifies Lock returns nil without side effects.
+func TestMachineUnlocker_LockIsNoop(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	unlocker, err := credential.NewMachineUnlocker(tmpDir)
+	require.NoError(t, err)
+
+	assert.NoError(t, unlocker.Lock(context.Background(), "any-name"))
+}
+
+// TestMachineUnlocker_MissingFileReturnsErrLocked verifies Unlock wraps ErrLocked for absent credentials.
+func TestMachineUnlocker_MissingFileReturnsErrLocked(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	unlocker, err := credential.NewMachineUnlocker(tmpDir)
+	require.NoError(t, err)
+
+	_, err = unlocker.Unlock(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrLocked)
+}
+
+// TestMachineUnlocker_TamperedCiphertextReturnsErrLocked verifies Unlock wraps ErrLocked
+// when decryption fails due to a corrupted .enc file.
+func TestMachineUnlocker_TamperedCiphertextReturnsErrLocked(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	enc, err := steward.NewPlatformEncryptor(tmpDir)
+	require.NoError(t, err)
+	ct, err := enc.Encrypt([]byte("original"))
+	require.NoError(t, err)
+
+	// Tamper: flip last byte.
+	ct[len(ct)-1] ^= 0xFF
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "ctrl.enc"), ct, 0600))
+
+	unlocker, err := credential.NewMachineUnlocker(tmpDir)
+	require.NoError(t, err)
+
+	_, err = unlocker.Unlock(context.Background(), "ctrl")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrLocked)
+}
+
+// TestMachineUnlocker_PathTraversalRejected verifies Unlock rejects names containing
+// path traversal sequences to prevent reading files outside the credentials directory.
+func TestMachineUnlocker_PathTraversalRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	unlocker, err := credential.NewMachineUnlocker(tmpDir)
+	require.NoError(t, err)
+
+	traversalNames := []string{
+		"../evil",
+		"../../etc/passwd",
+		"foo/../bar",
+		"foo/bar",
+		"",
+		".",
+		"..",
+	}
+	for _, name := range traversalNames {
+		_, err := unlocker.Unlock(context.Background(), name)
+		require.Error(t, err, "name %q should be rejected", name)
+	}
+}
+
+// TestValidateCredentialName verifies the exported validator accepts valid names and
+// rejects traversal attempts.
+func TestValidateCredentialName(t *testing.T) {
+	valid := []string{"my-ctrl", "controller.prod", "ctrl_1", "a"}
+	for _, name := range valid {
+		assert.NoError(t, credential.ValidateCredentialName(name), "name %q should be valid", name)
+	}
+
+	invalid := []string{"", "../evil", "foo/bar", "foo\\bar", "..", "."}
+	for _, name := range invalid {
+		assert.Error(t, credential.ValidateCredentialName(name), "name %q should be invalid", name)
+	}
+}
+
+// TestMachineUnlocker_NonInteractive verifies Unlock completes with stdin closed —
+// the machine-bound unlock requires no passphrase prompt or TTY.
+func TestMachineUnlocker_NonInteractive(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	enc, err := steward.NewPlatformEncryptor(tmpDir)
+	require.NoError(t, err)
+	ciphertext, err := enc.Encrypt([]byte("bundle-data"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "ctrl.enc"), ciphertext, 0600))
+
+	origStdin := os.Stdin
+	f, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	os.Stdin = f
+	defer func() {
+		os.Stdin = origStdin
+		if closeErr := f.Close(); closeErr != nil {
+			t.Logf("close devnull: %v", closeErr)
+		}
+	}()
+
+	unlocker, err := credential.NewMachineUnlocker(tmpDir)
+	require.NoError(t, err)
+
+	got, err := unlocker.Unlock(context.Background(), "ctrl")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("bundle-data"), got)
 }


### PR DESCRIPTION
## Summary

- Adds `machineUnlocker` (machine-bound default) to `pkg/credential`, wrapping `pkg/secrets/providers/steward.NewPlatformEncryptor` — DPAPI on Windows, AES-256-GCM/HKDF on Linux/macOS. No `crypto/*` is imported directly by `pkg/credential`.
- Adds `ValidateCredentialName` (path-traversal guard) rejecting empty, dot-reference, and directory-component names before any file I/O.
- Adds `CredentialStore` in `cmd/cfg/cmd` with `Store`/`Load`/`Lock` over `os.UserConfigDir()/cfgms/credentials/<name>.enc` (dir 0700, files 0600); `credentialsDirFn` hook mirrors `userConfigDirFn` for test isolation.
- Replaces pre-existing `stubUnlocker` in `unlocker_test.go` (now that the real `machineUnlocker` exists) with a real `NewMachineUnlocker` call.

Fixes #2231

## Specialist Review Results

**QA Test Runner:** PASS — `make test-agent-complete` exits 0; all 22 credential/store tests pass with `-race`.

**QA Code Reviewer:** Initial FAIL (stubUnlocker stub, no assertions in interface test, missing constructor error paths). All three blocking issues resolved: stubUnlocker removed, interface test uses real constructor, constructor error path + path-traversal rejection tests added.

**Security Engineer:** Initial FAIL (path traversal via unvalidated `name` in Unlock/Store). Resolved: `ValidateCredentialName` added with `filepath.Base` check + explicit dot-reference rejection; gosec G304/G306 `#nosec` annotations updated with accurate justification.

## Test Plan

- [x] `TestCredentialStore_NoPlaintextOnDisk` — required AC; raw `.enc` bytes contain no `-----BEGIN` PEM header
- [x] `TestCredentialStore_NoBespokeCrypto` — required AC; `pkg/credential` imports no `crypto/aes`, `crypto/cipher`, `crypto/des`, `crypto/rc4`, or `golang.org/x/crypto/*`
- [x] `TestMachineUnlocker_NonInteractive` — Unlock completes with stdin closed (no TTY required)
- [x] `TestMachineUnlocker_PathTraversalRejected` / `TestCredentialStore_StoreRejectsTraversalName` — path traversal is rejected
- [x] Round-trip, tamper, missing-file, lock no-op, file mode, multiple credential, overwrite tests
- [x] `make test-agent-complete` — full suite passes, lint clean, security-scan PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)