### PR TITLE
hyperv: vm resource HA-role option — CSV seed-dir guard + clustered-role registration (Issue #2240)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -112,6 +112,41 @@ The resource type is selected via the `module` field as `hyperv.<type>`
     state: running
 ```
 
+### Highly-available (clustered) VM
+
+Add an optional `ha_role` block to register the VM as a clustered HA role on a
+failover cluster after it is created. The primary VHDX lives on a Cluster Shared
+Volume (`C:\ClusterStorage\...`) so it is reachable from every node; after
+`New-VM`, the module registers the VM as a clustered role via the cluster write
+path, reusing the **CNO ownership gate** and **existence idempotency** — the role
+is added exactly once cluster-wide and a non-owner node is a no-op. Standalone
+(non-HA) VMs omit `ha_role` and behave exactly as before.
+
+```yaml
+- name: ci-runner-01
+  module: hyperv.vm
+  config:
+    memory_mb: 8192
+    cpu_count: 4
+    # Primary VHDX on a Cluster Shared Volume — reachable from every cluster node.
+    vhd_path: C:\ClusterStorage\CSV01\ci-runner-01.vhdx
+    switch_name: External
+    generation: 2
+    state: running
+    ha_role:
+      # Must equal the module-level cluster_name scope cap.
+      cluster_name: lab-hv
+      # Optional cluster resource-group name; defaults to the VM name.
+      resource_group_name: ci-runner-01
+```
+
+> **CSV seed-dir constraint.** When `vhd_path` is on a Cluster Shared Volume, the
+> module-level **`seed_dir`** (configure-time) must be set and **host-local** —
+> not under `C:\ClusterStorage\`. A CSV (or empty) seed directory would hang the
+> provisioning build, so the resource is rejected at validate time with
+> `ErrInvalidHARoleSeedDir`. Set `seed_dir` to a per-node path such as
+> `C:\ProgramData\cfgms\seed`.
+
 ### Create an external virtual switch
 
 ```yaml

--- a/features/modules/hyperv/schema.yaml
+++ b/features/modules/hyperv/schema.yaml
@@ -98,6 +98,25 @@ resources:
               - never
               - recreate
             default: never
+      ha_role:
+        type: object
+        description: >
+          When present, registers the VM as a clustered HA role on the named
+          failover cluster after creation (reuses the cluster CNO ownership gate
+          and existence-based idempotency). Absent: the VM is a standalone
+          (non-HA) resource. When the primary vhd_path is on a Cluster Shared
+          Volume (C:\ClusterStorage\...), the module-level seed_dir must be set
+          and host-local (not under CSV) or the resource is rejected at validate
+          time.
+        required:
+          - cluster_name
+        properties:
+          cluster_name:
+            type: string
+            description: Target failover cluster (must equal the module's declared cluster_name).
+          resource_group_name:
+            type: string
+            description: Optional cluster resource-group name (defaults to the VM name).
 
   vswitch:
     description: Hyper-V virtual switch (external, internal, or private)

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -56,7 +56,19 @@ var (
 
 	// ErrInvalidSourceOnExisting is returned when source on_existing is not never or recreate.
 	ErrInvalidSourceOnExisting = errors.New("hyperv: invalid source on_existing: must be never or recreate")
+
+	// ErrInvalidHARoleSeedDir is returned when an HA-role VM places its primary
+	// VHDX on a Cluster Shared Volume but the module-level seed_dir is empty or
+	// also on CSV. The provisioning seed directory must be host-local so the
+	// ephemeral seed media never lands on the clustered volume (which would hang
+	// the build); this is enforced eagerly at validate-time rather than letting
+	// the provisioning path stall (see vm_provision.go CSV seed-dir hang).
+	ErrInvalidHARoleSeedDir = errors.New("hyperv: invalid ha_role: a CSV primary vhd_path requires a host-local seed_dir (seed_dir must be set and not under C:\\ClusterStorage\\)")
 )
+
+// csvPathPrefix is the Cluster Shared Volume mount root. A VHDX or seed dir under
+// this prefix lives on shared cluster storage.
+const csvPathPrefix = `C:\ClusterStorage\`
 
 // vmNamePattern is the allowlist for user-supplied VM names. It is an injection
 // safety guard only — the name is used verbatim as the host-side VM name.
@@ -138,6 +150,30 @@ type VMConfig struct {
 	// Source, when non-nil, activates the ISO provisioning state machine.
 	// Absent source: block leaves the VM managed by the existing lifecycle only.
 	Source *SourceConfig `yaml:"source,omitempty"`
+	// HARole, when non-nil, registers the VM as a clustered HA role on the named
+	// failover cluster after creation (see setVM). Absent: the VM is a standalone
+	// (non-HA) resource with unchanged behavior.
+	HARole *HARoleConfig `yaml:"ha_role,omitempty"`
+
+	// seedDir is the module-level provisioning seed directory (m.seedDir),
+	// injected by setVM before Validate so the HA-role CSV seed-dir rule can be
+	// checked. It is NOT a per-VM YAML field (seed_dir is module-level config) —
+	// hence unexported and untagged so it never round-trips through YAML/AsMap.
+	seedDir string
+}
+
+// HARoleConfig declares that a vm resource is a highly-available clustered role.
+// When present on a VMConfig, setVM registers the VM as a clustered VM role on
+// the named failover cluster after creation, reusing the cluster module's CNO
+// gate and idempotency (registered exactly once cluster-wide; a no-op on a
+// non-owner node).
+type HARoleConfig struct {
+	// ClusterName is the target failover cluster (must equal the module's
+	// declared cluster_name; setCluster enforces the scope cap).
+	ClusterName string `yaml:"cluster_name"`
+	// ResourceGroupName is the optional cluster resource-group name. It defaults
+	// to the VM name (the clustered role is registered under the VM name).
+	ResourceGroupName string `yaml:"resource_group_name,omitempty"`
 }
 
 // stringOrStringList is a YAML scalar-or-sequence: switch_name may be a single
@@ -308,7 +344,21 @@ func (c *VMConfig) Validate() error {
 			return err
 		}
 	}
+	// HA-role CSV seed-dir rule: when the primary VHDX is on a Cluster Shared
+	// Volume, the provisioning seed_dir must be host-local — empty or also-on-CSV
+	// would hang the build, so reject it eagerly here.
+	if c.HARole != nil && isUnderCSV(c.VHDPath) {
+		if c.seedDir == "" || isUnderCSV(c.seedDir) {
+			return ErrInvalidHARoleSeedDir
+		}
+	}
 	return nil
+}
+
+// isUnderCSV reports whether a Windows path is under the Cluster Shared Volume
+// root (case-insensitive).
+func isUnderCSV(path string) bool {
+	return strings.HasPrefix(strings.ToLower(path), strings.ToLower(csvPathPrefix))
 }
 
 // isCloudInit reports whether this source uses the cloud-init/NoCloud path: a
@@ -439,6 +489,14 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 			"edition":     c.Source.Edition,
 		}
 	}
+	// ha_role is only emitted when present so a non-HA VMConfig round-trips
+	// unchanged (omitempty parity with the YAML tag).
+	if c.HARole != nil {
+		m["ha_role"] = map[string]interface{}{
+			"cluster_name":        c.HARole.ClusterName,
+			"resource_group_name": c.HARole.ResourceGroupName,
+		}
+	}
 	return m
 }
 
@@ -482,7 +540,7 @@ func (c *VMConfig) FromYAML(data []byte) error {
 
 // GetManagedFields returns the list of fields this configuration manages.
 func (c *VMConfig) GetManagedFields() []string {
-	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state", "source"}
+	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state", "source", "ha_role"}
 }
 
 // psGetVM is the script block passed to ExecutePS for VM retrieval.
@@ -741,6 +799,11 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	// YAML, not on this executor-supplied map.
 	cfg.Source = parseSourceMap(configMap["source"])
 
+	// ha_role (the clustered HA-role block) arrives as a nested map on the
+	// executor-supplied config map. Parse it so the create path registers the VM
+	// as a clustered role; absent ⇒ standalone VM (unchanged behavior).
+	cfg.HARole = parseHARoleMap(configMap["ha_role"])
+
 	// Also handle *VMConfig passed directly
 	if vc, ok := config.(*VMConfig); ok {
 		*cfg = *vc
@@ -781,6 +844,9 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	// the update path now routes switch names to Add/Remove-VMNetworkAdapter,
 	// so a malformed name must be rejected before reconcileNetwork, not only on
 	// create (defense-in-depth, even though values also travel via ArgumentList).
+	// Inject the module-level seed_dir so the HA-role CSV seed-dir rule can be
+	// enforced in Validate (seed_dir is module-level config, not a per-VM field).
+	cfg.seedDir = m.seedDir
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
@@ -811,6 +877,16 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		return err
 	}
 
+	// HA-role registration: after the VM is created and before the power-state
+	// transition, register it as a clustered VM role. Reuses the cluster module's
+	// CNO gate + idempotency — registered exactly once cluster-wide, a no-op on a
+	// non-owner node.
+	if cfg.HARole != nil {
+		if err := m.registerClusteredRole(ctx, cfg); err != nil {
+			return err
+		}
+	}
+
 	if state == "running" {
 		if err := m.execStartVM(ctx, "vm:"+vmName, hostName,
 			map[string]interface{}{"state": "stopped"},
@@ -827,6 +903,37 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	m.vmsMu.Unlock()
 
 	return nil
+}
+
+// parseHARoleMap extracts an HARoleConfig from the generic executor-supplied
+// config map. Returns nil when no ha_role block is present (standalone VM).
+func parseHARoleMap(v interface{}) *HARoleConfig {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	cluster, _ := m["cluster_name"].(string)
+	if strings.TrimSpace(cluster) == "" {
+		return nil
+	}
+	rg, _ := m["resource_group_name"].(string)
+	return &HARoleConfig{ClusterName: cluster, ResourceGroupName: rg}
+}
+
+// registerClusteredRole registers a just-created VM as a clustered HA role by
+// delegating to the cluster module's setCluster write path. The clustered role
+// name is the VM name (the default cluster group name Add-ClusterVirtualMachineRole
+// assigns); resource_group_name is reserved for an explicit group name and
+// currently defaults to the VM name. setCluster applies the S5 scope cap, the
+// CNO ownership gate, and existence-based idempotency — so the role is added
+// exactly once cluster-wide and re-converges are no-ops.
+func (m *hypervModule) registerClusteredRole(ctx context.Context, cfg *VMConfig) error {
+	cc := &ClusterConfig{
+		Name:      cfg.HARole.ClusterName,
+		RoleNames: []string{cfg.Name},
+		State:     "present",
+	}
+	return m.setCluster(ctx, "cluster:"+cfg.HARole.ClusterName, cc)
 }
 
 // applySourceGated enforces the ADR-009 §2 existence-gating safety invariant for

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -1295,3 +1295,165 @@ func TestSetVM_SetVMMemory_TransportError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "Set-VMMemory")
 }
+
+// ─── HA-role tests (Issue #2240) ───────────────────────────────────────────────
+
+// TestVMConfig_HARole_SeedDirValidation verifies the CSV seed-dir rule: when an
+// HA-role VM places its primary VHDX on a Cluster Shared Volume, Validate()
+// rejects an empty or also-on-CSV seed_dir and accepts a host-local one.
+func TestVMConfig_HARole_SeedDirValidation(t *testing.T) {
+	base := func() *VMConfig {
+		return &VMConfig{
+			Name:    "ha-vm",
+			VHDPath: `C:\ClusterStorage\CSV01\ha-vm.vhdx`,
+			HARole:  &HARoleConfig{ClusterName: "lab-hv"},
+		}
+	}
+
+	// Empty seed_dir → reject.
+	c := base()
+	c.seedDir = ""
+	require.ErrorIs(t, c.Validate(), ErrInvalidHARoleSeedDir,
+		"CSV vhd_path with empty seed_dir must be rejected")
+
+	// seed_dir also on CSV → reject.
+	c = base()
+	c.seedDir = `C:\ClusterStorage\CSV01\seed`
+	require.ErrorIs(t, c.Validate(), ErrInvalidHARoleSeedDir,
+		"CSV vhd_path with a CSV seed_dir must be rejected")
+
+	// Case-insensitive CSV prefix is still detected.
+	c = base()
+	c.VHDPath = `c:\clusterstorage\csv01\ha-vm.vhdx`
+	c.seedDir = ""
+	require.ErrorIs(t, c.Validate(), ErrInvalidHARoleSeedDir,
+		"the CSV prefix check must be case-insensitive")
+
+	// Host-local seed_dir → pass.
+	c = base()
+	c.seedDir = `C:\ProgramData\cfgms\seed`
+	require.NoError(t, c.Validate(),
+		"CSV vhd_path with a host-local seed_dir must pass")
+}
+
+// TestVMConfig_HARole_NonCSV_Unaffected verifies the seed-dir rule applies only
+// to CSV VHDX paths, and that non-HA VMConfigs round-trip through AsMap/ToYAML/
+// FromYAML unchanged (no ha_role key) while HA configs round-trip ha_role.
+func TestVMConfig_HARole_NonCSV_Unaffected(t *testing.T) {
+	// HA role with a local (non-CSV) vhd_path: the seed-dir rule does not apply,
+	// so an empty seed_dir is fine.
+	local := &VMConfig{
+		Name:    "ha-vm",
+		VHDPath: `C:\VMs\ha-vm.vhdx`,
+		HARole:  &HARoleConfig{ClusterName: "lab-hv"},
+	}
+	local.seedDir = ""
+	require.NoError(t, local.Validate(),
+		"a non-CSV vhd_path must not trigger the HA seed-dir rule")
+
+	// Non-HA VMConfig: AsMap must NOT emit ha_role, and YAML round-trips unchanged.
+	plain := &VMConfig{
+		Name: "plain", MemoryMB: 2048, CPUCount: 2,
+		VHDPath: `C:\VMs\plain.vhdx`, Generation: 2, State: "running",
+	}
+	if _, ok := plain.AsMap()["ha_role"]; ok {
+		t.Fatal("non-HA AsMap must not emit ha_role")
+	}
+	y, err := plain.ToYAML()
+	require.NoError(t, err)
+	var plainBack VMConfig
+	require.NoError(t, plainBack.FromYAML(y))
+	assert.Nil(t, plainBack.HARole, "non-HA config must round-trip with nil HARole")
+	assert.Equal(t, plain.Name, plainBack.Name)
+
+	// HA VMConfig: ha_role round-trips through AsMap and YAML.
+	ha := &VMConfig{
+		Name: "ha2", VHDPath: `C:\VMs\ha2.vhdx`,
+		HARole: &HARoleConfig{ClusterName: "lab-hv", ResourceGroupName: "rg-ha2"},
+	}
+	haMap, ok := ha.AsMap()["ha_role"].(map[string]interface{})
+	require.True(t, ok, "HA AsMap must emit an ha_role map")
+	assert.Equal(t, "lab-hv", haMap["cluster_name"])
+	assert.Equal(t, "rg-ha2", haMap["resource_group_name"])
+
+	hy, err := ha.ToYAML()
+	require.NoError(t, err)
+	var haBack VMConfig
+	require.NoError(t, haBack.FromYAML(hy))
+	require.NotNil(t, haBack.HARole)
+	assert.Equal(t, "lab-hv", haBack.HARole.ClusterName)
+	assert.Equal(t, "rg-ha2", haBack.HARole.ResourceGroupName)
+}
+
+// TestSetVM_HARole_RegistersClusteredRole verifies that on the create path an
+// HA-role VM is registered as a clustered role exactly once (the CNO owner calls
+// Add-ClusterVirtualMachineRole), and that a re-converge where the role already
+// exists cluster-wide is an idempotent no-op (S2's existence gate).
+func TestSetVM_HARole_RegistersClusteredRole(t *testing.T) {
+	const vmName = "ha-vm"
+	const cluster = "lab-hv"
+
+	haCfg := func() *VMConfig {
+		return &VMConfig{
+			Name:       vmName,
+			MemoryMB:   4096,
+			CPUCount:   2,
+			VHDPath:    `C:\VMs\ha-vm.vhdx`, // non-CSV: seed-dir rule not triggered
+			SwitchName: "Default Switch",
+			Generation: 2,
+			State:      "stopped",
+			HARole:     &HARoleConfig{ClusterName: cluster},
+		}
+	}
+
+	// First converge: role absent → exactly one Add-ClusterVirtualMachineRole.
+	t.Run("first_converge_registers_once", func(t *testing.T) {
+		transport := &testWinRMTransport{perCallOutputs: []string{
+			`{"found":false}`,   // getVM: VM absent
+			``,                  // New-VM: create succeeds
+			`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)
+			`{"owners":{}}`,     // ownership helper: resource owners (role absent)
+			`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read
+			``,                  // Add-ClusterVirtualMachineRole: success
+		}}
+		m := vmModuleWithTransport(transport, "t-ha")
+		m.clusterName = cluster
+		m.nodeHostname = "NODE1"
+
+		require.NoError(t, m.Set(context.Background(), "vm:"+vmName, haCfg()))
+
+		assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+			"the create path must register the clustered role exactly once")
+
+		// Names travel via psArgs only, never composed into the scriptBlock (S3).
+		for _, sb := range scriptBlocks(transport) {
+			assert.NotContains(t, sb, vmName,
+				"VM/role name must travel via ArgumentList, never the scriptBlock")
+			assert.NotContains(t, sb, cluster,
+				"cluster name must travel via ArgumentList, never the scriptBlock")
+		}
+		addArgs := psArgsForCmd(transport, psAddClusterVMRole)
+		require.NotNil(t, addArgs, "the Add call's psArgs must be recorded")
+		assert.Equal(t, cluster, addArgs["ClusterName"])
+		assert.Equal(t, vmName, addArgs["VMName"])
+	})
+
+	// Re-converge with the role already present cluster-wide → idempotent no-op.
+	t.Run("role_present_is_noop", func(t *testing.T) {
+		transport := &testWinRMTransport{perCallOutputs: []string{
+			`{"found":false}`,              // getVM: VM absent on this node
+			``,                             // New-VM
+			`{"owner":"NODE1"}`,            // CNO owner read
+			`{"owners":{"ha-vm":"NODE1"}}`, // resource owners: role ALREADY present
+			`{"owner":"NODE1"}`,            // cnoOwner re-read
+		}}
+		m := vmModuleWithTransport(transport, "t-ha")
+		m.clusterName = cluster
+		m.nodeHostname = "NODE1"
+
+		require.NoError(t, m.Set(context.Background(), "vm:"+vmName, haCfg()))
+
+		assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+			"an already-registered role must not be added again (S2 idempotency)")
+	})
+}


### PR DESCRIPTION
## Summary

The `hyperv.vm` resource accepts a new optional **`ha_role`** block. When present, the create path registers the VM as a clustered HA role on the named failover cluster after `New-VM`, and validate-time rejects a CSV primary VHDX paired with a non-host-local `seed_dir` rather than letting the build hang. Standalone (non-HA) VMs are unchanged. Part of epic #2198 (cluster-aware Hyper-V HA), building on the merged cluster module (#2199/#2202).

## Changes

- **`vm.go`** — `HARoleConfig{ClusterName, ResourceGroupName}` + the `HARole` field on `VMConfig` (plus an unexported, untagged `seedDir` field that `setVM` injects from `m.seedDir` so the module-level `seed_dir` is checkable in `Validate()` without changing its signature or adding a YAML field). `Validate()` gains the CSV seed-dir rule: `HARole` set + `vhd_path` under `C:\ClusterStorage\` (case-insensitive) + empty-or-CSV `seed_dir` → `ErrInvalidHARoleSeedDir`. `AsMap` emits `ha_role` only when present (non-HA round-trips unchanged); `GetManagedFields` includes it. `setVM` parses `ha_role` and, after `createVM` succeeds and before the power-state transition, calls `registerClusteredRole` → `setCluster("cluster:<name>", {RoleNames:[vmName]})`, reusing the cluster module's **CNO ownership gate + existence idempotency**.
- **`schema.yaml`** — `ha_role` sub-object (`cluster_name` required, `resource_group_name` optional).
- **`vm_test.go`** — the 3 required tests (below).
- **`README.md`** — `ha_role` option, CSV seed-dir constraint, annotated HA VM example.

## Tests (all [REQUIRED] — PASS)
- `TestVMConfig_HARole_SeedDirValidation` — CSV `vhd_path` + empty/CSV `seed_dir` → `ErrInvalidHARoleSeedDir` (case-insensitive); host-local `seed_dir` passes.
- `TestSetVM_HARole_RegistersClusteredRole` — recording transport: `createVM` followed by **exactly one** `Add-ClusterVirtualMachineRole` on first converge; role-present re-converge is a **no-op** (S2 idempotency). Cluster/role names travel via `ArgumentList` only, never the scriptBlock (S3).
- `TestVMConfig_HARole_NonCSV_Unaffected` — non-CSV `vhd_path` exempt from the seed-dir rule; non-HA `AsMap`/YAML round-trips clean; HA round-trips `ha_role`.
- Full `hyperv` package passes under `-race` — no regression to existing `vm_test.go`.

## Reviews (all PASS, 0 blocking, 0 warnings)
- **Acceptance:** PASS — all ACs verified.
- **qa-test-runner:** PASS — build/vet/gofmt/race(full package)/check-architecture/linux-cross-compile all clean.
- **qa-code-review:** PASS — recording transport confirmed the established no-mock PS seam; white-box `seedDir` access sound; assertions substantive (positive + negative).
- **security:** PASS — no new PS script text, names via ArgumentList only; VM-name allowlist not bypassable (`Validate` runs before registration); `cluster_name` scope cap (`ErrClusterNotDeclared`) inherited from S2; seed-dir fail-safe enforced before any transport call.

## Notes for reviewers
- **`seedDir` field:** the story says `Validate()` enforces the seed-dir rule, but `seed_dir` is module-level config, not a per-VM YAML field. I added an unexported, untagged `seedDir` on `VMConfig` that `setVM` injects from `m.seedDir` before `Validate()` — keeps `Validate()`'s signature and the no-YAML-field contract; the package-internal test sets it directly.
- **Role name:** the registered clustered role uses the **VM name** (the default group name `Add-ClusterVirtualMachineRole` assigns). `resource_group_name` is captured/round-tripped for forward-compat; renaming the group is out of scope (S2's `setCluster` passes one value as both the `-VirtualMachine` arg and the existence key).

Validated on the Windows host. `make check-architecture` passes.

Fixes #2240

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>