### PR TITLE
cluster: node membership state machine and drain

### DIFF
--- a/docs/operations/rolling-cluster-upgrade.md
+++ b/docs/operations/rolling-cluster-upgrade.md
@@ -39,9 +39,41 @@ Wait for the drain to complete. The command prints the resulting node state:
 Node <node-id> is now draining.
 ```
 
-### 3. Upgrade the binary on the drained node
+### 3. Verify the load balancer health gate
 
-SSH to the node and run the upgrade (see `controller-upgrade.md` for the full
+After drain, confirm `GET /api/v1/health` on the draining node returns HTTP 503.
+Poll the node directly (not through the load balancer):
+
+```bash
+curl -o /dev/null -w "%{http_code}\n" \
+    --cert ~/.config/cfgms/admin.crt \
+    --key ~/.config/cfgms/admin.key \
+    --cacert ~/.config/cfgms/ca.crt \
+    https://<node-host>:9080/api/v1/health
+# Expected: 503
+```
+
+The `"services"` field in the response body will include `"drain": "draining"`.
+The load balancer stops routing new steward connections once it sees the 503.
+
+### 4. Observe session drain
+
+Existing steward sessions established before the drain continue until they close
+naturally. Monitor the active session count until it reaches zero before
+stopping the process (optional but minimises reconnect storms):
+
+```bash
+# Run on the draining node — repeat until count is 0
+cfg controller status --url=https://<node-host>:9080
+```
+
+In environments where brief reconnect storms are acceptable, you can stop
+the controller immediately after the 503 is confirmed; stewards reconnect to
+remaining nodes within one heartbeat interval.
+
+### 5. Upgrade the binary on the drained node
+
+SSH to the node and run the upgrade (see [controller-upgrade.md](controller-upgrade.md) for the full
 single-node upgrade runbook):
 
 ```bash
@@ -50,7 +82,7 @@ cfg controller upgrade run \
     --config /etc/cfgms/controller.cfg
 ```
 
-### 4. Decommission the old node entry
+### 6. Decommission the old node entry
 
 After the upgraded node has rejoined the cluster under a new node ID, remove
 the old node entry:
@@ -67,9 +99,9 @@ and an error message. The command prints the resulting state on success:
 Node <node-id> is now decommissioned.
 ```
 
-### 5. Repeat for each remaining node
+### 7. Repeat for each remaining node
 
-Repeat steps 2–4 for each remaining node, one at a time.
+Repeat steps 2–6 for each remaining node, one at a time.
 
 ## Error handling
 

--- a/features/controller/api/handlers_cluster.go
+++ b/features/controller/api/handlers_cluster.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/controller/cluster"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// clusterNodeDrainResponse is the JSON body for a successful drain request.
+type clusterNodeDrainResponse struct {
+	NodeID string `json:"node_id"`
+	State  string `json:"state"`
+}
+
+// handleClusterNodeDrain handles POST /api/v1/cluster/nodes/{id}/drain.
+//
+// Requires an admin mTLS principal. Non-admin and unauthenticated callers receive
+// HTTP 403 before any membership state is touched (defense-in-depth on top of the
+// TierMTLSOnly subrouter middleware).
+//
+// On success returns HTTP 202 Accepted: {"node_id": "...", "state": "draining"}.
+// Story 6 will append handleClusterNodeDecommission below this function.
+func (s *Server) handleClusterNodeDrain(w http.ResponseWriter, r *http.Request) {
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil {
+		s.respondError(w, http.StatusForbidden, "authentication required")
+		return
+	}
+	if !principal.IsAdmin {
+		s.respondError(w, http.StatusForbidden, "admin mTLS certificate required")
+		return
+	}
+
+	nodeID := mux.Vars(r)["id"]
+
+	if s.membershipStore == nil {
+		s.respondError(w, http.StatusServiceUnavailable, "cluster membership not configured")
+		return
+	}
+
+	if err := cluster.Drain(r.Context(), nodeID, s.membershipStore, s); err != nil {
+		switch {
+		case errors.Is(err, cluster.ErrNodeNotFound):
+			s.respondError(w, http.StatusNotFound, "node not found")
+		case errors.Is(err, cluster.ErrNodeNotActive):
+			s.respondError(w, http.StatusConflict, "node is not active")
+		default:
+			s.logger.Error("cluster drain failed",
+				"node_id", logging.SanitizeLogValue(nodeID),
+				"error", err)
+			s.respondError(w, http.StatusInternalServerError, "drain failed")
+		}
+		return
+	}
+
+	s.logger.Info("cluster node drain initiated",
+		"node_id", logging.SanitizeLogValue(nodeID),
+		"principal_id", logging.SanitizeLogValue(principal.ID))
+
+	s.respondJSON(w, http.StatusAccepted, clusterNodeDrainResponse{
+		NodeID: nodeID,
+		State:  string(cluster.StateDraining),
+	})
+}

--- a/features/controller/api/handlers_cluster_test.go
+++ b/features/controller/api/handlers_cluster_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/cluster"
+)
+
+// setupClusterTestServer returns a test server with an InMemoryMembershipStore.
+func setupClusterTestServer(t *testing.T) (*Server, *cluster.InMemoryMembershipStore) {
+	t.Helper()
+	srv := setupTestServer(t)
+	store := cluster.NewInMemoryMembershipStore()
+	srv.SetMembershipStore(store)
+	return srv, store
+}
+
+// drainRequest builds a POST request for the drain endpoint with mux vars set.
+func drainRequest(nodeID string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster/nodes/"+nodeID+"/drain", nil)
+	return mux.SetURLVars(req, map[string]string{"id": nodeID})
+}
+
+// TestHandleClusterNodeDrain_NonAdminRejects403 is the required AC test:
+// non-admin principal (or nil) must receive HTTP 403 with no membership state change.
+func TestHandleClusterNodeDrain_NonAdminRejects403(t *testing.T) {
+	srv, store := setupClusterTestServer(t)
+	require.NoError(t, store.Register(cluster.NodeRecord{
+		ID:           "node-1",
+		State:        cluster.StateActive,
+		RegisteredAt: time.Now(),
+	}))
+
+	t.Run("nil principal", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		srv.handleClusterNodeDrain(rec, drainRequest("node-1"))
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+
+		got, err := store.GetNode("node-1")
+		require.NoError(t, err)
+		assert.Equal(t, cluster.StateActive, got.State, "state must not change on 403")
+		assert.False(t, srv.clusterDraining.Load(), "health gate must not be set on 403")
+	})
+
+	t.Run("non-admin principal", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := injectNonAdminPrincipal(drainRequest("node-1"))
+		srv.handleClusterNodeDrain(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+
+		got, err := store.GetNode("node-1")
+		require.NoError(t, err)
+		assert.Equal(t, cluster.StateActive, got.State, "state must not change on 403")
+	})
+}
+
+// TestHandleClusterNodeDrain_AdminValidNode_Returns202 is the required AC test:
+// admin principal + valid node ID -> HTTP 202 and node state becomes StateDraining.
+func TestHandleClusterNodeDrain_AdminValidNode_Returns202(t *testing.T) {
+	srv, store := setupClusterTestServer(t)
+	require.NoError(t, store.Register(cluster.NodeRecord{
+		ID:           "node-1",
+		State:        cluster.StateActive,
+		RegisteredAt: time.Now(),
+	}))
+
+	req := injectAdminPrincipal(drainRequest("node-1"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDrain(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code, "body: %s", rec.Body.String())
+
+	var resp clusterNodeDrainResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "node-1", resp.NodeID)
+	assert.Equal(t, "draining", resp.State)
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, cluster.StateDraining, got.State)
+	assert.True(t, srv.clusterDraining.Load(), "health gate must be set after drain")
+}
+
+// TestHandleClusterNodeDrain_NodeNotFound_Returns404 verifies HTTP 404 for an
+// unknown node ID with no membership state side-effects.
+func TestHandleClusterNodeDrain_NodeNotFound_Returns404(t *testing.T) {
+	srv, _ := setupClusterTestServer(t)
+
+	req := injectAdminPrincipal(drainRequest("ghost"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDrain(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.False(t, srv.clusterDraining.Load())
+}
+
+// TestHandleClusterNodeDrain_AlreadyDraining_Returns409 verifies HTTP 409 when the
+// target node is already draining.
+func TestHandleClusterNodeDrain_AlreadyDraining_Returns409(t *testing.T) {
+	srv, store := setupClusterTestServer(t)
+	require.NoError(t, store.Register(cluster.NodeRecord{
+		ID:    "node-1",
+		State: cluster.StateDraining,
+	}))
+
+	req := injectAdminPrincipal(drainRequest("node-1"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDrain(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// TestHandleClusterNodeDrain_NilMembershipStore_Returns503 verifies that calling
+// drain when the store is unconfigured returns 503 with no panic.
+func TestHandleClusterNodeDrain_NilMembershipStore_Returns503(t *testing.T) {
+	srv := setupTestServer(t) // no membership store set
+
+	req := injectAdminPrincipal(drainRequest("node-1"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDrain(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleHealth_ReturnsDegradedWhenDraining verifies that the health endpoint
+// returns HTTP 503 and includes the "drain" service key after SetDraining(true).
+// The health endpoint wraps its response in an APIResponse envelope
+// ({"data": {...}, "timestamp": ...}) because it uses s.writeResponse.
+func TestHandleHealth_ReturnsDegradedWhenDraining(t *testing.T) {
+	srv := setupTestServer(t)
+	srv.SetDraining(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+	srv.handleHealth(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	// Unwrap the APIResponse envelope: {"data": {HealthStatus}, "timestamp": ...}
+	var envelope map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&envelope))
+	data, ok := envelope["data"].(map[string]interface{})
+	require.True(t, ok, "response must have a data field")
+	services, ok := data["services"].(map[string]interface{})
+	require.True(t, ok, "data must have a services field")
+	assert.Equal(t, "draining", services["drain"])
+	assert.Equal(t, "degraded", data["status"])
+}

--- a/features/controller/api/handlers_health.go
+++ b/features/controller/api/handlers_health.go
@@ -53,6 +53,13 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		Services:  make(map[string]string),
 	}
 
+	// Issue #2283: drain gate — must be first so the LB health check fails
+	// as soon as an operator initiates a drain, before any session drains.
+	if s.clusterDraining {
+		health.Status = "degraded"
+		health.Services["drain"] = "draining"
+	}
+
 	// Check gRPC services
 	if s.controllerService != nil {
 		health.Services["controller"] = "healthy"

--- a/features/controller/api/handlers_health.go
+++ b/features/controller/api/handlers_health.go
@@ -55,7 +55,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	// Issue #2283: drain gate — must be first so the LB health check fails
 	// as soon as an operator initiates a drain, before any session drains.
-	if s.clusterDraining {
+	if s.clusterDraining.Load() {
 		health.Status = "degraded"
 		health.Services["drain"] = "draining"
 	}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -119,7 +120,7 @@ type Server struct {
 	sessionManager                 session.Manager                       // Issue #2232: admin session token issuance/revocation
 	sessionCfg                     session.Config                        // Issue #2232: session lifecycle tunables (idle TTL, absolute cap, grace window)
 	membershipStore                cluster.MembershipStore               // Issue #2283: cluster node membership (nil when cluster not configured)
-	clusterDraining                bool                                  // Issue #2283: true after drain is initiated; causes /health to return 503
+	clusterDraining                atomic.Bool                           // Issue #2283: true after drain is initiated; causes /health to return 503
 	stopCleanup                    chan struct{}                         // signals startAPIKeyCleanup to exit
 	cleanupDone                    chan struct{}                         // closed when cleanup goroutine exits
 	closeOnce                      sync.Once                             // idempotent Close
@@ -128,9 +129,9 @@ type Server struct {
 // SetDraining implements cluster.DrainHealthRegistrar. When draining is true,
 // GET /api/v1/health returns HTTP 503 so the load balancer stops routing new
 // steward connections to this node. Called by cluster.Drain() after setting the
-// membership state; never called directly by handlers.
+// membership state; safe to call concurrently with handleHealth.
 func (s *Server) SetDraining(draining bool) {
-	s.clusterDraining = draining
+	s.clusterDraining.Store(draining)
 }
 
 // APIKey represents an API key for external authentication
@@ -1058,6 +1059,15 @@ func (s *Server) SetSessionManager(mgr session.Manager) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessionManager = mgr
+}
+
+// SetMembershipStore wires the cluster MembershipStore used by the drain endpoint
+// (Issue #2283). When nil (default), POST /api/v1/cluster/nodes/{id}/drain returns
+// 503. Call after New() but before Start().
+func (s *Server) SetMembershipStore(store cluster.MembershipStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.membershipStore = store
 }
 
 // SetStewardEventLoggingManager injects the dedicated steward-event

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/features/config/rollback"
+	"github.com/cfgis/cfgms/features/controller/cluster"
 	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/fleet"
@@ -117,9 +118,19 @@ type Server struct {
 	stewardEventLoggingManager     *logging.LoggingManager               // Issue #2139: dedicated sink for steward events; queried by handleGetStewardLogs (S6)
 	sessionManager                 session.Manager                       // Issue #2232: admin session token issuance/revocation
 	sessionCfg                     session.Config                        // Issue #2232: session lifecycle tunables (idle TTL, absolute cap, grace window)
+	membershipStore                cluster.MembershipStore               // Issue #2283: cluster node membership (nil when cluster not configured)
+	clusterDraining                bool                                  // Issue #2283: true after drain is initiated; causes /health to return 503
 	stopCleanup                    chan struct{}                         // signals startAPIKeyCleanup to exit
 	cleanupDone                    chan struct{}                         // closed when cleanup goroutine exits
 	closeOnce                      sync.Once                             // idempotent Close
+}
+
+// SetDraining implements cluster.DrainHealthRegistrar. When draining is true,
+// GET /api/v1/health returns HTTP 503 so the load balancer stops routing new
+// steward connections to this node. Called by cluster.Drain() after setting the
+// membership state; never called directly by handlers.
+func (s *Server) SetDraining(draining bool) {
+	s.clusterDraining = draining
 }
 
 // APIKey represents an API key for external authentication
@@ -555,6 +566,11 @@ func (s *Server) setupRouter() {
 	ha.Handle("/cluster", s.requirePermission("ha", "read-cluster")(http.HandlerFunc(s.handleHACluster))).Methods("GET")
 	ha.Handle("/leader", s.requirePermission("ha", "read-leader")(http.HandlerFunc(s.handleHALeader))).Methods("GET")
 	ha.Handle("/nodes", s.requirePermission("ha", "read-nodes")(http.HandlerFunc(s.handleHANodes))).Methods("GET")
+
+	// Cluster node lifecycle endpoints (Issue #2283)
+	clusterRouter := api.PathPrefix("/cluster").Subrouter()
+	clusterRouter.Handle("/nodes/{id}/drain",
+		s.requireTier(TierMTLSOnly)(http.HandlerFunc(s.handleClusterNodeDrain))).Methods("POST")
 
 	// Compliance reporting endpoints (Story #212)
 	// Steward-specific compliance endpoints

--- a/features/controller/cluster/drain.go
+++ b/features/controller/cluster/drain.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrNodeNotActive is returned by Drain when the target node exists but is not
+// in StateActive. Draining a node that is already draining or decommissioned is
+// a no-op-equivalent that callers should treat as HTTP 409.
+var ErrNodeNotActive = errors.New("cluster: node is not active")
+
+// DrainHealthRegistrar is implemented by the API server to bridge the drain
+// operation to the health endpoint. When SetDraining(true) is called, GET
+// /api/v1/health returns HTTP 503, signalling the load balancer to stop routing
+// new steward connections to this node.
+type DrainHealthRegistrar interface {
+	SetDraining(bool)
+}
+
+// Drain marks nodeID as StateDraining in store and calls registrar.SetDraining(true).
+// It validates that the node exists and is currently StateActive before making any
+// state change, so the store and the health gate are never mutated for invalid targets.
+func Drain(_ context.Context, nodeID string, store MembershipStore, registrar DrainHealthRegistrar) error {
+	node, err := store.GetNode(nodeID)
+	if err != nil {
+		return fmt.Errorf("drain %s: %w", nodeID, err)
+	}
+	if node.State != StateActive {
+		return fmt.Errorf("drain %s: %w (current state: %s)", nodeID, ErrNodeNotActive, node.State)
+	}
+	if err := store.SetState(nodeID, StateDraining); err != nil {
+		return fmt.Errorf("drain %s: set state: %w", nodeID, err)
+	}
+	registrar.SetDraining(true)
+	return nil
+}

--- a/features/controller/cluster/drain_test.go
+++ b/features/controller/cluster/drain_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRegistrar records the most-recent SetDraining call for assertions.
+// This minimal implementation is explicitly required by the story #2283 AC
+// ("a stub DrainHealthRegistrar recorded SetDraining(true)") and is
+// necessary because the real DrainHealthRegistrar implementation (*api.Server)
+// cannot be imported from the cluster package without a circular import.
+// The integration path — Drain() wired to a real *api.Server — is tested in
+// features/controller/api/handlers_cluster_test.go
+// (TestHandleClusterNodeDrain_AdminValidNode_Returns202).
+type stubRegistrar struct {
+	called   bool
+	draining bool
+}
+
+func (s *stubRegistrar) SetDraining(v bool) {
+	s.called = true
+	s.draining = v
+}
+
+// TestDrain_SetsDrainingStateAndTriggersHealthGate is the required AC test:
+// after Drain() returns nil, the node state is StateDraining and the registrar
+// recorded SetDraining(true).
+func TestDrain_SetsDrainingStateAndTriggersHealthGate(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateActive}))
+
+	reg := &stubRegistrar{}
+	err := Drain(context.Background(), "node-1", store, reg)
+	require.NoError(t, err)
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateDraining, got.State)
+	assert.True(t, reg.called, "SetDraining must be called")
+	assert.True(t, reg.draining, "SetDraining must be called with true")
+}
+
+func TestDrain_NodeNotFound_ReturnsError(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	reg := &stubRegistrar{}
+
+	err := Drain(context.Background(), "ghost", store, reg)
+	assert.True(t, errors.Is(err, ErrNodeNotFound))
+	assert.False(t, reg.called, "SetDraining must not be called when node is not found")
+}
+
+func TestDrain_AlreadyDraining_ReturnsError(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining}))
+
+	reg := &stubRegistrar{}
+	err := Drain(context.Background(), "node-1", store, reg)
+	assert.True(t, errors.Is(err, ErrNodeNotActive))
+	assert.False(t, reg.called, "SetDraining must not be called for an already-draining node")
+}
+
+func TestDrain_Decommissioned_ReturnsError(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDecommissioned}))
+
+	reg := &stubRegistrar{}
+	err := Drain(context.Background(), "node-1", store, reg)
+	assert.True(t, errors.Is(err, ErrNodeNotActive))
+	assert.False(t, reg.called)
+}

--- a/features/controller/cluster/membership.go
+++ b/features/controller/cluster/membership.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cluster
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// MemberState is the lifecycle state of a cluster node.
+type MemberState string
+
+const (
+	StateActive         MemberState = "active"
+	StateDraining       MemberState = "draining"
+	StateDecommissioned MemberState = "decommissioned"
+)
+
+// NodeRecord holds the identity and state of a cluster node.
+type NodeRecord struct {
+	ID           string
+	State        MemberState
+	Address      string
+	RegisteredAt time.Time
+}
+
+// MembershipStore is the persistence contract for cluster node membership.
+type MembershipStore interface {
+	Register(node NodeRecord) error
+	SetState(id string, s MemberState) error
+	GetNode(id string) (NodeRecord, error)
+	ListActiveNodes() []NodeRecord
+}
+
+// ErrNodeNotFound is returned when a node ID has no record in the store.
+var ErrNodeNotFound = errors.New("cluster: node not found")
+
+// InMemoryMembershipStore is a thread-safe, non-durable MembershipStore.
+// Suitable for single-controller deployments and tests; not HA-safe.
+type InMemoryMembershipStore struct {
+	mu    sync.RWMutex
+	nodes map[string]NodeRecord
+}
+
+// NewInMemoryMembershipStore returns an empty InMemoryMembershipStore.
+func NewInMemoryMembershipStore() *InMemoryMembershipStore {
+	return &InMemoryMembershipStore{nodes: make(map[string]NodeRecord)}
+}
+
+// Register adds or replaces a node record.
+func (s *InMemoryMembershipStore) Register(node NodeRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodes[node.ID] = node
+	return nil
+}
+
+// SetState updates the state of an existing node. Returns ErrNodeNotFound if the
+// node has not been registered.
+func (s *InMemoryMembershipStore) SetState(id string, state MemberState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	node, ok := s.nodes[id]
+	if !ok {
+		return ErrNodeNotFound
+	}
+	node.State = state
+	s.nodes[id] = node
+	return nil
+}
+
+// GetNode returns the record for the given node ID.
+func (s *InMemoryMembershipStore) GetNode(id string) (NodeRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	node, ok := s.nodes[id]
+	if !ok {
+		return NodeRecord{}, ErrNodeNotFound
+	}
+	return node, nil
+}
+
+// ListActiveNodes returns all nodes whose state is StateActive.
+func (s *InMemoryMembershipStore) ListActiveNodes() []NodeRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []NodeRecord
+	for _, n := range s.nodes {
+		if n.State == StateActive {
+			out = append(out, n)
+		}
+	}
+	return out
+}

--- a/features/controller/cluster/membership_test.go
+++ b/features/controller/cluster/membership_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryMembershipStore_RegisterAndGet(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	node := NodeRecord{
+		ID:           "node-1",
+		State:        StateActive,
+		Address:      "10.0.0.1:9090",
+		RegisteredAt: time.Now(),
+	}
+
+	require.NoError(t, store.Register(node))
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, node.ID, got.ID)
+	assert.Equal(t, node.State, got.State)
+	assert.Equal(t, node.Address, got.Address)
+}
+
+func TestInMemoryMembershipStore_GetNode_NotFound(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	_, err := store.GetNode("missing")
+	assert.ErrorIs(t, err, ErrNodeNotFound)
+}
+
+func TestInMemoryMembershipStore_SetState(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateActive}))
+
+	require.NoError(t, store.SetState("node-1", StateDraining))
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateDraining, got.State)
+}
+
+func TestInMemoryMembershipStore_SetState_NotFound(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	err := store.SetState("ghost", StateDraining)
+	assert.ErrorIs(t, err, ErrNodeNotFound)
+}
+
+func TestInMemoryMembershipStore_ListActiveNodes(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateActive}))
+	require.NoError(t, store.Register(NodeRecord{ID: "node-2", State: StateDraining}))
+	require.NoError(t, store.Register(NodeRecord{ID: "node-3", State: StateActive}))
+
+	active := store.ListActiveNodes()
+	assert.Len(t, active, 2)
+	ids := make(map[string]struct{}, 2)
+	for _, n := range active {
+		ids[n.ID] = struct{}{}
+	}
+	assert.Contains(t, ids, "node-1")
+	assert.Contains(t, ids, "node-3")
+	assert.NotContains(t, ids, "node-2")
+}
+
+func TestInMemoryMembershipStore_ListActiveNodes_Empty(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	assert.Empty(t, store.ListActiveNodes())
+}
+
+func TestInMemoryMembershipStore_RegisterOverwritesExisting(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateActive, Address: "old"}))
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining, Address: "new"}))
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateDraining, got.State)
+	assert.Equal(t, "new", got.Address)
+}


### PR DESCRIPTION
Fixes #2283

Agent session failed with exit code 1. Review container logs for details.