### PR TITLE
pipeline: dispatch dep-gate accepts MERGED PR deps (not only CLOSED issues)

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -1034,7 +1034,11 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states, 
             })
             continue
 
-        open_deps = [d for d in s["deps_parsed"] if dep_states.get(d) != "CLOSED"]
+        # A dependency is satisfied whether it resolves to a CLOSED issue or a
+        # MERGED pull request. PR numbers appear in deps when the body annotates
+        # "(PR: #MMM)" (per ba.md); a merged PR means the dependency is delivered,
+        # so it must NOT hold the dependent story (Issue: dep-gate held on MERGED PRs).
+        open_deps = [d for d in s["deps_parsed"] if dep_states.get(d) not in ("CLOSED", "MERGED")]
         if open_deps:
             dep_desc = ", ".join(
                 f"#{d}({dep_states.get(d, 'UNKNOWN')})" for d in open_deps


### PR DESCRIPTION
## Problem

The preflight dependency gate held a Ready story unless **every** `#NNN` in its `## Dependencies` resolved to issue state `CLOSED`. PR numbers appear in deps via the `ba.md` `(PR: #MMM)` annotation and resolve to state `MERGED` — never `CLOSED` — so a story whose dependency had already merged was **held forever**.

Live examples at time of discovery: #2230 held on #2185(MERGED); #2224/#2225 held on #2218/#2221(MERGED). Likely a major contributor to the Draft-pile-up / "stories never dispatch" symptom.

## Fix

One line in `compute_dispatch_recommendations` (`po-cycle-preflight.py`): a dependency is satisfied when its state is `CLOSED` **or** `MERGED`.

```python
open_deps = [d for d in s["deps_parsed"] if dep_states.get(d) not in ("CLOSED", "MERGED")]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
