### PR TITLE
ha: add ClusterCapable() to storage and secrets provider interfaces (Issue #2272)

### DIFF
--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -390,6 +390,29 @@ Per ADR-003, the providers and interfaces above are **not all implemented today*
 - `pkg/storage/providers/sqlite`: `commands` and `command_transitions` tables added to the shared SQLite schema. This is the OSS default.
 - `pkg/storage/providers/flatfile`, `database`, `git`: return `ErrNotSupported` — command state is business data, not config data.
 
+## Cluster Mode Provider Compatibility
+
+Controllers in cluster mode require a storage backend that supports shared state across multiple concurrent controller nodes. Each storage provider and secrets provider declares this via `ClusterCapable() bool` on its respective interface (`StorageProvider`, `SecretProvider`).
+
+### Storage providers
+
+| Provider | `ClusterCapable()` | Reason |
+|----------|--------------------|--------|
+| `pkg/storage/providers/database` (PostgreSQL) | `true` | Postgres handles concurrent writers from multiple controller nodes via its transaction and locking model; the same DSN is accessible from all nodes |
+| `pkg/storage/providers/flatfile` | `false` | Local filesystem — concurrent writes across nodes are not coordinated; last-writer-wins semantics are unsafe for multi-active cluster mode |
+| `pkg/storage/providers/sqlite` | `false` | Single-file SQLite is node-local; no cross-node access or coordination |
+
+### Secrets providers
+
+| Provider | `ClusterCapable()` | Reason |
+|----------|--------------------|--------|
+| `pkg/secrets/providers/openbao` | `true` | OpenBao cluster exposes a shared KV service reachable by all controller nodes |
+| `pkg/secrets/providers/sops` | `false` | Git-backed file store is node-local at runtime; no shared-state coordination |
+| `pkg/secrets/providers/oskeychain` | `false` | Host OS keychain — per-host only, inaccessible from other nodes |
+| `pkg/secrets/providers/steward` | `false` | Steward-local encrypted store on the endpoint host, not a controller backend |
+
+The startup gate (sibling Story B) uses `ClusterCapable()` to reject misconfigured cluster deployments early, before any state is written.
+
 ## References
 
 - [ADR-003: Storage Data Taxonomy](decisions/003-storage-data-taxonomy.md) — authoritative design document

--- a/features/workflow/trigger/integration_test.go
+++ b/features/workflow/trigger/integration_test.go
@@ -179,6 +179,8 @@ func (t *TestStorageProvider) GetVersion() string {
 	return "1.0.0-test"
 }
 
+func (t *TestStorageProvider) ClusterCapable() bool { return false }
+
 // TestWorkflowTrigger implements a test workflow trigger that records executions
 type TestWorkflowTrigger struct {
 	executions []*workflow.WorkflowExecution

--- a/features/workflow/trigger/manager_test.go
+++ b/features/workflow/trigger/manager_test.go
@@ -146,6 +146,8 @@ func (m *MockStorageProvider) GetVersion() string {
 	return args.String(0)
 }
 
+func (m *MockStorageProvider) ClusterCapable() bool { return false }
+
 // MockScheduler implements Scheduler for testing
 type MockScheduler struct {
 	mock.Mock

--- a/pkg/secrets/interfaces/provider.go
+++ b/pkg/secrets/interfaces/provider.go
@@ -44,6 +44,10 @@ type SecretProvider interface {
 	// Provider capabilities and metadata
 	GetCapabilities() ProviderCapabilities
 	GetVersion() string
+
+	// ClusterCapable returns true if this provider can serve as shared state
+	// across multiple CFGMS controller nodes in cluster mode.
+	ClusterCapable() bool
 }
 
 // Global provider registry (Salt-style auto-registration)

--- a/pkg/secrets/interfaces/provider_test.go
+++ b/pkg/secrets/interfaces/provider_test.go
@@ -81,6 +81,7 @@ func (m *mockSecretProvider) Available() (bool, error) {
 func (m *mockSecretProvider) GetCapabilities() ProviderCapabilities {
 	return ProviderCapabilities{}
 }
+func (m *mockSecretProvider) ClusterCapable() bool { return false }
 func (m *mockSecretProvider) CreateSecretStore(_ map[string]interface{}) (SecretStore, error) {
 	return nil, nil
 }

--- a/pkg/secrets/providers/openbao/provider.go
+++ b/pkg/secrets/providers/openbao/provider.go
@@ -70,6 +70,10 @@ func (p *OpenBaoProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	}
 }
 
+// ClusterCapable returns true if this provider can serve as shared state across
+// multiple CFGMS controller nodes in cluster mode.
+func (p *OpenBaoProvider) ClusterCapable() bool { return true }
+
 // Available performs a connectivity check against the configured OpenBao instance.
 // It returns true if the health endpoint responds successfully.
 func (p *OpenBaoProvider) Available() (bool, error) {

--- a/pkg/secrets/providers/openbao/provider_test.go
+++ b/pkg/secrets/providers/openbao/provider_test.go
@@ -39,6 +39,11 @@ func TestOpenBaoProvider_GetCapabilities(t *testing.T) {
 	assert.Greater(t, caps.MaxKeyLength, 0)
 }
 
+func TestOpenBaoProvider_ClusterCapable_True(t *testing.T) {
+	p := &OpenBaoProvider{}
+	assert.True(t, p.ClusterCapable(), "OpenBaoProvider must be cluster-capable (OpenBao cluster supports shared state across controller nodes)")
+}
+
 // TestProductionGuard_Reject verifies that a dev-mode token is refused when
 // CFGMS_TELEMETRY_ENVIRONMENT=production.
 func TestProductionGuard_Reject(t *testing.T) {

--- a/pkg/secrets/providers/oskeychain/provider.go
+++ b/pkg/secrets/providers/oskeychain/provider.go
@@ -103,6 +103,10 @@ func (p *Provider) GetCapabilities() interfaces.ProviderCapabilities {
 	}
 }
 
+// ClusterCapable returns true if this provider can serve as shared state across
+// multiple CFGMS controller nodes in cluster mode.
+func (p *Provider) ClusterCapable() bool { return false }
+
 // Available reports whether a usable OS keychain backend exists on this host.
 // It returns (false, nil) — never an error — when no backend is usable (e.g.
 // Linux with neither Secret Service nor a kernel keyring), so callers fall back

--- a/pkg/secrets/providers/oskeychain/provider_test.go
+++ b/pkg/secrets/providers/oskeychain/provider_test.go
@@ -336,3 +336,8 @@ func randHex(t *testing.T, n int) string {
 	require.NoError(t, err)
 	return hex.EncodeToString(buf)
 }
+
+func TestOSKeychainProvider_ClusterCapable_False(t *testing.T) {
+	p := &Provider{}
+	assert.False(t, p.ClusterCapable(), "Provider must not be cluster-capable (OS keychain is host-local, inaccessible from other controller nodes)")
+}

--- a/pkg/secrets/providers/sops/provider.go
+++ b/pkg/secrets/providers/sops/provider.go
@@ -48,6 +48,10 @@ func (p *SOPSProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	}
 }
 
+// ClusterCapable returns true if this provider can serve as shared state across
+// multiple CFGMS controller nodes in cluster mode.
+func (p *SOPSProvider) ClusterCapable() bool { return false }
+
 // Available checks if SOPS and git are available
 func (p *SOPSProvider) Available() (bool, error) {
 	// Check if we can access storage provider (git provider should be registered)

--- a/pkg/secrets/providers/sops/provider_test.go
+++ b/pkg/secrets/providers/sops/provider_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSOPSProvider_ClusterCapable_False(t *testing.T) {
+	p := &SOPSProvider{}
+	assert.False(t, p.ClusterCapable(), "SOPSProvider must not be cluster-capable (git-backed file store cannot serve as shared state across controller nodes)")
+}

--- a/pkg/secrets/providers/steward/provider.go
+++ b/pkg/secrets/providers/steward/provider.go
@@ -31,6 +31,10 @@ func (p *StewardProvider) GetVersion() string {
 	return "1.0.0"
 }
 
+// ClusterCapable returns true if this provider can serve as shared state across
+// multiple CFGMS controller nodes in cluster mode.
+func (p *StewardProvider) ClusterCapable() bool { return false }
+
 // Available reports whether the provider can be used on the current platform.
 func (p *StewardProvider) Available() (bool, error) {
 	return true, nil

--- a/pkg/secrets/providers/steward/store_test.go
+++ b/pkg/secrets/providers/steward/store_test.go
@@ -454,3 +454,8 @@ func TestStore_EncryptedAtRest(t *testing.T) {
 func readBlobFile(secretsDir, blobFile string) ([]byte, error) {
 	return os.ReadFile(filepath.Join(secretsDir, "blobs", blobFile)) //#nosec G304
 }
+
+func TestStewardProvider_ClusterCapable_False(t *testing.T) {
+	p := &StewardProvider{}
+	assert.False(t, p.ClusterCapable(), "StewardProvider must not be cluster-capable (endpoint-local storage, inaccessible from other controller nodes)")
+}

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -410,6 +410,8 @@ func (p *mockProvider) GetVersion() string {
 	return "1.0.0"
 }
 
+func (p *mockProvider) ClusterCapable() bool { return false }
+
 // Mock store implementations
 type mockClientTenantStore struct {
 	tenants map[string]*business.ClientTenant

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -86,6 +86,10 @@ type StorageProvider interface {
 	// Provider capabilities and metadata
 	GetCapabilities() ProviderCapabilities
 	GetVersion() string
+
+	// ClusterCapable returns true if this provider can serve as shared state
+	// across multiple CFGMS controller nodes in cluster mode.
+	ClusterCapable() bool
 }
 
 // Global provider registry (Salt-style auto-registration)

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -120,6 +120,8 @@ func (m *MockStorageProvider) GetCapabilities() ProviderCapabilities {
 	return m.MockCapabilities
 }
 
+func (m *MockStorageProvider) ClusterCapable() bool { return false }
+
 func (m *MockStorageProvider) CreateClientTenantStore(_ map[string]interface{}) (business.ClientTenantStore, error) {
 	return newMockClientTenantStore(), nil
 }
@@ -1060,6 +1062,7 @@ func (m *MockOSSProvider) Available() (bool, error) {
 	return true, nil
 }
 func (m *MockOSSProvider) GetCapabilities() ProviderCapabilities { return ProviderCapabilities{} }
+func (m *MockOSSProvider) ClusterCapable() bool                  { return false }
 
 func (m *MockOSSProvider) CreateConfigStore(_ map[string]interface{}) (cfgconfig.ConfigStore, error) {
 	return &MockConfigStore{}, nil
@@ -1119,6 +1122,7 @@ func (m *MockOSSProviderWithError) Available() (bool, error) { return true, nil 
 func (m *MockOSSProviderWithError) GetCapabilities() ProviderCapabilities {
 	return ProviderCapabilities{}
 }
+func (m *MockOSSProviderWithError) ClusterCapable() bool { return false }
 
 func (m *MockOSSProviderWithError) mayFail(method string) error {
 	if m.failMethod == method {

--- a/pkg/storage/providers/database/plugin.go
+++ b/pkg/storage/providers/database/plugin.go
@@ -52,6 +52,10 @@ func (p *DatabaseProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	}
 }
 
+// ClusterCapable returns true if this provider can serve as shared state across
+// multiple CFGMS controller nodes in cluster mode.
+func (p *DatabaseProvider) ClusterCapable() bool { return true }
+
 // Available checks if PostgreSQL is available and accessible
 func (p *DatabaseProvider) Available() (bool, error) {
 	// Assumes PostgreSQL driver is available; live connection ping is deferred.

--- a/pkg/storage/providers/database/plugin_test.go
+++ b/pkg/storage/providers/database/plugin_test.go
@@ -20,6 +20,11 @@ import (
 	"github.com/cfgis/cfgms/pkg/testutil"
 )
 
+func TestDatabaseProvider_ClusterCapable_True(t *testing.T) {
+	p := &DatabaseProvider{}
+	assert.True(t, p.ClusterCapable(), "DatabaseProvider must be cluster-capable (Postgres supports shared state across controller nodes)")
+}
+
 // buildTestDSN creates a DSN string from test configuration
 func buildTestDSN() string {
 	config := getTestConfig()

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -115,6 +115,10 @@ func (p *FlatFileProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	}
 }
 
+// ClusterCapable returns true if this provider can serve as shared state across
+// multiple CFGMS controller nodes in cluster mode.
+func (p *FlatFileProvider) ClusterCapable() bool { return false }
+
 // Available returns true if the flat-file provider can operate on this system.
 // The flat-file provider only requires the OS filesystem and is always available.
 func (p *FlatFileProvider) Available() (bool, error) {

--- a/pkg/storage/providers/flatfile/plugin_test.go
+++ b/pkg/storage/providers/flatfile/plugin_test.go
@@ -73,6 +73,12 @@ func TestProviderDescription(t *testing.T) {
 	assert.NotEmpty(t, p.Description())
 }
 
+func TestFlatFileProvider_ClusterCapable_False(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+	assert.False(t, p.ClusterCapable(), "FlatFileProvider must not be cluster-capable (no shared-state coordination across controller nodes)")
+}
+
 func TestUnsupportedStoresReturnErrNotSupported(t *testing.T) {
 	p, err := interfaces.GetStorageProvider("flatfile")
 	require.NoError(t, err)

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -70,6 +70,10 @@ func (p *SQLiteProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	}
 }
 
+// ClusterCapable returns true if this provider can serve as shared state across
+// multiple CFGMS controller nodes in cluster mode.
+func (p *SQLiteProvider) ClusterCapable() bool { return false }
+
 // Available reports whether the SQLite library is usable and, when basePath is set,
 // whether that directory exists and is writable.
 //

--- a/pkg/storage/providers/sqlite/plugin_test.go
+++ b/pkg/storage/providers/sqlite/plugin_test.go
@@ -125,3 +125,10 @@ func TestCreateAuditStore_FileDB(t *testing.T) {
 	require.NotNil(t, store)
 	t.Cleanup(func() { _ = store.Close() })
 }
+
+// TestSQLiteProvider_ClusterCapable_False verifies SQLite is not cluster-capable.
+func TestSQLiteProvider_ClusterCapable_False(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	assert.False(t, p.ClusterCapable(), "SQLiteProvider must not be cluster-capable (single-file DB cannot serve as shared state across controller nodes)")
+}


### PR DESCRIPTION
## Summary

- Adds `ClusterCapable() bool` to `StorageProvider` (`pkg/storage/interfaces/provider.go`) and `SecretProvider` (`pkg/secrets/interfaces/provider.go`) interfaces
- `DatabaseProvider` (PostgreSQL) and `OpenBaoProvider` return `true`; all node-local providers (flatfile, SQLite, SOPS, oskeychain, steward) return `false`
- All 7 registered providers and 5 test-local mock/stub types updated so `go build ./...` stays clean
- 7 deterministic unit tests added; new `pkg/secrets/providers/sops/provider_test.go` created
- `docs/architecture/storage-architecture.md` updated with Cluster Mode Provider Compatibility section

Fixes #2272

## Specialist Review Results

**Security Review: PASS**
- No hardcoded secrets, SQL injection, TLS issues, or central provider violations
- `make security-precommit`, `make check-architecture`, `make security-scan` all PASS
- Pure interface extension — no new user-input, network, or secret-handling code paths

**QA Code Review: PASS** (after fix iteration)
- Initial review found missing tests for oskeychain and steward providers → added `TestOSKeychainProvider_ClusterCapable_False` and `TestStewardProvider_ClusterCapable_False`
- No mocks, no `t.Skip()` bypass, no empty assertions

**QA Test Runner: PASS** (after fix iteration)
- Initial run found 4 test-local mock/stub structs missing `ClusterCapable()` in `pkg/storage/interfaces/`, `pkg/secrets/interfaces/`, and `features/workflow/trigger/`
- All fixed; `make test-agent-complete` passes cleanly

## Test plan

- [ ] Verify `go build ./...` is clean with no missing-method compile errors
- [ ] Verify `TestDatabaseProvider_ClusterCapable_True` passes
- [ ] Verify `TestFlatFileProvider_ClusterCapable_False` and `TestSQLiteProvider_ClusterCapable_False` pass
- [ ] Verify `TestOpenBaoProvider_ClusterCapable_True` passes
- [ ] Verify `TestSOPSProvider_ClusterCapable_False`, `TestOSKeychainProvider_ClusterCapable_False`, `TestStewardProvider_ClusterCapable_False` pass
- [ ] Verify CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)