### PR TITLE
cfg: workflow list/status/cancel + controller cancel endpoint (Issue #2276)

### DIFF
--- a/cmd/cfg/cmd/workflow.go
+++ b/cmd/cfg/cmd/workflow.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -26,11 +28,19 @@ import (
 // AND the path segment is url.PathEscape'd at the sink (defense at the call).
 var workflowNameRE = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,128}$`)
 
+// workflowExecutionIDRE bounds execution IDs to a safe character set to prevent
+// path injection when constructing request URLs. url.PathEscape is applied at the
+// sink as defense-in-depth.
+var workflowExecutionIDRE = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
+
 var (
 	workflowURL         string
 	workflowAPIKey      string
 	workflowTLSCACert   string
 	workflowTLSInsecure bool
+
+	workflowStatusWorkflow string
+	workflowCancelWorkflow string
 )
 
 // workflowCmd is the parent command for workflow subcommands.
@@ -57,15 +67,76 @@ Examples:
 	RunE: runWorkflow,
 }
 
+// workflowListCmd prints a table of workflow definitions registered on the controller.
+var workflowListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List workflow definitions",
+	Long: `Print a table of workflow definitions (name, version, step count) registered on the controller.
+
+Examples:
+  cfg workflow list --url=https://controller.example.com
+  cfg workflow list --url=https://controller.example.com --api-key=mykey`,
+	RunE: runWorkflowList,
+}
+
+// workflowStatusCmd prints the status of a single workflow execution.
+var workflowStatusCmd = &cobra.Command{
+	Use:   "status <execution-id>",
+	Short: "Show the status of a workflow execution",
+	Long: `Print execution state, current step, started_at, and error for a workflow execution.
+
+The execution ID is returned by 'cfg workflow run'.
+
+Examples:
+  cfg workflow status exec_1234_1 --workflow my-workflow --url=https://controller.example.com`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWorkflowStatus,
+}
+
+// workflowCancelCmd cancels a running workflow execution.
+var workflowCancelCmd = &cobra.Command{
+	Use:   "cancel <execution-id>",
+	Short: "Cancel a running workflow execution",
+	Long: `Cancel a running workflow execution. Returns an error if the execution is already in a terminal state (completed, failed, or cancelled).
+
+The execution ID is returned by 'cfg workflow run'.
+
+Examples:
+  cfg workflow cancel exec_1234_1 --workflow my-workflow --url=https://controller.example.com`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWorkflowCancel,
+}
+
 func init() {
 	workflowRunCmd.Flags().StringVar(&workflowURL, "url", "", "Controller API URL (required)")
 	workflowRunCmd.Flags().StringVar(&workflowAPIKey, "api-key", "", "API key for authentication")
 	workflowRunCmd.Flags().StringVar(&workflowTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
 	workflowRunCmd.Flags().BoolVar(&workflowTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
-
 	_ = workflowRunCmd.MarkFlagRequired("url")
 
-	workflowCmd.AddCommand(workflowRunCmd)
+	workflowListCmd.Flags().StringVar(&workflowURL, "url", "", "Controller API URL (required)")
+	workflowListCmd.Flags().StringVar(&workflowAPIKey, "api-key", "", "API key for authentication")
+	workflowListCmd.Flags().StringVar(&workflowTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	workflowListCmd.Flags().BoolVar(&workflowTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
+	_ = workflowListCmd.MarkFlagRequired("url")
+
+	workflowStatusCmd.Flags().StringVar(&workflowURL, "url", "", "Controller API URL (required)")
+	workflowStatusCmd.Flags().StringVar(&workflowAPIKey, "api-key", "", "API key for authentication")
+	workflowStatusCmd.Flags().StringVar(&workflowTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	workflowStatusCmd.Flags().BoolVar(&workflowTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
+	workflowStatusCmd.Flags().StringVar(&workflowStatusWorkflow, "workflow", "", "Workflow name (required)")
+	_ = workflowStatusCmd.MarkFlagRequired("url")
+	_ = workflowStatusCmd.MarkFlagRequired("workflow")
+
+	workflowCancelCmd.Flags().StringVar(&workflowURL, "url", "", "Controller API URL (required)")
+	workflowCancelCmd.Flags().StringVar(&workflowAPIKey, "api-key", "", "API key for authentication")
+	workflowCancelCmd.Flags().StringVar(&workflowTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	workflowCancelCmd.Flags().BoolVar(&workflowTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
+	workflowCancelCmd.Flags().StringVar(&workflowCancelWorkflow, "workflow", "", "Workflow name (required)")
+	_ = workflowCancelCmd.MarkFlagRequired("url")
+	_ = workflowCancelCmd.MarkFlagRequired("workflow")
+
+	workflowCmd.AddCommand(workflowRunCmd, workflowListCmd, workflowStatusCmd, workflowCancelCmd)
 }
 
 // workflowDefinition is the local representation of a workflow YAML file.
@@ -76,6 +147,29 @@ type workflowDefinition struct {
 	Version     string                   `yaml:"version"     json:"version,omitempty"`
 	Steps       []map[string]interface{} `yaml:"steps"       json:"steps"`
 	Variables   map[string]interface{}   `yaml:"variables"   json:"variables,omitempty"`
+}
+
+// workflowListEntry is a single workflow entry returned by GET /api/v1/workflows.
+type workflowListEntry struct {
+	Name    string                   `json:"name"`
+	Version string                   `json:"version"`
+	Steps   []map[string]interface{} `json:"steps"`
+}
+
+// workflowListAPIResponse is the JSON shape of GET /api/v1/workflows.
+type workflowListAPIResponse struct {
+	Workflows []workflowListEntry `json:"workflows"`
+	Count     int                 `json:"count"`
+}
+
+// workflowExecutionStatus is the JSON shape of GET /api/v1/workflows/{name}/executions/{exec_id}.
+type workflowExecutionStatus struct {
+	ID           string    `json:"id"`
+	WorkflowName string    `json:"workflow_name"`
+	Status       string    `json:"status"`
+	CurrentStep  string    `json:"current_step,omitempty"`
+	StartTime    time.Time `json:"start_time"`
+	Error        string    `json:"error,omitempty"`
 }
 
 // getWorkflowClient creates an API client using bundle auth (mTLS) when available,
@@ -187,4 +281,140 @@ func runWorkflow(cmd *cobra.Command, args []string) error {
 		execResult.WorkflowName, execResult.ExecutionID, execResult.Status)
 
 	return nil
+}
+
+func runWorkflowList(cmd *cobra.Command, args []string) error {
+	client, err := getWorkflowClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodGet, "/api/v1/workflows", nil)
+	if err != nil {
+		return fmt.Errorf("failed to list workflows: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("controller returned %s: %s", resp.Status, string(respBody))
+	}
+
+	var result workflowListAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(result.Workflows) == 0 {
+		if _, err := fmt.Fprintln(os.Stdout, "No workflows registered."); err != nil {
+			return fmt.Errorf("failed to write output: %w", err)
+		}
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "NAME\tVERSION\tSTEPS"); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+	for _, wf := range result.Workflows {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%d\n", wf.Name, wf.Version, len(wf.Steps)); err != nil {
+			return fmt.Errorf("failed to write output: %w", err)
+		}
+	}
+	return w.Flush()
+}
+
+func runWorkflowStatus(cmd *cobra.Command, args []string) error {
+	execID := args[0]
+	if !workflowExecutionIDRE.MatchString(execID) {
+		return fmt.Errorf("execution ID %q invalid: must match %s", execID, workflowExecutionIDRE.String())
+	}
+
+	wfName := workflowStatusWorkflow
+	if !workflowNameRE.MatchString(wfName) {
+		return fmt.Errorf("workflow name %q invalid: must match %s", wfName, workflowNameRE.String())
+	}
+
+	client, err := getWorkflowClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	// url.PathEscape prevents path injection at the sink.
+	path := "/api/v1/workflows/" + url.PathEscape(wfName) + "/executions/" + url.PathEscape(execID)
+	resp, err := client.doRequest(context.Background(), http.MethodGet, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get execution status: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("execution %q not found for workflow %q", execID, wfName)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("controller returned %s: %s", resp.Status, string(respBody))
+	}
+
+	var ex workflowExecutionStatus
+	if err := json.NewDecoder(resp.Body).Decode(&ex); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	errStr := ex.Error
+	if errStr == "" {
+		errStr = "-"
+	}
+	currentStep := ex.CurrentStep
+	if currentStep == "" {
+		currentStep = "-"
+	}
+
+	fmt.Printf("execution_id:  %s\n", ex.ID)
+	fmt.Printf("workflow:      %s\n", ex.WorkflowName)
+	fmt.Printf("status:        %s\n", ex.Status)
+	fmt.Printf("current_step:  %s\n", currentStep)
+	fmt.Printf("started_at:    %s\n", ex.StartTime.UTC().Format(time.RFC3339))
+	fmt.Printf("error:         %s\n", errStr)
+
+	return nil
+}
+
+func runWorkflowCancel(cmd *cobra.Command, args []string) error {
+	execID := args[0]
+	if !workflowExecutionIDRE.MatchString(execID) {
+		return fmt.Errorf("execution ID %q invalid: must match %s", execID, workflowExecutionIDRE.String())
+	}
+
+	wfName := workflowCancelWorkflow
+	if !workflowNameRE.MatchString(wfName) {
+		return fmt.Errorf("workflow name %q invalid: must match %s", wfName, workflowNameRE.String())
+	}
+
+	client, err := getWorkflowClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	// url.PathEscape prevents path injection at the sink.
+	path := "/api/v1/workflows/" + url.PathEscape(wfName) + "/executions/" + url.PathEscape(execID) + "/cancel"
+	resp, err := client.doRequest(context.Background(), http.MethodPost, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to cancel execution: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		fmt.Printf("Cancelled execution %s\n", execID)
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("execution %q not found for workflow %q", execID, wfName)
+	case http.StatusConflict:
+		return fmt.Errorf("execution %q is already in a terminal state", execID)
+	default:
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("controller returned %s: %s", resp.Status, string(respBody))
+	}
 }

--- a/cmd/cfg/cmd/workflow_test.go
+++ b/cmd/cfg/cmd/workflow_test.go
@@ -321,3 +321,349 @@ func TestWorkflowCmd_RegisteredOnRoot(t *testing.T) {
 	}
 	assert.True(t, found, "workflow command must be registered on rootCmd")
 }
+
+// ---- workflow list -----------------------------------------------------------
+
+func TestWorkflowList_CallsWorkflowsEndpoint(t *testing.T) {
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"workflows": []map[string]interface{}{
+				{"name": "my-workflow", "version": "1.0.0", "steps": []map[string]string{{"name": "s1"}, {"name": "s2"}}},
+				{"name": "another-wf", "version": "2.1.0", "steps": []map[string]string{{"name": "s1"}}},
+			},
+			"count": 2,
+		})
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runWorkflowList(workflowListCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/workflows", requestPath)
+	assert.Contains(t, output, "my-workflow")
+	assert.Contains(t, output, "1.0.0")
+	assert.Contains(t, output, "another-wf")
+	assert.Contains(t, output, "2.1.0")
+}
+
+func TestWorkflowList_HeaderPresent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"workflows": []map[string]interface{}{
+				{"name": "wf1", "version": "1.0.0", "steps": []map[string]string{{"name": "s1"}}},
+			},
+			"count": 1,
+		})
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runWorkflowList(workflowListCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.True(t, strings.Contains(output, "NAME"), "header NAME must be present")
+	assert.True(t, strings.Contains(output, "VERSION"), "header VERSION must be present")
+	assert.True(t, strings.Contains(output, "STEPS"), "header STEPS must be present")
+}
+
+func TestWorkflowList_EmptyList_PrintsNoWorkflows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"workflows": []interface{}{},
+			"count":     0,
+		})
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runWorkflowList(workflowListCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No workflows")
+}
+
+func TestWorkflowList_NonOKStatus_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+
+	err := runWorkflowList(workflowListCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestWorkflowList_FlagsRegistered(t *testing.T) {
+	assert.NotNil(t, workflowListCmd.Flags().Lookup("url"), "--url flag must be registered on workflow list")
+	assert.NotNil(t, workflowListCmd.Flags().Lookup("api-key"), "--api-key flag must be registered on workflow list")
+	assert.NotNil(t, workflowListCmd.Flags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered on workflow list")
+	assert.NotNil(t, workflowListCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered on workflow list")
+}
+
+// ---- workflow status ---------------------------------------------------------
+
+func TestWorkflowStatus_HappyPath_PrintsFields(t *testing.T) {
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":            "exec_1234_1",
+			"workflow_name": "my-workflow",
+			"status":        "running",
+			"current_step":  "step1",
+			"start_time":    "2026-07-01T10:00:00Z",
+			"error":         "",
+		})
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	origWF := workflowStatusWorkflow
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+		workflowStatusWorkflow = origWF
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+	workflowStatusWorkflow = "my-workflow"
+
+	output := captureStdout(t, func() {
+		err := runWorkflowStatus(workflowStatusCmd, []string{"exec_1234_1"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/workflows/my-workflow/executions/exec_1234_1", requestPath)
+	assert.Contains(t, output, "exec_1234_1")
+	assert.Contains(t, output, "my-workflow")
+	assert.Contains(t, output, "running")
+	assert.Contains(t, output, "step1")
+	assert.Contains(t, output, "2026-07-01")
+}
+
+func TestWorkflowStatus_NotFound_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"execution not found"}`))
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	origWF := workflowStatusWorkflow
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+		workflowStatusWorkflow = origWF
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+	workflowStatusWorkflow = "my-workflow"
+
+	err := runWorkflowStatus(workflowStatusCmd, []string{"exec_9999_0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestWorkflowStatus_InvalidExecutionID_ReturnsError(t *testing.T) {
+	origWF := workflowStatusWorkflow
+	t.Cleanup(func() { workflowStatusWorkflow = origWF })
+	workflowStatusWorkflow = "my-workflow"
+
+	err := runWorkflowStatus(workflowStatusCmd, []string{"../../../etc/passwd"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
+}
+
+func TestWorkflowStatus_FlagsRegistered(t *testing.T) {
+	assert.NotNil(t, workflowStatusCmd.Flags().Lookup("url"), "--url flag must be registered on workflow status")
+	assert.NotNil(t, workflowStatusCmd.Flags().Lookup("workflow"), "--workflow flag must be registered on workflow status")
+	assert.NotNil(t, workflowStatusCmd.Flags().Lookup("api-key"))
+	assert.NotNil(t, workflowStatusCmd.Flags().Lookup("tls-ca-cert"))
+	assert.NotNil(t, workflowStatusCmd.Flags().Lookup("tls-insecure"))
+}
+
+func TestWorkflowStatus_RequiresExactlyOneArg(t *testing.T) {
+	err := workflowStatusCmd.Args(workflowStatusCmd, []string{})
+	require.Error(t, err, "zero args must error")
+
+	err = workflowStatusCmd.Args(workflowStatusCmd, []string{"exec_1_1", "extra"})
+	require.Error(t, err, "two args must error")
+}
+
+// ---- workflow cancel ---------------------------------------------------------
+
+func TestWorkflowCancel_Success_PrintsCancelled(t *testing.T) {
+	var requestPath string
+	var requestMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"cancelled": "exec_1234_1",
+		})
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	origWF := workflowCancelWorkflow
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+		workflowCancelWorkflow = origWF
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+	workflowCancelWorkflow = "my-workflow"
+
+	output := captureStdout(t, func() {
+		err := runWorkflowCancel(workflowCancelCmd, []string{"exec_1234_1"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/workflows/my-workflow/executions/exec_1234_1/cancel", requestPath)
+	assert.Equal(t, http.MethodPost, requestMethod)
+	assert.Contains(t, output, "Cancelled execution exec_1234_1")
+}
+
+func TestWorkflowCancel_NotFound_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"execution not found"}`))
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	origWF := workflowCancelWorkflow
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+		workflowCancelWorkflow = origWF
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+	workflowCancelWorkflow = "my-workflow"
+
+	err := runWorkflowCancel(workflowCancelCmd, []string{"exec_9999_0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestWorkflowCancel_AlreadyTerminal_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"execution is already in a terminal state"}`))
+	}))
+	defer server.Close()
+
+	origURL := workflowURL
+	origInsecure := workflowTLSInsecure
+	origWF := workflowCancelWorkflow
+	t.Cleanup(func() {
+		workflowURL = origURL
+		workflowTLSInsecure = origInsecure
+		workflowCancelWorkflow = origWF
+	})
+	workflowURL = server.URL
+	workflowTLSInsecure = true
+	workflowCancelWorkflow = "my-workflow"
+
+	err := runWorkflowCancel(workflowCancelCmd, []string{"exec_1234_1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal")
+}
+
+func TestWorkflowCancel_InvalidExecutionID_ReturnsError(t *testing.T) {
+	origWF := workflowCancelWorkflow
+	t.Cleanup(func() { workflowCancelWorkflow = origWF })
+	workflowCancelWorkflow = "my-workflow"
+
+	err := runWorkflowCancel(workflowCancelCmd, []string{"../../../etc/passwd"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
+}
+
+func TestWorkflowCancel_FlagsRegistered(t *testing.T) {
+	assert.NotNil(t, workflowCancelCmd.Flags().Lookup("url"), "--url flag must be registered on workflow cancel")
+	assert.NotNil(t, workflowCancelCmd.Flags().Lookup("workflow"), "--workflow flag must be registered on workflow cancel")
+	assert.NotNil(t, workflowCancelCmd.Flags().Lookup("api-key"))
+	assert.NotNil(t, workflowCancelCmd.Flags().Lookup("tls-ca-cert"))
+	assert.NotNil(t, workflowCancelCmd.Flags().Lookup("tls-insecure"))
+}
+
+func TestWorkflowCancel_RequiresExactlyOneArg(t *testing.T) {
+	err := workflowCancelCmd.Args(workflowCancelCmd, []string{})
+	require.Error(t, err, "zero args must error")
+
+	err = workflowCancelCmd.Args(workflowCancelCmd, []string{"exec_1_1", "extra"})
+	require.Error(t, err, "two args must error")
+}
+
+// ---- subcommand registration -------------------------------------------------
+
+func TestWorkflowCmd_SubcommandsRegistered(t *testing.T) {
+	names := make(map[string]bool)
+	for _, cmd := range workflowCmd.Commands() {
+		names[cmd.Name()] = true
+	}
+	assert.True(t, names["run"], "workflow run must be registered")
+	assert.True(t, names["list"], "workflow list must be registered")
+	assert.True(t, names["status"], "workflow status must be registered")
+	assert.True(t, names["cancel"], "workflow cancel must be registered")
+}

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -476,6 +476,7 @@ The workflow engine must support the following capabilities to fulfill its role 
 - **Debugging** — failed workflow runs retain full execution detail (inputs, outputs, and API request/response at every node) so failures can be diagnosed from history without re-execution. Successful runs retain summary-level traces. Debug depth and retention are configurable per workflow. Step-through execution with breakpoints available during development. Resume or re-run from any failed node without restarting the entire workflow
 - **Testing** — sandbox execution, replay failed runs, input/output inspection per node
 - **Versioning** — workflow version history, rollback to previous versions
+- **Operability** — operators can inspect and control running executions via the `cfg` CLI: `cfg workflow list` (definitions), `cfg workflow status <exec-id> --workflow <name>` (per-execution state and current step), `cfg workflow cancel <exec-id> --workflow <name>` (cancel a running execution). See [commands reference](../development/commands-reference.md#workflow-management).
 
 ### Workflow vs Cfg Summary
 

--- a/docs/development/commands-reference.md
+++ b/docs/development/commands-reference.md
@@ -482,3 +482,98 @@ No connections configured.
 | Flag | Description |
 |------|-------------|
 | `--json` | Emit a JSON array instead of a human-readable table |
+
+## Workflow Management
+
+`cfg workflow` subcommands manage workflow definitions and their executions on the controller.
+
+### cfg workflow list
+
+List all workflow definitions registered on the controller.
+
+```bash
+cfg workflow list --url=https://controller.example.com
+cfg workflow list --url=https://controller.example.com --api-key=mykey
+```
+
+Prints a plain-text table with columns: NAME, VERSION, STEPS.
+
+Example output:
+
+```
+NAME         VERSION  STEPS
+deploy-ring  1.2.0    4
+sync-entra   2.0.0    7
+```
+
+When no workflows are registered, exits 0 and prints:
+
+```
+No workflows registered.
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--url` | — | Controller API URL (required) |
+| `--api-key` | — | API key for authentication |
+| `--tls-ca-cert` | — | Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT) |
+| `--tls-insecure` | false | Skip TLS verification (development only, env: CFGMS_TLS_INSECURE) |
+
+### cfg workflow status
+
+Show the status of a single workflow execution.
+
+```bash
+cfg workflow status <execution-id> --workflow <name> --url=https://controller.example.com
+```
+
+The `<execution-id>` is returned by `cfg workflow run`.
+
+Example output:
+
+```
+execution_id:  exec_1782879897336049056_1
+workflow:      deploy-ring
+status:        running
+current_step:  step-canary
+started_at:    2026-07-01T10:00:00Z
+error:         -
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--workflow` | — | Workflow name (required) |
+| `--url` | — | Controller API URL (required) |
+| `--api-key` | — | API key for authentication |
+| `--tls-ca-cert` | — | Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT) |
+| `--tls-insecure` | false | Skip TLS verification (development only, env: CFGMS_TLS_INSECURE) |
+
+### cfg workflow cancel
+
+Cancel a running workflow execution.
+
+```bash
+cfg workflow cancel <execution-id> --workflow <name> --url=https://controller.example.com
+```
+
+Returns an error if the execution is already in a terminal state (completed, failed, or cancelled).
+
+On success:
+
+```
+Cancelled execution exec_1782879897336049056_1
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--workflow` | — | Workflow name (required) |
+| `--url` | — | Controller API URL (required) |
+| `--api-key` | — | API key for authentication |
+| `--tls-ca-cert` | — | Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT) |
+| `--tls-insecure` | false | Skip TLS verification (development only, env: CFGMS_TLS_INSECURE) |

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -63,6 +63,8 @@ func (h *WorkflowHandler) RegisterWorkflowRoutes(router *mux.Router) {
 	router.HandleFunc("/{id}", h.handleDeleteWorkflow).Methods("DELETE")
 	router.HandleFunc("/{id}/execute", h.handleExecuteWorkflow).Methods("POST")
 	router.HandleFunc("/{id}/executions", h.handleGetWorkflowExecutions).Methods("GET")
+	router.HandleFunc("/{id}/executions/{exec_id}", h.handleGetExecution).Methods("GET")
+	router.HandleFunc("/{id}/executions/{exec_id}/cancel", h.handleCancelExecution).Methods("POST")
 }
 
 // NewRegistrationApprovalHook creates a RegistrationApprovalHook backed by this handler's
@@ -382,6 +384,116 @@ func (h *WorkflowHandler) handleGetWorkflowExecutions(w http.ResponseWriter, r *
 	h.sendJSON(w, http.StatusOK, map[string]interface{}{
 		"executions": executions,
 		"count":      len(executions),
+	})
+}
+
+// handleGetExecution handles GET /api/v1/workflows/{id}/executions/{exec_id}
+func (h *WorkflowHandler) handleGetExecution(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	vars := mux.Vars(r)
+	name := vars["id"]
+	execID := vars["exec_id"]
+
+	if name == "" || execID == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name and execution ID are required")
+		return
+	}
+
+	nameForLog := logging.SanitizeLogValue(name)
+	execIDForLog := logging.SanitizeLogValue(execID)
+
+	execution, err := h.engine.GetExecution(execID)
+	if err != nil || execution == nil {
+		h.logger.Error("Execution not found", "name", nameForLog, "exec_id", execIDForLog, "error", err)
+		h.sendError(w, http.StatusNotFound, fmt.Sprintf("execution %q not found", execID))
+		return
+	}
+
+	if execution.WorkflowName != name {
+		h.sendError(w, http.StatusNotFound, fmt.Sprintf("execution %q not found for workflow %q", execID, name))
+		return
+	}
+
+	// Tenant isolation: verify the workflow exists in the calling tenant's namespace.
+	// A future GET /api/v1/executions/{exec_id} lookup-by-ID endpoint can bypass this
+	// once executions carry a tenant_id field.
+	if h.configStore != nil {
+		store := h.workflowStoreForRequest(r)
+		if _, storeErr := store.GetLatestWorkflow(r.Context(), name); storeErr != nil {
+			h.logger.Error("Tenant isolation check failed for execution get",
+				"name", nameForLog, "exec_id", execIDForLog)
+			h.sendError(w, http.StatusForbidden, "access denied")
+			return
+		}
+	}
+
+	h.sendJSON(w, http.StatusOK, execution)
+}
+
+// handleCancelExecution handles POST /api/v1/workflows/{id}/executions/{exec_id}/cancel
+func (h *WorkflowHandler) handleCancelExecution(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	vars := mux.Vars(r)
+	name := vars["id"]
+	execID := vars["exec_id"]
+
+	if name == "" || execID == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name and execution ID are required")
+		return
+	}
+
+	nameForLog := logging.SanitizeLogValue(name)
+	execIDForLog := logging.SanitizeLogValue(execID)
+
+	// Pre-check existence before acting. CancelExecution returns nil for already-terminal
+	// executions (it skips the cancel when Cancel func is nil) and a plain error string for
+	// not-found — neither signal is suitable for HTTP status mapping, so we gate here.
+	execution, err := h.engine.GetExecution(execID)
+	if err != nil || execution == nil {
+		h.logger.Error("Execution not found for cancel", "name", nameForLog, "exec_id", execIDForLog, "error", err)
+		h.sendError(w, http.StatusNotFound, fmt.Sprintf("execution %q not found", execID))
+		return
+	}
+
+	if execution.WorkflowName != name {
+		h.sendError(w, http.StatusNotFound, fmt.Sprintf("execution %q not found for workflow %q", execID, name))
+		return
+	}
+
+	// Tenant isolation: reject cross-tenant cancellation.
+	if h.configStore != nil {
+		store := h.workflowStoreForRequest(r)
+		if _, storeErr := store.GetLatestWorkflow(r.Context(), name); storeErr != nil {
+			h.logger.Error("Tenant isolation check failed for execution cancel",
+				"name", nameForLog, "exec_id", execIDForLog)
+			h.sendError(w, http.StatusForbidden, "access denied")
+			return
+		}
+	}
+
+	// Reject already-terminal executions before calling CancelExecution.
+	status := execution.GetStatus()
+	if status == workflow.StatusCompleted || status == workflow.StatusFailed || status == workflow.StatusCancelled {
+		h.sendError(w, http.StatusConflict, "execution is already in a terminal state")
+		return
+	}
+
+	if cancelErr := h.engine.CancelExecution(execID); cancelErr != nil {
+		h.logger.Error("Failed to cancel execution", "name", nameForLog, "exec_id", execIDForLog, "error", cancelErr)
+		h.sendError(w, http.StatusInternalServerError, "failed to cancel execution")
+		return
+	}
+
+	h.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"cancelled": execID,
 	})
 }
 

--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -90,6 +91,8 @@ func TestWorkflowHandler_NilEngine_ReturnsServiceUnavailable(t *testing.T) {
 		{"PUT", "/workflows/wf", minimalWorkflowBody("wf")},
 		{"DELETE", "/workflows/wf", nil},
 		{"POST", "/workflows/wf/execute", nil},
+		{"GET", "/workflows/wf/executions/exec_1_1", nil},
+		{"POST", "/workflows/wf/executions/exec_1_1/cancel", nil},
 	}
 	for _, tc := range tests {
 		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
@@ -570,4 +573,205 @@ func TestWorkflowHandler_SpecialCharsInName_HandledSafely(t *testing.T) {
 		assert.NotContains(t, name, "\n", "logger must not receive raw LF in workflow name")
 		assert.NotContains(t, name, "\r", "logger must not receive raw CR in workflow name")
 	}
+}
+
+// newTestWorkflowHandlerAndEngine creates a WorkflowHandler and returns the engine separately
+// so tests that need to inspect or wait on execution state can do so directly.
+func newTestWorkflowHandlerAndEngine(t *testing.T) (*WorkflowHandler, cfgconfig.ConfigStore, *workflow.Engine) {
+	t.Helper()
+	storageManager := pkgtesting.SetupTestStorage(t)
+	configStore := storageManager.GetConfigStore()
+	logger := logging.NewNoopLogger()
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil)
+	handler := NewWorkflowHandler(engine, configStore, nil, logger)
+	return handler, configStore, engine
+}
+
+// createAndExecuteWorkflow is a test helper that creates a workflow then executes it,
+// returning the execution ID. Uses the provided router and tenant ID.
+func createAndExecuteWorkflow(t *testing.T, router *mux.Router, wfName, tenantID string, longRunning bool) string {
+	t.Helper()
+
+	// Create workflow
+	var body []byte
+	if longRunning {
+		// Delay step keeps execution alive long enough for the cancel test.
+		body = mustMarshal(CreateWorkflowRequest{
+			Name: wfName,
+			Steps: []workflow.Step{
+				{
+					Name:  "long-wait",
+					Type:  workflow.StepTypeDelay,
+					Delay: &workflow.DelayConfig{Duration: 30 * time.Second},
+				},
+			},
+		})
+	} else {
+		// Task step with no module fails immediately → execution reaches terminal state.
+		body = minimalWorkflowBody(wfName)
+	}
+
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(body))
+	createReq = withTenantContext(createReq, tenantID)
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code, "workflow create must succeed")
+
+	// Execute workflow
+	execReq := httptest.NewRequest("POST", "/workflows/"+wfName+"/execute", bytes.NewReader([]byte("{}")))
+	execReq = withTenantContext(execReq, tenantID)
+	execRec := httptest.NewRecorder()
+	router.ServeHTTP(execRec, execReq)
+	require.Equal(t, http.StatusAccepted, execRec.Code, "workflow execute must succeed")
+
+	var execResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(execRec.Body.Bytes(), &execResp))
+	execID, ok := execResp["execution_id"].(string)
+	require.True(t, ok && execID != "", "execution_id must be non-empty")
+	return execID
+}
+
+// --- cancel execution ---------------------------------------------------------
+
+func TestWorkflowHandler_CancelExecution_UnknownExecID_Returns404(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("POST", "/workflows/my-wf/executions/exec_9999_0/cancel", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["error"], "not found")
+}
+
+func TestWorkflowHandler_CancelExecution_RunningExecution_Returns200(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newWorkflowRouter(h)
+
+	// Use a long-running delay step so the execution stays non-terminal.
+	execID := createAndExecuteWorkflow(t, router, "long-wf", "test-tenant", true)
+
+	req := httptest.NewRequest("POST", "/workflows/long-wf/executions/"+execID+"/cancel", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, execID, resp["cancelled"])
+}
+
+// waitForTerminalState blocks until the execution reaches a terminal state or fails the test
+// after 5 seconds. Uses a ticker so the goroutine scheduler drives the check, not a sleep.
+func waitForTerminalState(t *testing.T, eng *workflow.Engine, execID string) {
+	t.Helper()
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(5 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			ex, err := eng.GetExecution(execID)
+			if err == nil && ex != nil {
+				s := ex.GetStatus()
+				if s == workflow.StatusCompleted || s == workflow.StatusFailed || s == workflow.StatusCancelled {
+					return
+				}
+			}
+		case <-timeout.C:
+			t.Fatalf("execution %s did not reach a terminal state within 5 seconds", execID)
+		}
+	}
+}
+
+func TestWorkflowHandler_CancelExecution_TerminalExecution_Returns409(t *testing.T) {
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
+	router := newWorkflowRouter(h)
+
+	// Task step with no module name fails immediately → terminal state reached quickly.
+	execID := createAndExecuteWorkflow(t, router, "quick-wf", "test-tenant", false)
+	waitForTerminalState(t, engine, execID)
+
+	req := httptest.NewRequest("POST", "/workflows/quick-wf/executions/"+execID+"/cancel", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["error"], "terminal")
+}
+
+func TestWorkflowHandler_CancelExecution_CrossTenant_Returns403(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newWorkflowRouter(h)
+
+	// Create and execute the workflow in tenant A with a long delay so it stays non-terminal.
+	execID := createAndExecuteWorkflow(t, router, "xsec-cancel-wf", "tenant-a", true)
+
+	// Tenant B tries to cancel tenant A's execution. tenant-b has no workflow
+	// named "xsec-cancel-wf" in its config namespace → 403.
+	req := httptest.NewRequest("POST", "/workflows/xsec-cancel-wf/executions/"+execID+"/cancel", nil)
+	req = withTenantContext(req, "tenant-b")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// --- get execution ------------------------------------------------------------
+
+func TestWorkflowHandler_GetExecution_CorrectRecord_Returns200(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newWorkflowRouter(h)
+
+	execID := createAndExecuteWorkflow(t, router, "get-exec-wf", "test-tenant", true)
+
+	req := httptest.NewRequest("GET", "/workflows/get-exec-wf/executions/"+execID, nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, execID, resp["id"])
+	assert.Equal(t, "get-exec-wf", resp["workflow_name"])
+	assert.NotEmpty(t, resp["status"])
+}
+
+func TestWorkflowHandler_GetExecution_CrossTenant_Returns403(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newWorkflowRouter(h)
+
+	// Create and execute the workflow in tenant A.
+	execID := createAndExecuteWorkflow(t, router, "xsec-wf", "tenant-a", true)
+
+	// Tenant B tries to access tenant A's execution.
+	// tenant-b has no workflow named "xsec-wf" → 403.
+	req := httptest.NewRequest("GET", "/workflows/xsec-wf/executions/"+execID, nil)
+	req = withTenantContext(req, "tenant-b")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestWorkflowHandler_GetExecution_NotFound_Returns404(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("GET", "/workflows/my-wf/executions/exec_9999_0", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/workflows/{id}/executions/{exec_id}` and `POST /api/v1/workflows/{id}/executions/{exec_id}/cancel` controller endpoints (wrapping the already-implemented `GetExecution` and `CancelExecution` engine methods)
- Adds `cfg workflow list`, `cfg workflow status`, and `cfg workflow cancel` CLI subcommands with input validation and tabular/key-value output
- Tenant isolation enforced on both new endpoints (403 for cross-tenant access); cancel pre-checks existence (404) and terminal state (409) before delegating to the engine

Fixes #2276

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — 170+ packages, lint, license, architecture, security scan, cross-platform builds all green |
| QA Code Reviewer | **PASS** (after fix: replaced `time.Sleep` polling with `waitForTerminalState` ticker helper; added cross-tenant 403 test for cancel handler) |
| Security Engineer | **PASS** — log injection sanitized on all user-supplied path vars, path injection blocked by regex + `url.PathEscape`, tenant isolation tested, no secrets, no architecture violations |

## Test plan

- [ ] `TestWorkflowHandler_CancelExecution_UnknownExecID_Returns404` — 404 for unknown exec
- [ ] `TestWorkflowHandler_CancelExecution_RunningExecution_Returns200` — cancel live execution
- [ ] `TestWorkflowHandler_CancelExecution_TerminalExecution_Returns409` — 409 for already-terminal
- [ ] `TestWorkflowHandler_CancelExecution_CrossTenant_Returns403` — tenant isolation
- [ ] `TestWorkflowHandler_GetExecution_CorrectRecord_Returns200` — returns execution data
- [ ] `TestWorkflowHandler_GetExecution_CrossTenant_Returns403` — tenant isolation
- [ ] `TestWorkflowList_*`, `TestWorkflowStatus_*`, `TestWorkflowCancel_*` — CLI happy path + error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)