### PR TITLE
docs: codify serena+grep code-navigation discipline (measured)

### DIFF
--- a/.serena/memories/code_navigation.md
+++ b/.serena/memories/code_navigation.md
@@ -1,0 +1,30 @@
+# Code navigation: serena + grep discipline (CFGMS)
+
+Serena's symbolic tools are best for **structure** (`get_symbols_overview`,
+`find_symbol`, `replace_symbol_body`). For **completeness** (callers, usages, impls)
+they are *hints, not a complete set* — combine with grep. Measured details +
+re-run harness: `docs/development/code-navigation-tooling.md`.
+
+Two reproducible failure modes to guard against:
+
+1. **Cold gopls index → incomplete relational results.** The first
+   `find_referencing_symbols` / `find_implementations` of a session can silently
+   miss real callers (observed: it dropped `vm.go:registerClusteredRole` as a caller
+   of `setCluster`; a warm re-run found it). Mitigation: prime gopls with a
+   `get_symbols_overview` on the target + likely caller packages, then re-run and
+   union. Don't trust the first relational call of a session.
+
+2. **gopls sees ONE build configuration → blind to other-`GOOS` code.** On Linux
+   (the dev containers' default `GOOS=linux`), serena cannot see `//go:build windows`
+   files. Verified: a Linux gopls drops `pollClusterStatus`→`getCluster` because
+   `cluster_windows.go` is excluded. **Build-tagged packages where serena under-reports
+   on Linux — use grep (build-tag-agnostic) as authoritative:**
+   - `features/modules/hyperv/*_windows.go` — `cluster_windows.go` (cluster DNA
+     Monitor), `monitor_windows.go`, `pstransport_dispatch_windows.go` (PS dispatch
+     table), `pstransport_*_windows.go`, `detection_windows.go`, `executor_windows.go`.
+   - Generally: any `*_windows.go` / `*_nonwindows.go` / build-tagged file.
+
+Also: `find_implementations` includes test doubles — filter them and reconcile with a
+`var _ Iface = (*T)(nil)` grep. For "is it implemented or a stub?", read the body and
+run the real gate (`go vet`, `make check-architecture`, tests) — don't infer from a
+symbol's existence. Calibrate claim confidence to verification depth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,9 +259,17 @@ docs/          # Documentation
 - Committing test artifacts — use `git add <specific files>`
 - Logging unsanitized input — use `logging.SanitizeLogValue()`
 
-### Code Navigation (serena MCP)
+### Code Navigation (serena MCP + grep)
 
-When the `serena` MCP server is connected (interactive, PO, and dev-agent sessions), prefer its semantic tools over text search for navigating and editing Go code: `find_symbol`, `get_symbols_overview`, and `find_referencing_symbols` to locate code; `replace_symbol_body` / `insert_after_symbol` / `insert_before_symbol` for symbol-level edits. They are more precise and burn far less context than `Grep` + `Read` + whole-file `Edit`. Fall back to grep/read only when the target isn't a code symbol (config, docs, generated files) or serena is unavailable. Serena ships its own usage manual — call its `initial_instructions` tool at the start of a coding task to load it.
+Use the right tool per question; never trust one weak query for "what's been done" (this is measured — see [code-navigation-tooling](docs/development/code-navigation-tooling.md)). Each tool has a distinct, reproducible failure mode, so combine them:
+
+- **Structure → serena.** `get_symbols_overview` / `find_symbol` for a file/type's surface + signatures; `replace_symbol_body` / `insert_after_symbol` / `insert_before_symbol` for symbol-level edits. Cheap, precise, low-context — serena's strongest use.
+- **Every caller / usage / import → grep, exhaustively.** serena's `find_referencing_symbols` / `find_implementations` are *hints, not a complete set*: they (1) under-report on a **cold gopls index** — prime gopls first (a `get_symbols_overview` on the target + likely caller packages) and union a re-run; (2) `find_implementations` includes test doubles — filter them and reconcile with a `var _ Iface = (*T)(nil)` grep. Always cross-check a "complete caller/impl set" with grep.
+- **gopls sees ONE build configuration.** Linux dev containers default to `GOOS=linux`, so serena is **blind to `//go:build windows` code** (verified: a Linux gopls drops `pollClusterStatus`→`getCluster` because `cluster_windows.go` is excluded from the package). For build-tagged packages — the hyperv `*_windows.go` cluster/monitor/PS-dispatch surface especially — **grep is authoritative; serena is not.** grep reads text regardless of `GOOS`.
+- **"Real or a stub?" → read the body** + grep stub markers (`ErrNotImplemented`, `panic("TODO")`, bare `return nil`) + run the real gate (`go vet`, `make check-architecture`, the tests). A symbol existing is not evidence it's implemented; not having read it is not evidence it's a stub. When an authoritative gate exists, run it instead of inferring.
+- **Calibrate confidence to verification depth.** One grep keyword or one relational query → *low* confidence until cross-verified; "read the body and two independent methods agree" → *high*.
+
+Call serena's `initial_instructions` at the start of a coding task to load its manual.
 
 ## Desired State Development (DSD)
 

--- a/docs/development/code-navigation-tooling.md
+++ b/docs/development/code-navigation-tooling.md
@@ -1,0 +1,104 @@
+# Code Navigation Tooling — serena (gopls) vs grep
+
+This is a **measured**, re-runnable record of how reliable our two code-comprehension
+tools are for answering "what work has been done" across the codebase, and the
+workflow that follows from the data. It backs the [Code Navigation](../../CLAUDE.md#code-navigation-serena-mcp--grep)
+rules in `CLAUDE.md`. Re-run it when the serena or gopls version changes.
+
+**Why this exists:** weak grepping (or over-trusting a single semantic query) produces
+*false confidence* — an agent concludes it understands a topic without actually knowing
+what is there. The fix is not "pick the better tool"; it is a verification discipline,
+because **each tool has a distinct, reproducible failure mode.**
+
+## The two failure modes (verified 2026-06-30, go1.26.4, gopls v0.22.0)
+
+### 1. grep — false confidence on "is it real?"
+grep finds *text*. It cannot tell you whether a symbol is wired or a stub, and a
+keyword that *looks* covered invites a confident-but-wrong conclusion. In testing,
+the grep arm found `RaftConsensus` and **guessed "stub"** without reading the body —
+it is fully implemented. grep's strength is the opposite: exhaustive, stable recall of
+callers / usages / imports.
+
+### 2. serena (gopls) — false completeness on "who calls this?"
+serena's `find_referencing_symbols` / `find_implementations` run on gopls and can
+silently return *incomplete* sets:
+
+- **Cold-index miss (timing — fixable).** gopls type-checks packages lazily into an
+  in-memory snapshot (no persistent index; every fresh session starts cold). A
+  relational query that races the initial workspace load returns partial results.
+  *Observed:* the first `find_referencing_symbols(setCluster)` of a session **omitted
+  the real caller `vm.go:registerClusteredRole`**; the identical query, re-run warm,
+  returned the complete set. **Mitigation:** prime gopls (a `get_symbols_overview` on
+  the target + likely caller packages) and union a re-run; don't trust the first
+  relational call of a session.
+
+- **Build-tag / `GOOS` blindness (structural — NOT fixable by warming).** gopls
+  analyzes one build configuration at a time. *Verified with gopls directly:*
+
+  ```
+  # callers of getCluster (features/modules/hyperv/cluster.go:194)
+  GOOS=windows gopls references … → cluster_windows.go:79 (pollClusterStatus) + module.go:380
+  GOOS=linux   gopls references … → module.go:380 only   # pollClusterStatus vanishes
+  ```
+
+  Because Linux dev containers default to `GOOS=linux`, serena there is blind to the
+  windows-tagged hyperv surface — confirmed by cross-listing the package:
+
+  ```
+  GOOS=linux go list -f '{{.GoFiles}}' ./features/modules/hyperv   # excludes *_windows.go
+  ```
+
+  Files invisible to a Linux gopls/serena include `cluster_windows.go` (the entire
+  cluster DNA Monitor: `monitorClusterLoop`, `pollClusterStatus`, `dispatchCluster`),
+  `monitor_windows.go` (`startClusterMonitorLocked`), and
+  `pstransport_dispatch_windows.go` (the closed PS dispatch table). **grep is
+  build-tag-agnostic and is the mandatory backstop for these packages.**
+
+## Recommended workflow
+
+1. **Structure first → serena** (`get_symbols_overview` / `find_symbol`): accurate,
+   cheap surface + signature maps.
+2. **Completeness → grep, exhaustively.** Treat serena's relational finders as hints;
+   cross-check and union a warm re-run. Filter `find_implementations` test doubles and
+   reconcile with a `var _ Iface = (*T)(nil)` grep.
+3. **Build-tagged packages → grep is authoritative.** On a Linux host, do not rely on
+   serena for `//go:build windows` code (or set `GOOS` in gopls' config for the task —
+   but it is single-GOOS, so you then lose the other platform's variants).
+4. **Wired-vs-stub → read the body** + grep stub markers
+   (`ErrNotImplemented|panic\("TODO"|return nil //`) + run the real gate
+   (`go vet`, `make check-architecture`, tests). Run an authoritative gate rather than
+   inferring; e.g. `make check-architecture` is the oracle for provider-import
+   violations (note it is two parts: a staged-only delta gate in the `Makefile`, plus
+   the full-tree `scripts/check-providers.sh`).
+5. **Confidence = verification depth.** One grep keyword or one relational query is
+   *low* confidence until cross-verified; "read the body + two methods agree" is *high*.
+
+The adversarial gates (acceptance-checker, tech-lead validation, QA, security review,
+`make check-architecture`, tests) are the safety net that converts "thought it
+understood" into "verified" — these navigation rules reduce how often the gates must
+catch a comprehension error, they do not replace them.
+
+## Re-running the comparison
+
+A repeatable 3-probe harness, each probe with an objective ground truth and a known
+blind spot:
+
+| Probe | Domain | Blind spot it targets | Objective oracle |
+|---|---|---|---|
+| P1 | Controller multi-node/cluster orchestration (#415) | finding the package when it isn't named "cluster"; wired-vs-stub | `go vet`, stub-marker grep, roadmap checkbox |
+| P2 | Steward hyperv cluster module | cross-file *indirect* callers; PS verb mapping; build-tagged monitor | verified caller set; `pstransport_dispatch_windows.go` |
+| P3 | Pluggable provider system | counting/locating interface *implementations*; provider-import violations | `make check-architecture`; `var _ Iface =` assertions; `pkg/README.md` |
+
+Run two **isolated** agents (fresh context, identical probes, each logging its tool
+calls + per-claim confidence): a **GREP-only** arm (no serena) and a **SERENA-only**
+arm (no grep/glob for discovery). An **ORACLE** agent (all tools, cross-verified)
+builds the scoring key and flags every grep/serena disagreement. A **JUDGE** scores both
+arms vs the oracle on **recall / precision / false-confidence count / grounding % /
+tool-cost**, per probe and overall.
+
+Score the metric that matters most for our problem — **false-confidence count**: claims
+asserted at high confidence that the oracle proves wrong. In the 2026-06-30 run the
+worst event was the SERENA arm asserting (High confidence) architecture-violation
+"pluggability breaks" that `make check-architecture` shows do not exist — a confident
+wrong claim produced by reflexively grepping outside the tool's competence and trusting
+the result. That is exactly the failure these rules exist to prevent.


### PR DESCRIPTION
## Summary

Replaces the oversimplified "prefer serena" guidance in `CLAUDE.md`'s **Code Navigation** section with an **evidence-based** workflow, after measuring grep vs serena (gopls) for code comprehension across three domains (controller cluster, steward hyperv cluster module, pluggable providers). Addresses the project-wide problem of weak greps / over-trusted semantic queries producing **false confidence** ("thinks it understands a topic without knowing what's there").

## What the measurement found

Each tool has a **distinct, reproducible failure mode** — so the fix is a verification discipline, not a tool swap:

- **grep — false confidence on "is it real?":** found `RaftConsensus` and *guessed "stub"* without reading the body (it's fully implemented).
- **serena/gopls — false completeness on "who calls this?":**
  - **Cold-index timing (fixable):** the first relational query of a session can drop a real caller — observed `find_referencing_symbols(setCluster)` missing `vm.go:registerClusteredRole`; a **warm re-run returned the complete set**. Mitigation: prime gopls + union a re-run.
  - **Build-tag / `GOOS` blindness (structural):** gopls analyzes one build config. Verified directly with gopls — references to `getCluster`:
    - `GOOS=windows` → `cluster_windows.go:79` (`pollClusterStatus`) **+** `module.go:380`
    - `GOOS=linux` → `module.go:380` **only** (`pollClusterStatus` vanishes)
    
    Dev agents run in **Linux containers** (`GOOS=linux`), so serena is silently blind there to the windows-tagged hyperv surface (the cluster DNA Monitor, the PS dispatch table, the PS host). **grep is the build-tag-agnostic backstop.**

## Changes

- **`CLAUDE.md`** — rewrite the Code Navigation section: structure→serena; completeness→grep + cross-check (warm re-run / union, filter `find_implementations` test doubles); the `GOOS`/build-tag rule; wired-vs-stub via read-body + run the real gate; confidence = verification depth.
- **`docs/development/code-navigation-tooling.md`** — the dated measured findings (go1.26.4 / gopls v0.22.0), the verified gopls evidence, and a **re-runnable 3-probe harness** (isolated GREP-only / SERENA-only arms + oracle + judge, scored on recall / precision / **false-confidence count** / grounding / cost) so this can be re-validated when serena/gopls versions change.
- **`.serena/memories/code_navigation.md`** — serena-specific gotchas surfaced to serena-using agents on onboarding (warm-up, GOOS blindness + the build-tagged hyperv packages, filter `find_implementations` test doubles).

Docs + guidance only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)