### PR TITLE
agents: grant serena semantic navigation to BA, Tech-Lead, acceptance-checker

### DIFF
--- a/.claude/agents/acceptance-checker.md
+++ b/.claude/agents/acceptance-checker.md
@@ -2,7 +2,7 @@
 name: acceptance-checker
 description: Pre-PR acceptance-criteria verification for the story-complete review team. Reads the story body, extracts concrete code references, and verifies them against the working tree. Catches "AC names a stub function but the stub is still there" before the PR is created.
 model: sonnet
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__serena__find_symbol, mcp__serena__get_symbols_overview, mcp__serena__find_referencing_symbols
 ---
 
 # Acceptance Checker — Pre-PR AC Alignment Reviewer
@@ -69,11 +69,11 @@ You read files directly from disk — no `gh api` fetch needed. The working tree
 
 For each reference recorded in Phase 2:
 
-1. **Named function**: Read the function body from the file on disk. Compare against the AC's described "after" behavior. If the function still matches the pre-change pattern (the AC's "before" stub — typically marked by a banned phrase), record FAIL. Quote the actual current code in the report.
+1. **Named function**: locate and read the function body precisely. Prefer serena `find_symbol` (name_path `<SymbolName>`, relative_path `<path>`) — it resolves the symbol to its real definition even if it was moved or renamed, and returns the exact body, so an AC that names a function which no longer exists at the cited location surfaces as an unresolved symbol (a finding in itself) rather than a silent grep miss. Compare the body against the AC's described "after" behavior. If the function still matches the pre-change pattern (the AC's "before" stub — typically marked by a banned phrase), record FAIL. Quote the actual current code in the report.
 
    ```bash
-   # Use Read tool on the file, find the function, examine its body.
-   # Or via Bash:
+   # Preferred: serena find_symbol (exact, move/rename-proof).
+   # Fallback for non-symbol cases:
    grep -nA 20 "^func.*<SymbolName>" <path>
    ```
 

--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -2,7 +2,7 @@
 name: ba
 description: Business Analyst agent — decomposes an epic into story drafts (private project items, never public issues) with full implementation specs. Spawned by PO agent during pipeline cycles.
 model: sonnet
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__serena__find_symbol, mcp__serena__get_symbols_overview, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration
 ---
 
 # Business Analyst — Epic Decomposition
@@ -36,6 +36,8 @@ Before decomposing, gather context in parallel:
 2. **CLAUDE.md** — read for architecture rules, central providers, anti-patterns, testing standards
 3. **Roadmap** — read `docs/product/roadmap.md` for milestone context
 4. **Relevant source files** — use Grep/Glob to find files related to the epic's scope. Read key files to understand current implementation.
+
+> **Ground every code reference with serena, not guesswork.** A story is a spec a dev agent builds against blind — a wrong symbol, file path, or line number becomes a gap they hit at implementation time. Before you put any concrete code reference in a story body (`## Files In Scope`, `## Implementation Notes`, an AC, or a `[REQUIRED TEST]` target), verify it with serena's semantic tools: `find_symbol` to confirm a function/type/method exists and where it lives (exact file + line), `get_symbols_overview` to map a package's surface, `find_referencing_symbols` to find real call sites and existing patterns, `find_implementations`/`find_declaration` for interface↔impl wiring. If serena cannot resolve a symbol you were about to cite, the citation is wrong — fix it before writing it down. Fall back to Grep/Read only for non-symbol targets (config, docs, generated files).
 5. **Existing sub-issues** — check if the epic already has sub-issues:
    ```bash
    EPIC_ID=$(gh api "repos/cfg-is/cfgms/issues/$ISSUE_NUM" --jq .node_id)
@@ -327,5 +329,5 @@ When spawned as a teammate (with `team_name` parameter), you operate as part of 
 - Story quality bar (self-contained, explicit files, testable criteria, single concern, no vague verbs)
 - Story body format
 - Decomposition process (understand epic → survey codebase → identify stories → order by dependency)
-- Codebase survey tools (Read, Grep, Glob)
+- Codebase survey tools (Read, Grep, Glob) — plus serena semantic navigation (`find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `find_implementations`, `find_declaration`) to symbol-verify every code citation before proposing it
 - Max 10 stories per epic rule

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -2,7 +2,7 @@
 name: tech-lead
 description: Tech Lead agent — validates Draft stories for dev agent executability. Promotes passing stories to Ready status. Spawned by PO agent during pipeline cycles.
 model: sonnet
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__serena__find_symbol, mcp__serena__get_symbols_overview, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration
 ---
 
 # Tech Lead — Story Validation for Dev Agent Executability
@@ -74,12 +74,14 @@ For each story, run all 7 checks. A story must pass ALL checks to be promoted.
 
 ### 2. Implementation Notes
 
+> **Symbol-verify every code reference with serena — this is your strongest catch.** Each citation in the story (`## Files In Scope`, `## Implementation Notes`, ACs, `[REQUIRED TEST]` targets) is something a dev agent will build against blind. Verifying with grep finds string matches; verifying with serena resolves *symbols*, which is what actually catches a story that points at the wrong file, a renamed function, or the write-path when it meant the load-path. Use `find_symbol` to confirm each cited function/type/method exists and get its true file+line; `get_symbols_overview` to confirm a package's surface; `find_referencing_symbols` to confirm the "follow the existing pattern" examples are real and to surface call sites the story should account for; `find_implementations`/`find_declaration` for interface↔impl claims. If serena cannot resolve a symbol the story cites, that reference is wrong — correct it (or mark Revision if the BA must rethink). Fall back to Grep/Read only for non-symbol targets.
+
 - Read every file listed in `## Files In Scope` — verify they exist
-- Check that referenced functions, interfaces, and types exist
+- Check that referenced functions, interfaces, and types exist — resolve each with `find_symbol`, don't trust the string
 - If `## Implementation Notes` is missing or insufficient, write it:
   - Which central providers to use (check `pkg/README.md` and CLAUDE.md)
-  - Which existing patterns to follow (find concrete examples via Grep)
-  - Specific function signatures or interface methods to implement
+  - Which existing patterns to follow (find concrete examples via `find_referencing_symbols`/Grep)
+  - Specific function signatures or interface methods to implement (read the real signature with `find_symbol`)
   - Edge cases the dev agent should handle
 - If a referenced file doesn't exist, check if another story creates it (dependency) or if the path is wrong (fix it)
 
@@ -336,6 +338,6 @@ When spawned as a teammate (with `team_name` parameter), you operate as part of 
 ### What Stays the Same
 
 - The 7-check validation checklist (dependency ordering, implementation notes, scope, constraints, ambiguity, required-test markers, docs+tests currency)
-- Codebase validation tools (Read, Grep, Glob, Bash)
+- Codebase validation tools (Read, Grep, Glob, Bash) — plus serena semantic navigation (`find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `find_implementations`, `find_declaration`) to symbol-verify every code reference a story cites
 - File conflict detection logic
 - The standard for what makes a story executable by a dev agent


### PR DESCRIPTION
## What

Grant the planning + pre-PR acceptance agents serena's read-only semantic-navigation tools and instruct them to symbol-verify every code reference before writing/approving it:

- **`ba`** and **`tech-lead`**: `find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `find_implementations`, `find_declaration`
- **`acceptance-checker`**: `find_symbol`, `get_symbols_overview`, `find_referencing_symbols`

## Why

A story is a spec a dev agent builds against blind. If the BA grounds a citation imprecisely (wrong file, renamed symbol, write-path cited where the load-path was meant), the dev agent hits that gap at implementation time. Until now these agents navigated code with `Grep`/`Read` only — string matching, not symbol resolution.

Concrete motivation from the #2256 decomposition: the BA mis-cited `CreateSecretStoreFromConfig`'s file, pointed at the CA *write* path instead of `ca.LoadCA`, and proposed a test using a package-internal helper that can't be imported. The Tech Lead caught all three — but with more grep. serena's `find_symbol` makes those errors structurally impossible: a symbol resolves to a real definition (exact file+line) or it doesn't.

Scope notes:
- **Read-only nav tools only** — no `replace_symbol_body`/`insert_*`/`write_memory`. These agents never modify code.
- **`acceptance-reviewer` deliberately excluded** — it reviews an *open PR* via `gh` while the local working tree may be on a different branch, so serena would navigate the wrong code. It stays diff-based.
- **`po` orchestrator excluded** — it does gh/lease/dispatch work, no code navigation.

## Validation

Smoke-tested end-to-end against real repo state (per the "smoke-test skills before merge" rule — `make test` doesn't exercise agent prompts; this is a markdown-only agent-definition change with no Go diff):

1. serena reachable from a spawned subagent — ✅ resolved `LoadCA` → `pkg/cert/ca.go:119` + 5 references.
2. Frontmatter grant **hot-loads per fresh spawn** (no session restart needed) — a freshly-spawned `tech-lead` called `mcp__serena__find_symbol` directly and returned `pkg/cert/ca.go:119`. ✅
3. Frontmatter YAML parses for all three agents. ✅

The instruction language (not just the tool grant) is load-bearing: an early test showed the default habit is to fall back to grep, so each agent is now explicitly told to ground citations with serena first and treat an unresolved symbol as a wrong citation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
