### PR TITLE
ha: wire cfg.HA.Mode into ha.Manager to eliminate single-server split-brain (Issue #2277)

### DIFF
--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -402,7 +402,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 
 	// Initialize HA manager
 	logger.Info("Initializing HA manager...")
-	haManager, err := initializeHAManager(logger, storageManager)
+	haManager, err := initializeHAManager(cfg, logger, storageManager)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize HA manager: %w", err)
 	}
@@ -1963,9 +1963,29 @@ func loadExistingCertificateManager(cfg *config.Config, logger logging.Logger) (
 	return manager, nil
 }
 
-// initializeHAManager initializes the HA manager using ha.DefaultConfig().
-func initializeHAManager(logger logging.Logger, storageManager *interfaces.StorageManager) (*ha.Manager, error) {
-	haManager, err := ha.NewManager(ha.DefaultConfig(), logger, storageManager)
+// initializeHAManager initializes the HA manager, transferring the deployment
+// mode from the YAML config before loading environment overrides. This ordering
+// is required because ha.NewManager calls Validate() before LoadFromEnvironment(),
+// and Validate() requires Node.ID for non-single modes; Node.ID comes exclusively
+// from CFGMS_NODE_ID (env), never from YAML. Pre-loading env here populates
+// Node.ID first so the subsequent NewManager call does not fail Validate().
+// CFGMS_HA_MODE env overrides YAML (env > YAML precedence) via the re-run inside NewManager.
+func initializeHAManager(cfg *config.Config, logger logging.Logger, storageManager *interfaces.StorageManager) (*ha.Manager, error) {
+	haConfig := ha.DefaultConfig()
+
+	if cfg != nil && cfg.HA != nil && cfg.HA.Mode != "" {
+		mode, err := ha.ModeFromString(cfg.HA.Mode)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ha.mode in config: %w", err)
+		}
+		haConfig.Mode = mode
+	}
+
+	if err := haConfig.LoadFromEnvironment(); err != nil {
+		return nil, fmt.Errorf("failed to load HA configuration from environment: %w", err)
+	}
+
+	haManager, err := ha.NewManager(haConfig, logger, storageManager)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HA manager: %w", err)
 	}

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -301,6 +301,7 @@ func TestInitializeHAManager_UsesConfigMode(t *testing.T) {
 		tempDir+"/cfgms.db",
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
 
 	cfg := &config.Config{
 		HA: &config.HAConfig{
@@ -311,6 +312,7 @@ func TestInitializeHAManager_UsesConfigMode(t *testing.T) {
 	haManager, err := initializeHAManager(cfg, logging.NewNoopLogger(), sm)
 	require.NoError(t, err, "initializeHAManager must succeed with ha.mode=cluster and CFGMS_NODE_ID set")
 	require.NotNil(t, haManager)
+	t.Cleanup(func() { _ = haManager.Stop(context.Background()) })
 
 	assert.Equal(t, ha.ClusterMode, haManager.GetDeploymentMode(),
 		"HA manager must report ClusterMode when cfg.HA.Mode is \"cluster\"")
@@ -325,6 +327,7 @@ func TestInitializeHAManager_InvalidMode(t *testing.T) {
 		tempDir+"/cfgms.db",
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
 
 	cfg := &config.Config{
 		HA: &config.HAConfig{

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/pkg/ha"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
 
 // recordingLogger implements logging.Logger and captures every log call so
@@ -280,6 +282,60 @@ func TestInitializeHAManager_UsesDefaultConfig(t *testing.T) {
 	node := haManager.GetLocalNode()
 	require.NotNil(t, node)
 	assert.NotEmpty(t, node.ID, "auto-generated node ID must not be empty")
+}
+
+// TestInitializeHAManager_UsesConfigMode verifies that initializeHAManager transfers
+// the YAML-configured deployment mode into the ha.Config before calling ha.NewManager.
+// This is the root-cause fix for the split-brain where every node assumed SingleServerMode
+// because DefaultConfig() hardcodes it regardless of the YAML ha.mode field.
+//
+// The env pre-load ordering is also verified: CFGMS_NODE_ID (required by Validate() for
+// non-single modes) must be set in the environment before NewManager's Validate() runs,
+// or every cluster-mode controller crashes at startup.
+func TestInitializeHAManager_UsesConfigMode(t *testing.T) {
+	t.Setenv("CFGMS_NODE_ID", "test-cluster-node-uses-config-mode")
+
+	tempDir := t.TempDir()
+	sm, err := interfaces.CreateOSSStorageManager(
+		tempDir+"/flatfile",
+		tempDir+"/cfgms.db",
+	)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		HA: &config.HAConfig{
+			Mode: "cluster",
+		},
+	}
+
+	haManager, err := initializeHAManager(cfg, logging.NewNoopLogger(), sm)
+	require.NoError(t, err, "initializeHAManager must succeed with ha.mode=cluster and CFGMS_NODE_ID set")
+	require.NotNil(t, haManager)
+
+	assert.Equal(t, ha.ClusterMode, haManager.GetDeploymentMode(),
+		"HA manager must report ClusterMode when cfg.HA.Mode is \"cluster\"")
+}
+
+// TestInitializeHAManager_InvalidMode verifies that an unrecognised ha.mode string
+// surfaces an error instead of silently falling back to single-server mode.
+func TestInitializeHAManager_InvalidMode(t *testing.T) {
+	tempDir := t.TempDir()
+	sm, err := interfaces.CreateOSSStorageManager(
+		tempDir+"/flatfile",
+		tempDir+"/cfgms.db",
+	)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		HA: &config.HAConfig{
+			Mode: "clustr", // deliberate typo
+		},
+	}
+
+	_, err = initializeHAManager(cfg, logging.NewNoopLogger(), sm)
+	require.Error(t, err, "initializeHAManager must return error for invalid ha.mode")
+	assert.Contains(t, err.Error(), "invalid HA mode",
+		"error must identify the bad mode string")
 }
 
 // TestBuiltinWorkflowSeedingIPTrust verifies that a controller started with no

--- a/pkg/ha/config.go
+++ b/pkg/ha/config.go
@@ -62,20 +62,31 @@ func DefaultConfig() *Config {
 	}
 }
 
+// ModeFromString parses a deployment mode string into a DeploymentMode.
+// Valid values (case-insensitive): "single", "blue-green", "cluster".
+// Returns SingleServerMode and an error for unrecognised values.
+func ModeFromString(s string) (DeploymentMode, error) {
+	switch strings.ToLower(s) {
+	case "single":
+		return SingleServerMode, nil
+	case "blue-green":
+		return BlueGreenMode, nil
+	case "cluster":
+		return ClusterMode, nil
+	default:
+		return SingleServerMode, fmt.Errorf("invalid HA mode: %s", s)
+	}
+}
+
 // LoadFromEnvironment loads HA configuration from environment variables
 func (c *Config) LoadFromEnvironment() error {
 	// Load deployment mode
 	if mode := os.Getenv("CFGMS_HA_MODE"); mode != "" {
-		switch strings.ToLower(mode) {
-		case "single":
-			c.Mode = SingleServerMode
-		case "blue-green":
-			c.Mode = BlueGreenMode
-		case "cluster":
-			c.Mode = ClusterMode
-		default:
-			return fmt.Errorf("invalid HA mode: %s", mode)
+		m, err := ModeFromString(mode)
+		if err != nil {
+			return err
 		}
+		c.Mode = m
 	}
 
 	// Load CA certificate path for TLS verification between HA nodes

--- a/pkg/ha/manager_test.go
+++ b/pkg/ha/manager_test.go
@@ -6,14 +6,19 @@ package ha
 import (
 	"context"
 	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
 
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	cpgrpc "github.com/cfgis/cfgms/pkg/controlplane/providers/grpc"
@@ -439,6 +444,36 @@ func TestConfig_LoadFromEnvironment_InvalidQuorum(t *testing.T) {
 	_, err = NewManager(cfg, logger, storageManager)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "quorum")
+}
+
+// TestModeFromString verifies all valid mode strings (case-insensitive) and the
+// error path for unrecognised values.
+func TestModeFromString(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  DeploymentMode
+		isErr bool
+	}{
+		{"single", SingleServerMode, false},
+		{"Single", SingleServerMode, false},
+		{"SINGLE", SingleServerMode, false},
+		{"blue-green", BlueGreenMode, false},
+		{"Blue-Green", BlueGreenMode, false},
+		{"cluster", ClusterMode, false},
+		{"CLUSTER", ClusterMode, false},
+		{"", SingleServerMode, true},
+		{"clustr", SingleServerMode, true},
+		{"Cluster!", SingleServerMode, true},
+	} {
+		got, err := ModeFromString(tc.input)
+		if tc.isErr {
+			require.Error(t, err, "ModeFromString(%q) should return error", tc.input)
+			assert.Equal(t, SingleServerMode, got, "error path must return SingleServerMode")
+		} else {
+			require.NoError(t, err, "ModeFromString(%q) must not error", tc.input)
+			assert.Equal(t, tc.want, got, "ModeFromString(%q) wrong mode", tc.input)
+		}
+	}
 }
 
 // TestHashStringToUint64_DistinguishesKnownPolynomialColliders verifies that the
@@ -1148,4 +1183,130 @@ func TestManager_Start_WiresOnBecomeLeaderCallback(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("steward did not receive CommandReconnect within 5s via wired callback")
 	}
+}
+
+// TestManager_TwoNodeCluster verifies that two Manager instances in cluster mode,
+// each configured with the other as a peer, complete Raft leader election so that
+// exactly one is IsLeader()==true within 15 seconds. Real RaftConsensus instances
+// are used throughout; httptest.NewTLSServer provides the transport layer.
+//
+// The production HandleMessage handler requires mTLS peer-CN verification, which in
+// turn requires the transport client to present a client certificate — a capability
+// not yet wired into raftTransport. This test therefore routes Raft messages directly
+// through RaftConsensus.Process (the same code path HandleMessage uses internally),
+// bypassing only the TLS CN gate that is irrelevant to testing leader election.
+func TestManager_TwoNodeCluster(t *testing.T) {
+	sm1, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+	sm2, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	const nodeA = "two-node-cluster-a"
+	const nodeB = "two-node-cluster-b"
+
+	// Start HTTPS test servers before creating managers so we have real listen
+	// addresses to put into the discovery configs. Handlers are registered after
+	// the RaftConsensus pointers are available (no race: first election tick fires
+	// after HeartbeatInterval=100ms, well after the Go setup below completes).
+	muxA := http.NewServeMux()
+	muxB := http.NewServeMux()
+
+	srvA := httptest.NewTLSServer(muxA)
+	t.Cleanup(srvA.Close)
+	addrA := strings.TrimPrefix(srvA.URL, "https://")
+
+	srvB := httptest.NewTLSServer(muxB)
+	t.Cleanup(srvB.Close)
+	addrB := strings.TrimPrefix(srvB.URL, "https://")
+
+	logger := logging.GetLogger()
+
+	makeCfg := func(selfID, peerID, selfAddr, peerAddr string) *Config {
+		cfg := DefaultConfig()
+		cfg.Mode = ClusterMode
+		cfg.Node.ID = selfID
+		cfg.Node.ExternalAddress = selfAddr
+		cfg.Cluster.HeartbeatInterval = 100 * time.Millisecond
+		cfg.Cluster.ElectionTimeout = 1 * time.Second
+		cfg.Cluster.ExpectedSize = 2
+		cfg.Cluster.MinQuorum = 2
+		cfg.Cluster.Discovery.Config = map[string]interface{}{
+			"nodes": []interface{}{
+				map[string]interface{}{"id": selfID, "address": selfAddr},
+				map[string]interface{}{"id": peerID, "address": peerAddr},
+			},
+		}
+		return cfg
+	}
+
+	managerA, err := NewManager(makeCfg(nodeA, nodeB, addrA, addrB), logger, sm1)
+	require.NoError(t, err)
+	require.NotNil(t, managerA.raftConsensus)
+	t.Cleanup(func() { assert.NoError(t, managerA.raftConsensus.Stop()) })
+
+	managerB, err := NewManager(makeCfg(nodeB, nodeA, addrB, addrA), logger, sm2)
+	require.NoError(t, err)
+	require.NotNil(t, managerB.raftConsensus)
+	t.Cleanup(func() { assert.NoError(t, managerB.raftConsensus.Stop()) })
+
+	rcA := managerA.raftConsensus
+	rcB := managerB.raftConsensus
+
+	// raftMessageHandler reads a binary-encoded Raft message from the request body
+	// and steps it into the target RaftConsensus via Process (= node.Step). This is
+	// the same operation HandleMessage performs after passing the mTLS CN gate.
+	var handlerCallCount atomic.Int64
+	raftMessageHandler := func(rc *RaftConsensus) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			handlerCallCount.Add(1)
+			data, readErr := io.ReadAll(r.Body)
+			if readErr != nil {
+				http.Error(w, readErr.Error(), http.StatusBadRequest)
+				return
+			}
+			var msg raftpb.Message
+			if unmarshalErr := msg.Unmarshal(data); unmarshalErr != nil {
+				http.Error(w, unmarshalErr.Error(), http.StatusBadRequest)
+				return
+			}
+			if stepErr := rc.Process(r.Context(), msg); stepErr != nil {
+				http.Error(w, stepErr.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+
+	muxA.HandleFunc("/raft/message", raftMessageHandler(rcA))
+	muxB.HandleFunc("/raft/message", raftMessageHandler(rcB))
+
+	// Replace each transport's HTTP client with one that trusts the httptest CA.
+	// All httptest.NewTLSServer instances share the same hardcoded CA, so a client
+	// from either server can reach both.
+	testHTTPClient := srvA.Client()
+	testHTTPClient.Timeout = 3 * time.Second
+
+	managerA.raftConsensus.transport.mu.Lock()
+	managerA.raftConsensus.transport.client = testHTTPClient
+	managerA.raftConsensus.transport.mu.Unlock()
+
+	managerB.raftConsensus.transport.mu.Lock()
+	managerB.raftConsensus.transport.client = testHTTPClient
+	managerB.raftConsensus.transport.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	require.NoError(t, managerA.Start(ctx))
+	require.NoError(t, managerB.Start(ctx))
+
+	require.Eventually(t, func() bool {
+		la, lb := managerA.IsLeader(), managerB.IsLeader()
+		return (la && !lb) || (!la && lb)
+	}, 15*time.Second, 50*time.Millisecond, "exactly one of the two managers must be leader")
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopCancel()
+	require.NoError(t, managerA.Stop(stopCtx))
+	require.NoError(t, managerB.Stop(stopCtx))
 }

--- a/pkg/ha/raft_consensus.go
+++ b/pkg/ha/raft_consensus.go
@@ -247,18 +247,31 @@ func (rc *RaftConsensus) runRaft() {
 			rc.processReady(rd)
 
 		case prop := <-rc.proposeC:
-			// Propose new entry to Raft log
-			rc.logger.Debug("Received proposal", "node_id", rc.nodeID)
-			if err := rc.node.Propose(rc.ctx, prop); err != nil {
-				rc.logger.Error("Failed to propose to Raft", "error", err)
-			}
+			// Spawn a goroutine so the raft event loop continues ticking while
+			// the proposal waits for a leader. etcd/raft's n.propc is unbuffered
+			// and n.run() nil-gates it when no leader is known, so calling
+			// Propose directly here would deadlock the election timer.
+			// Track in rc.wg so Stop() does not return until the goroutine exits.
+			rc.wg.Add(1)
+			go func(p []byte) {
+				defer rc.wg.Done()
+				if err := rc.node.Propose(rc.ctx, p); err != nil {
+					rc.logger.Error("Failed to propose to Raft", "error", err)
+				}
+			}(prop)
 
 		case cc := <-rc.confChangeC:
-			// Propose configuration change
-			rc.logger.Debug("Received conf change", "node_id", rc.nodeID)
-			if err := rc.node.ProposeConfChange(rc.ctx, cc); err != nil {
-				rc.logger.Error("Failed to propose conf change", "error", err)
-			}
+			// Same reasoning as proposeC: ProposeConfChange blocks on the
+			// unbuffered n.propc when no leader exists. Run it off the
+			// raft loop so ticks continue to fire.
+			// Track in rc.wg so Stop() does not return until the goroutine exits.
+			rc.wg.Add(1)
+			go func(c raftpb.ConfChange) {
+				defer rc.wg.Done()
+				if err := rc.node.ProposeConfChange(rc.ctx, c); err != nil {
+					rc.logger.Error("Failed to propose conf change", "error", err)
+				}
+			}(cc)
 
 		case <-rc.stopC:
 			rc.logger.Debug("Raft loop stopping", "node_id", rc.nodeID)


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `ha.DefaultConfig()` hardcodes `SingleServerMode`, so every controller node assumed leadership regardless of `ha.mode: cluster` in YAML — classic split-brain.
- **Config wiring**: `initializeHAManager` now calls `ha.ModeFromString(cfg.HA.Mode)` to transfer the YAML mode into `ha.Config`, pre-loads environment overrides before `ha.NewManager` so `CFGMS_NODE_ID` is visible to `Validate()`, then passes the complete config to `ha.NewManager`. `CFGMS_HA_MODE` env retains precedence over YAML.
- **Raft deadlock fixed**: `RaftConsensus.runRaft`'s `proposeC`/`confChangeC` cases blocked the raft event loop. etcd/raft v3's `n.propc` is unbuffered and `n.run()` nil-gates it when no leader is known — calling `Propose`/`ProposeConfChange` inline starved the election ticker indefinitely. Both cases now spawn goroutines tracked in `rc.wg` so the ticker continues firing and Stop() still provides full quiescence.
- **Error propagation**: Invalid `ha.mode` strings now return an error from `initializeHAManager` (previously silently fell back to single-server mode — a typo like `clustr` would cause undetected mis-configuration).

## Changed files

| File | Change |
|------|--------|
| `pkg/ha/config.go` | Added `ModeFromString(s string) (DeploymentMode, error)`; refactored `LoadFromEnvironment` to use it |
| `pkg/ha/raft_consensus.go` | Fixed election-timer deadlock: `proposeC`/`confChangeC` dispatch via goroutines tracked in `rc.wg` |
| `pkg/ha/manager_test.go` | `TestModeFromString` (valid + error paths); `TestManager_TwoNodeCluster` (two real Manager instances, exactly one leader within 15 s) |
| `features/controller/server/server.go` | `initializeHAManager` accepts `cfg *config.Config`; propagates invalid-mode errors |
| `features/controller/server/server_test.go` | `TestInitializeHAManager_UsesConfigMode`; `TestInitializeHAManager_InvalidMode` |

## Test plan

- [x] `TestModeFromString` — all valid modes case-insensitively, error on invalid input
- [x] `TestManager_TwoNodeCluster` — two real Manager instances converge to exactly one leader (1.4 s)
- [x] `TestInitializeHAManager_UsesConfigMode` — `ha.mode: cluster` + `CFGMS_NODE_ID` → `ClusterMode` reported
- [x] `TestInitializeHAManager_InvalidMode` — typo in `ha.mode` → error returned, not silent fallback
- [x] `TestHandleConfigPush_NonLeader` regression gate — passes
- [x] `go test ./pkg/ha/... ./features/controller/server/... ./features/controller/api/...` — all green
- [x] `make check-architecture` — no violations

Fixes #2277

🤖 Generated with [Claude Code](https://claude.com/claude-code)