### PR TITLE
cluster: node decommission after drain (Issue #2288)

### DIFF
--- a/docs/operations/rolling-cluster-upgrade.md
+++ b/docs/operations/rolling-cluster-upgrade.md
@@ -99,6 +99,37 @@ and an error message. The command prints the resulting state on success:
 Node <node-id> is now decommissioned.
 ```
 
+**Timeout behaviour.** The controller waits up to five minutes for all active
+steward sessions on the local node to reach zero before marking the node
+decommissioned. If sessions have not drained by the end of that window the
+node is force-decommissioned and the controller logs a warning at `WARN` level:
+
+```
+decommission timeout: sessions still active on node, proceeding
+  active_sessions=<n>  node_id=<node-id>
+```
+
+Force-decommission on timeout is by design — it bounds the time a rolling
+upgrade step can block while still allowing a clean drain in the common case.
+
+### 6a. Verify the node is excluded from active nodes
+
+After the decommission command returns, confirm the node no longer appears in
+the active node list (available via the cluster status command in a future
+story). You can also query the API directly:
+
+```bash
+# Must return an empty list or a list that does not include <node-id>
+curl --cert ~/.config/cfgms/admin.crt \
+     --key  ~/.config/cfgms/admin.key \
+     --cacert ~/.config/cfgms/ca.crt \
+     https://controller.example.com/api/v1/cluster/nodes
+```
+
+A decommissioned node has state `"decommissioned"` and is not returned by
+`ListActiveNodes`. If the node still appears as active, do not proceed — check
+the controller logs for errors.
+
 ### 7. Repeat for each remaining node
 
 Repeat steps 2–6 for each remaining node, one at a time.

--- a/features/controller/api/handlers_cluster.go
+++ b/features/controller/api/handlers_cluster.go
@@ -5,12 +5,17 @@ package api
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/features/controller/cluster"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// defaultDecommissionTimeout is the maximum time Decommission waits for
+// steward sessions to drain before force-marking the node decommissioned.
+const defaultDecommissionTimeout = 5 * time.Minute
 
 // clusterNodeDrainResponse is the JSON body for a successful drain request.
 type clusterNodeDrainResponse struct {
@@ -66,5 +71,68 @@ func (s *Server) handleClusterNodeDrain(w http.ResponseWriter, r *http.Request) 
 	s.respondJSON(w, http.StatusAccepted, clusterNodeDrainResponse{
 		NodeID: nodeID,
 		State:  string(cluster.StateDraining),
+	})
+}
+
+// clusterNodeDecommissionResponse is the JSON body for a successful decommission.
+type clusterNodeDecommissionResponse struct {
+	NodeID string `json:"node_id"`
+	State  string `json:"state"`
+}
+
+// handleClusterNodeDecommission handles POST /api/v1/cluster/nodes/{id}/decommission.
+//
+// Requires an admin mTLS principal. Non-admin callers receive HTTP 403 before
+// any membership state is touched. The node must be in StateDraining; any
+// other state returns HTTP 409.
+//
+// The handler blocks until all active steward sessions on the local node drain
+// or defaultDecommissionTimeout elapses, then marks the node StateDecommissioned
+// and returns HTTP 200: {"node_id": "...", "state": "decommissioned"}.
+func (s *Server) handleClusterNodeDecommission(w http.ResponseWriter, r *http.Request) {
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil {
+		s.respondError(w, http.StatusForbidden, "authentication required")
+		return
+	}
+	if !principal.IsAdmin {
+		s.respondError(w, http.StatusForbidden, "admin mTLS certificate required")
+		return
+	}
+
+	nodeID := mux.Vars(r)["id"]
+
+	if s.membershipStore == nil {
+		s.respondError(w, http.StatusServiceUnavailable, "cluster membership not configured")
+		return
+	}
+
+	if s.registry == nil {
+		s.respondError(w, http.StatusServiceUnavailable, "session registry not configured")
+		return
+	}
+
+	if err := cluster.Decommission(r.Context(), nodeID, s.membershipStore, s.registry, s.logger, defaultDecommissionTimeout); err != nil {
+		switch {
+		case errors.Is(err, cluster.ErrNodeNotFound):
+			s.respondError(w, http.StatusNotFound, "node not found")
+		case errors.Is(err, cluster.ErrNodeNotDraining):
+			s.respondError(w, http.StatusConflict, "node is not in draining state")
+		default:
+			s.logger.Error("cluster decommission failed",
+				"node_id", logging.SanitizeLogValue(nodeID),
+				"error", err)
+			s.respondError(w, http.StatusInternalServerError, "decommission failed")
+		}
+		return
+	}
+
+	s.logger.Info("cluster node decommissioned",
+		"node_id", logging.SanitizeLogValue(nodeID),
+		"principal_id", logging.SanitizeLogValue(principal.ID))
+
+	s.respondJSON(w, http.StatusOK, clusterNodeDecommissionResponse{
+		NodeID: nodeID,
+		State:  string(cluster.StateDecommissioned),
 	})
 }

--- a/features/controller/api/handlers_cluster.go
+++ b/features/controller/api/handlers_cluster.go
@@ -58,7 +58,7 @@ func (s *Server) handleClusterNodeDrain(w http.ResponseWriter, r *http.Request) 
 		default:
 			s.logger.Error("cluster drain failed",
 				"node_id", logging.SanitizeLogValue(nodeID),
-				"error", err)
+				"error", logging.SanitizeLogValue(err.Error()))
 			s.respondError(w, http.StatusInternalServerError, "drain failed")
 		}
 		return
@@ -121,7 +121,7 @@ func (s *Server) handleClusterNodeDecommission(w http.ResponseWriter, r *http.Re
 		default:
 			s.logger.Error("cluster decommission failed",
 				"node_id", logging.SanitizeLogValue(nodeID),
-				"error", err)
+				"error", logging.SanitizeLogValue(err.Error()))
 			s.respondError(w, http.StatusInternalServerError, "decommission failed")
 		}
 		return

--- a/features/controller/api/handlers_cluster_test.go
+++ b/features/controller/api/handlers_cluster_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/controller/cluster"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
 
 // setupClusterTestServer returns a test server with an InMemoryMembershipStore.
@@ -155,4 +156,136 @@ func TestHandleHealth_ReturnsDegradedWhenDraining(t *testing.T) {
 	require.True(t, ok, "data must have a services field")
 	assert.Equal(t, "draining", services["drain"])
 	assert.Equal(t, "degraded", data["status"])
+}
+
+// decommissionRequest builds a POST request for the decommission endpoint with
+// mux vars set.
+func decommissionRequest(nodeID string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster/nodes/"+nodeID+"/decommission", nil)
+	return mux.SetURLVars(req, map[string]string{"id": nodeID})
+}
+
+// setupClusterTestServerWithRegistry returns a test server with an
+// InMemoryMembershipStore and a real InMemoryRegistry so that the decommission
+// handler can call cluster.Decommission without a nil counter.
+func setupClusterTestServerWithRegistry(t *testing.T) (*Server, *cluster.InMemoryMembershipStore) {
+	t.Helper()
+	srv, store := setupClusterTestServer(t)
+	srv.SetRegistry(registry.NewRegistry())
+	return srv, store
+}
+
+// TestHandleClusterNodeDecommission_NonAdminRejects403 is the required AC test:
+// non-admin principal (or nil) must receive HTTP 403 with no membership state change.
+func TestHandleClusterNodeDecommission_NonAdminRejects403(t *testing.T) {
+	srv, store := setupClusterTestServer(t)
+	require.NoError(t, store.Register(cluster.NodeRecord{
+		ID:           "node-1",
+		State:        cluster.StateDraining,
+		RegisteredAt: time.Now(),
+	}))
+
+	t.Run("nil principal", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		srv.handleClusterNodeDecommission(rec, decommissionRequest("node-1"))
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+
+		got, err := store.GetNode("node-1")
+		require.NoError(t, err)
+		assert.Equal(t, cluster.StateDraining, got.State, "state must not change on 403")
+	})
+
+	t.Run("non-admin principal", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := injectNonAdminPrincipal(decommissionRequest("node-1"))
+		srv.handleClusterNodeDecommission(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+
+		got, err := store.GetNode("node-1")
+		require.NoError(t, err)
+		assert.Equal(t, cluster.StateDraining, got.State, "state must not change on 403")
+	})
+}
+
+// TestHandleClusterNodeDecommission_NilMembershipStore_Returns503 verifies that
+// calling decommission when the store is unconfigured returns 503 with no panic.
+func TestHandleClusterNodeDecommission_NilMembershipStore_Returns503(t *testing.T) {
+	srv := setupTestServer(t) // no membership store set
+
+	req := injectAdminPrincipal(decommissionRequest("node-1"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDecommission(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleClusterNodeDecommission_NilRegistry_Returns503 verifies that calling
+// decommission when the session registry is not configured returns 503 with no panic.
+func TestHandleClusterNodeDecommission_NilRegistry_Returns503(t *testing.T) {
+	srv, store := setupClusterTestServer(t) // membership store set, registry NOT set
+	require.NoError(t, store.Register(cluster.NodeRecord{
+		ID:    "node-1",
+		State: cluster.StateDraining,
+	}))
+
+	req := injectAdminPrincipal(decommissionRequest("node-1"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDecommission(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleClusterNodeDecommission_NodeNotDraining_Returns409 verifies HTTP 409
+// when the target node is not in StateDraining.
+func TestHandleClusterNodeDecommission_NodeNotDraining_Returns409(t *testing.T) {
+	srv, store := setupClusterTestServerWithRegistry(t)
+	require.NoError(t, store.Register(cluster.NodeRecord{
+		ID:    "node-1",
+		State: cluster.StateActive,
+	}))
+
+	req := injectAdminPrincipal(decommissionRequest("node-1"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDecommission(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// TestHandleClusterNodeDecommission_NodeNotFound_Returns404 verifies HTTP 404
+// for an unknown node ID.
+func TestHandleClusterNodeDecommission_NodeNotFound_Returns404(t *testing.T) {
+	srv, _ := setupClusterTestServerWithRegistry(t)
+
+	req := injectAdminPrincipal(decommissionRequest("ghost"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDecommission(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestHandleClusterNodeDecommission_AdminDrainingNode_Returns200 verifies the
+// success path: admin principal + node in StateDraining with no active sessions
+// returns HTTP 200 with the decommissioned state.
+func TestHandleClusterNodeDecommission_AdminDrainingNode_Returns200(t *testing.T) {
+	srv, store := setupClusterTestServerWithRegistry(t)
+	require.NoError(t, store.Register(cluster.NodeRecord{
+		ID:           "node-1",
+		State:        cluster.StateDraining,
+		RegisteredAt: time.Now(),
+	}))
+
+	req := injectAdminPrincipal(decommissionRequest("node-1"), "alice")
+	rec := httptest.NewRecorder()
+	srv.handleClusterNodeDecommission(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp clusterNodeDecommissionResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "node-1", resp.NodeID)
+	assert.Equal(t, "decommissioned", resp.State)
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, cluster.StateDecommissioned, got.State)
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -568,10 +568,12 @@ func (s *Server) setupRouter() {
 	ha.Handle("/leader", s.requirePermission("ha", "read-leader")(http.HandlerFunc(s.handleHALeader))).Methods("GET")
 	ha.Handle("/nodes", s.requirePermission("ha", "read-nodes")(http.HandlerFunc(s.handleHANodes))).Methods("GET")
 
-	// Cluster node lifecycle endpoints (Issue #2283)
+	// Cluster node lifecycle endpoints (Issue #2283, Issue #2288)
 	clusterRouter := api.PathPrefix("/cluster").Subrouter()
 	clusterRouter.Handle("/nodes/{id}/drain",
 		s.requireTier(TierMTLSOnly)(http.HandlerFunc(s.handleClusterNodeDrain))).Methods("POST")
+	clusterRouter.Handle("/nodes/{id}/decommission",
+		s.requireTier(TierMTLSOnly)(http.HandlerFunc(s.handleClusterNodeDecommission))).Methods("POST")
 
 	// Compliance reporting endpoints (Story #212)
 	// Steward-specific compliance endpoints

--- a/features/controller/cluster/decommission.go
+++ b/features/controller/cluster/decommission.go
@@ -52,7 +52,7 @@ func Decommission(ctx context.Context, nodeID string, store MembershipStore, cou
 	if !waitForSessionDrain(pollCtx, counter) {
 		logger.Warn("decommission timeout: sessions still active on node, proceeding",
 			"active_sessions", counter.Count(),
-			"node_id", nodeID)
+			"node_id", logging.SanitizeLogValue(nodeID))
 	}
 
 	if err := store.SetState(nodeID, StateDecommissioned); err != nil {

--- a/features/controller/cluster/decommission.go
+++ b/features/controller/cluster/decommission.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ErrNodeNotDraining is returned by Decommission when the target node is not
+// in StateDraining. Callers should treat this as HTTP 409.
+var ErrNodeNotDraining = errors.New("cluster: node is not draining")
+
+// SessionCounter provides the active-session count on the local node.
+// Satisfied by registry.Registry; defined here as a minimal interface to
+// avoid coupling the cluster package to the transport layer.
+type SessionCounter interface {
+	Count() int
+}
+
+// decommissionPollInterval is the interval between session-count polls.
+const decommissionPollInterval = 5 * time.Second
+
+// Decommission waits for active steward sessions on the local node to reach
+// zero (or for timeout to elapse), then marks nodeID as StateDecommissioned
+// in store.
+//
+// The node must be in StateDraining before Decommission is called. If it is
+// not, Decommission returns ErrNodeNotDraining without touching the store.
+//
+// If timeout elapses before counter.Count() reaches zero, Decommission logs a
+// warning and proceeds to mark the node decommissioned anyway — forced
+// decommission on timeout is by design.
+//
+// After a successful return, store.ListActiveNodes() will not include nodeID.
+func Decommission(ctx context.Context, nodeID string, store MembershipStore, counter SessionCounter, logger logging.Logger, timeout time.Duration) error {
+	node, err := store.GetNode(nodeID)
+	if err != nil {
+		return fmt.Errorf("decommission %s: %w", nodeID, err)
+	}
+	if node.State != StateDraining {
+		return fmt.Errorf("decommission %s: %w (current state: %s)", nodeID, ErrNodeNotDraining, node.State)
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if !waitForSessionDrain(pollCtx, counter) {
+		logger.Warn("decommission timeout: sessions still active on node, proceeding",
+			"active_sessions", counter.Count(),
+			"node_id", nodeID)
+	}
+
+	if err := store.SetState(nodeID, StateDecommissioned); err != nil {
+		return fmt.Errorf("decommission %s: set state: %w", nodeID, err)
+	}
+	return nil
+}
+
+// waitForSessionDrain polls counter.Count() every decommissionPollInterval
+// until it reaches zero or ctx is cancelled. Returns true when drained,
+// false on context cancellation (timeout or explicit cancel).
+func waitForSessionDrain(ctx context.Context, counter SessionCounter) bool {
+	if counter.Count() == 0 {
+		return true
+	}
+	ticker := time.NewTicker(decommissionPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+			if counter.Count() == 0 {
+				return true
+			}
+		}
+	}
+}

--- a/features/controller/cluster/decommission_test.go
+++ b/features/controller/cluster/decommission_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// stubCounter is a minimal SessionCounter for testing. It returns a fixed
+// count, simulating a node with no sessions (count=0) or sessions that never
+// drain (count>0). The real SessionCounter is registry.Registry; using a stub
+// here avoids a circular import while the integration path is covered by
+// features/controller/api/handlers_cluster_test.go.
+type stubCounter struct{ count int }
+
+func (s *stubCounter) Count() int { return s.count }
+
+// TestDecommission_MarksDecommissionedAfterSessionsDrain is a required AC test:
+// when reg.Count()==0 from the start, Decommission returns nil, the node state
+// is StateDecommissioned, and ListActiveNodes() excludes the node.
+func TestDecommission_MarksDecommissionedAfterSessionsDrain(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining}))
+
+	counter := &stubCounter{count: 0}
+	logger := logging.NewNoopLogger()
+
+	err := Decommission(context.Background(), "node-1", store, counter, logger, 5*time.Minute)
+	require.NoError(t, err)
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateDecommissioned, got.State)
+
+	for _, n := range store.ListActiveNodes() {
+		assert.NotEqual(t, "node-1", n.ID, "decommissioned node must not appear in ListActiveNodes")
+	}
+}
+
+// TestDecommission_TimeoutForcesDecommission is a required AC test: when
+// reg.Count()>0 throughout and timeout elapses, Decommission still marks the
+// node StateDecommissioned (forced decommission on timeout is by design).
+func TestDecommission_TimeoutForcesDecommission(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining}))
+
+	counter := &stubCounter{count: 1} // sessions never drain
+	logger := logging.NewNoopLogger()
+
+	err := Decommission(context.Background(), "node-1", store, counter, logger, 50*time.Millisecond)
+	require.NoError(t, err, "forced decommission on timeout must succeed")
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateDecommissioned, got.State)
+
+	for _, n := range store.ListActiveNodes() {
+		assert.NotEqual(t, "node-1", n.ID, "decommissioned node must not appear in ListActiveNodes")
+	}
+}
+
+func TestDecommission_NodeNotFound_ReturnsError(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	counter := &stubCounter{count: 0}
+	logger := logging.NewNoopLogger()
+
+	err := Decommission(context.Background(), "ghost", store, counter, logger, 5*time.Minute)
+	assert.True(t, errors.Is(err, ErrNodeNotFound))
+}
+
+func TestDecommission_NodeNotDraining_ReturnsError(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateActive}))
+
+	counter := &stubCounter{count: 0}
+	logger := logging.NewNoopLogger()
+
+	err := Decommission(context.Background(), "node-1", store, counter, logger, 5*time.Minute)
+	assert.True(t, errors.Is(err, ErrNodeNotDraining), "active node should return ErrNodeNotDraining")
+}
+
+func TestDecommission_AlreadyDecommissioned_ReturnsError(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDecommissioned}))
+
+	counter := &stubCounter{count: 0}
+	logger := logging.NewNoopLogger()
+
+	err := Decommission(context.Background(), "node-1", store, counter, logger, 5*time.Minute)
+	assert.True(t, errors.Is(err, ErrNodeNotDraining), "already-decommissioned node should return ErrNodeNotDraining")
+}
+
+func TestDecommission_CancelledContext_ForcesDecommission(t *testing.T) {
+	store := NewInMemoryMembershipStore()
+	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining}))
+
+	counter := &stubCounter{count: 1} // sessions never drain
+	logger := logging.NewNoopLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately — poll context derives from this and is done at once
+
+	// Forced decommission proceeds even when the context is cancelled, consistent
+	// with the timeout path: both exit waitForSessionDrain and call SetState.
+	err := Decommission(ctx, "node-1", store, counter, logger, 5*time.Minute)
+	require.NoError(t, err)
+
+	got, err := store.GetNode("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateDecommissioned, got.State)
+}

--- a/features/controller/cluster/decommission_test.go
+++ b/features/controller/cluster/decommission_test.go
@@ -12,16 +12,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
 
-// stubCounter is a minimal SessionCounter for testing. It returns a fixed
-// count, simulating a node with no sessions (count=0) or sessions that never
-// drain (count>0). The real SessionCounter is registry.Registry; using a stub
-// here avoids a circular import while the integration path is covered by
-// features/controller/api/handlers_cluster_test.go.
-type stubCounter struct{ count int }
+// noopSender is a minimal registry.MessageSender for tests that need a
+// non-nil Sender to register a StewardConnection.
+type noopSender struct{}
 
-func (s *stubCounter) Count() int { return s.count }
+func (noopSender) SendMsg(_ interface{}) error { return nil }
+
+// registerConn registers a StewardConnection with the given ID so that
+// reg.Count() returns a non-zero value.
+func registerConn(t *testing.T, reg registry.Registry, stewardID string) {
+	t.Helper()
+	require.NoError(t, reg.Register(&registry.StewardConnection{
+		StewardID: stewardID,
+		Sender:    noopSender{},
+	}))
+}
 
 // TestDecommission_MarksDecommissionedAfterSessionsDrain is a required AC test:
 // when reg.Count()==0 from the start, Decommission returns nil, the node state
@@ -30,10 +38,10 @@ func TestDecommission_MarksDecommissionedAfterSessionsDrain(t *testing.T) {
 	store := NewInMemoryMembershipStore()
 	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining}))
 
-	counter := &stubCounter{count: 0}
+	reg := registry.NewRegistry() // no connections registered → Count() == 0
 	logger := logging.NewNoopLogger()
 
-	err := Decommission(context.Background(), "node-1", store, counter, logger, 5*time.Minute)
+	err := Decommission(context.Background(), "node-1", store, reg, logger, 5*time.Minute)
 	require.NoError(t, err)
 
 	got, err := store.GetNode("node-1")
@@ -52,10 +60,12 @@ func TestDecommission_TimeoutForcesDecommission(t *testing.T) {
 	store := NewInMemoryMembershipStore()
 	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining}))
 
-	counter := &stubCounter{count: 1} // sessions never drain
+	reg := registry.NewRegistry()
+	registerConn(t, reg, "steward-1") // Count() == 1, never drains within timeout
+
 	logger := logging.NewNoopLogger()
 
-	err := Decommission(context.Background(), "node-1", store, counter, logger, 50*time.Millisecond)
+	err := Decommission(context.Background(), "node-1", store, reg, logger, 50*time.Millisecond)
 	require.NoError(t, err, "forced decommission on timeout must succeed")
 
 	got, err := store.GetNode("node-1")
@@ -69,10 +79,10 @@ func TestDecommission_TimeoutForcesDecommission(t *testing.T) {
 
 func TestDecommission_NodeNotFound_ReturnsError(t *testing.T) {
 	store := NewInMemoryMembershipStore()
-	counter := &stubCounter{count: 0}
+	reg := registry.NewRegistry()
 	logger := logging.NewNoopLogger()
 
-	err := Decommission(context.Background(), "ghost", store, counter, logger, 5*time.Minute)
+	err := Decommission(context.Background(), "ghost", store, reg, logger, 5*time.Minute)
 	assert.True(t, errors.Is(err, ErrNodeNotFound))
 }
 
@@ -80,10 +90,10 @@ func TestDecommission_NodeNotDraining_ReturnsError(t *testing.T) {
 	store := NewInMemoryMembershipStore()
 	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateActive}))
 
-	counter := &stubCounter{count: 0}
+	reg := registry.NewRegistry()
 	logger := logging.NewNoopLogger()
 
-	err := Decommission(context.Background(), "node-1", store, counter, logger, 5*time.Minute)
+	err := Decommission(context.Background(), "node-1", store, reg, logger, 5*time.Minute)
 	assert.True(t, errors.Is(err, ErrNodeNotDraining), "active node should return ErrNodeNotDraining")
 }
 
@@ -91,10 +101,10 @@ func TestDecommission_AlreadyDecommissioned_ReturnsError(t *testing.T) {
 	store := NewInMemoryMembershipStore()
 	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDecommissioned}))
 
-	counter := &stubCounter{count: 0}
+	reg := registry.NewRegistry()
 	logger := logging.NewNoopLogger()
 
-	err := Decommission(context.Background(), "node-1", store, counter, logger, 5*time.Minute)
+	err := Decommission(context.Background(), "node-1", store, reg, logger, 5*time.Minute)
 	assert.True(t, errors.Is(err, ErrNodeNotDraining), "already-decommissioned node should return ErrNodeNotDraining")
 }
 
@@ -102,7 +112,9 @@ func TestDecommission_CancelledContext_ForcesDecommission(t *testing.T) {
 	store := NewInMemoryMembershipStore()
 	require.NoError(t, store.Register(NodeRecord{ID: "node-1", State: StateDraining}))
 
-	counter := &stubCounter{count: 1} // sessions never drain
+	reg := registry.NewRegistry()
+	registerConn(t, reg, "steward-1") // Count() == 1, never drains
+
 	logger := logging.NewNoopLogger()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -110,7 +122,7 @@ func TestDecommission_CancelledContext_ForcesDecommission(t *testing.T) {
 
 	// Forced decommission proceeds even when the context is cancelled, consistent
 	// with the timeout path: both exit waitForSessionDrain and call SetState.
-	err := Decommission(ctx, "node-1", store, counter, logger, 5*time.Minute)
+	err := Decommission(ctx, "node-1", store, reg, logger, 5*time.Minute)
 	require.NoError(t, err)
 
 	got, err := store.GetNode("node-1")


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/cluster/nodes/{id}/decommission` under `TierMTLSOnly` — admin mTLS required (HTTP 403 otherwise)
- New `Decommission()` function in `features/controller/cluster` polls `SessionCounter.Count()` every 5 s; marks `StateDecommissioned` when zero or after 5-minute timeout (forced decommission on timeout is by design)
- Handler guards: nil membership store → 503, nil registry → 503, node not draining → 409, node not found → 404
- `docs/operations/rolling-cluster-upgrade.md` extended with timeout behaviour and step 6a verification

Fixes #2288

## Specialist Review Results

### QA Test Runner
`make test-agent-complete` — PASS
- All pre-commit checks passed
- Fast comprehensive tests passed
- Production-critical tests passed
- Cross-platform compilation validated (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

### QA Code Reviewer
QA Code Review: **PASS** — 0 blocking issues
- All required AC tests present: `TestDecommission_MarksDecommissionedAfterSessionsDrain`, `TestDecommission_TimeoutForcesDecommission`, `TestHandleClusterNodeDecommission_NonAdminRejects403`
- `stubCounter` follows the same justified pattern as `stubRegistrar` in drain_test.go (local interface, no circular import)
- Added `TestHandleClusterNodeDecommission_NilRegistry_Returns503` to close the warning about the nil-registry branch

### Security Engineer
Security Review: **PASS** — 0 blocking issues
- `security-precommit`: PASS
- `check-architecture`: PASS (no central provider violations)
- `security-scan`: PASS (gosec/Trivy/Nancy/staticcheck all clean)
- Admin authorization (IsAdmin + TierMTLSOnly) verified; log sanitization with `logging.SanitizeLogValue()` on all HTTP-sourced values; no hardcoded secrets; fail-closed nil checks

## Test Plan

- [ ] `POST /api/v1/cluster/nodes/{id}/decommission` requires admin mTLS — non-admin → 403
- [ ] Node not in `StateDraining` → 409 Conflict
- [ ] Node in `StateDraining` with 0 active sessions → 200, state `StateDecommissioned`, excluded from `ListActiveNodes()`
- [ ] Node in `StateDraining` with sessions that never drain → timeout forces decommission, state `StateDecommissioned`
- [ ] All CI gates pass (unit-tests, integration-tests, Build Gate, security-deployment-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)