### PR TITLE
po: migrate Planning Team orchestration to the implicit-team model

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -232,7 +232,7 @@ Run the full autonomous pipeline cycle once. Use when the founder says "cron", "
 
 This runs **locally** with full Docker access for dispatch and fix cycles. The remote `po-cron` trigger runs the same logic but sets project status `Blocked` for Docker-dependent steps (3 and 4) since it has no Docker access.
 
-**Execution context — inline vs subagent.** `/po cron` is routed to a **clean-context `po` subagent** (see `.claude/commands/po.md` Path B); `/po cycle` and `/po decompose` run **inline** in the main session because they need the Planning Team (`TeamCreate`/`SendMessage`), which a subagent lacks. When this cycle runs **as a subagent**, two adaptations apply (they do NOT change behavior when run inline):
+**Execution context — inline vs subagent.** `/po cron` is routed to a **clean-context `po` subagent** (see `.claude/commands/po.md` Path B); `/po cycle` and `/po decompose` run **inline** in the main session because the Planning Team is a **live team of named `Agent` teammates that coordinate via `SendMessage`** — teammates address the orchestrator as `main`, so the team is driven from the main conversation, not from a backgrounded `po` subagent. (The old `TeamCreate`/`TeamDelete` tools no longer exist; the session has a **single implicit team** — you create teammates simply by spawning named background `Agent`s. See Step 7.) When this cycle runs **as a subagent**, two adaptations apply (they do NOT change behavior when run inline):
 - **No `Skill` tool.** Invoke the pin-refresh (Step 1.6) and pipeline-sweep (Step 7.5) skills by spawning a `general-purpose` Agent that reads and runs the skill's `SKILL.md` inline — equivalent to the inline `Skill:` call.
 - **Nested spawns are async.** The Tech Lead pass (Step 2) `Agent` spawn is backgrounded by the harness, which re-invokes you on its completion. Hold the relevant inline-op lease (e.g. `epic-decompose-*`, or just the cycle's own work) across the gap and act on the result on the completion turn. The dispatch/review/fix **containers** are unaffected (they are docker, not `Agent` subagents).
 
@@ -703,7 +703,7 @@ gh issue view <NUM> --repo cfg-is/cfgms --json number,title,body,labels
 ```
 Extract the epic's Goal, Success Criteria, Non-Goals, Constraints, and PM Notes. Also read `CLAUDE.md` architecture rules and `docs/product/roadmap.md` for milestone context.
 
-**7b. Acquire the decompose lease, then create the planning team:**
+**7b. Acquire the decompose lease:**
 
 Decomposition is a multi-minute operation with no mid-flight idempotency marker
 (the decomposed-marker is posted only at the end), so two hosts would otherwise
@@ -714,20 +714,33 @@ both run a full planning team and double-create the story set. Guard it:
 On `HELD:*`, another host is decomposing this epic — skip it. On
 `ACQUIRED`/`RECLAIMED`, proceed. **Release `epic-decompose-<NUM>` after 7g (summary
 posted) or on any early exit** — including the 7i convergence-failure path.
-```
-TeamCreate(team_name: "planning-epic-<NUM>")
-```
+
+There is **no separate team-creation step**. The session has a **single implicit
+team** (the `Agent` tool's `team_name` parameter is deprecated and ignored), so you
+create teammates simply by spawning named background `Agent`s in 7c; they become
+addressable for `SendMessage` the moment they start.
 
 **7c. Spawn BA and Tech Lead as teammates (in parallel):**
 
-Spawn both using the **Agent tool** with `team_name` and `name` parameters. Read each agent's `.claude/agents/*.md` file and include the **Team Mode** section instructions in the prompt. Use `subagent_type: "general-purpose"`, `model: "sonnet"`, `mode: "auto"`.
+Spawn both using the **Agent tool** with a `name` (their handle for `SendMessage`)
+and `run_in_background: true` (so they stay live and addressable while you
+orchestrate). Read each agent's `.claude/agents/*.md` file and include the **Team
+Mode** section instructions in the prompt. Use `subagent_type: "general-purpose"`,
+`model: "sonnet"`, `mode: "auto"`. Do **not** pass `team_name` — it is deprecated
+and ignored.
 
-- BA: `Agent(subagent_type: "general-purpose", team_name: "planning-epic-<NUM>", name: "ba", model: "sonnet", mode: "auto", prompt: <ba.md Team Mode instructions>)`
-- Tech Lead: `Agent(subagent_type: "general-purpose", team_name: "planning-epic-<NUM>", name: "tech-lead", model: "sonnet", mode: "auto", prompt: <tech-lead.md Team Mode instructions>)`
+- BA: `Agent(subagent_type: "general-purpose", name: "ba", run_in_background: true, model: "sonnet", mode: "auto", prompt: <ba.md Team Mode instructions>)`
+- Tech Lead: `Agent(subagent_type: "general-purpose", name: "tech-lead", run_in_background: true, model: "sonnet", mode: "auto", prompt: <tech-lead.md Team Mode instructions>)`
 
-**7d. Broadcast epic context to the team:**
+Teammates address you as `main` (`SendMessage(to: "main", ...)`) and each other by
+name; you address them by name.
+
+**7d. Send epic context to the team:**
+There is no `to: "*"` broadcast in the implicit-team model — send the context to
+each teammate by name:
 ```
-SendMessage(to: "*", summary: "Epic context for planning", message: <epic body + architectural context from CLAUDE.md>)
+SendMessage(to: "ba", summary: "Epic context for planning", message: <epic body + architectural context from CLAUDE.md>)
+SendMessage(to: "tech-lead", summary: "Epic context for planning", message: <same context>)
 ```
 
 **7e. Orchestrate the planning conversation:**
@@ -738,7 +751,7 @@ The conversation follows this protocol:
 2. **PO relays to Tech Lead** — forward BA's proposals: `SendMessage(to: "tech-lead", message: <proposals>)`
 3. **Tech Lead reviews** — validates proposals against the codebase (5-check validation) and sends per-story verdicts (APPROVED / REVISION NEEDED) to PO. Tech Lead may also message BA directly for clarifications.
 4. **If revisions needed** — PO relays Tech Lead feedback to BA: `SendMessage(to: "ba", message: <feedback>)`. BA revises and re-proposes. PO relays to Tech Lead for re-review. Only unresolved stories iterate — approved stories are locked.
-5. **PO product decisions** — if BA and Tech Lead disagree on scope, priority, or approach, PO makes the product call and sends the decision to both: `SendMessage(to: "*", message: "PO DECISION: ...")`
+5. **PO product decisions** — if BA and Tech Lead disagree on scope, priority, or approach, PO makes the product call and sends the decision to each teammate by name: `SendMessage(to: "ba", message: "PO DECISION: ...")` and `SendMessage(to: "tech-lead", message: "PO DECISION: ...")`
 
 **Maximum 3 revision rounds.** A round = BA revises + Tech Lead re-reviews. After 3 rounds, any remaining REVISION NEEDED stories are resolved by PO decision: either accept with a PO note, or drop and document the convergence failure by blocking the epic (use `po-act.sh block <EPIC_NUM> "<reason>"`). Do NOT create a parallel tracking issue — the epic's Blocked status + comment IS the escalation.
 
@@ -790,11 +803,15 @@ SUMMARY_EOF
 rm /tmp/planning-summary.md
 ```
 
-**7h. Shutdown the planning team and release the lease:**
-Send shutdown to both teammates: `SendMessage(to: "*", message: {type: "shutdown_request"})`. Then clean up:
+**7h. Shut down the planning team and release the lease:**
+Send each still-live teammate a shutdown request by name (no `to: "*"` broadcast, and
+no `TeamDelete` — there is no explicit team object to tear down):
 ```
-TeamDelete()
+SendMessage(to: "ba", message: {type: "shutdown_request"})
+SendMessage(to: "tech-lead", message: {type: "shutdown_request"})
 ```
+A background teammate that has already returned its PROPOSALS FINAL / verdicts has
+exited and needs no shutdown — shutdown only matters for one still running.
 Release the decompose lease so it doesn't linger until TTL:
 ```bash
 ./scripts/pipeline-helper.sh lease-release "epic-decompose-<NUM>"

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -15,15 +15,15 @@ The PO manages the autonomous pipeline: dashboard, intent capture, targeted unbl
 
 Three execution paths depending on `$ARGUMENTS`. The dividing line is what the action needs:
 
-- **Agent teams** (`TeamCreate`/`SendMessage`) — only the main session has these, so anything that spawns the Planning Team runs **inline** (Path A).
+- **Live agent team** (named `Agent` teammates coordinated via `SendMessage`, addressing the orchestrator as `main`) — the team is driven from the main conversation, so anything that spawns the Planning Team runs **inline** (Path A).
 - **Clean per-run context, no teams** — the autonomous `cron` cycle skips the Planning Team, so it runs as a **clean-context subagent** (Path B) to keep the main session free of per-cycle bloat.
 - **Ongoing conversation** — `status`/`intent`/`next` spawn a long-lived PO subagent (Path C).
 
-> **Subagents CAN nest subagents and run bash under `mode: auto` with no approval prompts** (empirically validated 2026-06-29: a `po` subagent ran a full cron cycle — Tech Lead nested-spawn worked, `po-act.sh dispatch`/`gh`/lease ops all prompt-free, docker access intact since it's the same host). What a subagent **cannot** do is `TeamCreate`/`SendMessage` — so the **only** reason to stay inline is the Planning Team. This corrects the earlier (now-stale) `feedback_po_run_inline` rationale.
+> **Subagents CAN nest subagents and run bash under `mode: auto` with no approval prompts** (empirically validated 2026-06-29: a `po` subagent ran a full cron cycle — Tech Lead nested-spawn worked, `po-act.sh dispatch`/`gh`/lease ops all prompt-free, docker access intact since it's the same host). What a backgrounded subagent **cannot** host is the **live Planning Team**: its named teammates report to the `main` conversation via `SendMessage`, so the team must be driven from the main session — that is the **only** reason `decompose`/`cycle` stay inline. (Note: the old `TeamCreate`/`TeamDelete` tools no longer exist — the session has a single implicit team; you spawn named background `Agent` teammates directly. See `.claude/agents/po.md` §4.1 Step 7.) This corrects the earlier (now-stale) `feedback_po_run_inline` rationale.
 
 ### Path A — needs agent teams (run inline in the main session)
 
-If `$ARGUMENTS` starts with `cycle`, `decompose`, or `plan`, do **NOT** spawn a subagent — execute directly in the main session, because these invoke the **Planning Team** (`TeamCreate` + `SendMessage`), which a subagent's toolset lacks. `work` also runs inline (in-process self-dispatch, no docker).
+If `$ARGUMENTS` starts with `cycle`, `decompose`, or `plan`, do **NOT** spawn a subagent — execute directly in the main session, because these invoke the **Planning Team** — a live team of named `Agent` teammates coordinated via `SendMessage` to the `main` conversation, which a backgrounded subagent can't host. `work` also runs inline (in-process self-dispatch, no docker).
 
 **Routing within Path A:**
 
@@ -38,7 +38,7 @@ If `$ARGUMENTS` starts with `cycle`, `decompose`, or `plan`, do **NOT** spawn a 
 1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the relevant section.
 2. Execute the section directly in the main session in priority order — preflight, unblock check, agent cleanup, pin refresh (§4.1 Step 1.6), Tech Lead pass, rebase (§4.1 Step 3), Acceptance Reviewer (§4.1 Step 4), fix cycle (§4.1 Step 5), dispatch (§4.1 Step 6), Planning Team (§4.1 Step 7), forward edge, session log.
 3. Host capacity is enforced automatically by the resource admission gate (`.claude/agents/po.md` §4.-1) — every launch path defers when the host is out of RAM/disk/CPU headroom.
-4. Spawn nested subagents via the Agent tool with `mode: auto`. Spawn the Planning Team via `TeamCreate` + Agent calls with `team_name` (per `.claude/agents/po.md` §4.1 Step 7c).
+4. Spawn nested subagents via the Agent tool with `mode: auto`. Spawn the Planning Team as named background `Agent` teammates (`name` + `run_in_background: true`) and coordinate via `SendMessage` — no `TeamCreate` (per `.claude/agents/po.md` §4.1 Step 7c).
 5. Report the summary back to the founder using the same format the PO subagent uses.
 
 ### Path B — autonomous cron (clean-context subagent)


### PR DESCRIPTION
## Summary

The `TeamCreate`/`TeamDelete` tools no longer exist in the current harness — the session has a **single implicit team**, and teammates are created by spawning **named background `Agent`s** coordinated via `SendMessage` (the `Agent` tool's `team_name` parameter is now deprecated and ignored). But `/po` Step 7 and the Path A routing notes still invoked `TeamCreate(team_name)` / `TeamDelete()` literally, so every recent `/po decompose` **silently fell back to the sequential BA→Tech-Lead flow** instead of running a live planning team.

This patch updates the PO orchestration docs to the implicit-team model.

## Changes

**`.claude/agents/po.md`**
- Step 7b: drop the `TeamCreate(team_name)` call; note the single implicit team (no creation step).
- Step 7c: spawn `ba` + `tech-lead` via `Agent(name, run_in_background: true)` instead of `team_name`; teammates address the orchestrator as `main`.
- Step 7d / 7e / 7h: replace `to: "*"` broadcasts with explicit per-teammate `SendMessage`; drop `TeamDelete()` (no team object to tear down — shutdown still-live teammates by name).
- §4 execution-context note: correct the inline-vs-subagent rationale (the live team is driven from the `main` conversation; it's not that subagents "lack TeamCreate/SendMessage").

**`.claude/commands/po.md`**
- Path A routing notes (lines 18, 22, 26, 41): same rationale correction; spawn the Planning Team as named background `Agent` teammates, no `TeamCreate`.

## Scope / follow-up

Docs-only (`.claude/*.md`). `/story-complete` (`.claude/commands/story-complete.md`) carries the same stale `TeamCreate`/`TeamDelete`/`team_name` pattern but already has a "team creation fails → fall back to sequential" path, so it degrades gracefully; left for a scoped follow-up.

## Validation

No code/scripts touched — `make test` has no coverage of prompt-doc content. Internal consistency verified: no remaining live `TeamCreate`/`TeamDelete`/`team_name`/`to:"*"` instructions (only intentional "these tools are gone, don't use them" mentions remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
