### PR TITLE
ha: cluster-mode startup gate for storage and blob backends (Issue #2286)

### DIFF
--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -358,6 +358,30 @@ controller ← admin authors workflows
 
 This is the same controller — it just has no stewards registered. The workflow engine operates independently of steward management.
 
+## Cluster Prerequisites
+
+Controller startup in `ha.mode: cluster` performs an early prerequisite gate before reading or writing any state. If any prerequisite is unmet, the controller exits immediately with a clear error.
+
+### Required backends
+
+| Backend | What it provides | How to configure |
+|---------|-----------------|------------------|
+| Postgres storage provider | Shared business-store state across all controller nodes (RBAC, tenants, sessions, registrations) | `storage.cluster.postgres_dsn` or `CFGMS_STORAGE_CLUSTER_POSTGRES_DSN` |
+| S3-compatible blob store | Shared installer artifact repository so all nodes serve the same steward binaries | `CFGMS_S3_INSTALLER_BUCKET` (required); `CFGMS_S3_INSTALLER_REGION`, `CFGMS_S3_INSTALLER_ENDPOINT_URL` (optional) |
+
+### Startup error messages
+
+```
+cluster mode requires a cluster-capable storage backend; provider "flatfile" does not support cluster coordination
+cluster mode requires S3-compatible blob storage: set CFGMS_S3_INSTALLER_BUCKET
+```
+
+Both gates fire before any tenant, RBAC, or steward state is touched, so a misconfigured cluster fails fast rather than partially initialising.
+
+### Non-cluster modes
+
+Single-server and blue/green deployments skip the cluster gate entirely. They use the OSS composite backend (flatfile + SQLite) or a standalone Postgres provider, and store installer artifacts on the local filesystem under `BlobStorage.Root`.
+
 ## UX Surfaces
 
 Operators interact with CFGMS through layered UX surfaces.

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -210,6 +210,9 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 			return nil, fmt.Errorf("failed to initialize cluster storage: %w", clusterErr)
 		}
 		logger.Info("Cluster storage backend initialized")
+		if backendErr := assertClusterBackendsReady(cfg, storageManager); backendErr != nil {
+			return nil, backendErr
+		}
 	} else if cfg.Storage.FlatfileRoot != "" {
 		logger.Info("Initializing OSS composite storage backend...",
 			"flatfile_root", cfg.Storage.FlatfileRoot,
@@ -883,10 +886,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	var installerBlobStore blob.BlobStore
 	var blobErr error
 	if isClusterMode {
-		bucket := os.Getenv("CFGMS_S3_INSTALLER_BUCKET")
-		if bucket == "" {
-			return nil, fmt.Errorf("cluster mode requires CFGMS_S3_INSTALLER_BUCKET to be set for installer artifact storage")
-		}
+		bucket := os.Getenv("CFGMS_S3_INSTALLER_BUCKET") // guaranteed non-empty by assertClusterBackendsReady
 		s3Cfg := map[string]interface{}{
 			"bucket": bucket,
 		}
@@ -2266,4 +2266,22 @@ resources:
 	} else {
 		logger.Info("fleet cascade seed: MSP-level parent policy stored under fleet-root")
 	}
+}
+
+// assertClusterBackendsReady verifies cluster-mode prerequisites before any state is read
+// or written. Called immediately after CreateClusterStorageManager in New(), still inside
+// the cfg.HA.IsClusterMode() block, so callers need not re-check the mode.
+//
+// Gates (in order):
+//  1. Storage provider must be cluster-capable (shared state across controller nodes).
+//  2. CFGMS_S3_INSTALLER_BUCKET must be set (S3-compatible blob store for installer artifacts).
+func assertClusterBackendsReady(cfg *config.Config, storageManager *interfaces.StorageManager) error {
+	if p := storageManager.GetProvider(); p != nil && !p.ClusterCapable() {
+		return fmt.Errorf("cluster mode requires a cluster-capable storage backend; provider %q does not support cluster coordination", storageManager.GetProviderName())
+	}
+	if os.Getenv("CFGMS_S3_INSTALLER_BUCKET") == "" {
+		return fmt.Errorf("cluster mode requires S3-compatible blob storage: set CFGMS_S3_INSTALLER_BUCKET")
+	}
+	_ = cfg // reserved for future per-config gate extensions
+	return nil
 }

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -16,7 +16,121 @@ import (
 	"github.com/cfgis/cfgms/pkg/ha"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
+
+// testNonClusterProvider implements interfaces.StorageProvider with ClusterCapable() == false.
+// All store factory methods return business.ErrNotSupported. Used to verify that
+// assertClusterBackendsReady rejects non-cluster-capable backends.
+type testNonClusterProvider struct{}
+
+var _ interfaces.StorageProvider = (*testNonClusterProvider)(nil)
+
+func (p *testNonClusterProvider) Name() string { return "test-noncluster" }
+func (p *testNonClusterProvider) Description() string {
+	return "test-only non-cluster-capable provider"
+}
+func (p *testNonClusterProvider) GetVersion() string       { return "0.0.1-test" }
+func (p *testNonClusterProvider) Available() (bool, error) { return true, nil }
+func (p *testNonClusterProvider) ClusterCapable() bool     { return false }
+func (p *testNonClusterProvider) GetCapabilities() interfaces.ProviderCapabilities {
+	return interfaces.ProviderCapabilities{}
+}
+func (p *testNonClusterProvider) CreateClientTenantStore(_ map[string]interface{}) (business.ClientTenantStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateConfigStore(_ map[string]interface{}) (cfgconfig.ConfigStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateAuditStore(_ map[string]interface{}) (business.AuditStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateRBACStore(_ map[string]interface{}) (business.RBACStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateTenantStore(_ map[string]interface{}) (business.TenantStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateRegistrationTokenStore(_ map[string]interface{}) (business.RegistrationTokenStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateSessionStore(_ map[string]interface{}) (business.SessionStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateStewardStore(_ map[string]interface{}) (business.StewardStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateCommandStore(_ map[string]interface{}) (business.CommandStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateTriggerStore(_ map[string]interface{}) (business.TriggerStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreatePendingRegistrationStore(_ map[string]interface{}) (business.PendingRegistrationStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testNonClusterProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
+
+// testClusterProvider implements interfaces.StorageProvider with ClusterCapable() == true.
+// All store factory methods return business.ErrNotSupported. Used to isolate the S3 gate
+// in assertClusterBackendsReady without requiring a real Postgres connection.
+type testClusterProvider struct{}
+
+var _ interfaces.StorageProvider = (*testClusterProvider)(nil)
+
+func (p *testClusterProvider) Name() string             { return "test-cluster" }
+func (p *testClusterProvider) Description() string      { return "test-only cluster-capable provider" }
+func (p *testClusterProvider) GetVersion() string       { return "0.0.1-test" }
+func (p *testClusterProvider) Available() (bool, error) { return true, nil }
+func (p *testClusterProvider) ClusterCapable() bool     { return true }
+func (p *testClusterProvider) GetCapabilities() interfaces.ProviderCapabilities {
+	return interfaces.ProviderCapabilities{}
+}
+func (p *testClusterProvider) CreateClientTenantStore(_ map[string]interface{}) (business.ClientTenantStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateConfigStore(_ map[string]interface{}) (cfgconfig.ConfigStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateAuditStore(_ map[string]interface{}) (business.AuditStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateRBACStore(_ map[string]interface{}) (business.RBACStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateTenantStore(_ map[string]interface{}) (business.TenantStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateRegistrationTokenStore(_ map[string]interface{}) (business.RegistrationTokenStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateSessionStore(_ map[string]interface{}) (business.SessionStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateStewardStore(_ map[string]interface{}) (business.StewardStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateCommandStore(_ map[string]interface{}) (business.CommandStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateTriggerStore(_ map[string]interface{}) (business.TriggerStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreatePendingRegistrationStore(_ map[string]interface{}) (business.PendingRegistrationStore, error) {
+	return nil, business.ErrNotSupported
+}
+func (p *testClusterProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
 
 // recordingLogger implements logging.Logger and captures every log call so
 // tests can assert on what was (or was not) logged.
@@ -339,6 +453,76 @@ func TestInitializeHAManager_InvalidMode(t *testing.T) {
 	require.Error(t, err, "initializeHAManager must return error for invalid ha.mode")
 	assert.Contains(t, err.Error(), "invalid HA mode",
 		"error must identify the bad mode string")
+}
+
+// TestNew_ClusterModeRequiresClusterCapableProviders verifies that assertClusterBackendsReady
+// rejects a non-cluster-capable storage provider and a missing S3 bucket, and that the gate
+// is not triggered in non-cluster mode, leaving New() free to succeed with a flatfile backend.
+func TestNew_ClusterModeRequiresClusterCapableProviders(t *testing.T) {
+	t.Run("cluster mode with non-cluster-capable provider returns error", func(t *testing.T) {
+		t.Setenv("CFGMS_S3_INSTALLER_BUCKET", "")
+
+		// Register a non-cluster-capable test provider and create a StorageManager from it.
+		// CreateAllStoresFromConfig accepts ErrNotSupported from individual store factories,
+		// so the resulting manager is valid but has nil stores — sufficient for the gate check.
+		interfaces.RegisterStorageProvider(&testNonClusterProvider{})
+		t.Cleanup(func() { interfaces.UnregisterStorageProvider("test-noncluster") })
+		//nolint:staticcheck // CreateAllStoresFromConfig is retained for single-provider and test use
+		sm, err := interfaces.CreateAllStoresFromConfig("test-noncluster", nil)
+		require.NoError(t, err, "test-noncluster storage manager must initialise without error")
+
+		backendErr := assertClusterBackendsReady(nil, sm)
+		require.Error(t, backendErr, "cluster mode with non-cluster-capable provider must fail")
+		assert.Contains(t, backendErr.Error(), "cluster-capable",
+			"error must explain that a cluster-capable backend is required")
+		assert.Contains(t, backendErr.Error(), "test-noncluster",
+			"error must name the offending provider")
+	})
+
+	t.Run("cluster mode with cluster-capable provider but no S3 bucket returns error", func(t *testing.T) {
+		t.Setenv("CFGMS_S3_INSTALLER_BUCKET", "")
+
+		// database provider is cluster-capable; use it directly via NewStorageManagerFromStores
+		// with a nil provider override constructed manually to avoid a real Postgres connection.
+		// We need a StorageManager whose GetProvider() is cluster-capable, so register a
+		// cluster-capable test provider instead.
+		clusterProvider := &testClusterProvider{}
+		interfaces.RegisterStorageProvider(clusterProvider)
+		t.Cleanup(func() { interfaces.UnregisterStorageProvider("test-cluster") })
+		//nolint:staticcheck // CreateAllStoresFromConfig is retained for single-provider and test use
+		sm, err := interfaces.CreateAllStoresFromConfig("test-cluster", nil)
+		require.NoError(t, err, "test-cluster storage manager must initialise without error")
+
+		backendErr := assertClusterBackendsReady(nil, sm)
+		require.Error(t, backendErr, "cluster mode with no S3 bucket must fail")
+		assert.Contains(t, backendErr.Error(), "CFGMS_S3_INSTALLER_BUCKET",
+			"error must name the missing environment variable")
+	})
+
+	t.Run("non-cluster mode does not invoke cluster gate", func(t *testing.T) {
+		// CFGMS_S3_INSTALLER_BUCKET is deliberately unset: if the cluster gate fired,
+		// New() would fail on the S3 prerequisite. Passing here proves the gate is
+		// not called for non-cluster deployments.
+		t.Setenv("CFGMS_S3_INSTALLER_BUCKET", "")
+
+		tempDir := t.TempDir()
+		cfg := &config.Config{
+			ListenAddr: "127.0.0.1:0",
+			Certificate: &config.CertificateConfig{
+				EnableCertManagement: false,
+			},
+			Storage: &config.StorageConfig{
+				Provider:     "flatfile",
+				FlatfileRoot: tempDir + "/flatfile",
+				SQLitePath:   tempDir + "/cfgms.db",
+			},
+		}
+
+		srv, err := New(cfg, logging.NewNoopLogger())
+		require.NoError(t, err, "non-cluster mode with flatfile must not trigger the cluster-capable gate")
+		require.NotNil(t, srv)
+		t.Cleanup(func() { _ = srv.Stop() })
+	})
 }
 
 // TestBuiltinWorkflowSeedingIPTrust verifies that a controller started with no


### PR DESCRIPTION
## Summary

- Added `assertClusterBackendsReady` to `features/controller/server/server.go`, called immediately after `CreateClusterStorageManager` in `New()` before any RBAC/tenant/audit state is touched
- Gate 1: rejects storage providers where `ClusterCapable() == false` (error names the provider)
- Gate 2: rejects cluster mode when `CFGMS_S3_INSTALLER_BUCKET` is unset; consolidates the previously late S3 check (~700 lines after storage init) into one place
- Added `TestNew_ClusterModeRequiresClusterCapableProviders` with three sub-cases covering both gates and the non-cluster mode passthrough
- Added "Cluster prerequisites" section to `docs/architecture/operating-model.md`

Fixes #2286

## Specialist Review Results

- **QA test runner**: PASS — all packages pass including cross-platform compilation; applied `gofmt` to test file during run
- **QA code reviewer**: PASS — both blocking issues (missing `t.Cleanup` for registry and missing S3 gate test) identified and fixed before re-review; re-review confirmed clean
- **Security engineer**: PASS — no vulnerabilities, no central provider violations, no log injection; change strengthens security posture (fail-fast on misconfigured cluster backends)

## Test Plan

- [ ] `TestNew_ClusterModeRequiresClusterCapableProviders/cluster_mode_with_non-cluster-capable_provider_returns_error` — gate 1 fires, error contains "cluster-capable" and provider name
- [ ] `TestNew_ClusterModeRequiresClusterCapableProviders/cluster_mode_with_cluster-capable_provider_but_no_S3_bucket_returns_error` — gate 2 fires, error contains "CFGMS_S3_INSTALLER_BUCKET"
- [ ] `TestNew_ClusterModeRequiresClusterCapableProviders/non-cluster_mode_does_not_invoke_cluster_gate` — `New()` with flatfile succeeds when S3 bucket is unset, proving gate not called
- [ ] CI required checks (unit-tests, integration-tests, Build Gate, security-deployment-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)