### PR TITLE
controller: rolling-batch executor — dispatch ConfigSyncBatch to stewards in configurable batches (Issue #2295)

### DIFF
--- a/features/controller/batchjob/executor.go
+++ b/features/controller/batchjob/executor.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package batchjob
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/commands"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+const batchStepTimeout = 10 * time.Minute
+
+// FleetQuery is the selector resolution interface the executor depends on.
+// Defined here (not in the fleet package) to avoid the import cycle:
+//
+//	batchjob → fleet → business → batchjob
+//
+// The real wiring uses a thin adapter around fleet.FleetQuery; tests use a
+// staticFleetQuery that returns a fixed list of IDs.
+type FleetQuery interface {
+	// Search resolves selector scoped to tenantID and returns the matching steward IDs.
+	Search(ctx context.Context, selector, tenantID string) ([]string, error)
+}
+
+// QuorumChecker partitions a steward list so no batch violates cluster-quorum rules.
+// A nil QuorumChecker performs naive round-robin partitioning only.
+// The quorum story will implement this interface using fleet.StewardResult context;
+// for now (nil) the executor uses naivePartition.
+type QuorumChecker interface {
+	Partition(stewardIDs []string, batchSize int) [][]string
+}
+
+// RollingBatchExecutor dispatches CommandSyncConfig to stewards in sequential batches,
+// advancing to the next batch only when all members of the current batch succeed.
+// On any batch failure the job transitions to paused and execution stops.
+type RollingBatchExecutor struct {
+	store       BatchJobStore
+	fleetQuery  FleetQuery
+	publisher   *commands.Publisher
+	quorumCheck QuorumChecker
+	logger      logging.Logger
+}
+
+// NewRollingBatchExecutor creates an executor with the provided dependencies.
+// quorumCheck may be nil; in that case naive round-robin partitioning is used.
+func NewRollingBatchExecutor(
+	store BatchJobStore,
+	fleetQuery FleetQuery,
+	publisher *commands.Publisher,
+	quorumCheck QuorumChecker,
+	logger logging.Logger,
+) *RollingBatchExecutor {
+	return &RollingBatchExecutor{
+		store:       store,
+		fleetQuery:  fleetQuery,
+		publisher:   publisher,
+		quorumCheck: quorumCheck,
+		logger:      logger,
+	}
+}
+
+// Execute runs the rolling batch job to completion (or pause on failure).
+//
+// Algorithm:
+//  1. Resolve job.Selector via fleetQuery scoped to job.TenantID; persist Targets.
+//  2. Partition steward IDs into batches (quorum-aware or naive round-robin).
+//  3. For each batch: dispatch CommandSyncConfig with callback; wait for all results.
+//     All succeeded → advance. Any failed → set job status paused, return nil.
+//  4. All batches done → set job status completed.
+func (e *RollingBatchExecutor) Execute(ctx context.Context, job *BatchJob) error {
+	// 1. Resolve fleet selector scoped to the job's tenant.
+	ids, err := e.fleetQuery.Search(ctx, job.Selector, job.TenantID)
+	if err != nil {
+		return fmt.Errorf("executor: fleet search: %w", err)
+	}
+	job.Targets = ids
+
+	if err := e.store.UpdateBatchTargets(ctx, job.ID, ids); err != nil {
+		return fmt.Errorf("executor: persist targets: %w", err)
+	}
+
+	// 2. Partition into batches.
+	var batches [][]string
+	if e.quorumCheck != nil {
+		batches = e.quorumCheck.Partition(ids, job.Config.BatchSize)
+	} else {
+		batches = naivePartition(ids, job.Config.BatchSize)
+	}
+
+	if err := e.store.UpdateBatchJobStatus(ctx, job.ID, BatchJobStatusRunning); err != nil {
+		return fmt.Errorf("executor: set running: %w", err)
+	}
+	job.Status = BatchJobStatusRunning
+
+	// 3. Execute batches sequentially.
+	for i, batch := range batches {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// a. Mark step running.
+		now := time.Now().UTC()
+		step := BatchStep{
+			Index:      i,
+			StewardIDs: batch,
+			Status:     BatchStepStatusRunning,
+			StartedAt:  &now,
+		}
+		if err := e.store.UpdateBatchStep(ctx, job.ID, step); err != nil {
+			return fmt.Errorf("executor: set step %d running: %w", i, err)
+		}
+
+		e.logger.Info("Executing batch step",
+			"job_id", logging.SanitizeLogValue(job.ID),
+			"step", i,
+			"size", len(batch))
+
+		// b–c. Dispatch and wait for all results.
+		failedIDs, err := e.dispatchBatch(ctx, batch)
+		if err != nil {
+			return err
+		}
+
+		completedAt := time.Now().UTC()
+		step.CompletedAt = &completedAt
+
+		if len(failedIDs) > 0 {
+			// e. At least one steward failed → pause.
+			step.Status = BatchStepStatusFailed
+			step.FailedIDs = failedIDs
+			if persistErr := e.store.UpdateBatchStep(ctx, job.ID, step); persistErr != nil {
+				e.logger.Error("Failed to persist failed step",
+					"job_id", logging.SanitizeLogValue(job.ID),
+					"step", i, "error", persistErr)
+			}
+			if pauseErr := e.store.UpdateBatchJobStatus(ctx, job.ID, BatchJobStatusPaused); pauseErr != nil {
+				e.logger.Error("Failed to set job paused",
+					"job_id", logging.SanitizeLogValue(job.ID),
+					"error", pauseErr)
+			}
+			job.Status = BatchJobStatusPaused
+			e.logger.Info("Batch step failed; job paused",
+				"job_id", logging.SanitizeLogValue(job.ID),
+				"step", i, "failed_count", len(failedIDs))
+			return nil
+		}
+
+		// d. All succeeded → advance.
+		step.Status = BatchStepStatusCompleted
+		if err := e.store.UpdateBatchStep(ctx, job.ID, step); err != nil {
+			return fmt.Errorf("executor: set step %d completed: %w", i, err)
+		}
+
+		e.logger.Info("Batch step completed",
+			"job_id", logging.SanitizeLogValue(job.ID), "step", i)
+	}
+
+	// 4. All batches completed.
+	if err := e.store.UpdateBatchJobStatus(ctx, job.ID, BatchJobStatusCompleted); err != nil {
+		return fmt.Errorf("executor: set job completed: %w", err)
+	}
+	job.Status = BatchJobStatusCompleted
+	e.logger.Info("Batch job completed", "job_id", logging.SanitizeLogValue(job.ID))
+	return nil
+}
+
+type stewardDispatchResult struct {
+	stewardID string
+	success   bool
+}
+
+// dispatchBatch sends CommandSyncConfig to each steward in batch and waits for all
+// callbacks (success, failure, or timeout). Returns the IDs of failed stewards.
+func (e *RollingBatchExecutor) dispatchBatch(ctx context.Context, batch []string) ([]string, error) {
+	ch := make(chan stewardDispatchResult, len(batch))
+
+	for _, id := range batch {
+		id := id
+		_, publishErr := e.publisher.PublishCommandWithCallback(
+			ctx, id,
+			controlplaneTypes.CommandSyncConfig, nil,
+			batchStepTimeout,
+			func(event *controlplaneTypes.Event) {
+				success := event.Type == controlplaneTypes.EventCommandCompleted
+				ch <- stewardDispatchResult{id, success}
+			},
+			func() {
+				e.logger.Warn("Batch dispatch timed out for steward",
+					"steward_id", logging.SanitizeLogValue(id))
+				ch <- stewardDispatchResult{id, false}
+			},
+		)
+		if publishErr != nil {
+			e.logger.Error("Failed to dispatch to steward",
+				"steward_id", logging.SanitizeLogValue(id), "error", publishErr)
+			ch <- stewardDispatchResult{id, false}
+		}
+	}
+
+	var failedIDs []string
+	for range batch {
+		select {
+		case r := <-ch:
+			if !r.success {
+				failedIDs = append(failedIDs, r.stewardID)
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return failedIDs, nil
+}
+
+// naivePartition splits ids into consecutive slices of at most batchSize each.
+func naivePartition(ids []string, batchSize int) [][]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	if batchSize <= 0 {
+		batchSize = len(ids)
+	}
+	var batches [][]string
+	for len(ids) > 0 {
+		size := batchSize
+		if size > len(ids) {
+			size = len(ids)
+		}
+		batches = append(batches, ids[:size])
+		ids = ids[size:]
+	}
+	return batches
+}

--- a/features/controller/batchjob/executor_test.go
+++ b/features/controller/batchjob/executor_test.go
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package batchjob_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	cpinterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// ----------------------------------------------------------------------------
+// Test control plane — real ControlPlaneProvider implementation, no mocks.
+// ----------------------------------------------------------------------------
+
+var _ cpinterfaces.ControlPlaneProvider = (*executorTestCP)(nil)
+
+// executorTestCP records sent commands and allows tests to inject completion events.
+type executorTestCP struct {
+	mu           sync.Mutex
+	sent         []*controlplaneTypes.SignedCommand
+	sentByID     map[string]*controlplaneTypes.SignedCommand
+	eventHandler cpinterfaces.EventHandler
+}
+
+func newExecutorTestCP() *executorTestCP {
+	return &executorTestCP{sentByID: make(map[string]*controlplaneTypes.SignedCommand)}
+}
+
+func (p *executorTestCP) Name() string      { return "executor-test" }
+func (p *executorTestCP) IsConnected() bool { return true }
+func (p *executorTestCP) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (p *executorTestCP) Start(_ context.Context) error     { return nil }
+func (p *executorTestCP) Stop(_ context.Context) error      { return nil }
+func (p *executorTestCP) Reconnect(_ context.Context) error { return nil }
+func (p *executorTestCP) FanOutCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand, ids []string) (*controlplaneTypes.FanOutResult, error) {
+	return &controlplaneTypes.FanOutResult{Succeeded: ids, Failed: map[string]error{}}, nil
+}
+func (p *executorTestCP) SubscribeCommands(_ context.Context, _ string, _ cpinterfaces.CommandHandler) error {
+	return nil
+}
+func (p *executorTestCP) PublishEvent(_ context.Context, _ *controlplaneTypes.Event) error {
+	return nil
+}
+func (p *executorTestCP) SendHeartbeat(_ context.Context, _ *controlplaneTypes.Heartbeat) error {
+	return nil
+}
+func (p *executorTestCP) SubscribeHeartbeats(_ context.Context, _ cpinterfaces.HeartbeatHandler) error {
+	return nil
+}
+func (p *executorTestCP) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
+	return &controlplaneTypes.ControlPlaneStats{}, nil
+}
+func (p *executorTestCP) SendCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	p.mu.Lock()
+	p.sent = append(p.sent, cmd)
+	p.sentByID[cmd.Command.ID] = cmd
+	p.mu.Unlock()
+	return nil
+}
+func (p *executorTestCP) SubscribeEvents(_ context.Context, _ *controlplaneTypes.EventFilter, handler cpinterfaces.EventHandler) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.eventHandler = handler
+	return nil
+}
+
+func (p *executorTestCP) injectCommandCompleted(ctx context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	p.mu.Lock()
+	h := p.eventHandler
+	p.mu.Unlock()
+	if h == nil {
+		return nil
+	}
+	return h(ctx, &controlplaneTypes.Event{
+		ID:        "evt-" + cmd.Command.ID,
+		Type:      controlplaneTypes.EventCommandCompleted,
+		StewardID: cmd.Command.StewardID,
+		CommandID: cmd.Command.ID,
+		Timestamp: time.Now(),
+	})
+}
+
+func (p *executorTestCP) injectCommandFailed(ctx context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	p.mu.Lock()
+	h := p.eventHandler
+	p.mu.Unlock()
+	if h == nil {
+		return nil
+	}
+	return h(ctx, &controlplaneTypes.Event{
+		ID:        "fail-" + cmd.Command.ID,
+		Type:      controlplaneTypes.EventCommandFailed,
+		StewardID: cmd.Command.StewardID,
+		CommandID: cmd.Command.ID,
+		Timestamp: time.Now(),
+	})
+}
+
+func (p *executorTestCP) getByID(cmdID string) *controlplaneTypes.SignedCommand {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.sentByID[cmdID]
+}
+
+func (p *executorTestCP) sentCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.sent)
+}
+
+// ----------------------------------------------------------------------------
+// Fleet adapter — bridges fleet.FleetQuery to batchjob.FleetQuery.
+// The import from fleet is only in this test file; executor.go avoids it to
+// prevent the cycle: batchjob → fleet → business → batchjob.
+// ----------------------------------------------------------------------------
+
+type fleetQueryAdapter struct {
+	q fleet.FleetQuery
+}
+
+func (a *fleetQueryAdapter) Search(ctx context.Context, selector, tenantID string) ([]string, error) {
+	filter, err := fleet.ParseTargetSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+	filter.TenantID = tenantID
+	results, err := a.q.Search(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids, nil
+}
+
+type staticFleetProvider struct {
+	stewards []fleet.StewardData
+}
+
+func (p *staticFleetProvider) GetAllStewards() []fleet.StewardData { return p.stewards }
+
+func makeStewards(ids ...string) []fleet.StewardData {
+	out := make([]fleet.StewardData, len(ids))
+	for i, id := range ids {
+		out[i] = fleet.StewardData{
+			ID:            id,
+			TenantID:      "tenant-1",
+			Status:        "online",
+			LastHeartbeat: time.Now(),
+		}
+	}
+	return out
+}
+
+func newTestFleetQuery(ids ...string) batchjob.FleetQuery {
+	return &fleetQueryAdapter{
+		q: fleet.NewMemoryQuery(&staticFleetProvider{stewards: makeStewards(ids...)}),
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Completion driver — polls publisher pending commands and injects events.
+// Using GetPendingCommands() instead of a cmdCh avoids the race where the
+// event is injected before PublishCommandWithCallback registers the pending entry.
+// ----------------------------------------------------------------------------
+
+// completionDriver polls a Publisher for pending commands and injects completion
+// events. shouldFail(stewardID) controls whether each steward succeeds or fails.
+type completionDriver struct {
+	t          testing.TB
+	cp         *executorTestCP
+	publisher  *commands.Publisher
+	shouldFail func(stewardID string) bool
+	cancel     context.CancelFunc
+	done       chan struct{}
+}
+
+func newCompletionDriver(t testing.TB, cp *executorTestCP, pub *commands.Publisher, shouldFail func(string) bool) *completionDriver {
+	t.Helper()
+	return &completionDriver{
+		t:          t,
+		cp:         cp,
+		publisher:  pub,
+		shouldFail: shouldFail,
+		done:       make(chan struct{}),
+	}
+}
+
+// start begins the polling loop in a goroutine. Call stop() when done.
+func (d *completionDriver) start(parentCtx context.Context) {
+	ctx, cancel := context.WithCancel(parentCtx)
+	d.cancel = cancel
+	go func() {
+		defer close(d.done)
+		defer cancel()
+		completed := make(map[string]bool)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Millisecond):
+			}
+			for _, cmdID := range d.publisher.GetPendingCommands() {
+				if completed[cmdID] {
+					continue
+				}
+				cmd := d.cp.getByID(cmdID)
+				if cmd == nil {
+					continue
+				}
+				completed[cmdID] = true
+				var injectErr error
+				if d.shouldFail(cmd.Command.StewardID) {
+					injectErr = d.cp.injectCommandFailed(ctx, cmd)
+				} else {
+					injectErr = d.cp.injectCommandCompleted(ctx, cmd)
+				}
+				if injectErr != nil {
+					d.t.Logf("completionDriver: inject event for %s: %v", cmdID, injectErr)
+				}
+			}
+		}
+	}()
+}
+
+func (d *completionDriver) stop() {
+	d.cancel()
+	<-d.done
+}
+
+// ----------------------------------------------------------------------------
+// Shared test setup.
+// ----------------------------------------------------------------------------
+
+type executorFixture struct {
+	cp        *executorTestCP
+	store     *memory.BatchJobStore
+	publisher *commands.Publisher
+	executor  *batchjob.RollingBatchExecutor
+	ctx       context.Context
+	cancel    context.CancelFunc
+}
+
+func newExecutorFixture(t *testing.T, stewardIDs ...string) *executorFixture {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
+	cp := newExecutorTestCP()
+	logger := pkgtesting.NewMockLogger(true)
+
+	pub, err := commands.New(&commands.Config{
+		ControlPlane: cp,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+	require.NoError(t, pub.Start(ctx))
+
+	store := memory.NewBatchJobStore()
+	require.NoError(t, store.Initialize(ctx))
+
+	exec := batchjob.NewRollingBatchExecutor(
+		store,
+		newTestFleetQuery(stewardIDs...),
+		pub,
+		nil, // no quorum checker
+		logger,
+	)
+
+	return &executorFixture{
+		cp:        cp,
+		store:     store,
+		publisher: pub,
+		executor:  exec,
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+}
+
+func (f *executorFixture) cleanup() { f.cancel() }
+
+// driveAllSucceed starts a completion driver that succeeds all stewards.
+func (f *executorFixture) driveAllSucceed(t testing.TB) *completionDriver {
+	t.Helper()
+	d := newCompletionDriver(t, f.cp, f.publisher, func(_ string) bool { return false })
+	d.start(f.ctx)
+	return d
+}
+
+// driveFirstFails starts a driver that fails the first unique steward it sees
+// and succeeds the rest.
+func (f *executorFixture) driveFirstFails(t testing.TB) *completionDriver {
+	t.Helper()
+	var mu sync.Mutex
+	failedOne := false
+	d := newCompletionDriver(t, f.cp, f.publisher, func(stewardID string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		if !failedOne {
+			failedOne = true
+			return true
+		}
+		return false
+	})
+	d.start(f.ctx)
+	return d
+}
+
+func newPendingJob(id string, batchSize int) *batchjob.BatchJob {
+	now := time.Now().UTC()
+	return &batchjob.BatchJob{
+		ID:          id,
+		TenantID:    "tenant-1",
+		Selector:    "all",
+		Config:      batchjob.BatchJobConfig{BatchSize: batchSize},
+		Status:      batchjob.BatchJobStatusPending,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		InitiatedBy: "test-operator",
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests.
+// ----------------------------------------------------------------------------
+
+// TestRollingBatchExecutor_SequentialBatches is the REQUIRED test:
+// 4 stewards, BatchSize=2 → batch 0 timestamps must precede batch 1 timestamps.
+func TestRollingBatchExecutor_SequentialBatches(t *testing.T) {
+	f := newExecutorFixture(t, "s-0", "s-1", "s-2", "s-3")
+	defer f.cleanup()
+
+	job := newPendingJob("job-seq", 2)
+	require.NoError(t, f.store.CreateBatchJob(f.ctx, job))
+
+	d := f.driveAllSucceed(t)
+	defer d.stop()
+
+	require.NoError(t, f.executor.Execute(f.ctx, job))
+
+	got, err := f.store.GetBatchJob(f.ctx, "job-seq")
+	require.NoError(t, err)
+	assert.Equal(t, batchjob.BatchJobStatusCompleted, got.Status)
+	require.Len(t, got.Steps, 2, "4 stewards / batch 2 = 2 steps")
+
+	// [REQUIRED]: batch 0 timestamps precede batch 1 timestamps (no parallel dispatch).
+	s0 := got.Steps[0]
+	s1 := got.Steps[1]
+	require.NotNil(t, s0.StartedAt, "step 0 must have StartedAt")
+	require.NotNil(t, s0.CompletedAt, "step 0 must have CompletedAt")
+	require.NotNil(t, s1.StartedAt, "step 1 must have StartedAt")
+
+	assert.False(t, s0.StartedAt.After(*s1.StartedAt),
+		"step 0 StartedAt must not be after step 1 StartedAt")
+	assert.False(t, s0.CompletedAt.After(*s1.StartedAt),
+		"step 0 CompletedAt must not be after step 1 StartedAt — batches must be sequential")
+
+	// Exactly 4 commands must have been sent (2 per batch).
+	assert.Equal(t, 4, f.cp.sentCount())
+}
+
+// TestRollingBatchExecutor_FailurePausesBatchZero is the REQUIRED test:
+// injected failure on one steward in batch 0 → job paused, batch 1 never dispatched.
+func TestRollingBatchExecutor_FailurePausesBatchZero(t *testing.T) {
+	f := newExecutorFixture(t, "s-0", "s-1", "s-2", "s-3")
+	defer f.cleanup()
+
+	job := newPendingJob("job-fail", 2)
+	require.NoError(t, f.store.CreateBatchJob(f.ctx, job))
+
+	d := f.driveFirstFails(t)
+	defer d.stop()
+
+	require.NoError(t, f.executor.Execute(f.ctx, job))
+
+	got, err := f.store.GetBatchJob(f.ctx, "job-fail")
+	require.NoError(t, err)
+
+	// [REQUIRED]: job must be paused after batch 0 failure.
+	assert.Equal(t, batchjob.BatchJobStatusPaused, got.Status,
+		"job must be paused when a steward in batch 0 fails")
+
+	// [REQUIRED]: only 2 commands sent (batch 0 only), none to batch 1 stewards.
+	assert.Equal(t, 2, f.cp.sentCount(),
+		"no CommandSyncConfig must be sent to batch 1 stewards")
+
+	// Step 0 must be failed with the failing steward recorded.
+	require.Len(t, got.Steps, 1, "only step 0 should be persisted")
+	assert.Equal(t, batchjob.BatchStepStatusFailed, got.Steps[0].Status)
+	assert.NotEmpty(t, got.Steps[0].FailedIDs, "failed IDs must be recorded")
+}
+
+// TestRollingBatchExecutor_AllCompleted validates end-to-end completion
+// with a single batch of 3 stewards.
+func TestRollingBatchExecutor_AllCompleted(t *testing.T) {
+	f := newExecutorFixture(t, "s-0", "s-1", "s-2")
+	defer f.cleanup()
+
+	job := newPendingJob("job-all", 10) // batch size > steward count → single batch
+	require.NoError(t, f.store.CreateBatchJob(f.ctx, job))
+
+	d := f.driveAllSucceed(t)
+	defer d.stop()
+
+	require.NoError(t, f.executor.Execute(f.ctx, job))
+
+	got, err := f.store.GetBatchJob(f.ctx, "job-all")
+	require.NoError(t, err)
+	assert.Equal(t, batchjob.BatchJobStatusCompleted, got.Status)
+	require.Len(t, got.Steps, 1)
+	assert.Equal(t, batchjob.BatchStepStatusCompleted, got.Steps[0].Status)
+	assert.Len(t, got.Steps[0].StewardIDs, 3)
+}
+
+// TestRollingBatchExecutor_TargetsPersisted verifies that Execute resolves and
+// persists the fleet selector's resolved steward IDs in job.Targets.
+func TestRollingBatchExecutor_TargetsPersisted(t *testing.T) {
+	f := newExecutorFixture(t, "s-a", "s-b", "s-c")
+	defer f.cleanup()
+
+	job := newPendingJob("job-targets", 10)
+	require.NoError(t, f.store.CreateBatchJob(f.ctx, job))
+
+	d := f.driveAllSucceed(t)
+	defer d.stop()
+
+	require.NoError(t, f.executor.Execute(f.ctx, job))
+
+	got, err := f.store.GetBatchJob(f.ctx, "job-targets")
+	require.NoError(t, err)
+	assert.Len(t, got.Targets, 3, "resolved targets must be persisted")
+}
+
+// TestRollingBatchExecutor_ContextCancellation verifies that Execute returns
+// ctx.Err() when the context is cancelled while waiting for batch completion.
+func TestRollingBatchExecutor_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cp := newExecutorTestCP()
+	logger := pkgtesting.NewMockLogger(true)
+	pub, err := commands.New(&commands.Config{ControlPlane: cp, Logger: logger})
+	require.NoError(t, err)
+	require.NoError(t, pub.Start(ctx))
+
+	store := memory.NewBatchJobStore()
+	require.NoError(t, store.Initialize(ctx))
+
+	exec := batchjob.NewRollingBatchExecutor(
+		store,
+		newTestFleetQuery("s-0"),
+		pub,
+		nil,
+		logger,
+	)
+
+	job := newPendingJob("job-cancel", 10)
+	require.NoError(t, store.CreateBatchJob(ctx, job))
+
+	// Run Execute in a goroutine (no driver — commands never complete).
+	errCh := make(chan error, 1)
+	go func() { errCh <- exec.Execute(ctx, job) }()
+
+	// Cancel once the first command is dispatched so Execute is blocked in dispatchBatch.
+	require.Eventually(t, func() bool { return cp.sentCount() > 0 }, 5*time.Second, time.Millisecond,
+		"command must be dispatched before cancellation")
+	cancel()
+
+	select {
+	case execErr := <-errCh:
+		require.ErrorIs(t, execErr, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return after context cancellation")
+	}
+}

--- a/features/controller/batchjob/store.go
+++ b/features/controller/batchjob/store.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package batchjob
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrBatchJobNotFound is returned when a batch job record does not exist.
+// Defined here (not in pkg/storage/interfaces/business) so that storage
+// implementations in this package can reference it without an import cycle:
+//
+//	batchjob → business → batchjob
+//
+// pkg/storage/interfaces/business re-exports this value so all callers that
+// already import business continue to work unchanged.
+var ErrBatchJobNotFound = errors.New("batch job not found")
+
+// BatchJobStore defines the storage interface for fleet rolling-batch job persistence.
+//
+// Defined here so executor.go and store_sqlite.go can reference it from within the
+// batchjob package, avoiding the import cycle that would arise if they depended on
+// pkg/storage/interfaces/business (which itself imports this package for the domain types).
+//
+// pkg/storage/interfaces/business re-exports this interface as a type alias so all
+// existing callers continue to compile without changes.
+//
+// All implementations must be safe for concurrent use.
+type BatchJobStore interface {
+	// CreateBatchJob inserts a new batch job record.
+	// Returns an error if a record with the same ID already exists.
+	CreateBatchJob(ctx context.Context, job *BatchJob) error
+
+	// UpdateBatchJobStatus sets the top-level status of an existing batch job.
+	// Returns ErrBatchJobNotFound if no record exists for the given id.
+	UpdateBatchJobStatus(ctx context.Context, id string, status BatchJobStatus) error
+
+	// UpdateBatchTargets replaces the resolved target steward IDs for the job.
+	// Called by the executor after fleet selector resolution at job start.
+	// Returns ErrBatchJobNotFound if the job does not exist.
+	UpdateBatchTargets(ctx context.Context, id string, targets []string) error
+
+	// UpdateBatchStep upserts a step within the batch job identified by jobID.
+	// If a step with the same Index already exists it is replaced; otherwise the
+	// step is appended. Returns ErrBatchJobNotFound if the job does not exist.
+	UpdateBatchStep(ctx context.Context, jobID string, step BatchStep) error
+
+	// GetBatchJob retrieves the batch job with the given id.
+	// Returns ErrBatchJobNotFound if no record exists.
+	GetBatchJob(ctx context.Context, id string) (*BatchJob, error)
+
+	// ListBatchJobsByTenant returns all batch jobs belonging to tenantID.
+	// Returns an empty slice (not an error) when no records exist.
+	ListBatchJobsByTenant(ctx context.Context, tenantID string) ([]*BatchJob, error)
+
+	// HealthCheck verifies the store is reachable and operational.
+	HealthCheck(ctx context.Context) error
+
+	// Initialize prepares the store (creates directories, tables, schemas, etc.).
+	Initialize(ctx context.Context) error
+
+	// Close releases resources held by the store.
+	Close() error
+}

--- a/features/controller/batchjob/store_sqlite.go
+++ b/features/controller/batchjob/store_sqlite.go
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package batchjob
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// SQLiteBatchJobStore is the SQLite-backed implementation of BatchJobStore.
+// Call Initialize before any other method — it creates tables idempotently.
+type SQLiteBatchJobStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteBatchJobStoreFromDSN opens a SQLite database at dsn and returns a
+// SQLiteBatchJobStore backed by it. The caller must call Initialize and Close.
+func NewSQLiteBatchJobStoreFromDSN(dsn string) (*SQLiteBatchJobStore, error) {
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("batch job store: open sqlite %s: %w", dsn, err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("batch job store: set busy_timeout: %w", err)
+	}
+	return &SQLiteBatchJobStore{db: db}, nil
+}
+
+// NewSQLiteBatchJobStore creates a SQLiteBatchJobStore that uses an existing db connection.
+// The caller must call Initialize and is responsible for closing db.
+func NewSQLiteBatchJobStore(db *sql.DB) *SQLiteBatchJobStore {
+	return &SQLiteBatchJobStore{db: db}
+}
+
+// Initialize creates the batch_jobs and batch_steps tables if they do not already exist.
+// Safe to call multiple times (idempotent).
+func (s *SQLiteBatchJobStore) Initialize(_ context.Context) error {
+	const createJobs = `
+CREATE TABLE IF NOT EXISTS batch_jobs (
+    id              TEXT NOT NULL PRIMARY KEY,
+    tenant_id       TEXT NOT NULL,
+    selector        TEXT NOT NULL,
+    config_json     TEXT NOT NULL,
+    targets_json    TEXT NOT NULL DEFAULT '[]',
+    status          TEXT NOT NULL,
+    created_at      DATETIME NOT NULL,
+    updated_at      DATETIME NOT NULL,
+    initiated_by    TEXT
+);`
+
+	const createSteps = `
+CREATE TABLE IF NOT EXISTS batch_steps (
+    job_id           TEXT NOT NULL,
+    step_index       INTEGER NOT NULL,
+    status           TEXT NOT NULL,
+    steward_ids_json TEXT NOT NULL DEFAULT '[]',
+    started_at       DATETIME,
+    completed_at     DATETIME,
+    failed_ids_json  TEXT NOT NULL DEFAULT '[]',
+    rollback_job_id  TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (job_id, step_index)
+);`
+
+	const createStepsIndex = `
+CREATE INDEX IF NOT EXISTS idx_batch_steps_job_id ON batch_steps(job_id);`
+
+	for _, stmt := range []string{createJobs, createSteps, createStepsIndex} {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return fmt.Errorf("batch job store init: %w", err)
+		}
+	}
+	return nil
+}
+
+// CreateBatchJob inserts a new batch job. Returns an error if the ID already exists.
+func (s *SQLiteBatchJobStore) CreateBatchJob(_ context.Context, job *BatchJob) error {
+	configJSON, err := json.Marshal(job.Config)
+	if err != nil {
+		return fmt.Errorf("batch job store create: marshal config: %w", err)
+	}
+	targetsJSON, err := json.Marshal(job.Targets)
+	if err != nil {
+		return fmt.Errorf("batch job store create: marshal targets: %w", err)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("batch job store create: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const q = `
+INSERT INTO batch_jobs
+    (id, tenant_id, selector, config_json, targets_json, status, created_at, updated_at, initiated_by)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err = tx.Exec(q,
+		job.ID, job.TenantID, job.Selector,
+		string(configJSON), string(targetsJSON),
+		string(job.Status),
+		job.CreatedAt.UTC(), job.UpdatedAt.UTC(),
+		nullableStr(job.InitiatedBy),
+	)
+	if err != nil {
+		return fmt.Errorf("batch job store create: insert job: %w", err)
+	}
+
+	for _, step := range job.Steps {
+		if err := insertStep(tx, job.ID, step); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("batch job store create: commit: %w", err)
+	}
+	return nil
+}
+
+// UpdateBatchJobStatus sets the top-level status and updated_at for the job.
+func (s *SQLiteBatchJobStore) UpdateBatchJobStatus(_ context.Context, id string, status BatchJobStatus) error {
+	const q = `UPDATE batch_jobs SET status = ?, updated_at = ? WHERE id = ?`
+	res, err := s.db.Exec(q, string(status), time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("batch job store update status: %w", err)
+	}
+	return requireOneRow(res, "update status", id)
+}
+
+// UpdateBatchTargets replaces the resolved target steward IDs for the job.
+func (s *SQLiteBatchJobStore) UpdateBatchTargets(_ context.Context, id string, targets []string) error {
+	if targets == nil {
+		targets = []string{}
+	}
+	targetsJSON, err := json.Marshal(targets)
+	if err != nil {
+		return fmt.Errorf("batch job store update targets: marshal: %w", err)
+	}
+	const q = `UPDATE batch_jobs SET targets_json = ?, updated_at = ? WHERE id = ?`
+	res, err := s.db.Exec(q, string(targetsJSON), time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("batch job store update targets: %w", err)
+	}
+	return requireOneRow(res, "update targets", id)
+}
+
+// UpdateBatchStep upserts a step within the batch job identified by jobID.
+func (s *SQLiteBatchJobStore) UpdateBatchStep(_ context.Context, jobID string, step BatchStep) error {
+	var exists int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM batch_jobs WHERE id = ?`, jobID,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("batch job store update step: check job: %w", err)
+	}
+	if exists == 0 {
+		return ErrBatchJobNotFound
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("batch job store update step: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(
+		`DELETE FROM batch_steps WHERE job_id = ? AND step_index = ?`,
+		jobID, step.Index,
+	); err != nil {
+		return fmt.Errorf("batch job store update step: delete old: %w", err)
+	}
+	if err := insertStep(tx, jobID, step); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`UPDATE batch_jobs SET updated_at = ? WHERE id = ?`,
+		time.Now().UTC(), jobID,
+	); err != nil {
+		return fmt.Errorf("batch job store update step: update job timestamp: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("batch job store update step: commit: %w", err)
+	}
+	return nil
+}
+
+// GetBatchJob retrieves the batch job with the given id, including all its steps.
+func (s *SQLiteBatchJobStore) GetBatchJob(_ context.Context, id string) (*BatchJob, error) {
+	const q = `
+SELECT id, tenant_id, selector, config_json, targets_json, status,
+       created_at, updated_at, initiated_by
+FROM batch_jobs WHERE id = ?`
+
+	row := s.db.QueryRow(q, id)
+	job, err := scanJob(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrBatchJobNotFound
+		}
+		return nil, fmt.Errorf("batch job store get: %w", err)
+	}
+
+	steps, err := s.loadSteps(id)
+	if err != nil {
+		return nil, err
+	}
+	job.Steps = steps
+	return job, nil
+}
+
+// ListBatchJobsByTenant returns all batch jobs belonging to tenantID including steps.
+func (s *SQLiteBatchJobStore) ListBatchJobsByTenant(_ context.Context, tenantID string) ([]*BatchJob, error) {
+	const q = `
+SELECT id, tenant_id, selector, config_json, targets_json, status,
+       created_at, updated_at, initiated_by
+FROM batch_jobs WHERE tenant_id = ?
+ORDER BY created_at ASC`
+
+	rows, err := s.db.Query(q, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("batch job store list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var jobs []*BatchJob
+	for rows.Next() {
+		job, err := scanJob(rows)
+		if err != nil {
+			return nil, fmt.Errorf("batch job store list scan: %w", err)
+		}
+		steps, err := s.loadSteps(job.ID)
+		if err != nil {
+			return nil, err
+		}
+		job.Steps = steps
+		jobs = append(jobs, job)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("batch job store list rows: %w", err)
+	}
+	if jobs == nil {
+		jobs = []*BatchJob{}
+	}
+	return jobs, nil
+}
+
+// HealthCheck verifies the store is reachable.
+func (s *SQLiteBatchJobStore) HealthCheck(_ context.Context) error {
+	if err := s.db.Ping(); err != nil {
+		return fmt.Errorf("batch job store health check: %w", err)
+	}
+	return nil
+}
+
+// Close releases the underlying database connection.
+func (s *SQLiteBatchJobStore) Close() error {
+	return s.db.Close()
+}
+
+var _ BatchJobStore = (*SQLiteBatchJobStore)(nil)
+
+// --- helpers ---
+
+// scanner is the common interface for sql.Row and sql.Rows.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanJob(s scanner) (*BatchJob, error) {
+	var (
+		configJSON  string
+		targetsJSON string
+		initiatedBy sql.NullString
+		createdAt   time.Time
+		updatedAt   time.Time
+	)
+	job := &BatchJob{}
+	err := s.Scan(
+		&job.ID, &job.TenantID, &job.Selector,
+		&configJSON, &targetsJSON,
+		(*string)(&job.Status),
+		&createdAt, &updatedAt,
+		&initiatedBy,
+	)
+	if err != nil {
+		return nil, err
+	}
+	job.CreatedAt = createdAt.UTC()
+	job.UpdatedAt = updatedAt.UTC()
+	job.InitiatedBy = initiatedBy.String
+
+	if err := json.Unmarshal([]byte(configJSON), &job.Config); err != nil {
+		return nil, fmt.Errorf("scan job: unmarshal config: %w", err)
+	}
+	if targetsJSON != "" {
+		if err := json.Unmarshal([]byte(targetsJSON), &job.Targets); err != nil {
+			return nil, fmt.Errorf("scan job: unmarshal targets: %w", err)
+		}
+	}
+	if job.Targets == nil {
+		job.Targets = []string{}
+	}
+	return job, nil
+}
+
+func (s *SQLiteBatchJobStore) loadSteps(jobID string) ([]BatchStep, error) {
+	const q = `
+SELECT step_index, status, steward_ids_json, started_at, completed_at, failed_ids_json, rollback_job_id
+FROM batch_steps WHERE job_id = ?
+ORDER BY step_index ASC`
+
+	rows, err := s.db.Query(q, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("batch job store load steps: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var steps []BatchStep
+	for rows.Next() {
+		var (
+			stewardIDsJSON string
+			failedIDsJSON  string
+			rollbackJobID  string
+			startedAt      sql.NullTime
+			completedAt    sql.NullTime
+		)
+		step := BatchStep{}
+		if err := rows.Scan(
+			&step.Index,
+			(*string)(&step.Status),
+			&stewardIDsJSON,
+			&startedAt, &completedAt,
+			&failedIDsJSON, &rollbackJobID,
+		); err != nil {
+			return nil, fmt.Errorf("batch job store scan step: %w", err)
+		}
+		if stewardIDsJSON != "" {
+			if err := json.Unmarshal([]byte(stewardIDsJSON), &step.StewardIDs); err != nil {
+				return nil, fmt.Errorf("batch job store scan step steward_ids: %w", err)
+			}
+		}
+		if failedIDsJSON != "" {
+			if err := json.Unmarshal([]byte(failedIDsJSON), &step.FailedIDs); err != nil {
+				return nil, fmt.Errorf("batch job store scan step failed_ids: %w", err)
+			}
+		}
+		step.RollbackJobID = rollbackJobID
+		if startedAt.Valid {
+			t := startedAt.Time.UTC()
+			step.StartedAt = &t
+		}
+		if completedAt.Valid {
+			t := completedAt.Time.UTC()
+			step.CompletedAt = &t
+		}
+		if step.StewardIDs == nil {
+			step.StewardIDs = []string{}
+		}
+		if step.FailedIDs == nil {
+			step.FailedIDs = []string{}
+		}
+		steps = append(steps, step)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("batch job store steps rows: %w", err)
+	}
+	return steps, nil
+}
+
+// txer is the common interface for sql.DB and sql.Tx for Exec.
+type txer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+func insertStep(tx txer, jobID string, step BatchStep) error {
+	stewardIDs := step.StewardIDs
+	if stewardIDs == nil {
+		stewardIDs = []string{}
+	}
+	failedIDs := step.FailedIDs
+	if failedIDs == nil {
+		failedIDs = []string{}
+	}
+	stewardIDsJSON, err := json.Marshal(stewardIDs)
+	if err != nil {
+		return fmt.Errorf("batch job store insert step: marshal steward_ids: %w", err)
+	}
+	failedIDsJSON, err := json.Marshal(failedIDs)
+	if err != nil {
+		return fmt.Errorf("batch job store insert step: marshal failed_ids: %w", err)
+	}
+
+	var startedAt, completedAt interface{}
+	if step.StartedAt != nil {
+		startedAt = step.StartedAt.UTC()
+	}
+	if step.CompletedAt != nil {
+		completedAt = step.CompletedAt.UTC()
+	}
+
+	const q = `
+INSERT INTO batch_steps
+    (job_id, step_index, status, steward_ids_json, started_at, completed_at, failed_ids_json, rollback_job_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err = tx.Exec(q,
+		jobID, step.Index, string(step.Status),
+		string(stewardIDsJSON),
+		startedAt, completedAt,
+		string(failedIDsJSON),
+		step.RollbackJobID,
+	)
+	if err != nil {
+		return fmt.Errorf("batch job store insert step: %w", err)
+	}
+	return nil
+}
+
+func requireOneRow(res sql.Result, op, id string) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("batch job store %s %q: rows affected: %w", op, id, err)
+	}
+	if n == 0 {
+		return ErrBatchJobNotFound
+	}
+	return nil
+}
+
+func nullableStr(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/features/controller/batchjob/store_sqlite_test.go
+++ b/features/controller/batchjob/store_sqlite_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package batchjob_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+func openTestSQLiteStore(t *testing.T) *batchjob.SQLiteBatchJobStore {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "batch_jobs.db")
+	store, err := batchjob.NewSQLiteBatchJobStoreFromDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestSQLiteBatchJobStore_Contract validates that SQLiteBatchJobStore satisfies the
+// full BatchJobStore interface contract defined in pkg/storage/interfaces/business.
+// Run with -race to verify concurrent-access safety.
+func TestSQLiteBatchJobStore_Contract(t *testing.T) {
+	store := openTestSQLiteStore(t)
+	// business.BatchJobStoreContract calls Initialize and Close internally.
+	business.BatchJobStoreContract(t, store)
+}
+
+// TestSQLiteBatchJobStore_ReopenPersists verifies that data written in one
+// SQLiteBatchJobStore instance is visible after reopening the same file.
+func TestSQLiteBatchJobStore_ReopenPersists(t *testing.T) {
+	dir := t.TempDir()
+	dsn := filepath.Join(dir, "batch_jobs.db")
+
+	// First connection: create and populate a job.
+	{
+		store, err := batchjob.NewSQLiteBatchJobStoreFromDSN(dsn)
+		require.NoError(t, err)
+		ctx := t.Context()
+		require.NoError(t, store.Initialize(ctx))
+		job := &batchjob.BatchJob{
+			ID:       "persist-job-1",
+			TenantID: "t-1",
+			Selector: "all",
+			Config:   batchjob.BatchJobConfig{BatchSize: 2},
+			Targets:  []string{"s-1"},
+			Status:   batchjob.BatchJobStatusPending,
+		}
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+		require.NoError(t, store.Close())
+	}
+
+	// Second connection: data must still be there.
+	{
+		store, err := batchjob.NewSQLiteBatchJobStoreFromDSN(dsn)
+		require.NoError(t, err)
+		ctx := t.Context()
+		require.NoError(t, store.Initialize(ctx))
+		got, err := store.GetBatchJob(ctx, "persist-job-1")
+		require.NoError(t, err)
+		require.Equal(t, batchjob.BatchJobStatusPending, got.Status)
+		require.Equal(t, []string{"s-1"}, got.Targets)
+		require.NoError(t, store.Close())
+	}
+}

--- a/pkg/storage/interfaces/business/batch_job_store.go
+++ b/pkg/storage/interfaces/business/batch_job_store.go
@@ -1,52 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// Package business defines the BatchJobStore interface for durable batch-job persistence.
+// Package business defines storage interfaces for the controller business tier.
 package business
 
 import (
-	"context"
-	"errors"
-
 	"github.com/cfgis/cfgms/features/controller/batchjob"
 )
 
 // ErrBatchJobNotFound is returned when a batch job record does not exist.
-var ErrBatchJobNotFound = errors.New("batch job not found")
+// Re-exported from the batchjob package so callers that already import business
+// continue to work unchanged.
+var ErrBatchJobNotFound = batchjob.ErrBatchJobNotFound
 
 // BatchJobStore defines the storage interface for fleet rolling-batch job persistence.
+// Re-exported from the batchjob package as a type alias to break the import cycle:
+//
+//	batchjob (executor/store) → business → batchjob
+//
+// Because it is a type alias (=) callers that declare variables as business.BatchJobStore
+// or pass implementations to functions accepting batchjob.BatchJobStore interchangeably
+// continue to compile and behave identically.
 //
 // All implementations must be safe for concurrent use.
-// The interface is used by the batch executor, REST API, quorum-check logic,
-// and rollback dispatch — none of which may import each other, so all depend
-// on this package and features/controller/batchjob for shared types.
-type BatchJobStore interface {
-	// CreateBatchJob inserts a new batch job record.
-	// Returns an error if a record with the same ID already exists.
-	CreateBatchJob(ctx context.Context, job *batchjob.BatchJob) error
-
-	// UpdateBatchJobStatus sets the top-level status of an existing batch job.
-	// Returns ErrBatchJobNotFound if no record exists for the given id.
-	UpdateBatchJobStatus(ctx context.Context, id string, status batchjob.BatchJobStatus) error
-
-	// UpdateBatchStep upserts a step within the batch job identified by jobID.
-	// If a step with the same Index already exists it is replaced; otherwise the
-	// step is appended. Returns ErrBatchJobNotFound if the job does not exist.
-	UpdateBatchStep(ctx context.Context, jobID string, step batchjob.BatchStep) error
-
-	// GetBatchJob retrieves the batch job with the given id.
-	// Returns ErrBatchJobNotFound if no record exists.
-	GetBatchJob(ctx context.Context, id string) (*batchjob.BatchJob, error)
-
-	// ListBatchJobsByTenant returns all batch jobs belonging to tenantID.
-	// Returns an empty slice (not an error) when no records exist.
-	ListBatchJobsByTenant(ctx context.Context, tenantID string) ([]*batchjob.BatchJob, error)
-
-	// HealthCheck verifies the store is reachable and operational.
-	HealthCheck(ctx context.Context) error
-
-	// Initialize prepares the store (creates directories, tables, schemas, etc.).
-	Initialize(ctx context.Context) error
-
-	// Close releases resources held by the store.
-	Close() error
-}
+type BatchJobStore = batchjob.BatchJobStore

--- a/pkg/storage/interfaces/business/batch_job_store_test.go
+++ b/pkg/storage/interfaces/business/batch_job_store_test.go
@@ -15,7 +15,11 @@ import (
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
-// inMemBatchJobStore is a minimal in-memory BatchJobStore for contract testing only.
+// inMemBatchJobStore is a minimal in-memory BatchJobStore used to validate the
+// shared contract harness (BatchJobStoreContract). It is not a substitute for
+// production implementations — the real memory provider and SQLite store each
+// run the same contract in their own test packages where provider imports are
+// permitted by the architecture rules.
 type inMemBatchJobStore struct {
 	mu   sync.RWMutex
 	jobs map[string]*batchjob.BatchJob
@@ -47,6 +51,18 @@ func (s *inMemBatchJobStore) UpdateBatchJobStatus(_ context.Context, id string, 
 		return business.ErrBatchJobNotFound
 	}
 	j.Status = status
+	j.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+func (s *inMemBatchJobStore) UpdateBatchTargets(_ context.Context, id string, targets []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return business.ErrBatchJobNotFound
+	}
+	j.Targets = append([]string(nil), targets...)
 	j.UpdatedAt = time.Now().UTC()
 	return nil
 }
@@ -207,6 +223,23 @@ func TestBatchJobStore_Contract(t *testing.T) {
 
 	t.Run("UpdateBatchJobStatus not found", func(t *testing.T) {
 		err := store.UpdateBatchJobStatus(ctx, "ghost", batchjob.BatchJobStatusFailed)
+		assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchTargets reflects in Get", func(t *testing.T) {
+		job := newTestBatchJob("job-targets", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		newTargets := []string{"s-10", "s-11", "s-12"}
+		require.NoError(t, store.UpdateBatchTargets(ctx, "job-targets", newTargets))
+
+		got, err := store.GetBatchJob(ctx, "job-targets")
+		require.NoError(t, err)
+		assert.Equal(t, newTargets, got.Targets)
+	})
+
+	t.Run("UpdateBatchTargets not found", func(t *testing.T) {
+		err := store.UpdateBatchTargets(ctx, "ghost-targets", []string{"s-1"})
 		assert.ErrorIs(t, err, business.ErrBatchJobNotFound)
 	})
 

--- a/pkg/storage/interfaces/business/contract.go
+++ b/pkg/storage/interfaces/business/contract.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package business
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+)
+
+func newContractBatchJob(id, tenantID string) *batchjob.BatchJob {
+	now := time.Now().UTC()
+	return &batchjob.BatchJob{
+		ID:       id,
+		TenantID: tenantID,
+		Selector: "tag:prod",
+		Config: batchjob.BatchJobConfig{
+			BatchSize:         5,
+			PreviousConfigRef: "cfg-v1",
+		},
+		Targets:     []string{"s-1", "s-2", "s-3"},
+		Status:      batchjob.BatchJobStatusPending,
+		Steps:       []batchjob.BatchStep{{Index: 0, StewardIDs: []string{"s-1"}, Status: batchjob.BatchStepStatusPending}},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		InitiatedBy: "operator@example.com",
+	}
+}
+
+// BatchJobStoreContract runs the full BatchJobStore contract test suite against store.
+// Call from provider-specific test files to validate a new BatchJobStore implementation:
+//
+//	func TestMySQLiteBatchJobStore_Contract(t *testing.T) {
+//	    store := openStore(t)
+//	    business.BatchJobStoreContract(t, store)
+//	}
+func BatchJobStoreContract(t *testing.T, store BatchJobStore) {
+	t.Helper()
+	ctx := context.Background()
+
+	require.NoError(t, store.Initialize(ctx))
+	require.NoError(t, store.HealthCheck(ctx))
+
+	t.Run("create and get round-trip", func(t *testing.T) {
+		job := newContractBatchJob("ctr-job-1", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		got, err := store.GetBatchJob(ctx, "ctr-job-1")
+		require.NoError(t, err)
+		assert.Equal(t, "ctr-job-1", got.ID)
+		assert.Equal(t, "tenant-1", got.TenantID)
+		assert.Equal(t, batchjob.BatchJobStatusPending, got.Status)
+		assert.Equal(t, "tag:prod", got.Selector)
+		assert.Equal(t, 5, got.Config.BatchSize)
+		assert.Equal(t, "cfg-v1", got.Config.PreviousConfigRef)
+		assert.Equal(t, []string{"s-1", "s-2", "s-3"}, got.Targets)
+		assert.Equal(t, "operator@example.com", got.InitiatedBy)
+		assert.Len(t, got.Steps, 1)
+	})
+
+	t.Run("duplicate ID returns error", func(t *testing.T) {
+		job := newContractBatchJob("ctr-job-dup", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+		err := store.CreateBatchJob(ctx, job)
+		require.Error(t, err)
+	})
+
+	t.Run("get not found returns ErrBatchJobNotFound", func(t *testing.T) {
+		_, err := store.GetBatchJob(ctx, "ctr-no-such-id")
+		assert.ErrorIs(t, err, ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchJobStatus reflects in Get", func(t *testing.T) {
+		job := newContractBatchJob("ctr-job-status", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		require.NoError(t, store.UpdateBatchJobStatus(ctx, "ctr-job-status", batchjob.BatchJobStatusRunning))
+		got, err := store.GetBatchJob(ctx, "ctr-job-status")
+		require.NoError(t, err)
+		assert.Equal(t, batchjob.BatchJobStatusRunning, got.Status)
+
+		require.NoError(t, store.UpdateBatchJobStatus(ctx, "ctr-job-status", batchjob.BatchJobStatusCompleted))
+		got, err = store.GetBatchJob(ctx, "ctr-job-status")
+		require.NoError(t, err)
+		assert.Equal(t, batchjob.BatchJobStatusCompleted, got.Status)
+	})
+
+	t.Run("UpdateBatchJobStatus not found", func(t *testing.T) {
+		err := store.UpdateBatchJobStatus(ctx, "ctr-ghost", batchjob.BatchJobStatusFailed)
+		assert.ErrorIs(t, err, ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchTargets reflects in Get", func(t *testing.T) {
+		job := newContractBatchJob("ctr-job-targets", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		newTargets := []string{"s-10", "s-11", "s-12"}
+		require.NoError(t, store.UpdateBatchTargets(ctx, "ctr-job-targets", newTargets))
+
+		got, err := store.GetBatchJob(ctx, "ctr-job-targets")
+		require.NoError(t, err)
+		assert.Equal(t, newTargets, got.Targets)
+	})
+
+	t.Run("UpdateBatchTargets not found", func(t *testing.T) {
+		err := store.UpdateBatchTargets(ctx, "ctr-ghost-targets", []string{"s-1"})
+		assert.ErrorIs(t, err, ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchStep round-trips step fields", func(t *testing.T) {
+		job := newContractBatchJob("ctr-job-step", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		now := time.Now().UTC()
+		step := batchjob.BatchStep{
+			Index:         0,
+			StewardIDs:    []string{"s-1"},
+			Status:        batchjob.BatchStepStatusRunning,
+			StartedAt:     &now,
+			FailedIDs:     []string{"s-1"},
+			RollbackJobID: "rj-001",
+		}
+		require.NoError(t, store.UpdateBatchStep(ctx, "ctr-job-step", step))
+
+		got, err := store.GetBatchJob(ctx, "ctr-job-step")
+		require.NoError(t, err)
+		require.Len(t, got.Steps, 1)
+		s := got.Steps[0]
+		assert.Equal(t, 0, s.Index)
+		assert.Equal(t, batchjob.BatchStepStatusRunning, s.Status)
+		assert.Equal(t, []string{"s-1"}, s.FailedIDs)
+		assert.Equal(t, "rj-001", s.RollbackJobID)
+		require.NotNil(t, s.StartedAt)
+	})
+
+	t.Run("UpdateBatchStep not found", func(t *testing.T) {
+		step := batchjob.BatchStep{Index: 0, Status: batchjob.BatchStepStatusFailed}
+		err := store.UpdateBatchStep(ctx, "ctr-ghost-step", step)
+		assert.ErrorIs(t, err, ErrBatchJobNotFound)
+	})
+
+	t.Run("UpdateBatchStep appends step with new index", func(t *testing.T) {
+		job := newContractBatchJob("ctr-job-step-append", "tenant-1")
+		require.NoError(t, store.CreateBatchJob(ctx, job))
+
+		newStep := batchjob.BatchStep{
+			Index:      1,
+			StewardIDs: []string{"s-2"},
+			Status:     batchjob.BatchStepStatusPending,
+		}
+		require.NoError(t, store.UpdateBatchStep(ctx, "ctr-job-step-append", newStep))
+
+		got, err := store.GetBatchJob(ctx, "ctr-job-step-append")
+		require.NoError(t, err)
+		assert.Len(t, got.Steps, 2, "new index must be appended, not replace existing")
+	})
+
+	t.Run("ListBatchJobsByTenant scopes by tenant", func(t *testing.T) {
+		require.NoError(t, store.CreateBatchJob(ctx, newContractBatchJob("ctr-job-ta-1", "ctr-tenant-A")))
+		require.NoError(t, store.CreateBatchJob(ctx, newContractBatchJob("ctr-job-ta-2", "ctr-tenant-A")))
+		require.NoError(t, store.CreateBatchJob(ctx, newContractBatchJob("ctr-job-tb-1", "ctr-tenant-B")))
+
+		listA, err := store.ListBatchJobsByTenant(ctx, "ctr-tenant-A")
+		require.NoError(t, err)
+		assert.Len(t, listA, 2)
+
+		listB, err := store.ListBatchJobsByTenant(ctx, "ctr-tenant-B")
+		require.NoError(t, err)
+		assert.Len(t, listB, 1)
+		assert.Equal(t, "ctr-job-tb-1", listB[0].ID)
+
+		listNone, err := store.ListBatchJobsByTenant(ctx, "ctr-tenant-unknown")
+		require.NoError(t, err)
+		assert.Empty(t, listNone)
+	})
+
+	require.NoError(t, store.Close())
+}

--- a/pkg/storage/providers/memory/batch_job_store.go
+++ b/pkg/storage/providers/memory/batch_job_store.go
@@ -51,6 +51,19 @@ func (s *BatchJobStore) UpdateBatchJobStatus(_ context.Context, id string, statu
 	return nil
 }
 
+// UpdateBatchTargets replaces the resolved target steward IDs for the job.
+func (s *BatchJobStore) UpdateBatchTargets(_ context.Context, id string, targets []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return business.ErrBatchJobNotFound
+	}
+	j.Targets = append([]string(nil), targets...)
+	j.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
 // UpdateBatchStep upserts the step identified by step.Index within the job.
 // A matching index is replaced in-place; an unrecognised index appends a new step.
 func (s *BatchJobStore) UpdateBatchStep(_ context.Context, jobID string, step batchjob.BatchStep) error {


### PR DESCRIPTION
## Summary

- Implements `RollingBatchExecutor` that resolves fleet selectors, partitions stewards into sequential batches, dispatches `CommandSyncConfig` via `commands.Publisher.PublishCommandWithCallback`, and pauses on first batch failure
- `SQLiteBatchJobStore` provides durable persistence with idempotent `Initialize`, parameterized queries throughout, and propagated JSON unmarshal errors
- Moves `BatchJobStore` interface + `ErrBatchJobNotFound` into `features/controller/batchjob/store.go` to break the `batchjob→business→batchjob` import cycle; `business` package re-exports via type alias so existing callers compile unchanged
- Exports `BatchJobStoreContract` from `pkg/storage/interfaces/business/contract.go` for shared contract testing across implementations (SQLite + future providers)

## Required acceptance criteria verified

- `RollingBatchExecutor.Execute` dispatches `CommandSyncConfig` sequentially → `completed` when all batches succeed ✓
- `TestRollingBatchExecutor_SequentialBatches`: 4 stewards, BatchSize=2 → step 0 timestamps precede step 1 timestamps ✓
- `TestRollingBatchExecutor_FailurePausesBatchZero`: failure in batch 0 → `job.Status == paused`, 2 commands total (batch 1 never dispatched) ✓
- `SQLiteBatchJobStore` passes `business.BatchJobStoreContract` with `-race` (11 subtests) ✓

## Test plan

- [ ] `go test -race ./features/controller/batchjob/...` — 6 test functions, all pass
- [ ] `go test -race ./pkg/storage/interfaces/business/...` — contract + error sentinel tests pass
- [ ] `go test -race ./pkg/storage/providers/memory/...` — memory store with UpdateBatchTargets passes
- [ ] `make check-architecture` — no violations
- [ ] `make test-agent-complete` — all CI checks pass

Fixes #2295

🤖 Generated with [Claude Code](https://claude.com/claude-code)