### PR TITLE
fix: move batchjob memory provider import to allowlisted providers_test.go (unbreak develop) (Issue #2303)

### DIFF
--- a/features/controller/batchjob/executor_test.go
+++ b/features/controller/batchjob/executor_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	cpinterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
-	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -250,7 +249,7 @@ func (d *completionDriver) stop() {
 
 type executorFixture struct {
 	cp        *executorTestCP
-	store     *memory.BatchJobStore
+	store     batchjob.BatchJobStore
 	publisher *commands.Publisher
 	executor  *batchjob.RollingBatchExecutor
 	ctx       context.Context
@@ -271,7 +270,7 @@ func newExecutorFixture(t *testing.T, stewardIDs ...string) *executorFixture {
 	require.NoError(t, err)
 	require.NoError(t, pub.Start(ctx))
 
-	store := memory.NewBatchJobStore()
+	store := newTestBatchJobStore()
 	require.NoError(t, store.Initialize(ctx))
 
 	exec := batchjob.NewRollingBatchExecutor(
@@ -458,7 +457,7 @@ func TestRollingBatchExecutor_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, pub.Start(ctx))
 
-	store := memory.NewBatchJobStore()
+	store := newTestBatchJobStore()
 	require.NoError(t, store.Initialize(ctx))
 
 	exec := batchjob.NewRollingBatchExecutor(

--- a/features/controller/batchjob/providers_test.go
+++ b/features/controller/batchjob/providers_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package batchjob_test
+
+import (
+	"github.com/cfgis/cfgms/features/controller/batchjob"
+	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
+)
+
+// newTestBatchJobStore returns a memory-backed BatchJobStore for tests.
+//
+// The concrete pkg/storage/providers/memory import lives here — an allowlisted
+// */providers_test.go file (see scripts/check-providers.sh) — so the rest of the
+// batchjob test suite depends only on the batchjob.BatchJobStore interface and
+// stays free of direct storage-provider imports.
+func newTestBatchJobStore() batchjob.BatchJobStore {
+	return memory.NewBatchJobStore()
+}


### PR DESCRIPTION
## Unbreaks develop — fixes #2303

PR #2301 (merge commit `e7c1d8c0`) landed a `check-architecture` violation: `features/controller/batchjob/executor_test.go` directly imported `pkg/storage/providers/memory`. `scripts/check-providers.sh` only allows direct `pkg/storage/providers/*` imports in provider-internal packages and `*/providers_test.go`. The develop merge queue's required checks (unit/integration/Build Gate/security) don't run `check-architecture`, so it slipped in — and now **blocks all dispatch** (dev agents trip it in `make test-agent-complete`; the #415 chain's #2296 is held on it).

## Fix (test-only, behavior unchanged)
- New allowlisted **`features/controller/batchjob/providers_test.go`** holds the concrete `memory` import and exposes `newTestBatchJobStore() batchjob.BatchJobStore`.
- `executor_test.go`'s fixture field is retyped from `*memory.BatchJobStore` to the `batchjob.BatchJobStore` interface (every usage — `Initialize`, `CreateBatchJob`, `GetBatchJob`, etc. — is an interface method), and the two `memory.NewBatchJobStore()` call sites use the helper.

## Verification
- `scripts/check-providers.sh` → **clean** (the failing gate)
- `make check-architecture` → clean
- `go build ./...` → passes
- `go vet` + `go test ./features/controller/batchjob/...` → pass

Merging this returns develop to green; re-running `/po cron` then dispatches #2296 and resumes the #415 chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
