### PR TITLE
secrets: OS-native keychain provider for session tokens (Issue #2233)

### DIFF
--- a/pkg/secrets/providers/oskeychain/provider.go
+++ b/pkg/secrets/providers/oskeychain/provider.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Package oskeychain implements a cross-platform OS-native secret-store provider
+// for CFGMS. It holds the short-lived `cfg` session token in the operating
+// system's own credential store so the token is never written to disk as
+// cleartext.
+//
+// Backends (selected at build time):
+//   - Windows: Credential Manager (CredRead/CredWrite/CredDelete, CRED_TYPE_GENERIC)
+//   - macOS:   Keychain (security add/find/delete-generic-password)
+//   - Linux:   Secret Service (libsecret) with a kernel session-keyring (keyctl)
+//     fallback for headless hosts with no Secret Service.
+//
+// The provider stores only the small session token value. Larger credential
+// bundles use the machine-bound encrypted-file path (a separate story) because
+// a full bundle exceeds Windows Credential Manager's per-entry blob limit.
+package oskeychain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+const (
+	providerName    = "oskeychain"
+	providerVersion = "1.0.0"
+
+	// serviceName groups CFGMS entries in OS stores that split identity into a
+	// service + account pair (macOS Keychain, Secret Service attributes).
+	serviceName = "cfgms"
+
+	// maxSecretSize bounds the stored value to a session token. Windows
+	// Credential Manager caps a CRED_TYPE_GENERIC blob at 2560 bytes
+	// (CRED_MAX_CREDENTIAL_BLOB_SIZE = 5*512); larger bundles use the
+	// encrypted-file path (story Out of Scope).
+	maxSecretSize = 2560
+
+	// maxKeyLength bounds the namespaced key (e.g. cfgms/session/<connection>).
+	maxKeyLength = 256
+)
+
+// errSecretNotFound is the sentinel a backend returns when a key is absent.
+// Store.GetSecret maps it to interfaces.ErrSecretNotFound.
+var errSecretNotFound = errors.New("oskeychain: secret not found")
+
+// backend is the platform-specific OS keychain implementation. Each platform
+// file (provider_windows.go, provider_darwin.go, provider_linux.go) provides a
+// concrete implementation and a platformNewBackend constructor.
+type backend interface {
+	// set stores value under key, overwriting any existing value.
+	set(key string, value []byte) error
+	// get returns the value stored under key, or errSecretNotFound.
+	get(key string) ([]byte, error)
+	// del removes the value stored under key. Absent keys are not an error.
+	del(key string) error
+	// available reports whether this backend can be used on the current host.
+	available() bool
+	// name identifies the backend for diagnostics.
+	name() string
+}
+
+// newBackend constructs the platform backend. It is a package var so tests can
+// substitute a fake or force the unavailable path on any platform.
+var newBackend = platformNewBackend
+
+// Provider implements interfaces.SecretProvider using the host OS keychain.
+type Provider struct{}
+
+// Name returns the provider name.
+func (p *Provider) Name() string { return providerName }
+
+// Description returns a human-readable description.
+func (p *Provider) Description() string {
+	return "OS-native keychain secret storage (Windows Credential Manager, macOS Keychain, Linux Secret Service/keyring) for short-lived session tokens"
+}
+
+// GetVersion returns the provider version.
+func (p *Provider) GetVersion() string { return providerVersion }
+
+// GetCapabilities returns the provider's capabilities. The OS store encrypts at
+// rest; the provider intentionally does not implement versioning, rotation,
+// metadata, or listing (it holds only the session token).
+func (p *Provider) GetCapabilities() interfaces.ProviderCapabilities {
+	return interfaces.ProviderCapabilities{
+		SupportsVersioning:     false,
+		SupportsRotation:       false,
+		SupportsEncryption:     true, // OS keychain encrypts at rest
+		SupportsAuditTrail:     false,
+		SupportsLeasing:        false,
+		SupportsRenewal:        false,
+		SupportsRevocation:     true, // DeleteSecret removes immediately
+		SupportsMetadata:       false,
+		SupportsTags:           false,
+		SupportsAccessPolicies: false,
+		MaxSecretSize:          maxSecretSize,
+		MaxKeyLength:           maxKeyLength,
+		EncryptionAlgorithm:    "os-native",
+	}
+}
+
+// Available reports whether a usable OS keychain backend exists on this host.
+// It returns (false, nil) — never an error — when no backend is usable (e.g.
+// Linux with neither Secret Service nor a kernel keyring), so callers fall back
+// to the one-shot --bundle path rather than failing hard.
+func (p *Provider) Available() (bool, error) {
+	b, err := newBackend()
+	if err != nil {
+		return false, nil
+	}
+	return b.available(), nil
+}
+
+// CreateSecretStore creates an OS-keychain-backed secret store. The config map
+// is accepted for interface conformance but is unused — the backend is selected
+// by platform.
+func (p *Provider) CreateSecretStore(_ map[string]interface{}) (interfaces.SecretStore, error) {
+	b, err := newBackend()
+	if err != nil {
+		return nil, fmt.Errorf("oskeychain: no OS keychain backend available: %w", err)
+	}
+	if !b.available() {
+		return nil, errors.New("oskeychain: no OS keychain backend available on this host")
+	}
+	return newStore(b), nil
+}
+
+// Store implements interfaces.SecretStore backed by an OS keychain. Only the
+// three core operations are real; the remaining contract methods are
+// unsupported (the provider holds a single short-lived token, not a versioned,
+// listable secret database).
+type Store struct {
+	backend backend
+}
+
+// newStore wraps a backend in a Store.
+func newStore(b backend) *Store { return &Store{backend: b} }
+
+// StoreSecret persists the session token in the OS keychain.
+func (s *Store) StoreSecret(_ context.Context, req *interfaces.SecretRequest) error {
+	if req == nil {
+		return errors.New("oskeychain: secret request is nil")
+	}
+	if req.Key == "" {
+		return errors.New("oskeychain: secret key cannot be empty")
+	}
+	if len(req.Key) > maxKeyLength {
+		return fmt.Errorf("oskeychain: secret key exceeds maximum length of %d characters", maxKeyLength)
+	}
+	if req.Value == "" {
+		return errors.New("oskeychain: secret value cannot be empty")
+	}
+	if len(req.Value) > maxSecretSize {
+		return fmt.Errorf("oskeychain: secret value exceeds maximum size of %d bytes", maxSecretSize)
+	}
+	if err := s.backend.set(req.Key, []byte(req.Value)); err != nil {
+		return fmt.Errorf("oskeychain: store %q: %w", req.Key, err)
+	}
+	return nil
+}
+
+// GetSecret retrieves the session token from the OS keychain. Only Key and
+// Value are populated — the OS store holds the token alone, not metadata.
+func (s *Store) GetSecret(_ context.Context, key string) (*interfaces.Secret, error) {
+	value, err := s.backend.get(key)
+	if err != nil {
+		if errors.Is(err, errSecretNotFound) {
+			return nil, fmt.Errorf("oskeychain: %q: %w", key, interfaces.ErrSecretNotFound)
+		}
+		return nil, fmt.Errorf("oskeychain: get %q: %w", key, err)
+	}
+	now := time.Now()
+	return &interfaces.Secret{
+		Key:       key,
+		Value:     string(value),
+		Version:   1,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, nil
+}
+
+// DeleteSecret removes the session token from the OS keychain.
+func (s *Store) DeleteSecret(_ context.Context, key string) error {
+	if err := s.backend.del(key); err != nil {
+		return fmt.Errorf("oskeychain: delete %q: %w", key, err)
+	}
+	return nil
+}
+
+// unsupported wraps errors.ErrUnsupported with the operation name. The OS
+// keychain provider deliberately implements only the three core operations.
+func unsupported(op string) error {
+	return fmt.Errorf("oskeychain: %s not supported by oskeychain provider: %w", op, errors.ErrUnsupported)
+}
+
+// ListSecrets is not supported.
+func (s *Store) ListSecrets(_ context.Context, _ *interfaces.SecretFilter) ([]*interfaces.SecretMetadata, error) {
+	return nil, unsupported("ListSecrets")
+}
+
+// GetSecrets is not supported.
+func (s *Store) GetSecrets(_ context.Context, _ []string) (map[string]*interfaces.Secret, error) {
+	return nil, unsupported("GetSecrets")
+}
+
+// StoreSecrets is not supported.
+func (s *Store) StoreSecrets(_ context.Context, _ map[string]*interfaces.SecretRequest) error {
+	return unsupported("StoreSecrets")
+}
+
+// GetSecretVersion is not supported.
+func (s *Store) GetSecretVersion(_ context.Context, _ string, _ int) (*interfaces.Secret, error) {
+	return nil, unsupported("GetSecretVersion")
+}
+
+// ListSecretVersions is not supported.
+func (s *Store) ListSecretVersions(_ context.Context, _ string) ([]*interfaces.SecretVersion, error) {
+	return nil, unsupported("ListSecretVersions")
+}
+
+// GetSecretMetadata is not supported.
+func (s *Store) GetSecretMetadata(_ context.Context, _ string) (*interfaces.SecretMetadata, error) {
+	return nil, unsupported("GetSecretMetadata")
+}
+
+// UpdateSecretMetadata is not supported.
+func (s *Store) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return unsupported("UpdateSecretMetadata")
+}
+
+// RotateSecret is not supported.
+func (s *Store) RotateSecret(_ context.Context, _ string, _ string) error {
+	return unsupported("RotateSecret")
+}
+
+// ExpireSecret is not supported.
+func (s *Store) ExpireSecret(_ context.Context, _ string) error {
+	return unsupported("ExpireSecret")
+}
+
+// HealthCheck is a no-op — the OS keychain has no connection to verify.
+func (s *Store) HealthCheck(_ context.Context) error { return nil }
+
+// Close is a no-op — the OS keychain holds no open handles.
+func (s *Store) Close() error { return nil }
+
+// Auto-register this provider (Salt-style).
+func init() {
+	interfaces.RegisterSecretProvider(&Provider{})
+}

--- a/pkg/secrets/providers/oskeychain/provider_darwin.go
+++ b/pkg/secrets/providers/oskeychain/provider_darwin.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package oskeychain
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+// keychainBackend stores secrets in the macOS login Keychain via the `security`
+// CLI (add/find/delete-generic-password against the Security framework).
+type keychainBackend struct {
+	bin string // resolved path to `security`, "" when unavailable
+}
+
+// platformNewBackend returns the macOS Keychain backend.
+func platformNewBackend() (backend, error) {
+	bin, err := exec.LookPath("security")
+	if err != nil {
+		return &keychainBackend{}, nil
+	}
+	return &keychainBackend{bin: bin}, nil
+}
+
+func (b *keychainBackend) name() string { return "macos-keychain" }
+
+func (b *keychainBackend) available() bool { return b.bin != "" }
+
+func (b *keychainBackend) set(key string, value []byte) error {
+	// -U updates an existing generic-password item instead of failing.
+	//
+	// Security note: add-generic-password takes the secret via -w on argv, so
+	// the token is briefly visible in the process table (`ps`) to other
+	// processes of the SAME user for the sub-second lifetime of this exec. The
+	// `security` CLI has no stdin-fed equivalent for add-generic-password
+	// (unlike libsecret's secret-tool, which the Linux backend feeds via stdin).
+	// Exposure is same-UID only — an attacker already at this UID can read the
+	// Keychain directly — and momentary. Accepted, documented limitation; do not
+	// assume this is leak-free.
+	cmd := exec.Command(b.bin, "add-generic-password", //nolint:gosec // fixed binary + discrete args, no shell
+		"-U", "-s", serviceName, "-a", key, "-w", string(value))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("security add-generic-password: %w: %s", err, stderr.String())
+	}
+	return nil
+}
+
+func (b *keychainBackend) get(key string) ([]byte, error) {
+	cmd := exec.Command(b.bin, "find-generic-password", //nolint:gosec // fixed binary + discrete args, no shell
+		"-s", serviceName, "-a", key, "-w")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// `security` exits non-zero with no stdout when the item is absent.
+		if stdout.Len() == 0 {
+			return nil, errSecretNotFound
+		}
+		return nil, fmt.Errorf("security find-generic-password: %w: %s", err, stderr.String())
+	}
+	// find-generic-password -w prints the password followed by a single newline.
+	out := bytes.TrimSuffix(stdout.Bytes(), []byte("\n"))
+	return out, nil
+}
+
+func (b *keychainBackend) del(key string) error {
+	cmd := exec.Command(b.bin, "delete-generic-password", //nolint:gosec // fixed binary + discrete args, no shell
+		"-s", serviceName, "-a", key)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// Deleting an absent item is not an error.
+		if bytes.Contains(stderr.Bytes(), []byte("could not be found")) {
+			return nil
+		}
+		return fmt.Errorf("security delete-generic-password: %w: %s", err, stderr.String())
+	}
+	return nil
+}

--- a/pkg/secrets/providers/oskeychain/provider_linux.go
+++ b/pkg/secrets/providers/oskeychain/provider_linux.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package oskeychain
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+// keyringType is the kernel keyring key type used for session tokens.
+const keyringType = "user"
+
+// platformNewBackend selects the Linux backend in fallback order: the Secret
+// Service (libsecret) if a session bus exposes one, otherwise the kernel
+// session keyring (headless-safe). Returns an unavailable backend if neither is
+// usable, so Provider.Available reports (false, nil).
+func platformNewBackend() (backend, error) {
+	if ss := newSecretServiceBackend(); ss.available() {
+		return ss, nil
+	}
+	if kr := newKeyringBackend(); kr.available() {
+		return kr, nil
+	}
+	return unavailableBackend{}, nil
+}
+
+// unavailableBackend is returned on Linux hosts with no Secret Service and no
+// usable kernel keyring (e.g. a minimal container). Its operations error; the
+// provider reports it as unavailable so callers fall back to the --bundle path.
+type unavailableBackend struct{}
+
+func (unavailableBackend) name() string    { return "none" }
+func (unavailableBackend) available() bool { return false }
+func (unavailableBackend) set(string, []byte) error {
+	return errors.New("no OS keychain backend available")
+}
+func (unavailableBackend) get(string) ([]byte, error) {
+	return nil, errors.New("no OS keychain backend available")
+}
+func (unavailableBackend) del(string) error { return errors.New("no OS keychain backend available") }
+
+// ---- Secret Service (libsecret via secret-tool) ----
+
+// secretServiceBackend stores secrets in the freedesktop Secret Service
+// (gnome-keyring, KWallet, etc.) via the libsecret `secret-tool` CLI.
+type secretServiceBackend struct {
+	bin string // resolved path to secret-tool, "" when unavailable
+}
+
+func newSecretServiceBackend() *secretServiceBackend {
+	bin, err := exec.LookPath("secret-tool")
+	if err != nil {
+		return &secretServiceBackend{}
+	}
+	return &secretServiceBackend{bin: bin}
+}
+
+func (b *secretServiceBackend) name() string { return "linux-secret-service" }
+
+// available reports the Secret Service usable: the secret-tool binary is present
+// and a session bus exists for it to talk to. Headless hosts (no
+// DBUS_SESSION_BUS_ADDRESS) report false so selection falls through to the
+// kernel keyring.
+func (b *secretServiceBackend) available() bool {
+	return b.bin != "" && os.Getenv("DBUS_SESSION_BUS_ADDRESS") != ""
+}
+
+func (b *secretServiceBackend) set(key string, value []byte) error {
+	// secret-tool store reads the secret from stdin; attributes come from argv.
+	cmd := exec.Command(b.bin, "store", "--label=CFGMS session token", //nolint:gosec // fixed binary + discrete args, no shell
+		"service", serviceName, "account", key)
+	cmd.Stdin = bytes.NewReader(value)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("secret-tool store: %w: %s", err, stderr.String())
+	}
+	return nil
+}
+
+func (b *secretServiceBackend) get(key string) ([]byte, error) {
+	cmd := exec.Command(b.bin, "lookup", "service", serviceName, "account", key) //nolint:gosec // fixed binary + discrete args, no shell
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// secret-tool exits non-zero with no output when the item is absent.
+		if stdout.Len() == 0 {
+			return nil, errSecretNotFound
+		}
+		return nil, fmt.Errorf("secret-tool lookup: %w: %s", err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+func (b *secretServiceBackend) del(key string) error {
+	cmd := exec.Command(b.bin, "clear", "service", serviceName, "account", key) //nolint:gosec // fixed binary + discrete args, no shell
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("secret-tool clear: %w: %s", err, stderr.String())
+	}
+	return nil
+}
+
+// ---- Kernel session keyring (keyctl) ----
+
+// keyringBackend stores secrets in the kernel session keyring. It is
+// headless-safe and the token dies with the login session — acceptable for a
+// short-lived session token.
+type keyringBackend struct{}
+
+func newKeyringBackend() *keyringBackend { return &keyringBackend{} }
+
+func (b *keyringBackend) name() string { return "linux-kernel-keyring" }
+
+// available probes whether the kernel keyring is usable by materializing the
+// session keyring. Returns false on kernels without keyctl support (ENOSYS) or
+// where access is denied.
+func (b *keyringBackend) available() bool {
+	_, err := unix.KeyctlGetKeyringID(unix.KEY_SPEC_SESSION_KEYRING, true)
+	return err == nil
+}
+
+func (b *keyringBackend) set(key string, value []byte) error {
+	// add_key updates the payload in place when a "user" key with this
+	// description already exists in the session keyring.
+	if _, err := unix.AddKey(keyringType, key, value, unix.KEY_SPEC_SESSION_KEYRING); err != nil {
+		return fmt.Errorf("add_key: %w", err)
+	}
+	return nil
+}
+
+func (b *keyringBackend) get(key string) ([]byte, error) {
+	id, err := unix.KeyctlSearch(unix.KEY_SPEC_SESSION_KEYRING, keyringType, key, 0)
+	if err != nil {
+		// ENOKEY (and friends) mean the key is absent.
+		return nil, errSecretNotFound
+	}
+
+	// First call sizes the payload, second reads it.
+	size, err := unix.KeyctlBuffer(unix.KEYCTL_READ, id, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("keyctl read (size): %w", err)
+	}
+	buf := make([]byte, size)
+	n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, id, buf, 0)
+	if err != nil {
+		return nil, fmt.Errorf("keyctl read: %w", err)
+	}
+	if n > len(buf) {
+		n = len(buf)
+	}
+	return buf[:n], nil
+}
+
+func (b *keyringBackend) del(key string) error {
+	id, err := unix.KeyctlSearch(unix.KEY_SPEC_SESSION_KEYRING, keyringType, key, 0)
+	if err != nil {
+		// Absent key is not an error.
+		return nil
+	}
+	if _, err := unix.KeyctlInt(unix.KEYCTL_UNLINK, id, unix.KEY_SPEC_SESSION_KEYRING, 0, 0); err != nil {
+		return fmt.Errorf("keyctl unlink: %w", err)
+	}
+	return nil
+}

--- a/pkg/secrets/providers/oskeychain/provider_linux_test.go
+++ b/pkg/secrets/providers/oskeychain/provider_linux_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package oskeychain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinuxKeyringFallback is the [REQUIRED TEST]: with the Secret Service
+// unavailable, the provider must store/load via the kernel session keyring and
+// still round-trip.
+func TestLinuxKeyringFallback(t *testing.T) {
+	// Force the Secret Service backend to report unavailable by removing the
+	// session bus address. With no bus, libsecret/secret-tool cannot be used.
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
+	require.False(t, newSecretServiceBackend().available(),
+		"Secret Service must report unavailable without a session bus")
+
+	kr := newKeyringBackend()
+	if !kr.available() {
+		// Justified skip: the kernel keyring (keyctl) is a host/kernel
+		// capability, not something the test controls. GitHub-hosted Linux
+		// runners support the session keyring; a kernel built without
+		// CONFIG_KEYS (ENOSYS) cannot exercise this path.
+		t.Skip("kernel session keyring unavailable (no CONFIG_KEYS); cannot exercise keyring fallback")
+	}
+
+	// With Secret Service unavailable, backend selection must fall through to
+	// the kernel keyring.
+	b, err := platformNewBackend()
+	require.NoError(t, err)
+	require.Equal(t, "linux-kernel-keyring", b.name(),
+		"with Secret Service unavailable, the keyring must be selected")
+
+	store := newStore(b)
+	ctx := context.Background()
+	key := "cfgms/session/keyring-fallback-" + randHex(t, 6)
+	token := "keyring-tok-" + randHex(t, 16)
+
+	t.Cleanup(func() { _ = store.DeleteSecret(ctx, key) })
+
+	require.NoError(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: key, Value: token}))
+
+	got, err := store.GetSecret(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, token, got.Value, "keyring round-trip must preserve the token")
+
+	require.NoError(t, store.DeleteSecret(ctx, key))
+	_, err = store.GetSecret(ctx, key)
+	assert.Error(t, err, "secret must be gone after delete")
+}

--- a/pkg/secrets/providers/oskeychain/provider_test.go
+++ b/pkg/secrets/providers/oskeychain/provider_test.go
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package oskeychain
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time interface conformance.
+var (
+	_ interfaces.SecretProvider = (*Provider)(nil)
+	_ interfaces.SecretStore    = (*Store)(nil)
+)
+
+// fakeBackend is an in-memory backend for deterministic, platform-independent
+// tests of the Store/Provider logic.
+type fakeBackend struct {
+	mu    sync.Mutex
+	m     map[string][]byte
+	avail bool
+	nm    string
+}
+
+func newFakeBackend(avail bool) *fakeBackend {
+	return &fakeBackend{m: make(map[string][]byte), avail: avail, nm: "fake"}
+}
+
+func (f *fakeBackend) set(key string, value []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([]byte, len(value))
+	copy(cp, value)
+	f.m[key] = cp
+	return nil
+}
+
+func (f *fakeBackend) get(key string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.m[key]
+	if !ok {
+		return nil, errSecretNotFound
+	}
+	cp := make([]byte, len(v))
+	copy(cp, v)
+	return cp, nil
+}
+
+func (f *fakeBackend) del(key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.m, key)
+	return nil
+}
+
+func (f *fakeBackend) available() bool { return f.avail }
+func (f *fakeBackend) name() string    { return f.nm }
+
+func TestProviderMetadata(t *testing.T) {
+	p := &Provider{}
+	assert.Equal(t, "oskeychain", p.Name())
+	assert.NotEmpty(t, p.Description())
+	assert.NotEmpty(t, p.GetVersion())
+
+	caps := p.GetCapabilities()
+	assert.True(t, caps.SupportsEncryption, "OS keychain encrypts at rest")
+	assert.True(t, caps.SupportsRevocation, "DeleteSecret revokes immediately")
+	assert.GreaterOrEqual(t, caps.MaxSecretSize, 0)
+	assert.GreaterOrEqual(t, caps.MaxKeyLength, 0)
+}
+
+func TestProviderRegistered(t *testing.T) {
+	names := interfaces.GetRegisteredProviderNames()
+	assert.Contains(t, names, "oskeychain", "provider should auto-register via init()")
+}
+
+func TestStoreCoreOps(t *testing.T) {
+	store := newStore(newFakeBackend(true))
+	ctx := context.Background()
+	key := "cfgms/session/test-conn"
+	token := "session-token-abc123"
+
+	require.NoError(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: key, Value: token}))
+
+	got, err := store.GetSecret(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, token, got.Value)
+	assert.Equal(t, key, got.Key)
+
+	require.NoError(t, store.DeleteSecret(ctx, key))
+
+	_, err = store.GetSecret(ctx, key)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, interfaces.ErrSecretNotFound)
+}
+
+func TestStoreValidation(t *testing.T) {
+	store := newStore(newFakeBackend(true))
+	ctx := context.Background()
+
+	assert.Error(t, store.StoreSecret(ctx, nil), "nil request")
+	assert.Error(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: "", Value: "x"}), "empty key")
+	assert.Error(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: "k", Value: ""}), "empty value")
+
+	longKey := make([]byte, maxKeyLength+1)
+	for i := range longKey {
+		longKey[i] = 'a'
+	}
+	assert.Error(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: string(longKey), Value: "x"}), "oversized key")
+
+	bigVal := make([]byte, maxSecretSize+1)
+	for i := range bigVal {
+		bigVal[i] = 'a'
+	}
+	assert.Error(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: "k", Value: string(bigVal)}), "oversized value")
+}
+
+func TestUnsupportedOps(t *testing.T) {
+	store := newStore(newFakeBackend(true))
+	ctx := context.Background()
+
+	_, err := store.ListSecrets(ctx, nil)
+	assert.ErrorIs(t, err, errors.ErrUnsupported)
+	_, err = store.GetSecrets(ctx, []string{"k"})
+	assert.ErrorIs(t, err, errors.ErrUnsupported)
+	assert.ErrorIs(t, store.StoreSecrets(ctx, nil), errors.ErrUnsupported)
+	_, err = store.GetSecretVersion(ctx, "k", 1)
+	assert.ErrorIs(t, err, errors.ErrUnsupported)
+	_, err = store.ListSecretVersions(ctx, "k")
+	assert.ErrorIs(t, err, errors.ErrUnsupported)
+	_, err = store.GetSecretMetadata(ctx, "k")
+	assert.ErrorIs(t, err, errors.ErrUnsupported)
+	assert.ErrorIs(t, store.UpdateSecretMetadata(ctx, "k", nil), errors.ErrUnsupported)
+	assert.ErrorIs(t, store.RotateSecret(ctx, "k", "v"), errors.ErrUnsupported)
+	assert.ErrorIs(t, store.ExpireSecret(ctx, "k"), errors.ErrUnsupported)
+
+	// HealthCheck and Close are no-ops.
+	assert.NoError(t, store.HealthCheck(ctx))
+	assert.NoError(t, store.Close())
+}
+
+// TestAvailableReportsNoBackend verifies Available() returns (false, nil) — not
+// an error — when no platform backend is usable, so callers fall back to the
+// one-shot --bundle path rather than failing hard.
+func TestAvailableReportsNoBackend(t *testing.T) {
+	orig := newBackend
+	t.Cleanup(func() { newBackend = orig })
+
+	newBackend = func() (backend, error) { return newFakeBackend(false), nil }
+
+	p := &Provider{}
+	ok, err := p.Available()
+	assert.NoError(t, err, "Available must not error when no backend exists")
+	assert.False(t, ok)
+
+	_, err = p.CreateSecretStore(nil)
+	assert.Error(t, err, "CreateSecretStore must fail when no backend is available")
+}
+
+func TestAvailableReportsBackendPresent(t *testing.T) {
+	orig := newBackend
+	t.Cleanup(func() { newBackend = orig })
+
+	newBackend = func() (backend, error) { return newFakeBackend(true), nil }
+
+	p := &Provider{}
+	ok, err := p.Available()
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	store, err := p.CreateSecretStore(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}
+
+// TestRealBackendRoundTrip exercises the actual OS keychain on the build
+// platform (live Credential Manager on Windows, Keychain on macOS, Secret
+// Service / keyring on Linux). Skips when no backend is usable (e.g. a headless
+// Linux host with neither Secret Service nor a kernel keyring).
+func TestRealBackendRoundTrip(t *testing.T) {
+	b, err := newBackend()
+	require.NoError(t, err)
+	if !b.available() {
+		t.Skipf("no OS keychain backend available on this host (%s); nothing to round-trip", b.name())
+	}
+	t.Logf("exercising backend: %s", b.name())
+
+	store := newStore(b)
+	ctx := context.Background()
+	key := "cfgms/session/roundtrip-" + randHex(t, 6)
+	token := "tok-" + randHex(t, 16)
+
+	t.Cleanup(func() { _ = store.DeleteSecret(ctx, key) })
+
+	require.NoError(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: key, Value: token}))
+
+	got, err := store.GetSecret(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, token, got.Value)
+
+	require.NoError(t, store.DeleteSecret(ctx, key))
+	_, err = store.GetSecret(ctx, key)
+	assert.ErrorIs(t, err, interfaces.ErrSecretNotFound)
+}
+
+// TestNoCleartextOnDisk is the [REQUIRED TEST] no-cleartext-on-disk acceptance
+// check: after StoreSecret, neither os.UserConfigDir()/cfgms nor the working
+// tree contains a file holding the token value — the secret lives only in the
+// OS store / keyring.
+func TestNoCleartextOnDisk(t *testing.T) {
+	b, err := newBackend()
+	require.NoError(t, err)
+	if !b.available() {
+		t.Skipf("no OS keychain backend available on this host (%s); cannot prove no-disk behavior", b.name())
+	}
+
+	store := newStore(b)
+	ctx := context.Background()
+	key := "cfgms/session/nodisk-" + randHex(t, 6)
+	token := "NODISK-" + randHex(t, 24) // unique, won't pre-exist in any file
+
+	t.Cleanup(func() { _ = store.DeleteSecret(ctx, key) })
+	require.NoError(t, store.StoreSecret(ctx, &interfaces.SecretRequest{Key: key, Value: token}))
+
+	roots := scanRoots(t)
+	require.NotEmpty(t, roots, "expected at least one scan root")
+	for _, root := range roots {
+		if hit := findTokenInTree(t, root, token); hit != "" {
+			t.Fatalf("token found in cleartext on disk at %s — provider must never write the secret to a file", hit)
+		}
+	}
+}
+
+// scanRoots returns the directories the no-disk test scans: the CFGMS user
+// config dir and the module working tree.
+func scanRoots(t *testing.T) []string {
+	t.Helper()
+	var roots []string
+	if cfgDir, err := os.UserConfigDir(); err == nil {
+		roots = append(roots, filepath.Join(cfgDir, "cfgms"))
+	}
+	if modRoot := moduleRoot(t); modRoot != "" {
+		roots = append(roots, modRoot)
+	}
+	return roots
+}
+
+// moduleRoot walks up from the test's working directory to the directory
+// containing go.mod (the repository working tree root).
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// findTokenInTree scans root recursively for the token, skipping .git and large
+// files. Returns the path of the first file containing the token, or "".
+func findTokenInTree(t *testing.T, root, token string) string {
+	t.Helper()
+	if _, err := os.Stat(root); err != nil {
+		return "" // root absent (e.g. user config dir never created) — nothing to scan
+	}
+	needle := []byte(token)
+	var found string
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable entry — skip
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil || info.Size() > 4*1024*1024 {
+			return nil // skip large/binary files
+		}
+		data, err := os.ReadFile(path) //#nosec G304 -- test scans the working tree for the token
+		if err != nil {
+			return nil
+		}
+		if contains(data, needle) {
+			found = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// contains reports whether haystack contains needle.
+func contains(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return false
+	}
+outer:
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				continue outer
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func randHex(t *testing.T, n int) string {
+	t.Helper()
+	buf := make([]byte, n)
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
+	return hex.EncodeToString(buf)
+}

--- a/pkg/secrets/providers/oskeychain/provider_windows.go
+++ b/pkg/secrets/providers/oskeychain/provider_windows.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package oskeychain
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Windows Credential Manager constants.
+const (
+	credTypeGeneric = 1 // CRED_TYPE_GENERIC
+
+	// credPersistSession scopes the credential to the current logon session: it
+	// lives in memory for the session and is never persisted to disk, matching
+	// the short-lived session-token model and the Linux session-keyring fallback.
+	credPersistSession = 1 // CRED_PERSIST_SESSION
+
+	// errorNotFound is returned by CredReadW/CredDeleteW when the target is absent.
+	errorNotFound = 1168 // ERROR_NOT_FOUND
+)
+
+var (
+	modadvapi32      = windows.NewLazySystemDLL("advapi32.dll")
+	procCredWriteW   = modadvapi32.NewProc("CredWriteW")
+	procCredReadW    = modadvapi32.NewProc("CredReadW")
+	procCredDeleteW  = modadvapi32.NewProc("CredDeleteW")
+	procCredFreeProc = modadvapi32.NewProc("CredFree")
+)
+
+// credentialW mirrors the Windows CREDENTIALW structure. Field order and
+// padding must match the C ABI exactly (see wincred.h).
+type credentialW struct {
+	Flags              uint32
+	Type               uint32
+	TargetName         *uint16
+	Comment            *uint16
+	LastWritten        windows.Filetime
+	CredentialBlobSize uint32
+	CredentialBlob     *byte
+	Persist            uint32
+	AttributeCount     uint32
+	Attributes         uintptr
+	TargetAlias        *uint16
+	UserName           *uint16
+}
+
+// credManBackend implements backend using the Windows Credential Manager.
+type credManBackend struct{}
+
+// platformNewBackend returns the Credential Manager backend. It is always
+// available on Windows.
+func platformNewBackend() (backend, error) {
+	return &credManBackend{}, nil
+}
+
+func (b *credManBackend) name() string { return "windows-credential-manager" }
+
+func (b *credManBackend) available() bool { return true }
+
+func (b *credManBackend) set(key string, value []byte) error {
+	target, err := windows.UTF16PtrFromString(key)
+	if err != nil {
+		return fmt.Errorf("invalid key: %w", err)
+	}
+
+	cred := credentialW{
+		Type:               credTypeGeneric,
+		TargetName:         target,
+		CredentialBlobSize: uint32(len(value)),
+		Persist:            credPersistSession,
+	}
+	if len(value) > 0 {
+		cred.CredentialBlob = &value[0]
+	}
+
+	ret, _, callErr := procCredWriteW.Call(
+		uintptr(unsafe.Pointer(&cred)),
+		0, // flags
+	)
+	if ret == 0 {
+		return fmt.Errorf("CredWriteW failed: %w", callErr)
+	}
+	return nil
+}
+
+func (b *credManBackend) get(key string) ([]byte, error) {
+	target, err := windows.UTF16PtrFromString(key)
+	if err != nil {
+		return nil, fmt.Errorf("invalid key: %w", err)
+	}
+
+	var pcred *credentialW
+	ret, _, callErr := procCredReadW.Call(
+		uintptr(unsafe.Pointer(target)),
+		uintptr(credTypeGeneric),
+		0, // flags
+		uintptr(unsafe.Pointer(&pcred)),
+	)
+	if ret == 0 {
+		if errno, ok := callErr.(windows.Errno); ok && uintptr(errno) == errorNotFound {
+			return nil, errSecretNotFound
+		}
+		return nil, fmt.Errorf("CredReadW failed: %w", callErr)
+	}
+	defer procCredFreeProc.Call(uintptr(unsafe.Pointer(pcred)))
+
+	// Copy the blob out of the Credential Manager-allocated buffer before freeing.
+	if pcred.CredentialBlobSize == 0 || pcred.CredentialBlob == nil {
+		return []byte{}, nil
+	}
+	out := make([]byte, pcred.CredentialBlobSize)
+	copy(out, unsafe.Slice(pcred.CredentialBlob, pcred.CredentialBlobSize))
+	return out, nil
+}
+
+func (b *credManBackend) del(key string) error {
+	target, err := windows.UTF16PtrFromString(key)
+	if err != nil {
+		return fmt.Errorf("invalid key: %w", err)
+	}
+
+	ret, _, callErr := procCredDeleteW.Call(
+		uintptr(unsafe.Pointer(target)),
+		uintptr(credTypeGeneric),
+		0, // flags
+	)
+	if ret == 0 {
+		if errno, ok := callErr.(windows.Errno); ok && uintptr(errno) == errorNotFound {
+			// Deleting an absent key is not an error.
+			return nil
+		}
+		return fmt.Errorf("CredDeleteW failed: %w", callErr)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds `pkg/secrets/providers/oskeychain` — a cross-platform `SecretProvider` that holds the short-lived `cfg` session token in the host OS credential store, so the token is **never written to disk as cleartext**. Larger credential bundles use the machine-bound encrypted-file path (separate story); this provider stores only the small session token.

## Changes

- **`provider.go`** — `Provider` + `Store` implementing `interfaces.SecretProvider` / `interfaces.SecretStore`. Core `StoreSecret`/`GetSecret`/`DeleteSecret` delegate to a platform `backend`; the 9 non-core operations return `errors.ErrUnsupported`, `HealthCheck`/`Close` are no-ops (the provider holds a single token, not a versioned secret DB). `Available()` returns `(false, nil)` — never an error — when no backend is usable, so callers fall back to the `--bundle` path. Auto-registers via `init()`.
- **`provider_windows.go`** — Windows Credential Manager via `advapi32` `CredWriteW`/`CredReadW`/`CredDeleteW`, `CRED_TYPE_GENERIC`, `CRED_PERSIST_SESSION` (in-memory, dies with the logon session).
- **`provider_linux.go`** — Secret Service (libsecret via `secret-tool`, secret fed over stdin) with a kernel session-keyring (`x/sys/unix` keyctl) fallback for headless hosts; `(false, nil)` when neither is usable.
- **`provider_darwin.go`** — macOS Keychain via `security` add/find/delete-generic-password (argv `-w` limitation documented inline).
- **Tests** — core ops / validation / unsupported-op / `Available` semantics on an in-memory fake; live round-trip + the `[REQUIRED]` no-cleartext-on-disk scan on the real backend; `[REQUIRED]` `TestLinuxKeyringFallback`.

## Test results (qa-test-runner: PASS)

- `go build ./...`, `CGO_ENABLED=0 GOOS=linux/darwin go build` — clean on all platforms.
- `go test -race -short ./pkg/secrets/providers/oskeychain/` — **9/9 PASS** on the Windows host, exercising the **live Windows Credential Manager** (`TestRealBackendRoundTrip`, `TestNoCleartextOnDisk`).
- `gofmt`/`go vet` clean. `golangci-lint`/`gitleaks`/`gosec` deferred to CI (not installed on the Windows self-dispatch host).
- The Linux keyring path is unit-tested in Linux CI; macOS Keychain compiles under its build tag and is live-validated on a Mac later.

## QA code review (PASS)
0 blocking issues. `fakeBackend` confirmed a legitimate internal OS-adaptor test seam (not a mocked CFGMS component); all `t.Skip` uses are infrastructure-gated and justified; the no-disk assertion is substantive (unique random token, asserts absence across user-config-dir + working tree).

## Security review (PASS)
0 blocking (0 critical/high). `check-architecture` passes (no central-provider violations). Windows `unsafe.Pointer`/`CREDENTIALW` marshaling sound — `CredFree` always called, blob copied before free, nil/zero guards present. Subprocess exec uses fixed `LookPath` binaries + discrete argv, no shell/interpolation (CLAUDE.md banned-pattern compliant). No secret values logged. One LOW finding (macOS `-w` argv exposure, same-UID/momentary) addressed with an inline doc comment.

## Validation reality
First-pass implementation and validation ran on the Windows host so the **Windows Credential Manager backend is exercised for real** (Windows-first priority). All four backends cross-compile; the Windows-CM path is now live-validated ahead of the dependent `cfg connect` flow.

Fixes #2233

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>