### PR TITLE
controller: orchestration job model — BatchJob types, storage interface, in-memory provider (Issue #2294)

### DIFF
--- a/features/controller/batchjob/types.go
+++ b/features/controller/batchjob/types.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package batchjob defines the domain types for fleet-wide rolling batch update jobs.
+// It is intentionally import-free of other CFGMS packages so that the storage
+// interface, executor, REST API, quorum-check, and rollback stories can all depend
+// on it without circular imports.
+package batchjob
+
+import "time"
+
+// BatchJobStatus is the lifecycle state of a batch job.
+type BatchJobStatus string
+
+const (
+	// BatchJobStatusPending — job is created but execution has not started.
+	BatchJobStatusPending BatchJobStatus = "pending"
+
+	// BatchJobStatusRunning — at least one step is actively deploying.
+	BatchJobStatusRunning BatchJobStatus = "running"
+
+	// BatchJobStatusPaused — execution halted on step failure; awaits operator action.
+	BatchJobStatusPaused BatchJobStatus = "paused"
+
+	// BatchJobStatusCompleted — all steps finished successfully.
+	BatchJobStatusCompleted BatchJobStatus = "completed"
+
+	// BatchJobStatusFailed — terminal; rollback not attempted or itself failed.
+	BatchJobStatusFailed BatchJobStatus = "failed"
+
+	// BatchJobStatusRolledBack — compensating dispatch completed.
+	BatchJobStatusRolledBack BatchJobStatus = "rolled_back"
+)
+
+// BatchStepStatus is the lifecycle state of a single step within a batch job.
+type BatchStepStatus string
+
+const (
+	// BatchStepStatusPending — step has not yet started.
+	BatchStepStatusPending BatchStepStatus = "pending"
+
+	// BatchStepStatusRunning — step is actively deploying to its stewards.
+	BatchStepStatusRunning BatchStepStatus = "running"
+
+	// BatchStepStatusCompleted — all stewards in the step converged successfully.
+	BatchStepStatusCompleted BatchStepStatus = "completed"
+
+	// BatchStepStatusFailed — one or more stewards failed; step is terminal.
+	BatchStepStatusFailed BatchStepStatus = "failed"
+
+	// BatchStepStatusRolledBack — compensating dispatch for this step completed.
+	BatchStepStatusRolledBack BatchStepStatus = "rolled_back"
+)
+
+// BatchStep is one wave of stewards within a rolling batch job.
+type BatchStep struct {
+	// Index is the zero-based position of this step in the job's step sequence.
+	Index int
+
+	// StewardIDs is the set of stewards targeted by this step.
+	StewardIDs []string
+
+	// Status is the current lifecycle state of the step.
+	Status BatchStepStatus
+
+	// StartedAt is set when the step transitions to running.
+	StartedAt *time.Time
+
+	// CompletedAt is set when the step reaches a terminal state.
+	CompletedAt *time.Time
+
+	// FailedIDs lists stewards that reported a failure during this step.
+	FailedIDs []string
+
+	// RollbackJobID is set when a compensating dispatch is queued for this step.
+	RollbackJobID string
+}
+
+// BatchJobConfig holds the parameters that control batch execution.
+type BatchJobConfig struct {
+	// BatchSize is the number of stewards per batch wave; must be > 0.
+	BatchSize int
+
+	// PreviousConfigRef is the config version to restore on rollback.
+	// Captured at job creation time so rollback is always available.
+	PreviousConfigRef string
+}
+
+// BatchJob is a fleet-wide rolling update operation managed by the controller.
+type BatchJob struct {
+	// ID is the unique job identifier.
+	ID string
+
+	// TenantID scopes the job to a single tenant.
+	TenantID string
+
+	// Selector is the fleet.Filter expression used to resolve Targets.
+	// Stored verbatim for audit — re-evaluating later could yield different results.
+	Selector string
+
+	// Config holds the static parameters for this job.
+	Config BatchJobConfig
+
+	// Targets is the resolved set of steward IDs captured at job creation time.
+	Targets []string
+
+	// Status is the current lifecycle state of the job.
+	Status BatchJobStatus
+
+	// Steps is the ordered sequence of batch waves.
+	Steps []BatchStep
+
+	// CreatedAt is the wall-clock time when the job was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is the wall-clock time of the last state change.
+	UpdatedAt time.Time
+
+	// InitiatedBy identifies the operator who created the job.
+	InitiatedBy string
+}

--- a/features/controller/batchjob/types_test.go
+++ b/features/controller/batchjob/types_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package batchjob_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+)
+
+func TestBatchJobStatusConstants(t *testing.T) {
+	assert.Equal(t, batchjob.BatchJobStatus("pending"), batchjob.BatchJobStatusPending)
+	assert.Equal(t, batchjob.BatchJobStatus("running"), batchjob.BatchJobStatusRunning)
+	assert.Equal(t, batchjob.BatchJobStatus("paused"), batchjob.BatchJobStatusPaused)
+	assert.Equal(t, batchjob.BatchJobStatus("completed"), batchjob.BatchJobStatusCompleted)
+	assert.Equal(t, batchjob.BatchJobStatus("failed"), batchjob.BatchJobStatusFailed)
+	assert.Equal(t, batchjob.BatchJobStatus("rolled_back"), batchjob.BatchJobStatusRolledBack)
+}
+
+func TestBatchStepStatusConstants(t *testing.T) {
+	assert.Equal(t, batchjob.BatchStepStatus("pending"), batchjob.BatchStepStatusPending)
+	assert.Equal(t, batchjob.BatchStepStatus("running"), batchjob.BatchStepStatusRunning)
+	assert.Equal(t, batchjob.BatchStepStatus("completed"), batchjob.BatchStepStatusCompleted)
+	assert.Equal(t, batchjob.BatchStepStatus("failed"), batchjob.BatchStepStatusFailed)
+	assert.Equal(t, batchjob.BatchStepStatus("rolled_back"), batchjob.BatchStepStatusRolledBack)
+}
+
+func TestBatchStepZeroValue(t *testing.T) {
+	var s batchjob.BatchStep
+	assert.Equal(t, 0, s.Index)
+	assert.Nil(t, s.StewardIDs)
+	assert.Equal(t, batchjob.BatchStepStatus(""), s.Status)
+	assert.Nil(t, s.StartedAt)
+	assert.Nil(t, s.CompletedAt)
+	assert.Nil(t, s.FailedIDs)
+	assert.Empty(t, s.RollbackJobID)
+}
+
+func TestBatchJobConfigZeroValue(t *testing.T) {
+	var c batchjob.BatchJobConfig
+	assert.Equal(t, 0, c.BatchSize)
+	assert.Empty(t, c.PreviousConfigRef)
+}
+
+func TestBatchJobZeroValue(t *testing.T) {
+	var j batchjob.BatchJob
+	assert.Empty(t, j.ID)
+	assert.Empty(t, j.TenantID)
+	assert.Empty(t, j.Selector)
+	assert.Nil(t, j.Targets)
+	assert.Equal(t, batchjob.BatchJobStatus(""), j.Status)
+	assert.Nil(t, j.Steps)
+	assert.True(t, j.CreatedAt.IsZero())
+	assert.True(t, j.UpdatedAt.IsZero())
+	assert.Empty(t, j.InitiatedBy)
+}
+
+func TestBatchStepFields(t *testing.T) {
+	now := time.Now().UTC()
+	completed := now.Add(time.Minute)
+	s := batchjob.BatchStep{
+		Index:         2,
+		StewardIDs:    []string{"s-1", "s-2"},
+		Status:        batchjob.BatchStepStatusRunning,
+		StartedAt:     &now,
+		CompletedAt:   &completed,
+		FailedIDs:     []string{"s-2"},
+		RollbackJobID: "rj-abc",
+	}
+	assert.Equal(t, 2, s.Index)
+	assert.Equal(t, []string{"s-1", "s-2"}, s.StewardIDs)
+	assert.Equal(t, batchjob.BatchStepStatusRunning, s.Status)
+	assert.Equal(t, &now, s.StartedAt)
+	assert.Equal(t, &completed, s.CompletedAt)
+	assert.Equal(t, []string{"s-2"}, s.FailedIDs)
+	assert.Equal(t, "rj-abc", s.RollbackJobID)
+}
+
+func TestBatchJobFields(t *testing.T) {
+	now := time.Now().UTC()
+	j := batchjob.BatchJob{
+		ID:       "job-1",
+		TenantID: "tenant-1",
+		Selector: "tag:prod",
+		Config: batchjob.BatchJobConfig{
+			BatchSize:         10,
+			PreviousConfigRef: "v1.2",
+		},
+		Targets:     []string{"s-1", "s-2"},
+		Status:      batchjob.BatchJobStatusPending,
+		Steps:       []batchjob.BatchStep{{Index: 0, StewardIDs: []string{"s-1"}}},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		InitiatedBy: "operator@example.com",
+	}
+	assert.Equal(t, "job-1", j.ID)
+	assert.Equal(t, "tenant-1", j.TenantID)
+	assert.Equal(t, "tag:prod", j.Selector)
+	assert.Equal(t, 10, j.Config.BatchSize)
+	assert.Equal(t, "v1.2", j.Config.PreviousConfigRef)
+	assert.Equal(t, []string{"s-1", "s-2"}, j.Targets)
+	assert.Equal(t, batchjob.BatchJobStatusPending, j.Status)
+	assert.Len(t, j.Steps, 1)
+	assert.Equal(t, now, j.CreatedAt)
+	assert.Equal(t, now, j.UpdatedAt)
+	assert.Equal(t, "operator@example.com", j.InitiatedBy)
+}

--- a/pkg/storage/interfaces/README.md
+++ b/pkg/storage/interfaces/README.md
@@ -42,6 +42,7 @@ pkg/storage/interfaces/
 | `steward_store.go` | `StewardStore`, `StewardRecord`, `StewardStatus` | Durable fleet registry |
 | `command_store.go` | `CommandStore`, `CommandRecord`, `CommandStatus`, `CommandTransition` | Durable command dispatch state |
 | `dna_history_store.go` | `DNAHistoryStore` | DNA history access interface used by drift detection |
+| `batch_job_store.go` | `BatchJobStore`, `ErrBatchJobNotFound` | Fleet rolling-batch update job persistence (types in `features/controller/batchjob`) |
 
 Sentinel errors live in the sub-packages: `business.ErrNotSupported`,
 `business.ErrImmutable`, `business.ErrStewardNotFound`,

--- a/pkg/storage/interfaces/business/batch_job_store.go
+++ b/pkg/storage/interfaces/business/batch_job_store.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package business defines the BatchJobStore interface for durable batch-job persistence.
+package business
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+)
+
+// ErrBatchJobNotFound is returned when a batch job record does not exist.
+var ErrBatchJobNotFound = errors.New("batch job not found")
+
+// BatchJobStore defines the storage interface for fleet rolling-batch job persistence.
+//
+// All implementations must be safe for concurrent use.
+// The interface is used by the batch executor, REST API, quorum-check logic,
+// and rollback dispatch — none of which may import each other, so all depend
+// on this package and features/controller/batchjob for shared types.
+type BatchJobStore interface {
+	// CreateBatchJob inserts a new batch job record.
+	// Returns an error if a record with the same ID already exists.
+	CreateBatchJob(ctx context.Context, job *batchjob.BatchJob) error
+
+	// UpdateBatchJobStatus sets the top-level status of an existing batch job.
+	// Returns ErrBatchJobNotFound if no record exists for the given id.
+	UpdateBatchJobStatus(ctx context.Context, id string, status batchjob.BatchJobStatus) error
+
+	// UpdateBatchStep upserts a step within the batch job identified by jobID.
+	// If a step with the same Index already exists it is replaced; otherwise the
+	// step is appended. Returns ErrBatchJobNotFound if the job does not exist.
+	UpdateBatchStep(ctx context.Context, jobID string, step batchjob.BatchStep) error
+
+	// GetBatchJob retrieves the batch job with the given id.
+	// Returns ErrBatchJobNotFound if no record exists.
+	GetBatchJob(ctx context.Context, id string) (*batchjob.BatchJob, error)
+
+	// ListBatchJobsByTenant returns all batch jobs belonging to tenantID.
+	// Returns an empty slice (not an error) when no records exist.
+	ListBatchJobsByTenant(ctx context.Context, tenantID string) ([]*batchjob.BatchJob, error)
+
+	// HealthCheck verifies the store is reachable and operational.
+	HealthCheck(ctx context.Context) error
+
+	// Initialize prepares the store (creates directories, tables, schemas, etc.).
+	Initialize(ctx context.Context) error
+
+	// Close releases resources held by the store.
+	Close() error
+}

--- a/pkg/storage/interfaces/business/batch_job_store_test.go
+++ b/pkg/storage/interfaces/business/batch_job_store_test.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package business_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemBatchJobStore is a minimal in-memory BatchJobStore for contract testing only.
+type inMemBatchJobStore struct {
+	mu   sync.RWMutex
+	jobs map[string]*batchjob.BatchJob
+}
+
+func newInMemBatchJobStore() business.BatchJobStore {
+	return &inMemBatchJobStore{jobs: make(map[string]*batchjob.BatchJob)}
+}
+
+func (s *inMemBatchJobStore) CreateBatchJob(_ context.Context, job *batchjob.BatchJob) error {
+	if job == nil {
+		return errBatchJobTestNilRecord
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.jobs[job.ID]; exists {
+		return errBatchJobTestDuplicateID
+	}
+	cp := deepCopyBatchJob(job)
+	s.jobs[job.ID] = cp
+	return nil
+}
+
+func (s *inMemBatchJobStore) UpdateBatchJobStatus(_ context.Context, id string, status batchjob.BatchJobStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return business.ErrBatchJobNotFound
+	}
+	j.Status = status
+	j.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+func (s *inMemBatchJobStore) UpdateBatchStep(_ context.Context, jobID string, step batchjob.BatchStep) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[jobID]
+	if !ok {
+		return business.ErrBatchJobNotFound
+	}
+	for i := range j.Steps {
+		if j.Steps[i].Index == step.Index {
+			j.Steps[i] = copyBatchStep(step)
+			j.UpdatedAt = time.Now().UTC()
+			return nil
+		}
+	}
+	j.Steps = append(j.Steps, copyBatchStep(step))
+	j.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+func (s *inMemBatchJobStore) GetBatchJob(_ context.Context, id string) (*batchjob.BatchJob, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return nil, business.ErrBatchJobNotFound
+	}
+	return deepCopyBatchJob(j), nil
+}
+
+func (s *inMemBatchJobStore) ListBatchJobsByTenant(_ context.Context, tenantID string) ([]*batchjob.BatchJob, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*batchjob.BatchJob
+	for _, j := range s.jobs {
+		if j.TenantID == tenantID {
+			out = append(out, deepCopyBatchJob(j))
+		}
+	}
+	return out, nil
+}
+
+func (s *inMemBatchJobStore) HealthCheck(_ context.Context) error { return nil }
+func (s *inMemBatchJobStore) Initialize(_ context.Context) error  { return nil }
+func (s *inMemBatchJobStore) Close() error                        { return nil }
+
+var _ business.BatchJobStore = (*inMemBatchJobStore)(nil)
+
+// deep copy helpers
+func deepCopyBatchJob(j *batchjob.BatchJob) *batchjob.BatchJob {
+	cp := *j
+	cp.Targets = append([]string(nil), j.Targets...)
+	cp.Steps = make([]batchjob.BatchStep, len(j.Steps))
+	for i, s := range j.Steps {
+		cp.Steps[i] = copyBatchStep(s)
+	}
+	return &cp
+}
+
+func copyBatchStep(s batchjob.BatchStep) batchjob.BatchStep {
+	cp := s
+	cp.StewardIDs = append([]string(nil), s.StewardIDs...)
+	cp.FailedIDs = append([]string(nil), s.FailedIDs...)
+	if s.StartedAt != nil {
+		t := *s.StartedAt
+		cp.StartedAt = &t
+	}
+	if s.CompletedAt != nil {
+		t := *s.CompletedAt
+		cp.CompletedAt = &t
+	}
+	return cp
+}
+
+var (
+	errBatchJobTestNilRecord   = errBatchJobTestStr("nil job record")
+	errBatchJobTestDuplicateID = errBatchJobTestStr("duplicate batch job ID")
+)
+
+type errBatchJobTestStr string
+
+func (e errBatchJobTestStr) Error() string { return string(e) }
+
+// --- Contract tests ---
+
+func newTestBatchJob(id, tenantID string) *batchjob.BatchJob {
+	now := time.Now().UTC()
+	return &batchjob.BatchJob{
+		ID:       id,
+		TenantID: tenantID,
+		Selector: "tag:prod",
+		Config: batchjob.BatchJobConfig{
+			BatchSize:         5,
+			PreviousConfigRef: "cfg-v1",
+		},
+		Targets:     []string{"s-1", "s-2", "s-3"},
+		Status:      batchjob.BatchJobStatusPending,
+		Steps:       []batchjob.BatchStep{{Index: 0, StewardIDs: []string{"s-1"}, Status: batchjob.BatchStepStatusPending}},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		InitiatedBy: "operator@example.com",
+	}
+}
+
+func TestBatchJobStore_Contract(t *testing.T) {
+	store := newInMemBatchJobStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Initialize(ctx))
+	require.NoError(t, store.HealthCheck(ctx))
+
+	t.Run("create and get round-trip", func(t *testing.T) {
+		job := newTestBatchJob("job-1", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		got, err := store.GetBatchJob(ctx, "job-1")
+		require.NoError(t, err)
+		assert.Equal(t, "job-1", got.ID)
+		assert.Equal(t, "tenant-1", got.TenantID)
+		assert.Equal(t, batchjob.BatchJobStatusPending, got.Status)
+		assert.Equal(t, "tag:prod", got.Selector)
+		assert.Equal(t, 5, got.Config.BatchSize)
+		assert.Equal(t, "cfg-v1", got.Config.PreviousConfigRef)
+		assert.Equal(t, []string{"s-1", "s-2", "s-3"}, got.Targets)
+		assert.Equal(t, "operator@example.com", got.InitiatedBy)
+		assert.Len(t, got.Steps, 1)
+	})
+
+	t.Run("duplicate ID returns error", func(t *testing.T) {
+		job := newTestBatchJob("job-dup", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+		err := store.CreateBatchJob(ctx, job)
+		require.Error(t, err)
+	})
+
+	t.Run("get not found returns ErrBatchJobNotFound", func(t *testing.T) {
+		_, err := store.GetBatchJob(ctx, "no-such-id")
+		assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchJobStatus reflects in Get", func(t *testing.T) {
+		job := newTestBatchJob("job-status", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		require.NoError(t, store.UpdateBatchJobStatus(ctx, "job-status", batchjob.BatchJobStatusRunning))
+		got, err := store.GetBatchJob(ctx, "job-status")
+		require.NoError(t, err)
+		assert.Equal(t, batchjob.BatchJobStatusRunning, got.Status)
+
+		require.NoError(t, store.UpdateBatchJobStatus(ctx, "job-status", batchjob.BatchJobStatusCompleted))
+		got, err = store.GetBatchJob(ctx, "job-status")
+		require.NoError(t, err)
+		assert.Equal(t, batchjob.BatchJobStatusCompleted, got.Status)
+	})
+
+	t.Run("UpdateBatchJobStatus not found", func(t *testing.T) {
+		err := store.UpdateBatchJobStatus(ctx, "ghost", batchjob.BatchJobStatusFailed)
+		assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchStep round-trips step fields", func(t *testing.T) {
+		job := newTestBatchJob("job-step", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		now := time.Now().UTC()
+		step := batchjob.BatchStep{
+			Index:         0,
+			StewardIDs:    []string{"s-1"},
+			Status:        batchjob.BatchStepStatusRunning,
+			StartedAt:     &now,
+			FailedIDs:     []string{"s-1"},
+			RollbackJobID: "rj-001",
+		}
+		require.NoError(t, store.UpdateBatchStep(ctx, "job-step", step))
+
+		got, err := store.GetBatchJob(ctx, "job-step")
+		require.NoError(t, err)
+		require.Len(t, got.Steps, 1)
+		s := got.Steps[0]
+		assert.Equal(t, 0, s.Index)
+		assert.Equal(t, batchjob.BatchStepStatusRunning, s.Status)
+		assert.Equal(t, []string{"s-1"}, s.FailedIDs)
+		assert.Equal(t, "rj-001", s.RollbackJobID)
+		require.NotNil(t, s.StartedAt)
+	})
+
+	t.Run("UpdateBatchStep not found", func(t *testing.T) {
+		step := batchjob.BatchStep{Index: 0, Status: batchjob.BatchStepStatusFailed}
+		err := store.UpdateBatchStep(ctx, "ghost-job", step)
+		assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchStep appends step with new index", func(t *testing.T) {
+		job := newTestBatchJob("job-step-append", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		newStep := batchjob.BatchStep{
+			Index:      1,
+			StewardIDs: []string{"s-2"},
+			Status:     batchjob.BatchStepStatusPending,
+		}
+		require.NoError(t, store.UpdateBatchStep(ctx, "job-step-append", newStep))
+
+		got, err := store.GetBatchJob(ctx, "job-step-append")
+		require.NoError(t, err)
+		assert.Len(t, got.Steps, 2, "new index must be appended, not replace existing")
+	})
+
+	t.Run("ListBatchJobsByTenant scopes by tenant", func(t *testing.T) {
+		require.NoError(t, store.CreateBatchJob(ctx, newTestBatchJob("job-ta-1", "tenant-A")))
+		require.NoError(t, store.CreateBatchJob(ctx, newTestBatchJob("job-ta-2", "tenant-A")))
+		require.NoError(t, store.CreateBatchJob(ctx, newTestBatchJob("job-tb-1", "tenant-B")))
+
+		listA, err := store.ListBatchJobsByTenant(ctx, "tenant-A")
+		require.NoError(t, err)
+		assert.Len(t, listA, 2)
+
+		listB, err := store.ListBatchJobsByTenant(ctx, "tenant-B")
+		require.NoError(t, err)
+		assert.Len(t, listB, 1)
+		assert.Equal(t, "job-tb-1", listB[0].ID)
+
+		listNone, err := store.ListBatchJobsByTenant(ctx, "tenant-unknown")
+		require.NoError(t, err)
+		assert.Empty(t, listNone)
+	})
+
+	require.NoError(t, store.Close())
+}
+
+func TestErrBatchJobNotFound(t *testing.T) {
+	assert.NotNil(t, business.ErrBatchJobNotFound)
+	assert.Equal(t, "batch job not found", business.ErrBatchJobNotFound.Error())
+}

--- a/pkg/storage/providers/memory/batch_job_store.go
+++ b/pkg/storage/providers/memory/batch_job_store.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package memory provides in-memory storage implementations for development and testing.
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// BatchJobStore is a thread-safe in-memory implementation of business.BatchJobStore.
+// Used in tests and development environments where durable batch-job persistence
+// is not required. All mutations deep-copy the stored record to prevent aliasing.
+type BatchJobStore struct {
+	mu   sync.RWMutex
+	jobs map[string]*batchjob.BatchJob
+}
+
+// NewBatchJobStore returns an initialised in-memory BatchJobStore.
+func NewBatchJobStore() *BatchJobStore {
+	return &BatchJobStore{jobs: make(map[string]*batchjob.BatchJob)}
+}
+
+// CreateBatchJob inserts a new batch job. Returns an error if a record with
+// the same ID already exists.
+func (s *BatchJobStore) CreateBatchJob(_ context.Context, job *batchjob.BatchJob) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.jobs[job.ID]; exists {
+		return fmt.Errorf("batch job %q already exists", job.ID)
+	}
+	s.jobs[job.ID] = deepCopyJob(job)
+	return nil
+}
+
+// UpdateBatchJobStatus sets the top-level status and updates UpdatedAt.
+func (s *BatchJobStore) UpdateBatchJobStatus(_ context.Context, id string, status batchjob.BatchJobStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return business.ErrBatchJobNotFound
+	}
+	j.Status = status
+	j.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+// UpdateBatchStep upserts the step identified by step.Index within the job.
+// A matching index is replaced in-place; an unrecognised index appends a new step.
+func (s *BatchJobStore) UpdateBatchStep(_ context.Context, jobID string, step batchjob.BatchStep) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[jobID]
+	if !ok {
+		return business.ErrBatchJobNotFound
+	}
+	cp := copyStep(step)
+	for i := range j.Steps {
+		if j.Steps[i].Index == step.Index {
+			j.Steps[i] = cp
+			j.UpdatedAt = time.Now().UTC()
+			return nil
+		}
+	}
+	j.Steps = append(j.Steps, cp)
+	j.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+// GetBatchJob retrieves a deep copy of the batch job identified by id.
+func (s *BatchJobStore) GetBatchJob(_ context.Context, id string) (*batchjob.BatchJob, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return nil, business.ErrBatchJobNotFound
+	}
+	return deepCopyJob(j), nil
+}
+
+// ListBatchJobsByTenant returns deep copies of all jobs belonging to tenantID.
+func (s *BatchJobStore) ListBatchJobsByTenant(_ context.Context, tenantID string) ([]*batchjob.BatchJob, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*batchjob.BatchJob
+	for _, j := range s.jobs {
+		if j.TenantID == tenantID {
+			out = append(out, deepCopyJob(j))
+		}
+	}
+	return out, nil
+}
+
+func (s *BatchJobStore) HealthCheck(_ context.Context) error { return nil }
+func (s *BatchJobStore) Initialize(_ context.Context) error  { return nil }
+func (s *BatchJobStore) Close() error                        { return nil }
+
+var _ business.BatchJobStore = (*BatchJobStore)(nil)
+
+// deepCopyJob returns a fully independent copy of job, preventing aliasing
+// between the store's internal state and caller-held pointers.
+func deepCopyJob(j *batchjob.BatchJob) *batchjob.BatchJob {
+	cp := *j
+	cp.Targets = append([]string(nil), j.Targets...)
+	cp.Steps = make([]batchjob.BatchStep, len(j.Steps))
+	for i, s := range j.Steps {
+		cp.Steps[i] = copyStep(s)
+	}
+	return &cp
+}
+
+// copyStep returns an independent copy of a BatchStep.
+func copyStep(s batchjob.BatchStep) batchjob.BatchStep {
+	cp := s
+	cp.StewardIDs = append([]string(nil), s.StewardIDs...)
+	cp.FailedIDs = append([]string(nil), s.FailedIDs...)
+	if s.StartedAt != nil {
+		t := *s.StartedAt
+		cp.StartedAt = &t
+	}
+	if s.CompletedAt != nil {
+		t := *s.CompletedAt
+		cp.CompletedAt = &t
+	}
+	return cp
+}

--- a/pkg/storage/providers/memory/batch_job_store_test.go
+++ b/pkg/storage/providers/memory/batch_job_store_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package memory_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
+)
+
+func newMemTestBatchJob(id, tenantID string) *batchjob.BatchJob {
+	now := time.Now().UTC()
+	return &batchjob.BatchJob{
+		ID:       id,
+		TenantID: tenantID,
+		Selector: "tag:staging",
+		Config: batchjob.BatchJobConfig{
+			BatchSize:         3,
+			PreviousConfigRef: "cfg-v2",
+		},
+		Targets:     []string{"s-a", "s-b"},
+		Status:      batchjob.BatchJobStatusPending,
+		Steps:       []batchjob.BatchStep{{Index: 0, StewardIDs: []string{"s-a"}, Status: batchjob.BatchStepStatusPending}},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		InitiatedBy: "admin@example.com",
+	}
+}
+
+func TestBatchJobStore_Memory_InitializeAndHealthCheck(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx))
+	require.NoError(t, store.HealthCheck(ctx))
+	require.NoError(t, store.Close())
+}
+
+func TestBatchJobStore_Memory_CreateAndGet(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	job := newMemTestBatchJob("job-mem-1", "tenant-1")
+	require.NoError(t, store.CreateBatchJob(ctx, job))
+
+	got, err := store.GetBatchJob(ctx, "job-mem-1")
+	require.NoError(t, err)
+	assert.Equal(t, "job-mem-1", got.ID)
+	assert.Equal(t, "tenant-1", got.TenantID)
+	assert.Equal(t, batchjob.BatchJobStatusPending, got.Status)
+	assert.Equal(t, "tag:staging", got.Selector)
+	assert.Equal(t, 3, got.Config.BatchSize)
+	assert.Equal(t, "cfg-v2", got.Config.PreviousConfigRef)
+	assert.Equal(t, []string{"s-a", "s-b"}, got.Targets)
+	assert.Equal(t, "admin@example.com", got.InitiatedBy)
+}
+
+func TestBatchJobStore_Memory_CreateDuplicateIDReturnsError(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	job := newMemTestBatchJob("job-dup", "tenant-1")
+	require.NoError(t, store.CreateBatchJob(ctx, job))
+	err := store.CreateBatchJob(ctx, job)
+	require.Error(t, err)
+}
+
+func TestBatchJobStore_Memory_GetNotFound(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	_, err := store.GetBatchJob(context.Background(), "no-such-id")
+	assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
+}
+
+func TestBatchJobStore_Memory_UpdateBatchJobStatus(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateBatchJob(ctx, newMemTestBatchJob("job-s", "tenant-1")))
+
+	require.NoError(t, store.UpdateBatchJobStatus(ctx, "job-s", batchjob.BatchJobStatusRunning))
+	got, err := store.GetBatchJob(ctx, "job-s")
+	require.NoError(t, err)
+	assert.Equal(t, batchjob.BatchJobStatusRunning, got.Status)
+
+	require.NoError(t, store.UpdateBatchJobStatus(ctx, "job-s", batchjob.BatchJobStatusPaused))
+	got, err = store.GetBatchJob(ctx, "job-s")
+	require.NoError(t, err)
+	assert.Equal(t, batchjob.BatchJobStatusPaused, got.Status)
+}
+
+func TestBatchJobStore_Memory_UpdateBatchJobStatusNotFound(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	err := store.UpdateBatchJobStatus(context.Background(), "ghost", batchjob.BatchJobStatusFailed)
+	assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
+}
+
+func TestBatchJobStore_Memory_UpdateBatchStep(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateBatchJob(ctx, newMemTestBatchJob("job-step", "tenant-1")))
+
+	now := time.Now().UTC()
+	completed := now.Add(30 * time.Second)
+	step := batchjob.BatchStep{
+		Index:         0,
+		StewardIDs:    []string{"s-a"},
+		Status:        batchjob.BatchStepStatusCompleted,
+		StartedAt:     &now,
+		CompletedAt:   &completed,
+		FailedIDs:     []string{},
+		RollbackJobID: "",
+	}
+	require.NoError(t, store.UpdateBatchStep(ctx, "job-step", step))
+
+	got, err := store.GetBatchJob(ctx, "job-step")
+	require.NoError(t, err)
+	require.Len(t, got.Steps, 1)
+	s := got.Steps[0]
+	assert.Equal(t, 0, s.Index)
+	assert.Equal(t, batchjob.BatchStepStatusCompleted, s.Status)
+	require.NotNil(t, s.StartedAt)
+	require.NotNil(t, s.CompletedAt)
+}
+
+func TestBatchJobStore_Memory_UpdateBatchStepNotFound(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	step := batchjob.BatchStep{Index: 0}
+	err := store.UpdateBatchStep(context.Background(), "ghost-job", step)
+	assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
+}
+
+func TestBatchJobStore_Memory_ListBatchJobsByTenant(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateBatchJob(ctx, newMemTestBatchJob("j-a1", "tenant-A")))
+	require.NoError(t, store.CreateBatchJob(ctx, newMemTestBatchJob("j-a2", "tenant-A")))
+	require.NoError(t, store.CreateBatchJob(ctx, newMemTestBatchJob("j-b1", "tenant-B")))
+
+	listA, err := store.ListBatchJobsByTenant(ctx, "tenant-A")
+	require.NoError(t, err)
+	assert.Len(t, listA, 2)
+
+	listB, err := store.ListBatchJobsByTenant(ctx, "tenant-B")
+	require.NoError(t, err)
+	assert.Len(t, listB, 1)
+	assert.Equal(t, "j-b1", listB[0].ID)
+
+	listNone, err := store.ListBatchJobsByTenant(ctx, "tenant-unknown")
+	require.NoError(t, err)
+	assert.Empty(t, listNone)
+}
+
+func TestBatchJobStore_Memory_ConcurrencySafe(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	const workers = 20
+	errs := make(chan error, workers*4)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := range workers {
+		go func(n int) {
+			defer wg.Done()
+			id := "concurrent-job-" + string(rune('a'+n))
+			tenantID := "tenant-" + string(rune('a'+n%3))
+			job := newMemTestBatchJob(id, tenantID)
+			if err := store.CreateBatchJob(ctx, job); err != nil {
+				errs <- err
+				return
+			}
+			if _, err := store.GetBatchJob(ctx, id); err != nil {
+				errs <- err
+			}
+			if err := store.UpdateBatchJobStatus(ctx, id, batchjob.BatchJobStatusRunning); err != nil {
+				errs <- err
+			}
+			if _, err := store.ListBatchJobsByTenant(ctx, tenantID); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestBatchJobStore_Memory_CreateIsolatesFromMutation(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	job := newMemTestBatchJob("job-alias", "tenant-1")
+	require.NoError(t, store.CreateBatchJob(ctx, job))
+
+	// Mutating original after create must not affect stored copy.
+	job.Status = batchjob.BatchJobStatusFailed
+	job.Targets = append(job.Targets, "s-mutated")
+	job.Steps[0].StewardIDs = append(job.Steps[0].StewardIDs, "s-injected")
+
+	got, err := store.GetBatchJob(ctx, "job-alias")
+	require.NoError(t, err)
+	assert.Equal(t, batchjob.BatchJobStatusPending, got.Status)
+	assert.Len(t, got.Targets, 2)
+	require.Len(t, got.Steps, 1)
+	assert.Len(t, got.Steps[0].StewardIDs, 1, "step StewardIDs must be deep-copied on create")
+}
+
+func TestBatchJobStore_Memory_GetIsolatesFromMutation(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateBatchJob(ctx, newMemTestBatchJob("job-get-alias", "tenant-1")))
+
+	got, err := store.GetBatchJob(ctx, "job-get-alias")
+	require.NoError(t, err)
+
+	// Mutating returned copy must not affect stored value.
+	got.Status = batchjob.BatchJobStatusFailed
+	got.Targets = append(got.Targets, "s-extra")
+	got.Steps[0].StewardIDs = append(got.Steps[0].StewardIDs, "s-injected")
+
+	got2, err := store.GetBatchJob(ctx, "job-get-alias")
+	require.NoError(t, err)
+	assert.Equal(t, batchjob.BatchJobStatusPending, got2.Status)
+	assert.Len(t, got2.Targets, 2)
+	require.Len(t, got2.Steps, 1)
+	assert.Len(t, got2.Steps[0].StewardIDs, 1, "step StewardIDs must be deep-copied on get")
+}
+
+func TestBatchJobStore_Memory_UpdateBatchStepAppendNewIndex(t *testing.T) {
+	store := memory.NewBatchJobStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateBatchJob(ctx, newMemTestBatchJob("job-append", "tenant-1")))
+
+	// Append a step with an index not present in the original fixture.
+	newStep := batchjob.BatchStep{
+		Index:      1,
+		StewardIDs: []string{"s-b"},
+		Status:     batchjob.BatchStepStatusPending,
+	}
+	require.NoError(t, store.UpdateBatchStep(ctx, "job-append", newStep))
+
+	got, err := store.GetBatchJob(ctx, "job-append")
+	require.NoError(t, err)
+	assert.Len(t, got.Steps, 2, "new index must be appended, not replace existing")
+
+	// The original step (index 0) is unchanged.
+	assert.Equal(t, 0, got.Steps[0].Index)
+	// The new step (index 1) is present.
+	found := false
+	for _, s := range got.Steps {
+		if s.Index == 1 {
+			found = true
+			assert.Equal(t, batchjob.BatchStepStatusPending, s.Status)
+			assert.Equal(t, []string{"s-b"}, s.StewardIDs)
+		}
+	}
+	assert.True(t, found, "appended step with index 1 must be present")
+}


### PR DESCRIPTION
## Summary

- Introduces `features/controller/batchjob` — pure domain types (`BatchJob`, `BatchStep`, `BatchJobConfig`, status enums) with no CFGMS imports, so all epic dependents can share them without circular imports
- Adds `pkg/storage/interfaces/business.BatchJobStore` interface with `CreateBatchJob`, `UpdateBatchJobStatus`, `UpdateBatchStep` (upsert-by-index), `GetBatchJob`, `ListBatchJobsByTenant`, plus `ErrBatchJobNotFound`
- Implements `pkg/storage/providers/memory.BatchJobStore` — thread-safe (sync.RWMutex), deep-copy on all reads/writes, race-detector clean
- Adds README entry for `BatchJobStore` in the business/ tier table

Fixes #2294

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | ✅ PASS | All packages pass with `-race`; cross-platform builds pass (linux/darwin/windows × amd64/arm64) |
| QA Code Reviewer | ✅ PASS | 2 blocking issues found and fixed before commit: (1) concurrency test error swallowing → now collects errors and asserts after wg.Wait; (2) deep-copy isolation tests extended to cover `Steps[0].StewardIDs` mutation |
| Security Engineer | ✅ PASS | No secrets, no SQL injection surface, no log injection, `ErrBatchJobNotFound` is static text, mutex correctness confirmed |

## Test plan

- [ ] `go test -race ./features/controller/batchjob/...` — types, constants, zero-value guards
- [ ] `go test -race ./pkg/storage/interfaces/business/...` — BatchJobStore contract (create/get/update-status/update-step/list-by-tenant/not-found/append-path)
- [ ] `go test -race ./pkg/storage/providers/memory/...` — memory provider contract + concurrency (20 workers) + deep-copy isolation (Targets, Status, Steps[0].StewardIDs)
- [ ] `make check-architecture` — no central provider violations
- [ ] `make lint-log-injection` — clean
- [ ] `make test-agent-complete` — all CI gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)