### PR TITLE
migrate(secrets): file <-> OpenBao incl. CA key (Issue #2270)

### DIFF
--- a/cmd/cfg/cmd/migrate.go
+++ b/cmd/cfg/cmd/migrate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/migrate"
+	_ "github.com/cfgis/cfgms/pkg/migrate/secrets" // register "secrets" migrator
 	_ "github.com/cfgis/cfgms/pkg/migrate/storage" // register "storage" migrator
 )
 

--- a/pkg/migrate/secrets/migrate.go
+++ b/pkg/migrate/secrets/migrate.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package secrets implements the "secrets" migrator for CFGMS.
+//
+// The migrator moves all secrets between backends through pkg/secrets/interfaces:
+//
+//	cfg migrate --provider secrets --from sops --to openbao
+//
+// Supported backend names: "sops" (flatfile+SOPS), "openbao" (OpenBao KV v2).
+// Both directions are supported.
+//
+// An optional CA relocation sub-step moves an existing file-based CA private key
+// into the target SecretStore without writing the key to any new disk location.
+// Configuration is read from environment variables:
+//
+//	CFGMS_SECRETS_SOPS_STORAGE_ROOT   – flatfile root directory (sops backend)
+//	CFGMS_SECRETS_OPENBAO_ADDR        – OpenBao address (openbao backend; fallback: OPENBAO_ADDR)
+//	CFGMS_SECRETS_OPENBAO_TOKEN       – OpenBao token (openbao backend; fallback: OPENBAO_TOKEN)
+//	CFGMS_MIGRATE_CA_STORAGE_PATH     – path holding ca.key/ca.crt (enables CA sub-step)
+//	CFGMS_MIGRATE_CA_TENANT_ID        – tenant ID for CA in target store
+//	CFGMS_MIGRATE_CA_KEY_PATH         – secret key name for CA cert (default: "ca")
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/migrate"
+	secretsinterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+
+	_ "github.com/cfgis/cfgms/pkg/secrets/providers/openbao"  // register openbao provider
+	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops"     // register sops provider
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile" // register flatfile for sops backend
+)
+
+const (
+	kindSecret = "secret"
+	kindCA     = "ca"
+)
+
+func init() {
+	migrate.Register("secrets", func(from, to string) (migrate.Migrator, error) {
+		srcStore, err := openSecretBackend(from)
+		if err != nil {
+			return nil, fmt.Errorf("secrets migrator: source backend %q: %w", from, err)
+		}
+		dstStore, err := openSecretBackend(to)
+		if err != nil {
+			return nil, fmt.Errorf("secrets migrator: target backend %q: %w", to, err)
+		}
+
+		caStoragePath := os.Getenv("CFGMS_MIGRATE_CA_STORAGE_PATH")
+		caTenantID := os.Getenv("CFGMS_MIGRATE_CA_TENANT_ID")
+		caKeyPath := os.Getenv("CFGMS_MIGRATE_CA_KEY_PATH")
+		if caKeyPath == "" {
+			caKeyPath = "ca"
+		}
+
+		return NewSecretsMigrator(srcStore, dstStore, caStoragePath, caTenantID, caKeyPath), nil
+	})
+}
+
+// openSecretBackend creates a SecretStore for the named backend using environment variables.
+func openSecretBackend(name string) (secretsinterfaces.SecretStore, error) {
+	switch name {
+	case "sops":
+		root := os.Getenv("CFGMS_SECRETS_SOPS_STORAGE_ROOT")
+		if root == "" {
+			return nil, fmt.Errorf("CFGMS_SECRETS_SOPS_STORAGE_ROOT must be set for sops backend")
+		}
+		return secretsinterfaces.CreateSecretStoreFromConfig("sops", map[string]interface{}{
+			"storage_provider": "flatfile",
+			"storage_config":   map[string]interface{}{"root": root},
+			"cache_enabled":    false,
+		})
+	case "openbao":
+		cfg := map[string]interface{}{}
+		if addr := os.Getenv("CFGMS_SECRETS_OPENBAO_ADDR"); addr != "" {
+			cfg["address"] = addr
+		}
+		if token := os.Getenv("CFGMS_SECRETS_OPENBAO_TOKEN"); token != "" {
+			cfg["token"] = token
+		}
+		return secretsinterfaces.CreateSecretStoreFromConfig("openbao", cfg)
+	default:
+		return nil, fmt.Errorf("unknown secrets backend %q; supported: sops, openbao", name)
+	}
+}
+
+// SecretsMigrator moves all secrets from src to dst via pkg/secrets/interfaces.
+// Values are held in memory only — no intermediate disk files are written.
+// An optional CA sub-step (caStoragePath non-empty) relocates a file-based CA
+// private key into the target SecretStore without writing the key to any new location.
+type SecretsMigrator struct {
+	src           secretsinterfaces.SecretStore
+	dst           secretsinterfaces.SecretStore
+	caStoragePath string
+	caTenantID    string
+	caKeyPath     string
+}
+
+// NewSecretsMigrator returns a SecretsMigrator that copies secrets from src to dst.
+// Set caStoragePath, caTenantID, and caKeyPath to enable the CA relocation sub-step;
+// leave caStoragePath empty to skip it.
+func NewSecretsMigrator(src, dst secretsinterfaces.SecretStore, caStoragePath, caTenantID, caKeyPath string) *SecretsMigrator {
+	if src == nil {
+		panic("secrets.NewSecretsMigrator: src must not be nil")
+	}
+	if dst == nil {
+		panic("secrets.NewSecretsMigrator: dst must not be nil")
+	}
+	return &SecretsMigrator{
+		src:           src,
+		dst:           dst,
+		caStoragePath: caStoragePath,
+		caTenantID:    caTenantID,
+		caKeyPath:     caKeyPath,
+	}
+}
+
+// Plan exports secrets from the source and returns per-kind counts.
+// No writes to the target are performed.
+func (m *SecretsMigrator) Plan(ctx context.Context) (migrate.Report, error) {
+	records, err := m.exportSecrets(ctx)
+	if err != nil {
+		return migrate.Report{}, fmt.Errorf("secrets plan: %w", err)
+	}
+	counts := countByKind(records)
+	if m.caStoragePath != "" {
+		counts[kindCA] = 1
+	}
+	return migrate.Report{Counts: counts, Errors: make(map[string]error)}, nil
+}
+
+// Run migrates all secrets and (if configured) the file-based CA private key.
+// Idempotent: re-running overwrites with identical values using upsert semantics.
+func (m *SecretsMigrator) Run(ctx context.Context) (migrate.Report, error) {
+	records, err := m.exportSecrets(ctx)
+	if err != nil {
+		return migrate.Report{}, fmt.Errorf("secrets run: export failed: %w", err)
+	}
+	if err := m.importSecrets(ctx, records); err != nil {
+		return migrate.Report{}, fmt.Errorf("secrets run: import failed: %w", err)
+	}
+
+	counts := countByKind(records)
+	errs := make(map[string]error)
+
+	if m.caStoragePath != "" {
+		sourceKeyFile, err := m.migrateCA(ctx)
+		if err != nil {
+			return migrate.Report{Counts: counts, Errors: errs},
+				fmt.Errorf("secrets run: CA migration failed: %w", err)
+		}
+		counts[kindCA] = 1
+		// Report the source ca.key path for operator removal — never auto-delete.
+		errs["ca_source_key_path"] = fmt.Errorf("residual CA private key requires manual removal: %s", sourceKeyFile)
+	}
+
+	return migrate.Report{Counts: counts, Errors: errs}, nil
+}
+
+// exportSecrets lists and fetches all secrets from the source store.
+// Values are held in memory only — no temp files are written.
+func (m *SecretsMigrator) exportSecrets(ctx context.Context) ([]migrate.Record, error) {
+	metas, err := m.src.ListSecrets(ctx, &secretsinterfaces.SecretFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+
+	if len(metas) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]string, 0, len(metas))
+	for _, meta := range metas {
+		if meta.TenantID == "" || meta.Key == "" {
+			continue
+		}
+		keys = append(keys, meta.TenantID+"/"+meta.Key)
+	}
+
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	fetched, err := m.src.GetSecrets(ctx, keys)
+	if err != nil {
+		return nil, fmt.Errorf("get secrets: %w", err)
+	}
+
+	records := make([]migrate.Record, 0, len(fetched))
+	for fullKey, secret := range fetched {
+		data, err := json.Marshal(secret)
+		if err != nil {
+			return nil, fmt.Errorf("marshal secret %q: %w", fullKey, err)
+		}
+		records = append(records, migrate.Record{Kind: kindSecret, ID: fullKey, Data: data})
+	}
+	return records, nil
+}
+
+// importSecrets writes secrets to the target store using StoreSecrets (upsert).
+// Values are read from Record.Data in memory — no temp files are written.
+func (m *SecretsMigrator) importSecrets(ctx context.Context, records []migrate.Record) error {
+	batch := make(map[string]*secretsinterfaces.SecretRequest, len(records))
+	for i := range records {
+		if records[i].Kind != kindSecret {
+			continue
+		}
+		var secret secretsinterfaces.Secret
+		if err := json.Unmarshal(records[i].Data, &secret); err != nil {
+			return fmt.Errorf("unmarshal secret %q: %w", records[i].ID, err)
+		}
+		batch[records[i].ID] = &secretsinterfaces.SecretRequest{
+			Key:         secret.Key,
+			Value:       secret.Value,
+			Metadata:    secret.Metadata,
+			Tags:        secret.Tags,
+			CreatedBy:   secret.CreatedBy,
+			TenantID:    secret.TenantID,
+			Description: secret.Description,
+		}
+	}
+	if len(batch) == 0 {
+		return nil
+	}
+	return m.dst.StoreSecrets(ctx, batch)
+}
+
+// migrateCA loads the CA from disk into memory and stores it in the target
+// SecretStore via StoreCAToSecretStore. The private key is never written to any
+// new disk location. Returns the source ca.key path for operator cleanup reporting.
+func (m *SecretsMigrator) migrateCA(ctx context.Context) (string, error) {
+	ca := &cert.CA{}
+	if err := ca.LoadCA(m.caStoragePath); err != nil {
+		return "", fmt.Errorf("load CA from %q: %w", m.caStoragePath, err)
+	}
+
+	if err := ca.StoreCAToSecretStore(ctx, m.dst, m.caTenantID, m.caKeyPath); err != nil {
+		return "", fmt.Errorf("store CA to secret store (tenant=%q keyPath=%q): %w",
+			m.caTenantID, m.caKeyPath, err)
+	}
+
+	return filepath.Join(m.caStoragePath, "ca.key"), nil
+}
+
+func countByKind(records []migrate.Record) map[string]int {
+	counts := make(map[string]int, 2)
+	for _, r := range records {
+		counts[r.Kind]++
+	}
+	return counts
+}

--- a/pkg/migrate/secrets/migrate_test.go
+++ b/pkg/migrate/secrets/migrate_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package secrets_test contains integration tests for the secrets migrator.
+//
+// Prerequisites:
+//
+//	docker compose --profile openbao -f docker-compose.test.yml up -d openbao-test
+//
+// Environment variables:
+//
+//	OPENBAO_ADDR=http://localhost:8201  (default)
+//	OPENBAO_TOKEN=root                  (default for dev mode)
+package secrets_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	migratesecrets "github.com/cfgis/cfgms/pkg/migrate/secrets"
+	"github.com/cfgis/cfgms/pkg/cert"
+	secretsinterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+// testOpenBaoStore creates a store connected to the docker-compose openbao-test instance.
+func testOpenBaoStore(t *testing.T) secretsinterfaces.SecretStore {
+	t.Helper()
+
+	addr := os.Getenv("OPENBAO_ADDR")
+	if addr == "" {
+		addr = "http://localhost:8201"
+	}
+	token := os.Getenv("OPENBAO_TOKEN")
+	if token == "" {
+		token = "root"
+	}
+
+	store, err := secretsinterfaces.CreateSecretStoreFromConfig("openbao", map[string]interface{}{
+		"address":    addr,
+		"token":      token,
+		"mount_path": "secret",
+	})
+	require.NoError(t, err, "failed to create OpenBao test store")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, store.HealthCheck(ctx), "OpenBao health check failed — is the container running?")
+
+	return store
+}
+
+// TestSecretsMigrate_FileToOpenBaoIncludingCA migrates secrets from a SOPS/flatfile
+// source to a real OpenBao target, then relocates a file-based CA private key into
+// the vault path via StoreCAToSecretStore, verifying that no cleartext key is written
+// to disk during the migration.
+func TestSecretsMigrate_FileToOpenBaoIncludingCA(t *testing.T) {
+	ctx := context.Background()
+
+	// Source: SOPS store backed by flatfile in a temp dir (no SOPS encryption needed for tests).
+	srcDir := t.TempDir()
+	srcStore, err := secretsinterfaces.CreateSecretStoreFromConfig("sops", map[string]interface{}{
+		"storage_provider": "flatfile",
+		"storage_config":   map[string]interface{}{"root": srcDir},
+		"cache_enabled":    false,
+	})
+	require.NoError(t, err, "failed to create source SOPS store")
+
+	tenantID := fmt.Sprintf("test-tenant-%d", time.Now().UnixNano())
+
+	// Populate source with test secrets.
+	testSecrets := map[string]string{
+		"api-key":     "test-api-value-1",
+		"db-password": "test-db-value-2",
+	}
+	for key, value := range testSecrets {
+		require.NoError(t, srcStore.StoreSecret(ctx, &secretsinterfaces.SecretRequest{
+			Key:         key,
+			Value:       value,
+			TenantID:    tenantID,
+			CreatedBy:   "test",
+			Description: "migration test secret",
+		}))
+	}
+
+	// Create a file-based CA to exercise the CA relocation sub-step.
+	caDir := t.TempDir()
+	caConfig := &cert.CAConfig{
+		Organization: "Test CA Org",
+		StoragePath:  caDir,
+		ValidityDays: 365,
+		KeySize:      2048,
+	}
+	ca, err := cert.NewCA(caConfig)
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(caConfig))
+
+	// Confirm ca.key exists on disk before migration.
+	caKeyOnDisk := filepath.Join(caDir, "ca.key")
+	_, err = os.Stat(caKeyOnDisk)
+	require.NoError(t, err, "ca.key must exist on disk before migration")
+
+	// Target: real OpenBao store.
+	dstStore := testOpenBaoStore(t)
+
+	caSecretKeyPath := "cluster-ca"
+	t.Cleanup(func() {
+		cleanCtx := context.Background()
+		for key := range testSecrets {
+			_ = dstStore.DeleteSecret(cleanCtx, tenantID+"/"+key)
+		}
+		_ = dstStore.DeleteSecret(cleanCtx, tenantID+"/"+caSecretKeyPath)
+		_ = dstStore.DeleteSecret(cleanCtx, tenantID+"/"+caSecretKeyPath+"-key")
+	})
+
+	// Run migration: SOPS → OpenBao including CA sub-step.
+	m := migratesecrets.NewSecretsMigrator(srcStore, dstStore, caDir, tenantID, caSecretKeyPath)
+	report, err := m.Run(ctx)
+	require.NoError(t, err, "migration must succeed")
+
+	// Verify secret and CA counts.
+	assert.Equal(t, len(testSecrets), report.Counts["secret"], "all secrets must be migrated")
+	assert.Equal(t, 1, report.Counts["ca"], "CA sub-step must be counted")
+
+	// Report must contain the residual key path warning (operator action required).
+	caWarn, hasWarn := report.Errors["ca_source_key_path"]
+	require.True(t, hasWarn, "report must warn about residual ca.key requiring operator removal")
+	assert.Contains(t, caWarn.Error(), "ca.key", "warning must reference the source key file path")
+
+	// All secrets must be readable from the target with correct values.
+	for key, want := range testSecrets {
+		got, err := dstStore.GetSecret(ctx, tenantID+"/"+key)
+		require.NoErrorf(t, err, "secret %q must be readable from target", key)
+		assert.Equalf(t, want, got.Value, "secret %q value must match after migration", key)
+	}
+
+	// CA must load from the target store — no cleartext ca.key on disk required.
+	caFromStore := &cert.CA{}
+	err = caFromStore.LoadCAFromSecretStore(ctx, dstStore, tenantID, caSecretKeyPath)
+	require.NoError(t, err, "CA must load from secret store after migration")
+	assert.True(t, caFromStore.IsInitialized(), "migrated CA must be initialized")
+
+	// Verify no cleartext key was written to the sops source directory during migration.
+	_, err = os.Stat(filepath.Join(srcDir, "ca.key"))
+	assert.ErrorIs(t, err, os.ErrNotExist, "ca.key must not be written to the sops source dir during migration")
+}

--- a/pkg/migrate/secrets/migrate_unit_test.go
+++ b/pkg/migrate/secrets/migrate_unit_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package secrets_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/migrate"
+	migratesecrets "github.com/cfgis/cfgms/pkg/migrate/secrets"
+	secretsinterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+// TestSecretsMigratorFactory_Registered verifies that importing pkg/migrate/secrets
+// registers the "secrets" factory in the migrate registry.
+func TestSecretsMigratorFactory_Registered(t *testing.T) {
+	factory, err := migrate.Lookup("secrets")
+	require.NoError(t, err, "secrets factory must be registered via init()")
+	assert.NotNil(t, factory)
+}
+
+// TestSecretsMigratorFactory_UnknownBackend verifies that the factory rejects an
+// unknown backend name with a descriptive error.
+func TestSecretsMigratorFactory_UnknownBackend(t *testing.T) {
+	factory, err := migrate.Lookup("secrets")
+	require.NoError(t, err)
+
+	_, err = factory("bogus-backend", "sops")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus-backend")
+}
+
+// TestSecretsMigratorFactory_SopsMissingEnv verifies that the factory returns an
+// error when the sops backend is selected but the required env var is absent.
+func TestSecretsMigratorFactory_SopsMissingEnv(t *testing.T) {
+	t.Setenv("CFGMS_SECRETS_SOPS_STORAGE_ROOT", "")
+
+	factory, err := migrate.Lookup("secrets")
+	require.NoError(t, err)
+
+	_, err = factory("sops", "sops")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CFGMS_SECRETS_SOPS_STORAGE_ROOT")
+}
+
+// TestNewSecretsMigrator_NilPanics verifies that passing nil stores panics with a clear message.
+func TestNewSecretsMigrator_NilPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		migratesecrets.NewSecretsMigrator(nil, nil, "", "", "")
+	})
+}
+
+// TestSecretsMigrator_PlanEmpty verifies that Plan on an empty store returns zero counts.
+func TestSecretsMigrator_PlanEmpty(t *testing.T) {
+	src := newSOPSStore(t)
+	dst := newSOPSStore(t)
+
+	m := migratesecrets.NewSecretsMigrator(src, dst, "", "", "")
+	report, err := m.Plan(context.Background())
+	require.NoError(t, err)
+	total := 0
+	for _, c := range report.Counts {
+		total += c
+	}
+	assert.Equal(t, 0, total, "empty source must produce zero-count plan")
+}
+
+// TestSecretsMigrator_RunEmpty verifies that migrating an empty source succeeds with zero records.
+func TestSecretsMigrator_RunEmpty(t *testing.T) {
+	src := newSOPSStore(t)
+	dst := newSOPSStore(t)
+
+	m := migratesecrets.NewSecretsMigrator(src, dst, "", "", "")
+	report, err := m.Run(context.Background())
+	require.NoError(t, err)
+	total := 0
+	for _, c := range report.Counts {
+		total += c
+	}
+	assert.Equal(t, 0, total, "empty source must produce zero-count run report")
+}
+
+// TestSecretsMigrator_SOPStoSOPS verifies a full secret round-trip between two SOPS stores
+// without external services.
+func TestSecretsMigrator_SOPStoSOPS(t *testing.T) {
+	ctx := context.Background()
+
+	src := newSOPSStore(t)
+	dst := newSOPSStore(t)
+
+	tenantID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+
+	wantSecrets := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	for key, val := range wantSecrets {
+		require.NoError(t, src.StoreSecret(ctx, &secretsinterfaces.SecretRequest{
+			Key: key, Value: val, TenantID: tenantID, CreatedBy: "test",
+		}))
+	}
+
+	m := migratesecrets.NewSecretsMigrator(src, dst, "", "", "")
+	report, err := m.Run(ctx)
+	require.NoError(t, err, "SOPS→SOPS migration must succeed")
+	assert.Equal(t, len(wantSecrets), report.Counts["secret"], "all secrets must be migrated")
+	assert.Empty(t, report.Errors, "no errors expected without CA sub-step")
+
+	for key, want := range wantSecrets {
+		got, err := dst.GetSecret(ctx, tenantID+"/"+key)
+		require.NoErrorf(t, err, "secret %q must be readable from destination", key)
+		assert.Equalf(t, want, got.Value, "secret %q value must match", key)
+	}
+}
+
+// TestSecretsMigrator_SOPStoSOPS_Idempotent verifies that running the migration twice
+// yields identical counts with no duplicates.
+func TestSecretsMigrator_SOPStoSOPS_Idempotent(t *testing.T) {
+	ctx := context.Background()
+
+	src := newSOPSStore(t)
+	dst := newSOPSStore(t)
+
+	tenantID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	require.NoError(t, src.StoreSecret(ctx, &secretsinterfaces.SecretRequest{
+		Key: "mykey", Value: "myval", TenantID: tenantID, CreatedBy: "test",
+	}))
+
+	m := migratesecrets.NewSecretsMigrator(src, dst, "", "", "")
+
+	report1, err := m.Run(ctx)
+	require.NoError(t, err, "first run must succeed")
+
+	report2, err := m.Run(ctx)
+	require.NoError(t, err, "second run must succeed (idempotent)")
+
+	for kind, c1 := range report1.Counts {
+		c2, ok := report2.Counts[kind]
+		assert.True(t, ok, "second run must include kind %q", kind)
+		assert.Equal(t, c1, c2, "second run count for %q must match first", kind)
+	}
+}
+
+// newSOPSStore creates a SOPS secret store backed by flatfile in a per-test temp dir.
+// No external services are required.
+func newSOPSStore(t *testing.T) secretsinterfaces.SecretStore {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := secretsinterfaces.CreateSecretStoreFromConfig("sops", map[string]interface{}{
+		"storage_provider": "flatfile",
+		"storage_config":   map[string]interface{}{"root": dir},
+		"cache_enabled":    false,
+	})
+	require.NoError(t, err, "create SOPS test store")
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}

--- a/scripts/check-providers.sh
+++ b/scripts/check-providers.sh
@@ -32,6 +32,7 @@ is_allowed() {
     [[ "$file" == cmd/controller/main.go ]] && return 0
     [[ "$file" == cmd/cfg/cmd/storage.go ]] && return 0
     [[ "$file" == pkg/migrate/storage/* ]] && return 0
+    [[ "$file" == pkg/migrate/secrets/* ]] && return 0
     [[ "$file" == features/controller/initialization/initialization.go ]] && return 0
     [[ "$file" == features/controller/server/server.go ]] && return 0
     [[ "$file" == */providers_test.go ]] && return 0
@@ -72,6 +73,7 @@ else
     echo "  cmd/controller/main.go                                      (registry bootstrap)"
     echo "  cmd/cfg/cmd/storage.go                                      (CLI registry bootstrap)"
     echo "  pkg/migrate/storage/                                        (migration engine registry bootstrap)"
+    echo "  pkg/migrate/secrets/                                        (migration engine registry bootstrap)"
     echo "  features/controller/initialization/initialization.go        (registry bootstrap)"
     echo "  features/controller/server/server.go                        (registry bootstrap)"
     echo "  */providers_test.go                                         (per-package test provider registration)"


### PR DESCRIPTION
## Summary

- Registers a `"secrets"` migrator in `pkg/migrate/secrets` that transfers all secrets between SOPS/flatfile and OpenBao KV v2 backends through `pkg/secrets/interfaces` — values stay in memory only, no intermediate disk writes.
- Includes a CA relocation sub-step: loads an existing file-based CA private key into memory and stores it in the target SecretStore via `StoreCAToSecretStore`; the key is never written to any new disk location. Reports the residual source `ca.key` path for operator removal.
- Covers both directions (sops ↔ openbao); migration is idempotent (upsert semantics on target).

Fixes #2270

## Changed files

| File | Change |
|------|--------|
| `pkg/migrate/secrets/migrate.go` | New — `SecretsMigrator`, CA sub-step, registry `init()` |
| `pkg/migrate/secrets/migrate_unit_test.go` | New — unit tests (no build tag, real SOPS/flatfile stores) |
| `pkg/migrate/secrets/migrate_test.go` | New — `//go:build integration`: real SOPS → real OpenBao round-trip + CA |
| `cmd/cfg/cmd/migrate.go` | Added blank import to register `"secrets"` in the CLI binary |
| `scripts/check-providers.sh` | Added `pkg/migrate/secrets/*` to registry-bootstrap allowlist |

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| **QA Test Runner** | ✅ PASS | All gates: unit tests, lint, license headers, architecture check, security scan, cross-platform builds (linux/amd64/arm64, darwin, windows) |
| **QA Code Reviewer** | ✅ PASS | 0 blocking issues; 3 non-blocking warnings (non-empty Plan path not unit-tested directly; cleanup `_ =` pattern; CA error path unit coverage) |
| **Security Engineer** | ✅ PASS | 0 blocking issues; CA key confirmed never written to disk; no secrets logged; all automated scans (gosec, Trivy, Nancy, staticcheck, check-architecture) green |

## Test plan

- [x] `go test ./pkg/migrate/secrets/...` — all 8 unit tests pass with `-race`
- [x] `make test` — passes
- [x] `make check-architecture` — no violations
- [x] `make security-scan` — all tools pass
- [x] Integration test `TestSecretsMigrate_FileToOpenBaoIncludingCA` requires `docker compose --profile openbao -f docker-compose.test.yml up -d openbao-test` then `go test -tags integration ./pkg/migrate/secrets/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)