### PR TITLE
workflow: CI-runner provisioning sequence descriptor + register scripts (Issue #2229)

### DIFF
--- a/features/controller/cirunner/scripts_test.go
+++ b/features/controller/cirunner/scripts_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package cirunner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/modules/script"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// dirScriptRepository is a minimal read-only script.ScriptRepository backed by
+// an on-disk directory of VersionedScript YAML files (one <id>.yaml per script).
+// It exists so the register scripts are loaded through the real
+// script.ScriptRepository / script.VersionedScript contract rather than ad-hoc
+// YAML decoding. Only the read methods are implemented; the rest return an
+// unsupported error.
+type dirScriptRepository struct {
+	dir string
+}
+
+func newDirScriptRepository(dir string) *dirScriptRepository {
+	return &dirScriptRepository{dir: dir}
+}
+
+var errReadOnly = fmt.Errorf("dirScriptRepository is read-only")
+
+func (r *dirScriptRepository) Get(id, _ string) (*script.VersionedScript, error) {
+	path := filepath.Join(r.dir, id+".yaml")
+	data, err := os.ReadFile(path) //#nosec G304 -- test loads scripts from the in-repo template directory
+	if err != nil {
+		return nil, fmt.Errorf("read script %q: %w", id, err)
+	}
+	var vs script.VersionedScript
+	if err := yaml.Unmarshal(data, &vs); err != nil {
+		return nil, fmt.Errorf("parse script %q: %w", id, err)
+	}
+	return &vs, nil
+}
+
+func (r *dirScriptRepository) List(_ *script.ScriptFilter) ([]*script.ScriptMetadata, error) {
+	entries, err := os.ReadDir(r.dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []*script.ScriptMetadata
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".yaml")
+		vs, err := r.Get(id, "")
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vs.Metadata)
+	}
+	return out, nil
+}
+
+func (r *dirScriptRepository) Create(*script.VersionedScript) error { return errReadOnly }
+func (r *dirScriptRepository) Update(*script.VersionedScript) error { return errReadOnly }
+func (r *dirScriptRepository) Delete(string, string) error          { return errReadOnly }
+func (r *dirScriptRepository) ListVersions(string) ([]*script.Version, error) {
+	return nil, errReadOnly
+}
+func (r *dirScriptRepository) GetLatestVersion(string) (*script.Version, error) {
+	return nil, errReadOnly
+}
+func (r *dirScriptRepository) Rollback(string, string) error { return errReadOnly }
+
+// Compile-time assertion that dirScriptRepository satisfies the contract.
+var _ script.ScriptRepository = (*dirScriptRepository)(nil)
+
+// bannedPatterns are the runtime-code-composition patterns forbidden in CFGMS
+// scripts (CLAUDE.md "Banned patterns"). Matched case-insensitively, with word
+// boundaries on the single-token commands (iex, eval, python -c) so legitimate
+// words like "evaluate" or "index" don't false-positive as the guardrail grows.
+var bannedPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\biex\b`),
+	regexp.MustCompile(`(?i)\binvoke-expression\b`),
+	regexp.MustCompile(`(?i)-command\s+"`),
+	regexp.MustCompile(`(?i)-encodedcommand\b`),
+	regexp.MustCompile(`(?i)-executionpolicy\s+bypass\b`),
+	regexp.MustCompile(`(?i)\bbash\s+-c\b`),
+	regexp.MustCompile(`(?i)\beval\b`),
+	regexp.MustCompile(`(?i)\bpython3?\s+-c\b`),
+}
+
+// TestRegisterScriptsBannedPatterns loads both register scripts via a
+// ScriptRepository backed by the on-disk templates/scripts/cirunner/ directory
+// and asserts: (a) both parse as valid VersionedScript; (b) the body contains no
+// banned patterns; (c) CFGMS_SECRET_RUNNER_TOKEN is referenced as a secret param
+// (env var), never interpolated into a command string.
+func TestRegisterScriptsBannedPatterns(t *testing.T) {
+	dir := cirunnerScriptsDir(t)
+	repo := newDirScriptRepository(dir)
+
+	cases := []struct {
+		id       string
+		shell    script.ShellType
+		platform string
+		tokenRef string // the env-var reference form expected in the body
+	}{
+		{"register-github-runner-linux", script.ShellBash, "linux", "$CFGMS_SECRET_RUNNER_TOKEN"},
+		{"register-github-runner-windows", script.ShellPowerShell, "windows", "$env:CFGMS_SECRET_RUNNER_TOKEN"},
+	}
+
+	// AC #5: exactly ONE register script per OS in the library.
+	metas, err := repo.List(nil)
+	require.NoError(t, err)
+	assert.Len(t, metas, len(cases), "exactly one register script per OS must live in the library")
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			// (a) parses as a valid VersionedScript
+			vs, err := repo.Get(tc.id, "")
+			require.NoError(t, err, "must parse as a valid VersionedScript")
+			require.NotNil(t, vs.Metadata)
+			require.NoError(t, vs.Metadata.Validate(), "metadata must be valid")
+			assert.Equal(t, tc.id, vs.Metadata.ID)
+			assert.Equal(t, tc.shell, vs.Metadata.Shell)
+			assert.Equal(t, []string{tc.platform}, vs.Metadata.Platform)
+			require.NotEmpty(t, vs.Content, "script body must not be empty")
+
+			body := vs.Content
+
+			// (b) no banned runtime-code-composition patterns
+			for _, banned := range bannedPatterns {
+				assert.Falsef(t, banned.MatchString(body),
+					"script %s must not contain banned pattern %q", tc.id, banned.String())
+			}
+
+			// (c) the registration token is referenced as the secret env var,
+			// never a literal value composed into a command string.
+			assert.Contains(t, body, "CFGMS_SECRET_RUNNER_TOKEN",
+				"token must be referenced via the secret env var")
+			assert.Contains(t, body, tc.tokenRef,
+				"token must be referenced as an environment variable, not interpolated")
+
+			// RUNNER_TOKEN must be declared as a script parameter (the secret
+			// the staging step binds from the secret store).
+			assert.True(t, hasParam(vs.Metadata, "RUNNER_TOKEN"),
+				"RUNNER_TOKEN must be declared as a script parameter")
+		})
+	}
+}
+
+func hasParam(meta *script.ScriptMetadata, name string) bool {
+	for _, p := range meta.Parameters {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// cirunnerScriptsDir resolves the in-repo templates/scripts/cirunner directory
+// by walking up from the test working directory to the module root (go.mod).
+func cirunnerScriptsDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			scriptsDir := filepath.Join(dir, "templates", "scripts", "cirunner")
+			info, err := os.Stat(scriptsDir)
+			require.NoErrorf(t, err, "expected register-script directory at %s", scriptsDir)
+			require.True(t, info.IsDir())
+			return scriptsDir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqualf(t, parent, dir, "could not locate module root (go.mod) from test dir")
+		dir = parent
+	}
+}

--- a/features/controller/cirunner/timings.go
+++ b/features/controller/cirunner/timings.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package cirunner holds controller-side helpers for the CI-runner provisioning
+// de-risking spike (epic #565). It is plain data + functions — not a central
+// provider and not a module.
+package cirunner
+
+import (
+	"fmt"
+	"time"
+)
+
+// ProvisionTimings records the wall-clock milestones of one CI-runner
+// provisioning sequence so the de-risking spike can measure each phase:
+//
+//	StartedAt ──► TokenMintedAt ──► SyncTriggeredAt ──► EnrollmentConfirmedAt
+//	          token-mint        sync-trigger        enrollment-confirmed
+//
+// Timestamps are injected by the caller (recorded as each milestone is reached)
+// rather than read from time.Now() inside the duration math, so the phase
+// computations are deterministic and unit-testable with no wall-clock
+// dependency.
+type ProvisionTimings struct {
+	// StartedAt is when provisioning began (before token mint).
+	StartedAt time.Time
+	// TokenMintedAt is when the registration token was minted.
+	TokenMintedAt time.Time
+	// SyncTriggeredAt is when the config-sync to the steward was triggered.
+	SyncTriggeredAt time.Time
+	// EnrollmentConfirmedAt is when the github_runner module first reported the
+	// runner service enrolled and running.
+	EnrollmentConfirmedAt time.Time
+}
+
+// TokenMintDuration is the time spent minting the registration token
+// (StartedAt → TokenMintedAt).
+func (t ProvisionTimings) TokenMintDuration() time.Duration {
+	return t.TokenMintedAt.Sub(t.StartedAt)
+}
+
+// SyncTriggerDuration is the time from token mint to config-sync trigger
+// (TokenMintedAt → SyncTriggeredAt).
+func (t ProvisionTimings) SyncTriggerDuration() time.Duration {
+	return t.SyncTriggeredAt.Sub(t.TokenMintedAt)
+}
+
+// EnrollmentDuration is the time from config-sync trigger to enrollment
+// confirmation (SyncTriggeredAt → EnrollmentConfirmedAt) — the wait-for-runner
+// phase.
+func (t ProvisionTimings) EnrollmentDuration() time.Duration {
+	return t.EnrollmentConfirmedAt.Sub(t.SyncTriggeredAt)
+}
+
+// TotalDuration is the end-to-end provisioning time
+// (StartedAt → EnrollmentConfirmedAt).
+func (t ProvisionTimings) TotalDuration() time.Duration {
+	return t.EnrollmentConfirmedAt.Sub(t.StartedAt)
+}
+
+// Valid reports whether the milestones are monotonically non-decreasing and
+// all set — i.e. the three phase durations are non-negative and meaningful.
+func (t ProvisionTimings) Valid() bool {
+	if t.StartedAt.IsZero() || t.TokenMintedAt.IsZero() ||
+		t.SyncTriggeredAt.IsZero() || t.EnrollmentConfirmedAt.IsZero() {
+		return false
+	}
+	return !t.TokenMintedAt.Before(t.StartedAt) &&
+		!t.SyncTriggeredAt.Before(t.TokenMintedAt) &&
+		!t.EnrollmentConfirmedAt.Before(t.SyncTriggeredAt)
+}
+
+// String renders a one-line summary of the three phases and the total, for the
+// spike's provisioning report.
+func (t ProvisionTimings) String() string {
+	return fmt.Sprintf(
+		"cirunner provisioning: token-mint=%s sync-trigger=%s enrollment=%s total=%s",
+		t.TokenMintDuration(), t.SyncTriggerDuration(), t.EnrollmentDuration(), t.TotalDuration(),
+	)
+}

--- a/features/controller/cirunner/timings_test.go
+++ b/features/controller/cirunner/timings_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package cirunner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProvisionTimings constructs a ProvisionTimings value with injected
+// timestamps (never time.Now()) and asserts all three phase durations are
+// computed correctly with no wall-clock dependency.
+func TestProvisionTimings(t *testing.T) {
+	// Fixed, injected anchor — deterministic, no time.Now().
+	base := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+
+	timings := ProvisionTimings{
+		StartedAt:             base,
+		TokenMintedAt:         base.Add(2 * time.Second),  // token-mint took 2s
+		SyncTriggeredAt:       base.Add(5 * time.Second),  // sync-trigger 3s after mint
+		EnrollmentConfirmedAt: base.Add(35 * time.Second), // enrollment 30s after sync
+	}
+
+	assert.Equal(t, 2*time.Second, timings.TokenMintDuration(), "token-mint phase")
+	assert.Equal(t, 3*time.Second, timings.SyncTriggerDuration(), "sync-trigger phase")
+	assert.Equal(t, 30*time.Second, timings.EnrollmentDuration(), "enrollment-confirmed phase")
+	assert.Equal(t, 35*time.Second, timings.TotalDuration(), "total end-to-end")
+	assert.True(t, timings.Valid(), "monotonic, fully-populated timings are valid")
+
+	// The three phases sum to the total — no wall-clock drift, pure arithmetic.
+	assert.Equal(t,
+		timings.TotalDuration(),
+		timings.TokenMintDuration()+timings.SyncTriggerDuration()+timings.EnrollmentDuration(),
+		"phase durations must sum to the total",
+	)
+
+	// String summary is non-empty and mentions every phase.
+	summary := timings.String()
+	for _, want := range []string{"token-mint", "sync-trigger", "enrollment", "total"} {
+		assert.Contains(t, summary, want)
+	}
+}
+
+// TestProvisionTimings_Invalid covers non-monotonic and incomplete milestone
+// sets — Valid() must reject them.
+func TestProvisionTimings_Invalid(t *testing.T) {
+	base := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+
+	// Out-of-order: sync before token mint.
+	nonMonotonic := ProvisionTimings{
+		StartedAt:             base,
+		TokenMintedAt:         base.Add(5 * time.Second),
+		SyncTriggeredAt:       base.Add(2 * time.Second),
+		EnrollmentConfirmedAt: base.Add(10 * time.Second),
+	}
+	assert.False(t, nonMonotonic.Valid(), "non-monotonic milestones are invalid")
+
+	// Incomplete: enrollment never confirmed.
+	incomplete := ProvisionTimings{
+		StartedAt:       base,
+		TokenMintedAt:   base.Add(2 * time.Second),
+		SyncTriggeredAt: base.Add(5 * time.Second),
+	}
+	assert.False(t, incomplete.Valid(), "zero EnrollmentConfirmedAt is invalid")
+}

--- a/features/workflow/cirunner_provision_test.go
+++ b/features/workflow/cirunner_provision_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCIRunnerProvisionWorkflowDescriptor loads the CI-runner provisioning
+// descriptor via the workflow engine's loader and asserts its structure.
+//
+// NOTE: the descriptor uses api/http/while step types with typed api:/http:/loop:
+// blocks. These are represented by the rich workflow.Workflow / Step model and
+// are loaded by the engine's actual loader (Engine.loadWorkflowFromPath ->
+// yaml.Unmarshal into Workflow) — the same path the engine runs at execution
+// time and the same flat format as github-app-runner-token.yaml. (The separate
+// features/workflow/parser.go Parser models only task/sequential/parallel/
+// conditional steps and a `workflow:`-wrapped format; it cannot represent
+// api/http/while steps, so it is not the loader for this descriptor.)
+func TestCIRunnerProvisionWorkflowDescriptor(t *testing.T) {
+	engine := &Engine{} // loadWorkflowFromPath only reads+unmarshals; no engine state needed
+
+	wf, err := engine.loadWorkflowFromPath("examples/cirunner-provision.yaml")
+	// (a) YAML parses without error.
+	require.NoError(t, err, "descriptor must parse via the workflow engine loader")
+	assert.Equal(t, "cirunner-provision", wf.Name)
+
+	// (b) Step sequence is api -> stage(task) -> http -> while.
+	require.Len(t, wf.Steps, 4, "expected exactly 4 top-level steps")
+	assert.Equal(t, StepTypeAPI, wf.Steps[0].Type, "step 1 must be api")
+	assert.Equal(t, StepTypeTask, wf.Steps[1].Type, "step 2 (stage) must be a task")
+	assert.Contains(t, strings.ToLower(wf.Steps[1].Name), "stage", "step 2 is the stage step")
+	assert.Equal(t, StepTypeHTTP, wf.Steps[2].Type, "step 3 must be http")
+	assert.Equal(t, StepTypeWhile, wf.Steps[3].Type, "step 4 must be while")
+
+	// (c) The api step resolves provider: github, service: runners,
+	//     operation: registration-token.
+	api := wf.Steps[0].API
+	require.NotNil(t, api, "api step must carry an api block")
+	assert.Equal(t, "github", api.Provider)
+	assert.Equal(t, "runners", api.Service)
+	assert.Equal(t, "registration-token", api.Operation)
+
+	// (d) The http step targets POST /api/v1/config/push.
+	httpStep := wf.Steps[2].HTTP
+	require.NotNil(t, httpStep, "http step must carry an http block")
+	assert.Equal(t, "POST", httpStep.Method)
+	assert.Contains(t, httpStep.URL, "/api/v1/config/push")
+
+	// AC #5: the stage step references the register script by id + version
+	// (a named library script), NOT a per-standup generated script.
+	stageCfg := wf.Steps[1].Config
+	require.NotNil(t, stageCfg, "stage step must have config")
+	assert.Equal(t, "stage", stageCfg["action"])
+	assert.Contains(t, stageCfg, "script_id", "stage references a library script by id")
+	assert.Contains(t, stageCfg, "script_version", "stage references the script by version")
+
+	// The token is bound as a secret-store param, never a literal value.
+	bindings, ok := stageCfg["param_bindings"].([]interface{})
+	require.True(t, ok, "stage step must declare param_bindings")
+	assert.True(t, hasSecretBinding(bindings, "RUNNER_TOKEN"),
+		"RUNNER_TOKEN must be bound from the secret store")
+
+	// AC #4: the wait/poll step keys off the github_runner module's reported
+	// state (a while condition), NOT a fixed sleep.
+	loop := wf.Steps[3].Loop
+	require.NotNil(t, loop, "while step must carry a loop block")
+	require.NotNil(t, loop.Condition, "the poll loop must have a state condition, not a fixed sleep")
+	assert.Contains(t, loop.Condition.Expression, "github_runner",
+		"the poll condition must key off the github_runner module's reported state")
+	require.Len(t, wf.Steps[3].Steps, 1, "the while body polls the steward DNA")
+	pollStep := wf.Steps[3].Steps[0]
+	assert.Equal(t, StepTypeHTTP, pollStep.Type)
+	require.NotNil(t, pollStep.HTTP)
+	assert.Equal(t, "GET", pollStep.HTTP.Method)
+	assert.Contains(t, pollStep.HTTP.URL, "/dna", "the poll reads the steward DNA")
+
+	// No fixed-sleep step anywhere in the descriptor.
+	assertNoDelaySteps(t, wf.Steps)
+}
+
+// hasSecretBinding reports whether a param_bindings list contains a binding for
+// name sourced from the secret store (and never a literal token value).
+func hasSecretBinding(bindings []interface{}, name string) bool {
+	for _, b := range bindings {
+		m, ok := b.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["name"] == name && m["from"] == "secret-store" {
+			// A secret binding must not carry an inline literal value.
+			if _, hasValue := m["value"]; !hasValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// assertNoDelaySteps fails if any step (recursively) is a fixed-sleep delay step.
+func assertNoDelaySteps(t *testing.T, steps []Step) {
+	t.Helper()
+	for _, s := range steps {
+		assert.NotEqualf(t, StepTypeDelay, s.Type,
+			"provisioning must be state-driven; step %q is a fixed-sleep delay", s.Name)
+		if len(s.Steps) > 0 {
+			assertNoDelaySteps(t, s.Steps)
+		}
+	}
+}

--- a/features/workflow/examples/cirunner-provision.yaml
+++ b/features/workflow/examples/cirunner-provision.yaml
@@ -1,0 +1,121 @@
+name: cirunner-provision
+description: >
+  One-time, NON-idempotent provisioning sequence that turns an already-enrolled
+  CI host into a registered, running GitHub Actions self-hosted runner:
+
+    1. api    — mint a single-use registration token (github_app provider).
+    2. stage  — stage the stable per-OS register script from the controller
+                script library and bind the token as a secret-store param
+                (the token never lands in a command string or on disk).
+    3. http   — POST the controller config-push endpoint to sync config to the
+                steward, which runs the staged register script.
+    4. while  — poll the steward DNA until the github_runner module reports the
+                runner service enrolled and running (state-driven, not a sleep).
+
+  Loaded by the workflow engine (engine.loadWorkflowFromPath -> yaml.Unmarshal
+  into workflow.Workflow); this is the flat descriptor format the engine runs,
+  the same shape as github-app-runner-token.yaml. App credentials and the
+  steward secret token come from the secrets provider — never this file.
+  See docs/development/ci-runner-github-app-setup.md for operator setup.
+version: "1.0"
+
+# The whole sequence is bounded by the workflow-level timeout; the await step's
+# poll loop is bound by this and by max_iterations, never a fixed sleep.
+timeout: 30m
+on_failure: stop
+
+variables:
+  github_owner: "your-org"
+  github_repo: "your-repo"
+  repo_url: "https://github.com/your-org/your-repo"
+  controller_url: "https://controller.example.com:8443"
+  steward_id: "your-steward-id"
+  runner_os: "linux"
+  runner_labels: "self-hosted,linux,cfgms"
+  register_script_id: "register-github-runner-linux"
+  register_script_version: "1.0.0"
+  # Secret-store key the staging step binds to the RUNNER_TOKEN script param.
+  runner_token_secret_key: "cfgms/cirunner/registration-token"
+
+steps:
+  # 1. Mint a fresh single-use runner registration token (~1h lifetime).
+  - name: mint-runner-token
+    type: api
+    timeout: 30s
+    api:
+      provider: github
+      service: runners
+      operation: registration-token
+      parameters:
+        owner: "{{ .github_owner }}"
+        repo: "{{ .github_repo }}"
+      retry:
+        max_attempts: 2
+        initial_delay: 2s
+        backoff_multiplier: 2.0
+
+  # 2. Stage the stable per-OS register script from the library and bind the
+  #    just-minted token as a SECRET param (from: secret-store). The script is
+  #    referenced by id + version — NOT generated per standup. The token value
+  #    is resolved at execution time and injected as CFGMS_SECRET_RUNNER_TOKEN;
+  #    it is never written here.
+  - name: stage-register-script
+    type: task
+    module: script
+    config:
+      action: stage
+      script_id: "{{ .register_script_id }}"
+      script_version: "{{ .register_script_version }}"
+      param_bindings:
+        - name: RUNNER_TOKEN
+          from: secret-store
+          key: "{{ .runner_token_secret_key }}"
+        - name: REPO_URL
+          from: literal
+          value: "{{ .repo_url }}"
+        - name: RUNNER_LABELS
+          from: literal
+          value: "{{ .runner_labels }}"
+
+  # 3. Trigger a config sync to the steward via the controller's existing
+  #    config-push endpoint (StepTypeHTTP -> handleConfigPush -> push.Fanout ->
+  #    CommandSyncConfig). This is the data-defined path; the workflow never
+  #    calls commands.Publisher.TriggerConfigSync directly.
+  - name: trigger-config-sync
+    type: http
+    timeout: 30s
+    http:
+      method: POST
+      url: "{{ .controller_url }}/api/v1/config/push"
+      headers:
+        Content-Type: application/json
+      body:
+        steward_id: "{{ .steward_id }}"
+      expected_status:
+        - 200
+        - 202
+
+  # 4. Wait for enrollment by polling the steward DNA until the github_runner
+  #    module reports the runner service enrolled AND running. State-driven:
+  #    each iteration is an HTTP GET of the steward DNA, and the loop continues
+  #    WHILE the module is not yet enrolled+running. Bounded by max_iterations
+  #    and the workflow timeout — never a fixed sleep.
+  - name: await-runner-enrollment
+    type: while
+    loop:
+      type: while
+      max_iterations: 60
+      condition:
+        type: expression
+        # Keep looping while the github_runner module has not yet reported the
+        # service enrolled and running in the polled steward DNA.
+        expression: '{{ ne (index .poll_steward_dna_http_response.modules "github_runner").state "enrolled-running" }}'
+    steps:
+      - name: poll-steward-dna
+        type: http
+        timeout: 15s
+        http:
+          method: GET
+          url: "{{ .controller_url }}/api/v1/stewards/{{ .steward_id }}/dna"
+          expected_status:
+            - 200

--- a/templates/scripts/cirunner/register-github-runner-linux.yaml
+++ b/templates/scripts/cirunner/register-github-runner-linux.yaml
@@ -1,0 +1,64 @@
+metadata:
+  id: register-github-runner-linux
+  name: Register GitHub Actions Runner (Linux)
+  description: >
+    Registers this already-enrolled Linux host as a GitHub Actions self-hosted
+    runner by invoking the runner's own config.sh against the on-disk
+    actions-runner directory. The single-use registration token is supplied by
+    the provisioning workflow's staging step as the secret env var
+    CFGMS_SECRET_RUNNER_TOKEN (secret-store param binding); it is never written
+    into this file nor composed into a command string.
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  author: cfgms-team@cfg.is
+  tags:
+    - cirunner
+    - github-actions
+    - registration
+    - linux
+  category: ci-runner
+  platform:
+    - linux
+  shell: bash
+  parameters:
+    - name: REPO_URL
+      type: string
+      description: GitHub repository (or org) URL the runner registers against. Injected as CFGMS_PARAM_REPO_URL.
+      required: true
+    - name: RUNNER_LABELS
+      type: string
+      description: Comma-separated runner labels. Injected as CFGMS_PARAM_RUNNER_LABELS.
+      required: false
+      default: "self-hosted,linux,cfgms"
+    - name: RUNNER_TOKEN
+      type: string
+      description: >
+        Single-use GitHub Actions registration token. Bound at staging from the
+        secret store and injected as the secret env var CFGMS_SECRET_RUNNER_TOKEN
+        — never passed on the command line or stored in this file.
+      required: true
+  created_at: 2026-06-29T00:00:00Z
+  updated_at: 2026-06-29T00:00:00Z
+content: |
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  # Register this host as a GitHub Actions self-hosted runner.
+  #
+  # The registration token arrives as the secret environment variable
+  # CFGMS_SECRET_RUNNER_TOKEN (resolved by the staging step's secret-store param
+  # binding). It is referenced here only as an environment variable — it is
+  # never interpolated into a command string, logged, or written to disk.
+
+  repo_url="${CFGMS_PARAM_REPO_URL:?REPO_URL is required}"
+  runner_labels="${CFGMS_PARAM_RUNNER_LABELS:-self-hosted,linux,cfgms}"
+
+  cd ./actions-runner
+  ./config.sh \
+    --url "$repo_url" \
+    --token "$CFGMS_SECRET_RUNNER_TOKEN" \
+    --labels "$runner_labels" \
+    --unattended \
+    --replace

--- a/templates/scripts/cirunner/register-github-runner-windows.yaml
+++ b/templates/scripts/cirunner/register-github-runner-windows.yaml
@@ -1,0 +1,61 @@
+metadata:
+  id: register-github-runner-windows
+  name: Register GitHub Actions Runner (Windows)
+  description: >
+    Registers this already-enrolled Windows host as a GitHub Actions self-hosted
+    runner by invoking the runner's own config.cmd against the on-disk
+    actions-runner directory. The single-use registration token is supplied by
+    the provisioning workflow's staging step as the secret env var
+    CFGMS_SECRET_RUNNER_TOKEN (secret-store param binding); it is never written
+    into this file nor composed into a command string.
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  author: cfgms-team@cfg.is
+  tags:
+    - cirunner
+    - github-actions
+    - registration
+    - windows
+  category: ci-runner
+  platform:
+    - windows
+  shell: powershell
+  parameters:
+    - name: REPO_URL
+      type: string
+      description: GitHub repository (or org) URL the runner registers against. Injected as CFGMS_PARAM_REPO_URL.
+      required: true
+    - name: RUNNER_LABELS
+      type: string
+      description: Comma-separated runner labels. Injected as CFGMS_PARAM_RUNNER_LABELS.
+      required: false
+      default: "self-hosted,windows,cfgms"
+    - name: RUNNER_TOKEN
+      type: string
+      description: >
+        Single-use GitHub Actions registration token. Bound at staging from the
+        secret store and injected as the secret env var CFGMS_SECRET_RUNNER_TOKEN
+        — never passed on the command line or stored in this file.
+      required: true
+  created_at: 2026-06-29T00:00:00Z
+  updated_at: 2026-06-29T00:00:00Z
+content: |
+  #Requires -Version 5.1
+  Set-StrictMode -Version Latest
+  $ErrorActionPreference = 'Stop'
+
+  # Register this host as a GitHub Actions self-hosted runner.
+  #
+  # The registration token arrives as the secret environment variable
+  # CFGMS_SECRET_RUNNER_TOKEN (resolved by the staging step's secret-store param
+  # binding). It is referenced here only as $env:CFGMS_SECRET_RUNNER_TOKEN — never
+  # interpolated into a command string, logged, or written to disk.
+
+  $repoUrl = $env:CFGMS_PARAM_REPO_URL
+  if ([string]::IsNullOrWhiteSpace($repoUrl)) { throw 'REPO_URL is required' }
+  $runnerLabels = if ($env:CFGMS_PARAM_RUNNER_LABELS) { $env:CFGMS_PARAM_RUNNER_LABELS } else { 'self-hosted,windows,cfgms' }
+
+  Set-Location .\actions-runner
+  .\config.cmd --url $repoUrl --token $env:CFGMS_SECRET_RUNNER_TOKEN --labels $runnerLabels --unattended --replace


### PR DESCRIPTION
## Summary

De-risking spike for epic #565: a **data-defined** controller workflow that turns an already-enrolled CI host into a registered, running GitHub Actions self-hosted runner, via the one-time sequence **mint-token → stage register script → trigger config sync → await enrollment**.

## Changes

- **`features/workflow/examples/cirunner-provision.yaml`** — the provisioning descriptor. Four sequential steps:
  1. `api` — mint a single-use registration token (`provider: github`, `service: runners`, `operation: registration-token`).
  2. `task` (stage) — stage the per-OS register script from the library, binding the token as a **secret-store** param (`from: secret-store`, no inline value).
  3. `http` — `POST /api/v1/config/push` to sync config to the steward (the existing config-push endpoint → `push.Fanout`, not a direct privileged Go call).
  4. `while` — poll the steward DNA until the `github_runner` module reports the service enrolled+running. **State-driven**, bounded by the workflow timeout + `max_iterations` — never a fixed sleep.
- **`templates/scripts/cirunner/register-github-runner-{linux,windows}.yaml`** — exactly **ONE** stable `VersionedScript` per OS in the library, referenced by id+version (not generated per-standup). Each invokes the runner's own `config.sh`/`config.cmd` directly with discrete args. The token arrives as the secret env var `CFGMS_SECRET_RUNNER_TOKEN` (secret-store binding) and is **never composed into a command string**. No banned patterns.
- **`features/controller/cirunner/timings.go`** — `ProvisionTimings`: plain struct + funcs computing the three phase durations (token-mint, sync-trigger, enrollment) from **injected** timestamps for the spike's report. No provider, no `time.Now()` in the math.

## Tests (all [REQUIRED] — PASS)
- `TestRegisterScriptsBannedPatterns` — loads both scripts via a `ScriptRepository` backed by the on-disk template dir; asserts valid `VersionedScript` parse, **no banned patterns** (anchored regexes), and the secret token reference.
- `TestCIRunnerProvisionWorkflowDescriptor` — loads the descriptor via the engine loader; asserts step sequence, api provider resolution, the `POST /api/v1/config/push` target, the while-poll condition keying off `github_runner` state, and no delay steps.
- `TestProvisionTimings` — deterministic phase math from injected timestamps.

## Reviews (all PASS, 0 blocking)
- **Acceptance:** PASS — all ACs verified, including the parser-loader resolution below.
- **qa-test-runner:** PASS — build/vet/gofmt/race/check-architecture clean.
- **qa-code-review:** PASS — `dirScriptRepository` confirmed a legitimate read-only test repo; assertions substantive. (Suggested hardening the banned-pattern matchers with word boundaries — **applied**.)
- **security:** PASS (0 critical/high) — scripts banned-pattern-clean; token bound from secret-store with no literal/no on-disk write; http steps target only the controller's own endpoints (no SSRF); HTTPS default; secrets injected into child env only.

## Notes for reviewers
- **Loader:** the AC names `features/workflow/parser.go`, but that `Parser` models only `task/sequential/parallel/conditional` steps in a `workflow:`-wrapped format and **cannot represent** `api`/`http`/`while` steps (it would reject them at validation). The engine's real loader is `Engine.loadWorkflowFromPath` (`yaml.Unmarshal` into the rich `workflow.Workflow`) — the path the engine runs at execution time and the same flat format as `github-app-runner-token.yaml`. The test loads via that real loader and documents the discrepancy.
- **bash env-var naming (LOW, out of scope):** per the story the linux script references `$CFGMS_SECRET_RUNNER_TOKEN`; the bash secret-binding convention (`script.SecretEnvVarName`) otherwise injects bare `RUNNER_TOKEN`. The script runs under `set -u`, so this fails closed (no empty/garbage token reaches GitHub). Aligning the `github_runner` module's bash execution-path env-var naming is its concern (explicitly Out of Scope here) — flagged for follow-up before a live Linux run.

Validated on the Windows host: all new package tests pass under `-race`; cross-compiles clean; `make check-architecture` passes.

Fixes #2229

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>