### PR TITLE
docs: auth-tier policy documentation + E2E Tier-3 enforcement test (Issue #2227)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,8 @@ Publisher public keys are baked into the steward binary at build time and cannot
 - Principle of least privilege enforced throughout
 - No implicit trust between system components
 
+For the controller REST API auth-tier policy (Tier-3 mTLS-only enforcement, the four-tier table, and the full Tier-3 endpoint list), see [Security Architecture — Auth-Tier Policy](security/architecture.md#auth-tier-policy).
+
 ### Certificate Management
 
 - Unique identity for each component

--- a/docs/deployment/single-controller/walkthrough.md
+++ b/docs/deployment/single-controller/walkthrough.md
@@ -180,6 +180,33 @@ sudo journalctl -u cfgms-controller --no-pager -n 20
 
 Look for: `Certificate manager initialized`, `Transport server listening on :4433`, `REST API server listening on :9080`.
 
+### Startup Warnings
+
+On each startup the controller scans all stored API keys for permissions that overlap the Tier-3 (mTLS-only) endpoint surface. If any key holds such a permission, it cannot be used to reach those endpoints — the tier gate blocks it regardless of what permissions the key carries. The controller logs a warning at `WARN` level for each affected key:
+
+```
+WARN  API key holds permissions that overlap Tier-3 (mTLS-only) endpoints;
+      these are now unreachable via API key — consider revoking this key
+      key_id=<id>  tenant_id=<tenant>  overlapping_permissions=<perm1,perm2,...>
+```
+
+**Remediation:**
+
+1. Identify the key from the `key_id` field in the warning.
+2. Decide whether the key needs those permissions. If not, revoke it and issue a replacement with only the permissions it actually requires:
+
+   ```bash
+   # Revoke the over-privileged key
+   cfg api-keys delete --id <key_id>
+
+   # Issue a replacement with only the permissions the caller needs
+   cfg api-keys create --name <name> --permissions <perm1,perm2,...>
+   ```
+
+3. If the key legitimately needs to call a Tier-3 operation, the caller must use an mTLS admin credential bundle instead. Issue a bundle with `cfgms-controller bootstrap-admin` and update the caller to use it.
+
+These warnings do not prevent the controller from starting or serving requests. They are informational alerts that help operators identify over-privileged keys before a Tier-3 call fails at runtime.
+
 ## Step 3: Deploy the Controller-Steward
 
 The controller-steward is the first steward in your environment. It manages the controller node itself — directories, packages, firewall rules, systemd service, and the controller config file. If anything drifts from the desired state, the steward converges it back.

--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -117,6 +117,44 @@ For detailed information about our security decisions, see:
 - Permission inheritance
 - Access audit logging
 
+### Auth-Tier Policy
+
+The controller REST API assigns every endpoint to one of four authentication tiers. The tier determines what credential strength is required to reach the handler — independently of which permissions the caller holds.
+
+| Tier | Name | Credential requirement |
+|------|------|------------------------|
+| 0 | Public | No authentication (health check, registration) |
+| 1 | Any | Any valid credential: mTLS admin cert **or** API key |
+| 2 | Elevated | Reserved for future use |
+| 3 | mTLS-Only | mTLS admin certificate required; API keys are rejected even when they carry the exact matching permission |
+
+**Tier-3 discriminator:** The sole check is whether the request carries a valid mTLS admin certificate (`principal.IsAdmin`). The permission set of the caller is never consulted. An API key that holds every Tier-3 permission will still receive HTTP 403 `MTLS_REQUIRED`.
+
+**Tier-3 endpoint surface** (Issue #1419):
+
+| Permission | Endpoint |
+|------------|----------|
+| `certificate:provision` | `POST /api/v1/certificates/provision` |
+| `certificate:rotate` | `POST /api/v1/certificates/signing/rotate` |
+| `rbac:create-role` | `POST /api/v1/rbac/roles` |
+| `rbac:update-role` | `PUT /api/v1/rbac/roles/{id}` |
+| `rbac:delete-role` | `DELETE /api/v1/rbac/roles/{id}` |
+| `api-key:create` | `POST /api/v1/api-keys` |
+| `api-key:delete` | `DELETE /api/v1/api-keys/{id}` |
+| `registration:create-token` | `POST /api/v1/registration/tokens` |
+| `registration:delete-token` | `DELETE /api/v1/registration/tokens/{token}` |
+| `registration:revoke-token` | `POST /api/v1/registration/tokens/{token}/revoke` |
+| `registration:rotate-token` | `POST /api/v1/registration/tokens/{tenant_id}/rotate` |
+| `registration:approve` | `POST /api/v1/registration/{id}/approve`, `/approve-all`, `/approve-by-cidr` |
+| `registration:manage-ip-trust` | `POST /api/v1/registration/ip-trust`, `DELETE /api/v1/registration/ip-trust/{tenant}/{cidr}` |
+| `tenant:create` | `POST /api/v1/tenants` |
+| `refresh:approve` | `POST /api/v1/stewards/refresh/{pending_id}/approve` |
+| `refresh:set-policy` | `PUT /api/v1/tenants/{tenant_path}/refresh-policy` |
+
+The canonical source of truth for this list is `tier3Permissions` in `features/controller/api/auth_tiers.go`. The `TestTier3Enforcement_RouteSetMatchesCanonicalSet` test in `features/controller/api/tier_enforcement_test.go` asserts at test time that the wired route set exactly equals this map — any drift is a test failure.
+
+**Rationale:** Endpoints in this tier can issue credentials, modify trust anchors, or alter the authorization model itself. Restricting them to mTLS provides a hardware-backed authentication guarantee that cannot be replicated by a compromised or stolen API key. Operators who need these capabilities must use an admin credential bundle (mTLS client certificate) rather than an API key.
+
 ## Security Best Practices
 
 ### Certificate Management

--- a/test/e2e/auth_tier_e2e_test.go
+++ b/test/e2e/auth_tier_e2e_test.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// TestAuthTierE2E_Tier3Enforcement verifies the full Tier-3 auth enforcement path
+// against a real controller using real TLS+mTLS credentials. No mocks, no context
+// injection — the test exercises authenticationMiddleware → extractAdminPrincipal →
+// requireTier(TierMTLSOnly) end-to-end.
+//
+// Sub-test Tier3_APIKeyHolder_Gets403:
+//
+//	An API-key principal carrying api-key:create is rejected with HTTP 403 MTLS_REQUIRED
+//	on POST /api/v1/api-keys — the tier gate fires before the permission gate, so even a
+//	key with the exact matching permission is blocked.
+//
+// Sub-test Tier3_AdminCertHolder_PassesTierCheck:
+//
+//	An mTLS admin-cert principal passes the Tier-3 gate and receives any response other
+//	than 403, proving the gate does not block admin principals.
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller"
+	controllerConfig "github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// tier3ErrorResp mirrors the JSON error envelope returned by writeErrorResponse.
+type tier3ErrorResp struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// tier3KeyCreateResp mirrors the JSON data envelope from handleCreateAPIKey.
+type tier3KeyCreateResp struct {
+	Data struct {
+		Key string `json:"key"`
+	} `json:"data"`
+}
+
+func TestAuthTierE2E_Tier3Enforcement(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	tempDir := t.TempDir()
+	logger := logging.NewNoopLogger()
+
+	// ── 1. Certificate manager — creates CA at tempDir/certs. ──────────────────
+	certPath := filepath.Join(tempDir, "certs")
+	require.NoError(t, os.MkdirAll(certPath, 0755))
+
+	certMgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: certPath,
+		CAConfig: &cert.CAConfig{
+			Organization:       "CFGMS Auth-Tier E2E Test CA",
+			Country:            "US",
+			State:              "Test",
+			City:               "Test",
+			OrganizationalUnit: "Auth-Tier E2E",
+			ValidityDays:       1,
+			KeySize:            2048,
+		},
+		LoadExistingCA:       false,
+		RenewalThresholdDays: 1,
+	})
+	require.NoError(t, err, "cert manager init")
+
+	// ── 2. Boot a real controller with TLS+mTLS enabled. ───────────────────────
+	httpPort := findFreePort(t)
+	transportPort := findFreePort(t)
+
+	cfg := &controllerConfig.Config{
+		ListenAddr: fmt.Sprintf("localhost:%d", httpPort),
+		CertPath:   certPath,
+		DataDir:    filepath.Join(tempDir, "data"),
+		LogLevel:   "error",
+		Storage: &controllerConfig.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: filepath.Join(tempDir, "storage"),
+			SQLitePath:   filepath.Join(tempDir, "cfgms.db"),
+		},
+		Certificate: &controllerConfig.CertificateConfig{
+			EnableCertManagement:   true,
+			CAPath:                 filepath.Join(certPath, "ca"),
+			RenewalThresholdDays:   1,
+			ServerCertValidityDays: 1,
+			ClientCertValidityDays: 1,
+			Server: &controllerConfig.ServerCertificateConfig{
+				CommonName:   "localhost",
+				DNSNames:     []string{"localhost", "127.0.0.1"},
+				IPAddresses:  []string{"127.0.0.1", "::1"},
+				Organization: "Test Organization",
+			},
+		},
+		Transport: &controllerConfig.TransportConfig{
+			ListenAddr:      fmt.Sprintf("localhost:%d", transportPort),
+			UseCertManager:  true,
+			MaxConnections:  10,
+			KeepalivePeriod: controllerConfig.Duration(30 * time.Second),
+			IdleTimeout:     controllerConfig.Duration(5 * time.Minute),
+		},
+		Registration: &controllerConfig.RegistrationConfig{
+			Workflow: "auto-approve",
+		},
+	}
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "storage"), 0755))
+
+	ctrl, err := controller.New(cfg, logger)
+	require.NoError(t, err, "controller.New")
+
+	ctrlErrCh := make(chan error, 1)
+	go func() {
+		ctrlErrCh <- ctrl.Start(ctx)
+	}()
+
+	httpBase := fmt.Sprintf("https://localhost:%d", httpPort)
+	waitForControllerHTTP(t, certMgr, httpBase, 30*time.Second)
+
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		if err := ctrl.Stop(stopCtx); err != nil && err.Error() != "controller not running" {
+			t.Logf("controller Stop returned: %v", err)
+		}
+		select {
+		case err := <-ctrlErrCh:
+			if err != nil && err.Error() != "controller not running" {
+				t.Logf("controller Start returned: %v", err)
+			}
+		default:
+		}
+	})
+
+	// ── 3. Build CA pool and admin mTLS client cert. ───────────────────────────
+	caPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+	caPool := x509.NewCertPool()
+	require.True(t, caPool.AppendCertsFromPEM(caPEM), "CA pool append")
+
+	adminCert, err := certMgr.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:       "e2e-auth-tier-admin",
+		Organization:     "CFGMS",
+		ValidityDays:     1,
+		KeySize:          2048,
+		TemplateModifier: cert.SetAdminMarker,
+	})
+	require.NoError(t, err, "issue admin cert")
+
+	adminTLSCert, err := tls.X509KeyPair(adminCert.CertificatePEM, adminCert.PrivateKeyPEM)
+	require.NoError(t, err)
+
+	adminHTTPClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{adminTLSCert},
+				RootCAs:      caPool,
+				MinVersion:   tls.VersionTLS13,
+			},
+		},
+	}
+
+	// ── 4. Mint an API key via admin mTLS (itself a Tier-3 call). ──────────────
+	// Creating the key through POST /api/v1/api-keys with the admin cert also proves
+	// that step works before the sub-tests exercise the rejection path.
+	createBody, err := json.Marshal(map[string]interface{}{
+		"name":        "e2e-tier3-test-key",
+		"permissions": []string{"api-key:create"},
+	})
+	require.NoError(t, err)
+
+	createReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		httpBase+"/api/v1/api-keys", bytes.NewReader(createBody))
+	require.NoError(t, err)
+	createReq.Header.Set("Content-Type", "application/json")
+
+	createResp, err := adminHTTPClient.Do(createReq)
+	require.NoError(t, err)
+	createRespBytes, err := io.ReadAll(createResp.Body)
+	_ = createResp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode,
+		"admin POST /api/v1/api-keys must succeed (body: %s)", string(createRespBytes))
+
+	var keyResult tier3KeyCreateResp
+	require.NoError(t, json.Unmarshal(createRespBytes, &keyResult))
+	apiKeyValue := keyResult.Data.Key
+	require.NotEmpty(t, apiKeyValue, "created API key must be non-empty")
+
+	// ── 5. Plain HTTPS client (no mTLS cert) for API-key auth. ────────────────
+	apiKeyHTTPClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    caPool,
+				MinVersion: tls.VersionTLS13,
+			},
+		},
+	}
+
+	// ── Sub-test A: API-key holder gets 403 MTLS_REQUIRED. ────────────────────
+	t.Run("Tier3_APIKeyHolder_Gets403", func(t *testing.T) {
+		reqBody, err := json.Marshal(map[string]interface{}{
+			"name":        "e2e-apikey-attempt",
+			"permissions": []string{"api-key:create"},
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			httpBase+"/api/v1/api-keys", bytes.NewReader(reqBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", apiKeyValue)
+
+		resp, err := apiKeyHTTPClient.Do(req)
+		require.NoError(t, err)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.NoError(t, err, "read response body")
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"API-key principal must receive 403 on Tier-3 endpoint (body: %s)", string(bodyBytes))
+
+		var errResp tier3ErrorResp
+		require.NoError(t, json.Unmarshal(bodyBytes, &errResp),
+			"response must be valid JSON error envelope (body: %s)", string(bodyBytes))
+		assert.Equal(t, "MTLS_REQUIRED", errResp.Error.Code,
+			"error code must be MTLS_REQUIRED, got %q", errResp.Error.Code)
+	})
+
+	// ── Sub-test B: Admin cert holder passes the Tier-3 gate. ─────────────────
+	// The assertion is NOT 403: any non-403 proves requireTier(TierMTLSOnly) passed the
+	// admin principal through. Handler-level codes (201 success, 409 conflict, etc.)
+	// are all acceptable — they come from the handler, not the tier gate. A TLS
+	// handshake failure (cert rejected by server) would surface as a transport error
+	// caught by require.NoError, not as a 403, so that path is also covered.
+	t.Run("Tier3_AdminCertHolder_PassesTierCheck", func(t *testing.T) {
+		reqBody, err := json.Marshal(map[string]interface{}{
+			"name":        "e2e-admin-cert-check",
+			"permissions": []string{"api-key:create"},
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			httpBase+"/api/v1/api-keys", bytes.NewReader(reqBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := adminHTTPClient.Do(req)
+		require.NoError(t, err)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.NoError(t, err, "read response body")
+
+		assert.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+			"mTLS admin cert principal must not be rejected by the Tier-3 gate (body: %s)", string(bodyBytes))
+	})
+}


### PR DESCRIPTION
## Summary

- **docs/security/architecture.md**: New "Auth-Tier Policy" section with the four-tier table, the full 16-entry Tier-3 endpoint list, and an explicit statement that Tier-3 rejects API keys regardless of permission — the discriminator is auth method, not permission set.
- **docs/deployment/single-controller/walkthrough.md**: New "Startup Warnings" subsection documenting the over-privileged-key warning and remediation steps (identify by `key_id`, revoke/re-provision, or switch to an admin bundle for Tier-3 calls).
- **docs/architecture.md**: One-line cross-reference in the Security Model section pointing to the auth-tier policy doc.
- **test/e2e/auth_tier_e2e_test.go**: `TestAuthTierE2E_Tier3Enforcement` — self-contained E2E test that boots a real controller with TLS+mTLS and verifies the full Tier-3 enforcement path (no mocks, no `t.Skip`).

## Test plan

- [ ] `Tier3_APIKeyHolder_Gets403`: API key with `api-key:create` gets HTTP 403 `MTLS_REQUIRED` on `POST /api/v1/api-keys` — tier gate fires before permission gate
- [ ] `Tier3_AdminCertHolder_PassesTierCheck`: mTLS admin-cert holder receives non-403 on the same endpoint — gate passes the admin principal through
- [ ] `make test-agent-complete` passes (unit, integration, security scans, cross-platform builds)

## Specialist Review Results

| Specialist | Result |
|------------|--------|
| QA Test Runner | ✅ PASS — 170+ packages, zero failures; cross-platform builds pass |
| QA Code Reviewer | ✅ PASS — no mocks, no t.Skip, all error paths handled |
| Security Engineer | ✅ PASS — no secrets, no injection, no central provider violations |

Fixes #2227

🤖 Generated with [Claude Code](https://claude.ai/claude-code)