### PR TITLE
cli(controller): cluster drain and decommission commands (Issue #2278)

### DIFF
--- a/cmd/cfg/cmd/controller.go
+++ b/cmd/cfg/cmd/controller.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -133,6 +134,48 @@ Examples:
 	RunE: runSigningCertRotate,
 }
 
+// clusterCmd groups cluster node management operations.
+var clusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Cluster node management",
+	Long: `Manage controller cluster nodes.
+
+Subcommands:
+  drain         Drain a cluster node, preventing it from accepting new work
+  decommission  Decommission a drained cluster node, removing it from the cluster`,
+}
+
+// clusterDrainCmd drains a cluster node.
+var clusterDrainCmd = &cobra.Command{
+	Use:   "drain <node-id>",
+	Short: "Drain a cluster node",
+	Long: `Drain a cluster node, preventing it from accepting new work.
+
+The node continues running until all in-flight requests complete,
+then transitions to the 'draining' state. Run decommission after
+drain completes to remove the node from the cluster.
+
+Examples:
+  cfg controller cluster drain node-1 --url=https://controller.example.com`,
+	Args: cobra.ExactArgs(1),
+	RunE: runClusterDrain,
+}
+
+// clusterDecommissionCmd decommissions a drained cluster node.
+var clusterDecommissionCmd = &cobra.Command{
+	Use:   "decommission <node-id>",
+	Short: "Decommission a cluster node",
+	Long: `Decommission a drained cluster node, removing it from the cluster.
+
+The node must be in 'draining' state before it can be decommissioned.
+Returns an error (HTTP 409) if the node is not in 'draining' state.
+
+Examples:
+  cfg controller cluster decommission node-1 --url=https://controller.example.com`,
+	Args: cobra.ExactArgs(1),
+	RunE: runClusterDecommission,
+}
+
 func init() {
 	// Controller command flags
 	controllerCmd.PersistentFlags().StringVar(&healthURL, "url", "", "Controller API URL (required)")
@@ -150,10 +193,14 @@ func init() {
 	// signing-cert subcommand tree
 	signingCertCmd.AddCommand(signingCertRotateCmd)
 
+	// cluster subcommand tree
+	clusterCmd.AddCommand(clusterDrainCmd, clusterDecommissionCmd)
+
 	// Add subcommands
 	controllerCmd.AddCommand(controllerStatusCmd)
 	controllerCmd.AddCommand(controllerMetricsCmd)
 	controllerCmd.AddCommand(signingCertCmd)
+	controllerCmd.AddCommand(clusterCmd)
 }
 
 // getControllerClient creates an API client using bundle auth (mTLS) when available,
@@ -479,6 +526,84 @@ func runSigningCertRotate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Overlap days:      %d\n", result.OverlapDays)
 	fmt.Printf("Stewards notified: %d\n", result.StewardsNotified)
 	return nil
+}
+
+func runClusterDrain(cmd *cobra.Command, args []string) error {
+	nodeID := args[0]
+	client, err := getControllerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	path := "/api/v1/cluster/nodes/" + url.PathEscape(nodeID) + "/drain"
+	resp, err := client.doRequest(context.Background(), "POST", path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to drain node: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusForbidden:
+		return fmt.Errorf("admin mTLS certificate required")
+	case http.StatusOK:
+		var result struct {
+			State string `json:"state"`
+		}
+		state := "draining"
+		if jsonErr := json.Unmarshal(body, &result); jsonErr == nil && result.State != "" {
+			state = result.State
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Node %s is now %s.\n", nodeID, state)
+		return nil
+	default:
+		return fmt.Errorf("%s - %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+}
+
+func runClusterDecommission(cmd *cobra.Command, args []string) error {
+	nodeID := args[0]
+	client, err := getControllerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	path := "/api/v1/cluster/nodes/" + url.PathEscape(nodeID) + "/decommission"
+	resp, err := client.doRequest(context.Background(), "POST", path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to decommission node: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusForbidden:
+		return fmt.Errorf("admin mTLS certificate required")
+	case http.StatusConflict:
+		return fmt.Errorf("%s", strings.TrimSpace(string(body)))
+	case http.StatusOK:
+		var result struct {
+			State string `json:"state"`
+		}
+		state := "decommissioned"
+		if jsonErr := json.Unmarshal(body, &result); jsonErr == nil && result.State != "" {
+			state = result.State
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Node %s is now %s.\n", nodeID, state)
+		return nil
+	default:
+		return fmt.Errorf("%s - %s", resp.Status, strings.TrimSpace(string(body)))
+	}
 }
 
 func getStatusIcon(status string) string {

--- a/cmd/cfg/cmd/controller_test.go
+++ b/cmd/cfg/cmd/controller_test.go
@@ -579,3 +579,160 @@ func TestSigningCertRotateCmd_OverlapDaysFlagRegistered(t *testing.T) {
 	require.NotNil(t, f, "--overlap-days flag must be registered on signing-cert rotate")
 	assert.Equal(t, "30", f.DefValue, "--overlap-days default must be 30")
 }
+
+func TestClusterDrainCmd_PostsToDrainEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"state":"draining"}`))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := clusterDrainCmd.RunE(clusterDrainCmd, []string{"test-node"})
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/cluster/nodes/test-node/drain", gotPath)
+}
+
+func TestClusterDecommissionCmd_PostsToDecommissionEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"state":"decommissioned"}`))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := clusterDecommissionCmd.RunE(clusterDecommissionCmd, []string{"test-node"})
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/cluster/nodes/test-node/decommission", gotPath)
+}
+
+func TestClusterDrainCmd_HTTP403_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := clusterDrainCmd.RunE(clusterDrainCmd, []string{"test-node"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mTLS")
+}
+
+func TestClusterDecommissionCmd_HTTP403_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := clusterDecommissionCmd.RunE(clusterDecommissionCmd, []string{"test-node"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mTLS")
+}
+
+func TestClusterDecommissionCmd_HTTP409_ReturnsBodyAsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte("node is not in draining state"))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := clusterDecommissionCmd.RunE(clusterDecommissionCmd, []string{"test-node"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "draining state")
+}
+
+func TestClusterDrainCmd_OtherHTTPError_ReturnsStatusAndBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := clusterDrainCmd.RunE(clusterDrainCmd, []string{"test-node"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestClusterCmd_SubcommandsRegistered(t *testing.T) {
+	var clusterFound bool
+	for _, sub := range controllerCmd.Commands() {
+		if sub.Use == "cluster" {
+			clusterFound = true
+			var drainFound, decommissionFound bool
+			for _, csub := range sub.Commands() {
+				switch csub.Use {
+				case "drain <node-id>":
+					drainFound = true
+				case "decommission <node-id>":
+					decommissionFound = true
+				}
+			}
+			assert.True(t, drainFound, "cluster must have a drain subcommand")
+			assert.True(t, decommissionFound, "cluster must have a decommission subcommand")
+		}
+	}
+	assert.True(t, clusterFound, "controllerCmd must have a cluster subcommand")
+}

--- a/docs/operations/rolling-cluster-upgrade.md
+++ b/docs/operations/rolling-cluster-upgrade.md
@@ -1,0 +1,87 @@
+# Rolling Cluster Upgrade Runbook
+
+How to perform a zero-downtime rolling upgrade of a CFGMS controller cluster.
+
+## Overview
+
+A rolling cluster upgrade replaces controller nodes one at a time, ensuring the
+cluster remains available throughout. Each node is drained before its binary is
+replaced, then re-joined once the upgraded binary is healthy.
+
+## Prerequisites
+
+- Admin mTLS bundle (`~/.config/cfgms/admin.bundle.yaml` or `--bundle <path>`)
+- Cluster has at least two nodes (single-node clusters cannot drain without downtime)
+- All nodes healthy before starting
+
+## Procedure
+
+### 1. Identify the node to upgrade
+
+```bash
+# List cluster nodes and their current states (available in a future story)
+cfg controller cluster status --url=https://controller.example.com
+```
+
+### 2. Drain the node
+
+Draining prevents the node from accepting new work while allowing in-flight
+requests to complete.
+
+```bash
+cfg controller cluster drain <node-id> \
+    --url=https://controller.example.com
+```
+
+Wait for the drain to complete. The command prints the resulting node state:
+
+```
+Node <node-id> is now draining.
+```
+
+### 3. Upgrade the binary on the drained node
+
+SSH to the node and run the upgrade (see `controller-upgrade.md` for the full
+single-node upgrade runbook):
+
+```bash
+cfg controller upgrade run \
+    --binary /opt/cfgms/cfgms-controller-v0.6.0 \
+    --config /etc/cfgms/controller.cfg
+```
+
+### 4. Decommission the old node entry
+
+After the upgraded node has rejoined the cluster under a new node ID, remove
+the old node entry:
+
+```bash
+cfg controller cluster decommission <node-id> \
+    --url=https://controller.example.com
+```
+
+The node must be in `draining` state. If it is not, the command returns HTTP 409
+and an error message. The command prints the resulting state on success:
+
+```
+Node <node-id> is now decommissioned.
+```
+
+### 5. Repeat for each remaining node
+
+Repeat steps 2–4 for each remaining node, one at a time.
+
+## Error handling
+
+| Exit condition | Message | Action |
+|---|---|---|
+| Node not in draining state | Error from HTTP 409 response | Wait for drain or check node state |
+| Not authenticated with admin mTLS | `Error: admin mTLS certificate required` | Ensure admin bundle is present |
+| API unreachable | Connection error | Check controller URL and network |
+
+## Authentication
+
+Both `drain` and `decommission` require the admin mTLS bundle. The `--bundle`
+flag or `CFGMS_ADMIN_BUNDLE` environment variable selects the bundle file.
+The bundle is auto-discovered at `~/.config/cfgms/admin.bundle.yaml` and
+`/etc/cfgms/admin.bundle.yaml` when neither flag nor env var is set.


### PR DESCRIPTION
## Summary

- Adds `cfg controller cluster drain <node-id> --url <url>` — POSTs to `/api/v1/cluster/nodes/<node-id>/drain` with admin mTLS bundle, prints resulting node state to stdout
- Adds `cfg controller cluster decommission <node-id> --url <url>` — POSTs to `/api/v1/cluster/nodes/<node-id>/decommission`, returns HTTP 409 error on non-draining node
- Adds `docs/operations/rolling-cluster-upgrade.md` with example drain and decommission invocations

Fixes #2278

## Files Changed

- `cmd/cfg/cmd/controller.go` — `clusterCmd`, `clusterDrainCmd`, `clusterDecommissionCmd` var block + `runClusterDrain`, `runClusterDecommission` functions; wired in `init()`
- `cmd/cfg/cmd/controller_test.go` — 7 new tests (2 required AC tests + 4 error-path tests + 1 subcommand registration test)
- `docs/operations/rolling-cluster-upgrade.md` — new operations runbook

## Test Plan

- [ ] `TestClusterDrainCmd_PostsToDrainEndpoint` — mock server validates POST to `/api/v1/cluster/nodes/test-node/drain`; command exits without error ✅
- [ ] `TestClusterDecommissionCmd_PostsToDecommissionEndpoint` — same for decommission endpoint ✅
- [ ] `TestClusterDrainCmd_HTTP403_ReturnsError` — 403 returns "mTLS" error ✅
- [ ] `TestClusterDecommissionCmd_HTTP403_ReturnsError` — 403 returns "mTLS" error ✅
- [ ] `TestClusterDecommissionCmd_HTTP409_ReturnsBodyAsError` — 409 body surfaced as error ✅
- [ ] `TestClusterDrainCmd_OtherHTTPError_ReturnsStatusAndBody` — 5xx includes status code in error ✅
- [ ] `TestClusterCmd_SubcommandsRegistered` — `controllerCmd` has `cluster` with `drain` and `decommission` ✅

## Specialist Review Results

**QA Test Runner:** PASS — `make test-agent-complete` clean; 0 lint issues, all unit/integration/cross-platform builds pass

**QA Code Reviewer:** PASS — no mocks, no t.Skip(), error paths covered, state cleanup via t.Cleanup, no hacky workarounds

**Security Engineer:** PASS — no hardcoded secrets, node-id path-escaped via `url.PathEscape`, not logged, mTLS delegated to `getControllerClient()`, no architecture violations, lint-log-injection clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)