### PR TITLE
pipeline: route /po cron to a clean-context subagent

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -232,6 +232,10 @@ Run the full autonomous pipeline cycle once. Use when the founder says "cron", "
 
 This runs **locally** with full Docker access for dispatch and fix cycles. The remote `po-cron` trigger runs the same logic but sets project status `Blocked` for Docker-dependent steps (3 and 4) since it has no Docker access.
 
+**Execution context — inline vs subagent.** `/po cron` is routed to a **clean-context `po` subagent** (see `.claude/commands/po.md` Path B); `/po cycle` and `/po decompose` run **inline** in the main session because they need the Planning Team (`TeamCreate`/`SendMessage`), which a subagent lacks. When this cycle runs **as a subagent**, two adaptations apply (they do NOT change behavior when run inline):
+- **No `Skill` tool.** Invoke the pin-refresh (Step 1.6) and pipeline-sweep (Step 7.5) skills by spawning a `general-purpose` Agent that reads and runs the skill's `SKILL.md` inline — equivalent to the inline `Skill:` call.
+- **Nested spawns are async.** The Tech Lead pass (Step 2) `Agent` spawn is backgrounded by the harness, which re-invokes you on its completion. Hold the relevant inline-op lease (e.g. `epic-decompose-*`, or just the cycle's own work) across the gap and act on the result on the completion turn. The dispatch/review/fix **containers** are unaffected (they are docker, not `Agent` subagents).
+
 ### 4.-1 Multi-host coordination (stateless cron — run on many hosts at once)
 
 `/po cron` is safe to run **concurrently on multiple hosts**, including homogeneous

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -13,32 +13,48 @@ The PO manages the autonomous pipeline: dashboard, intent capture, targeted unbl
 
 ## Execution
 
-Two execution paths depending on `$ARGUMENTS`. The dividing line is whether the action needs to spawn nested subagents or an agent team — those need the parent session's full tool access, so they run inline.
+Three execution paths depending on `$ARGUMENTS`. The dividing line is what the action needs:
 
-### Path A — team-relevant args (run inline in the main session)
+- **Agent teams** (`TeamCreate`/`SendMessage`) — only the main session has these, so anything that spawns the Planning Team runs **inline** (Path A).
+- **Clean per-run context, no teams** — the autonomous `cron` cycle skips the Planning Team, so it runs as a **clean-context subagent** (Path B) to keep the main session free of per-cycle bloat.
+- **Ongoing conversation** — `status`/`intent`/`next` spawn a long-lived PO subagent (Path C).
 
-If `$ARGUMENTS` starts with any of `cron`, `cycle`, `work`, `decompose`, or `plan`, do **NOT** spawn the PO as a subagent. Instead, execute directly in the main session.
+> **Subagents CAN nest subagents and run bash under `mode: auto` with no approval prompts** (empirically validated 2026-06-29: a `po` subagent ran a full cron cycle — Tech Lead nested-spawn worked, `po-act.sh dispatch`/`gh`/lease ops all prompt-free, docker access intact since it's the same host). What a subagent **cannot** do is `TeamCreate`/`SendMessage` — so the **only** reason to stay inline is the Planning Team. This corrects the earlier (now-stale) `feedback_po_run_inline` rationale.
 
-**Why:** A subagent cannot reliably spawn nested subagents (Acceptance Reviewer, BA, Tech Lead, Planning Team) — its `tools:` field is restricted (no `TeamCreate`, `TeamDelete`, `SendMessage`), and its bash commands trigger approval prompts despite `mode: auto`. Running inline gives the cycle full Agent-tool access and the parent session's allow list. Documented in memory `feedback_po_run_inline.md`.
+### Path A — needs agent teams (run inline in the main session)
+
+If `$ARGUMENTS` starts with `cycle`, `decompose`, or `plan`, do **NOT** spawn a subagent — execute directly in the main session, because these invoke the **Planning Team** (`TeamCreate` + `SendMessage`), which a subagent's toolset lacks. `work` also runs inline (in-process self-dispatch, no docker).
 
 **Routing within Path A:**
 
 | Args | Action |
 |------|--------|
-| `cron` | Pipeline Cycle (§4) — **skip Step 7 (Planning Team)**. Autonomous; cheap; runs every interval. Dispatches via docker containers (orchestrator role). |
-| `cycle` | Pipeline Cycle (§4) — **including Step 7**. Manual; full cycle on demand. |
+| `cycle` | Pipeline Cycle (§4) — **including Step 7 (Planning Team)**. Manual; full cycle on demand. |
 | `work` | Self-Dispatch Mode (§7) — **no docker**. The local session claims and works this host's tagged stories one at a time, in-process, for a host (e.g. Windows) whose `CFGMS_PO_HOST_CAPS` names a non-default execution environment. **Drain-then-stop, not a timer:** works every currently-claimable story back-to-back in ONE invocation — re-running a FRESH preflight after each completed story (the orchestrator on another host drains the pipeline concurrently) — then stops when nothing is claimable. Do NOT wrap in `/loop`/cron; re-invoke on demand or when a blocker clears. |
 | `decompose [<epic#>]` | Run §4.1 Step 7 (Planning Team) only — for the named epic, or every `epic` with no sub-issues if no number is given. |
 | `plan [<epic#>]` | Alias for `decompose`. |
 
-**How:**
+**How (Path A):**
 1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the relevant section.
-2. Execute the section directly in the main session in priority order — preflight, unblock check, agent cleanup, pin refresh (§4.1 Step 1.6), Tech Lead pass, rebase (§4.1 Step 3), Acceptance Reviewer (§4.1 Step 4), fix cycle (§4.1 Step 5), dispatch (§4.1 Step 6), Planning Team (§4.1 Step 7 — see routing table above), forward edge, session log.
-3. Host capacity is enforced automatically by the resource admission gate (`.claude/agents/po.md` §4.-1) — every launch path defers when the host is out of RAM/disk/CPU headroom. When capacity is scarce, finish in-flight work first (Steps 3-5); new dev dispatch (Step 6) auto-defers (`DISPATCH_DEFERRED:…:resources`) and is picked up a later cycle.
+2. Execute the section directly in the main session in priority order — preflight, unblock check, agent cleanup, pin refresh (§4.1 Step 1.6), Tech Lead pass, rebase (§4.1 Step 3), Acceptance Reviewer (§4.1 Step 4), fix cycle (§4.1 Step 5), dispatch (§4.1 Step 6), Planning Team (§4.1 Step 7), forward edge, session log.
+3. Host capacity is enforced automatically by the resource admission gate (`.claude/agents/po.md` §4.-1) — every launch path defers when the host is out of RAM/disk/CPU headroom.
 4. Spawn nested subagents via the Agent tool with `mode: auto`. Spawn the Planning Team via `TeamCreate` + Agent calls with `team_name` (per `.claude/agents/po.md` §4.1 Step 7c).
 5. Report the summary back to the founder using the same format the PO subagent uses.
 
-### Path B — lightweight conversation (spawn the PO subagent)
+### Path B — autonomous cron (clean-context subagent)
+
+If `$ARGUMENTS` starts with `cron`, spawn a **`po` subagent** to run the full Pipeline Cycle (§4, **skip Step 7 — Planning Team**). This gives each interval a **fresh context window** (the cron cycle is stateless — re-derived from GitHub every run — so nothing is lost), keeping the main session free for founder dialogue. The subagent is on the same host, so it has full Docker access for dispatch/review/fix containers.
+
+```
+Agent tool:
+  subagent_type: po
+  prompt: "Run a full /po cron pipeline cycle per §4 of your agent definition (.claude/agents/po.md) — cron mode, SKIP Step 7 (Planning Team). Execute every step that has work. Two subagent-context adaptations: (1) you have NO `Skill` tool — invoke the pin-refresh (§4.1 Step 1.6) and pipeline-sweep (§7.5) skills by spawning a `general-purpose` Agent that reads and runs the skill's SKILL.md inline; (2) your nested Tech Lead (§2) spawns run async — the harness backgrounds them and re-invokes you on completion, so hold the relevant inline-op lease across the gap and release it on the completion turn. Use the distributed leases (§4.-1) as normal. Report the standard cycle summary."
+  mode: auto
+```
+
+Then relay the subagent's cycle summary to the founder. If the subagent reports a blocker only the main session can resolve (e.g. an epic that needs the Planning Team), surface it as a `/po cycle` / `/po decompose <#>` recommendation.
+
+### Path C — lightweight conversation (spawn the PO subagent)
 
 For `status` (default), `intent <topic>`, `next`, `unblock #NNN`, or any natural-language pipeline query, spawn the PO agent so it stays in role for the rest of the session:
 
@@ -56,4 +72,4 @@ The PO agent definition is at `.claude/agents/po.md`. It will:
 
 If `$ARGUMENTS` contains a subcommand (e.g., `intent certificate rotation`), pass it to the agent so it routes to the correct action immediately.
 
-**Note:** Intent capture (§2) runs in Path B because it's a structured conversation that ends in a `gh issue create` — no Planning Team, no agent dispatch. The created epic is later picked up by `/po cycle` or `/po decompose <#>` (Path A) for BA/Tech Lead orchestration.
+**Note:** Intent capture (§2) runs in Path C because it's a structured conversation that ends in a `gh issue create` — no Planning Team, no agent dispatch. The created epic is later picked up by `/po cycle` or `/po decompose <#>` (Path A) for BA/Tech Lead orchestration.


### PR DESCRIPTION
## What

Switch `/po cron` from inline execution to a **`po` subagent** so each 20-min interval runs in a **fresh context window**, keeping the main session free for founder dialogue. The cron cycle is **stateless** (re-derived from GitHub every run via preflight), so clean context loses nothing.

`cycle`/`decompose`/`plan` stay **inline** (they invoke the Planning Team via `TeamCreate`/`SendMessage`, which a subagent lacks); `work` stays inline (in-process self-dispatch).

## Why this is safe (empirically validated 2026-06-29)

A `po` subagent ran a full `/po cron` cycle end-to-end under `mode: auto`:
- **Zero approval prompts** on any call — `po-act.sh dispatch/sync/preflight/log`, `agent-dispatch.sh`, `pipeline-helper.sh` leases, raw `gh`, `git`, `python3`, `Write`, and nested `Agent` spawns.
- **Nested Tech Lead subagent spawned + completed** (promoted #2226/#2227 to Ready).
- **Docker access intact** (same host) — `po-act.sh dispatch` launched a container with no prompt.

This corrects the now-stale `feedback_po_run_inline` rationale: subagents *can* nest and run bash prompt-free; the only thing they can't do is agent teams.

## Two subagent adaptations (documented in `agents/po.md` §4)

1. **No `Skill` tool** in a subagent context → pin-refresh (§1.6) and pipeline-sweep (§7.5) are forked via a `general-purpose` Agent running the skill's `SKILL.md` (equivalent to the inline `Skill:` call).
2. **Nested spawns are async** → the Tech Lead `Agent` spawn is backgrounded; act on its result on the completion turn, holding the inline-op lease across the gap. Dispatch/review/fix **containers** are unaffected.

## Files
- `.claude/commands/po.md` — three-path routing (A inline-teams / B cron-subagent / C conversation)
- `.claude/agents/po.md` — §4 execution-context note

Markdown/config only; no Go or script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)