### PR TITLE
refresh-pins: cover .mcp.json git-pinned servers (serena) with breaking-change classification

### DIFF
--- a/.claude/skills/refresh-pins/SKILL.md
+++ b/.claude/skills/refresh-pins/SKILL.md
@@ -66,6 +66,7 @@ For each pin (run in parallel where independent — separate Bash calls in one a
    done
    ```
    Then for each artifact URL, download, unzip, and grep the SARIF for `"Installed Version": "<current_pin>"`. A match means the gate is currently failing on this exact pin → flag for cooldown override.
+4. **MCP pins only (`kind: mcp`, e.g. serena)** — research the **consumed-tool delta**: the set of `mcp__<server>__<tool>` names we use (`grep -rhoE 'mcp__<server>__[a-z_]+' .claude/agents/ .mcp.json | sort -u`) versus any tool renamed/removed/signature-changed between `current` and `latest` (WebFetch the release notes for each intervening tag). This is what Phase 3 needs to classify the bump as mechanical vs. breaking. Release notes are also the CVE source for these pins (GHSA rarely resolves a git-installed server; `ecosystem`/`package` are null).
 
 ## Phase 3: Justify (apply the decision matrix)
 
@@ -88,6 +89,8 @@ If `$ARGUMENTS` started with `--urgent`, force BUMP NOW for the named pin regard
 ## Phase 4: Create stories
 
 For each pin with verdict BUMP or BUMP NOW:
+
+> **`kind: mcp` pins** carry an extra blast-radius classification (decision-matrix.md "MCP server pins"). If the consumed-tool delta (Phase 2 step 4) shows a tool we use was renamed/removed/changed, this is a **REWIRE story** — expand the scope to every `.claude/agents/*.md` that names the tool (allowlist + prose) plus `.mcp.json`, title it `deps: rewire <server> ... (breaking: ...)`, require a fresh-spawn smoke test in the ACs, and mark it **not auto-mergeable** (human-reviewed). A non-breaking `mcp` bump uses the standard one-line template below.
 
 1. Read `assets/story-template.md` (lazy load)
 2. Substitute placeholders:

--- a/.claude/skills/refresh-pins/references/cooldown-policy.md
+++ b/.claude/skills/refresh-pins/references/cooldown-policy.md
@@ -42,6 +42,10 @@ Example:
 
 Claude reads this in Phase 3 and applies the per-pin value when present.
 
+### MCP/agent-tooling pins (kind `mcp`, e.g. serena)
+
+These use the **default 3-day cooldown** for the *version* decision — same few days as any other pin. We deliberately do NOT lengthen the cooldown for them. The extra safety for agent tooling is not a longer wait; it's the **blast-radius classification** in `decision-matrix.md` ("MCP server pins"): a release that renames/removes a tool we consume routes to a human-reviewed **rewire story** (touching the `.claude/agents/*.md` allowlists + prose), not a mechanical bump that could auto-merge. So a non-breaking serena patch refreshes routinely after 3 days, while a breaking one is gated by review regardless of how long it's been out.
+
 ## Override conditions (skip the cooldown)
 
 The cooldown is overridden when ANY of these are true:

--- a/.claude/skills/refresh-pins/references/decision-matrix.md
+++ b/.claude/skills/refresh-pins/references/decision-matrix.md
@@ -77,6 +77,36 @@ Verdict: **BUMP**. Story body explains: routine refresh, past cooldown, no urgen
 
 Verdict: **INVESTIGATE**. Don't create a bump story (there's nowhere to bump to). Create a `high-priority` tracking issue describing the pin, the CVE, and the lack of upstream fix — assign to founder and set Blocked status via `po-act.sh block`. The skill should print this case explicitly in the report so the founder can escalate to the upstream or accept the risk.
 
+## MCP server pins (kind `mcp`, e.g. serena)
+
+MCP server pins run the **same** CVE/cooldown matrix above to decide *whether* to bump (cooldown is the default 3 days from the tag's `published_at`; an active HIGH/CRITICAL advisory affecting our pinned tag overrides it). What's different is a second, blast-radius classification that decides *what kind of story* the bump produces — because these are agent **tooling** dependencies: the planning and dev agents consume their tools by name (`mcp__<server>__<tool>` appears in `.claude/agents/*.md` `tools:` allowlists **and** instruction prose). A release that renames or removes a consumed tool silently breaks those agents — the `tools:` grant stops matching and the agent falls back to grep (or errors), which a one-line version bump would ship unnoticed.
+
+### Step A — research the consumed-tool delta (Phase 2 add-on)
+
+For an `mcp` pin with a newer release past cooldown:
+
+1. **Our consumed surface:** `grep -rhoE 'mcp__<server>__[a-z_]+' .claude/agents/ .mcp.json | sort -u` — the exact tools we depend on by name (e.g. `mcp__serena__find_symbol`, `find_referencing_symbols`, …).
+2. **Upstream tool-surface change between `current` and `latest`:** WebFetch the release notes / CHANGELOG for every tag in `(current, latest]` and look for renamed, removed, or signature-changed tools. (GHSA rarely resolves a git-installed server, so release notes are also the CVE source — `ecosystem`/`package` are null by design.)
+3. **Intersect.** A change is **breaking for us** only if it touches a tool in our consumed surface (a renamed tool we don't use is irrelevant).
+
+### Step B — classify the bump
+
+| Consumed-tool delta | Story shape | Auto-mergeable? |
+|---|---|---|
+| None of our consumed tools renamed/removed/changed (patch/minor, additive only) | **Mechanical bump** — one-line `.mcp.json` tag change. Standard pin-bump story (`assets/story-template.md`); `locations[]` is just the `.mcp.json` line. | Yes, normal pipeline |
+| Any consumed tool renamed / removed / signature-changed | **REWIRE story** — see below | **No** — needs deliberate review |
+
+### The rewire story (breaking change)
+
+Title it `deps: rewire <server> <from> → <to> (breaking: <tool> renamed/removed)` and expand the scope beyond `.mcp.json`:
+
+- `.mcp.json` — bump the tag.
+- **Every `.claude/agents/*.md`** returned by `grep -rl 'mcp__<server>__' .claude/agents/` — update the `tools:` frontmatter allowlist entries AND the instruction prose that names the old tool, in lockstep.
+- Acceptance must include a **fresh-spawn smoke test** of an affected agent: spawn it and have it call a renamed/new tool directly, asserting it resolves. (Agent-definition edits hot-load on the next fresh subagent spawn — no restart — but an agent's self-report of its own toolset is unreliable, so force the actual tool call rather than asking it to introspect.)
+- Note the lockstep hazard explicitly in the body: bumping `.mcp.json` without updating the allowlists ships agents whose serena grant silently no-ops.
+
+This is the one pin class where the bump is **not** purely mechanical — treat a breaking `mcp` bump as a real rewire, not a version swap. When in doubt about whether a change is breaking, classify as REWIRE (false-positive costs one review; false-negative ships broken agents).
+
 ## Multiple CVEs in one pin
 
 Aggregate by maximum severity. If a pin has both LOW and HIGH CVEs, treat it as HIGH.

--- a/.claude/skills/refresh-pins/references/inventory-schema.md
+++ b/.claude/skills/refresh-pins/references/inventory-schema.md
@@ -7,7 +7,7 @@
 ```jsonc
 {
   "name": "go-toolchain",       // string — stable identifier for this pin (used in story titles, override audit log)
-  "kind": "lockstep",           // "lockstep" | "tool"
+  "kind": "lockstep",           // "lockstep" | "tool" | "mcp"
   "current": "1.25.10",         // string — version string as it appears in the source (no leading "v" for Go)
   "release_source": "https://go.dev/dl/?mode=json",  // URL or "gh:<owner>/<repo>"
   "ecosystem": "GO",            // GHSA SecurityAdvisoryEcosystem enum, or null if not GHSA-queryable
@@ -25,6 +25,7 @@
 - **`tool`** — covers two distinct sub-cases that share the same downstream Phase 2/3 handling:
   - **Tool-pin declarations** in `dependency-pin-check.yml` (gosec, staticcheck, trivy, …). `locations[]` starts with the `check_version` declaration, then every install/usage site found by grepping `.github/workflows/`, `.devcontainer/Dockerfile`, `Makefile`, `cmd/*/Dockerfile`, and `scripts/*.sh` for the literal version string. All entries must move together in a single bump PR.
   - **GitHub Action SHA pins** (`uses: <owner>/<name>@<sha>` lines in workflows). The name embeds the short SHA (`gha:actions/checkout@34e11487`) so each unique (action, sha) pair is its own inventory entry. `locations[]` lists every workflow file:line that uses that exact SHA. Multiple entries for the same action with different SHAs is the natural representation of SHA drift across workflows — a drift-finder consumer can group by stripping `@<sha>` from `name`.
+- **`mcp`** — a git-pinned MCP server in `.mcp.json` (`git+https://github.com/<owner>/<repo>@<tag>`, e.g. `serena`). `current` is the git tag (with leading `v`), `release_source` is `gh:<owner>/<repo>`, `locations[]` is the `.mcp.json` line. **Distinct downstream handling:** these are agent *tooling* dependencies — their tool names are consumed by name in `.claude/agents/*.md` (`tools:` allowlists + prose). Phase 3 applies the **blast-radius classification** (see `decision-matrix.md` "MCP server pins"): a non-breaking bump is a one-line `.mcp.json` story; a release that renames/removes/changes a consumed tool is a **rewire story** that also touches every agent file using the affected tool.
 
 ## `release_source` values
 

--- a/.claude/skills/refresh-pins/scripts/discover-pins.py
+++ b/.claude/skills/refresh-pins/scripts/discover-pins.py
@@ -17,6 +17,10 @@ Discovery sources:
   — one inventory entry per unique (action, sha) tuple so SHA drift across
   workflows is naturally visible (multiple entries with the same action name
   but different SHAs).
+- .mcp.json — git-pinned MCP servers (git+https://github.com/<owner>/<repo>@<tag>,
+  e.g. serena). kind="mcp"; these are agent *tooling* dependencies whose tool
+  names are consumed by name in .claude/agents/*.md, so a tool-renaming release
+  is a breaking change (see references/decision-matrix.md "MCP server pins").
 
 Run from repo root or any subdir — uses `git rev-parse --show-toplevel`
 to anchor.
@@ -265,11 +269,71 @@ def discover_github_actions(root: Path) -> list[dict]:
     return pins
 
 
+def discover_mcp_pins(root: Path) -> list[dict]:
+    """MCP server pins in .mcp.json — git+https://github.com/<owner>/<repo>@<tag>.
+
+    Each git-pinned MCP server (e.g. serena) becomes one pin entry. Generic:
+    any current/future .mcp.json server pinned to a GitHub git tag is covered.
+
+    These are agent *tooling* dependencies — the planning/dev agents consume
+    their tools by name (e.g. `mcp__serena__find_symbol` appears in
+    .claude/agents/*.md `tools:` allowlists and prose), so a release that
+    renames/removes a tool is a BREAKING change that needs a rewire story, not a
+    one-line pin bump. The blast-radius classification lives in Phase 3 (see
+    references/decision-matrix.md "MCP server pins"); this discovery only emits
+    the pin + its .mcp.json location.
+    """
+    pins: list[dict] = []
+    mcp_file = root / ".mcp.json"
+    if not mcp_file.exists():
+        return pins
+    try:
+        text = mcp_file.read_text()
+        data = json.loads(text)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return pins
+    git_ref = re.compile(
+        r"git\+https://github\.com/([^/]+)/([^/@]+?)(?:\.git)?@(v?[0-9][^\s\"']*)"
+    )
+    raw_lines = text.splitlines()
+    servers = data.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        return pins
+    for name in sorted(servers):
+        cfg = servers[name]
+        args = cfg.get("args", []) if isinstance(cfg, dict) else []
+        match = None
+        for arg in args:
+            if isinstance(arg, str):
+                match = git_ref.search(arg)
+                if match:
+                    break
+        if not match:
+            continue  # non-git-pinned server (uvx latest, npx, local path) — not a versioned pin
+        owner, repo, tag = match.group(1), match.group(2), match.group(3)
+        locations = [
+            {"file": ".mcp.json", "line": i, "match": line.strip()}
+            for i, line in enumerate(raw_lines, 1)
+            if git_ref.search(line)
+        ]
+        pins.append({
+            "name": name,
+            "kind": "mcp",
+            "current": tag,
+            "release_source": f"gh:{owner}/{repo}",
+            "ecosystem": None,  # git-installed; GHSA rarely resolves — Phase 2 falls back to release notes
+            "package": None,
+            "locations": locations,
+        })
+    return pins
+
+
 def main() -> int:
     root = repo_root()
     inventory = [discover_go_toolchain(root)]
     inventory.extend(discover_tool_pins(root))
     inventory.extend(discover_github_actions(root))
+    inventory.extend(discover_mcp_pins(root))
     json.dump(inventory, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 0


### PR DESCRIPTION
## What

Bring the `serena` MCP pin (and any future `.mcp.json` git-pinned server) under the `refresh-pins` skill, with a serena-specific breaking-change policy.

**Before:** `discover-pins.py` scanned `go.mod`, Dockerfiles, the `dependency-pin-check.yml` tool list, and GitHub Action SHAs — but **not `.mcp.json`**. So `serena@v1.5.3` was invisible: no bump candidate ever surfaced, no security visibility.

## Changes

- **`scripts/discover-pins.py`** — new `discover_mcp_pins()`: generic scan of `.mcp.json` for `git+https://github.com/<owner>/<repo>@<tag>` servers, emitted as `kind: "mcp"` with `release_source: gh:<owner>/<repo>`. The existing Phase 2 `gh api .../releases/latest` research and the cooldown/CVE matrix work on it unchanged.
- **`references/decision-matrix.md`** — new "MCP server pins" section: the **blast-radius classification**. Because tool names (`mcp__serena__find_symbol`, …) are consumed by name in `.claude/agents/*.md` allowlists + prose, a release that renames/removes a consumed tool silently breaks the agents. So:
  - non-breaking bump → one-line `.mcp.json` pin story (normal pipeline)
  - consumed tool renamed/removed/changed → **REWIRE story** touching every affected agent file (allowlist + prose) + `.mcp.json`, with a fresh-spawn smoke test in the ACs, **not auto-mergeable**
- **`SKILL.md`** — Phase 2 consumed-tool-delta research step; Phase 4 routes `mcp` breaking bumps to the rewire scope.
- **`references/cooldown-policy.md`** — serena uses the **default 3-day** cooldown (per founder: "same few days"); the breaking-change gate is the extra safety, not a longer wait.
- **`references/inventory-schema.md`** — document the `mcp` kind.

## Policy (per founder direction)

> Research the current version, give it the same few days to cool down after release unless it's patching an active vulnerability in the version we use. Give the pin-check agent a decision matrix (e.g. breaking changes in tool names) that requires a full story to rewire for serena.

Cooldown = default 3 days from the tag's `published_at`; an active HIGH/CRITICAL advisory on our pinned tag overrides it (existing CVE path). Tool-name/contract breaking changes route to a human-reviewed rewire story, never a mechanical bump.

## Validation

Smoke-tested against real repo state (the skill's behavior, not `make test`, which exercises Go and carries a worktree-contamination flake; this change is a skill script + docs, no Go diff):
- `python3 -m py_compile` passes.
- `discover-pins.py` emits `serena` as `kind: mcp` (`v1.5.3`, `gh:oraios/serena`, `.mcp.json:8`) alongside the existing 1 lockstep + 22 tool pins.
- The Phase 2 consumed-tool grep returns our 5 serena tools (`find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `find_implementations`, `find_declaration`).
- Confirmed `serena@v1.5.3` is currently the latest upstream release — so no bump is due now; this is forward coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
