### PR TITLE
controller/api: startup scan for API keys with Tier-3 permissions (Issue #2226)

### DIFF
--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -250,6 +250,11 @@ func New(
 		logger.Warn("Failed to load API keys from store", "error", err)
 	}
 
+	// Issue #2226: Scan for API keys holding Tier-3 permissions so operators can revoke them.
+	if err := server.scanAPIKeysForPrivilegedAccess(context.Background()); err != nil {
+		logger.Warn("Startup scan for privileged API keys failed; continuing", "error", err)
+	}
+
 	// Seed test API keys only when explicitly requested via environment variable.
 	// Never runs in production — must be set deliberately in test environments.
 	if os.Getenv("CFGMS_SEED_TEST_API_KEYS") == "1" {
@@ -1444,6 +1449,43 @@ func (s *Server) loadAPIKeysFromStore() error {
 	// This lazy-loading approach provides better performance and security
 
 	s.logger.Info("Secret store ready - API keys will be loaded on first access")
+	return nil
+}
+
+// Issue #2226: scanAPIKeysForPrivilegedAccess reports API keys that hold permissions in the
+// Tier-3 (mTLS-only) set. Those permissions are now unreachable via API key; operators should
+// revoke or reprovision the affected keys. The scan consumes tier3Permissions from auth_tiers.go
+// so the two sources can never drift.
+func (s *Server) scanAPIKeysForPrivilegedAccess(ctx context.Context) error {
+	if s.secretStore == nil {
+		return nil
+	}
+	secrets, err := s.secretStore.ListSecrets(ctx, &secretsif.SecretFilter{
+		Metadata: map[string]string{
+			secretsif.MetadataKeySecretType: string(secretsif.SecretTypeAPIKey),
+		},
+	})
+	if err != nil {
+		s.logger.Warn("Startup scan: failed to list API keys from secret store", "error", err)
+		return err
+	}
+	for _, meta := range secrets {
+		var overlapping []string
+		for _, p := range parsePermissions(meta.Metadata["permissions"]) {
+			if _, isT3 := tier3Permissions[p]; isT3 {
+				overlapping = append(overlapping, p)
+			}
+		}
+		if len(overlapping) > 0 {
+			s.logger.Warn(
+				"API key holds permissions that overlap Tier-3 (mTLS-only) endpoints; "+
+					"these are now unreachable via API key — consider revoking this key",
+				"key_id", logging.SanitizeLogValue(meta.Metadata["id"]),
+				"tenant_id", logging.SanitizeLogValue(meta.TenantID),
+				"overlapping_permissions", logging.SanitizeLogValue(strings.Join(overlapping, ",")),
+			)
+		}
+	}
 	return nil
 }
 

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -26,6 +27,7 @@ import (
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -1606,4 +1608,111 @@ func TestSetupRouter_Tier1Routes_RequireAuthentication(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"Tier-1 route GET /api/v1/stewards must return 401 with no auth credentials")
+}
+
+// errListSecretStore wraps a real SecretStore and forces ListSecrets to return an error.
+// Used by TestStartupScan_ContinuesOnListError to exercise the error path in
+// scanAPIKeysForPrivilegedAccess without mocking unrelated store operations.
+type errListSecretStore struct {
+	secretsif.SecretStore
+	listErr error
+}
+
+func (s *errListSecretStore) ListSecrets(_ context.Context, _ *secretsif.SecretFilter) ([]*secretsif.SecretMetadata, error) {
+	return nil, s.listErr
+}
+
+// TestStartupScan_ContinuesOnListError verifies that scanAPIKeysForPrivilegedAccess emits
+// a Warn and returns the error when ListSecrets fails, and that the caller (New()) treats
+// this as non-fatal — confirmed by the server being fully constructed in every other test
+// whose setup calls New() with the scan wired in (Issue #2226).
+func TestStartupScan_ContinuesOnListError(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	// Clear entries from server construction.
+	capLog.mu.Lock()
+	capLog.entries = nil
+	capLog.mu.Unlock()
+
+	// Replace the secret store with one whose ListSecrets always fails.
+	listErr := fmt.Errorf("simulated store failure")
+	server.secretStore = &errListSecretStore{SecretStore: server.secretStore, listErr: listErr}
+
+	err := server.scanAPIKeysForPrivilegedAccess(context.Background())
+	assert.ErrorIs(t, err, listErr, "scan must return the ListSecrets error to the caller")
+	assert.True(t, capLog.hasLevel("WARN"), "scan must emit a Warn when ListSecrets fails")
+}
+
+// TestStartupScan_WarnsOnPrivilegedAPIKey verifies that scanAPIKeysForPrivilegedAccess
+// emits a Warn entry containing key_id and overlapping_permissions when a stored API key
+// holds at least one Tier-3 permission (Issue #2226).
+func TestStartupScan_WarnsOnPrivilegedAPIKey(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	// Clear any entries accumulated during server construction (scan ran against empty store).
+	capLog.mu.Lock()
+	capLog.entries = nil
+	capLog.mu.Unlock()
+
+	// Seed a key that holds the Tier-3 permission "api-key:create".
+	const keyID = "test-privileged-key-id"
+	const tenantID = "default"
+	err := server.secretStore.StoreSecret(context.Background(), &secretsif.SecretRequest{
+		Key:       "hash-privileged-test-key",
+		Value:     "hash-privileged-test-key",
+		TenantID:  tenantID,
+		CreatedBy: "test",
+		Metadata: map[string]string{
+			secretsif.MetadataKeySecretType: string(secretsif.SecretTypeAPIKey),
+			"id":                            keyID,
+			"permissions":                   "steward:read,api-key:create",
+		},
+	})
+	require.NoError(t, err, "seeding privileged key into secret store must succeed")
+
+	err = server.scanAPIKeysForPrivilegedAccess(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, capLog.hasLevel("WARN"), "scan must emit a Warn entry for a key with Tier-3 permissions")
+	assert.Equal(t, keyID, capLog.kvValue("key_id"),
+		"Warn entry must include the key_id of the over-privileged key")
+	overlapping, _ := capLog.kvValue("overlapping_permissions").(string)
+	assert.Contains(t, overlapping, "api-key:create",
+		"overlapping_permissions must name the Tier-3 permission held by the key")
+}
+
+// TestStartupScan_NoWarnForUnprivilegedKey verifies that scanAPIKeysForPrivilegedAccess
+// does not emit a Tier-3 over-privilege warning when the stored API key only holds
+// non-Tier-3 permissions (Issue #2226).
+func TestStartupScan_NoWarnForUnprivilegedKey(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	// Clear any entries accumulated during server construction.
+	capLog.mu.Lock()
+	capLog.entries = nil
+	capLog.mu.Unlock()
+
+	// Seed a key that holds only the non-Tier-3 permission "steward:read".
+	err := server.secretStore.StoreSecret(context.Background(), &secretsif.SecretRequest{
+		Key:       "hash-unprivileged-test-key",
+		Value:     "hash-unprivileged-test-key",
+		TenantID:  "default",
+		CreatedBy: "test",
+		Metadata: map[string]string{
+			secretsif.MetadataKeySecretType: string(secretsif.SecretTypeAPIKey),
+			"id":                            "test-unprivileged-key-id",
+			"permissions":                   "steward:read",
+		},
+	})
+	require.NoError(t, err, "seeding unprivileged key into secret store must succeed")
+
+	err = server.scanAPIKeysForPrivilegedAccess(context.Background())
+	require.NoError(t, err)
+
+	// No Warn entry whose overlapping_permissions field is populated — the key is clean.
+	assert.Nil(t, capLog.kvValue("overlapping_permissions"),
+		"scan must not emit an overlapping_permissions warning for a key with no Tier-3 permissions")
 }


### PR DESCRIPTION
## Summary

- Adds `scanAPIKeysForPrivilegedAccess(ctx context.Context) error` on `*Server` that lists all stored API keys and emits a Warn log for any key holding a Tier-3 (mTLS-only) permission, since those routes are now unreachable via API key since #2225.
- Consumes the canonical `tier3Permissions` map from `auth_tiers.go` (#2222) — no duplicate permission list introduced.
- Called from `New()` after `loadAPIKeysFromStore()`; errors logged at Warn and never prevent server startup.

Fixes #2226

## Test plan

- [x] `TestStartupScan_WarnsOnPrivilegedAPIKey` — seeds key with `api-key:create` in real SOPS store; asserts Warn with `key_id` and `overlapping_permissions`
- [x] `TestStartupScan_NoWarnForUnprivilegedKey` — seeds key with `steward:read`; asserts no Tier-3 warning
- [x] `TestStartupScan_ContinuesOnListError` — injects failing store via `errListSecretStore` wrapper; asserts error returned + Warn logged; server construction completes successfully in all other tests
- [x] `make test-agent-complete` — all 160+ packages pass, linting clean, security scan clean, cross-platform compilation passes

## Specialist review results

| Reviewer | Result |
|----------|--------|
| QA test runner (`make test-agent-complete`) | **PASS** — 0 failures, marker written |
| QA code reviewer | **PASS** (after adding `TestStartupScan_ContinuesOnListError` for error-path coverage) |
| Security engineer | **PASS** — log injection scan clean, no central provider violations, gosec/staticcheck/Trivy all green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)