### PR TITLE
session: controller session-token issuance and revocation (Issue #2232)

### DIFF
--- a/.github/codeql/extensions/models/log-injection-sanitizers.model.yml
+++ b/.github/codeql/extensions/models/log-injection-sanitizers.model.yml
@@ -38,8 +38,9 @@ extensions:
   # barrierModel does not suppress (e.g., json.Decode field-selection sources on some
   # CodeQL versions) are caught here. Both models must be present; neither alone is
   # reliable across all taint-flow paths (per testing in pack 0.0.5 / 0.0.6 history).
-  # Alerts #669, #713, #714, #715, #722 — belt-and-suspenders for SanitizeLogValue
-  # log-injection FPs that originate from JSON-decoded request fields.
+  # Alerts #669, #713, #714, #715, #722, #998, #999, #1000 — belt-and-suspenders for
+  # SanitizeLogValue log-injection FPs (mux.Vars URL params + JSON-decoded struct
+  # fields returned from interface calls, e.g. session.Manager.Issue → sess.ConnectionName).
   - addsTo:
       pack: codeql/go-all
       extensible: summaryModel

--- a/.github/codeql/extensions/models/log-injection-sanitizers.model.yml
+++ b/.github/codeql/extensions/models/log-injection-sanitizers.model.yml
@@ -47,3 +47,16 @@ extensions:
     data:
       - ["github.com/cfgis/cfgms/pkg/logging", "", false, "SanitizeLogValue", "", "", "Argument[0]", "ReturnValue", "value", "manual"]
       - ["github.com/cfgis/cfgms/pkg/logging", "", false, "RedactedID", "", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      # session.Manager.Issue() — the returned *Session carries ConnectionName, PrincipalID,
+      # and TenantID fields that originate from the string arguments (Argument[1..3]).
+      # CodeQL traces through the concrete manager.Issue() body and finds these args stored
+      # in the returned struct, creating taint paths: req.ConnectionName (from JSON decode)
+      # → Issue() Argument[2] → sess.ConnectionName → SanitizeLogValue() arg → logger sink.
+      # summaryModel(kind=value) for Manager.Issue() (subtypes: true covers the manager
+      # concrete type) overrides the source-code taint analysis, declaring that args 1–3
+      # have only value-flow (not taint-flow) to ReturnValue[0]. Combined with the
+      # SanitizeLogValue barrierModel above, this breaks the taint path at the method
+      # boundary. Covers alert #998.
+      - ["github.com/cfgis/cfgms/pkg/session", "Manager", true, "Issue", "", "", "Argument[1]", "ReturnValue[0]", "value", "manual"]
+      - ["github.com/cfgis/cfgms/pkg/session", "Manager", true, "Issue", "", "", "Argument[2]", "ReturnValue[0]", "value", "manual"]
+      - ["github.com/cfgis/cfgms/pkg/session", "Manager", true, "Issue", "", "", "Argument[3]", "ReturnValue[0]", "value", "manual"]

--- a/.github/codeql/extensions/qlpack.yml
+++ b/.github/codeql/extensions/qlpack.yml
@@ -1,5 +1,5 @@
 name: cfg-is/cfgms-go-extensions
-version: 0.0.7
+version: 0.0.8
 library: true
 
 # Apply our model extensions on top of the standard Go query pack so that

--- a/.github/codeql/extensions/qlpack.yml
+++ b/.github/codeql/extensions/qlpack.yml
@@ -1,5 +1,5 @@
 name: cfg-is/cfgms-go-extensions
-version: 0.0.8
+version: 0.0.9
 library: true
 
 # Apply our model extensions on top of the standard Go query pack so that

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -612,6 +612,33 @@ Three authentication mechanisms, used for different purposes.
 - Scoped, expirable tokens for the steward registration flow described in [Steward Registration](#steward-registration)
 - Not usable for general API authentication after bootstrap
 
+### Admin Session Model
+
+The zero-standing-privilege session model (ADR-014) eliminates long-lived admin credentials: a human admin authenticates once with a short-lived mTLS certificate, receives a rolling bearer token, and the token automatically expires if unused.
+
+**Session lifecycle:**
+
+1. `POST /api/v1/sessions` — admin mTLS only; returns `{session_id, token, issued_at, idle_ttl, absolute_expiry}` (HTTP 201). The token is a 43-char base64url string (32 random bytes from `crypto/rand`, 256 bits of entropy).
+2. Every authenticated request carrying `Authorization: Bearer <session-token>` resets the idle TTL and returns a refreshed token in the `X-Session-Token` response header. The client replaces its stored token with the refreshed value on each response.
+3. `DELETE /api/v1/sessions/{id}` — revokes immediately; callable with a valid session token or an admin mTLS cert.
+
+**Token lifecycle parameters (ADR-014 ratified defaults):**
+
+| Parameter | Default | Description |
+|---|---|---|
+| Idle TTL | 15 minutes | Session expires if no request is made within this window |
+| Absolute cap | 8 hours | Hard ceiling from original connect, regardless of activity |
+| Grace window | 30 seconds | Prior token remains valid this long after a renewal (tolerates racing requests from a stateless CLI) |
+
+**Rolling-token model:** On each successful request, the controller generates a fresh token (current token → new token, old token moves to grace slot). Concurrent requests carrying the prior token during the grace window are accepted without triggering a second rotation. After the grace window, the prior token is rejected (HTTP 401).
+
+**Security properties:**
+- The controller stores only SHA-256(token) — raw token values are never persisted or logged.
+- Token values are sanitized from all log output via `logging.SanitizeLogValue()`.
+- Session-token principals carry `IsAdmin=true` with the same tenant scope as the originating mTLS cert (typically empty for admin certs, meaning no tenant restriction).
+- Session tokens are length-distinguishable from API keys: session tokens are 43 chars (base64url without padding), API keys are 44 chars (base64url with padding). The middleware uses this length difference to route auth correctly.
+- A controller restart drops all sessions (re-auth required); durable session store is deferred to the SaaS cluster story (#2051).
+
 ## Multi-Tenancy
 
 The controller enforces strict tenant isolation across all operations.

--- a/features/controller/api/handlers_sessions.go
+++ b/features/controller/api/handlers_sessions.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// sessionCreateRequest is the JSON body for POST /api/v1/sessions.
+type sessionCreateRequest struct {
+	ConnectionName string `json:"connection_name"`
+}
+
+// sessionCreateResponse is returned on successful session creation (HTTP 201).
+// The token is the opaque 43-char base64url bearer credential; it is returned
+// exactly once and never re-issued — the client must store it securely.
+type sessionCreateResponse struct {
+	SessionID      string    `json:"session_id"`
+	Token          string    `json:"token"`
+	IssuedAt       time.Time `json:"issued_at"`
+	IdleTTLSeconds int64     `json:"idle_ttl"`
+	AbsoluteExpiry time.Time `json:"absolute_expiry"`
+}
+
+// handleSessionCreate handles POST /api/v1/sessions.
+// Requires an admin mTLS principal (principal.IsAdmin == true).
+// Returns HTTP 201 with session metadata and a one-time bearer token.
+func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil || !principal.IsAdmin {
+		s.writeErrorResponse(w, http.StatusForbidden, "Admin mTLS certificate required", "NOT_ADMIN")
+		return
+	}
+	if s.sessionManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Session management not available", "SESSION_UNAVAILABLE")
+		return
+	}
+
+	var req sessionCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid JSON body", "INVALID_JSON")
+		return
+	}
+
+	sess, token, err := s.sessionManager.Issue(r.Context(), principal.ID, req.ConnectionName, principal.TenantID)
+	if err != nil {
+		s.logger.Error("Failed to issue session",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create session", "SESSION_CREATE_ERROR")
+		return
+	}
+
+	s.logger.Info("Session issued",
+		"session_id", logging.SanitizeLogValue(sess.ID),
+		"principal_id", logging.SanitizeLogValue(sess.PrincipalID),
+		"connection_name", logging.SanitizeLogValue(sess.ConnectionName))
+
+	resp := sessionCreateResponse{
+		SessionID:      sess.ID,
+		Token:          token,
+		IssuedAt:       sess.IssuedAt,
+		IdleTTLSeconds: int64(s.sessionCfg.IdleTimeout / time.Second),
+		AbsoluteExpiry: sess.AbsoluteExpiresAt,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleSessionRevoke handles DELETE /api/v1/sessions/{id}.
+// Accepts either a valid session token or an admin mTLS cert as credentials.
+// Returns HTTP 200 on success or HTTP 404 if the session does not exist.
+func (s *Server) handleSessionRevoke(w http.ResponseWriter, r *http.Request) {
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil || !principal.IsAdmin {
+		s.writeErrorResponse(w, http.StatusForbidden, "Admin credential required", "NOT_ADMIN")
+		return
+	}
+	if s.sessionManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Session management not available", "SESSION_UNAVAILABLE")
+		return
+	}
+
+	vars := mux.Vars(r)
+	sessionID := vars["id"]
+	if sessionID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Session ID required", "MISSING_ID")
+		return
+	}
+
+	if err := s.sessionManager.Revoke(r.Context(), sessionID); err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Session not found", "SESSION_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to revoke session",
+			"session_id", logging.SanitizeLogValue(sessionID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to revoke session", "SESSION_REVOKE_ERROR")
+		return
+	}
+
+	s.logger.Info("Session revoked",
+		"session_id", logging.SanitizeLogValue(sessionID),
+		"principal_id", logging.SanitizeLogValue(principal.ID))
+
+	s.writeSuccessResponse(w, map[string]interface{}{
+		"id":      sessionID,
+		"revoked": true,
+	})
+}

--- a/features/controller/api/handlers_sessions_test.go
+++ b/features/controller/api/handlers_sessions_test.go
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// testClock is a controllable clock for handler tests that need to advance time
+// without sleeping. Separate from the session_test.fakeClock (different package).
+type testClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// setupTestServerWithSession returns a test server wired with a default-config
+// in-memory session manager.
+func setupTestServerWithSession(t *testing.T) (*Server, session.Manager, *session.MemStore) {
+	t.Helper()
+	srv := setupTestServer(t)
+	cfg := session.DefaultConfig()
+	store := session.NewMemStore(cfg, time.Now)
+	t.Cleanup(store.Close)
+	mgr := session.NewManager(cfg, store, time.Now)
+	srv.SetSessionManager(mgr)
+	return srv, mgr, store
+}
+
+// injectAdminPrincipal returns a copy of r with an admin Principal set in context.
+func injectAdminPrincipal(r *http.Request, principalID string) *http.Request {
+	p := &Principal{
+		ID:      principalID,
+		Name:    "mtls-admin:" + principalID,
+		IsAdmin: true,
+	}
+	return r.WithContext(context.WithValue(r.Context(), principalContextKey, p))
+}
+
+// injectNonAdminPrincipal returns a copy of r with a non-admin API-key Principal.
+func injectNonAdminPrincipal(r *http.Request) *http.Request {
+	p := &Principal{
+		ID:          "api-key-user",
+		Name:        "apikey",
+		IsAdmin:     false,
+		Permissions: []string{"steward:list"},
+		TenantID:    "default",
+	}
+	return r.WithContext(context.WithValue(r.Context(), principalContextKey, p))
+}
+
+// injectSessionMuxVars sets gorilla/mux route variables directly on the request
+// so handler unit tests bypass the router without losing URL variables.
+func injectSessionMuxVars(r *http.Request, vars map[string]string) *http.Request {
+	return mux.SetURLVars(r, vars)
+}
+
+// TestHandleSessionCreate_AdminReturns201 verifies that an admin principal can create
+// a session and receives the expected response fields including a 43-char bearer token
+// (32 random bytes, base64url no-padding, 256 bits of entropy).
+func TestHandleSessionCreate_AdminReturns201(t *testing.T) {
+	srv, _, _ := setupTestServerWithSession(t)
+
+	body := `{"connection_name":"test-ctrl"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(body))
+	req = injectAdminPrincipal(req, "alice")
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionCreate(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp sessionCreateResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.SessionID == "" {
+		t.Error("session_id must not be empty")
+	}
+	if len(resp.Token) != 43 {
+		t.Errorf("token length = %d, want 43 (256-bit base64url no-padding)", len(resp.Token))
+	}
+	if resp.IssuedAt.IsZero() {
+		t.Error("issued_at must be set")
+	}
+	if resp.IdleTTLSeconds != int64(15*time.Minute/time.Second) {
+		t.Errorf("idle_ttl = %d, want %d (15 min)", resp.IdleTTLSeconds, int64(15*time.Minute/time.Second))
+	}
+	if resp.AbsoluteExpiry.IsZero() {
+		t.Error("absolute_expiry must be set")
+	}
+}
+
+// TestHandleSessionCreate_NonAdminReturns403 verifies non-admin principals are rejected.
+func TestHandleSessionCreate_NonAdminReturns403(t *testing.T) {
+	srv, _, _ := setupTestServerWithSession(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(`{}`))
+	req = injectNonAdminPrincipal(req)
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionCreate(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+// TestHandleSessionCreate_InvalidJSON verifies HTTP 400 when the request body is not valid JSON.
+func TestHandleSessionCreate_InvalidJSON(t *testing.T) {
+	srv, _, _ := setupTestServerWithSession(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(`not-json`))
+	req = injectAdminPrincipal(req, "alice")
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionCreate(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for invalid JSON body", rec.Code)
+	}
+}
+
+// TestHandleSessionRevoke_ImmediateRevocation verifies DELETE /api/v1/sessions/{id}
+// revokes immediately; a subsequent request with the revoked token returns 401.
+func TestHandleSessionRevoke_ImmediateRevocation(t *testing.T) {
+	srv, mgr, _ := setupTestServerWithSession(t)
+
+	sess, token, err := mgr.Issue(context.Background(), "bob", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Revoke via handler.
+	revokeReq := httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/"+sess.ID, nil)
+	revokeReq = injectAdminPrincipal(revokeReq, "bob")
+	revokeReq = injectSessionMuxVars(revokeReq, map[string]string{"id": sess.ID})
+	revokeRec := httptest.NewRecorder()
+	srv.handleSessionRevoke(revokeRec, revokeReq)
+
+	if revokeRec.Code != http.StatusOK {
+		t.Fatalf("revoke status = %d, want 200; body: %s", revokeRec.Code, revokeRec.Body.String())
+	}
+
+	// A subsequent request with the revoked token must receive 401 from the middleware.
+	authReq := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	authReq.Header.Set("Authorization", "Bearer "+token)
+	authRec := httptest.NewRecorder()
+	srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // should never be reached
+	})).ServeHTTP(authRec, authReq)
+
+	if authRec.Code != http.StatusUnauthorized {
+		t.Errorf("revoked token: status = %d, want 401", authRec.Code)
+	}
+}
+
+// TestHandleSessionRevoke_NotFound verifies HTTP 404 when the session ID does not exist.
+func TestHandleSessionRevoke_NotFound(t *testing.T) {
+	srv, _, _ := setupTestServerWithSession(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/no-such-id", nil)
+	req = injectAdminPrincipal(req, "admin")
+	req = injectSessionMuxVars(req, map[string]string{"id": "no-such-id"})
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionRevoke(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// TestHandleSessionRevoke_NonAdminReturns403 verifies non-admin principals cannot revoke sessions.
+func TestHandleSessionRevoke_NonAdminReturns403(t *testing.T) {
+	srv, mgr, _ := setupTestServerWithSession(t)
+
+	sess, _, err := mgr.Issue(context.Background(), "alice", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/"+sess.ID, nil)
+	req = injectNonAdminPrincipal(req)
+	req = injectSessionMuxVars(req, map[string]string{"id": sess.ID})
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionRevoke(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+// TestSessionTokenAuthMiddleware_ValidToken verifies that a 43-char Bearer token
+// resolves to an admin Principal and sets X-Session-Token on the response.
+func TestSessionTokenAuthMiddleware_ValidToken(t *testing.T) {
+	srv, mgr, _ := setupTestServerWithSession(t)
+
+	_, token, err := mgr.Issue(context.Background(), "carol", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	var capturedPrincipal *Principal
+	handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if capturedPrincipal == nil {
+		t.Fatal("principal not set in context")
+	}
+	if !capturedPrincipal.IsAdmin {
+		t.Error("session-token principal must have IsAdmin=true")
+	}
+	if capturedPrincipal.ID != "carol" {
+		t.Errorf("principal ID = %q, want %q", capturedPrincipal.ID, "carol")
+	}
+	if rec.Header().Get("X-Session-Token") == "" {
+		t.Error("X-Session-Token response header must be set after session-token auth")
+	}
+}
+
+// TestSessionTokenAuthMiddleware_ExpiredToken verifies 401 for expired session tokens.
+// Uses an injectable clock to avoid time.Sleep.
+func TestSessionTokenAuthMiddleware_ExpiredToken(t *testing.T) {
+	srv := setupTestServer(t)
+	cfg := session.Config{
+		IdleTimeout:     100 * time.Millisecond,
+		AbsoluteTimeout: 100 * time.Millisecond,
+		GraceWindow:     10 * time.Millisecond,
+	}
+	clock := &testClock{t: time.Now()}
+	store := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(store.Close)
+	mgr := session.NewManager(cfg, store, clock.Now)
+	srv.SetSessionManager(mgr)
+
+	_, token, err := mgr.Issue(context.Background(), "dave", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Advance clock past both idle TTL and absolute timeout — no sleep needed.
+	clock.advance(200 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expired token: status = %d, want 401", rec.Code)
+	}
+}
+
+// TestSessionTokenAuthMiddleware_FallsThrough_NonSessionToken verifies that a
+// non-43-char Bearer token falls through to the API-key auth path (not rejected
+// as an invalid session token), because API keys are 44 chars (base64url+padding).
+func TestSessionTokenAuthMiddleware_FallsThrough_NonSessionToken(t *testing.T) {
+	srv, _, _ := setupTestServerWithSession(t)
+
+	// 44-char key (standard base64url with padding, len == 44 ≠ 43).
+	apiKey44 := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // 44 chars
+	injectAPIKey(srv, &APIKey{
+		ID:          "k1",
+		Key:         apiKey44,
+		Name:        "test-key",
+		Permissions: []string{"steward:list"},
+		TenantID:    "default",
+	})
+
+	var reached bool
+	handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey44)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !reached {
+		t.Errorf("44-char Bearer token should fall through to API-key path, got status %d", rec.Code)
+	}
+}
+
+// TestSessionTokenNotInLogs verifies that raw token values do not appear in HTTP
+// response bodies or error messages — the logging assertion for the controller layer.
+// The pkg/session package has no logging; token sanitization is verified at the
+// handler level by inspecting that error responses never echo the raw token.
+func TestSessionTokenNotInLogs(t *testing.T) {
+	srv, mgr, _ := setupTestServerWithSession(t)
+
+	sess, token, err := mgr.Issue(context.Background(), "eve", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Trigger middleware renew cycle; capture X-Session-Token.
+	handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	newToken := rec.Header().Get("X-Session-Token")
+
+	// Revoke.
+	revokeReq := httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/"+sess.ID, nil)
+	revokeReq = injectAdminPrincipal(revokeReq, "eve")
+	revokeReq = injectSessionMuxVars(revokeReq, map[string]string{"id": sess.ID})
+	srv.handleSessionRevoke(httptest.NewRecorder(), revokeReq)
+
+	// Attempt to use the revoked token — the error response must not echo back the token.
+	errReq := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	errReq.Header.Set("Authorization", "Bearer "+token)
+	errRec := httptest.NewRecorder()
+	srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(errRec, errReq)
+
+	errBody := errRec.Body.String()
+	if strings.Contains(errBody, token) {
+		t.Errorf("error response body contains raw token value — must not echo tokens")
+	}
+	if newToken != "" && strings.Contains(errBody, newToken) {
+		t.Errorf("error response body contains renewed token value — must not echo tokens")
+	}
+}
+
+// TestHandleSessionCreate_NoSessionManager returns 503 when no manager is wired.
+func TestHandleSessionCreate_NoSessionManager(t *testing.T) {
+	srv := setupTestServer(t) // no SetSessionManager call
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(`{}`))
+	req = injectAdminPrincipal(req, "alice")
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionCreate(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 when sessionManager is nil", rec.Code)
+	}
+}

--- a/features/controller/api/handlers_sessions_test.go
+++ b/features/controller/api/handlers_sessions_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/session"
 )
 
@@ -48,6 +50,48 @@ func setupTestServerWithSession(t *testing.T) (*Server, session.Manager, *sessio
 	mgr := session.NewManager(cfg, store, time.Now)
 	srv.SetSessionManager(mgr)
 	return srv, mgr, store
+}
+
+// captureAllLogger records every log call at every level into a buffer so tests
+// can assert that sensitive values (e.g. raw session tokens) never appear in logs.
+type captureAllLogger struct {
+	logging.NoopLogger
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (l *captureAllLogger) record(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.buf.WriteString(msg)
+	for _, v := range kvs {
+		fmt.Fprintf(&l.buf, " %v", v)
+	}
+	l.buf.WriteByte('\n')
+}
+
+func (l *captureAllLogger) captured() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+func (l *captureAllLogger) Debug(msg string, kvs ...interface{}) { l.record(msg, kvs...) }
+func (l *captureAllLogger) Info(msg string, kvs ...interface{})  { l.record(msg, kvs...) }
+func (l *captureAllLogger) Warn(msg string, kvs ...interface{})  { l.record(msg, kvs...) }
+func (l *captureAllLogger) Error(msg string, kvs ...interface{}) { l.record(msg, kvs...) }
+
+func (l *captureAllLogger) DebugCtx(_ context.Context, msg string, kvs ...interface{}) {
+	l.record(msg, kvs...)
+}
+func (l *captureAllLogger) InfoCtx(_ context.Context, msg string, kvs ...interface{}) {
+	l.record(msg, kvs...)
+}
+func (l *captureAllLogger) WarnCtx(_ context.Context, msg string, kvs ...interface{}) {
+	l.record(msg, kvs...)
+}
+func (l *captureAllLogger) ErrorCtx(_ context.Context, msg string, kvs ...interface{}) {
+	l.record(msg, kvs...)
 }
 
 // injectAdminPrincipal returns a copy of r with an admin Principal set in context.
@@ -322,48 +366,66 @@ func TestSessionTokenAuthMiddleware_FallsThrough_NonSessionToken(t *testing.T) {
 	}
 }
 
-// TestSessionTokenNotInLogs verifies that raw token values do not appear in HTTP
-// response bodies or error messages — the logging assertion for the controller layer.
-// The pkg/session package has no logging; token sanitization is verified at the
-// handler level by inspecting that error responses never echo the raw token.
+// TestSessionTokenNotInLogs verifies that raw token values never appear in any
+// controller log line across a full connect/renew/revoke cycle.  It wires a
+// buffer-backed logger (captureAllLogger) so every Info/Error/Warn/Debug call is
+// recorded, then asserts that neither the original token nor the renewed token is
+// present in the captured output.
 func TestSessionTokenNotInLogs(t *testing.T) {
-	srv, mgr, _ := setupTestServerWithSession(t)
+	// Wire a capture logger so we can inspect every log line produced during
+	// the connect/renew/revoke cycle.
+	clog := &captureAllLogger{}
+	srv := setupTestServerWithLogger(t, clog)
+	cfg := session.DefaultConfig()
+	store := session.NewMemStore(cfg, time.Now)
+	t.Cleanup(store.Close)
+	mgr := session.NewManager(cfg, store, time.Now)
+	srv.SetSessionManager(mgr)
 
-	sess, token, err := mgr.Issue(context.Background(), "eve", "ctrl", "")
-	if err != nil {
-		t.Fatalf("Issue: %v", err)
+	// Connect: issue session via the handler so "Session issued" is logged.
+	createBody := `{"connection_name":"log-test-ctrl"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(createBody))
+	createReq = injectAdminPrincipal(createReq, "log-user")
+	createRec := httptest.NewRecorder()
+	srv.handleSessionCreate(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("handleSessionCreate: status = %d, want 201; body: %s", createRec.Code, createRec.Body.String())
 	}
+	var createResp sessionCreateResponse
+	if err := json.NewDecoder(createRec.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	token := createResp.Token
+	sessID := createResp.SessionID
 
-	// Trigger middleware renew cycle; capture X-Session-Token.
-	handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// Renew: trigger the middleware path that calls Renew internally.
+	// Per the middleware comment, the raw new token is never logged.
+	renewHandler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-	newToken := rec.Header().Get("X-Session-Token")
+	renewReq := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	renewReq.Header.Set("Authorization", "Bearer "+token)
+	renewRec := httptest.NewRecorder()
+	renewHandler.ServeHTTP(renewRec, renewReq)
+	newToken := renewRec.Header().Get("X-Session-Token")
 
-	// Revoke.
-	revokeReq := httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/"+sess.ID, nil)
-	revokeReq = injectAdminPrincipal(revokeReq, "eve")
-	revokeReq = injectSessionMuxVars(revokeReq, map[string]string{"id": sess.ID})
-	srv.handleSessionRevoke(httptest.NewRecorder(), revokeReq)
-
-	// Attempt to use the revoked token — the error response must not echo back the token.
-	errReq := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
-	errReq.Header.Set("Authorization", "Bearer "+token)
-	errRec := httptest.NewRecorder()
-	srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})).ServeHTTP(errRec, errReq)
-
-	errBody := errRec.Body.String()
-	if strings.Contains(errBody, token) {
-		t.Errorf("error response body contains raw token value — must not echo tokens")
+	// Revoke: revoke via handler so "Session revoked" is logged.
+	revokeReq := httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/"+sessID, nil)
+	revokeReq = injectAdminPrincipal(revokeReq, "log-user")
+	revokeReq = injectSessionMuxVars(revokeReq, map[string]string{"id": sessID})
+	revokeRec := httptest.NewRecorder()
+	srv.handleSessionRevoke(revokeRec, revokeReq)
+	if revokeRec.Code != http.StatusOK {
+		t.Fatalf("handleSessionRevoke: status = %d, want 200", revokeRec.Code)
 	}
-	if newToken != "" && strings.Contains(errBody, newToken) {
-		t.Errorf("error response body contains renewed token value — must not echo tokens")
+
+	// Assert: inspect every captured log line for raw token values.
+	logOutput := clog.captured()
+	if strings.Contains(logOutput, token) {
+		t.Errorf("log output contains raw session token — tokens must not be logged\nlog:\n%s", logOutput)
+	}
+	if newToken != "" && strings.Contains(logOutput, newToken) {
+		t.Errorf("log output contains renewed token value — tokens must not be logged\nlog:\n%s", logOutput)
 	}
 }
 

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -21,6 +22,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 )
 
 // contextKey is a custom type for context keys to avoid collisions
@@ -259,7 +261,63 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// State (c)/(d): no admin cert presented — use API-key path.
+		// State (c)/(d): no admin cert presented.
+
+		// Session-token path (Issue #2232): intercept Bearer tokens that are 43 chars
+		// (base64url without padding for 32 random bytes — length-distinguishable from
+		// API keys, which use base64url with padding: 44 chars). Only attempted when a
+		// sessionManager is wired; falls through to API-key path otherwise.
+		//
+		// Contract:
+		//   - Token present, 43 chars, manager wired, valid   → admin Principal from session + X-Session-Token header
+		//   - Token present, 43 chars, manager wired, invalid → 401 (no fallthrough to API-key)
+		//   - Token present, non-43 chars OR manager nil       → fall through to API-key path
+		if s.sessionManager != nil {
+			authHeader := r.Header.Get("Authorization")
+			if strings.HasPrefix(authHeader, "Bearer ") {
+				bearerToken := strings.TrimPrefix(authHeader, "Bearer ")
+				// sessionTokenLen is the exact length of a session token:
+				// base64.RawURLEncoding of 32 bytes = 43 chars (no padding).
+				const sessionTokenLen = 43
+				if len(bearerToken) == sessionTokenLen {
+					sess, err := s.sessionManager.Validate(r.Context(), bearerToken)
+					if err != nil {
+						switch {
+						case errors.Is(err, session.ErrSessionRevoked):
+							s.writeErrorResponse(w, http.StatusUnauthorized, "Session has been revoked", "SESSION_REVOKED")
+						case errors.Is(err, session.ErrSessionExpired):
+							s.writeErrorResponse(w, http.StatusUnauthorized, "Session has expired", "SESSION_EXPIRED")
+						default:
+							s.writeErrorResponse(w, http.StatusUnauthorized, "Invalid session token", "INVALID_SESSION_TOKEN")
+						}
+						return
+					}
+					// Renew the session to reset idle TTL; set X-Session-Token when
+					// a new token is issued (empty string = prior-token grace path,
+					// no new token to publish). The raw new token is never logged.
+					_, newToken, renewErr := s.sessionManager.Renew(r.Context(), bearerToken)
+					if renewErr == nil && newToken != "" {
+						w.Header().Set("X-Session-Token", newToken)
+					}
+					// Build an admin Principal from session state.
+					sessionPrincipal := &Principal{
+						ID:      sess.PrincipalID,
+						Name:    "session:" + logging.SanitizeLogValue(sess.PrincipalID),
+						IsAdmin: true,
+						// TenantID mirrors the issuing admin cert; "" means no tenant scope
+						// (same semantics as extractAdminPrincipal for mTLS admin certs).
+						TenantID: sess.TenantID,
+					}
+					ctx := context.WithValue(r.Context(), principalContextKey, sessionPrincipal)
+					ctx = context.WithValue(ctx, ctxkeys.UserIDKey, logging.SanitizeLogValue(sess.PrincipalID))
+					ctx = context.WithValue(ctx, ctxkeys.TenantID, sess.TenantID)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+			}
+		}
+
+		// API-key path.
 
 		// Extract API key from header
 		apiKeyStr := r.Header.Get("X-API-Key")

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/registration"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops" // Auto-register SOPS provider
+	"github.com/cfgis/cfgms/pkg/session"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -114,6 +115,8 @@ type Server struct {
 	popVerifier                    PoPVerifier                           // Issue #2096: injectable for revoked-before-PoP testing
 	isolationEngine                *tenantsecurity.TenantIsolationEngine // Issue #2123: tenant isolation enforcement for scoped API keys
 	stewardEventLoggingManager     *logging.LoggingManager               // Issue #2139: dedicated sink for steward events; queried by handleGetStewardLogs (S6)
+	sessionManager                 session.Manager                       // Issue #2232: admin session token issuance/revocation
+	sessionCfg                     session.Config                        // Issue #2232: session lifecycle tunables (idle TTL, absolute cap, grace window)
 	stopCleanup                    chan struct{}                         // signals startAPIKeyCleanup to exit
 	cleanupDone                    chan struct{}                         // closed when cleanup goroutine exits
 	closeOnce                      sync.Once                             // idempotent Close
@@ -214,6 +217,7 @@ func New(
 		blobStore:               blobStore,                // Issue #1702: installer artifact storage
 		nonceCache:              newNonceCache(),          // Issue #2096: nonce store for registration-refresh
 		popVerifier:             ed25519PoPVerifier{},     // Issue #2096: default PoP verifier; override in tests
+		sessionCfg:              session.DefaultConfig(),  // Issue #2232: ADR-014 session lifecycle tunables
 		stopCleanup:             make(chan struct{}),
 		cleanupDone:             make(chan struct{}),
 	}
@@ -484,6 +488,13 @@ func (s *Server) setupRouter() {
 	apiKeys.Handle("", s.requirePermission("api-key", "create")(http.HandlerFunc(s.handleCreateAPIKey))).Methods("POST")
 	apiKeys.Handle("/{id}", s.requirePermission("api-key", "read")(http.HandlerFunc(s.handleGetAPIKey))).Methods("GET")
 	apiKeys.Handle("/{id}", s.requirePermission("api-key", "delete")(http.HandlerFunc(s.handleDeleteAPIKey))).Methods("DELETE")
+
+	// Admin session endpoints (Issue #2232). POST requires an admin principal (IsAdmin==true);
+	// DELETE accepts either a valid session token or an admin mTLS cert.
+	// Both handlers check principal.IsAdmin internally — no tier-3 wrapper needed because
+	// session-token principals also have IsAdmin==true.
+	api.Handle("/sessions", http.HandlerFunc(s.handleSessionCreate)).Methods("POST")
+	api.Handle("/sessions/{id}", http.HandlerFunc(s.handleSessionRevoke)).Methods("DELETE")
 
 	// Registration token management endpoints (Story #264)
 	regTokens := api.PathPrefix("/registration/tokens").Subrouter()
@@ -1001,6 +1012,15 @@ func (s *Server) SetSigningRotationService(svc *service.SigningRotationService) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.signingRotationService = svc
+}
+
+// SetSessionManager wires the session Manager for admin session-token issuance and
+// revocation (Issue #2232). When nil (default), POST /api/v1/sessions and
+// DELETE /api/v1/sessions/{id} return 503. Call after New() but before Start().
+func (s *Server) SetSessionManager(mgr session.Manager) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessionManager = mgr
 }
 
 // SetStewardEventLoggingManager injects the dedicated steward-event

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// managedSession tracks the rolling-token state for a single live session.
+// mu serialises Renew calls so two concurrent prior-token requests cannot
+// each trigger a rotation (compare-and-swap semantics without atomic ops).
+type managedSession struct {
+	mu          sync.Mutex
+	session     *Session
+	currentHash string
+	prevHash    string    // non-empty during the GraceWindow following a Renew
+	prevExpiry  time.Time // absolute time after which prevHash is rejected; zero when prevHash is ""
+	revoked     bool
+}
+
+// manager implements Manager using a pluggable Store and an injectable clock.
+type manager struct {
+	cfg     Config
+	store   Store
+	clockFn func() time.Time
+
+	mu       sync.RWMutex
+	sessions map[string]*managedSession // key = session ID
+	byHash   map[string]*managedSession // key = token hash (current or prev)
+}
+
+// NewManager creates a Manager that delegates persistence to store.
+// Pass time.Now as clockFn in production; inject a fixed or advancing clock in tests.
+func NewManager(cfg Config, store Store, clockFn func() time.Time) Manager {
+	if clockFn == nil {
+		clockFn = time.Now
+	}
+	return &manager{
+		cfg:      cfg,
+		store:    store,
+		clockFn:  clockFn,
+		sessions: make(map[string]*managedSession),
+		byHash:   make(map[string]*managedSession),
+	}
+}
+
+// Issue mints a new session for the given principal. It returns the live Session
+// record and an opaque 43-char base64url bearer token. The controller stores only
+// SHA-256(token); the raw token is returned once and never persisted.
+func (m *manager) Issue(ctx context.Context, principalID, connectionName, tenantID string) (*Session, string, error) {
+	token, err := GenerateToken()
+	if err != nil {
+		return nil, "", err
+	}
+	hash := HashToken(token)
+	now := m.clockFn()
+	sess := &Session{
+		ID:                uuid.New().String(),
+		PrincipalID:       principalID,
+		ConnectionName:    connectionName,
+		TenantID:          tenantID,
+		IssuedAt:          now,
+		LastActivity:      now,
+		AbsoluteExpiresAt: now.Add(m.cfg.AbsoluteTimeout),
+	}
+	ms := &managedSession{
+		session:     sess,
+		currentHash: hash,
+	}
+	m.mu.Lock()
+	m.sessions[sess.ID] = ms
+	m.byHash[hash] = ms
+	m.mu.Unlock()
+	if err := m.store.Set(ctx, hash, sess); err != nil {
+		m.mu.Lock()
+		delete(m.sessions, sess.ID)
+		delete(m.byHash, hash)
+		m.mu.Unlock()
+		return nil, "", err
+	}
+	out := *sess
+	return &out, token, nil
+}
+
+// Validate authenticates the bearer token and returns the live session, updating
+// LastActivity. It returns ErrSessionExpired or ErrSessionRevoked on failure.
+// Prior-token grace entries (within GraceWindow after a Renew) are also accepted
+// but do NOT update LastActivity (the renewed token owns the idle TTL).
+func (m *manager) Validate(ctx context.Context, token string) (*Session, error) {
+	hash := HashToken(token)
+	m.mu.RLock()
+	ms := m.byHash[hash]
+	m.mu.RUnlock()
+	if ms == nil {
+		return nil, ErrSessionNotFound
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if ms.revoked {
+		return nil, ErrSessionRevoked
+	}
+	now := m.clockFn()
+	if now.After(ms.session.AbsoluteExpiresAt) {
+		return nil, ErrSessionExpired
+	}
+	if hash == ms.prevHash {
+		// Prior-token path: only grace-window check; idle TTL is on the new token.
+		if !ms.prevExpiry.IsZero() && now.After(ms.prevExpiry) {
+			return nil, ErrSessionExpired
+		}
+	} else {
+		// Current-token path: enforce idle TTL and bump LastActivity.
+		if now.After(ms.session.LastActivity.Add(m.cfg.IdleTimeout)) {
+			return nil, ErrSessionExpired
+		}
+		ms.session.LastActivity = now
+		_ = m.store.Set(ctx, hash, ms.session) // best-effort sync; in-memory is authoritative
+	}
+	out := *ms.session
+	return &out, nil
+}
+
+// Renew re-issues a fresh TTL'd token for an active session (rolling token model).
+// If token is the current token a new token is generated, the current token moves
+// to the grace slot, and the new token is returned. If token is already in the
+// grace slot (concurrent prior-token request), no rotation occurs and the returned
+// new-token string is empty — the caller should not overwrite any X-Session-Token
+// header the client may have already received.
+func (m *manager) Renew(ctx context.Context, token string) (*Session, string, error) {
+	hash := HashToken(token)
+	m.mu.RLock()
+	ms := m.byHash[hash]
+	m.mu.RUnlock()
+	if ms == nil {
+		return nil, "", ErrSessionNotFound
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if ms.revoked {
+		return nil, "", ErrSessionRevoked
+	}
+	now := m.clockFn()
+	if now.After(ms.session.AbsoluteExpiresAt) {
+		return nil, "", ErrSessionExpired
+	}
+	// Prior-token path: idempotent — don't double-rotate.
+	if hash == ms.prevHash {
+		if !ms.prevExpiry.IsZero() && now.After(ms.prevExpiry) {
+			return nil, "", ErrSessionExpired
+		}
+		out := *ms.session
+		return &out, "", nil
+	}
+	// Current-token path: check idle TTL.
+	if now.After(ms.session.LastActivity.Add(m.cfg.IdleTimeout)) {
+		return nil, "", ErrSessionExpired
+	}
+	// Rotate: generate a new token.
+	newToken, err := GenerateToken()
+	if err != nil {
+		return nil, "", err
+	}
+	newHash := HashToken(newToken)
+	ms.session.LastActivity = now
+	// Evict the old grace entry (if any) from byHash before overwriting prevHash.
+	if ms.prevHash != "" {
+		m.mu.Lock()
+		delete(m.byHash, ms.prevHash)
+		m.mu.Unlock()
+	}
+	ms.prevHash = ms.currentHash
+	ms.prevExpiry = now.Add(m.cfg.GraceWindow)
+	ms.currentHash = newHash
+	m.mu.Lock()
+	m.byHash[newHash] = ms
+	m.mu.Unlock()
+	// Persist the new hash mapping.
+	_ = m.store.Set(ctx, newHash, ms.session)
+	out := *ms.session
+	return &out, newToken, nil
+}
+
+// Revoke immediately invalidates the session identified by id. Subsequent Validate
+// or Renew calls for any token belonging to this session return ErrSessionRevoked.
+func (m *manager) Revoke(ctx context.Context, id string) error {
+	m.mu.RLock()
+	ms := m.sessions[id]
+	m.mu.RUnlock()
+	if ms == nil {
+		return ErrSessionNotFound
+	}
+	ms.mu.Lock()
+	ms.revoked = true
+	ms.mu.Unlock()
+	return m.store.Delete(ctx, id)
+}

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -78,11 +78,14 @@ func TestManagerRevoke(t *testing.T) {
 	mgr, _ := newTestManager(t, cfg, clock)
 	ctx := context.Background()
 
-	sess, token, _ := mgr.Issue(ctx, "bob", "ctrl", "")
+	sess, token, err := mgr.Issue(ctx, "bob", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
 	if err := mgr.Revoke(ctx, sess.ID); err != nil {
 		t.Fatalf("Revoke: %v", err)
 	}
-	_, err := mgr.Validate(ctx, token)
+	_, err = mgr.Validate(ctx, token)
 	if !errors.Is(err, session.ErrSessionRevoked) {
 		t.Errorf("after Revoke, Validate: got %v, want ErrSessionRevoked", err)
 	}
@@ -98,10 +101,13 @@ func TestManagerIdleTTL(t *testing.T) {
 	mgr, _ := newTestManager(t, cfg, clock)
 	ctx := context.Background()
 
-	_, token, _ := mgr.Issue(ctx, "carol", "ctrl", "")
+	_, token, err := mgr.Issue(ctx, "carol", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
 	// Advance past idle TTL without any Validate call.
 	clock.advance(200 * time.Millisecond)
-	_, err := mgr.Validate(ctx, token)
+	_, err = mgr.Validate(ctx, token)
 	if !errors.Is(err, session.ErrSessionExpired) {
 		t.Errorf("idle TTL exceeded: got %v, want ErrSessionExpired", err)
 	}
@@ -119,7 +125,10 @@ func TestSessionAbsoluteCap(t *testing.T) {
 	mgr, _ := newTestManager(t, cfg, clock)
 	ctx := context.Background()
 
-	_, token, _ := mgr.Issue(ctx, "dave", "ctrl", "")
+	_, token, err := mgr.Issue(ctx, "dave", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
 
 	// Continuously renew while advancing time, keeping idle TTL fresh.
 	// Advance in 100ms increments, renewing each time, until past absolute cap.
@@ -139,7 +148,7 @@ func TestSessionAbsoluteCap(t *testing.T) {
 	}
 
 	// After > 500ms total, the session must be expired.
-	_, err := mgr.Validate(ctx, token)
+	_, err = mgr.Validate(ctx, token)
 	if !errors.Is(err, session.ErrSessionExpired) {
 		t.Errorf("absolute cap: Validate returned %v, want ErrSessionExpired", err)
 	}
@@ -159,7 +168,10 @@ func TestRollingTokenGraceWindow(t *testing.T) {
 	mgr, _ := newTestManager(t, cfg, clock)
 	ctx := context.Background()
 
-	_, tokenA, _ := mgr.Issue(ctx, "eve", "ctrl", "")
+	_, tokenA, err := mgr.Issue(ctx, "eve", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
 
 	// Renew with tokenA → get tokenB.
 	_, tokenB, err := mgr.Renew(ctx, tokenA)

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// fakeClock is a monotonically-advanceable clock for time-injected tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func newTestManager(t *testing.T, cfg session.Config, clock *fakeClock) (session.Manager, *session.MemStore) {
+	t.Helper()
+	store := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(store.Close)
+	mgr := session.NewManager(cfg, store, clock.Now)
+	return mgr, store
+}
+
+func TestManagerIssueAndValidate(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     5 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, token, err := mgr.Issue(ctx, "alice", "my-ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if len(token) != 43 {
+		t.Errorf("token length = %d, want 43 (base64url no-padding for 32 bytes)", len(token))
+	}
+	if sess.ID == "" || sess.PrincipalID != "alice" {
+		t.Errorf("unexpected session: %+v", sess)
+	}
+
+	got, err := mgr.Validate(ctx, token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got.ID != sess.ID {
+		t.Errorf("session ID mismatch: got %q, want %q", got.ID, sess.ID)
+	}
+}
+
+func TestManagerRevoke(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     5 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, token, _ := mgr.Issue(ctx, "bob", "ctrl", "")
+	if err := mgr.Revoke(ctx, sess.ID); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	_, err := mgr.Validate(ctx, token)
+	if !errors.Is(err, session.ErrSessionRevoked) {
+		t.Errorf("after Revoke, Validate: got %v, want ErrSessionRevoked", err)
+	}
+}
+
+func TestManagerIdleTTL(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     100 * time.Millisecond,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	_, token, _ := mgr.Issue(ctx, "carol", "ctrl", "")
+	// Advance past idle TTL without any Validate call.
+	clock.advance(200 * time.Millisecond)
+	_, err := mgr.Validate(ctx, token)
+	if !errors.Is(err, session.ErrSessionExpired) {
+		t.Errorf("idle TTL exceeded: got %v, want ErrSessionExpired", err)
+	}
+}
+
+// TestSessionAbsoluteCap verifies that a continuously-renewed session is refused
+// once the absolute cap elapses, even though the idle TTL has not.
+func TestSessionAbsoluteCap(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     10 * time.Minute,
+		AbsoluteTimeout: 500 * time.Millisecond,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	_, token, _ := mgr.Issue(ctx, "dave", "ctrl", "")
+
+	// Continuously renew while advancing time, keeping idle TTL fresh.
+	// Advance in 100ms increments, renewing each time, until past absolute cap.
+	for i := 0; i < 7; i++ {
+		clock.advance(100 * time.Millisecond)
+		_, newToken, err := mgr.Renew(ctx, token)
+		if err != nil {
+			// If absolute cap hit during renewal, that's fine.
+			if errors.Is(err, session.ErrSessionExpired) {
+				return
+			}
+			t.Fatalf("unexpected Renew error at step %d: %v", i, err)
+		}
+		if newToken != "" {
+			token = newToken
+		}
+	}
+
+	// After > 500ms total, the session must be expired.
+	_, err := mgr.Validate(ctx, token)
+	if !errors.Is(err, session.ErrSessionExpired) {
+		t.Errorf("absolute cap: Validate returned %v, want ErrSessionExpired", err)
+	}
+}
+
+// TestRollingTokenGraceWindow verifies:
+//  1. After renewal, both prior and new tokens are accepted within GraceWindow.
+//  2. Two concurrent prior-token Renew calls do not double-rotate.
+//  3. Prior token is rejected after GraceWindow elapses.
+func TestRollingTokenGraceWindow(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     10 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     200 * time.Millisecond,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	_, tokenA, _ := mgr.Issue(ctx, "eve", "ctrl", "")
+
+	// Renew with tokenA → get tokenB.
+	_, tokenB, err := mgr.Renew(ctx, tokenA)
+	if err != nil {
+		t.Fatalf("first Renew: %v", err)
+	}
+	if tokenB == "" {
+		t.Fatal("first Renew must return a new token")
+	}
+
+	// Within grace window, both tokenA and tokenB must be accepted.
+	clock.advance(50 * time.Millisecond) // well inside 200ms grace
+	if _, err := mgr.Validate(ctx, tokenA); err != nil {
+		t.Errorf("prior token inside grace: Validate returned %v, want nil", err)
+	}
+	if _, err := mgr.Validate(ctx, tokenB); err != nil {
+		t.Errorf("new token inside grace: Validate returned %v, want nil", err)
+	}
+
+	// Concurrent prior-token Renew calls must not double-rotate.
+	var wg sync.WaitGroup
+	tokenResults := make([]string, 2)
+	errResults := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			// Both goroutines hold tokenA (the prev token).
+			_, newTok, err := mgr.Renew(ctx, tokenA)
+			tokenResults[idx] = newTok
+			errResults[idx] = err
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errResults {
+		if err != nil {
+			t.Errorf("concurrent Renew[%d]: unexpected error: %v", i, err)
+		}
+	}
+	// At most one of them should have received a new token (the other sees prev slot and returns "").
+	newTokenCount := 0
+	for _, tok := range tokenResults {
+		if tok != "" {
+			newTokenCount++
+		}
+	}
+	if newTokenCount > 1 {
+		t.Errorf("double-rotation: %d concurrent prior-token Renews both returned new tokens", newTokenCount)
+	}
+
+	// After GraceWindow elapses, prior token must be rejected.
+	clock.advance(300 * time.Millisecond) // past 200ms grace
+	_, err = mgr.Validate(ctx, tokenA)
+	if !errors.Is(err, session.ErrSessionExpired) {
+		t.Errorf("prior token after grace: got %v, want ErrSessionExpired", err)
+	}
+	// tokenB remains valid (it is now the current token; idle TTL was reset on first Validate).
+	if _, err := mgr.Validate(ctx, tokenB); err != nil {
+		t.Errorf("new token after grace elapsed: got %v (should still be valid)", err)
+	}
+}
+
+// TestTokenNotStoredRaw verifies that the Store never holds the raw token value.
+// The AC requires "raw-token lookup misses, hash lookup hits" as the assertion.
+// Controller-level log sanitization is verified in handlers_sessions_test.go.
+func TestTokenNotStoredRaw(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	store := session.NewMemStore(cfg, clock.Now)
+	defer store.Close()
+	mgr := session.NewManager(cfg, store, clock.Now)
+	ctx := context.Background()
+
+	sess, token, err := mgr.Issue(ctx, "frank", "ctrl", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Raw token must not be a valid store key.
+	_, rawErr := store.Get(ctx, token)
+	if !errors.Is(rawErr, session.ErrSessionNotFound) {
+		t.Errorf("raw-token lookup: got %v, want ErrSessionNotFound", rawErr)
+	}
+
+	// Hash of raw token must be a valid store key.
+	hash := session.HashToken(token)
+	_, hashErr := store.Get(ctx, hash)
+	if hashErr != nil {
+		t.Errorf("hash lookup: got %v, want nil", hashErr)
+	}
+
+	// Renew and verify the new token follows the same rule.
+	_, newToken, err := mgr.Renew(ctx, token)
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if newToken != "" {
+		_, rawErr2 := store.Get(ctx, newToken)
+		if !errors.Is(rawErr2, session.ErrSessionNotFound) {
+			t.Errorf("renewed raw-token lookup: got %v, want ErrSessionNotFound", rawErr2)
+		}
+		_, hashErr2 := store.Get(ctx, session.HashToken(newToken))
+		if hashErr2 != nil {
+			t.Errorf("renewed hash lookup: got %v, want nil", hashErr2)
+		}
+	}
+
+	if err := mgr.Revoke(ctx, sess.ID); err != nil {
+		t.Errorf("cleanup Revoke: %v", err)
+	}
+}
+
+func TestValidateUnknownToken(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	_, err := mgr.Validate(ctx, "not-a-real-token")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("unknown token: got %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestRevokeUnknownSession(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	err := mgr.Revoke(ctx, "no-such-id")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("Revoke unknown: got %v, want ErrSessionNotFound", err)
+	}
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session
+
+import "time"
+
+// TokenRecord is an internal type tracking rolling-token state for a single session.
+// The Manager maintains at most two TokenRecord entries per session: one for the
+// current token and one for the prior token during the GraceWindow after a renewal.
+// Neither the current nor the prior raw token is stored; only their SHA-256 hashes.
+type TokenRecord struct {
+	// Session is the live session this record belongs to.
+	Session *Session
+	// IsGrace marks this as a prior-token entry (the token has already been rotated).
+	// When true, GraceExpiry gives the deadline after which this entry is rejected.
+	IsGrace bool
+	// GraceExpiry is the absolute time after which this prior-token entry expires.
+	// Zero when IsGrace is false.
+	GraceExpiry time.Time
+}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// storeEntry is the internal record maintained by MemStore per token hash.
+type storeEntry struct {
+	session *Session
+	revoked bool
+}
+
+// MemStore is an in-memory Store implementation keyed by token hash.
+// It never holds raw token values. A background goroutine reaps sessions
+// whose AbsoluteExpiresAt has passed; call Close() to drain it on shutdown.
+type MemStore struct {
+	mu      sync.RWMutex
+	records map[string]*storeEntry // key = token hash
+	byID    map[string][]string    // key = session ID → token hashes (current + maybe prev)
+	cfg     Config
+	clockFn func() time.Time
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+// NewMemStore creates an in-memory Store and starts its background reaper.
+// Callers must call Close() when the store is no longer needed.
+func NewMemStore(cfg Config, clockFn func() time.Time) *MemStore {
+	if clockFn == nil {
+		clockFn = time.Now
+	}
+	s := &MemStore{
+		records: make(map[string]*storeEntry),
+		byID:    make(map[string][]string),
+		cfg:     cfg,
+		clockFn: clockFn,
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	go s.reap()
+	return s
+}
+
+// Set stores or updates the Session under the given token hash.
+// A session may appear under multiple hashes (current + prior-token grace entry);
+// each call registers this hash in the session's index for cleanup via Delete.
+func (s *MemStore) Set(_ context.Context, tokenHash string, session *Session) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.records[tokenHash]; !exists {
+		// Only append to byID when registering a new hash, not on updates.
+		s.byID[session.ID] = append(s.byID[session.ID], tokenHash)
+	}
+	s.records[tokenHash] = &storeEntry{session: session}
+	return nil
+}
+
+// Get returns the Session for the given token hash.
+// Returns ErrSessionNotFound when the hash is not present or the entry is revoked.
+func (s *MemStore) Get(_ context.Context, tokenHash string) (*Session, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.records[tokenHash]
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	if entry.revoked {
+		return nil, ErrSessionRevoked
+	}
+	return entry.session, nil
+}
+
+// Delete removes all token-hash entries associated with the given session ID,
+// effectively invalidating any tokens that map to this session.
+func (s *MemStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, h := range s.byID[id] {
+		delete(s.records, h)
+	}
+	delete(s.byID, id)
+	return nil
+}
+
+// ListAll returns all unique sessions in the store, de-duplicating by session ID.
+func (s *MemStore) ListAll(_ context.Context) ([]*Session, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	seen := make(map[string]struct{}, len(s.byID))
+	result := make([]*Session, 0, len(s.byID))
+	for _, entry := range s.records {
+		if entry.session == nil {
+			continue
+		}
+		if _, dup := seen[entry.session.ID]; dup {
+			continue
+		}
+		seen[entry.session.ID] = struct{}{}
+		result = append(result, entry.session)
+	}
+	return result, nil
+}
+
+// Close stops the background reaper goroutine and waits for it to exit.
+func (s *MemStore) Close() {
+	close(s.stop)
+	<-s.done
+}
+
+// reap runs a periodic sweep to evict sessions past their AbsoluteExpiresAt.
+func (s *MemStore) reap() {
+	defer close(s.done)
+	// Sweep at half the idle timeout so test-injected short TTLs are cleaned promptly.
+	interval := s.cfg.IdleTimeout / 2
+	if interval <= 0 {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			s.sweep()
+		}
+	}
+}
+
+// Sweep immediately evicts all sessions past their AbsoluteExpiresAt.
+// Exported for test synchronization; the background reaper calls this periodically.
+func (s *MemStore) Sweep() { s.sweep() }
+
+func (s *MemStore) sweep() {
+	now := s.clockFn()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for hash, entry := range s.records {
+		if entry.session == nil || !now.After(entry.session.AbsoluteExpiresAt) {
+			continue
+		}
+		id := entry.session.ID
+		delete(s.records, hash)
+		// Prune this hash from the byID index without clearing the whole session
+		// (another hash for the same session may still be valid).
+		hashes := s.byID[id]
+		filtered := hashes[:0]
+		for _, h := range hashes {
+			if h != hash {
+				filtered = append(filtered, h)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(s.byID, id)
+		} else {
+			s.byID[id] = filtered
+		}
+	}
+}

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+func TestMemStore_SetAndGet(t *testing.T) {
+	cfg := session.DefaultConfig()
+	store := session.NewMemStore(cfg, time.Now)
+	defer store.Close()
+
+	ctx := context.Background()
+	token, err := session.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	hash := session.HashToken(token)
+	sess := &session.Session{
+		ID:                "sess-1",
+		PrincipalID:       "admin",
+		TenantID:          "",
+		IssuedAt:          time.Now(),
+		LastActivity:      time.Now(),
+		AbsoluteExpiresAt: time.Now().Add(cfg.AbsoluteTimeout),
+	}
+
+	// Raw-token lookup must miss (store holds only hashes).
+	_, err = store.Get(ctx, token)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("raw-token lookup: got %v, want ErrSessionNotFound", err)
+	}
+
+	if err := store.Set(ctx, hash, sess); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Hash lookup must hit.
+	got, err := store.Get(ctx, hash)
+	if err != nil {
+		t.Fatalf("Get by hash: %v", err)
+	}
+	if got.ID != sess.ID {
+		t.Errorf("session ID mismatch: got %q, want %q", got.ID, sess.ID)
+	}
+}
+
+func TestMemStore_Delete(t *testing.T) {
+	cfg := session.DefaultConfig()
+	store := session.NewMemStore(cfg, time.Now)
+	defer store.Close()
+
+	ctx := context.Background()
+	token, err := session.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	hash := session.HashToken(token)
+	sess := &session.Session{
+		ID:                "sess-del",
+		PrincipalID:       "admin",
+		IssuedAt:          time.Now(),
+		LastActivity:      time.Now(),
+		AbsoluteExpiresAt: time.Now().Add(cfg.AbsoluteTimeout),
+	}
+	if err := store.Set(ctx, hash, sess); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := store.Delete(ctx, "sess-del"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err = store.Get(ctx, hash)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("after Delete, Get: got %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestMemStore_ListAll(t *testing.T) {
+	cfg := session.DefaultConfig()
+	store := session.NewMemStore(cfg, time.Now)
+	defer store.Close()
+
+	ctx := context.Background()
+	sessS2 := &session.Session{
+		ID:                "s2",
+		IssuedAt:          time.Now(),
+		LastActivity:      time.Now(),
+		AbsoluteExpiresAt: time.Now().Add(cfg.AbsoluteTimeout),
+	}
+
+	// s1: one hash entry.
+	t1, err := session.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken t1: %v", err)
+	}
+	if err := store.Set(ctx, session.HashToken(t1), &session.Session{
+		ID:                "s1",
+		IssuedAt:          time.Now(),
+		LastActivity:      time.Now(),
+		AbsoluteExpiresAt: time.Now().Add(cfg.AbsoluteTimeout),
+	}); err != nil {
+		t.Fatalf("Set s1: %v", err)
+	}
+
+	// s2: two hash entries (simulates current + prior-token grace slot after a Renew).
+	t2a, err := session.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken t2a: %v", err)
+	}
+	t2b, err := session.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken t2b: %v", err)
+	}
+	if err := store.Set(ctx, session.HashToken(t2a), sessS2); err != nil {
+		t.Fatalf("Set s2a: %v", err)
+	}
+	if err := store.Set(ctx, session.HashToken(t2b), sessS2); err != nil {
+		t.Fatalf("Set s2b: %v", err)
+	}
+
+	all, err := store.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	seen := make(map[string]int)
+	for _, s := range all {
+		seen[s.ID]++
+	}
+	// s1 and s2 must each appear exactly once despite s2 having two hash entries.
+	if seen["s1"] != 1 {
+		t.Errorf("s1 count = %d, want 1", seen["s1"])
+	}
+	if seen["s2"] != 1 {
+		t.Errorf("s2 count = %d, want 1 (dedup expected); got %+v", seen["s2"], all)
+	}
+}
+
+func TestMemStore_NotFoundAfterExpiry(t *testing.T) {
+	now := time.Now()
+	cfg := session.Config{
+		IdleTimeout:     50 * time.Millisecond,
+		AbsoluteTimeout: 50 * time.Millisecond,
+		GraceWindow:     10 * time.Millisecond,
+	}
+	clock := &fakeClock{t: now}
+	store := session.NewMemStore(cfg, clock.Now)
+	defer store.Close()
+
+	ctx := context.Background()
+	token, err := session.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	hash := session.HashToken(token)
+	sess := &session.Session{
+		ID:                "s-exp",
+		IssuedAt:          now,
+		LastActivity:      now,
+		AbsoluteExpiresAt: now.Add(50 * time.Millisecond),
+	}
+	if err := store.Set(ctx, hash, sess); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Advance clock past AbsoluteExpiresAt and trigger an explicit sweep
+	// instead of sleeping — deterministic and race-free.
+	clock.advance(200 * time.Millisecond)
+	store.Sweep()
+
+	all, err := store.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	for _, s := range all {
+		if s.ID == "s-exp" {
+			t.Error("reaper should have removed expired session from ListAll")
+		}
+	}
+}

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -109,7 +109,7 @@ func TestMemStore_ListAll(t *testing.T) {
 		t.Fatalf("Set s1: %v", err)
 	}
 
-	// s2: two hash entries (simulates current + prior-token grace slot after a Renew).
+	// s2: two hash entries — current token + prior-token grace slot, as produced by a Renew.
 	t2a, err := session.GenerateToken()
 	if err != nil {
 		t.Fatalf("GenerateToken t2a: %v", err)

--- a/pkg/session/token.go
+++ b/pkg/session/token.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+)
+
+// GenerateToken generates a cryptographically random 32-byte bearer token encoded
+// as base64url without padding (43 characters, 256 bits of entropy).
+// Session tokens are distinguishable from API keys by length: API keys use
+// base64url with padding (44 chars), session tokens use base64url without padding
+// (43 chars). The middleware uses this length difference to route tokens correctly.
+func GenerateToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("session: failed to generate token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// HashToken returns the lowercase hex-encoded SHA-256 hash of the token string.
+// The controller stores only this hash; the raw token exists only in transit and
+// in process memory during a single request.
+func HashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary

- Implements `POST /api/v1/sessions` (admin mTLS) that mints 43-char base64url session tokens (32 bytes crypto/rand, 256-bit entropy)
- Rolling token model: each authenticated request renews the token and returns the new value in `X-Session-Token`; prior token valid for a 30s grace window, preventing races on concurrent requests
- Sessions enforce 15m idle TTL and 8h absolute cap; `DELETE /api/v1/sessions/{id}` revokes immediately
- Token values stored SHA-256-hashed only — never in plaintext, never logged
- Middleware distinguishes session tokens (43 chars) from API keys (44 chars) by length, falls through to API-key path for non-session tokens

## Implementation notes

- `pkg/session`: `MemStore` (injectable clock, background reaper, exported `Sweep()` for test sync), `manager` (per-session mutex for grace-window idempotency, manager-level RWMutex for hash/session maps)
- `features/controller/api`: `handleSessionCreate`, `handleSessionRevoke`, session-token path in `authenticationMiddleware`, routes wired in `setupRouter`
- `docs/architecture/controller-operating-model.md`: Admin Session Model subsection added

## Test plan

- [x] `TestManagerIssueAndValidate` — 43-char token, session fields
- [x] `TestSessionAbsoluteCap` — continuously renewed session refused after 8h cap
- [x] `TestRollingTokenGraceWindow` — dual-token validity, concurrent Renew idempotency, post-grace rejection
- [x] `TestTokenNotStoredRaw` — raw-token lookup misses, hash lookup hits
- [x] `TestHandleSessionRevoke_ImmediateRevocation` — revoke via handler, middleware returns 401
- [x] `TestSessionTokenAuthMiddleware_ExpiredToken` — uses injectable clock (no `time.Sleep`)
- [x] `TestMemStore_NotFoundAfterExpiry` — uses `store.Sweep()` instead of `time.Sleep`
- [x] All tests pass under `-race`; `make test-agent-complete` passes

Fixes #2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)