### PR TITLE
ha(migrate): cluster-mode compatibility gate for cfg migrate (Issue #2290)

### DIFF
--- a/cmd/cfg/cmd/migrate.go
+++ b/cmd/cfg/cmd/migrate.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/cfgis/cfgms/pkg/ha"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/migrate"
 	_ "github.com/cfgis/cfgms/pkg/migrate/blob"    // register "blob" migrator
@@ -59,7 +61,29 @@ func init() {
 	rootCmd.AddCommand(migrateCmd)
 }
 
+// clusterCapableMigrationBackend reports whether the named storage migrator backend
+// can serve as shared state in a multi-node CFGMS cluster.
+// "database" (Postgres) is the only cluster-capable backend; "oss" (flatfile+sqlite
+// composite), "flatfile", "sqlite", and any other names are not.
+func clusterCapableMigrationBackend(name string) bool {
+	return strings.ToLower(name) == "database"
+}
+
 func runMigrate(cmd *cobra.Command, _ []string) error {
+	// CFGMS_HA_MODE is the canonical cluster-mode signal in the CLI context —
+	// consistent with features/controller/config/config.go. No controller config
+	// file is loaded; the env var alone determines mode.
+	haConfig := ha.DefaultConfig()
+	if err := haConfig.LoadFromEnvironment(); err != nil {
+		return fmt.Errorf("failed to read HA configuration from environment: %w", err)
+	}
+	if haConfig.IsClusterMode() && !clusterCapableMigrationBackend(migrateTo2) {
+		return fmt.Errorf("cfg migrate: target backend %q is not cluster-capable; "+
+			"in cluster mode only cluster-capable backends may be used "+
+			"(cluster-capable: database)",
+			logging.SanitizeLogValue(migrateTo2))
+	}
+
 	factory, err := migrate.Lookup(migrateProvider)
 	if err != nil {
 		return err

--- a/cmd/cfg/cmd/migrate_test.go
+++ b/cmd/cfg/cmd/migrate_test.go
@@ -153,6 +153,106 @@ func TestPrintMigrateReport_WithoutBytes(t *testing.T) {
 	assert.NotContains(t, out, " B", "output must not include byte suffix when Bytes is nil")
 }
 
+// TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget verifies that
+// runMigrate returns an error containing "not cluster-capable" when
+// CFGMS_HA_MODE=cluster and --to names a non-cluster-capable backend,
+// and that the gate is a no-op when cluster mode is not active.
+func TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget(t *testing.T) {
+	// Restore package-level vars after all subtests complete to avoid
+	// test-ordering dependency with other top-level test functions.
+	origProvider, origFrom, origTo, origDryRun := migrateProvider, migrateFrom2, migrateTo2, migrateDryRun
+	t.Cleanup(func() {
+		migrateProvider, migrateFrom2, migrateTo2, migrateDryRun = origProvider, origFrom, origTo, origDryRun
+	})
+
+	// sub-case 1: cluster mode + non-cluster-capable backend -> gate error
+	t.Run("cluster_mode_oss_rejected", func(t *testing.T) {
+		t.Setenv("CFGMS_HA_MODE", "cluster")
+		migrateProvider = "storage"
+		migrateFrom2 = "git"
+		migrateTo2 = "oss"
+		migrateDryRun = false
+
+		err := runMigrate(migrateCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not cluster-capable",
+			"error must identify the cluster-capable gate")
+	})
+
+	// sub-case 2: cluster mode + cluster-capable backend -> gate passes.
+	// The storage migrator will still fail (openBackend rejects "git" as a source),
+	// but the error must NOT name the cluster-capable gate.
+	t.Run("cluster_mode_database_passes_gate", func(t *testing.T) {
+		t.Setenv("CFGMS_HA_MODE", "cluster")
+		migrateProvider = "storage"
+		migrateFrom2 = "git"
+		migrateTo2 = "database"
+		migrateDryRun = false
+
+		err := runMigrate(migrateCmd, nil)
+		require.Error(t, err, "storage migrator rejects unknown source backend")
+		assert.NotContains(t, err.Error(), "not cluster-capable",
+			"cluster-capable backend must pass the gate")
+	})
+
+	// sub-case 3: no CFGMS_HA_MODE set -> gate is a no-op regardless of --to.
+	// The storage migrator still fails (unknown source backend), but that is not
+	// the cluster-capable gate.
+	t.Run("single_mode_no_gate_error", func(t *testing.T) {
+		migrateProvider = "storage"
+		migrateFrom2 = "git"
+		migrateTo2 = "oss"
+		migrateDryRun = false
+
+		err := runMigrate(migrateCmd, nil)
+		require.Error(t, err, "storage migrator rejects unknown source backend")
+		assert.NotContains(t, err.Error(), "not cluster-capable",
+			"non-cluster mode must not trigger the cluster-capable gate")
+	})
+
+	// sub-case 4: invalid CFGMS_HA_MODE -> LoadFromEnvironment error surfaces
+	// before the gate or factory are reached.
+	t.Run("invalid_ha_mode_returns_error", func(t *testing.T) {
+		t.Setenv("CFGMS_HA_MODE", "garbage")
+		migrateProvider = "storage"
+		migrateFrom2 = "git"
+		migrateTo2 = "oss"
+		migrateDryRun = false
+
+		err := runMigrate(migrateCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read HA configuration from environment")
+	})
+
+	// sub-case 5: blue-green mode -> gate is a no-op; only ClusterMode activates it.
+	t.Run("blue_green_mode_no_gate_error", func(t *testing.T) {
+		t.Setenv("CFGMS_HA_MODE", "blue-green")
+		migrateProvider = "storage"
+		migrateFrom2 = "git"
+		migrateTo2 = "oss"
+		migrateDryRun = false
+
+		err := runMigrate(migrateCmd, nil)
+		require.Error(t, err, "storage migrator rejects unknown source backend")
+		assert.NotContains(t, err.Error(), "not cluster-capable",
+			"blue-green mode must not trigger the cluster-capable gate")
+	})
+
+	// sub-case 6: clusterCapableMigrationBackend is case-insensitive.
+	t.Run("cluster_mode_DATABASE_uppercase_passes_gate", func(t *testing.T) {
+		t.Setenv("CFGMS_HA_MODE", "cluster")
+		migrateProvider = "storage"
+		migrateFrom2 = "git"
+		migrateTo2 = "DATABASE"
+		migrateDryRun = false
+
+		err := runMigrate(migrateCmd, nil)
+		require.Error(t, err, "storage migrator rejects unknown source backend")
+		assert.NotContains(t, err.Error(), "not cluster-capable",
+			"case-insensitive match must pass the gate for DATABASE")
+	})
+}
+
 // TestMigrateCmd_RunWritesRecords verifies that without --dry-run, Run is
 // invoked and the importer receives the exported records.
 func TestMigrateCmd_RunWritesRecords(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a cluster-mode guard at the top of `runMigrate()` that rejects `cfg migrate` before any factory or data access when `CFGMS_HA_MODE=cluster` and `--to` names a non-cluster-capable backend
- Only `"database"` (Postgres) is cluster-capable; all other names (`"oss"`, `"flatfile"`, `"sqlite"`, unrecognised) are rejected with a clear error containing "not cluster-capable"
- Gate is a no-op in single-server and blue-green modes; `LoadFromEnvironment` errors surface cleanly for invalid `CFGMS_HA_MODE` values

Fixes #2290

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner (`make test-agent-complete`) | ✅ PASS — all unit, integration, lint, security, and cross-platform build checks passed; marker file `/tmp/agent-validation-passed` written |
| QA Code Reviewer (2 passes) | ✅ PASS — initial pass found 4 blocking issues (empty conditional assertions, missing error-path test, no var cleanup, no invalid-mode coverage); all fixed and confirmed in second pass |
| Security Engineer | ✅ PASS — `logging.SanitizeLogValue` used correctly on `migrateTo2`; env-var-only gate (no file reads, no path traversal); fail-closed design; 0 gosec/staticcheck findings in changed files |

## Test Plan

- [ ] `TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget/cluster_mode_oss_rejected` — gate fires, error contains "not cluster-capable"
- [ ] `TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget/cluster_mode_database_passes_gate` — gate passes, error is from storage layer not gate
- [ ] `TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget/single_mode_no_gate_error` — gate is no-op
- [ ] `TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget/invalid_ha_mode_returns_error` — `LoadFromEnvironment` error surfaces
- [ ] `TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget/blue_green_mode_no_gate_error` — gate is no-op in blue-green mode
- [ ] `TestRunMigrate_ClusterModeRejectsNonClusterCapableTarget/cluster_mode_DATABASE_uppercase_passes_gate` — case-insensitive allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)