### PR TITLE
session: cfg connect / disconnect + transparent rolling-token renewal (Issue #2248)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -19,9 +20,11 @@ import (
 
 // APIClient provides HTTP client functionality for communicating with the controller API
 type APIClient struct {
-	baseURL    string
-	apiKey     string
-	httpClient *http.Client
+	baseURL        string
+	apiKey         string
+	httpClient     *http.Client
+	onTokenRenewed func(newToken string) error
+	onUnauthorized func() (*APIClient, error)
 }
 
 // APIClientConfig contains configuration for creating an API client
@@ -33,6 +36,18 @@ type APIClientConfig struct {
 	ClientKeyPEM  []byte // Client private key for mTLS authentication
 	TLSInsecure   bool   // Skip TLS verification (development only)
 	ServerName    string // Server name for TLS verification (extracted from URL if empty)
+
+	// OnTokenRenewed is called after each response when the server issues a renewed
+	// session token via the X-Session-Token response header. Nil = no-op.
+	// Errors from this callback are ignored (best-effort write-back).
+	OnTokenRenewed func(newToken string) error
+
+	// OnUnauthorized is called when the server returns 401 and may return a
+	// fallback APIClient to retry the request with. Nil = no fallback.
+	// When the fallback client is non-nil the request is retried once and the
+	// message "session expired or revoked — falling back to bundle auth" is
+	// printed to stderr.
+	OnUnauthorized func() (*APIClient, error)
 }
 
 // APITokenCreateRequest represents the request body for creating a registration token
@@ -101,8 +116,10 @@ func NewAPIClient(cfg *APIClientConfig) (*APIClient, error) {
 	}
 
 	return &APIClient{
-		baseURL: cfg.BaseURL,
-		apiKey:  cfg.APIKey,
+		baseURL:        cfg.BaseURL,
+		apiKey:         cfg.APIKey,
+		onTokenRenewed: cfg.OnTokenRenewed,
+		onUnauthorized: cfg.OnUnauthorized,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -424,6 +441,21 @@ func (c *APIClient) doRequest(ctx context.Context, method, path string, body io.
 // the request URL manually: parse the base URL, split path from query, apply the
 // pre-encoded path via RawPath, and restore RawPath after NewRequestWithContext.
 func (c *APIClient) doRequestWithContentType(ctx context.Context, method, path string, body io.Reader, contentType string) (*http.Response, error) {
+	// Buffer the body so it can be replayed on a 401 fallback retry.
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to buffer request body: %w", err)
+		}
+	}
+	return c.execRequest(ctx, method, path, bodyBytes, contentType, true)
+}
+
+// execRequest is the inner send-and-receive loop shared by doRequestWithContentType
+// and the 401-fallback retry path. allowFallback prevents infinite recursion.
+func (c *APIClient) execRequest(ctx context.Context, method, path string, bodyBytes []byte, contentType string, allowFallback bool) (*http.Response, error) {
 	base, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse base URL: %w", err)
@@ -448,7 +480,12 @@ func (c *APIClient) doRequestWithContentType(ctx context.Context, method, path s
 	base.RawPath = base.RawPath + rawPath
 	base.RawQuery = rawQuery
 
-	req, err := http.NewRequestWithContext(ctx, method, base.String(), body)
+	var bodyReader io.Reader
+	if bodyBytes != nil {
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, base.String(), bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -462,7 +499,28 @@ func (c *APIClient) doRequestWithContentType(ctx context.Context, method, path s
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
 
-	return c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Rolling token renewal: persist the rotated token when the server issues one.
+	if newToken := resp.Header.Get("X-Session-Token"); newToken != "" && c.onTokenRenewed != nil {
+		_ = c.onTokenRenewed(newToken) // best-effort; never fail the request
+	}
+
+	// 401 fallback: when the session token has been revoked or expired server-side,
+	// transparently retry with a bundle-auth client if one is available.
+	if allowFallback && resp.StatusCode == http.StatusUnauthorized && c.onUnauthorized != nil {
+		fallbackClient, fallbackErr := c.onUnauthorized()
+		if fallbackErr == nil && fallbackClient != nil {
+			_ = resp.Body.Close()
+			fmt.Fprintln(os.Stderr, "session expired or revoked — falling back to bundle auth")
+			return fallbackClient.execRequest(ctx, method, path, bodyBytes, contentType, false)
+		}
+	}
+
+	return resp, nil
 }
 
 // APITenantCreateRequest is the request body for POST /api/v1/tenants.
@@ -848,4 +906,57 @@ func (c *APIClient) parseError(resp *http.Response) error {
 
 	// Return raw body as error message
 	return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+}
+
+// sessionIssueRequest is the JSON body for POST /api/v1/sessions.
+type sessionIssueRequest struct {
+	ConnectionName string `json:"connection_name"`
+}
+
+// sessionIssueResponse is the JSON response from POST /api/v1/sessions (HTTP 201).
+type sessionIssueResponse struct {
+	SessionID      string    `json:"session_id"`
+	Token          string    `json:"token"`
+	IssuedAt       time.Time `json:"issued_at"`
+	IdleTTLSeconds int64     `json:"idle_ttl_seconds"`
+	AbsoluteExpiry time.Time `json:"absolute_expiry"`
+}
+
+// IssueSession calls POST /api/v1/sessions and returns the session response.
+// The caller must be using an admin mTLS credential (client cert).
+func (c *APIClient) IssueSession(ctx context.Context, connectionName string) (*sessionIssueResponse, error) {
+	body, err := json.Marshal(sessionIssueRequest{ConnectionName: connectionName})
+	if err != nil {
+		return nil, fmt.Errorf("session create: marshal: %w", err)
+	}
+	resp, err := c.doRequestWithContentType(ctx, "POST", "/api/v1/sessions", bytes.NewReader(body), "application/json")
+	if err != nil {
+		return nil, fmt.Errorf("session create: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		return nil, c.parseError(resp)
+	}
+	var out sessionIssueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("session create: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// RevokeSession calls DELETE /api/v1/sessions/{id}.
+// A 404 is treated as success (already gone).
+func (c *APIClient) RevokeSession(ctx context.Context, sessionID string) error {
+	resp, err := c.doRequestWithContentType(ctx, "DELETE", "/api/v1/sessions/"+url.PathEscape(sessionID), nil, "")
+	if err != nil {
+		return fmt.Errorf("session revoke: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil // already revoked or never existed
+	}
+	if resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+	return nil
 }

--- a/cmd/cfg/cmd/client_helpers.go
+++ b/cmd/cfg/cmd/client_helpers.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/cfgis/cfgms/pkg/cert/bundle"
 )
@@ -107,6 +108,51 @@ func resolveBundleClient(apiURL string) (*APIClient, error) {
 	}
 
 	return newClientFromBundle(path, apiURL)
+}
+
+// resolveSessionOrBundleClient tries the active OS-keychain session token first,
+// then falls through to resolveBundleClient.
+//
+// Falls through to bundle auth unconditionally when:
+//   - bundlePath is set (--bundle flag)
+//   - noBundle is set (--no-bundle flag)
+//   - apiURL is non-empty (explicit --api-url flag or CFGMS_API_URL env var)
+//   - no session token is stored
+//   - the stored token has passed its absolute expiry
+//   - the OS secret store is unavailable (Available()==false)
+//
+// When a valid session is found the returned client has OnTokenRenewed wired
+// to write rolled X-Session-Token values back to the secret store, and
+// OnUnauthorized wired to fall back to bundle auth on server-side 401.
+func resolveSessionOrBundleClient(apiURL string) (*APIClient, error) {
+	// Explicit one-shot overrides bypass the session entirely.
+	if bundlePath != "" || noBundle || apiURL != "" {
+		return resolveBundleClient(apiURL)
+	}
+
+	rec, err := loadSessionToken()
+	if err != nil || rec == nil || time.Now().After(rec.AbsoluteExpiry) {
+		return resolveBundleClient(apiURL)
+	}
+
+	// Use the stored CA cert when non-empty; nil → system cert pool (public CA controllers).
+	var caCertPEM []byte
+	if rec.CACertPEM != "" {
+		caCertPEM = []byte(rec.CACertPEM)
+	}
+
+	cfg := &APIClientConfig{
+		BaseURL:   rec.ControllerURL,
+		APIKey:    rec.Token,
+		CACertPEM: caCertPEM,
+		OnTokenRenewed: func(newToken string) error {
+			return updateSessionToken(newToken)
+		},
+		OnUnauthorized: func() (*APIClient, error) {
+			return resolveBundleClient("") // let bundle supply the URL
+		},
+	}
+	return NewAPIClient(cfg)
 }
 
 // findBundlePath walks the bundle lookup chain and returns the first path that exists.

--- a/cmd/cfg/cmd/config.go
+++ b/cmd/cfg/cmd/config.go
@@ -271,7 +271,7 @@ func getConfigClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}
@@ -304,7 +304,7 @@ func getConfigAPIClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/connect.go
+++ b/cmd/cfg/cmd/connect.go
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	certbundle "github.com/cfgis/cfgms/pkg/cert/bundle"
+)
+
+var (
+	connectBundlePath string
+	connectURL        string
+	connectName       string
+)
+
+var connectCmd = &cobra.Command{
+	Use:   "connect [<name>] [--bundle <path>] [--url <url>] [--name <name>]",
+	Short: "Start a zero-standing-privilege controller session",
+	Long: `Unlock the stored credential once, obtain a controller session token, and
+store it in the OS-native secret store.
+
+First time (import bundle):
+  cfg connect --bundle <path> --url <https://controller:9443>
+
+Reconnect with a named connection (no bundle re-import):
+  cfg connect <name>
+
+If the connection name is omitted and exactly one connection is registered it is
+selected automatically; otherwise a numbered selection is presented on stdin.
+
+The --url value must be an HTTPS URL for any non-loopback address.`,
+	RunE: runConnect,
+}
+
+var disconnectCmd = &cobra.Command{
+	Use:   "disconnect [<name>]",
+	Short: "End the active controller session",
+	Long: `Revoke the active controller session (DELETE /api/v1/sessions/{id}) and remove
+the session token from the OS-native secret store.
+
+If no active session is found, exits 0 with a notice.`,
+	RunE: runDisconnect,
+}
+
+func init() {
+	connectCmd.Flags().StringVar(&connectBundlePath, "bundle", "", "Admin bundle file for first-time import (requires --url)")
+	connectCmd.Flags().StringVar(&connectURL, "url", "", "Controller HTTPS URL (required with --bundle)")
+	connectCmd.Flags().StringVar(&connectName, "name", "", "Connection name (default: derived from --url host)")
+}
+
+// isLoopback returns true when host is a loopback address or name.
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// requireHTTPS returns an error when rawURL uses the http scheme for a non-loopback host.
+func requireHTTPS(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if strings.EqualFold(u.Scheme, "http") && !isLoopback(u.Hostname()) {
+		return fmt.Errorf("session connect requires HTTPS: use https:// for %s", u.Host)
+	}
+	return nil
+}
+
+// deriveConnectionName extracts a connection name from the URL hostname.
+func deriveConnectionName(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return "default"
+	}
+	return u.Hostname()
+}
+
+// parseBundleBytes deserialises YAML-encoded bundle bytes without writing a temp file.
+func parseBundleBytes(data []byte) (*certbundle.Bundle, error) {
+	var b certbundle.Bundle
+	if err := yaml.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("failed to parse bundle: %w", err)
+	}
+	return &b, nil
+}
+
+// newClientFromBundleData builds an mTLS-capable APIClient from a parsed Bundle struct.
+// apiURL overrides bundle.ControllerURL when non-empty.
+func newClientFromBundleData(b *certbundle.Bundle, apiURL string) (*APIClient, error) {
+	baseURL := apiURL
+	if baseURL == "" {
+		baseURL = b.ControllerURL
+	}
+	serverName := ""
+	if baseURL != "" {
+		if parsed, err := url.Parse(baseURL); err == nil && parsed.Hostname() != "" {
+			serverName = parsed.Hostname()
+		}
+	}
+	return NewAPIClient(&APIClientConfig{
+		BaseURL:       baseURL,
+		ClientCertPEM: []byte(b.CertPEM),
+		ClientKeyPEM:  []byte(b.KeyPEM),
+		CACertPEM:     []byte(b.CAPEM),
+		ServerName:    serverName,
+	})
+}
+
+func runConnect(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if connectBundlePath != "" {
+		return runConnectFirstTime(ctx, args)
+	}
+	return runConnectReconnect(ctx, args)
+}
+
+// runConnectFirstTime handles cfg connect --bundle <path> --url <url>.
+func runConnectFirstTime(ctx context.Context, args []string) error {
+	if connectURL == "" {
+		return fmt.Errorf("--url is required when --bundle is provided")
+	}
+	if err := requireHTTPS(connectURL); err != nil {
+		return err
+	}
+
+	// Determine connection name.
+	name := connectName
+	if name == "" && len(args) > 0 {
+		name = args[0]
+	}
+	if name == "" {
+		name = deriveConnectionName(connectURL)
+	}
+
+	// Read bundle bytes — stored encrypted; the raw file is only read here.
+	// #nosec G304 - bundle path provided by the user via --bundle flag
+	bundleBytes, err := os.ReadFile(connectBundlePath)
+	if err != nil {
+		return fmt.Errorf("read bundle: %w", err)
+	}
+	b, err := parseBundleBytes(bundleBytes)
+	if err != nil {
+		return fmt.Errorf("parse bundle: %w", err)
+	}
+
+	// Register non-secret connection metadata.
+	reg, err := newConnectionRegistry()
+	if err != nil {
+		return fmt.Errorf("open connection registry: %w", err)
+	}
+	if err := reg.Register(ConnectionEntry{
+		Name:          name,
+		ControllerURL: connectURL,
+		AdminIdentity: b.AuditSubject,
+		UnlockMethod:  "machine",
+	}); err != nil {
+		return fmt.Errorf("register connection: %w", err)
+	}
+
+	// Store encrypted credential.
+	credStore, err := newCredentialStore()
+	if err != nil {
+		return fmt.Errorf("open credential store: %w", err)
+	}
+	if err := credStore.Store(ctx, name, bundleBytes); err != nil {
+		return fmt.Errorf("store credential: %w", err)
+	}
+
+	// Build mTLS client and issue session.
+	client, err := newClientFromBundleData(b, connectURL)
+	if err != nil {
+		return fmt.Errorf("build mTLS client: %w", err)
+	}
+	sessResp, err := client.IssueSession(ctx, name)
+	if err != nil {
+		return fmt.Errorf("issue session: %w", err)
+	}
+
+	// Store session token in OS keychain (no file on disk).
+	if err := storeSessionToken(&sessionRecord{
+		Token:          sessResp.Token,
+		SessionID:      sessResp.SessionID,
+		ControllerURL:  connectURL,
+		ConnectionName: name,
+		AbsoluteExpiry: sessResp.AbsoluteExpiry,
+		CACertPEM:      b.CAPEM,
+	}); err != nil {
+		return fmt.Errorf("store session token: %w", err)
+	}
+
+	fmt.Printf("Connected as %q (expires %s)\n", name, sessResp.AbsoluteExpiry.Format(time.RFC3339))
+	return nil
+}
+
+// runConnectReconnect handles cfg connect [<name>] (without --bundle).
+func runConnectReconnect(ctx context.Context, args []string) error {
+	reg, err := newConnectionRegistry()
+	if err != nil {
+		return fmt.Errorf("open connection registry: %w", err)
+	}
+
+	// Resolve the connection name.
+	name := connectName
+	if name == "" && len(args) > 0 {
+		name = args[0]
+	}
+	if name == "" {
+		entries, err := reg.List()
+		if err != nil {
+			return fmt.Errorf("list connections: %w", err)
+		}
+		switch len(entries) {
+		case 0:
+			return fmt.Errorf("no connections registered; use --bundle --url for first-time connect")
+		case 1:
+			name = entries[0].Name
+		default:
+			// Present a numbered selection on stdin.
+			fmt.Println("Multiple connections available:")
+			for i, e := range entries {
+				fmt.Printf("  %d) %s (%s)\n", i+1, e.Name, e.ControllerURL)
+			}
+			fmt.Print("Select number: ")
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				var idx int
+				if _, err := fmt.Sscanf(scanner.Text(), "%d", &idx); err != nil || idx < 1 || idx > len(entries) {
+					return fmt.Errorf("invalid selection")
+				}
+				name = entries[idx-1].Name
+			}
+		}
+	}
+
+	entry, err := reg.Get(name)
+	if err != nil {
+		return fmt.Errorf("get connection %q: %w", name, err)
+	}
+	if entry == nil {
+		return fmt.Errorf("connection %q not found", name)
+	}
+
+	// Unlock stored credential (machine-bound decrypt — no interactive passphrase).
+	credStore, err := newCredentialStore()
+	if err != nil {
+		return fmt.Errorf("open credential store: %w", err)
+	}
+	bundleBytes, err := credStore.Load(ctx, name)
+	if err != nil {
+		return fmt.Errorf("load credential %q: %w", name, err)
+	}
+
+	b, err := parseBundleBytes(bundleBytes)
+	if err != nil {
+		return fmt.Errorf("parse stored bundle: %w", err)
+	}
+
+	client, err := newClientFromBundleData(b, entry.ControllerURL)
+	if err != nil {
+		return fmt.Errorf("build mTLS client: %w", err)
+	}
+	sessResp, err := client.IssueSession(ctx, name)
+	if err != nil {
+		return fmt.Errorf("issue session: %w", err)
+	}
+
+	if err := storeSessionToken(&sessionRecord{
+		Token:          sessResp.Token,
+		SessionID:      sessResp.SessionID,
+		ControllerURL:  entry.ControllerURL,
+		ConnectionName: name,
+		AbsoluteExpiry: sessResp.AbsoluteExpiry,
+		CACertPEM:      b.CAPEM,
+	}); err != nil {
+		return fmt.Errorf("store session token: %w", err)
+	}
+
+	// Update last-used timestamp (non-fatal).
+	_ = reg.UpdateLastUsed(name, time.Now())
+
+	fmt.Printf("Reconnected as %q (expires %s)\n", name, sessResp.AbsoluteExpiry.Format(time.RFC3339))
+	return nil
+}
+
+func runDisconnect(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	rec, err := loadSessionToken()
+	if err != nil {
+		return fmt.Errorf("load session token: %w", err)
+	}
+	if rec == nil {
+		fmt.Println("No active session.")
+		return nil
+	}
+
+	// Authenticate the revoke request with the stored session token (Bearer).
+	// Use the stored CA cert so the TLS verification matches the original connect.
+	// Nil when empty → system cert pool (public CA controllers).
+	var caCertPEM []byte
+	if rec.CACertPEM != "" {
+		caCertPEM = []byte(rec.CACertPEM)
+	}
+	client, err := NewAPIClient(&APIClientConfig{
+		BaseURL:   rec.ControllerURL,
+		APIKey:    rec.Token,
+		CACertPEM: caCertPEM,
+	})
+	if err != nil {
+		return fmt.Errorf("build client: %w", err)
+	}
+
+	// Revoke server-side (best-effort: proceed even on error).
+	if err := client.RevokeSession(ctx, rec.SessionID); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: server-side revoke failed: %v\n", err)
+	}
+
+	// Remove token from OS keychain.
+	if err := deleteSessionToken(); err != nil {
+		return fmt.Errorf("delete session token: %w", err)
+	}
+
+	// Lock credential (no-op for machine-bound unlocker).
+	if rec.ConnectionName != "" {
+		if credStore, err := newCredentialStore(); err == nil {
+			_ = credStore.Lock(ctx, rec.ConnectionName)
+		}
+	}
+
+	// Update last-used in registry (non-fatal).
+	if rec.ConnectionName != "" {
+		if reg, err := newConnectionRegistry(); err == nil {
+			_ = reg.UpdateLastUsed(rec.ConnectionName, time.Now())
+		}
+	}
+
+	fmt.Printf("Disconnected from %q.\n", rec.ConnectionName)
+	return nil
+}

--- a/cmd/cfg/cmd/connect_test.go
+++ b/cmd/cfg/cmd/connect_test.go
@@ -417,6 +417,8 @@ func TestConnectReconnectDisconnect(t *testing.T) {
 		)
 		require.NoError(t, rErr, "command %d: request error", i)
 		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"command %d: session Bearer token must be accepted by the controller", i)
 	}
 
 	assert.Equal(t, int64(1), atomic.LoadInt64(&unlockCount),

--- a/cmd/cfg/cmd/connect_test.go
+++ b/cmd/cfg/cmd/connect_test.go
@@ -1,0 +1,791 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	certbundle "github.com/cfgis/cfgms/pkg/cert/bundle"
+	"github.com/cfgis/cfgms/pkg/credential"
+	"github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+// ── in-memory SecretStore for tests ──────────────────────────────────────────
+
+// testSessionStore is a thread-safe in-memory SecretStore for injecting via sessionStoreFn.
+type testSessionStore struct {
+	mu      sync.Mutex
+	secrets map[string]string
+}
+
+func newTestSessionStore() *testSessionStore {
+	return &testSessionStore{secrets: make(map[string]string)}
+}
+
+func (s *testSessionStore) StoreSecret(_ context.Context, req *interfaces.SecretRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.secrets[req.Key] = req.Value
+	return nil
+}
+
+func (s *testSessionStore) GetSecret(_ context.Context, key string) (*interfaces.Secret, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.secrets[key]
+	if !ok {
+		return nil, interfaces.ErrSecretNotFound
+	}
+	return &interfaces.Secret{Key: key, Value: v}, nil
+}
+
+func (s *testSessionStore) DeleteSecret(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.secrets[key]; !ok {
+		return interfaces.ErrSecretNotFound
+	}
+	delete(s.secrets, key)
+	return nil
+}
+
+func (s *testSessionStore) ListSecrets(_ context.Context, _ *interfaces.SecretFilter) ([]*interfaces.SecretMetadata, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *testSessionStore) GetSecrets(_ context.Context, _ []string) (map[string]*interfaces.Secret, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *testSessionStore) StoreSecrets(_ context.Context, _ map[string]*interfaces.SecretRequest) error {
+	return errors.New("not implemented")
+}
+func (s *testSessionStore) GetSecretVersion(_ context.Context, _ string, _ int) (*interfaces.Secret, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *testSessionStore) ListSecretVersions(_ context.Context, _ string) ([]*interfaces.SecretVersion, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *testSessionStore) GetSecretMetadata(_ context.Context, _ string) (*interfaces.SecretMetadata, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *testSessionStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return errors.New("not implemented")
+}
+func (s *testSessionStore) RotateSecret(_ context.Context, _ string, _ string) error {
+	return errors.New("not implemented")
+}
+func (s *testSessionStore) ExpireSecret(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+func (s *testSessionStore) HealthCheck(_ context.Context) error { return nil }
+func (s *testSessionStore) Close() error                        { return nil }
+
+// ── counting CredentialUnlocker ───────────────────────────────────────────────
+
+// countingUnlocker wraps a real MachineUnlocker and counts Unlock invocations.
+type countingUnlocker struct {
+	underlying credential.CredentialUnlocker
+	count      *int64
+}
+
+func (u *countingUnlocker) Unlock(ctx context.Context, name string) ([]byte, error) {
+	atomic.AddInt64(u.count, 1)
+	return u.underlying.Unlock(ctx, name)
+}
+
+func (u *countingUnlocker) Lock(ctx context.Context, name string) error {
+	return u.underlying.Lock(ctx, name)
+}
+
+// ── HTTPS session test server ─────────────────────────────────────────────────
+
+// sessionStub is a minimal HTTPS server that handles /api/v1/sessions endpoints.
+// It tracks issued and revoked sessions for the test assertions.
+type sessionStub struct {
+	mu       sync.Mutex
+	sessions map[string]string // sessionID → token
+	revoked  map[string]bool   // sessionID → revoked
+	requests []string          // method+path log for assertions
+}
+
+func (s *sessionStub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	s.requests = append(s.requests, r.Method+" "+r.URL.Path)
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
+		s.mu.Lock()
+		id := "sess-test-id"
+		tok := strings.Repeat("A", 43) // exactly 43 chars
+		s.sessions[id] = tok
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(sessionIssueResponse{
+			SessionID:      id,
+			Token:          tok,
+			IssuedAt:       time.Now(),
+			IdleTTLSeconds: 900,
+			AbsoluteExpiry: time.Now().Add(8 * time.Hour),
+		})
+
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/sessions/"):
+		id := strings.TrimPrefix(r.URL.Path, "/api/v1/sessions/")
+		s.mu.Lock()
+		s.revoked[id] = true
+		delete(s.sessions, id)
+		s.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": id, "revoked": true})
+
+	default:
+		// For other requests, check if the bearer token belongs to a live session.
+		authHeader := r.Header.Get("Authorization")
+		tok := strings.TrimPrefix(authHeader, "Bearer ")
+		s.mu.Lock()
+		live := false
+		for _, t := range s.sessions {
+			if t == tok {
+				live = true
+				break
+			}
+		}
+		s.mu.Unlock()
+		if !live && authHeader != "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "SESSION_REVOKED"})
+			return
+		}
+		// Any other live-session request → 200 OK.
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}
+}
+
+// ── certificate helpers ───────────────────────────────────────────────────────
+
+type testCerts struct {
+	caKey      *ecdsa.PrivateKey
+	caCertDER  []byte
+	caCert     *x509.Certificate
+	caCertPEM  []byte
+	serverCert tls.Certificate
+	clientCert *certbundle.Bundle // ready to write
+}
+
+func generateConnectTestCerts(t *testing.T, serverURL string) *testCerts {
+	t.Helper()
+
+	// CA
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	// Server cert (valid for 127.0.0.1 / localhost so the TLS client trusts it).
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+	}
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+	serverKeyBytes, err := x509.MarshalECPrivateKey(serverKey)
+	require.NoError(t, err)
+	serverTLSCert, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyBytes}),
+	)
+	require.NoError(t, err)
+
+	// Client cert
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "test-admin"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+	clientKeyBytes, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+
+	return &testCerts{
+		caKey:      caKey,
+		caCertDER:  caCertDER,
+		caCert:     caCert,
+		caCertPEM:  caCertPEM,
+		serverCert: serverTLSCert,
+		clientCert: &certbundle.Bundle{
+			CertPEM:      string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})),
+			KeyPEM:       string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyBytes})),
+			CAPEM:        string(caCertPEM),
+			AuditSubject: "test:admin",
+		},
+	}
+}
+
+// startSessionServer creates and starts an HTTPS server backed by stub.
+func startSessionServer(t *testing.T, certs *testCerts, stub *sessionStub) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewUnstartedServer(stub)
+	ts.TLS = &tls.Config{
+		Certificates: []tls.Certificate{certs.serverCert},
+		ClientAuth:   tls.NoClientCert,
+		MinVersion:   tls.VersionTLS12,
+	}
+	ts.StartTLS()
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// ── override helpers ──────────────────────────────────────────────────────────
+
+// overrideSessionStore replaces sessionStoreFn with one that returns store.
+func overrideSessionStore(t *testing.T, store interfaces.SecretStore) {
+	t.Helper()
+	orig := sessionStoreFn
+	sessionStoreFn = func() (interfaces.SecretStore, error) { return store, nil }
+	t.Cleanup(func() { sessionStoreFn = orig })
+}
+
+// overrideConnectFlags saves and restores all connect command-level flag vars.
+func overrideConnectFlags(t *testing.T) {
+	t.Helper()
+	origBundle := connectBundlePath
+	origURL := connectURL
+	origName := connectName
+	origGlobalBundle := bundlePath
+	origNoBundle := noBundle
+	t.Cleanup(func() {
+		connectBundlePath = origBundle
+		connectURL = origURL
+		connectName = origName
+		bundlePath = origGlobalBundle
+		noBundle = origNoBundle
+	})
+}
+
+// ── TestConnectReconnectDisconnect ────────────────────────────────────────────
+
+func TestConnectReconnectDisconnect(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate CA, server, and client certificates.
+	certs := generateConnectTestCerts(t, "")
+
+	// Start the HTTPS session stub server.
+	stub := &sessionStub{
+		sessions: make(map[string]string),
+		revoked:  make(map[string]bool),
+	}
+	srv := startSessionServer(t, certs, stub)
+
+	// Set the bundle's ControllerURL to the actual server address.
+	certs.clientCert.ControllerURL = srv.URL
+	bundleFile := filepath.Join(tmpDir, "admin.bundle.yaml")
+	require.NoError(t, certbundle.Write(bundleFile, certs.clientCert))
+
+	// Inject in-memory session store (no disk writes for session token).
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	// Override connection registry + credential dirs to temp dirs.
+	withTempConfigDir(t)
+	credDir := t.TempDir()
+	origCredDir := credentialsDirFn
+	credentialsDirFn = func() (string, error) { return credDir, nil }
+	t.Cleanup(func() { credentialsDirFn = origCredDir })
+
+	// Inject a counting unlocker so we can assert unlock call count.
+	var unlockCount int64
+	origUnlockerFn := credentialStoreUnlockerFn
+	credentialStoreUnlockerFn = func(dir string) (credential.CredentialUnlocker, error) {
+		real, err := credential.NewMachineUnlocker(dir)
+		if err != nil {
+			return nil, err
+		}
+		return &countingUnlocker{underlying: real, count: &unlockCount}, nil
+	}
+	t.Cleanup(func() { credentialStoreUnlockerFn = origUnlockerFn })
+
+	overrideConnectFlags(t)
+
+	// ── Phase 1: first-time connect ──────────────────────────────────────────
+	connectBundlePath = bundleFile
+	connectURL = srv.URL
+	connectName = "test-ctrl"
+	bundlePath = ""
+	noBundle = false
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runConnect(connectCmd, nil))
+	})
+	assert.Contains(t, out, "Connected as")
+	assert.Contains(t, out, "test-ctrl")
+
+	// Token must be in the in-memory store, not in any file.
+	rec, err := loadSessionToken()
+	require.NoError(t, err)
+	require.NotNil(t, rec, "session token must be stored after connect")
+	assert.Equal(t, "sess-test-id", rec.SessionID)
+	assert.Equal(t, srv.URL, rec.ControllerURL)
+	assert.False(t, rec.AbsoluteExpiry.IsZero())
+
+	// Verify no token file exists anywhere in the credential directory.
+	entries, err := os.ReadDir(credDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "token",
+			"no token file must appear in the credential dir: %s", e.Name())
+		assert.NotContains(t, e.Name(), "session",
+			"no session file must appear in the credential dir: %s", e.Name())
+	}
+
+	// ── Phase 2: reconnect ───────────────────────────────────────────────────
+	// Clear first-time flags; use the stored name.
+	connectBundlePath = ""
+	connectURL = ""
+	connectName = ""
+
+	out = captureStdout(t, func() {
+		require.NoError(t, runConnect(connectCmd, []string{"test-ctrl"}))
+	})
+	assert.Contains(t, out, "Reconnected as")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&unlockCount),
+		"unlocker must be invoked exactly once (during reconnect)")
+
+	// ── Phase 3: N session-backed commands must NOT invoke the unlocker ──────
+	// After reconnect the session token is stored; resolveSessionOrBundleClient
+	// uses it without touching the credential store.
+	bundlePath = ""
+	noBundle = false
+
+	const N = 3
+	for i := range N {
+		client, cErr := resolveSessionOrBundleClient("")
+		require.NoError(t, cErr, "command %d: resolve client", i)
+		require.NotNil(t, client, "command %d: session client must not be nil", i)
+
+		// Simulate a command request against the stub.
+		resp, rErr := client.doRequestWithContentType(
+			context.Background(), http.MethodGet, "/api/v1/status", nil, "",
+		)
+		require.NoError(t, rErr, "command %d: request error", i)
+		_ = resp.Body.Close()
+	}
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&unlockCount),
+		"session-backed commands must not invoke the credential unlocker")
+
+	// ── Phase 4: disconnect ──────────────────────────────────────────────────
+	storedToken := store.secrets[sessionTokenKey] // capture before delete
+	out = captureStdout(t, func() {
+		require.NoError(t, runDisconnect(disconnectCmd, nil))
+	})
+	assert.Contains(t, out, "Disconnected")
+
+	// Token must be removed from the in-memory store.
+	rec, err = loadSessionToken()
+	require.NoError(t, err)
+	assert.Nil(t, rec, "session token must be removed from store after disconnect")
+
+	// Verify the stub received a DELETE /api/v1/sessions/{id}.
+	stub.mu.Lock()
+	revokedOK := stub.revoked["sess-test-id"]
+	stub.mu.Unlock()
+	assert.True(t, revokedOK, "server must have recorded the session as revoked")
+
+	// ── Phase 5: verify controller-side 401 after disconnect ─────────────────
+	// Extract the raw session token from the stored JSON (it was valid before disconnect).
+	var preRevoke sessionRecord
+	require.NoError(t, json.Unmarshal([]byte(storedToken), &preRevoke))
+
+	revokedClient, err := NewAPIClient(&APIClientConfig{
+		BaseURL:     srv.URL,
+		APIKey:      preRevoke.Token,
+		TLSInsecure: true,
+	})
+	require.NoError(t, err)
+
+	resp, err := revokedClient.doRequestWithContentType(
+		context.Background(), http.MethodGet, "/api/v1/status", nil, "",
+	)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"revoked session token must return 401 from the controller")
+}
+
+// ── TestBundleOverrideBypassesSession ────────────────────────────────────────
+
+// TestBundleOverrideBypassesSession verifies that a --bundle invocation does not
+// read the session token store and uses bundle auth even when a valid stored
+// session exists.
+func TestBundleOverrideBypassesSession(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Plant a valid (non-expired) session token in the store.
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	var storeReadCount int64
+	orig := sessionStoreFn
+	sessionStoreFn = func() (interfaces.SecretStore, error) {
+		atomic.AddInt64(&storeReadCount, 1)
+		return store, nil
+	}
+	t.Cleanup(func() { sessionStoreFn = orig })
+
+	// Store a fake valid session.
+	require.NoError(t, storeSessionToken(&sessionRecord{
+		Token:          strings.Repeat("B", 43),
+		SessionID:      "fake-session",
+		ControllerURL:  "https://session-ctrl.example.com",
+		ConnectionName: "session-conn",
+		AbsoluteExpiry: time.Now().Add(8 * time.Hour),
+	}))
+	// Reset count after seed call.
+	atomic.StoreInt64(&storeReadCount, 0)
+
+	// Create a bundle that points to a test HTTP server.
+	bundleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer bundleServer.Close()
+
+	bundleFile := filepath.Join(tmpDir, "admin.bundle.yaml")
+	generateTestBundleFile(t, bundleFile, bundleServer.URL)
+
+	// Call resolveSessionOrBundleClient with bundlePath set (simulates --bundle flag).
+	origBundlePath := bundlePath
+	t.Cleanup(func() { bundlePath = origBundlePath })
+	bundlePath = bundleFile
+
+	client, err := resolveSessionOrBundleClient("")
+	require.NoError(t, err)
+	require.NotNil(t, client, "bundle client must be returned when --bundle is set")
+
+	// The client must use the bundle URL, not the session's ControllerURL.
+	assert.Equal(t, bundleServer.URL, client.baseURL,
+		"resolved client must use bundle URL, not session URL")
+
+	// The session store must NOT have been queried for the bypass path.
+	assert.Equal(t, int64(0), atomic.LoadInt64(&storeReadCount),
+		"session store must not be read when --bundle flag is set")
+}
+
+// ── TestRequireHTTPS ──────────────────────────────────────────────────────────
+
+func TestRequireHTTPS_RejectsHTTPNonLoopback(t *testing.T) {
+	err := requireHTTPS("http://controller.example.com:9443")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires HTTPS", "error message must mention HTTPS requirement")
+}
+
+func TestRequireHTTPS_AllowsHTTPSNonLoopback(t *testing.T) {
+	assert.NoError(t, requireHTTPS("https://controller.example.com:9443"))
+}
+
+func TestRequireHTTPS_AllowsHTTPLoopback(t *testing.T) {
+	assert.NoError(t, requireHTTPS("http://localhost:9080"))
+	assert.NoError(t, requireHTTPS("http://127.0.0.1:9080"))
+}
+
+// ── TestDisconnect_NoActiveSession ────────────────────────────────────────────
+
+func TestDisconnect_NoActiveSession(t *testing.T) {
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runDisconnect(disconnectCmd, nil))
+	})
+	assert.Contains(t, out, "No active session")
+}
+
+// ── TestConnectionsCurrent ────────────────────────────────────────────────────
+
+func TestConnectionsCurrent_ActiveSession(t *testing.T) {
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	expiry := time.Now().Add(8 * time.Hour)
+	require.NoError(t, storeSessionToken(&sessionRecord{
+		Token:          strings.Repeat("C", 43),
+		SessionID:      "sess-current-test",
+		ControllerURL:  "https://ctrl.example.com",
+		ConnectionName: "prod",
+		AbsoluteExpiry: expiry,
+	}))
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runConnectionsCurrent(connectionsCurrentCmd, nil))
+	})
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "https://ctrl.example.com")
+	assert.Contains(t, out, "sess-current-test")
+}
+
+func TestConnectionsCurrent_NoSession(t *testing.T) {
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runConnectionsCurrent(connectionsCurrentCmd, nil))
+	})
+	assert.Contains(t, out, "no active session")
+}
+
+func TestConnectionsCurrent_ExpiredSession(t *testing.T) {
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	require.NoError(t, storeSessionToken(&sessionRecord{
+		Token:          strings.Repeat("D", 43),
+		SessionID:      "expired",
+		ControllerURL:  "https://ctrl.example.com",
+		ConnectionName: "old",
+		AbsoluteExpiry: time.Now().Add(-time.Hour), // in the past
+	}))
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runConnectionsCurrent(connectionsCurrentCmd, nil))
+	})
+	assert.Contains(t, out, "no active session")
+}
+
+// ── TestDeriveConnectionName ──────────────────────────────────────────────────
+
+func TestDeriveConnectionName(t *testing.T) {
+	cases := []struct{ url, want string }{
+		{"https://ctrl.example.com:9443", "ctrl.example.com"},
+		{"https://ctrl.example.com", "ctrl.example.com"},
+		{"http://localhost:9080", "localhost"},
+		{"not-a-url", "default"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, deriveConnectionName(c.url), "url=%s", c.url)
+	}
+}
+
+// ── TestSessionTokenRoundTrip ─────────────────────────────────────────────────
+
+func TestSessionTokenRoundTrip(t *testing.T) {
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	want := &sessionRecord{
+		Token:          strings.Repeat("E", 43),
+		SessionID:      "round-trip-id",
+		ControllerURL:  "https://ctrl.local:9443",
+		ConnectionName: "local",
+		AbsoluteExpiry: time.Now().Add(8 * time.Hour).Truncate(time.Second),
+	}
+	require.NoError(t, storeSessionToken(want))
+
+	got, err := loadSessionToken()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, want.Token, got.Token)
+	assert.Equal(t, want.SessionID, got.SessionID)
+	assert.Equal(t, want.ControllerURL, got.ControllerURL)
+	assert.Equal(t, want.ConnectionName, got.ConnectionName)
+	assert.WithinDuration(t, want.AbsoluteExpiry, got.AbsoluteExpiry, time.Second)
+
+	require.NoError(t, deleteSessionToken())
+	got, err = loadSessionToken()
+	require.NoError(t, err)
+	assert.Nil(t, got, "deleted token must not be loadable")
+}
+
+// ── TestUpdateSessionToken ────────────────────────────────────────────────────
+
+func TestUpdateSessionToken(t *testing.T) {
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	require.NoError(t, storeSessionToken(&sessionRecord{
+		Token:          "old-token",
+		SessionID:      "up-sid",
+		ControllerURL:  "https://ctrl.local",
+		ConnectionName: "upd",
+		AbsoluteExpiry: time.Now().Add(time.Hour),
+	}))
+
+	require.NoError(t, updateSessionToken("new-token"))
+
+	got, err := loadSessionToken()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "new-token", got.Token, "token must be updated")
+	assert.Equal(t, "up-sid", got.SessionID, "session ID must be unchanged")
+}
+
+// ── TestResolveSessionOrBundleClient_Expiry ───────────────────────────────────
+
+func TestResolveSessionOrBundleClient_ExpiredTokenFallsThrough(t *testing.T) {
+	store := newTestSessionStore()
+	overrideSessionStore(t, store)
+
+	// Store an expired session.
+	require.NoError(t, storeSessionToken(&sessionRecord{
+		Token:          strings.Repeat("F", 43),
+		SessionID:      "expired-sess",
+		ControllerURL:  "https://ctrl.example.com",
+		ConnectionName: "exp",
+		AbsoluteExpiry: time.Now().Add(-time.Hour),
+	}))
+
+	origBundlePath := bundlePath
+	origNoBundle := noBundle
+	t.Cleanup(func() {
+		bundlePath = origBundlePath
+		noBundle = origNoBundle
+	})
+	bundlePath = ""
+	noBundle = true // force nil return from resolveBundleClient
+
+	client, err := resolveSessionOrBundleClient("")
+	require.NoError(t, err)
+	assert.Nil(t, client, "expired session must fall through to bundle client (nil when no bundle)")
+}
+
+// ── TestAPIClientOnTokenRenewed ───────────────────────────────────────────────
+
+func TestAPIClientOnTokenRenewed(t *testing.T) {
+	var capturedToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Session-Token", "renewed-token-value")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewAPIClient(&APIClientConfig{
+		BaseURL: srv.URL,
+		OnTokenRenewed: func(tok string) error {
+			capturedToken = tok
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := client.doRequestWithContentType(context.Background(), http.MethodGet, "/", nil, "")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, "renewed-token-value", capturedToken,
+		"OnTokenRenewed must be called with the header value")
+}
+
+// ── TestAPIClientOnUnauthorizedFallback ───────────────────────────────────────
+
+func TestAPIClientOnUnauthorizedFallback(t *testing.T) {
+	callCount := 0
+	fallbackCalled := false
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"SESSION_REVOKED"}`))
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer fallback.Close()
+
+	fallbackClient, err := NewAPIClient(&APIClientConfig{BaseURL: fallback.URL})
+	require.NoError(t, err)
+
+	client, err := NewAPIClient(&APIClientConfig{
+		BaseURL: primary.URL,
+		OnUnauthorized: func() (*APIClient, error) {
+			return fallbackClient, nil
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := client.doRequestWithContentType(context.Background(), http.MethodGet, "/", nil, "")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "fallback client response must be returned")
+	assert.True(t, fallbackCalled, "fallback server must be called on 401")
+	assert.Equal(t, 1, callCount, "primary server must be called exactly once")
+}
+
+// ── TestConnectFirstTime_HTTPSGuard ───────────────────────────────────────────
+
+func TestConnectFirstTime_HTTPSGuard(t *testing.T) {
+	origBundle := connectBundlePath
+	origURL := connectURL
+	origName := connectName
+	t.Cleanup(func() {
+		connectBundlePath = origBundle
+		connectURL = origURL
+		connectName = origName
+	})
+
+	// Write a dummy bundle file so the file read doesn't fail first.
+	tmpDir := t.TempDir()
+	bundleFile := filepath.Join(tmpDir, "admin.bundle.yaml")
+	require.NoError(t, os.WriteFile(bundleFile, []byte("cert_pem: ''\nkey_pem: ''\nca_pem: ''\n"), 0600))
+
+	connectBundlePath = bundleFile
+	connectURL = "http://controller.example.com:9443" // non-loopback http://
+	connectName = "guard-test"
+
+	err := runConnect(connectCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires HTTPS")
+}

--- a/cmd/cfg/cmd/connections.go
+++ b/cmd/cfg/cmd/connections.go
@@ -46,6 +46,7 @@ Examples:
 func init() {
 	connectionsListCmd.Flags().BoolVar(&connectionsListJSON, "json", false, "Emit JSON array instead of human-readable table")
 	connectionsCmd.AddCommand(connectionsListCmd)
+	connectionsCmd.AddCommand(connectionsCurrentCmd)
 }
 
 func runConnectionsList(cmd *cobra.Command, args []string) error {
@@ -87,4 +88,38 @@ func runConnectionsList(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return w.Flush()
+}
+
+var connectionsCurrentCmd = &cobra.Command{
+	Use:   "current",
+	Short: "Show the active session from the token store and connection registry",
+	Long: `Print the active session details (connection name, controller URL, session ID, expiry)
+sourced from the OS-native secret store.
+
+Exits 0 and prints "no active session" when no session token is stored or the
+stored token has passed its absolute expiry.`,
+	RunE: runConnectionsCurrent,
+}
+
+func runConnectionsCurrent(cmd *cobra.Command, args []string) error {
+	rec, err := loadSessionToken()
+	if err != nil {
+		return fmt.Errorf("load session token: %w", err)
+	}
+	if rec == nil {
+		fmt.Println("no active session")
+		return nil
+	}
+
+	// Treat an expired token the same as absent.
+	if rec.AbsoluteExpiry.Before(time.Now()) {
+		fmt.Println("no active session (token expired)")
+		return nil
+	}
+
+	fmt.Printf("Connection: %s\n", rec.ConnectionName)
+	fmt.Printf("URL:        %s\n", rec.ControllerURL)
+	fmt.Printf("Session ID: %s\n", rec.SessionID)
+	fmt.Printf("Expires:    %s\n", rec.AbsoluteExpiry.Format(time.RFC3339))
+	return nil
 }

--- a/cmd/cfg/cmd/controller.go
+++ b/cmd/cfg/cmd/controller.go
@@ -165,7 +165,7 @@ func getControllerClient() (*APIClient, error) {
 	}
 
 	// Try admin bundle first (mTLS auto-discovery)
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/credential_store.go
+++ b/cmd/cfg/cmd/credential_store.go
@@ -12,6 +12,12 @@ import (
 	"github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
+// credentialStoreUnlockerFn creates the CredentialUnlocker for newCredentialStore.
+// Overridable in tests to inject a counting or stub unlocker.
+var credentialStoreUnlockerFn = func(dir string) (credential.CredentialUnlocker, error) {
+	return credential.NewMachineUnlocker(dir)
+}
+
 // credentialsDirFn is overridable in tests to avoid touching real user config directories.
 var credentialsDirFn = defaultCredentialsDir
 
@@ -48,7 +54,7 @@ func newCredentialStore() (*CredentialStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("credential store: init encryptor: %w", err)
 	}
-	unlocker, err := credential.NewMachineUnlocker(dir)
+	unlocker, err := credentialStoreUnlockerFn(dir)
 	if err != nil {
 		return nil, fmt.Errorf("credential store: init unlocker: %w", err)
 	}

--- a/cmd/cfg/cmd/installer.go
+++ b/cmd/cfg/cmd/installer.go
@@ -141,7 +141,7 @@ func getInstallerClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/module.go
+++ b/cmd/cfg/cmd/module.go
@@ -121,7 +121,7 @@ func getModuleAPIClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/refresh.go
+++ b/cmd/cfg/cmd/refresh.go
@@ -186,7 +186,7 @@ func getRefreshClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/registration.go
+++ b/cmd/cfg/cmd/registration.go
@@ -199,7 +199,7 @@ func getRegistrationClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -61,6 +61,8 @@ func init() {
 	rootCmd.AddCommand(installerCmd)
 	rootCmd.AddCommand(moduleCmd)
 	rootCmd.AddCommand(connectionsCmd)
+	rootCmd.AddCommand(connectCmd)
+	rootCmd.AddCommand(disconnectCmd)
 }
 
 // versionCmd represents the version command

--- a/cmd/cfg/cmd/script.go
+++ b/cmd/cfg/cmd/script.go
@@ -146,7 +146,7 @@ func getScriptLibClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/session_token.go
+++ b/cmd/cfg/cmd/session_token.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	_ "github.com/cfgis/cfgms/pkg/secrets/providers/oskeychain" // register OS-keychain provider
+)
+
+// sessionTokenKey is the key used to store the active session record in the OS keychain.
+const sessionTokenKey = "cfgms/active-session"
+
+// sessionRecord holds the active session state stored in the OS-native secret store.
+// No token material is ever written to a file on disk.
+type sessionRecord struct {
+	Token          string    `json:"token"`
+	SessionID      string    `json:"session_id"`
+	ControllerURL  string    `json:"controller_url"`
+	ConnectionName string    `json:"connection_name"`
+	AbsoluteExpiry time.Time `json:"absolute_expiry"`
+	CACertPEM      string    `json:"ca_cert_pem,omitempty"` // CA used to verify the controller; empty → system pool
+}
+
+// sessionStoreFn opens the OS-native secret store for session token management.
+// Overridable in tests to inject an in-memory SecretStore.
+var sessionStoreFn = openSessionStore
+
+// openSessionStore opens the oskeychain SecretStore.
+// Returns (nil, nil) when the provider is unavailable on this platform.
+func openSessionStore() (interfaces.SecretStore, error) {
+	p, err := interfaces.GetSecretProvider("oskeychain")
+	if err != nil {
+		return nil, nil // provider not registered; treat as unavailable
+	}
+	avail, err := p.Available()
+	if err != nil || !avail {
+		return nil, nil // keychain service not reachable on this system
+	}
+	store, err := p.CreateSecretStore(map[string]interface{}{})
+	if err != nil {
+		return nil, fmt.Errorf("session store: create: %w", err)
+	}
+	return store, nil
+}
+
+// storeSessionToken serialises rec as JSON and writes it to the OS keychain.
+// Returns an error if the store is unavailable or the write fails.
+func storeSessionToken(rec *sessionRecord) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("session token: marshal: %w", err)
+	}
+	store, err := sessionStoreFn()
+	if err != nil {
+		return fmt.Errorf("session token: open store: %w", err)
+	}
+	if store == nil {
+		return fmt.Errorf("session token: OS secret store unavailable")
+	}
+	return store.StoreSecret(context.Background(), &interfaces.SecretRequest{
+		Key:   sessionTokenKey,
+		Value: string(data),
+	})
+}
+
+// loadSessionToken reads and deserialises the active session record from the OS keychain.
+// Returns (nil, nil) when no session is stored or the store is unavailable.
+func loadSessionToken() (*sessionRecord, error) {
+	store, err := sessionStoreFn()
+	if err != nil || store == nil {
+		return nil, nil // treat unavailability as "no session"
+	}
+	secret, err := store.GetSecret(context.Background(), sessionTokenKey)
+	if err != nil {
+		if errors.Is(err, interfaces.ErrSecretNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("session token: get: %w", err)
+	}
+	var rec sessionRecord
+	if err := json.Unmarshal([]byte(secret.Value), &rec); err != nil {
+		return nil, fmt.Errorf("session token: decode: %w", err)
+	}
+	return &rec, nil
+}
+
+// updateSessionToken replaces only the token field in the stored session record.
+// Called by the OnTokenRenewed callback after each rolling-renewal response.
+func updateSessionToken(newToken string) error {
+	store, err := sessionStoreFn()
+	if err != nil || store == nil {
+		return nil // best-effort; don't fail commands on keychain hiccups
+	}
+	secret, err := store.GetSecret(context.Background(), sessionTokenKey)
+	if err != nil {
+		return fmt.Errorf("session token: load for update: %w", err)
+	}
+	var rec sessionRecord
+	if err := json.Unmarshal([]byte(secret.Value), &rec); err != nil {
+		return fmt.Errorf("session token: decode for update: %w", err)
+	}
+	rec.Token = newToken
+	data, err := json.Marshal(&rec)
+	if err != nil {
+		return fmt.Errorf("session token: marshal for update: %w", err)
+	}
+	return store.StoreSecret(context.Background(), &interfaces.SecretRequest{
+		Key:   sessionTokenKey,
+		Value: string(data),
+	})
+}
+
+// deleteSessionToken removes the active session record from the OS keychain.
+// Returns nil when the key is not present (idempotent).
+func deleteSessionToken() error {
+	store, err := sessionStoreFn()
+	if err != nil || store == nil {
+		return nil // nothing to delete
+	}
+	if err := store.DeleteSecret(context.Background(), sessionTokenKey); err != nil {
+		if errors.Is(err, interfaces.ErrSecretNotFound) {
+			return nil
+		}
+		return fmt.Errorf("session token: delete: %w", err)
+	}
+	return nil
+}

--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -429,7 +429,7 @@ func getStewardClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/tenant.go
+++ b/cmd/cfg/cmd/tenant.go
@@ -72,7 +72,7 @@ func getTenantAPIClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/token.go
+++ b/cmd/cfg/cmd/token.go
@@ -212,10 +212,10 @@ func getAPIClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	// Try admin bundle first (mTLS auto-discovery)
-	client, err := resolveBundleClient(apiURL)
+	// Try active session token first, then admin bundle (mTLS auto-discovery).
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
-		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+		return nil, fmt.Errorf("client lookup failed: %w", err)
 	}
 	if client != nil {
 		return client, nil

--- a/cmd/cfg/cmd/trace.go
+++ b/cmd/cfg/cmd/trace.go
@@ -66,7 +66,7 @@ func getTraceClient() (*APIClient, error) {
 	}
 
 	// Try admin bundle first (mTLS auto-discovery)
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/cmd/cfg/cmd/workflow.go
+++ b/cmd/cfg/cmd/workflow.go
@@ -86,7 +86,7 @@ func getWorkflowClient() (*APIClient, error) {
 		apiURL = os.Getenv("CFGMS_API_URL")
 	}
 
-	client, err := resolveBundleClient(apiURL)
+	client, err := resolveSessionOrBundleClient(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("bundle lookup failed: %w", err)
 	}

--- a/docs/development/commands-reference.md
+++ b/docs/development/commands-reference.md
@@ -379,6 +379,74 @@ For automation of these commands, use the CFGMS slash commands: `/story-start`, 
 
 ## Connection Management
 
+`cfg connect` and `cfg disconnect` manage zero-standing-privilege controller sessions. The session token is stored exclusively in the OS-native secret store (macOS Keychain, Windows Credential Manager, Linux Secret Service) — never written to any file on disk.
+
+### cfg connect (first-time import)
+
+Import an admin bundle and start a controller session.
+
+```bash
+cfg connect --bundle /path/to/admin.bundle.yaml --url https://controller:9443
+cfg connect --bundle /path/to/admin.bundle.yaml --url https://controller:9443 --name prod
+```
+
+The `--url` value must be HTTPS for any non-loopback address. On success the bundle is stored encrypted (machine-bound), a session token is issued via `POST /api/v1/sessions`, and the token is written to the OS keychain.
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--bundle` | — | Path to the admin bundle YAML (required for first-time import) |
+| `--url` | — | Controller HTTPS URL (required with `--bundle`; must be HTTPS for non-loopback) |
+| `--name` | derived from URL host | Human-readable connection name stored in the local registry |
+
+### cfg connect (reconnect)
+
+Re-use a previously registered connection without re-importing the bundle.
+
+```bash
+# Reconnect by name
+cfg connect prod
+
+# Auto-select when exactly one connection is registered
+cfg connect
+
+# Interactive numbered selection when multiple connections are registered
+cfg connect
+```
+
+The encrypted bundle is unlocked with the machine-bound key, a new session token is issued, and the token replaces the previous entry in the OS keychain.
+
+### cfg disconnect
+
+Revoke the active session and remove its token from the OS keychain.
+
+```bash
+cfg disconnect
+```
+
+Sends `DELETE /api/v1/sessions/{id}` to the controller (best-effort — proceeds even on network error), then removes the token from the OS keychain. Exits 0 with a notice when no active session is found.
+
+### cfg connections current
+
+Show the active session from the OS keychain.
+
+```bash
+cfg connections current
+```
+
+Prints the connection name, controller URL, session ID, and absolute expiry. Prints `no active session` and exits 0 when no valid session is stored.
+
+### Session lifecycle and rolling renewal
+
+After `cfg connect`, all admin commands transparently use the stored session token (Bearer auth). The controller sets an `X-Session-Token` response header on each authenticated request; the CLI automatically writes the new token back to the OS keychain, keeping sessions alive without explicit re-authentication.
+
+When the token is revoked server-side (401 response), the CLI falls back to bundle auth and prints `session expired or revoked — falling back to bundle auth` on stderr.
+
+Use `--bundle` or `--no-bundle` on any command to bypass the session entirely for one-shot overrides.
+
+---
+
 The `cfg connections` commands manage the local registry of known controller connections. The registry stores non-secret metadata only — no credentials, tokens, or keys are ever written to this file.
 
 Registry location:


### PR DESCRIPTION
## Summary

- Adds `cfg connect --bundle <path> --url <https://...>` for first-time session issuance: imports admin bundle, stores encrypted credential (machine-bound), issues a short-lived session token via `POST /api/v1/sessions`, and writes the token exclusively to the OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) — never to any file on disk.
- Adds `cfg connect <name>` (reconnect): unlocks stored credential, issues a new session token, and replaces the keychain entry without re-importing the bundle.
- Adds `cfg disconnect`: revokes the session server-side (`DELETE /api/v1/sessions/{id}`), removes the token from the keychain, and locks the credential.
- Adds `cfg connections current`: shows the active session (connection name, URL, session ID, expiry) from the keychain.
- Adds transparent rolling-token renewal: the `X-Session-Token` response header auto-updates the keychain entry via `OnTokenRenewed` on every authenticated request.
- All admin commands now use `resolveSessionOrBundleClient` (session-first, bundle fallback). `OnUnauthorized` falls back to bundle auth on server-side 401. `--bundle` / `--no-bundle` / `--api-url` flags bypass the session for one-shot overrides.
- CA cert PEM stored in the session record so the session client verifies the same TLS chain as the original mTLS connection; empty CA cert falls back to the system cert pool (nil-guard prevents `AppendCertsFromPEM([]byte{})` failure).
- HTTPS guard: `requireHTTPS` rejects `http://` for non-loopback URLs.
- Docs: updated `docs/development/commands-reference.md` Connection Management section.

## Test plan

- [ ] `TestConnectReconnectDisconnect` — HTTPS stub server with custom CA, in-memory `SecretStore` injected via `sessionStoreFn`, counting `CredentialUnlocker` injected via `credentialStoreUnlockerFn` (no mocks): connect → token stored in memory (not on disk) → reconnect invokes unlocker exactly once → 3 session-backed commands don't invoke unlocker → disconnect → token removed → server returns 401 for revoked token
- [ ] `TestBundleOverrideBypassesSession` — `--bundle` flag bypasses session store entirely even when a valid session exists
- [ ] `TestRequireHTTPS_*` — rejects non-loopback http://, allows https:// and loopback http://
- [ ] `TestConnectionsCurrent_*` — active session, no session, expired session
- [ ] `TestSessionTokenRoundTrip` / `TestUpdateSessionToken` — keychain round-trip and rolling-renewal update
- [ ] `TestAPIClientOnTokenRenewed` / `TestAPIClientOnUnauthorizedFallback` — callback wiring
- [ ] `go test -race ./cmd/cfg/cmd/` — race detector clean
- [ ] `golangci-lint run ./cmd/cfg/...` — 0 issues
- [ ] `make test-agent-complete` — all validation gates pass

Fixes #2248

🤖 Generated with [Claude Code](https://claude.com/claude-code)