### PR TITLE
steward: desired_version config + auto-converge + version-in-DNA (Issue #2260)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -202,6 +202,7 @@ For each steward, the controller tracks:
 | Compliance status | Convergence result reports | After each convergence run |
 | DNA hash | Heartbeat payload | With each heartbeat |
 | DNA snapshot | Full sync (data plane) or deltas (control plane) | On hash mismatch, initial registration, or as changes occur |
+| Steward version | Heartbeat `Version` field + `steward.version` DNA attribute | With each heartbeat and DNA delta |
 | Performance metrics | Steward metric uploads | Periodic + on-demand |
 
 ### Heartbeat Monitoring
@@ -273,6 +274,35 @@ The controller can send commands to stewards over the gRPC control plane service
 | `execute_script` | Run an ad-hoc script (outside the cfg) — [GAP: not implemented as a control-plane command — see issue #1523. Script execution is available via the REST API (`POST /api/v1/stewards/{id}/scripts`).] |
 
 Commands are fire-and-forget with completion tracking — the controller publishes the command and monitors for completion/failure events.
+
+### Steward Auto-Upgrade via `desired_version` (Issue #2260)
+
+Operators pin the steward version fleet-wide or per-tenant via the `steward.upgrade` cfg block:
+
+```yaml
+steward:
+  upgrade:
+    desired_version: "v1.4.2"
+    allow_downgrade: false   # default; set true to permit rollback
+```
+
+**Inheritance:** `desired_version` and `allow_downgrade` flow through the normal cfg-inheritance tree (root → tenant → group → device). A child setting overrides the parent. Absence at a level means the parent value is inherited unchanged.
+
+**How a steward converges to `desired_version`:**
+
+1. The controller pushes a new steward binary to the endpoint via the `push_steward_binary` data-plane command. The steward downloads, verifies, and stages the binary under `{Root}/versions/{version}/{binaryName}`, then invokes the launcher's `swap` sub-command. On success, the staged version and path are recorded internally (`lastStagedVersion` / `lastStagedBinaryPath`).
+2. On every cfg-convergence cycle (`TriggerConvergence`), the steward reads `desired_version` from its last received cfg. If it differs from the running version, the steward re-invokes the launcher swap against the already-staged binary without downloading again.
+3. If `allow_downgrade` is `false` (the default) and `desired_version` is older than the running version, the swap is blocked. Set `allow_downgrade: true` to permit explicit rollbacks.
+
+**Downgrade guard:**
+- Blocked unless `allow_downgrade` is `true` in either the running cfg or the controller-synced config cache (`upgradeAllowDowngrade`).
+- This prevents accidental downgrades from misconfigured cfg pushes.
+
+**Version tracking in DNA and heartbeats:**
+- `steward.version` is injected into every DNA delta before publish. The controller stores it as a DNA attribute and exposes it in the fleet list API (`GET /api/v1/stewards`).
+- Every heartbeat now carries a `Version` field, which `RecordHeartbeat` uses to keep the in-memory fleet registry current.
+
+**Fleet visibility:** the steward API list response includes `version` (from `steward.version` DNA attribute) alongside `id`, `status`, and `last_seen`. Operators can filter and audit version skew across the fleet without a separate inventory tool.
 
 ## Orchestration
 

--- a/features/config/stewardtypes/types.go
+++ b/features/config/stewardtypes/types.go
@@ -66,7 +66,14 @@ type StewardSettings struct {
 type UpgradeConfig struct {
 	// AllowDowngrade permits installing a version older than or equal to the
 	// running version. Disabled by default to prevent accidental rollbacks.
-	AllowDowngrade bool `yaml:"allow_downgrade,omitempty"`
+	AllowDowngrade bool `yaml:"allow_downgrade,omitempty" json:"allow_downgrade,omitempty"`
+
+	// DesiredVersion is the controller-declared target steward binary version
+	// (e.g. "v0.5.21"). When set and different from the running version, the
+	// steward convergence loop retries the launcher swap for the staged binary.
+	// Empty string disables version-convergence auto-upgrade (back-compat no-op).
+	// (Issue #2260)
+	DesiredVersion string `yaml:"desired_version,omitempty" json:"desired_version,omitempty"`
 }
 
 // SecretsConfig defines configuration for steward-side secret storage.

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -61,6 +61,7 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 				ID:       res.ID,
 				Status:   res.Status,
 				LastSeen: res.LastHeartbeat,
+				Version:  res.DNAAttributes["steward.version"],
 			}
 			if len(res.DNAAttributes) > 0 {
 				info.DNA = &DNAInfo{

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -363,6 +363,37 @@ func TestHandleListStewards_HTTPRegistration_NoDuplicates(t *testing.T) {
 	assert.Equal(t, "quarantined", resp.Data[0].Status)
 }
 
+// TestHandleListStewards_FleetQuery_VersionFromDNAAttributes verifies that the
+// filtered fleet query path (handleListStewards with a filter) populates the
+// Version field in StewardInfo from the steward.version DNA attribute. (Issue #2260)
+func TestHandleListStewards_FleetQuery_VersionFromDNAAttributes(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:list"})
+
+	// Register a steward whose DNA includes steward.version — this simulates
+	// what a steward publishes after the Issue #2260 change.
+	registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname":        "host-versioned",
+		"os":              "linux",
+		"steward.version": "v1.4.2",
+	})
+
+	// Use a filter to trigger the fleetQuery code path (not the no-filter path).
+	req := httptest.NewRequest("GET", "/api/v1/stewards?os=linux", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Data, 1, "exactly one steward must match the os=linux filter")
+	assert.Equal(t, "v1.4.2", resp.Data[0].Version,
+		"Version must be populated from steward.version DNA attribute in the filtered fleet query path")
+}
+
 // noopSender is a minimal transport stub that satisfies registry.MessageSender
 // so that registry.Register's nil-Sender guard passes in tests. It is not a
 // mock of a CFGMS business component — MessageSender is a low-level transport

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -183,6 +183,14 @@ type TransportClient struct {
 	// From steward.cfg upgrade.allow_downgrade. Protected by mu. (Issue #1943)
 	upgradeAllowDowngrade bool
 
+	// lastStagedVersion and lastStagedBinaryPath record the version and on-disk
+	// path of the binary most recently staged by handlePushStewardBinary.
+	// TriggerConvergence uses them to re-issue the launcher swap when the
+	// desired_version config key is set and the running binary hasn't changed yet.
+	// Protected by mu. (Issue #2260)
+	lastStagedVersion    string
+	lastStagedBinaryPath string
+
 	// launcherSwapFunc is the function invoked to call the launcher swap subcommand.
 	// When nil the default exec.CommandContext implementation is used. Injectable
 	// for testing so tests do not require the launcher binary on disk. (Issue #1943)
@@ -975,6 +983,12 @@ func (c *TransportClient) syncConfigNow(ctx context.Context, commandID string, m
 	// cannot set it (the local-file loading path clears the field).
 	executor.SetDriftMode(applyDriftModeDefault(goConfig.Steward.DriftMode))
 
+	// Thread allow_downgrade from the controller-delivered cfg so both
+	// handlePushStewardBinary and triggerVersionConvergence use the current value.
+	c.mu.Lock()
+	c.upgradeAllowDowngrade = goConfig.Steward.Upgrade.AllowDowngrade
+	c.mu.Unlock()
+
 	// Marshal to YAML for executor.
 	configYAML, err := yaml.Marshal(goConfig)
 	if err != nil {
@@ -1119,6 +1133,7 @@ func (c *TransportClient) SendHeartbeat(ctx context.Context, status string, metr
 		DNAHash:         currentDNAHash,
 		ActiveSessions:  activeSessions,
 		ConnectionState: connectionState,
+		Version:         version.Short(),
 	}
 
 	if err := cp.SendHeartbeat(ctx, heartbeat); err != nil {
@@ -1137,6 +1152,15 @@ func (c *TransportClient) SendHeartbeat(ctx context.Context, status string, metr
 // the data plane.
 // If the controller is unreachable the event is queued locally and delivered on reconnect (Issue #419).
 func (c *TransportClient) PublishDNAUpdate(ctx context.Context, dnaAttrs map[string]string, configHash, syncFingerprint string) error {
+	// Always inject the running binary version so the controller fleet view is
+	// always current. Copy to avoid mutating the caller's map. (Issue #2260)
+	enriched := make(map[string]string, len(dnaAttrs)+1)
+	for k, v := range dnaAttrs {
+		enriched[k] = v
+	}
+	enriched["steward.version"] = version.Short()
+	dnaAttrs = enriched
+
 	// Always update local DNA state first so the hash is available for heartbeats
 	// even when the control plane is temporarily unavailable.
 	c.dnaMu.Lock()
@@ -1359,7 +1383,89 @@ func (c *TransportClient) TriggerConvergence(ctx context.Context) error {
 	} else {
 		c.logger.Info("Convergence run completed", "version", lastVersion)
 	}
+
+	// Version auto-convergence: when desired_version is set and differs from
+	// the running binary, retry the launcher swap for the already-staged binary.
+	// Errors are non-fatal — the next convergence tick will retry. (Issue #2260)
+	var parsedCfg stewardconfig.StewardConfig
+	if unmarshalErr := yaml.Unmarshal(lastCfg, &parsedCfg); unmarshalErr == nil {
+		c.triggerVersionConvergence(ctx, parsedCfg.Steward.Upgrade.DesiredVersion, parsedCfg.Steward.Upgrade.AllowDowngrade)
+	}
+
 	return nil
+}
+
+// triggerVersionConvergence checks whether the running binary version matches
+// the controller-declared desired_version and, if not, re-issues the launcher
+// swap using the last staged binary. It is idempotent: a no-op when versions
+// already match, when desired_version is absent, or when no binary has been
+// staged for the desired version yet. (Issue #2260)
+func (c *TransportClient) triggerVersionConvergence(ctx context.Context, desiredVersion string, cfgAllowDowngrade bool) {
+	if desiredVersion == "" {
+		return
+	}
+
+	if !stewardBinaryVersionRe.MatchString(desiredVersion) {
+		c.logger.Warn("desired_version has invalid format; skipping version convergence",
+			"desired_version", logging.SanitizeLogValue(desiredVersion))
+		return
+	}
+
+	runningVersion := version.Short()
+	if desiredVersion == runningVersion {
+		return
+	}
+
+	// Downgrade guard: refuse if desired_version is older and downgrade is not
+	// permitted. cfgAllowDowngrade covers inheritance from the controller cfg;
+	// c.upgradeAllowDowngrade covers the initial local steward.cfg value.
+	c.mu.RLock()
+	allowDowngrade := c.upgradeAllowDowngrade || cfgAllowDowngrade
+	stagedVersion := c.lastStagedVersion
+	stagedPath := c.lastStagedBinaryPath
+	lPathOverride := c.launcherPathOverride
+	c.mu.RUnlock()
+
+	if !allowDowngrade && !isNewerVersion(desiredVersion, version.Version) {
+		c.logger.Warn("desired_version is not newer than running version and downgrade is not permitted",
+			"desired_version", logging.SanitizeLogValue(desiredVersion),
+			"running_version", runningVersion)
+		return
+	}
+
+	if stagedVersion != desiredVersion || stagedPath == "" {
+		c.logger.Info("Version convergence: desired_version differs from running; awaiting controller binary push",
+			"desired_version", logging.SanitizeLogValue(desiredVersion),
+			"running_version", runningVersion,
+			"staged_version", logging.SanitizeLogValue(stagedVersion))
+		return
+	}
+
+	lPath := lPathOverride
+	if lPath == "" {
+		lPath = launcherPath()
+	}
+
+	c.logger.Info("Version convergence: retrying launcher swap for desired version",
+		"desired_version", logging.SanitizeLogValue(desiredVersion),
+		"running_version", runningVersion)
+
+	if err := c.execLauncherSwap(ctx, lPath, desiredVersion, stagedPath); err != nil {
+		c.logger.Warn("Version convergence: launcher swap failed",
+			"desired_version", logging.SanitizeLogValue(desiredVersion),
+			"error", err)
+		return
+	}
+
+	c.logger.Info("Version convergence: launcher swap succeeded",
+		"desired_version", logging.SanitizeLogValue(desiredVersion))
+
+	c.mu.RLock()
+	launcherManaged := c.launcherManaged
+	c.mu.RUnlock()
+	if launcherManaged {
+		c.scheduleGracefulShutdownAfterSwap()
+	}
 }
 
 // StartDNARefreshLoop starts a background goroutine that re-collects system DNA

--- a/features/steward/client/client_transport_dna_test.go
+++ b/features/steward/client/client_transport_dna_test.go
@@ -18,6 +18,7 @@ import (
 	dataplaneInterfaces "github.com/cfgis/cfgms/pkg/dataplane/interfaces"
 	dpTypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -260,8 +261,10 @@ func TestPublishDNAUpdate_NoDeltaSkipsPublish(t *testing.T) {
 	c.stewardID = "steward-1"
 	c.tenantID = "tenant-1"
 	// Seed state so delta is empty on second call.
+	// Include steward.version because PublishDNAUpdate always enriches the
+	// incoming attrs with the running version before computing the delta.
 	c.dnaMu.Lock()
-	c.lastPublishedDNA = map[string]string{"k": "v"}
+	c.lastPublishedDNA = map[string]string{"k": "v", "steward.version": version.Short()}
 	c.currentDNAHash = "some-hash"
 	c.dnaMu.Unlock()
 
@@ -357,7 +360,9 @@ func TestDNARefreshLoop_NoDeltaSkipsPublish(t *testing.T) {
 	c, q := newClientWithOfflineQueue(t)
 
 	// Seed last-published DNA so the collector returns the same snapshot.
-	attrs := map[string]string{"hostname": "host-a", "os": "linux"}
+	// Include steward.version because PublishDNAUpdate enriches incoming attrs
+	// with the running version; the seed must match to produce an empty delta.
+	attrs := map[string]string{"hostname": "host-a", "os": "linux", "steward.version": version.Short()}
 	c.dnaMu.Lock()
 	c.lastPublishedDNA = copyStringMap(attrs)
 	c.dnaMu.Unlock()
@@ -387,8 +392,9 @@ func TestDNARefreshLoop_ChangedAttributePublishesOne(t *testing.T) {
 	c, q := newClientWithOfflineQueue(t)
 
 	// Seed a prior snapshot; collector will return a single changed value.
+	// Include steward.version so only the hostname change produces a delta.
 	c.dnaMu.Lock()
-	c.lastPublishedDNA = map[string]string{"hostname": "host-a", "os": "linux"}
+	c.lastPublishedDNA = map[string]string{"hostname": "host-a", "os": "linux", "steward.version": version.Short()}
 	c.dnaMu.Unlock()
 
 	stub := &stubDNACollector{attrs: map[string]string{"hostname": "host-b", "os": "linux"}}
@@ -431,7 +437,8 @@ func TestDNARefreshLoop_StopsOnContextCancel(t *testing.T) {
 	c, q := newClientWithOfflineQueue(t)
 
 	// Seed prior state so the first tick produces no event (stable baseline).
-	initial := map[string]string{"os": "linux"}
+	// Include steward.version to match what PublishDNAUpdate enriches the attrs with.
+	initial := map[string]string{"os": "linux", "steward.version": version.Short()}
 	c.dnaMu.Lock()
 	c.lastPublishedDNA = copyStringMap(initial)
 	c.dnaMu.Unlock()
@@ -465,7 +472,8 @@ func TestDNARefreshLoop_StopsOnDNARefreshStop(t *testing.T) {
 	c, q := newClientWithOfflineQueue(t)
 
 	// Seed prior state so the first tick produces no event (stable baseline).
-	initial := map[string]string{"os": "linux"}
+	// Include steward.version to match what PublishDNAUpdate enriches the attrs with.
+	initial := map[string]string{"os": "linux", "steward.version": version.Short()}
 	c.dnaMu.Lock()
 	c.lastPublishedDNA = copyStringMap(initial)
 	c.dnaMu.Unlock()

--- a/features/steward/client/client_transport_upgrade.go
+++ b/features/steward/client/client_transport_upgrade.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -41,6 +42,10 @@ const MaxBinarySizeBytes = 200 * 1024 * 1024
 // ErrDowngradeDenied is returned when the upgrade version is not newer than
 // the running version and allow_downgrade is not enabled. (Issue #1943)
 var ErrDowngradeDenied = errors.New("downgrade denied: target version is not newer than running version")
+
+// stewardBinaryVersionRe validates version strings before using them in paths
+// or commands. Accepts "v1.2.3" and "v1.2.3-pre.release" forms. (Issue #2260)
+var stewardBinaryVersionRe = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-zA-Z0-9][a-zA-Z0-9.-]*)?$`)
 
 // upgradeSeq is used to generate unique temp file names without crypto/rand.
 var upgradeSeq atomic.Int64
@@ -256,6 +261,13 @@ func (c *TransportClient) handlePushStewardBinary(ctx context.Context, cmd *cpTy
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("push_steward_binary: launcher swap failed: %w", err)
 	}
+
+	// Record the staged binary so TriggerConvergence can re-issue the swap if
+	// the steward has not restarted yet when the convergence loop fires. (Issue #2260)
+	c.mu.Lock()
+	c.lastStagedVersion = params.Version
+	c.lastStagedBinaryPath = tmpPath
+	c.mu.Unlock()
 
 	// Step 13: Swap succeeded — the new binary is now the launcher's "current".
 	// Schedule a graceful shutdown so the launcher's supervise loop re-execs the

--- a/features/steward/client/version_convergence_test.go
+++ b/features/steward/client/version_convergence_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Tests for desired_version auto-convergence in TriggerConvergence. (Issue #2260)
+//
+// Tests:
+//   - TestTriggerConvergence_VersionConvergence_InvokesSwapWhenVersionDiffers
+//   - TestTriggerConvergence_VersionConvergence_NoOpWhenVersionMatches
+//   - TestTriggerConvergence_VersionConvergence_NoOpWhenDesiredVersionAbsent
+//   - TestTriggerConvergence_VersionConvergence_DowngradeGuardBlocksOlderVersion
+//   - TestTriggerConvergence_VersionConvergence_AllowDowngradeInCfgPermitsOlderVersion
+package client
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/execution"
+	"github.com/cfgis/cfgms/pkg/version"
+)
+
+// makeVersionCfgYAML marshals a StewardConfig with the given upgrade settings
+// to YAML bytes for use as lastConfigYAML in convergence tests.
+func makeVersionCfgYAML(t *testing.T, desiredVersion string, allowDowngrade bool) []byte {
+	t.Helper()
+	cfg := stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			Upgrade: stewardconfig.UpgradeConfig{
+				DesiredVersion: desiredVersion,
+				AllowDowngrade: allowDowngrade,
+			},
+		},
+	}
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	return data
+}
+
+// newClientForVersionConvergenceTest returns a TransportClient wired for version
+// convergence unit tests. The injected launcherSwapFunc and executor avoid any
+// real binary I/O; launcherManaged=false prevents a shutdown trigger.
+func newClientForVersionConvergenceTest(
+	t *testing.T,
+	stagedVersion, stagedPath string,
+	swapFn func(ctx context.Context, lPath, ver, bin string) error,
+) *TransportClient {
+	t.Helper()
+	exec, err := execution.NewExecutor(&execution.ExecutorConfig{Logger: newTestLogger(t)})
+	require.NoError(t, err)
+
+	c := &TransportClient{
+		stewardID:            "test-steward",
+		tenantID:             "test-tenant",
+		heartbeatStop:        make(chan struct{}),
+		convergenceStop:      make(chan struct{}),
+		logger:               newTestLogger(t),
+		configExecutor:       exec,
+		launcherSwapFunc:     swapFn,
+		lastStagedVersion:    stagedVersion,
+		lastStagedBinaryPath: stagedPath,
+		// launcherManaged=false: successful swap must not trigger a real shutdown.
+		launcherManaged: false,
+	}
+	return c
+}
+
+// TestTriggerConvergence_VersionConvergence_InvokesSwapWhenVersionDiffers proves
+// that when desired_version differs from the running version and a matching staged
+// binary exists, TriggerConvergence invokes the launcher swap with the correct
+// version. (AC: required unit test with injectable launcherSwapFunc)
+func TestTriggerConvergence_VersionConvergence_InvokesSwapWhenVersionDiffers(t *testing.T) {
+	const desiredVersion = "v99.0.0" // clearly newer than any dev build
+
+	var swapCalled bool
+	var swappedVersion string
+	swapFn := func(_ context.Context, _, ver, _ string) error {
+		swapCalled = true
+		swappedVersion = ver
+		return nil
+	}
+
+	c := newClientForVersionConvergenceTest(t, desiredVersion, filepath.Join(t.TempDir(), "fake-steward"), swapFn)
+	c.lastConfigYAML = makeVersionCfgYAML(t, desiredVersion, false)
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, swapCalled, "expected launcher swap to be invoked for desired_version mismatch")
+	assert.Equal(t, desiredVersion, swappedVersion, "swap must target the desired version")
+}
+
+// TestTriggerConvergence_VersionConvergence_NoOpWhenVersionMatches proves that
+// TriggerConvergence does NOT invoke the swap when the running version already
+// equals desired_version. (AC: matching versions → no-op)
+func TestTriggerConvergence_VersionConvergence_NoOpWhenVersionMatches(t *testing.T) {
+	runningVersion := version.Short()
+
+	swapCalled := false
+	swapFn := func(_ context.Context, _, _, _ string) error {
+		swapCalled = true
+		return nil
+	}
+
+	c := newClientForVersionConvergenceTest(t, runningVersion, filepath.Join(t.TempDir(), "fake-steward"), swapFn)
+	c.lastConfigYAML = makeVersionCfgYAML(t, runningVersion, false)
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.False(t, swapCalled, "swap must NOT be called when running version equals desired_version")
+}
+
+// TestTriggerConvergence_VersionConvergence_NoOpWhenDesiredVersionAbsent proves
+// back-compat: when desired_version is absent from the config, TriggerConvergence
+// proceeds normally without invoking the swap path. (AC: absent desired_version → no-op)
+func TestTriggerConvergence_VersionConvergence_NoOpWhenDesiredVersionAbsent(t *testing.T) {
+	swapCalled := false
+	swapFn := func(_ context.Context, _, _, _ string) error {
+		swapCalled = true
+		return nil
+	}
+
+	c := newClientForVersionConvergenceTest(t, "", "", swapFn)
+	c.lastConfigYAML = makeVersionCfgYAML(t, "", false) // no desired_version
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.False(t, swapCalled, "swap must NOT be called when desired_version is absent")
+}
+
+// TestTriggerConvergence_VersionConvergence_DowngradeGuardBlocksOlderVersion
+// proves that when desired_version is older than the running version and
+// AllowDowngrade is false, the swap is not invoked. (AC: downgrade guard)
+func TestTriggerConvergence_VersionConvergence_DowngradeGuardBlocksOlderVersion(t *testing.T) {
+	const olderVersion = "v0.0.1"
+
+	swapCalled := false
+	swapFn := func(_ context.Context, _, _, _ string) error {
+		swapCalled = true
+		return nil
+	}
+
+	c := newClientForVersionConvergenceTest(t, olderVersion, filepath.Join(t.TempDir(), "fake-steward"), swapFn)
+	c.upgradeAllowDowngrade = false
+	c.lastConfigYAML = makeVersionCfgYAML(t, olderVersion, false)
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.False(t, swapCalled, "swap must NOT be called when downgrade is blocked and desired_version is older")
+}
+
+// TestTriggerConvergence_VersionConvergence_AllowDowngradeInCfgPermitsOlderVersion
+// proves that when allow_downgrade is set in the controller-delivered config, the
+// swap IS invoked even when desired_version is older than the running version.
+func TestTriggerConvergence_VersionConvergence_AllowDowngradeInCfgPermitsOlderVersion(t *testing.T) {
+	const olderVersion = "v0.0.1"
+
+	var swapCalled bool
+	var swappedVersion string
+	swapFn := func(_ context.Context, _, ver, _ string) error {
+		swapCalled = true
+		swappedVersion = ver
+		return nil
+	}
+
+	c := newClientForVersionConvergenceTest(t, olderVersion, filepath.Join(t.TempDir(), "fake-steward"), swapFn)
+	c.upgradeAllowDowngrade = false
+	c.lastConfigYAML = makeVersionCfgYAML(t, olderVersion, true) // allow_downgrade set in cfg
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, swapCalled, "swap MUST be called when AllowDowngrade is enabled in cfg")
+	assert.Equal(t, olderVersion, swappedVersion)
+}

--- a/pkg/config/inheritance.go
+++ b/pkg/config/inheritance.go
@@ -315,6 +315,22 @@ func (ir *InheritanceResolver) applyConfigurationWithSource(effective *Effective
 		effective.Sources["steward.drift_mode"] = source
 	}
 
+	// Upgrade settings — carry desired_version and allow_downgrade through the
+	// tenant hierarchy so MSP-level upgrade policy propagates to child stewards.
+	if config.Steward.Upgrade.DesiredVersion != "" {
+		effective.Config.Steward.Upgrade.DesiredVersion = config.Steward.Upgrade.DesiredVersion
+		effective.Sources["steward.upgrade.desired_version"] = source
+	}
+	// allow_downgrade uses "more-permissive-wins" semantics (a child cannot
+	// revoke a parent-granted permission within a single inheritance pass).
+	// This matches the existing bool-inheritance pattern in this function and
+	// is intentional: MSPs opt tenants into downgrade by setting it true;
+	// steward-level override is not supported for this field.
+	if config.Steward.Upgrade.AllowDowngrade {
+		effective.Config.Steward.Upgrade.AllowDowngrade = true
+		effective.Sources["steward.upgrade.allow_downgrade"] = source
+	}
+
 	// Apply logging settings
 	if config.Steward.Logging.Level != "" {
 		effective.Config.Steward.Logging.Level = config.Steward.Logging.Level

--- a/pkg/config/inheritance_test.go
+++ b/pkg/config/inheritance_test.go
@@ -314,3 +314,107 @@ func TestApplyConfigurationWithSource_OverrideKeepsPositionAppendsNew(t *testing
 	}
 	assert.Equal(t, 4, vm1.Config["cpu_count"], "child layer must override the base resource in place")
 }
+
+// TestResolveConfiguration_PropagatesDesiredVersionFromParent verifies that
+// steward.upgrade.desired_version set at a parent tenant cascades to child
+// stewards via applyConfigurationWithSource. (Issue #2260)
+func TestResolveConfiguration_PropagatesDesiredVersionFromParent(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+
+	ctx := context.Background()
+	seedThreeLevelTenants(t, ctx, sm)
+
+	cs := sm.GetConfigStore()
+	require.NotNil(t, cs)
+
+	// Parent (root) sets desired_version; child tenant has no upgrade config.
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{TenantID: "root", Namespace: "msp-policies", Name: "global"},
+		Data: marshalStewardConfig(t, stewardconfig.StewardConfig{
+			Steward: stewardconfig.StewardSettings{
+				Upgrade: stewardconfig.UpgradeConfig{DesiredVersion: "v0.5.21"},
+			},
+		}),
+	}))
+
+	ir := NewInheritanceResolverWithStorageManager(sm)
+	effective, err := ir.ResolveConfiguration(ctx, "client", "steward-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "v0.5.21", effective.Config.Steward.Upgrade.DesiredVersion,
+		"desired_version set at parent tenant must cascade to descendant stewards")
+	assert.NotNil(t, effective.Sources["steward.upgrade.desired_version"],
+		"inheritance source for desired_version must be recorded")
+}
+
+// TestApplyConfigurationWithSource_DesiredVersionInherited verifies the
+// applyConfigurationWithSource primitive: a parent config's desired_version is
+// carried into the effective config and its source is tracked. (Issue #2260)
+func TestApplyConfigurationWithSource_DesiredVersionInherited(t *testing.T) {
+	ir := &InheritanceResolver{}
+	effective := &EffectiveConfiguration{Sources: make(map[string]*InheritanceSource)}
+
+	parentSrc := &InheritanceSource{Source: "parent", TenantID: "root"}
+	parentCfg := &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			Upgrade: stewardconfig.UpgradeConfig{
+				DesiredVersion: "v0.5.21",
+				AllowDowngrade: true,
+			},
+		},
+	}
+	ir.applyConfigurationWithSource(effective, parentCfg, parentSrc)
+
+	assert.Equal(t, "v0.5.21", effective.Config.Steward.Upgrade.DesiredVersion,
+		"desired_version must be applied from parent config")
+	assert.True(t, effective.Config.Steward.Upgrade.AllowDowngrade,
+		"allow_downgrade must be applied from parent config")
+	assert.Equal(t, parentSrc, effective.Sources["steward.upgrade.desired_version"],
+		"desired_version source must be tracked")
+	assert.Equal(t, parentSrc, effective.Sources["steward.upgrade.allow_downgrade"],
+		"allow_downgrade source must be tracked")
+
+	// A child config with no desired_version must not clobber the inherited value.
+	childSrc := &InheritanceSource{Source: "child", TenantID: "client"}
+	childCfg := &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{ID: "child-steward"},
+	}
+	ir.applyConfigurationWithSource(effective, childCfg, childSrc)
+
+	assert.Equal(t, "v0.5.21", effective.Config.Steward.Upgrade.DesiredVersion,
+		"child with empty desired_version must not clobber inherited value")
+}
+
+// TestApplyConfigurationWithSource_AllowDowngrade_MorePermissiveWins pins the
+// intentional "more-permissive-wins" semantics: once a parent sets allow_downgrade=true
+// a child that sets allow_downgrade=false cannot revoke it within the same inheritance
+// pass. This is consistent with other bool fields in applyConfigurationWithSource and
+// is deliberate policy for this security control. (Issue #2260)
+func TestApplyConfigurationWithSource_AllowDowngrade_MorePermissiveWins(t *testing.T) {
+	ir := &InheritanceResolver{}
+	effective := &EffectiveConfiguration{Sources: make(map[string]*InheritanceSource)}
+
+	parentSrc := &InheritanceSource{Source: "root", TenantID: "root"}
+	parentCfg := &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			Upgrade: stewardconfig.UpgradeConfig{AllowDowngrade: true},
+		},
+	}
+	ir.applyConfigurationWithSource(effective, parentCfg, parentSrc)
+	require.True(t, effective.Config.Steward.Upgrade.AllowDowngrade, "parent sets allow_downgrade=true")
+
+	// Child explicitly sets allow_downgrade=false (zero-value for bool) — it cannot
+	// revoke the parent-granted permission via applyConfigurationWithSource.
+	childSrc := &InheritanceSource{Source: "child", TenantID: "client"}
+	childCfg := &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			Upgrade: stewardconfig.UpgradeConfig{AllowDowngrade: false},
+		},
+	}
+	ir.applyConfigurationWithSource(effective, childCfg, childSrc)
+
+	assert.True(t, effective.Config.Steward.Upgrade.AllowDowngrade,
+		"more-permissive-wins: child false cannot revoke parent true")
+	assert.Equal(t, parentSrc, effective.Sources["steward.upgrade.allow_downgrade"],
+		"source must remain the parent that set the permissive value")
+}


### PR DESCRIPTION
## Summary

- **`desired_version` in cfg**: New `UpgradeConfig.DesiredVersion` field flows root→tenant→device through the standard inheritance chain; `allow_downgrade` follows the same more-permissive-wins semantics as other bool fields
- **Auto-convergence**: `TriggerConvergence` calls `triggerVersionConvergence` on every cfg apply; if `desired_version` differs from the running version and a matching staged binary exists, the launcher swap is re-invoked without re-downloading
- **`steward.version` in DNA + heartbeats**: `PublishDNAUpdate` always enriches DNA deltas with `steward.version`; `SendHeartbeat` carries `Version`; controller fleet list API exposes it in the filtered query path

## Test plan

- [x] 5 unit tests in `version_convergence_test.go` with injectable `launcherSwapFunc` — swap invoked, no-op when matching, no-op when absent, downgrade blocked, downgrade permitted with `allow_downgrade`
- [x] 2 new tests in `inheritance_test.go` — `desired_version` propagates, `allow_downgrade` more-permissive-wins semantics pinned
- [x] 1 new test in `handlers_stewards_test.go` — `Version` field populated from `steward.version` DNA attribute in filtered fleet query path
- [x] Existing DNA refresh loop tests updated to seed `steward.version` in `lastPublishedDNA` (no mocks added)
- [x] `make test-agent-complete` — all gates pass; cross-platform compile clean
- [x] Security review: PASS (version string validated against anchored regex; binary path set only after full verification chain; no external input reaches DNA version field)
- [x] QA code review: PASS (no mocks, no `t.Skip()`, no hardcoded secrets, mutex coverage confirmed)

Fixes #2260

🤖 Generated with [Claude Code](https://claude.com/claude-code)