### PR TITLE
controller/api: enforce Tier 3 (mTLS-only) on auth-surface endpoints (Issue #2225)

### DIFF
--- a/features/controller/api/auth_tiers.go
+++ b/features/controller/api/auth_tiers.go
@@ -35,6 +35,8 @@ var tier3Permissions = map[string]struct{}{
 	"registration:approve":         {}, // POST /registration/{id}/approve, /approve-all, /approve-by-cidr
 	"registration:manage-ip-trust": {}, // POST + DELETE /registration/ip-trust
 	"tenant:create":                {}, // POST /tenants
+	"refresh:approve":              {}, // POST /stewards/refresh/{pending_id}/approve
+	"refresh:set-policy":           {}, // PUT /tenants/{tenant_path}/refresh-policy
 }
 
 // requireTier returns middleware that enforces the given authentication tier.

--- a/features/controller/api/handlers_certificates_test.go
+++ b/features/controller/api/handlers_certificates_test.go
@@ -349,7 +349,9 @@ func TestHandleRotateSigningCertRequiresAdminCert(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 		var errResp ErrorResponse
 		require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
-		assert.Equal(t, "FORBIDDEN", errResp.Error.Code)
+		// Tier-3 enforcement fires before the handler's own IsAdmin check, so the
+		// rejection comes from requireTier(TierMTLSOnly), not the handler.
+		assert.Equal(t, "MTLS_REQUIRED", errResp.Error.Code)
 	})
 
 	t.Run("nil_rbac_non_admin_principal_rejected", func(t *testing.T) {

--- a/features/controller/api/handlers_ip_trust_test.go
+++ b/features/controller/api/handlers_ip_trust_test.go
@@ -103,8 +103,10 @@ func (s *inMemIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*bu
 // Compile-time assertion: inMemIPTrustStore satisfies the interface.
 var _ business.IPTrustStore = (*inMemIPTrustStore)(nil)
 
-// newIPTrustServer creates a minimal test server with ip-trust management permissions.
-func newIPTrustServer(t *testing.T) (*Server, *httptest.Server, business.IPTrustStore) {
+// newIPTrustServer creates a minimal test server with ip-trust management wired.
+// Tier-3 enforcement means POST/DELETE on /registration/ip-trust require admin cert;
+// tests use makeAdminRequest and server.router.ServeHTTP directly.
+func newIPTrustServer(t *testing.T) (*Server, business.IPTrustStore) {
 	t.Helper()
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
@@ -112,39 +114,25 @@ func newIPTrustServer(t *testing.T) (*Server, *httptest.Server, business.IPTrust
 	ipStore := newInMemIPTrustStore()
 	server.SetIPTrustStore(ipStore)
 
-	server.apiKeys["ip-trust-key"] = &APIKey{
-		ID:          "ip-trust-key-id",
-		Key:         "ip-trust-key",
-		Permissions: []string{"registration:manage-ip-trust"},
-		TenantID:    "default",
-	}
-
-	ts := httptest.NewServer(server.router)
-	return server, ts, ipStore
+	return server, ipStore
 }
 
 func TestHandleAddIPTrust(t *testing.T) {
-	_, ts, ipStore := newIPTrustServer(t)
-	defer ts.Close()
+	server, ipStore := newIPTrustServer(t)
 
-	makeAdd := func(t *testing.T, body string) *http.Response {
+	makeAdd := func(t *testing.T, body string) *httptest.ResponseRecorder {
 		t.Helper()
-		req, err := http.NewRequestWithContext(context.Background(), "POST",
-			ts.URL+"/api/v1/registration/ip-trust",
-			bytes.NewReader([]byte(body)))
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer ip-trust-key")
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/ip-trust", bytes.NewReader([]byte(body)))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := ts.Client().Do(req)
-		require.NoError(t, err)
-		return resp
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+		return rec
 	}
 
 	t.Run("happy path - adds trusted range", func(t *testing.T) {
-		resp := makeAdd(t, `{"tenant_id":"acme","cidr":"10.0.0.0/8","pre_seeded":true}`)
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeAdd(t, `{"tenant_id":"acme","cidr":"10.0.0.0/8","pre_seeded":true}`)
 
-		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
 
 		// Verify the range was actually stored.
 		entries, err := ipStore.ListTrustedRanges(context.Background(), "acme")
@@ -155,24 +143,21 @@ func TestHandleAddIPTrust(t *testing.T) {
 	})
 
 	t.Run("missing tenant_id returns 400", func(t *testing.T) {
-		resp := makeAdd(t, `{"cidr":"10.0.0.0/8"}`)
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeAdd(t, `{"cidr":"10.0.0.0/8"}`)
 
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
 	t.Run("missing cidr returns 400", func(t *testing.T) {
-		resp := makeAdd(t, `{"tenant_id":"acme"}`)
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeAdd(t, `{"tenant_id":"acme"}`)
 
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
 	t.Run("invalid JSON returns 400", func(t *testing.T) {
-		resp := makeAdd(t, `{not-json}`)
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeAdd(t, `{not-json}`)
 
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 }
 
@@ -180,54 +165,35 @@ func TestHandleAddIPTrust_NoStore(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 	// Do NOT set ipTrustStore.
-	server.apiKeys["ip-trust-key"] = &APIKey{
-		ID:          "ip-trust-key-id",
-		Key:         "ip-trust-key",
-		Permissions: []string{"registration:manage-ip-trust"},
-		TenantID:    "default",
-	}
-	ts := httptest.NewServer(server.router)
-	defer ts.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), "POST",
-		ts.URL+"/api/v1/registration/ip-trust",
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/ip-trust",
 		bytes.NewReader([]byte(`{"tenant_id":"acme","cidr":"10.0.0.0/8"}`)))
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer ip-trust-key")
 	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 func TestHandleRevokeIPTrust(t *testing.T) {
-	_, ts, ipStore := newIPTrustServer(t)
-	defer ts.Close()
+	server, ipStore := newIPTrustServer(t)
 
 	// Pre-seed an entry to revoke.
 	require.NoError(t, ipStore.AddTrustedRange(context.Background(), "acme", "10.0.0.0/8", true))
 
-	makeRevoke := func(t *testing.T, tenantID, cidr string) *http.Response {
+	makeRevoke := func(t *testing.T, tenantID, cidr string) *httptest.ResponseRecorder {
 		t.Helper()
-		// Use literal slash in the URL path; gorilla/mux {cidr:.+} matches across path segments.
-		path := ts.URL + "/api/v1/registration/ip-trust/" + tenantID + "/" + cidr
-		req, err := http.NewRequestWithContext(context.Background(), "DELETE", path, nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer ip-trust-key")
-		resp, err := ts.Client().Do(req)
-		require.NoError(t, err)
-		return resp
+		path := "/api/v1/registration/ip-trust/" + tenantID + "/" + cidr
+		req := makeAdminRequest(t, "DELETE", path, nil)
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+		return rec
 	}
 
 	t.Run("happy path - revokes trusted range", func(t *testing.T) {
-		// Use literal slash in URL path; gorilla/mux {cidr:.+} matches across segments.
-		resp := makeRevoke(t, "acme", "10.0.0.0/8")
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeRevoke(t, "acme", "10.0.0.0/8")
 
-		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
 
 		// Verify revocation in store.
 		entries, err := ipStore.ListTrustedRanges(context.Background(), "acme")
@@ -237,35 +203,21 @@ func TestHandleRevokeIPTrust(t *testing.T) {
 	})
 
 	t.Run("not found returns 404", func(t *testing.T) {
-		resp := makeRevoke(t, "acme", "192.168.0.0/16")
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeRevoke(t, "acme", "192.168.0.0/16")
 
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
 	})
 }
 
 func TestHandleRevokeIPTrust_NoStore(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
-	server.apiKeys["ip-trust-key"] = &APIKey{
-		ID:          "ip-trust-key-id",
-		Key:         "ip-trust-key",
-		Permissions: []string{"registration:manage-ip-trust"},
-		TenantID:    "default",
-	}
-	ts := httptest.NewServer(server.router)
-	defer ts.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), "DELETE",
-		ts.URL+"/api/v1/registration/ip-trust/acme/10.0.0.0/8", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer ip-trust-key")
+	req := makeAdminRequest(t, "DELETE", "/api/v1/registration/ip-trust/acme/10.0.0.0/8", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 // errIPTrustStore wraps inMemIPTrustStore to inject errors for error-path tests.
@@ -302,50 +254,24 @@ func TestHandleAddIPTrust_StoreError(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 	server.SetIPTrustStore(&errIPTrustStore{addErr: errors.New("db failure")})
-	server.apiKeys["ip-trust-key"] = &APIKey{
-		ID:          "ip-trust-key-id",
-		Key:         "ip-trust-key",
-		Permissions: []string{"registration:manage-ip-trust"},
-		TenantID:    "default",
-	}
-	ts := httptest.NewServer(server.router)
-	defer ts.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), "POST",
-		ts.URL+"/api/v1/registration/ip-trust",
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/ip-trust",
 		bytes.NewReader([]byte(`{"tenant_id":"acme","cidr":"10.0.0.0/8"}`)))
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer ip-trust-key")
 	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestHandleRevokeIPTrust_StoreError(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 	server.SetIPTrustStore(&errIPTrustStore{revokeErr: errors.New("db failure")})
-	server.apiKeys["ip-trust-key"] = &APIKey{
-		ID:          "ip-trust-key-id",
-		Key:         "ip-trust-key",
-		Permissions: []string{"registration:manage-ip-trust"},
-		TenantID:    "default",
-	}
-	ts := httptest.NewServer(server.router)
-	defer ts.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), "DELETE",
-		ts.URL+"/api/v1/registration/ip-trust/acme/10.0.0.0/8", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer ip-trust-key")
+	req := makeAdminRequest(t, "DELETE", "/api/v1/registration/ip-trust/acme/10.0.0.0/8", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }

--- a/features/controller/api/handlers_registration_refresh_test.go
+++ b/features/controller/api/handlers_registration_refresh_test.go
@@ -828,10 +828,9 @@ func TestHandleRefreshApprove_ApprovesEntry(t *testing.T) {
 	}))
 
 	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	apiKey := NewTestKey(t, server, []string{"refresh:approve"})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
-	req.Header.Set("X-API-Key", apiKey)
+	// POST /api/v1/stewards/refresh/{id}/approve is Tier-3 (mTLS-only).
+	req := makeAdminRequest(t, http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 
@@ -897,10 +896,10 @@ func TestHandleRefreshApprove_RevokedDeviceRejected(t *testing.T) {
 	}))
 
 	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	apiKey := NewTestKey(t, server, []string{"refresh:approve"})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
-	req.Header.Set("X-API-Key", apiKey)
+	// POST /api/v1/stewards/refresh/{id}/approve is Tier-3 (mTLS-only).
+	// Use admin cert so the handler's own revocation check is exercised.
+	req := makeAdminRequest(t, http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 
@@ -1036,11 +1035,10 @@ func TestHandleGetRefreshPolicy_ReturnsDefault(t *testing.T) {
 func TestHandleSetRefreshPolicy_SetsMode(t *testing.T) {
 	ps := newTestRefreshPolicyStore()
 	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, ps)
-	apiKey := NewTestKey(t, server, []string{"refresh:set-policy"})
 
+	// PUT /api/v1/tenants/{tenant}/refresh-policy is Tier-3 (mTLS-only).
 	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "auto_accept"})
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
-	req.Header.Set("X-API-Key", apiKey)
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
@@ -1054,11 +1052,10 @@ func TestHandleSetRefreshPolicy_SetsMode(t *testing.T) {
 
 func TestHandleSetRefreshPolicy_InvalidMode_Returns400(t *testing.T) {
 	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, newTestRefreshPolicyStore())
-	apiKey := NewTestKey(t, server, []string{"refresh:set-policy"})
 
+	// PUT /api/v1/tenants/{tenant}/refresh-policy is Tier-3 (mTLS-only).
 	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "invalid_mode"})
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
-	req.Header.Set("X-API-Key", apiKey)
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
@@ -1068,10 +1065,9 @@ func TestHandleSetRefreshPolicy_InvalidMode_Returns400(t *testing.T) {
 
 func TestHandleRefreshApprove_NotFound(t *testing.T) {
 	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), newTestPendingRefreshStore(), nil)
-	apiKey := NewTestKey(t, server, []string{"refresh:approve"})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/nonexistent-id/approve", nil)
-	req.Header.Set("X-API-Key", apiKey)
+	// POST /api/v1/stewards/refresh/{id}/approve is Tier-3 (mTLS-only).
+	req := makeAdminRequest(t, http.MethodPost, "/api/v1/stewards/refresh/nonexistent-id/approve", nil)
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 
@@ -1105,7 +1101,8 @@ func TestHandleApproveRefresh_CrossTenantReturns404(t *testing.T) {
 	}))
 
 	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), prs, nil)
-	// API key scoped to a different tenant.
+	// API key from a different tenant — Tier-3 enforcement blocks at the gate (403 MTLS_REQUIRED)
+	// before the handler's own cross-tenant check can fire.
 	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:approve"}, "other-tenant", 5*time.Minute)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
@@ -1113,8 +1110,8 @@ func TestHandleApproveRefresh_CrossTenantReturns404(t *testing.T) {
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 
-	// 404 rather than 403 to avoid disclosing pending-refresh existence across tenants.
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// Tier-3: API keys are rejected with 403 MTLS_REQUIRED regardless of tenant.
+	assert.Equal(t, http.StatusForbidden, rec.Code)
 
 	// Entry must remain pending — nothing was mutated.
 	entry, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
@@ -1203,7 +1200,8 @@ func TestHandleGetRefreshPolicy_CrossTenantReturns404(t *testing.T) {
 func TestHandleSetRefreshPolicy_CrossTenantReturns404(t *testing.T) {
 	ps := newTestRefreshPolicyStore()
 	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, ps)
-	// Key scoped to "other-tenant" — must not write policy for testTenantID.
+	// API key scoped to "other-tenant" — Tier-3 enforcement blocks at the gate (403 MTLS_REQUIRED)
+	// before the handler's own cross-tenant check can fire.
 	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:set-policy"}, "other-tenant", 5*time.Minute)
 
 	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "reject"})
@@ -1213,7 +1211,8 @@ func TestHandleSetRefreshPolicy_CrossTenantReturns404(t *testing.T) {
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// Tier-3: API keys are rejected with 403 MTLS_REQUIRED regardless of tenant.
+	assert.Equal(t, http.StatusForbidden, rec.Code)
 
 	// Policy for testTenantID must remain at default — nothing mutated.
 	policy, err := ps.GetPolicy(context.Background(), testTenantID)

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -520,18 +520,15 @@ func TestHandleListPendingRegistrations(t *testing.T) {
 }
 
 func TestHandleApproveRegistration(t *testing.T) {
-	_, ts, pendingStore := newRegistrationApprovalServer(t)
+	server, ts, pendingStore := newRegistrationApprovalServer(t)
 	defer ts.Close()
 
-	makeApprove := func(t *testing.T, pendingID string) *http.Response {
+	makeApprove := func(t *testing.T, pendingID string) *httptest.ResponseRecorder {
 		t.Helper()
-		req, err := http.NewRequestWithContext(context.Background(), "POST",
-			ts.URL+"/api/v1/registration/"+pendingID+"/approve", nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer reg-approval-key")
-		resp, err := ts.Client().Do(req)
-		require.NoError(t, err)
-		return resp
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/"+pendingID+"/approve", nil)
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+		return rec
 	}
 
 	t.Run("happy path - marks pending entry as approved", func(t *testing.T) {
@@ -548,10 +545,9 @@ func TestHandleApproveRegistration(t *testing.T) {
 		}
 		require.NoError(t, pendingStore.AddPending(context.Background(), entry))
 
-		resp := makeApprove(t, "pending-approve-1")
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeApprove(t, "pending-approve-1")
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, rec.Code)
 
 		// Entry status must be updated to "approved" in the durable store.
 		got, err := pendingStore.GetPendingByID(context.Background(), "pending-approve-1")
@@ -560,11 +556,10 @@ func TestHandleApproveRegistration(t *testing.T) {
 	})
 
 	t.Run("not found returns 404", func(t *testing.T) {
-		resp := makeApprove(t, "nonexistent-pending-id")
-		defer func() { _ = resp.Body.Close() }()
+		rec := makeApprove(t, "nonexistent-pending-id")
 
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-		assert.Contains(t, resp.Header.Get("Content-Type"), "text/plain")
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.Contains(t, rec.Header().Get("Content-Type"), "text/plain")
 	})
 }
 
@@ -1004,7 +999,7 @@ func addPendingEntry(t *testing.T, store business.PendingRegistrationStore, pend
 // TestApproveByCIDR_FiltersCorrectly verifies that only entries whose source IP is in the
 // CIDR are approved; entries outside it remain pending (required test from AC).
 func TestApproveByCIDR_FiltersCorrectly(t *testing.T) {
-	_, ts, pendingStore := newBulkApprovalServer(t)
+	server, ts, pendingStore := newBulkApprovalServer(t)
 	defer ts.Close()
 
 	// Two entries inside the CIDR 192.168.1.0/24, one outside.
@@ -1012,24 +1007,18 @@ func TestApproveByCIDR_FiltersCorrectly(t *testing.T) {
 	addPendingEntry(t, pendingStore, "pending-cidr-in-2", "steward-in-2", "tenant-a", "192.168.1.200")
 	addPendingEntry(t, pendingStore, "pending-cidr-out-1", "steward-out-1", "tenant-a", "10.0.0.5")
 
-	body := `{"cidr":"192.168.1.0/24"}`
-	req, err := http.NewRequestWithContext(context.Background(), "POST",
-		ts.URL+"/api/v1/registration/approve-by-cidr",
-		strings.NewReader(body))
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer bulk-key")
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-by-cidr",
+		strings.NewReader(`{"cidr":"192.168.1.0/24"}`))
 	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var result struct {
 		Approved int `json:"approved"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&result))
 	assert.Equal(t, 2, result.Approved, "only two entries inside the CIDR should be approved")
 
 	// Verify store state: inside entries approved, outside entry still pending.
@@ -1050,7 +1039,7 @@ func TestApproveByCIDR_FiltersCorrectly(t *testing.T) {
 // TestApproveAll_Idempotent verifies that calling approve-all twice does not error and
 // the second call returns 0 approved (required test from AC).
 func TestApproveAll_Idempotent(t *testing.T) {
-	_, ts, pendingStore := newBulkApprovalServer(t)
+	server, ts, pendingStore := newBulkApprovalServer(t)
 	defer ts.Close()
 
 	addPendingEntry(t, pendingStore, "pending-idem-1", "steward-idem-1", "tenant-a", "10.0.0.1")
@@ -1058,21 +1047,16 @@ func TestApproveAll_Idempotent(t *testing.T) {
 
 	doApproveAll := func(t *testing.T) int {
 		t.Helper()
-		req, err := http.NewRequestWithContext(context.Background(), "POST",
-			ts.URL+"/api/v1/registration/approve-all", nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer bulk-key")
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-all", nil)
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
 
-		resp, err := ts.Client().Do(req)
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, http.StatusOK, rec.Code)
 
 		var result struct {
 			Approved int `json:"approved"`
 		}
-		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&result))
 		return result.Approved
 	}
 
@@ -1087,21 +1071,16 @@ func TestApproveAll_Idempotent(t *testing.T) {
 
 // TestHandleApproveByCIDR_InvalidCIDR verifies that a malformed CIDR returns 400.
 func TestHandleApproveByCIDR_InvalidCIDR(t *testing.T) {
-	_, ts, _ := newBulkApprovalServer(t)
+	server, ts, _ := newBulkApprovalServer(t)
 	defer ts.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), "POST",
-		ts.URL+"/api/v1/registration/approve-by-cidr",
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-by-cidr",
 		strings.NewReader(`{"cidr":"not-a-cidr"}`))
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer bulk-key")
 	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // TestHandleApproveByCIDR_NoPendingStore verifies 503 when pendingStore is nil.
@@ -1109,27 +1088,14 @@ func TestHandleApproveByCIDR_NoPendingStore(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 	// Do NOT set pendingStore.
-	server.apiKeys["bulk-key"] = &APIKey{
-		ID:          "bulk-key-id",
-		Key:         "bulk-key",
-		Permissions: []string{"registration:approve"},
-		TenantID:    "default",
-	}
-	ts := httptest.NewServer(server.router)
-	defer ts.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), "POST",
-		ts.URL+"/api/v1/registration/approve-by-cidr",
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-by-cidr",
 		strings.NewReader(`{"cidr":"10.0.0.0/8"}`))
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer bulk-key")
 	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 // TestHandleApproveAll_NoPendingStore verifies 503 when pendingStore is nil.
@@ -1137,25 +1103,12 @@ func TestHandleApproveAll_NoPendingStore(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 	// Do NOT set pendingStore.
-	server.apiKeys["bulk-key"] = &APIKey{
-		ID:          "bulk-key-id",
-		Key:         "bulk-key",
-		Permissions: []string{"registration:approve"},
-		TenantID:    "default",
-	}
-	ts := httptest.NewServer(server.router)
-	defer ts.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), "POST",
-		ts.URL+"/api/v1/registration/approve-all", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer bulk-key")
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-all", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
 
-	resp, err := ts.Client().Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 // TestGetTransportAddress_ExternalAddressConfig verifies that transport.external_address

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -119,9 +119,6 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 func TestCreateRegistrationToken(t *testing.T) {
 	server, _ := setupTestServerWithTokenStore(t)
 
-	// Create API key with token creation permission
-	apiKey := NewTestKey(t, server, []string{"registration:create-token"})
-
 	t.Run("successful token creation", func(t *testing.T) {
 		reqBody := registration.TokenCreateRequest{
 			TenantID:      "test-tenant",
@@ -133,8 +130,7 @@ func TestCreateRegistrationToken(t *testing.T) {
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
@@ -158,8 +154,7 @@ func TestCreateRegistrationToken(t *testing.T) {
 		// single_use was removed in Issue #1690; sending it must return 400
 		body := []byte(`{"tenant_id":"test-tenant","controller_url":"grpc://controller.example.com:7443","single_use":true}`)
 
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
@@ -177,8 +172,7 @@ func TestCreateRegistrationToken(t *testing.T) {
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
@@ -196,8 +190,7 @@ func TestCreateRegistrationToken(t *testing.T) {
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
@@ -208,8 +201,7 @@ func TestCreateRegistrationToken(t *testing.T) {
 	})
 
 	t.Run("invalid JSON returns error", func(t *testing.T) {
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader([]byte("not json")))
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens", bytes.NewReader([]byte("not json")))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
@@ -409,9 +401,6 @@ func TestGetRegistrationToken(t *testing.T) {
 
 func TestDeleteRegistrationToken(t *testing.T) {
 	server, tokenStore := setupTestServerWithTokenStore(t)
-
-	// Create API key with delete permission
-	apiKey := NewTestKey(t, server, []string{"registration:delete-token"})
 	ctx := context.Background()
 
 	t.Run("delete existing token", func(t *testing.T) {
@@ -424,8 +413,7 @@ func TestDeleteRegistrationToken(t *testing.T) {
 		err = tokenStore.SaveToken(ctx, token)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("DELETE", "/api/v1/registration/tokens/"+token.Token, nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "DELETE", "/api/v1/registration/tokens/"+token.Token, nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -438,8 +426,7 @@ func TestDeleteRegistrationToken(t *testing.T) {
 	})
 
 	t.Run("delete non-existent token returns 404", func(t *testing.T) {
-		req := httptest.NewRequest("DELETE", "/api/v1/registration/tokens/nonexistent-token", nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "DELETE", "/api/v1/registration/tokens/nonexistent-token", nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -459,9 +446,6 @@ func TestDeleteRegistrationToken(t *testing.T) {
 
 func TestRevokeRegistrationToken(t *testing.T) {
 	server, tokenStore := setupTestServerWithTokenStore(t)
-
-	// Create API key with revoke permission
-	apiKey := NewTestKey(t, server, []string{"registration:revoke-token"})
 	ctx := context.Background()
 
 	t.Run("revoke existing token", func(t *testing.T) {
@@ -474,8 +458,7 @@ func TestRevokeRegistrationToken(t *testing.T) {
 		err = tokenStore.SaveToken(ctx, token)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/"+token.Token+"/revoke", nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/"+token.Token+"/revoke", nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -497,8 +480,7 @@ func TestRevokeRegistrationToken(t *testing.T) {
 	})
 
 	t.Run("revoke non-existent token returns 404", func(t *testing.T) {
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/nonexistent-token/revoke", nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/nonexistent-token/revoke", nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -518,9 +500,6 @@ func TestRevokeRegistrationToken(t *testing.T) {
 
 func TestRotateRegistrationToken(t *testing.T) {
 	server, tokenStore := setupTestServerWithTokenStore(t)
-
-	// Create API key with rotate permission
-	apiKey := NewTestKey(t, server, []string{"registration:rotate-token"})
 	ctx := context.Background()
 
 	// Seed a token for rotation
@@ -534,8 +513,7 @@ func TestRotateRegistrationToken(t *testing.T) {
 
 	t.Run("rotate returns new token and revokes old", func(t *testing.T) {
 		body := []byte(`{"group":"rotate-group"}`)
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/rotate-tenant/rotate", bytes.NewReader(body))
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/rotate-tenant/rotate", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
@@ -561,8 +539,7 @@ func TestRotateRegistrationToken(t *testing.T) {
 	})
 
 	t.Run("rotate with no active tokens returns 404", func(t *testing.T) {
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/nonexistent-tenant/rotate", nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/nonexistent-tenant/rotate", nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -583,18 +560,9 @@ func TestRotateRegistrationToken(t *testing.T) {
 func TestRegistrationTokenCRUDFlow(t *testing.T) {
 	server, _ := setupTestServerWithTokenStore(t)
 
-	// Create API key with all token permissions
-	apiKey := NewTestKey(t, server, []string{
-		"registration:create-token",
-		"registration:list-tokens",
-		"registration:read-token",
-		"registration:revoke-token",
-		"registration:delete-token",
-	})
-
 	var createdToken string
 
-	// 1. Create a token
+	// 1. Create a token (Tier-3: requires admin cert)
 	t.Run("1_create_token", func(t *testing.T) {
 		reqBody := registration.TokenCreateRequest{
 			TenantID:      "crud-test-tenant",
@@ -606,8 +574,7 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		body, err := json.Marshal(reqBody)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
@@ -623,10 +590,9 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		assert.NotEmpty(t, createdToken)
 	})
 
-	// 2. List tokens and verify our token is included
+	// 2. List tokens and verify our token is included (Tier-1: admin cert still works)
 	t.Run("2_list_tokens", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/api/v1/registration/tokens?tenant_id=crud-test-tenant", nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "GET", "/api/v1/registration/tokens?tenant_id=crud-test-tenant", nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -649,10 +615,9 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		assert.True(t, found, "Created token should be in the list")
 	})
 
-	// 3. Get specific token
+	// 3. Get specific token (Tier-1)
 	t.Run("3_get_token", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/api/v1/registration/tokens/"+createdToken, nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "GET", "/api/v1/registration/tokens/"+createdToken, nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -669,10 +634,9 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		assert.False(t, resp.Revoked)
 	})
 
-	// 4. Revoke the token
+	// 4. Revoke the token (Tier-3)
 	t.Run("4_revoke_token", func(t *testing.T) {
-		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/"+createdToken+"/revoke", nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/"+createdToken+"/revoke", nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -686,10 +650,9 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		assert.True(t, resp.Revoked)
 	})
 
-	// 5. Verify token is revoked when getting it again
+	// 5. Verify token is revoked when getting it again (Tier-1)
 	t.Run("5_verify_revoked", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/api/v1/registration/tokens/"+createdToken, nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "GET", "/api/v1/registration/tokens/"+createdToken, nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -704,10 +667,9 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		assert.NotNil(t, resp.RevokedAt)
 	})
 
-	// 6. Delete the token
+	// 6. Delete the token (Tier-3)
 	t.Run("6_delete_token", func(t *testing.T) {
-		req := httptest.NewRequest("DELETE", "/api/v1/registration/tokens/"+createdToken, nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "DELETE", "/api/v1/registration/tokens/"+createdToken, nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -715,10 +677,9 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		require.Equal(t, http.StatusNoContent, rec.Code)
 	})
 
-	// 7. Verify token is deleted
+	// 7. Verify token is deleted (Tier-1)
 	t.Run("7_verify_deleted", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/api/v1/registration/tokens/"+createdToken, nil)
-		req.Header.Set("X-API-Key", apiKey)
+		req := makeAdminRequest(t, "GET", "/api/v1/registration/tokens/"+createdToken, nil)
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)

--- a/features/controller/api/handlers_tenants_test.go
+++ b/features/controller/api/handlers_tenants_test.go
@@ -20,12 +20,10 @@ import (
 
 func TestHandleCreateTenant_ExplicitID(t *testing.T) {
 	server := setupTestServer(t)
-	apiKey := NewTestKey(t, server, []string{"tenant:create"})
 
 	body, _ := json.Marshal(map[string]string{"id": "team-root"})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
+	req := makeAdminRequest(t, http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", apiKey)
 	w := httptest.NewRecorder()
 
 	server.router.ServeHTTP(w, req)
@@ -42,7 +40,6 @@ func TestHandleCreateTenant_ExplicitID(t *testing.T) {
 
 func TestHandleCreateTenant_DuplicateID(t *testing.T) {
 	server := setupTestServer(t)
-	apiKey := NewTestKey(t, server, []string{"tenant:create"})
 
 	// Create the tenant once
 	ctx := context.Background()
@@ -51,9 +48,8 @@ func TestHandleCreateTenant_DuplicateID(t *testing.T) {
 
 	// Attempt to create with the same ID — must return 409
 	body, _ := json.Marshal(map[string]string{"id": "dup-tenant"})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
+	req := makeAdminRequest(t, http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", apiKey)
 	w := httptest.NewRecorder()
 
 	server.router.ServeHTTP(w, req)
@@ -63,11 +59,9 @@ func TestHandleCreateTenant_DuplicateID(t *testing.T) {
 
 func TestHandleCreateTenant_InvalidBody(t *testing.T) {
 	server := setupTestServer(t)
-	apiKey := NewTestKey(t, server, []string{"tenant:create"})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewBufferString("not-json"))
+	req := makeAdminRequest(t, http.MethodPost, "/api/v1/tenants", bytes.NewBufferString("not-json"))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", apiKey)
 	w := httptest.NewRecorder()
 
 	server.router.ServeHTTP(w, req)
@@ -77,12 +71,10 @@ func TestHandleCreateTenant_InvalidBody(t *testing.T) {
 
 func TestHandleCreateTenant_InvalidExplicitID(t *testing.T) {
 	server := setupTestServer(t)
-	apiKey := NewTestKey(t, server, []string{"tenant:create"})
 
 	body, _ := json.Marshal(map[string]string{"id": "Team_Root"})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
+	req := makeAdminRequest(t, http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", apiKey)
 	w := httptest.NewRecorder()
 
 	server.router.ServeHTTP(w, req)

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -439,6 +440,20 @@ func requestWithTLSCert(method, path string, peerCert *x509.Certificate) *http.R
 	req := httptest.NewRequest(method, path, nil)
 	req.TLS = &tls.ConnectionState{
 		PeerCertificates: []*x509.Certificate{peerCert},
+	}
+	return req
+}
+
+// makeAdminRequest creates an httptest.Request authenticated as an mTLS admin cert principal.
+// Pass a non-nil body for requests that require a payload (json-encoded etc.).
+// Use this helper in tests that call Tier-3 endpoints — those require IsAdmin: true which
+// only an mTLS admin cert provides.
+func makeAdminRequest(t *testing.T, method, path string, body io.Reader) *http.Request {
+	t.Helper()
+	adminCert := makeSelfSignedAdminCert(t)
+	req := httptest.NewRequest(method, path, body)
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{adminCert},
 	}
 	return req
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -481,8 +481,8 @@ func (s *Server) setupRouter() {
 	// Certificate management endpoints
 	certs := api.PathPrefix("/certificates").Subrouter()
 	certs.Handle("", s.requirePermission("certificate", "list")(http.HandlerFunc(s.handleListCertificates))).Methods("GET")
-	certs.Handle("/provision", s.requirePermission("certificate", "provision")(http.HandlerFunc(s.handleProvisionCertificate))).Methods("POST")
-	certs.Handle("/signing/rotate", s.requirePermission("certificate", "rotate")(http.HandlerFunc(s.handleRotateSigningCert))).Methods("POST")
+	certs.Handle("/provision", s.requireTier(TierMTLSOnly)(s.requirePermission("certificate", "provision")(http.HandlerFunc(s.handleProvisionCertificate)))).Methods("POST")
+	certs.Handle("/signing/rotate", s.requireTier(TierMTLSOnly)(s.requirePermission("certificate", "rotate")(http.HandlerFunc(s.handleRotateSigningCert)))).Methods("POST")
 
 	// RBAC management endpoints
 	rbac := api.PathPrefix("/rbac").Subrouter()
@@ -493,17 +493,17 @@ func (s *Server) setupRouter() {
 
 	// Roles
 	rbac.Handle("/roles", s.requirePermission("rbac", "list-roles")(http.HandlerFunc(s.handleListRoles))).Methods("GET")
-	rbac.Handle("/roles", s.requirePermission("rbac", "create-role")(http.HandlerFunc(s.handleCreateRole))).Methods("POST")
+	rbac.Handle("/roles", s.requireTier(TierMTLSOnly)(s.requirePermission("rbac", "create-role")(http.HandlerFunc(s.handleCreateRole)))).Methods("POST")
 	rbac.Handle("/roles/{id}", s.requirePermission("rbac", "read-role")(http.HandlerFunc(s.handleGetRole))).Methods("GET")
-	rbac.Handle("/roles/{id}", s.requirePermission("rbac", "update-role")(http.HandlerFunc(s.handleUpdateRole))).Methods("PUT")
-	rbac.Handle("/roles/{id}", s.requirePermission("rbac", "delete-role")(http.HandlerFunc(s.handleDeleteRole))).Methods("DELETE")
+	rbac.Handle("/roles/{id}", s.requireTier(TierMTLSOnly)(s.requirePermission("rbac", "update-role")(http.HandlerFunc(s.handleUpdateRole)))).Methods("PUT")
+	rbac.Handle("/roles/{id}", s.requireTier(TierMTLSOnly)(s.requirePermission("rbac", "delete-role")(http.HandlerFunc(s.handleDeleteRole)))).Methods("DELETE")
 
 	// API key management endpoints (for managing API keys themselves)
 	apiKeys := api.PathPrefix("/api-keys").Subrouter()
 	apiKeys.Handle("", s.requirePermission("api-key", "list")(http.HandlerFunc(s.handleListAPIKeys))).Methods("GET")
-	apiKeys.Handle("", s.requirePermission("api-key", "create")(http.HandlerFunc(s.handleCreateAPIKey))).Methods("POST")
+	apiKeys.Handle("", s.requireTier(TierMTLSOnly)(s.requirePermission("api-key", "create")(http.HandlerFunc(s.handleCreateAPIKey)))).Methods("POST")
 	apiKeys.Handle("/{id}", s.requirePermission("api-key", "read")(http.HandlerFunc(s.handleGetAPIKey))).Methods("GET")
-	apiKeys.Handle("/{id}", s.requirePermission("api-key", "delete")(http.HandlerFunc(s.handleDeleteAPIKey))).Methods("DELETE")
+	apiKeys.Handle("/{id}", s.requireTier(TierMTLSOnly)(s.requirePermission("api-key", "delete")(http.HandlerFunc(s.handleDeleteAPIKey)))).Methods("DELETE")
 
 	// Admin session endpoints (Issue #2232). POST requires an admin principal (IsAdmin==true);
 	// DELETE accepts either a valid session token or an admin mTLS cert.
@@ -515,23 +515,23 @@ func (s *Server) setupRouter() {
 	// Registration token management endpoints (Story #264)
 	regTokens := api.PathPrefix("/registration/tokens").Subrouter()
 	regTokens.Handle("", s.requirePermission("registration", "list-tokens")(http.HandlerFunc(s.handleListRegistrationTokens))).Methods("GET")
-	regTokens.Handle("", s.requirePermission("registration", "create-token")(http.HandlerFunc(s.handleCreateRegistrationToken))).Methods("POST")
+	regTokens.Handle("", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "create-token")(http.HandlerFunc(s.handleCreateRegistrationToken)))).Methods("POST")
 	regTokens.Handle("/{token}", s.requirePermission("registration", "read-token")(http.HandlerFunc(s.handleGetRegistrationToken))).Methods("GET")
-	regTokens.Handle("/{token}", s.requirePermission("registration", "delete-token")(http.HandlerFunc(s.handleDeleteRegistrationToken))).Methods("DELETE")
-	regTokens.Handle("/{token}/revoke", s.requirePermission("registration", "revoke-token")(http.HandlerFunc(s.handleRevokeRegistrationToken))).Methods("POST")
-	regTokens.Handle("/{tenant_id}/rotate", s.requirePermission("registration", "rotate-token")(http.HandlerFunc(s.handleRotateRegistrationToken))).Methods("POST")
+	regTokens.Handle("/{token}", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "delete-token")(http.HandlerFunc(s.handleDeleteRegistrationToken)))).Methods("DELETE")
+	regTokens.Handle("/{token}/revoke", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "revoke-token")(http.HandlerFunc(s.handleRevokeRegistrationToken)))).Methods("POST")
+	regTokens.Handle("/{tenant_id}/rotate", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "rotate-token")(http.HandlerFunc(s.handleRotateRegistrationToken)))).Methods("POST")
 
 	// Registration approval endpoints (Issue #1568)
 	api.Handle("/registration/pending", s.requirePermission("registration", "list-pending")(http.HandlerFunc(s.handleListPendingRegistrations))).Methods("GET")
-	api.Handle("/registration/{id}/approve", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveRegistration))).Methods("POST")
+	api.Handle("/registration/{id}/approve", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveRegistration)))).Methods("POST")
 	api.Handle("/registration/{id}/deny", s.requirePermission("registration", "deny")(http.HandlerFunc(s.handleDenyRegistration))).Methods("POST")
 
 	// Bulk registration approval and IP-trust management (Issue #1698)
-	api.Handle("/registration/approve-all", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveAllRegistrations))).Methods("POST")
-	api.Handle("/registration/approve-by-cidr", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveByCIDR))).Methods("POST")
-	api.Handle("/registration/ip-trust", s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleAddIPTrust))).Methods("POST")
+	api.Handle("/registration/approve-all", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveAllRegistrations)))).Methods("POST")
+	api.Handle("/registration/approve-by-cidr", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveByCIDR)))).Methods("POST")
+	api.Handle("/registration/ip-trust", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleAddIPTrust)))).Methods("POST")
 	// {cidr:.+} allows the CIDR slash to appear literally in the URL path after decoding.
-	api.Handle("/registration/ip-trust/{tenant_id}/{cidr:.+}", s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleRevokeIPTrust))).Methods("DELETE")
+	api.Handle("/registration/ip-trust/{tenant_id}/{cidr:.+}", s.requireTier(TierMTLSOnly)(s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleRevokeIPTrust)))).Methods("DELETE")
 
 	// Monitoring endpoints
 	monitoring := api.PathPrefix("/monitoring").Subrouter()
@@ -565,7 +565,7 @@ func (s *Server) setupRouter() {
 
 	// Tenant management endpoints (Issue #1396, Issue #1848)
 	tenants := api.PathPrefix("/tenants").Subrouter()
-	tenants.Handle("", s.requirePermission("tenant", "create")(http.HandlerFunc(s.handleCreateTenant))).Methods("POST")
+	tenants.Handle("", s.requireTier(TierMTLSOnly)(s.requirePermission("tenant", "create")(http.HandlerFunc(s.handleCreateTenant)))).Methods("POST")
 	tenants.Handle("/{id}", s.requirePermission("tenant", "read")(http.HandlerFunc(s.handleGetTenant))).Methods("GET")
 	tenants.Handle("/{id}/suspend",
 		s.requirePermission("tenant", "manage")(http.HandlerFunc(s.handleSuspendTenant))).Methods("POST")
@@ -577,7 +577,7 @@ func (s *Server) setupRouter() {
 	api.Handle("/stewards/refresh/pending",
 		s.requirePermission("refresh", "list-pending")(http.HandlerFunc(s.handleListPendingRefreshes))).Methods("GET")
 	api.Handle("/stewards/refresh/{pending_id}/approve",
-		s.requirePermission("refresh", "approve")(http.HandlerFunc(s.handleApproveRefresh))).Methods("POST")
+		s.requireTier(TierMTLSOnly)(s.requirePermission("refresh", "approve")(http.HandlerFunc(s.handleApproveRefresh)))).Methods("POST")
 	api.Handle("/stewards/refresh/{pending_id}/reject",
 		s.requirePermission("refresh", "reject")(http.HandlerFunc(s.handleRejectRefresh))).Methods("POST")
 
@@ -586,7 +586,7 @@ func (s *Server) setupRouter() {
 	tenants.Handle("/{tenant_path:.+}/refresh-policy",
 		s.requirePermission("refresh", "get-policy")(http.HandlerFunc(s.handleGetRefreshPolicy))).Methods("GET")
 	tenants.Handle("/{tenant_path:.+}/refresh-policy",
-		s.requirePermission("refresh", "set-policy")(http.HandlerFunc(s.handleSetRefreshPolicy))).Methods("PUT")
+		s.requireTier(TierMTLSOnly)(s.requirePermission("refresh", "set-policy")(http.HandlerFunc(s.handleSetRefreshPolicy)))).Methods("PUT")
 
 	// Installer artifact management endpoints (Issue #1702).
 	// Always registered — handlers return 503 when blobStore is nil (nil-safe by design).

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -302,10 +302,7 @@ func TestListStewards(t *testing.T) {
 func TestAPIKeyManagement(t *testing.T) {
 	server := setupTestServer(t)
 
-	// Use ephemeral key for API key management (more secure for testing)
-	adminAPIKey := NewTestKey(t, server, []string{"api-key:create", "api-key:list"})
-
-	// Test creating a new API key
+	// POST /api/v1/api-keys is Tier-3 (mTLS-only): use admin cert.
 	createReq := APIKeyCreateRequest{
 		Name:        "Test Key",
 		Permissions: []string{"steward:read"},
@@ -315,8 +312,7 @@ func TestAPIKeyManagement(t *testing.T) {
 	reqBody, err := json.Marshal(createReq)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("POST", "/api/v1/api-keys", bytes.NewReader(reqBody))
-	req.Header.Set("X-API-Key", adminAPIKey)
+	req := makeAdminRequest(t, "POST", "/api/v1/api-keys", bytes.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -335,9 +331,10 @@ func TestAPIKeyManagement(t *testing.T) {
 	assert.Contains(t, keyData, "key") // Should include the actual key on creation
 	assert.Contains(t, keyData, "id")
 
-	// Test listing API keys
+	// Test listing API keys (GET /api/v1/api-keys is Tier-1)
+	listKey := NewTestKey(t, server, []string{"api-key:list"})
 	req = httptest.NewRequest("GET", "/api/v1/api-keys", nil)
-	req.Header.Set("X-API-Key", adminAPIKey)
+	req.Header.Set("X-API-Key", listKey)
 	rec = httptest.NewRecorder()
 
 	server.router.ServeHTTP(rec, req)
@@ -439,13 +436,8 @@ func TestConfigurationValidation(t *testing.T) {
 func TestErrorResponses(t *testing.T) {
 	server := setupTestServer(t)
 
-	// Use ephemeral keys for error response testing (more secure)
-	apiKeyCreateKey := NewTestKey(t, server, []string{"api-key:create"})
-	stewardReadKey := NewTestKey(t, server, []string{"steward:read"})
-
-	// Test invalid JSON
-	req := httptest.NewRequest("POST", "/api/v1/api-keys", bytes.NewReader([]byte("invalid json")))
-	req.Header.Set("X-API-Key", apiKeyCreateKey)
+	// Test invalid JSON on POST /api/v1/api-keys (Tier-3: use admin cert to reach the handler).
+	req := makeAdminRequest(t, "POST", "/api/v1/api-keys", bytes.NewReader([]byte("invalid json")))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -458,7 +450,8 @@ func TestErrorResponses(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "INVALID_JSON", errorResponse.Error.Code)
 
-	// Test not found
+	// Test not found on a Tier-1 endpoint (API key sufficient).
+	stewardReadKey := NewTestKey(t, server, []string{"steward:read"})
 	req = httptest.NewRequest("GET", "/api/v1/stewards/nonexistent", nil)
 	req.Header.Set("X-API-Key", stewardReadKey)
 	rec = httptest.NewRecorder()
@@ -478,6 +471,7 @@ func TestPermissionDenial(t *testing.T) {
 		method         string
 		permissions    []string
 		expectedStatus int
+		expectedCode   string
 		body           []byte
 	}{
 		{
@@ -486,13 +480,16 @@ func TestPermissionDenial(t *testing.T) {
 			method:         "GET",
 			permissions:    []string{"api-key:read"}, // Wrong permission
 			expectedStatus: http.StatusForbidden,
+			expectedCode:   "INSUFFICIENT_PERMISSIONS",
 		},
 		{
-			name:           "Insufficient permissions for API key creation",
+			// POST /api/v1/api-keys is Tier-3: API keys get MTLS_REQUIRED regardless of permissions.
+			name:           "API key cannot access Tier-3 endpoint (api-key creation)",
 			endpoint:       "/api/v1/api-keys",
 			method:         "POST",
-			permissions:    []string{"steward:list"}, // Wrong permission
+			permissions:    []string{"steward:list"},
 			expectedStatus: http.StatusForbidden,
+			expectedCode:   "MTLS_REQUIRED",
 			body:           []byte(`{"name":"Test","permissions":["test"],"tenant_id":"test"}`),
 		},
 		{
@@ -501,13 +498,13 @@ func TestPermissionDenial(t *testing.T) {
 			method:         "POST",
 			permissions:    []string{"steward:list"}, // Wrong permission
 			expectedStatus: http.StatusForbidden,
+			expectedCode:   "INSUFFICIENT_PERMISSIONS",
 			body:           []byte(`{"config":{},"version":"1.0.0"}`),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create key with insufficient permissions
 			insufficientKey := NewTestKey(t, server, tt.permissions)
 
 			var req *http.Request
@@ -528,7 +525,7 @@ func TestPermissionDenial(t *testing.T) {
 				var errorResponse ErrorResponse
 				err := json.Unmarshal(rec.Body.Bytes(), &errorResponse)
 				require.NoError(t, err)
-				assert.Contains(t, errorResponse.Error.Code, "INSUFFICIENT_PERMISSIONS")
+				assert.Equal(t, tt.expectedCode, errorResponse.Error.Code)
 			}
 		})
 	}
@@ -539,10 +536,11 @@ func TestActualAPIFunctionality(t *testing.T) {
 	server := setupTestServer(t)
 
 	t.Run("API Key CRUD operations work with proper permissions", func(t *testing.T) {
-		// Use proper admin permissions for full API key management
-		adminKey := NewTestKey(t, server, []string{"api-key:create", "api-key:list", "api-key:read", "api-key:delete"})
+		// POST/DELETE /api/v1/api-keys are Tier-3 (mTLS-only): use admin cert.
+		// GET /api/v1/api-keys and GET /api/v1/api-keys/{id} are Tier-1: API key suffices.
+		listReadKey := NewTestKey(t, server, []string{"api-key:list", "api-key:read"})
 
-		// 1. Create a new API key
+		// 1. Create a new API key (Tier-3: admin cert required).
 		createReq := APIKeyCreateRequest{
 			Name:        "Functional Test Key",
 			Permissions: []string{"steward:list"},
@@ -552,14 +550,13 @@ func TestActualAPIFunctionality(t *testing.T) {
 		reqBody, err := json.Marshal(createReq)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("POST", "/api/v1/api-keys", bytes.NewReader(reqBody))
-		req.Header.Set("X-API-Key", adminKey)
+		req := makeAdminRequest(t, "POST", "/api/v1/api-keys", bytes.NewReader(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
 
-		assert.Equal(t, http.StatusCreated, rec.Code, "API key creation should succeed with proper permissions")
+		assert.Equal(t, http.StatusCreated, rec.Code, "API key creation should succeed with admin cert")
 
 		var createResponse APIResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &createResponse)
@@ -570,7 +567,7 @@ func TestActualAPIFunctionality(t *testing.T) {
 		createdKeyID := keyData["id"].(string)
 		actualKey := keyData["key"].(string)
 
-		// 2. Verify the created key actually works for its intended purpose
+		// 2. Verify the created key actually works for its intended purpose.
 		req = httptest.NewRequest("GET", "/api/v1/stewards", nil)
 		req.Header.Set("X-API-Key", actualKey)
 		rec = httptest.NewRecorder()
@@ -578,9 +575,9 @@ func TestActualAPIFunctionality(t *testing.T) {
 		server.router.ServeHTTP(rec, req)
 		assert.Equal(t, http.StatusOK, rec.Code, "New API key should work for steward:list")
 
-		// 3. List API keys should include the created key
+		// 3. List API keys should include the created key (Tier-1).
 		req = httptest.NewRequest("GET", "/api/v1/api-keys", nil)
-		req.Header.Set("X-API-Key", adminKey)
+		req.Header.Set("X-API-Key", listReadKey)
 		rec = httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -594,9 +591,9 @@ func TestActualAPIFunctionality(t *testing.T) {
 		require.True(t, ok)
 		assert.GreaterOrEqual(t, len(keys), 1, "Should have at least one key")
 
-		// 4. Get specific API key by ID
+		// 4. Get specific API key by ID (Tier-1).
 		req = httptest.NewRequest("GET", "/api/v1/api-keys/"+createdKeyID, nil)
-		req.Header.Set("X-API-Key", adminKey)
+		req.Header.Set("X-API-Key", listReadKey)
 		rec = httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
@@ -610,16 +607,15 @@ func TestActualAPIFunctionality(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "Functional Test Key", keyDetails["name"])
 
-		// 5. Delete the API key
-		req = httptest.NewRequest("DELETE", "/api/v1/api-keys/"+createdKeyID, nil)
-		req.Header.Set("X-API-Key", adminKey)
+		// 5. Delete the API key (Tier-3: admin cert required).
+		req = makeAdminRequest(t, "DELETE", "/api/v1/api-keys/"+createdKeyID, nil)
 		rec = httptest.NewRecorder()
 
 		server.router.ServeHTTP(rec, req)
 
-		assert.Equal(t, http.StatusOK, rec.Code, "API key deletion should work")
+		assert.Equal(t, http.StatusOK, rec.Code, "API key deletion should work with admin cert")
 
-		// 6. Verify deleted key no longer works
+		// 6. Verify deleted key no longer works.
 		req = httptest.NewRequest("GET", "/api/v1/stewards", nil)
 		req.Header.Set("X-API-Key", actualKey)
 		rec = httptest.NewRecorder()

--- a/features/controller/api/tier_enforcement_test.go
+++ b/features/controller/api/tier_enforcement_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tier3RouteEntry is a single entry in the Tier-3 route table for parity testing.
+type tier3RouteEntry struct {
+	method     string
+	path       string
+	permission string
+}
+
+// tier3RouteTable is the authoritative list of all 19 Tier-3 routes wired in server.go.
+// Each entry maps to exactly one permission in tier3Permissions. The parity test
+// (TestTier3Enforcement_RouteSetMatchesCanonicalSet) asserts this set equals tier3Permissions.
+var tier3RouteTable = []tier3RouteEntry{
+	{"POST", "/api/v1/certificates/provision", "certificate:provision"},
+	{"POST", "/api/v1/certificates/signing/rotate", "certificate:rotate"},
+	{"POST", "/api/v1/rbac/roles", "rbac:create-role"},
+	{"PUT", "/api/v1/rbac/roles/test-id", "rbac:update-role"},
+	{"DELETE", "/api/v1/rbac/roles/test-id", "rbac:delete-role"},
+	{"POST", "/api/v1/api-keys", "api-key:create"},
+	{"DELETE", "/api/v1/api-keys/test-id", "api-key:delete"},
+	{"POST", "/api/v1/registration/tokens", "registration:create-token"},
+	{"DELETE", "/api/v1/registration/tokens/test-token", "registration:delete-token"},
+	{"POST", "/api/v1/registration/tokens/test-token/revoke", "registration:revoke-token"},
+	{"POST", "/api/v1/registration/tokens/test-tenant/rotate", "registration:rotate-token"},
+	{"POST", "/api/v1/registration/reg-123/approve", "registration:approve"},
+	{"POST", "/api/v1/registration/approve-all", "registration:approve"},
+	{"POST", "/api/v1/registration/approve-by-cidr", "registration:approve"},
+	{"POST", "/api/v1/registration/ip-trust", "registration:manage-ip-trust"},
+	{"DELETE", "/api/v1/registration/ip-trust/test-tenant/192.168.1.0/24", "registration:manage-ip-trust"},
+	{"POST", "/api/v1/tenants", "tenant:create"},
+	{"POST", "/api/v1/stewards/refresh/pending-123/approve", "refresh:approve"},
+	{"PUT", "/api/v1/tenants/test-tenant/refresh-policy", "refresh:set-policy"},
+}
+
+// TestTier3Enforcement_APIKeyWithAdminPermissions_Gets403 verifies that an API-key
+// principal carrying the exact admin permissions for a Tier-3 endpoint is still rejected
+// with HTTP 403 MTLS_REQUIRED, and that the handler is never called.
+func TestTier3Enforcement_APIKeyWithAdminPermissions_Gets403(t *testing.T) {
+	server := setupTestServer(t)
+
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierMTLSOnly)(probe)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", nil)
+	req = req.WithContext(context.WithValue(req.Context(), principalContextKey, &Principal{
+		IsAdmin:     false,
+		Permissions: []string{"api-key:create", "rbac:create-role", "tenant:create", "certificate:provision"},
+	}))
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, handlerCalled, "handler must not be called for API-key principal on Tier-3 endpoint")
+
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	require.NotNil(t, errResp.Error)
+	assert.Equal(t, "MTLS_REQUIRED", errResp.Error.Code)
+}
+
+// TestTier3Enforcement_AdminCertPrincipal_Passes verifies that an mTLS admin-cert
+// principal (IsAdmin: true) passes the Tier-3 check and reaches the inner handler.
+func TestTier3Enforcement_AdminCertPrincipal_Passes(t *testing.T) {
+	server := setupTestServer(t)
+
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierMTLSOnly)(probe)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", nil)
+	req = req.WithContext(context.WithValue(req.Context(), principalContextKey, &Principal{
+		IsAdmin:    true,
+		CertSerial: "abc123",
+	}))
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusForbidden, rec.Code, "admin cert principal must not receive 403")
+	assert.True(t, handlerCalled, "inner handler must be called for admin cert principal")
+}
+
+// TestTier3Enforcement_RelayPrincipal_Gets403 verifies that a relay-style principal
+// (IsAdmin: false, permissions from a grant scope) is rejected at the Tier-3 gate.
+// This explicitly closes the Issue #1675 relay-bypass vector.
+func TestTier3Enforcement_RelayPrincipal_Gets403(t *testing.T) {
+	server := setupTestServer(t)
+
+	handlerCalled := false
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := server.requireTier(TierMTLSOnly)(probe)
+
+	// Relay principal: IsAdmin is false (relay_handler.go sets this), but the grant
+	// scope carries the matching permission — simulating a relay that could otherwise
+	// appear to have authorization.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", nil)
+	req = req.WithContext(context.WithValue(req.Context(), principalContextKey, &Principal{
+		IsAdmin:     false,
+		Permissions: []string{"api-key:create"},
+		ID:          "relay-principal-id",
+		TenantID:    "relay-tenant",
+	}))
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"relay principal (IsAdmin: false) must be rejected at Tier-3 gate")
+	assert.False(t, handlerCalled, "handler must not be called for relay principal")
+
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	require.NotNil(t, errResp.Error)
+	assert.Equal(t, "MTLS_REQUIRED", errResp.Error.Code)
+}
+
+// TestTier3Enforcement_RouteSetMatchesCanonicalSet verifies two invariants:
+//
+//	(a) Every route in tier3RouteTable returns HTTP 403 MTLS_REQUIRED when called
+//	    by an API-key principal — even one carrying the matching admin permissions.
+//
+//	(b) The unique permission set in tier3RouteTable exactly equals tier3Permissions
+//	    (the canonical set from auth_tiers.go). No drift in either direction.
+func TestTier3Enforcement_RouteSetMatchesCanonicalSet(t *testing.T) {
+	server := setupTestServer(t)
+
+	// API key carries all Tier-3 permissions — proving the tier gate fires before
+	// the permission gate and rejects regardless of what permissions the key holds.
+	allTier3Perms := make([]string, 0, len(tier3Permissions))
+	for perm := range tier3Permissions {
+		allTier3Perms = append(allTier3Perms, perm)
+	}
+	apiKey := NewTestKey(t, server, allTier3Perms)
+
+	// Part (a): each route returns 403 MTLS_REQUIRED to an API-key principal.
+	for _, entry := range tier3RouteTable {
+		entry := entry
+		t.Run(entry.method+" "+entry.path, func(t *testing.T) {
+			req := httptest.NewRequest(entry.method, entry.path, nil)
+			req.Header.Set("X-API-Key", apiKey)
+			rec := httptest.NewRecorder()
+			server.router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusForbidden, rec.Code,
+				"Tier-3 route must reject API-key principal with 403")
+
+			var errResp ErrorResponse
+			require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+			require.NotNil(t, errResp.Error)
+			assert.Equal(t, "MTLS_REQUIRED", errResp.Error.Code,
+				"rejection must use MTLS_REQUIRED error code")
+		})
+	}
+
+	// Part (b): unique permissions in the route table must exactly match tier3Permissions.
+	tablePerms := make(map[string]struct{})
+	for _, entry := range tier3RouteTable {
+		tablePerms[entry.permission] = struct{}{}
+	}
+	assert.Equal(t, tier3Permissions, tablePerms,
+		"route table permissions must exactly match the tier3Permissions canonical set — add missing routes or remove stale entries")
+}
+
+// TestTier1Endpoint_RemainsReachableByAPIKey verifies that wrapping Tier-3 routes did
+// not accidentally elevate Tier-1 routes. A valid API-key principal must still reach
+// GET /api/v1/stewards (which uses only requirePermission, no requireTier(TierMTLSOnly)).
+func TestTier1Endpoint_RemainsReachableByAPIKey(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:list"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"Tier-1 endpoint must remain reachable by API-key principal after Tier-3 wiring")
+	assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+		"Tier-1 endpoint must authenticate valid API-key principal")
+}


### PR DESCRIPTION
## Summary

- Wraps 19 auth-surface REST endpoints with `requireTier(TierMTLSOnly)`, ensuring API-key principals receive HTTP 403 `MTLS_REQUIRED` before any handler logic runs
- Extends `tier3Permissions` in `auth_tiers.go` from 14 to 16 entries (`refresh:approve`, `refresh:set-policy`)
- Adds `tier_enforcement_test.go` with 5 new tests covering all attack vectors per acceptance criteria
- Updates 10 existing test files to use `makeAdminRequest` helper for Tier-3 routes; cross-tenant tests updated to expect 403 (Tier-3 blocks before handler's 404)
- Closes the Issue #1675 relay bypass: relay principals (`IsAdmin: false`) now blocked by `TestTier3Enforcement_RelayPrincipal_Gets403`

## Test plan

- [x] All 5 acceptance criteria tests present and passing: `TestTier3Enforcement_APIKeyWithAdminPermissions_Gets403`, `TestTier3Enforcement_AdminCertPrincipal_Passes`, `TestTier3Enforcement_RelayPrincipal_Gets403`, `TestTier3Enforcement_RouteSetMatchesCanonicalSet` (19 subtests + parity), `TestTier1Endpoint_RemainsReachableByAPIKey`
- [x] `go test ./features/controller/api/... -count=1` — 100% pass
- [x] `make test-agent-complete` — 196/196 pass, all platforms compile, lint clean
- [x] QA Code Reviewer: PASS (0 blocking issues)
- [x] Security Engineer: PASS (0 blocking issues; route ordering verified, `IsAdmin` path audited, relay bypass confirmed closed, all scans green)

Fixes #2225

🤖 Generated with [Claude Code](https://claude.com/claude-code)