### PR TITLE
docs: examples/ci-runners self-hosted CI runner walkthrough (Issue #2230)

### DIFF
--- a/examples/ci-runners/README.md
+++ b/examples/ci-runners/README.md
@@ -1,0 +1,154 @@
+# Self-Hosted CI Runners — CFGMS Example
+
+This directory contains a **secrets-free** example configuration for standing up
+GitHub Actions self-hosted CI runners on Hyper-V VMs managed by CFGMS.
+
+All sensitive fields use `REDACTED` or `PLACEHOLDER_*` values. Real lab
+configuration stays local and is never committed to this repository.
+
+---
+
+## Files in this directory
+
+| File | Purpose |
+|------|---------|
+| `linux-runner.cfg.yaml` | Steward cfg pushed to a Linux runner VM |
+| `windows-runner.cfg.yaml` | Steward cfg pushed to a Windows runner VM |
+| `github-app-secrets.example.yaml` | Documents the three secret key names loaded into the secrets provider |
+
+---
+
+## End-to-end walkthrough
+
+### Step 1 — Provision the VM (ADR-009)
+
+Runner VMs are declared as `hyperv.vm` resources on a Hyper-V host already
+managed by CFGMS.  The declarative `source:` block in ADR-009 drives the
+ISO-to-OS provisioning cycle:
+
+- OS installs unattended from a stored profile (`unattend: profile://...`).
+- Completion mode `steward-registration` boots the finished VM, enrolls the
+  steward, and hands control to the controller.
+
+See [ADR-009](../../docs/architecture/decisions/009-hyperv-vm-provisioning-from-install-media.md)
+for the full `hyperv.vm` schema and the provisioning state machine.
+
+### Step 2 — Enroll the steward
+
+After first boot the steward calls home and registers with the controller.
+No extra steps are required if `completion: { mode: steward-registration }` was
+set in the `hyperv.vm` source block — enrollment happens automatically as part
+of the provisioning workflow.
+
+For manually booted VMs:
+
+```bash
+cfg steward enroll --controller <CONTROLLER_URL> --name <STEWARD_ID>
+```
+
+### Step 3 — Push the runner cfg
+
+Upload the appropriate cfg to the enrolled steward:
+
+```bash
+# Linux runner
+cfg config upload --steward ci-runner-linux-01 --config linux-runner.cfg.yaml
+
+# Windows runner
+cfg config upload --steward ci-runner-windows-01 --config windows-runner.cfg.yaml
+```
+
+The `github_runner` module fetches the agent archive, verifies the SHA-256,
+installs it under `work_dir`, and manages the runner service.
+
+Before uploading, edit the cfg to set:
+
+- `steward.id` — the enrolled steward hostname.
+- `config.version` — the pinned runner agent release.
+- `config.agent_url` — the download URL matching the version and OS/arch.
+- `config.agent_sha256` — the SHA-256 of the archive (lowercase hex, 64 chars).
+  Verify with `sha256sum` (Linux) or `Get-FileHash` (Windows).
+
+Module field names come from
+[`features/modules/github_runner/config.go`](../../features/modules/github_runner/config.go).
+
+### Step 4 — Load the GitHub App secrets (one-time)
+
+The controller needs three secrets to mint runner registration tokens. These are
+stored in the CFGMS secrets provider (SOPS-encrypted) — never in cfg files or
+on disk in cleartext.
+
+See **[docs/development/ci-runner-github-app-setup.md](../../docs/development/ci-runner-github-app-setup.md)**
+for the full one-time GitHub App bootstrap:
+
+- Creating the App via the manifest flow (~1 click).
+- Installing it on the repository.
+- Storing the three credentials:
+
+  ```
+  github_app_id
+  github_app_installation_id
+  github_app_private_key_pem
+  ```
+
+The key names in `github-app-secrets.example.yaml` must match exactly — they are
+read verbatim by `features/workflow/github_app_provider.go`.
+
+```bash
+cfg secrets set github_app_id              <your-app-id>
+cfg secrets set github_app_installation_id <your-installation-id>
+cfg secrets set github_app_private_key_pem /path/to/private-key.pem
+```
+
+### Step 5 — Run the provisioning workflow
+
+Once the steward is enrolled and the secrets are loaded, trigger the runner
+provisioning workflow on the controller:
+
+```bash
+cfg workflow run github-runner-provision \
+  --param steward_id=ci-runner-linux-01 \
+  --param owner=<GITHUB_ORG_OR_USER> \
+  --param repo=<REPO_NAME>
+```
+
+The workflow:
+
+1. Mints a short-lived runner registration token via the GitHub App (§4 of the
+   setup runbook — fully automated, no human in the loop).
+2. Delivers the token to the steward and invokes `./config.sh` to register the
+   runner.
+3. Starts the runner service.
+
+Teardown (deregister + destroy VM) runs via the corresponding teardown workflow.
+
+---
+
+## Fork-gate safety
+
+Self-hosted runners on this PUBLIC repository must never execute untrusted
+fork-PR code. The CI workflow enforces this with:
+
+```yaml
+if: github.event.pull_request.head.repo.fork == false
+```
+
+External fork PRs fall back to GitHub-hosted runners. The repo is also
+configured to **require approval for fork pull request workflows** under
+Settings → Actions. No secrets or self-hosted infrastructure are exposed to
+fork-PR contexts.
+
+See [docs/development/ci-runner-github-app-setup.md §5](../../docs/development/ci-runner-github-app-setup.md)
+for the full public-repo safety guidance.
+
+---
+
+## No secrets in this directory
+
+All values in the cfg files and the secrets example file are placeholders.
+The Trivy secret scanner (`make security-scan`, included in `make test-complete`)
+covers this directory and will block any commit that introduces real secret
+material.
+
+Real GitHub App credentials, runner registration tokens, and private keys
+must never be committed here. Keep them in the CFGMS secrets provider.

--- a/examples/ci-runners/github-app-secrets.example.yaml
+++ b/examples/ci-runners/github-app-secrets.example.yaml
@@ -1,0 +1,21 @@
+# GitHub App Secrets — example key names only
+#
+# This file documents the THREE secret keys the CFGMS secrets provider
+# (SOPS-encrypted) must contain before the controller can mint runner
+# registration tokens. Values are intentionally REDACTED.
+#
+# NEVER commit real values here. Load secrets with:
+#
+#   cfg secrets set github_app_id              <your-app-id>
+#   cfg secrets set github_app_installation_id <your-installation-id>
+#   cfg secrets set github_app_private_key_pem /path/to/private-key.pem
+#
+# For the full one-time GitHub App bootstrap procedure, see:
+#   docs/development/ci-runner-github-app-setup.md
+#
+# Key names must match exactly — they are read verbatim by:
+#   features/workflow/github_app_provider.go
+
+github_app_id: "REDACTED"
+github_app_installation_id: "REDACTED"
+github_app_private_key_pem: "REDACTED"

--- a/examples/ci-runners/linux-runner.cfg.yaml
+++ b/examples/ci-runners/linux-runner.cfg.yaml
@@ -1,0 +1,54 @@
+# CFGMS CI Runner Config — Linux (x64)
+#
+# Push this to the runner VM's steward after enrollment:
+#   cfg config upload --steward <STEWARD_ID> --config linux-runner.cfg.yaml
+#
+# CHANGE: Replace every <placeholder> with real values for your environment.
+# See README.md for the full provisioning walkthrough.
+#
+# NO SECRETS in this file. GitHub App credentials are stored in the CFGMS
+# secrets provider, not here. See github-app-secrets.example.yaml.
+
+steward:
+  id: "ci-runner-linux-01"    # CHANGE: set to the actual enrolled steward hostname
+  mode: "standalone"
+
+resources:
+  # ── GitHub Actions Runner ────────────────────────────────────────────────────
+  # Installs and manages the GitHub Actions self-hosted runner agent as a
+  # persistent Linux service.
+  #
+  # The module fetches the agent archive, verifies the SHA-256, installs it
+  # under work_dir, and registers the service. Registration (the one-time token
+  # exchange) is handled by the controller workflow — the module only manages
+  # the installed agent state.
+  #
+  # Field reference: features/modules/github_runner/config.go
+
+  - name: "github-runner"
+    module: "github_runner"
+    config:
+      # Pinned runner agent version — update when bumping the runner.
+      # CHANGE: Set to the desired GitHub Actions runner release.
+      version: "2.319.1"
+
+      # Download URL for the agent archive at the pinned version.
+      # CHANGE: Update to match your pinned version and architecture.
+      agent_url: "https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-linux-x64-2.319.1.tar.gz"
+
+      # Expected SHA-256 of the archive (lowercase hex, 64 chars).
+      # CHANGE: Replace with the actual sha256sum of the archive.
+      # Verify: sha256sum actions-runner-linux-x64-2.319.1.tar.gz
+      agent_sha256: "PLACEHOLDER_SHA256_64HEX"
+
+      # Absolute install directory on the runner VM.
+      work_dir: "/opt/actions-runner"
+
+      # OS service name for the runner daemon.
+      service_name: "github-runner"
+
+      # Runner labels surfaced to GitHub Actions workflow selectors.
+      labels:
+        - "self-hosted"
+        - "linux"
+        - "x64"

--- a/examples/ci-runners/windows-runner.cfg.yaml
+++ b/examples/ci-runners/windows-runner.cfg.yaml
@@ -1,0 +1,54 @@
+# CFGMS CI Runner Config — Windows (x64)
+#
+# Push this to the runner VM's steward after enrollment:
+#   cfg config upload --steward <STEWARD_ID> --config windows-runner.cfg.yaml
+#
+# CHANGE: Replace every <placeholder> with real values for your environment.
+# See README.md for the full provisioning walkthrough.
+#
+# NO SECRETS in this file. GitHub App credentials are stored in the CFGMS
+# secrets provider, not here. See github-app-secrets.example.yaml.
+
+steward:
+  id: "ci-runner-windows-01"    # CHANGE: set to the actual enrolled steward hostname
+  mode: "standalone"
+
+resources:
+  # ── GitHub Actions Runner ────────────────────────────────────────────────────
+  # Installs and manages the GitHub Actions self-hosted runner agent as a
+  # persistent Windows service.
+  #
+  # The module fetches the agent archive, verifies the SHA-256, installs it
+  # under work_dir, and registers the Windows service. Registration (the
+  # one-time token exchange) is handled by the controller workflow — the module
+  # only manages the installed agent state.
+  #
+  # Field reference: features/modules/github_runner/config.go
+
+  - name: "github-runner"
+    module: "github_runner"
+    config:
+      # Pinned runner agent version — update when bumping the runner.
+      # CHANGE: Set to the desired GitHub Actions runner release.
+      version: "2.319.1"
+
+      # Download URL for the agent archive at the pinned version.
+      # CHANGE: Update to match your pinned version and architecture.
+      agent_url: "https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-win-x64-2.319.1.zip"
+
+      # Expected SHA-256 of the archive (lowercase hex, 64 chars).
+      # CHANGE: Replace with the actual sha256sum of the archive.
+      # Verify: Get-FileHash actions-runner-win-x64-2.319.1.zip -Algorithm SHA256
+      agent_sha256: "PLACEHOLDER_SHA256_64HEX"
+
+      # Absolute install directory on the runner VM (Windows path).
+      work_dir: 'C:\actions-runner'
+
+      # Windows service name for the runner daemon.
+      service_name: "github-runner"
+
+      # Runner labels surfaced to GitHub Actions workflow selectors.
+      labels:
+        - "self-hosted"
+        - "windows"
+        - "x64"


### PR DESCRIPTION
## Summary

- Ships `examples/ci-runners/` with README, Linux cfg, Windows cfg, and secrets example — all placeholder/REDACTED values, no real lab material
- README covers the full operator flow: hyperv.vm provisioning (ADR-009) → enrollment → runner cfg upload → GitHub App secret loading → provisioning workflow → fork-gate safety
- Field names in cfg files verified against `features/modules/github_runner/config.go`; secret key names verified against `features/workflow/github_app_provider.go`

## Specialist Review Results

| Reviewer | Result |
|---------|--------|
| QA Test Runner (`make test-agent-complete`) | PASS — 196 script tests, 29 trust boundary tests, cross-platform builds all green; Trivy secret scanner: zero findings in new files |
| QA Code Reviewer | PASS — all 6 schema field names match config.go exactly; README covers all required topics with correct file references; no real identifiers |
| Security Engineer | PASS — Trivy targeted scan of `examples/ci-runners/`: zero secret findings; `make security-scan`: all gates PASS |

## Test plan

- [x] `make security-scan` — Trivy, Nancy, gosec, staticcheck all PASS
- [x] `make test-agent-complete` — full gate suite PASS
- [x] No PEM blocks or real secret material in any added file
- [x] Field names match `github_runner` module schema exactly
- [x] README references ADR-009 and ci-runner-github-app-setup.md (both exist on disk)
- [x] Fork-gate safety property documented

Fixes #2230

🤖 Generated with [Claude Code](https://claude.com/claude-code)