### PR TITLE
hyperv: cluster membership/ownership DNA Monitor via ChangeEvent.Details (Issue #2241)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -571,6 +571,51 @@ re-verifies the signature over the changed manifest independently.
   config: {}        # read-only; the steward's cluster_name cap declares scope
 ```
 
+### Cluster DNA Monitor (`cluster:<name>`)
+
+`Monitor("cluster:<name>", nil)` registers interest in a failover cluster's
+membership and ownership and starts a **per-cluster polling goroutine**. Unlike
+the VM Monitor (one host-level Event Log subscription), there is no
+FailoverCluster event channel, so the module polls the read-only S1 cmdlets on a
+ticker and emits a `modules.ChangeEvent` on the `Changes()` channel whenever
+ownership or membership changes. The poller stops cleanly on `Close()` (the
+goroutine is joined before the channel is closed — no leak, no send on a closed
+channel). On non-Windows builds `Monitor("cluster:<name>", …)` returns
+`ErrNotSupported`, exactly as it does for `vm:`/`vswitch:`.
+
+- **Poll cadence.** Default **30s**; override with the `cluster_poll_interval`
+  Configure key (a Go duration string, e.g. `"15s"`).
+- **Anti-flap hysteresis (S8).** A detected change is emitted only after it is
+  observed on **two consecutive polls** — a mid-failover CNO transient that
+  reverts within one poll interval emits nothing. The first poll establishes the
+  baseline and emits nothing (read the initial state via `Get`).
+- **Receipt-time (S8).** `ChangeEvent.Timestamp` is `time.Now().Unix()` at
+  emission, never a cluster-reported time.
+
+Unlike the VM `ChangeEvent` (`Details: nil` — a re-check signal), the cluster
+event carries the observed `*ClusterStatus` as **`Details`** (a
+`modules.ConfigState`), the DNA payload the controller-side reconciler (epic
+\#415) reads. `Details.AsMap()` exposes the stable keys:
+
+| Key | Meaning |
+|-----|---------|
+| `member_nodes` | cluster member node names |
+| `resource_owner` | per-clustered-VM-role → current owner node |
+| `cno_owner_node` | node owning the core Cluster Group (CNO) |
+| `csv_paths` | Cluster Shared Volume friendly volume paths |
+| `name` | cluster (CNO) name |
+
+```go
+// Steward-side consumer (illustrative):
+_ = mod.Monitor(ctx, "cluster:lab-hv", nil)
+for ev := range mod.Changes() {
+    if ev.ResourceID == "cluster:lab-hv" && ev.Details != nil {
+        dna := ev.Details.AsMap() // member_nodes, resource_owner, cno_owner_node, ...
+        _ = dna
+    }
+}
+```
+
 ## Naming Convention
 
 Resources are created on the host with the **exact** name specified in the config — CFGMS never adds a prefix or suffix. A VM named `web-01` in the config appears as `web-01` in Hyper-V; a switch named `External` appears as `External`. Admins specify the name they expect to see on the host.

--- a/features/modules/hyperv/cluster_windows.go
+++ b/features/modules/hyperv/cluster_windows.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package hyperv
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// defaultClusterPollInterval is the default cadence for the cluster DNA poller.
+// There is no FailoverCluster event channel (unlike the Hyper-V VMMS Event Log),
+// so ownership / membership is polled on a ticker.
+const defaultClusterPollInterval = 30 * time.Second
+
+// monitorClusterLoop is the per-cluster DNA polling loop (S4 of epic #2198). On
+// each tick it reads the cluster status via the S1 read consts and emits a
+// ChangeTypeModified ChangeEvent carrying the *ClusterStatus whenever ownership
+// or membership changes — but only after a stability dwell (S8 anti-flap): a
+// change must be observed on two consecutive polls before it is emitted, which
+// suppresses mid-failover CNO-transient churn. The first poll establishes the
+// baseline and emits nothing (consumers read the initial state via Get).
+//
+// The tick channel is injected so the production caller passes a real
+// time.Ticker while tests drive the cadence deterministically. The loop returns
+// when stop is closed.
+func (m *hypervModule) monitorClusterLoop(clusterName string, tick <-chan time.Time, stop <-chan struct{}) {
+	var lastEmitted, pending string
+	var baselineSet bool
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-tick:
+			status := m.pollClusterStatus(clusterName)
+			if status == nil {
+				continue // poll failed — skip this tick, retry on the next
+			}
+			sig := clusterSignature(status)
+
+			if !baselineSet {
+				lastEmitted = sig
+				baselineSet = true
+				pending = ""
+				continue
+			}
+			if sig == lastEmitted {
+				// No net change (a transient may have reverted) — drop any pending.
+				pending = ""
+				continue
+			}
+			// sig differs from the last emitted state.
+			if pending == sig {
+				// Stable across two consecutive polls (S8 dwell) → emit.
+				m.dispatchCluster(clusterName, modules.ChangeTypeModified, status)
+				lastEmitted = sig
+				pending = ""
+			} else {
+				// First sighting of this change — confirm on the next poll.
+				pending = sig
+			}
+		}
+	}
+}
+
+// pollClusterStatus reads the current cluster status via getCluster (the S1
+// read-only PowerShell envelope). Returns nil on error so the loop simply
+// retries on the next tick.
+func (m *hypervModule) pollClusterStatus(clusterName string) *ClusterStatus {
+	cs, err := m.getCluster(context.Background(), clusterName)
+	if err != nil {
+		if logger, ok := m.GetLogger(); ok {
+			logger.Warn("hyperv: cluster DNA poll failed",
+				"cluster", logging.SanitizeLogValue(clusterName),
+				"error", logging.SanitizeLogValue(err.Error()))
+		}
+		return nil
+	}
+	status, _ := cs.(*ClusterStatus)
+	return status
+}
+
+// dispatchCluster emits a cluster ChangeEvent on the shared monitor channel.
+// Unlike dispatch() (VM events, Details: nil), the cluster event carries the
+// *ClusterStatus as Details — the epic #415 DNA contract. The send is
+// non-blocking and gated on registered interest + open channel, exactly like
+// dispatch(), so a wedged consumer never blocks the polling goroutine.
+func (m *hypervModule) dispatchCluster(clusterName string, ct modules.ChangeType, status *ClusterStatus) {
+	resourceID := "cluster:" + clusterName
+
+	m.monMu.Lock()
+	if m.monClosed || m.monChanges == nil {
+		m.monMu.Unlock()
+		return
+	}
+	if _, watched := m.monClusterInterest[resourceID]; !watched {
+		m.monMu.Unlock()
+		return
+	}
+	ch := m.monChanges
+	m.monMu.Unlock()
+
+	ev := modules.ChangeEvent{
+		ResourceID: resourceID,
+		Timestamp:  time.Now().Unix(), // S8: Go receipt-time, never a cluster-reported timestamp
+		ChangeType: ct,
+		Details:    status,
+	}
+	// Non-blocking send: a wedged consumer must not block the polling goroutine.
+	select {
+	case ch <- ev:
+	default:
+	}
+}
+
+// clusterSignature renders the change-relevant fields of a ClusterStatus into a
+// stable string for equality comparison across polls. Ownership (resource_owner
+// + cno_owner) and membership (member_nodes) drive change detection; CSV paths
+// and transient fields do not.
+func clusterSignature(s *ClusterStatus) string {
+	if s == nil {
+		return ""
+	}
+	members := append([]string(nil), s.MemberNodes...)
+	sort.Strings(members)
+
+	ownerKeys := make([]string, 0, len(s.RoleOwners))
+	for k := range s.RoleOwners {
+		ownerKeys = append(ownerKeys, k)
+	}
+	sort.Strings(ownerKeys)
+
+	var b strings.Builder
+	b.WriteString("found=")
+	b.WriteString(strconv.FormatBool(s.Found))
+	b.WriteString(";cno=")
+	b.WriteString(s.CNOOwnerNode)
+	b.WriteString(";members=")
+	b.WriteString(strings.Join(members, ","))
+	b.WriteString(";owners=")
+	for _, k := range ownerKeys {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(s.RoleOwners[k])
+		b.WriteString(",")
+	}
+	return b.String()
+}

--- a/features/modules/hyperv/cluster_windows_test.go
+++ b/features/modules/hyperv/cluster_windows_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+// The cluster DNA Monitor (#2241) is Windows-only (it polls FailoverCluster via
+// the S1 read consts), so its tests are build-tagged windows — the same split
+// the existing monitor_windows_test.go / monitor_nonwindows_test.go uses. They
+// drive monitorClusterLoop with an injected tick channel for deterministic
+// hysteresis assertions (no real-timer flakiness) and exercise the real
+// Monitor()/Close() lifecycle for the no-leak check.
+package hyperv
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// seqClusterTransport returns a per-scriptBlock sequence of canned outputs (the
+// last element repeats once the sequence is exhausted). This lets a test vary
+// only the resource-owner response across polls — simulating an ownership change
+// — without mutating shared state mid-flight. It implements the same
+// winrmTransport seam as testWinRMTransport.
+type seqClusterTransport struct {
+	mu   sync.Mutex
+	seqs map[string][]string
+	idx  map[string]int
+}
+
+func newSeqClusterTransport() *seqClusterTransport {
+	return &seqClusterTransport{seqs: map[string][]string{}, idx: map[string]int{}}
+}
+
+func (t *seqClusterTransport) set(scriptBlock string, outputs ...string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.seqs[scriptBlock] = outputs
+}
+
+func (t *seqClusterTransport) ExecutePS(_ context.Context, scriptBlock string, _ map[string]string) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := t.seqs[scriptBlock]
+	if len(s) == 0 {
+		return "", nil
+	}
+	i := t.idx[scriptBlock]
+	if i >= len(s) {
+		i = len(s) - 1
+	}
+	t.idx[scriptBlock]++
+	return s[i], nil
+}
+
+const (
+	clusterGetJSON   = `{"found":true,"Name":"lab-hv","MemberNodes":["NODE1","NODE2"],"CsvPaths":["C:\\ClusterStorage\\CSV01"]}`
+	clusterOwnerJSON = `{"owner":"NODE1"}`
+)
+
+func resourceOwnerJSON(owner string) string {
+	return `{"owners":{"web-01":"` + owner + `"}}`
+}
+
+// clusterMonitorModule builds a hypervModule wired for cluster monitoring with
+// the given transport, registered interest in cluster:lab-hv, and an open
+// changes channel.
+func clusterMonitorModule(transport winrmTransport) *hypervModule {
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.clusterName = "lab-hv"
+	m.nodeHostname = "NODE1"
+	m.monChanges = make(chan modules.ChangeEvent, 16)
+	m.monClusterInterest = map[string]struct{}{"cluster:lab-hv": {}}
+	return m
+}
+
+// TestMonitorCluster_EmitsDetails verifies that an ownership change (the
+// resource_owner map changing across polls), once stable across two consecutive
+// polls (S8 dwell), produces exactly one ChangeTypeModified event whose
+// Details.AsMap() carries member_nodes and resource_owner (the #415 contract).
+func TestMonitorCluster_EmitsDetails(t *testing.T) {
+	transport := newSeqClusterTransport()
+	transport.set(psGetCluster, clusterGetJSON)
+	transport.set(psGetClusterOwnerNode, clusterOwnerJSON)
+	// poll 1 → NODE1 (baseline); poll 2+ → NODE2 (stable change).
+	transport.set(psGetClusterResourceOwner, resourceOwnerJSON("NODE1"), resourceOwnerJSON("NODE2"))
+
+	m := clusterMonitorModule(transport)
+
+	tick := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() { m.monitorClusterLoop("lab-hv", tick, stop); close(done) }()
+
+	tick <- time.Now() // poll 1: baseline (owner NODE1), no emit
+	tick <- time.Now() // poll 2: candidate (owner NODE2), pending
+	tick <- time.Now() // poll 3: confirm (owner NODE2 stable) → emit
+	close(stop)
+	<-done
+
+	// Exactly one event, carrying the DNA payload.
+	select {
+	case ev := <-m.monChanges:
+		assert.Equal(t, "cluster:lab-hv", ev.ResourceID)
+		assert.Equal(t, modules.ChangeTypeModified, ev.ChangeType)
+		require.NotNil(t, ev.Details, "cluster ChangeEvent must carry *ClusterStatus Details")
+		assert.NotZero(t, ev.Timestamp, "receipt-time timestamp must be set")
+		mp := ev.Details.AsMap()
+		assert.NotEmpty(t, mp["member_nodes"], "member_nodes must be populated (#415 contract)")
+		owners, ok := mp["resource_owner"].(map[string]string)
+		require.True(t, ok, "resource_owner must be a map (#415 contract)")
+		assert.Equal(t, "NODE2", owners["web-01"], "the emitted owner must reflect the change")
+	default:
+		t.Fatal("expected exactly one ChangeTypeModified event, got none")
+	}
+
+	// No second event.
+	select {
+	case ev := <-m.monChanges:
+		t.Fatalf("expected exactly one event; got a second: %+v", ev)
+	default:
+	}
+}
+
+// TestMonitorCluster_AntiFlap verifies S8: a transient A→B→A within one dwell
+// (the change reverts before two consecutive confirming polls) emits zero events.
+func TestMonitorCluster_AntiFlap(t *testing.T) {
+	transport := newSeqClusterTransport()
+	transport.set(psGetCluster, clusterGetJSON)
+	transport.set(psGetClusterOwnerNode, clusterOwnerJSON)
+	// poll 1 → NODE1 (baseline); poll 2 → NODE2 (candidate); poll 3 → NODE1 (revert).
+	transport.set(psGetClusterResourceOwner,
+		resourceOwnerJSON("NODE1"), resourceOwnerJSON("NODE2"), resourceOwnerJSON("NODE1"))
+
+	m := clusterMonitorModule(transport)
+
+	tick := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() { m.monitorClusterLoop("lab-hv", tick, stop); close(done) }()
+
+	tick <- time.Now() // baseline NODE1
+	tick <- time.Now() // candidate NODE2 (pending)
+	tick <- time.Now() // revert to NODE1 → suppress
+	close(stop)
+	<-done
+
+	select {
+	case ev := <-m.monChanges:
+		t.Fatalf("a transient flap must emit zero events; got: %+v", ev)
+	default:
+	}
+}
+
+// TestMonitorCluster_PollFailureDuringDwell verifies that a transient poll
+// failure between the candidate poll and its confirming poll does NOT drop the
+// pending change nor spuriously emit: the dwell survives the failed poll, and
+// the next successful confirming poll still emits exactly one event.
+func TestMonitorCluster_PollFailureDuringDwell(t *testing.T) {
+	transport := newSeqClusterTransport()
+	// poll 3's getCluster fails (invalid JSON) — clusterOwnershipHelper is never
+	// reached that poll, so the owner/resource-owner sequences do not advance.
+	transport.set(psGetCluster, clusterGetJSON, clusterGetJSON, `not-json`, clusterGetJSON)
+	transport.set(psGetClusterOwnerNode, clusterOwnerJSON)
+	transport.set(psGetClusterResourceOwner,
+		resourceOwnerJSON("NODE1"), resourceOwnerJSON("NODE2"), resourceOwnerJSON("NODE2"))
+
+	m := clusterMonitorModule(transport)
+
+	tick := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() { m.monitorClusterLoop("lab-hv", tick, stop); close(done) }()
+
+	tick <- time.Now() // poll 1: baseline NODE1
+	tick <- time.Now() // poll 2: candidate NODE2 (pending)
+	tick <- time.Now() // poll 3: getCluster fails → skip, pending preserved
+	tick <- time.Now() // poll 4: confirm NODE2 → emit
+	close(stop)
+	<-done
+
+	select {
+	case ev := <-m.monChanges:
+		assert.Equal(t, modules.ChangeTypeModified, ev.ChangeType)
+		require.NotNil(t, ev.Details)
+		owners, _ := ev.Details.AsMap()["resource_owner"].(map[string]string)
+		assert.Equal(t, "NODE2", owners["web-01"])
+	default:
+		t.Fatal("a failed poll mid-dwell must not drop the pending change; expected one event")
+	}
+	select {
+	case ev := <-m.monChanges:
+		t.Fatalf("expected exactly one event; got a second: %+v", ev)
+	default:
+	}
+}
+
+// TestMonitorCluster_CloseStopsPoller verifies the full Monitor()/Close()
+// lifecycle: Close() stops the polling goroutine and closes the changes channel
+// with no leak and no send on a closed channel (a leaked poller would hang
+// Close()'s WaitGroup join or panic on the close).
+func TestMonitorCluster_CloseStopsPoller(t *testing.T) {
+	transport := newSeqClusterTransport()
+	transport.set(psGetCluster, clusterGetJSON)
+	transport.set(psGetClusterOwnerNode, clusterOwnerJSON)
+	transport.set(psGetClusterResourceOwner, resourceOwnerJSON("NODE1")) // constant → no change, no emit
+
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.clusterName = "lab-hv"
+	m.nodeHostname = "NODE1"
+	m.clusterPollInterval = 2 * time.Millisecond // fast poll for the test
+
+	ch := m.Changes() // capture the channel before Close
+	require.NoError(t, m.Monitor(context.Background(), "cluster:lab-hv", nil))
+
+	time.Sleep(30 * time.Millisecond) // let it poll several times (no ownership change)
+
+	require.NoError(t, m.Close(), "Close must join the poller and return cleanly")
+
+	// The channel must be closed (poller joined, no leak) and carry no events.
+	select {
+	case ev, ok := <-ch:
+		if ok {
+			t.Fatalf("no event expected from a steady cluster; got: %+v", ev)
+		}
+		// ok == false: channel closed — the poller was stopped and joined.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Changes channel was not closed after Close — poller leaked")
+	}
+
+	// Close is idempotent.
+	require.NoError(t, m.Close())
+}

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -126,6 +126,19 @@ type hypervModule struct {
 	// signal handles. It is set by the platform establish routine when the
 	// subscription is created and cleared on Close. nil means "no subscription".
 	monTeardown func() error //nolint:unused // written and read by monitor_windows.go; invisible to non-Windows builds
+
+	// Cluster DNA Monitor (#2241) state. Unlike the VM monitor (one host-level
+	// Event Log subscription), each watched cluster gets its own polling
+	// goroutine — there is no FailoverCluster event channel, so ownership /
+	// membership is polled on a ticker and emitted as a ChangeEvent with a
+	// *ClusterStatus payload (the epic #415 DNA contract). Fields are guarded by
+	// monMu; the pollers are owned by the Monitor()/Close() lifecycle.
+	monClusterInterest map[string]struct{}      //nolint:unused // written and read by monitor_windows.go / cluster_windows.go
+	monClusterStop     map[string]chan struct{} //nolint:unused // per-cluster poller stop channels
+	monClusterWG       sync.WaitGroup           //nolint:unused // joins cluster pollers before the changes channel is closed
+	// clusterPollInterval overrides the cluster DNA poll cadence (Configure key
+	// "cluster_poll_interval", a Go duration string). Zero ⇒ the 30s default.
+	clusterPollInterval time.Duration //nolint:unused // read by monitor_windows.go (cluster poller)
 }
 
 // HypervOption configures a hypervModule at construction time.
@@ -265,6 +278,13 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.clusterName, _ = configMap["cluster_name"].(string)
 	m.clusterRoleNames = parseStringList(configMap["cluster_role_names"])
 	m.nodeHostname, _ = os.Hostname()
+	// Optional cluster DNA poll cadence (#2241). Accept a Go duration string;
+	// an unset/invalid value leaves the 30s default in place.
+	if pollStr, ok := configMap["cluster_poll_interval"].(string); ok && pollStr != "" {
+		if d, derr := time.ParseDuration(pollStr); derr == nil && d > 0 {
+			m.clusterPollInterval = d
+		}
+	}
 
 	// Wire the stored-config-backed profile store when a config store is
 	// supplied (same injection pattern as audit_manager). Operators define

--- a/features/modules/hyperv/monitor_nonwindows_test.go
+++ b/features/modules/hyperv/monitor_nonwindows_test.go
@@ -25,3 +25,15 @@ func TestHypervMonitorNotSupportedOnNonWindows(t *testing.T) {
 	require.Nil(t, m.Changes(), "Changes() is nil when monitoring is unsupported")
 	require.NoError(t, m.Close(), "Close is a no-op on non-Windows")
 }
+
+// TestHypervClusterMonitorNotSupportedOnNonWindows verifies the #2241 AC: a
+// cluster:<name> Monitor on a non-Windows build returns ErrNotSupported via the
+// existing generic stub — no new non-Windows code is required.
+func TestHypervClusterMonitorNotSupportedOnNonWindows(t *testing.T) {
+	m, ok := New(nil).(*hypervModule)
+	require.True(t, ok, "New must return *hypervModule")
+
+	err := m.Monitor(context.Background(), "cluster:lab-hv", nil)
+	require.ErrorIs(t, err, ErrNotSupported,
+		"cluster monitoring is Windows-only; non-Windows must report ErrNotSupported")
+}

--- a/features/modules/hyperv/monitor_windows.go
+++ b/features/modules/hyperv/monitor_windows.go
@@ -352,6 +352,14 @@ func (m *hypervModule) Monitor(_ context.Context, resourceID string, _ modules.C
 	if m.monChanges == nil {
 		m.monChanges = make(chan modules.ChangeEvent, monitorChannelDepth)
 	}
+
+	// cluster:<name> resources are watched by a per-cluster polling goroutine
+	// (#2241), NOT the host Event Log subscription. Route them before the VM
+	// path so a cluster monitor never establishes the VM EvtSubscribe handle.
+	if strings.HasPrefix(resourceID, "cluster:") {
+		return m.startClusterMonitorLocked(resourceID)
+	}
+
 	if m.monInterest == nil {
 		m.monInterest = make(map[string]struct{})
 	}
@@ -364,6 +372,40 @@ func (m *hypervModule) Monitor(_ context.Context, resourceID string, _ modules.C
 			return err
 		}
 	}
+	return nil
+}
+
+// startClusterMonitorLocked registers interest in a cluster:<name> resource and
+// starts its polling goroutine. The caller holds m.monMu. Idempotent: a second
+// Monitor for the same cluster reuses the running poller. The poller is joined
+// and stopped by Close().
+func (m *hypervModule) startClusterMonitorLocked(resourceID string) error {
+	if m.monClusterInterest == nil {
+		m.monClusterInterest = make(map[string]struct{})
+	}
+	if m.monClusterStop == nil {
+		m.monClusterStop = make(map[string]chan struct{})
+	}
+	m.monClusterInterest[resourceID] = struct{}{}
+	if _, running := m.monClusterStop[resourceID]; running {
+		return nil // already polling this cluster
+	}
+
+	clusterName := strings.TrimPrefix(resourceID, "cluster:")
+	interval := m.clusterPollInterval
+	if interval <= 0 {
+		interval = defaultClusterPollInterval
+	}
+	stop := make(chan struct{})
+	m.monClusterStop[resourceID] = stop
+
+	m.monClusterWG.Add(1)
+	go func() {
+		defer m.monClusterWG.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		m.monitorClusterLoop(clusterName, ticker.C, stop)
+	}()
 	return nil
 }
 
@@ -388,7 +430,21 @@ func (m *hypervModule) Close() error {
 	m.monClosed = true
 	ch := m.monChanges
 	m.monChanges = nil
+	// Collect the cluster poller stop channels to signal after unlocking (#2241).
+	clusterStops := make([]chan struct{}, 0, len(m.monClusterStop))
+	for k, s := range m.monClusterStop {
+		clusterStops = append(clusterStops, s)
+		delete(m.monClusterStop, k)
+	}
 	m.monMu.Unlock()
+
+	// Stop and JOIN the cluster pollers BEFORE closing the changes channel, so no
+	// poller goroutine can send on a closed channel. monClosed is already set, so
+	// any in-flight dispatchCluster also short-circuits without sending.
+	for _, s := range clusterStops {
+		close(s)
+	}
+	m.monClusterWG.Wait()
 
 	var err error
 	if teardown != nil {


### PR DESCRIPTION
## Summary

`Monitor("cluster:<name>", nil)` starts a **per-cluster polling goroutine** that emits a `ChangeTypeModified` `ChangeEvent` carrying the observed `*ClusterStatus` on the `Changes()` channel whenever cluster ownership or membership changes — the DNA payload epic #415 reads. There is no FailoverCluster event channel, so ownership is polled on a ticker (default 30s) using only S1's read-only cmdlets. Part of epic #2198 (S4), building on the merged cluster module (#2199/#2202).

## Changes

- **`cluster_windows.go`** (new, `//go:build windows`) — `monitorClusterLoop` (tick-driven poll + S8 **anti-flap hysteresis**: a change must hold across two consecutive polls before it emits; the first poll is the baseline, emitting nothing), `pollClusterStatus` (`getCluster`), `dispatchCluster` (non-blocking, interest-gated send mirroring `dispatch()`, `Details = *ClusterStatus`, `Timestamp = time.Now().Unix()`), and the `clusterSignature` change-detector.
- **`module.go`** — `monClusterInterest`/`monClusterStop`/`monClusterWG`/`clusterPollInterval` fields (guarded by the existing `monMu`); `Configure` reads the optional `cluster_poll_interval` duration.
- **`monitor_windows.go`** — `cluster:<name>` routing in `Monitor()` (`startClusterMonitorLocked` — starts the poller, does **not** establish the VM `EvtSubscribe` handle); `Close()` signals + **joins** the cluster pollers (WaitGroup) **before** closing the changes channel, so no poller can send on a closed channel. The VM `dispatch()`/`EvtSubscribe` logic is untouched.
- **Tests** — see below.
- **`README.md`** — `cluster:<name>` Monitor, poll cadence, hysteresis, receipt-time, and the `ChangeEvent.Details` (`*ClusterStatus`) key schema (#415 contract).

## Tests (all [REQUIRED] + an extra invariant — PASS under -race)
- `TestMonitorCluster_EmitsDetails` — one event per stable owner change; `Details.AsMap()` carries `member_nodes` + `resource_owner`.
- `TestMonitorCluster_AntiFlap` — transient A→B→A within one dwell emits **zero** events.
- `TestMonitorCluster_CloseStopsPoller` — real `Monitor()`/`Close()` lifecycle: poller joined, channel closed, **no leak**.
- `TestMonitorCluster_PollFailureDuringDwell` (added per QA review) — a failed poll mid-dwell preserves the pending change and does not spuriously emit.
- `monitor_nonwindows_test.go` — cluster Monitor returns `ErrNotSupported` on non-Windows.
- Driven by an injected tick channel + a `seqClusterTransport` (the existing `winrmTransport` seam) for deterministic, timing-free assertions. Full `hyperv` package passes under `-race`.

## Reviews (all PASS, 0 blocking)
- **Acceptance:** PASS — all ACs + the 3 design deviations assessed as sound.
- **qa-test-runner:** PASS — `-race` clean (no goroutine/channel races), Linux test binary compiles, check-architecture passes.
- **qa-code-review:** PASS — `Close()` ordering proven safe (no send-on-closed-channel, no deadlock — `monMu` released before `WaitGroup.Wait()`); `seqClusterTransport` a legit seam; hysteresis correct. Two non-blocking warnings; the poll-failure-during-dwell test was **added** in response.
- **security:** PASS (0 critical/high) — no new PowerShell / no string composition (only S1 read consts via `ArgumentList`); scope cap (`ErrClusterNotDeclared`) blocks polling an undeclared cluster; ownership emitted as informational DNA only; logs sanitized; gosec clean on the new file.

## Notes for reviewers (design deviations from the story text, all sound)
- **Test placement:** the story names `cluster_test.go` (untagged), but `monitorCluster` is windows-only, so an untagged test would break the Linux build. Tests are in `cluster_windows_test.go` (`//go:build windows`) + `monitor_nonwindows_test.go`, following the existing `monitor_windows_test.go`/`monitor_nonwindows_test.go` convention.
- **Routing location:** the story says "module.go — add routing in `Monitor()`", but `Monitor()` lives in `monitor_windows.go` (module.go holds only the struct + `Configure`); the cluster branch was added there alongside (never modifying) the VM path.
- **Tick injection:** the poller tests inject a tick channel for deterministic hysteresis assertions; `CloseStopsPoller` uses the real ticker via `Monitor()`/`Close()`.

Validated on the Windows host: full `hyperv` package passes under `-race`; Linux test binary compiles; `make check-architecture` passes.

Fixes #2241

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>