### PR TITLE
docs+workflow: implicit-team planning docs + shared review-fix-verify workflow

### DIFF
--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -295,34 +295,34 @@ rm /tmp/ba-summary.md
 
 ## Team Mode
 
-When spawned as a teammate (with `team_name` parameter), you operate as part of a **Planning Team** alongside the PO (team lead) and Tech Lead. The collaboration protocol replaces the standalone workflow above.
+When spawned as a teammate (with a `name`, as a background agent), you operate as part of a **Planning Team** alongside the PO (`po`) and Tech Lead (`tech-lead`). The collaboration protocol replaces the standalone workflow above. This is a **three-way adversarial collaboration** — you talk **directly** to the Tech Lead and the PO.
 
 ### How Team Mode Differs
 
 - **No GitHub writes.** Never call `pipeline-helper.sh` in team mode. The PO handles all GitHub issue creation after the team reaches consensus.
 - **Input comes from PO messages.** The PO sends the epic context (goal, success criteria, non-goals, constraints, PM notes) via `SendMessage`. You do NOT read the epic from GitHub.
-- **Output is story proposals via SendMessage.** Send proposed stories to the PO using `SendMessage(to: "po")`. Each proposal uses the same story body format (## Parent Epic, ## Goal, ## Dependencies, ## Files In Scope, etc.) but as message text, not a GitHub issue.
-- **Respond to Tech Lead feedback.** The Tech Lead reviews your proposals and may challenge scope, feasibility, or story boundaries. You receive feedback via messages from the PO or directly from the Tech Lead. Revise proposals, defend decisions, or propose alternative splits as needed.
-- **Signal completion.** When all stories are agreed upon, send a final message to the PO with subject "PROPOSALS FINAL" containing the complete list of stories in their final form. Each story must include: title, and the full story body content.
+- **Send proposals to the whole team.** Send your story proposals to **both** the Tech Lead and the PO — `SendMessage(to: "tech-lead")` and `SendMessage(to: "po")`. Each proposal uses the same story body format (## Parent Epic, ## Goal, ## Dependencies, ## Files In Scope, etc.) as message text. **Large artifacts (full proposal set) go to a file** (`/tmp/ba-<epic>-proposals.md`); the `SendMessage` then carries just the file path + a one-line headline (long message bodies arrive as truncated summaries).
+- **Iterate directly with the Tech Lead.** The Tech Lead challenges your scope, feasibility, boundaries, and codebase grounding — and sends verdicts **directly to you**. Respond directly: revise, defend with codebase evidence, or propose an alternative split. Copy the PO on material changes.
+- **Challenge back, and challenge the PO too.** If the Tech Lead is wrong (e.g. cites a symbol at the wrong path), say so with evidence. If a PO product call misreads the epic, push back. Everyone can challenge everyone — that adversarial cross-examination is the point.
+- **Signal completion.** When all stories are agreed (Tech Lead APPROVED + no open PO product objection), write the final set to your proposals file and send a short "PROPOSALS FINAL" message (file path + headline) to both `tech-lead` and `po`.
 
 ### Team Mode Workflow
 
-1. **Receive context** — PO broadcasts epic details and architectural context
+1. **Receive context** — PO sends epic details and architectural context
 2. **Survey the codebase** — use Read/Grep/Glob as usual to understand current implementation (unchanged)
-3. **Propose stories** — send all story proposals to PO in a single `SendMessage(to: "po")` message
-4. **Iterate on feedback** — Tech Lead reviews your proposals and sends feedback (via PO relay or direct message). For each story marked REVISION NEEDED:
-   - Read the specific objection
-   - Re-examine the codebase if needed
-   - Revise the proposal, split the story, or defend your original decision with justification
-   - Send updated proposals to PO
-5. **Converge** — when all stories are APPROVED by Tech Lead, send the "PROPOSALS FINAL" message to PO
+3. **Propose stories** — write the full set to `/tmp/ba-<epic>-proposals.md`; send the path + headline to **both** `tech-lead` and `po`
+4. **Iterate directly** — the Tech Lead sends REVISION NEEDED verdicts straight to you. For each:
+   - Read the specific objection; re-examine the codebase if needed
+   - Revise, split, or defend with codebase evidence — reply **directly** to `tech-lead`
+   - Rewrite the proposals file and ping the updated path
+5. **Converge** — when the Tech Lead has APPROVED all stories and the PO has no product objection, send "PROPOSALS FINAL" to `tech-lead` and `po`
 
 ### Engaging with the Team
 
 - **Ask the PO product questions:** "Is offline support in scope for this epic?" — `SendMessage(to: "po")`
-- **Respond to Tech Lead challenges:** If Tech Lead says a story is too broad, propose a concrete split rather than arguing abstractly. Show the file boundaries.
-- **Challenge the Tech Lead back:** If you disagree with a Tech Lead objection, explain why with codebase evidence. "The files are in the same package and share internal types — splitting would require exporting internals."
-- **Escalate disagreements to PO:** If you and the Tech Lead can't agree after one round, ask the PO to make a product call: "PO — Tech Lead and I disagree on whether X belongs in this story or a separate one. My recommendation is Y because Z."
+- **Respond to Tech Lead challenges directly:** If the Tech Lead says a story is too broad, reply to `tech-lead` with a concrete split and the file boundaries.
+- **Challenge the Tech Lead back:** If you disagree with an objection, reply with codebase evidence. "The files share internal types — splitting would require exporting internals." If the Tech Lead cites a wrong path/symbol, verify and correct it directly.
+- **Escalate genuine deadlocks to PO:** If you and the Tech Lead can't converge after a round, ask the PO to make the product call: "PO — Tech Lead and I disagree on whether X belongs in this story or a separate one. My recommendation is Y because Z." The PO adjudicates.
 
 ### What Stays the Same
 

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -744,15 +744,18 @@ SendMessage(to: "ba", summary: "Epic context for planning", message: <epic body 
 SendMessage(to: "tech-lead", summary: "Epic context for planning", message: <same context>)
 ```
 
-**7e. Orchestrate the planning conversation:**
+**7e. Run the collaborative planning conversation:**
 
-The conversation follows this protocol:
+This is a **three-way adversarial collaboration**, not a relay through the PO. The BA and Tech Lead talk **directly** to each other; the PO (addressed by teammates as `main`) participates as a full member and owns the final product synthesis. The goal is for all three to converge on the right answer together.
 
-1. **BA proposes** — BA surveys the codebase and sends story proposals to PO via `SendMessage`
-2. **PO relays to Tech Lead** — forward BA's proposals: `SendMessage(to: "tech-lead", message: <proposals>)`
-3. **Tech Lead reviews** — validates proposals against the codebase (5-check validation) and sends per-story verdicts (APPROVED / REVISION NEEDED) to PO. Tech Lead may also message BA directly for clarifications.
-4. **If revisions needed** — PO relays Tech Lead feedback to BA: `SendMessage(to: "ba", message: <feedback>)`. BA revises and re-proposes. PO relays to Tech Lead for re-review. Only unresolved stories iterate — approved stories are locked.
-5. **PO product decisions** — if BA and Tech Lead disagree on scope, priority, or approach, PO makes the product call and sends the decision to each teammate by name: `SendMessage(to: "ba", message: "PO DECISION: ...")` and `SendMessage(to: "tech-lead", message: "PO DECISION: ...")`
+1. **BA proposes** — BA surveys the codebase and sends story proposals to **both** the Tech Lead (`SendMessage(to: "tech-lead")`) and the PO (`SendMessage(to: "main")`).
+2. **Tech Lead challenges directly** — the Tech Lead validates against the codebase (7-check validation) and sends per-story verdicts (APPROVED / REVISION NEEDED, with codebase evidence) **directly to the BA**, copying `main`. The BA defends or revises **directly** with the Tech Lead — they iterate between themselves without waiting on a PO relay.
+3. **PO interjects** — the PO reads the exchange and weighs in whenever a **product** question is at stake (scope, priority, an AC that misreads intent, a split that's wrong for the roadmap) or when the two are converging on something the PO disagrees with. The PO can challenge either agent, and either agent can challenge the PO. Send product calls to each teammate by name: `SendMessage(to: "ba", ...)` and `SendMessage(to: "tech-lead", ...)`.
+4. **Converge** — an item is locked when the BA and Tech Lead agree AND the PO has no product objection. Only unresolved items keep iterating.
+
+**Everyone can challenge everyone.** The value of the team is adversarial cross-examination — the Tech Lead catching a BA mis-grounding, the BA out-verifying a Tech Lead claim, the PO catching a scope drift both agents missed. Encourage disagreement backed by evidence; the PO adjudicates genuine deadlocks.
+
+**File handoff for large artifacts.** Teammate `SendMessage` bodies over a few paragraphs reach the PO only as truncated idle-notification summaries. Instruct both agents up front to **write big artifacts** (full story proposals, full verdicts) to `/tmp/<role>-<epic>-*.md` and send a short `SendMessage` with just the file path + headline; the reader `Read`s the file.
 
 **Maximum 3 revision rounds.** A round = BA revises + Tech Lead re-reviews. After 3 rounds, any remaining REVISION NEEDED stories are resolved by PO decision: either accept with a PO note, or drop and document the convergence failure by blocking the epic (use `po-act.sh block <EPIC_NUM> "<reason>"`). Do NOT create a parallel tracking issue — the epic's Blocked status + comment IS the escalation.
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -306,34 +306,36 @@ rm /tmp/tl-summary.md
 
 ## Team Mode
 
-When spawned as a teammate (with `team_name` parameter), you operate as part of a **Planning Team** alongside the PO (team lead) and BA. The collaboration protocol replaces the standalone workflow above.
+When spawned as a teammate (with a `name`, as a background agent), you operate as part of a **Planning Team** alongside the PO (`po`) and BA (`ba`). The collaboration protocol replaces the standalone workflow above. This is a **three-way adversarial collaboration** — you send your verdicts **directly to the BA** and iterate with it, keeping the PO copied.
 
 ### How Team Mode Differs
 
 - **No GitHub writes.** Never call `pipeline-helper.sh` in team mode. The PO handles all GitHub operations after the team reaches consensus.
-- **Input comes from messages.** The PO relays the BA's story proposals to you via `SendMessage`. You do NOT read stories from GitHub issues.
-- **Output is structured verdicts via SendMessage.** Send your review to the PO using `SendMessage(to: "po")`. For each proposed story, give a clear verdict:
-  - **APPROVED** — story passes all 5 checks. Include any implementation notes to add.
-  - **REVISION NEEDED** — story fails one or more checks. State the specific check that failed, why, and what needs to change.
-- **Challenge the BA directly.** You can message the BA via `SendMessage(to: "ba")` for quick clarifications or to propose alternative splits. The PO sees summaries in idle notifications.
-- **Request PO product decisions.** When you and the BA disagree on scope or priority, escalate to the PO: `SendMessage(to: "po")` with the disagreement and your recommendation.
+- **Input comes from the team.** The BA sends its story proposals to you directly (usually as a file path — `Read` it); the PO sends the epic context. You do NOT read stories from GitHub issues.
+- **Send verdicts directly to the BA (copy the PO).** For each story send a clear verdict to `ba`, and copy `po`:
+  - **APPROVED** — story passes all 7 checks. Include any implementation notes to add.
+  - **REVISION NEEDED** — story fails one or more checks. State the specific check, why, and the concrete fix (with file:line evidence). The BA revises and replies to you directly.
+  - **Large verdict sets go to a file** (`/tmp/tl-<epic>-verdicts.md`); the `SendMessage` carries the path + a one-line count (APPROVED vs REVISION NEEDED). Long message bodies get truncated to summaries in transit.
+- **Iterate directly with the BA.** Challenge scope, feasibility, boundaries, and grounding directly with `ba`; the BA defends or revises directly with you. Loop until convergence.
+- **Challenge back, including the PO.** If the BA rebuts with codebase evidence (e.g. proves a symbol lives where the BA said, not where you thought), re-verify and concede if it's right. If a PO product call is wrong on a technical constraint, say so. Everyone can challenge everyone — that cross-examination is the point.
+- **Request PO product decisions on genuine deadlocks.** When you and the BA disagree on scope or priority and can't converge, escalate to `po` with the disagreement and your recommendation; the PO adjudicates.
 
 ### Team Mode Workflow
 
-1. **Receive context** — PO broadcasts epic details and architectural context
-2. **Receive proposals** — PO relays the BA's story proposals to you
-3. **Validate against the codebase** — apply the same 7-check validation (dependency ordering, implementation notes, scope, constraints, ambiguity, required-test markers, docs+tests currency). Use Read/Grep/Glob as usual.
-4. **Send verdicts** — for each story, send APPROVED or REVISION NEEDED to the PO with specifics
-5. **Iterate** — if BA revises proposals, re-review only the changed stories. Previously approved stories are locked.
-6. **Converge** — when all stories are APPROVED, confirm to the PO that the full set is ready
+1. **Receive context** — PO sends epic details and architectural context
+2. **Receive proposals** — the BA sends its proposals directly (usually a file path — `Read` it)
+3. **Validate against the codebase** — apply the 7-check validation (dependency ordering, implementation notes, scope, constraints, ambiguity, required-test markers, docs+tests currency). Use Read/Grep/Glob as usual. **Verify every codebase anchor the BA cites** (paths, symbols, signatures) — mis-grounding is the most common defect.
+4. **Send verdicts** — write per-story APPROVED / REVISION NEEDED verdicts (with file:line evidence) to `/tmp/tl-<epic>-verdicts.md`; send the path + count to `ba`, copy `po`
+5. **Iterate directly** — as the BA revises, re-review only the changed stories directly with `ba`. Previously approved stories are locked.
+6. **Converge** — when all stories are APPROVED, confirm to both `ba` and `po` that the full set is ready
 
 ### Engaging with the Team
 
-- **Challenge the BA on feasibility:** "Story 3 touches 6 files across 3 packages — too broad for a single dev agent. Split the provider implementation from the CLI wiring." — `SendMessage(to: "ba")`
-- **Flag file conflicts between proposals:** "Stories 2 and 4 both edit `pkg/cert/manager.go`. One must depend on the other or they'll conflict when dev agents run in parallel." — `SendMessage(to: "po")`
+- **Challenge the BA on feasibility (directly):** "Story 3 touches 6 files across 3 packages — too broad for one dev agent. Split the provider implementation from the CLI wiring." — `SendMessage(to: "ba")`
+- **Flag file conflicts between proposals:** "Stories 2 and 4 both edit `pkg/cert/manager.go`. One must depend on the other or they'll conflict when dev agents run in parallel." — tell both `ba` (to re-sequence) and `po`.
 - **Ask the PO about constraints:** "Does this need to work on Windows, or is Linux-only acceptable for the first pass?" — `SendMessage(to: "po")`
-- **Accept BA pushback with evidence:** If the BA defends a scope decision with codebase evidence (e.g., "these files share internal types"), re-evaluate. Don't block stories to prove a point — block them because a dev agent would fail.
-- **Escalate disagreements to PO:** "PO — BA and I disagree on whether the integration test belongs in this story or a separate one. I recommend separate because the test requires fixtures from story 1. BA says it's trivial to include. Your call."
+- **Accept BA pushback with evidence:** If the BA defends a decision with codebase evidence (e.g. "these files share internal types"), re-evaluate. Don't block stories to prove a point — block them because a dev agent would fail.
+- **Escalate real deadlocks to PO:** "PO — BA and I disagree on whether the integration test belongs in this story or a separate one. I recommend separate because the test requires fixtures from story 1. BA says it's trivial to include. Your call."
 
 ### What Stays the Same
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -39,10 +39,10 @@ Parse output:
 
 ### 3. Launch PR Reviewer Agent
 
-Spawn the **pr-reviewer** agent via the Task tool:
+Spawn the **pr-reviewer** agent via the Agent tool:
 
 ```
-Task tool:
+Agent tool:
   subagent_type: pr-reviewer
   prompt: "Review PR #[number] for the CFGMS project. Execute all 6 phases of the review methodology."
 ```

--- a/.claude/commands/story-complete.md
+++ b/.claude/commands/story-complete.md
@@ -17,76 +17,36 @@ Final validation gate before PR creation. Orchestrates a **parallel adversarial 
 
 Auto-detect story from branch and fetch issue details. Verify all acceptance criteria are complete (100%). If < 100%, warn and confirm with user before proceeding.
 
-### 2. Create Review Team
+### 2. Run the review-fix-verify workflow
+
+The adversarial review, developer fix loop, and re-verification run as a single deterministic workflow — `.claude/workflows/story-review.js`. It fans out the four review lenses in parallel (acceptance check, `make test-quality`, QA code review, security scans + review), collects schema-validated verdicts, spawns a **developer** to fix any blocking findings, and re-runs **only the lenses that failed** — up to 3 fix rounds — then returns a structured verdict.
+
+Invoke it via the Workflow tool:
 
 ```
-TeamCreate(team_name: "story-review")
+Workflow({
+  name: "story-review",
+  args: {
+    changedFiles: [ ...files from `git diff --name-only origin/develop...HEAD` and `git status` ],
+    testTarget: "test-quality",          // interactive gate uses the full Docker-inclusive target
+    includeAcceptanceChecker: true,      // 4-lens review (AC verified pre-PR)
+    storyRef: "#<issue-number> — <title>"
+  }
+})
 ```
 
-Create four tasks on the team task list:
-1. **Acceptance check** — Verify the working tree delivers the story's named code references
-2. **Run test-quality** — Tests, linting, and builds (no security scans)
-3. **QA code review** — Review changed files for test quality
-4. **Security review** — All security scans + security code review
+The workflow returns `{ passed, reviewRounds, fixRounds, perRound, remainingFindings }`.
 
-### 3. Spawn Review Teammates (ALL IN PARALLEL)
+- **`passed: true`** → proceed to §3.
+- **`passed: false`** (fix loop exhausted after 3 rounds) → do NOT create the PR. Report `remainingFindings` (each has `file`, `severity`, `detail`) to the user for manual intervention.
 
-Spawn four teammates simultaneously via the Task tool. For each, use `subagent_type: general-purpose` with the `team_name` and `name` parameters. Read the corresponding agent file in `.claude/agents/` and include its instructions in the prompt.
+The developer stage is told to fix root causes only — NO mocks, NO `t.Skip()`, NO hacky workarounds, and NO helper-function-instead-of-the-named-fix when an AC names existing code that must change. The acceptance lens catches "AC names a stub but the stub is still there" before the PR exists (see `docs/development/acceptance-reviewer-verification.md`); the security lens is the sole owner of security scanning + review.
 
-**acceptance-checker** (sonnet):
-- Agent file: `.claude/agents/acceptance-checker.md`
-- Reads the story body, extracts concrete code references (file paths, function names, line numbers, banned-phrase quotes, required test names), and verifies each against the working tree
-- Catches "AC names a stub function but the stub is still there" before the PR is created
-- Reports blocking issues with file:line references and AC numbers
-- See `docs/development/acceptance-reviewer-verification.md` for the verification model and regression scenarios
-
-**qa-test-runner** (sonnet):
-- Agent file: `.claude/agents/qa-test-runner.md`
-- Runs `make test-quality` — unit tests, lint, production-critical, cross-platform builds, Docker integration (no security scans, no E2E)
-- Reports pass/fail with specific test names and error details
-
-**qa-code-reviewer** (sonnet):
-- Agent file: `.claude/agents/qa-code-reviewer.md`
-- Reviews all changed files for test quality issues
-- Catches mocks, t.Skip(), empty assertions, hacky workarounds
-- Reports blocking issues with file:line references
-- Does NOT check AC alignment — that's acceptance-checker's concern
-
-**security-engineer** (opus):
-- Agent file: `.claude/agents/security-engineer.md`
-- Sole owner of all security scanning and security code review
-- Runs make security-precommit, check-architecture, security-scan
-- Reviews changed files for vulnerabilities, central provider violations
-- Reports blocking issues with file:line references
-
-### 4. Collect Results
-
-Wait for all four teammates to complete and send their reports. Collect findings from each.
-
-### 5. Fix Issues (if any blocking issues found)
-
-If ANY teammate reported blocking issues, spawn a **developer** teammate:
-
-- Agent file: `.claude/agents/developer.md`
-- Model: opus
-- Provide combined findings from all reviewers with file:line references
-- For acceptance-checker FAILs specifically, tell the developer the AC number, the named symbol/file/line, and the AC's "after" behavior — and remind them that adding helper functions elsewhere is NOT a valid fix when the AC names existing code that must change
-- Developer fixes root causes properly (NO mocks, NO skips, NO hacks)
-
-After developer completes, re-spawn the reviewers that reported failures to verify fixes. Maximum 3 fix iterations. If issues persist after 3 rounds, shut down team and report to user for manual intervention.
-
-### 6. Shut Down Team
-
-Send shutdown requests to all active teammates. Wait for confirmations. Delete the team:
-```
-TeamDelete()
-```
-
-### 7. Documentation Review (invoke doc-review skill)
+### 3. Documentation Review (invoke doc-review skill)
 
 Scan for internal tracking documents that must be removed before PR. Blocks if found.
 
-### 8. Roadmap Update
+### 4. Roadmap Update
 
 Update `docs/product/roadmap.md` on the story branch:
 ```markdown
@@ -99,7 +59,7 @@ Update `docs/product/roadmap.md` on the story branch:
 
 Commit roadmap changes to the story branch so they're included in the single PR.
 
-### 9. Push to Remote
+### 5. Push to Remote
 
 ```bash
 git push -u origin HEAD
@@ -107,7 +67,7 @@ git push -u origin HEAD
 
 Verify push succeeds before creating PR.
 
-### 10. PR Creation (git-workflow skill provides rules)
+### 6. PR Creation (git-workflow skill provides rules)
 
 **Git workflow rules**: Feature/tooling branches ALWAYS target `develop`. Never `main`.
 
@@ -131,15 +91,15 @@ gh pr list --head <branch-name-from-above> --state=open
 - `Fixes #<issue-number>` on its own line (REQUIRED — develop uses squash merge, so the PR body becomes the merged commit message; without this keyword GitHub will not auto-close the linked issue)
 - `Co-Authored-By: Claude <noreply@anthropic.com>`
 
-### 11. GitHub Project Update (optional)
+### 7. GitHub Project Update (optional)
 
 Move issue to "Done" on project board if accessible.
 
 ## Error Handling
 
-- **Team creation fails**: Fall back to sequential validation (make test-complete then manual review).
-- **Teammate fails**: Report error, suggest re-running `/story-complete`.
-- **Fix iterations exhausted (3 rounds)**: Report remaining issues to user for manual intervention.
+- **Workflow fails to launch**: Fall back to sequential validation (`make test-complete` then manual review).
+- **A reviewer errors mid-workflow**: the workflow treats an errored lens as blocking (fails safe); re-run `/story-complete` after resolving the cause.
+- **Fix iterations exhausted (3 rounds, `passed: false`)**: Report `remainingFindings` to the user for manual intervention; do NOT create the PR.
 - **Doc review fails**: Block, report problematic files. User must remove/transform them.
 - **Push fails**: Block PR creation. Report error.
 - **PR creation fails**: Report error with manual alternative URL.

--- a/.claude/workflows/story-review.js
+++ b/.claude/workflows/story-review.js
@@ -1,0 +1,141 @@
+// story-review — shared adversarial review-fix-verify gate.
+//
+// One implementation for BOTH callers, replacing two hand-maintained (and
+// already drifted) copies of the same review team:
+//   - /story-complete (interactive):        4 lenses, testTarget=test-quality
+//   - .devcontainer/entrypoint.sh (headless -p): 3 lenses, testTarget=test-agent-complete
+//
+// Flow: parallel reviewers -> collect blocking findings -> developer fix loop
+// (re-running ONLY the lenses that failed) -> structured verdict.
+//
+// The orchestration in this script was validated end-to-end locally (seeded a
+// "new production code without a test" defect: reviewers flagged it, the
+// developer wrote a real passing table test, only the failed lenses re-ran, and
+// it converged with {passed:true, fixRounds:1}). The `tests`/`security` lenses
+// below use the same real specialist agents the existing gate already uses.
+//
+// args:
+//   changedFiles: string[]           — files under review (else discovered via git)
+//   testTarget: string               — make target for the test lens
+//                                       (default 'test-quality'; container passes 'test-agent-complete')
+//   includeAcceptanceChecker: bool   — 4th lens (default true; container passes false —
+//                                       AC is verified post-PR by the cron acceptance-reviewer)
+//   maxRounds: int                   — fix-loop cap (default 3)
+//   storyRef: string                 — story/issue reference for the acceptance checker
+
+export const meta = {
+  name: 'story-review',
+  description: 'Shared adversarial review-fix-verify gate: parallel reviewers -> collect -> developer fix loop -> structured verdict. Serves /story-complete and entrypoint.sh.',
+  phases: [{ title: 'Review' }, { title: 'Fix' }],
+}
+
+const cfg = args || {}
+const files = cfg.changedFiles || []
+const filesList = files.length ? files.map(f => `- ${f}`).join('\n') : '(discover changed files via `git diff --name-only origin/develop...HEAD` and `git status`)'
+const testTarget = cfg.testTarget || 'test-quality'
+const includeAcceptanceChecker = cfg.includeAcceptanceChecker !== false
+const maxRounds = cfg.maxRounds || 3
+const scopeNote = `Changed files under review:\n${filesList}\n\nReview ONLY these changes; ignore unrelated pre-existing code.`
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['passed', 'findings'],
+  properties: {
+    passed: { type: 'boolean', description: 'true ONLY if there are zero blocking issues' },
+    summary: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['file', 'severity', 'detail'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          severity: { type: 'string', enum: ['blocking', 'warning'] },
+          detail: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// Each reviewer's thunk produces a FRESH agent() call so only the lenses that
+// failed a round get re-run after a developer fix.
+const REVIEWERS = [
+  includeAcceptanceChecker && {
+    key: 'acceptance',
+    thunk: () => agent(
+      `${scopeNote}\nAcceptance reference: ${cfg.storyRef || '(none)'}.\nVerify the working tree delivers the story's named code references (file paths, function names, required test names, banned-phrase removals). Emit a blocking finding for any named symbol/behavior that is missing or still a stub.`,
+      { label: 'review:acceptance', phase: 'Review', schema: VERDICT_SCHEMA, agentType: 'acceptance-checker' }
+    ),
+  },
+  {
+    key: 'code',
+    thunk: () => agent(
+      `${scopeNote}\nReview the changed files for test quality. Emit a blocking finding for: new production code without a corresponding _test.go containing functional tests; mocks of CFGMS components; t.Skip without justification; empty assertions; hacky workarounds. If clean, return passed=true with empty findings.`,
+      { label: 'review:code', phase: 'Review', schema: VERDICT_SCHEMA, agentType: 'qa-code-reviewer' }
+    ),
+  },
+  {
+    key: 'tests',
+    thunk: () => agent(
+      `Run \`make ${testTarget}\` (tests, lint, builds — no security scans). ${testTarget === 'test-agent-complete' ? 'This is the container target (no Docker).' : ''} Report pass/fail: if it exits non-zero, return passed=false with a blocking finding naming the failing test/package; if it exits zero, return passed=true. Do NOT modify files.`,
+      { label: 'review:tests', phase: 'Review', schema: VERDICT_SCHEMA, agentType: 'qa-test-runner' }
+    ),
+  },
+  {
+    key: 'security',
+    thunk: () => agent(
+      `${scopeNote}\nRun all security scans (gosec, Trivy, Nancy, staticcheck, secret scanning) and check-architecture, and review the changed files for vulnerabilities, unsanitized logging (must use logging.SanitizeLogValue), hardcoded secrets, and central-provider violations. Emit blocking findings for genuine issues; passed=true if none. Do NOT modify files.`,
+      { label: 'review:security', phase: 'Review', schema: VERDICT_SCHEMA, agentType: 'security-engineer' }
+    ),
+  },
+].filter(Boolean)
+
+function developerPrompt(findings) {
+  const list = findings.map(f => `- [${f.reviewer}] ${f.file}${f.line ? ':' + f.line : ''} — ${f.detail}`).join('\n')
+  return `Fix the ROOT CAUSE of each blocking finding below. NO mocks, NO t.Skip, NO hacky workarounds, NO helper-function-instead-of-the-named-fix (when an AC names existing code that must change, change it). Only touch the files under review and their tests.\n\nBlocking findings:\n${list}\n\nAfter fixing, make sure \`make ${testTarget}\` passes.`
+}
+
+phase('Review')
+let round = 0
+let toRun = REVIEWERS
+let lastFindings = []
+const perRound = []
+let passed = false
+
+while (round < maxRounds) {
+  const results = await parallel(toRun.map(r => () =>
+    r.thunk().then(v => ({ key: r.key, v })).catch(e => ({ key: r.key, v: null, error: String(e) }))
+  ))
+  const blocking = []
+  for (const res of results) {
+    if (!res) continue
+    const { key, v, error } = res
+    if (!v) { blocking.push({ key, findings: [{ file: '(agent error)', severity: 'blocking', detail: error || 'reviewer agent errored' }] }); continue }
+    const bfs = (v.findings || []).filter(f => f.severity === 'blocking')
+    if (v.passed === false || bfs.length) {
+      blocking.push({ key, findings: bfs.length ? bfs : [{ file: '(unspecified)', severity: 'blocking', detail: v.summary || 'reviewer reported not-passed' }] })
+    }
+  }
+  perRound.push({ round: round + 1, ran: toRun.map(r => r.key), failed: blocking.map(b => b.key) })
+  log(`Round ${round + 1}: ran [${toRun.map(r => r.key).join(', ')}] -> blocking from [${blocking.map(b => b.key).join(', ') || 'none'}]`)
+  if (blocking.length === 0) { passed = true; break }
+  lastFindings = blocking.flatMap(b => b.findings.map(f => ({ ...f, reviewer: b.key })))
+  phase('Fix')
+  await agent(developerPrompt(lastFindings), { label: `fix:round${round + 1}`, phase: 'Fix', agentType: 'developer' })
+  const failedKeys = new Set(blocking.map(b => b.key))
+  toRun = REVIEWERS.filter(r => failedKeys.has(r.key))
+  round++
+  phase('Review')
+}
+
+return {
+  passed,
+  reviewRounds: perRound.length,
+  fixRounds: passed ? perRound.length - 1 : perRound.length,
+  perRound,
+  remainingFindings: passed ? [] : lastFindings,
+}

--- a/docs/product/autonomous-agent-system-prd.md
+++ b/docs/product/autonomous-agent-system-prd.md
@@ -33,7 +33,7 @@ The system mirrors a standard product delivery org. Each role is either a Claude
 | **Developer** | Container Agent | `make test-complete`, `gh pr create` | PR against develop (existing infrastructure, unchanged) |
 | **QA** | Subagent | `gh pr review`, `gh issue edit` | Structured verdict comment on PR; `pipeline:review` or `pipeline:fix` label |
 
-> **Planning Team model:** During epic decomposition, the PO creates a temporary team (via `TeamCreate`) with BA and Tech Lead as teammates. All three communicate via `SendMessage` — BA proposes stories, Tech Lead challenges and validates, PO mediates and makes product decisions. Stories are only created on GitHub after all three agree. This replaces the previous sequential model where BA and Tech Lead operated independently.
+> **Planning Team model:** During epic decomposition, the PO spawns BA and Tech Lead as named background agents in the session's implicit team. All three collaborate adversarially via `SendMessage`, communicating **directly with each other**: BA proposes stories, Tech Lead challenges and validates directly with the BA, and the PO participates as a full member — interjecting on product questions and owning the final synthesis. Everyone can challenge everyone with evidence. Stories are only created on GitHub after all three converge; the team dissolves when its agents shut down.
 
 ### 2.1 PO Split — Interactive vs. Cron
 
@@ -156,26 +156,24 @@ Work moves through the pipeline in one direction. Each stage is triggered by a l
 
 ### 5.2 Collaborative Planning (Planning Team, async)
 
-The PO creates a temporary team for epic decomposition. BA and Tech Lead collaborate in real time via `SendMessage`, with the PO mediating and making product decisions. Stories are only created on GitHub after all three agree.
+The PO forms a planning team for epic decomposition by spawning BA and Tech Lead as named background agents in the session's implicit team. All three collaborate adversarially and in real time via `SendMessage`, **communicating directly with each other**. The PO participates as a full member and owns the final synthesis. Stories are only created on GitHub after all three converge.
 
-- PO cron cycle finds `pipeline:epic` Issues with no child stories
+- PO cron cycle finds epic Issues with no child stories
 - PO reads the epic body and gathers architectural context
-- PO creates a planning team: `TeamCreate(team_name: "planning-epic-<NUM>")`
-- PO spawns BA and Tech Lead as teammates (in parallel, both using `SendMessage` for communication)
-- PO broadcasts epic context (goal, success criteria, non-goals, constraints, PM notes) to both teammates
+- PO spawns BA and Tech Lead **together** as named background agents (`Agent` with `name` + `run_in_background: true`), introducing each to its teammates by name
+- PO sends epic context (goal, success criteria, non-goals, constraints, PM notes) to each teammate individually
 
-**Planning conversation:**
-1. BA surveys the codebase and sends story proposals to PO via `SendMessage`
-2. PO relays proposals to Tech Lead for validation
-3. Tech Lead validates each proposal against the codebase (dependency ordering, implementation notes, scope, constraints, ambiguity) and sends per-story verdicts: APPROVED or REVISION NEEDED
-4. If revisions needed: PO relays feedback to BA → BA revises → PO relays to Tech Lead → repeat (max 3 rounds)
-5. BA and Tech Lead can also message each other directly for quick clarifications
-6. PO makes product decisions when BA and Tech Lead disagree on scope or priority
+**Planning conversation (three-way, not hub-and-spoke):**
+1. BA surveys the codebase and sends story proposals to **both** the Tech Lead and the PO (large artifacts via a `/tmp` file + a short path message)
+2. Tech Lead validates each proposal against the codebase (dependency ordering, implementation notes, scope, constraints, ambiguity, required-test markers, docs currency — including verifying every cited code anchor) and sends per-story verdicts (APPROVED / REVISION NEEDED with file:line evidence) **directly to the BA**, copying the PO
+3. BA and Tech Lead iterate **directly** — BA revises or defends with codebase evidence; Tech Lead re-reviews only changed stories (max 3 rounds)
+4. The PO interjects on any product question (scope, priority, an AC that misreads intent) and can challenge either agent; either agent can challenge the PO or the other with evidence
+5. An item locks when BA and Tech Lead agree and the PO has no product objection
 
 **After consensus:**
-- PO creates all agreed stories on GitHub via `pipeline-helper.sh create-ready-story` with labels `pipeline:story` + `agent:ready` — stories skip `pipeline:draft` entirely since the Tech Lead already validated them
+- PO creates all agreed stories as private project items (never `gh issue create`); for dependency chains it materializes them early with real `#NNN` deps so the dispatcher's dep-gate self-sequences
 - PO posts a planning summary comment on the epic
-- PO shuts down the team (`TeamDelete`)
+- PO shuts down the team by sending a `shutdown_request` to each teammate individually
 
 **Convergence failure:** If BA and Tech Lead cannot agree after 3 revision rounds, PO makes a unilateral decision — accept, modify, or drop the disputed stories. Dropped stories produce a `pipeline:blocked` Issue with both perspectives documented.
 
@@ -408,7 +406,7 @@ Docker containers, git worktrees, credential mounting, `cfg-agent:latest` image,
 
 Agents operate in two modes depending on the pipeline phase:
 
-**Team mode (Planning Team — BA + Tech Lead):** During epic decomposition, BA and Tech Lead are spawned as teammates via `TeamCreate`/`Agent` with `team_name` and `name` parameters. They communicate with each other and the PO via `SendMessage`. Team communication is ephemeral — not persisted to GitHub. The PO creates all GitHub state after the team reaches consensus. Teams are temporary and cleaned up via `TeamDelete` after each planning session.
+**Team mode (Planning Team — BA + Tech Lead):** During epic decomposition, BA and Tech Lead are spawned as named background agents (`Agent` with `name` + `run_in_background: true`) in the session's implicit team. They communicate **directly with each other and the PO** via `SendMessage` (adversarial cross-examination). Team communication is ephemeral — not persisted to GitHub. The PO creates all GitHub state after the team converges. The team dissolves when its agents shut down via `shutdown_request`.
 
 **Standalone subagent mode (QA, legacy Tech Lead pass):** QA runs as an independent subagent spawned by the PO with `mode: "auto"` (no approval prompts). It has read-only access to the repo and read/write access to GitHub via `gh`. The PO receives its response directly and knows if it completed or failed. The legacy standalone Tech Lead pass uses the same model for processing pre-existing `pipeline:draft` stories.
 


### PR DESCRIPTION
## Summary

Two related changes to the agent-orchestration layer:

1. **Corrected the agent-team docs** to the current **implicit-team** model (named background agents; no `TeamCreate`/`TeamDelete`), and made the **Planning Team a true peer-to-peer adversarial collaboration** rather than a PO-hub relay. BA and Tech Lead now message each other directly and challenge each other with evidence; the PO is a full member owning final synthesis.
2. **Added a shared `review-fix-verify` Workflow** and wired `/story-complete` to it, replacing the hand-orchestrated 4-agent review team.

### Why the workflow

The story-complete review team (adversarial reviewers → collect → developer fix loop → re-verify) existed as **two hand-maintained, already-drifted copies**: `/story-complete` (4 lenses, `test-quality`) and `.devcontainer/entrypoint.sh`'s `ADVERSARIAL_REVIEW_SECTION` (3 lenses, `test-agent-complete`). That control flow is deterministic — a Workflow encodes it once (loop cap, "re-run only failed lenses", schema-validated verdicts) instead of prose each caller re-interprets.

## Files

| File | Change |
|---|---|
| `.claude/agents/{po,ba,tech-lead}.md` | Implicit-team spawn/teardown; direct BA↔TL adversarial messaging; PO as full member |
| `.claude/commands/po.md` | Implicit-team spawn instructions |
| `.claude/commands/pr-review.md` | `Task tool` → `Agent tool` |
| `.claude/commands/story-complete.md` | Invoke the `story-review` workflow instead of manually spawning four teammates; section renumber |
| `.claude/workflows/story-review.js` | **New** — shared review-fix-verify gate, parameterized by `testTarget` / `includeAcceptanceChecker` |
| `docs/product/autonomous-agent-system-prd.md` | PRD updated to match |

## Validation

The workflow orchestration was **run end-to-end locally in-container** against a seeded defect (a new Go file with exported functions and no test):

```json
{ "passed": true, "reviewRounds": 2, "fixRounds": 1,
  "perRound": [ {"round":1,"ran":["code","tests","security"],"failed":["code","tests"]},
                {"round":2,"ran":["code","tests"],"failed":[]} ] }
```

- Parallel fan-out, adversarial catch, developer fix (wrote a real passing table test — no mocks/skips), **re-ran only the failed lenses** (security, which passed, was not re-run), and converged with a structured verdict.
- Headless `claude -p` mode (how dispatched dev agents run) was separately confirmed to expose **and complete** a Workflow end-to-end.

## Deliberately deferred (needs a separate, container-validated PR)

- **`entrypoint.sh` rewiring** is **not** in this PR. Pointing the autonomous dev-agent gate at the workflow changes how every dispatched agent validates (including the `/tmp/agent-validation-passed` marker + verdict handling), and I can't validate that integration without a real container dispatch. It's the intended follow-up so both callers share one implementation.

## Risk

- Doc changes: reviewed, no behavior change to running code.
- `/story-complete` wiring: interactive, human-supervised gate; the workflow uses the **same** specialist agents (`acceptance-checker`, `qa-test-runner`, `qa-code-reviewer`, `security-engineer`, `developer`) the gate already used — the orchestration is what changed, and it's validated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P32vHWafHTzGi9ZtyJj4aH