### PR TITLE
check-architecture: allowlist pkg/migrate/storage as registry bootstrap (Issue #2267)

### DIFF
--- a/scripts/check-providers.sh
+++ b/scripts/check-providers.sh
@@ -31,6 +31,7 @@ is_allowed() {
     [[ "$file" == test/* ]] && return 0
     [[ "$file" == cmd/controller/main.go ]] && return 0
     [[ "$file" == cmd/cfg/cmd/storage.go ]] && return 0
+    [[ "$file" == pkg/migrate/storage/* ]] && return 0
     [[ "$file" == features/controller/initialization/initialization.go ]] && return 0
     [[ "$file" == features/controller/server/server.go ]] && return 0
     [[ "$file" == */providers_test.go ]] && return 0
@@ -70,6 +71,7 @@ else
     echo "  test/                                                       (integration and e2e tests)"
     echo "  cmd/controller/main.go                                      (registry bootstrap)"
     echo "  cmd/cfg/cmd/storage.go                                      (CLI registry bootstrap)"
+    echo "  pkg/migrate/storage/                                        (migration engine registry bootstrap)"
     echo "  features/controller/initialization/initialization.go        (registry bootstrap)"
     echo "  features/controller/server/server.go                        (registry bootstrap)"
     echo "  */providers_test.go                                         (per-package test provider registration)"


### PR DESCRIPTION
## Summary

Unfreezes fleet-wide dispatch: `make check-architecture` was failing on develop because the storage migration engine `pkg/migrate/storage/` (from #2259) directly imports the database/flatfile/sqlite providers — a legitimate registry-bootstrap pattern, identical to `cmd/cfg/cmd/storage.go`, but not on the allowlist. The cron preflight holds all dispatch while develop's arch check is red (agents would inherit the broken base — #1039/#1051).

Per the founder decision on #2267 (**Option 2 — allowlist, do not refactor**).

## Changes (`scripts/check-providers.sh`)
- `is_allowed()`: permit `pkg/migrate/storage/*` (wildcard covers `migrate.go` plus `migrate_test.go`/`helpers_test.go`, which don't match the existing `*/providers_test.go` pattern).
- Violation help text: matching "migration engine registry bootstrap" line.

No source changes to `pkg/migrate/storage/*`.

## Validation
- `make check-architecture` **passes** (was the failing dispatch gate).
- `make test` was run: the only failure is `pkg/cert TestNoCertSliceIndex0InNonTest`, a **pre-existing local-environment false positive** unrelated to this change — it walks the repo tree and flags `certs[0]` indexing inside an in-tree `.cache/go-mod/` module cache (25 hits, all third-party deps: lego/quic-go/grpc/lib-pq/x-crypto; zero CFGMS paths). CI has no in-tree module cache, so it does not reproduce there. Tracked separately (the test's dir-walk skips `vendor`/`worktrees` but not `.cache`).

Fixes #2267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
