### PR TITLE
controller/api: annotate Tier 0/1 routes in setupRouter() (Issue #2224)

### DIFF
--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -380,9 +380,21 @@ func (s *Server) setupRouter() {
 
 	// API routes with authentication and validation
 	api := s.router.PathPrefix("/api/v1").Subrouter()
-	api.Use(s.authDefense.Middleware) // Story #380: Rate limiting before auth
-	api.Use(s.authenticationMiddleware)
+	api.Use(s.authDefense.Middleware)   // Story #380: rate limiting before auth
+	api.Use(s.authenticationMiddleware) // extract principal (API key or mTLS)
+	api.Use(s.requireTier(TierAny))     // Issue #1419: explicit Tier-1 default for the api subrouter
 	api.Use(s.validationMiddleware)
+
+	// --- Tier 0 (TierPublic) — no authentication required ---
+	//   GET  /api/v1/health
+	//   GET  /api/v1/ready
+	//   POST /api/v1/register
+	//   GET  /api/v1/registration/status/{pending_id}
+	//   POST /api/v1/stewards/{device_id}/refresh/challenge   (PoP-auth in handler)
+	//   POST /api/v1/stewards/{device_id}/refresh/complete    (PoP-auth in handler)
+	//   GET  /api/v1/installer/download/{platform}/{arch}
+	//   GET  /api/v1/public/steward-binaries/{version}/{platform}/{arch}
+	//   POST /raft/message                                     (internal mTLS peer CN in handler)
 
 	// Health check (no auth required) — liveness / object-presence.
 	s.router.HandleFunc("/api/v1/health", s.handleHealth).Methods("GET", "OPTIONS")
@@ -411,6 +423,10 @@ func (s *Server) setupRouter() {
 	// Registered on the base router like /api/v1/register (Issue #2096).
 	s.router.HandleFunc("/api/v1/stewards/{device_id}/refresh/challenge", s.handleRefreshChallenge).Methods("POST", "OPTIONS")
 	s.router.HandleFunc("/api/v1/stewards/{device_id}/refresh/complete", s.handleRefreshComplete).Methods("POST", "OPTIONS")
+
+	// --- Tier 1 (TierAny) — any valid credential: API key OR mTLS admin cert ---
+	// Default for all routes on the api subrouter. Tier-3 (TierMTLSOnly) endpoints are
+	// additionally wrapped with requireTier(TierMTLSOnly); see Issue #1419 story S3.
 
 	// Steward management endpoints (require API key authentication)
 	stewards := api.PathPrefix("/stewards").Subrouter()

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -1579,3 +1579,35 @@ func TestSeedTestAPIKeys(t *testing.T) {
 		}
 	})
 }
+
+// TestSetupRouter_Tier0Routes_AccessibleWithoutCredentials verifies that Tier-0 routes
+// registered on the base router (not the api subrouter) are reachable without any
+// authentication credentials (Issue #2224).
+func TestSetupRouter_Tier0Routes_AccessibleWithoutCredentials(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"Tier-0 route GET /api/v1/health must return 200 with no auth credentials")
+}
+
+// TestSetupRouter_Tier1Routes_RequireAuthentication verifies that Tier-1 routes on the
+// api subrouter reject unauthenticated callers with HTTP 401 (Issue #2224). The
+// requireTier(TierAny) middleware added to the api subrouter is pass-through (tier < 3),
+// so authentication is enforced by authenticationMiddleware, not requireTier — this test
+// confirms the full middleware chain rejects anonymous callers as expected.
+func TestSetupRouter_Tier1Routes_RequireAuthentication(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards", nil)
+	rec := httptest.NewRecorder()
+
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"Tier-1 route GET /api/v1/stewards must return 401 with no auth credentials")
+}


### PR DESCRIPTION
## Summary

- Added `api.Use(s.requireTier(TierAny))` between `authenticationMiddleware` and `validationMiddleware` on the api subrouter — pass-through (tier < TierMTLSOnly), zero enforcement change
- Added a Tier-0 comment block enumerating all nine public routes on the base router
- Added a Tier-1 comment block before api-subrouter route registrations declaring TierAny as the subrouter default
- Added `TestSetupRouter_Tier0Routes_AccessibleWithoutCredentials` and `TestSetupRouter_Tier1Routes_RequireAuthentication`

Fixes #2224

## Specialist Review Results

| Reviewer | Result |
|---|---|
| QA Test Runner (`make test-agent-complete`) | **PASS** — 158s api package, 100+ packages, cross-platform builds, integration tests |
| QA Code Reviewer | **PASS** — no mocks, no t.Skip, no empty assertions, no workarounds |
| Security Engineer | **PASS** — security-precommit, check-architecture, security-scan all clean |

## Test plan

- [ ] `GET /api/v1/health` with no auth → 200 (`TestSetupRouter_Tier0Routes_AccessibleWithoutCredentials`)
- [ ] `GET /api/v1/stewards` with no credentials → 401 (`TestSetupRouter_Tier1Routes_RequireAuthentication`)
- [ ] Existing auth tests in `TestAPIKeyAuthentication` and `TestPermissionDenial` continue to pass
- [ ] `make test-agent-complete` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)