### PR TITLE
hyperv: live-validate promote VM→HA role on cfg-lab + fix #2202 cluster path (Issue #2309)

### DIFF
--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -172,13 +172,24 @@ const psGetClusterResourceOwner = `$owners = @{}; Get-ClusterGroup -Cluster $Clu
 // CNO-owner node invokes it (the ownership gate ensures exactly-once across the
 // members). The Go caller normalises an "already exists"/"already registered"
 // error to nil (idempotency).
-const psAddClusterVMRole = `Add-ClusterVirtualMachineRole -Cluster $ClusterName -VirtualMachine $VMName | Out-Null`
+//
+// Cluster by -VMId, NOT -VirtualMachine <name>: the by-name path makes
+// Add-ClusterVirtualMachineRole resolve the VM via a WMI enumeration across
+// cluster nodes (ViridianVirtualMachine.GetAllVirtualMachinesByName ->
+// ManagementScope.Initialize), which fails "Access is denied" when the module
+// runs as the LocalSystem steward — cross-node WMI as the machine identity is
+// denied. Resolving the VM to its Id locally (Get-VM -Name is a local WMI call
+// that succeeds) and clustering by -VMId skips that enumeration and works as
+// SYSTEM. $VMName still travels via ArgumentList (never interpolated).
+const psAddClusterVMRole = `$vmid = (Get-VM -Name $VMName -ErrorAction Stop).Id; Add-ClusterVirtualMachineRole -Cluster $ClusterName -VMId $vmid | Out-Null`
 
-// psRemoveClusterResource removes a clustered role group (S2 destructive teardown,
-// gated behind allow_destructive: true). $Name travels via ArgumentList — never
-// interpolated. Remove-ClusterResource -Force is reached only after the Go
-// destructive gate has confirmed the operator opted in.
-const psRemoveClusterResource = `Remove-ClusterResource -Name $Name -Force`
+// psRemoveClusterResource removes a clustered VM role group (S2 destructive
+// teardown, gated behind allow_destructive: true). $Name travels via
+// ArgumentList — never interpolated. This const is a dispatch key; the executed
+// command is Cfgms-RemoveClusterResource in the preamble, which uses
+// Remove-ClusterGroup -RemoveResources (the VM role's GROUP name, not a resource
+// name — see that function). Reached only after the Go destructive gate.
+const psRemoveClusterResource = `Remove-ClusterGroup -Name $Name -RemoveResources -Force`
 
 // getCluster returns the observed state of a failover cluster on the host.
 //

--- a/features/modules/hyperv/cluster_integration_test.go
+++ b/features/modules/hyperv/cluster_integration_test.go
@@ -247,6 +247,7 @@ func TestClusterHA_CreateFailoverReconverge(t *testing.T) {
 	status := getClusterStatus(t, m, p.cluster)
 	origOwner := status.RoleOwners[role]
 	require.NotEmptyf(t, origOwner, "resource_owner[%s] must be non-empty after clustering", role)
+	require.NotEmpty(t, status.CNOOwnerNode, "CNOOwnerNode must be non-empty after clustering the role")
 
 	// The create must have recorded exactly one successful cluster-set-create.
 	require.NoError(t, m.auditMgr.Flush(ctx))

--- a/features/modules/hyperv/cluster_integration_test.go
+++ b/features/modules/hyperv/cluster_integration_test.go
@@ -116,7 +116,7 @@ const cfgmsMoveClusterGroup = `Move-ClusterGroup -Cluster $env:CFGMS_T_CLUSTER -
 
 // psTestOtherUpNode returns the name of an Up cluster node other than
 // $env:CFGMS_T_NODE, or empty when no such node exists (single-node cluster).
-const psTestOtherUpNode = `Get-ClusterNode -Cluster $env:CFGMS_T_CLUSTER | Where-Object { $_.State -eq 'Up' -and $_.Name -ne $env:CFGMS_T_NODE } | Select-Object -First 1 -ExpandProperty Name`
+const psTestOtherUpNode = `$n = @(Get-ClusterNode -Cluster $env:CFGMS_T_CLUSTER | Where-Object { $_.State -eq 'Up' -and $_.Name -ne $env:CFGMS_T_NODE }); if ($n.Count -gt 0) { $n[0].Name }`
 
 // psTestRemoveClusteredVM tears the clustered role group down (if present) and
 // removes the VM, leaving the lab recoverable after the test. Best-effort:

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -34,8 +34,8 @@ security:
 # behavioral_envelope documents the runtime behaviour of the module for the
 # signing/approval workflow. The hyperv module shells out to powershell.exe. The
 # read-only failover-cluster surface (#2199 S1) invokes the four Get-Cluster*
-# cmdlets; #2202 S2 adds the two cluster WRITE cmdlets below
-# (Add-ClusterVirtualMachineRole, Remove-ClusterResource) — clustered-VM-role
+# cmdlets; #2202 S2 adds the cluster WRITE cmdlets below
+# (Add-ClusterVirtualMachineRole, Remove-ClusterGroup, Get-VM) — clustered-VM-role
 # create + destructive teardown. Cluster FORMATION (New-Cluster, Add-ClusterNode,
 # Remove-ClusterNode, quorum cmdlets) is NOT declared and out of scope.
 #
@@ -54,8 +54,11 @@ behavioral_envelope:
     Get-ClusterGroup, Get-ClusterSharedVolume. The failover-cluster WRITE
     cmdlets (#2202 S2) are: Add-ClusterVirtualMachineRole (cluster an existing
     VM as a highly-available role — invoked only by the CNO-owner node, gated
-    exactly-once) and Remove-ClusterResource (remove a clustered role group —
-    gated behind allow_destructive: true, default off). All arguments travel via
+    exactly-once; the VM is resolved to its Id via a local Get-VM and clustered
+    by -VMId, avoiding a cross-node WMI name-enumeration that is denied when the
+    module runs as the LocalSystem steward) and Remove-ClusterGroup
+    -RemoveResources (remove a clustered VM role group by name — gated behind
+    allow_destructive: true, default off). All arguments travel via
     ArgumentList (never string-composed). Cluster FORMATION cmdlets
     (New-Cluster, Add-ClusterNode, Remove-ClusterNode, quorum) are NOT declared
     and out of scope. This envelope change requires ADR-006 module re-signing

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -556,7 +556,14 @@ function Cfgms-GetClusterResourceOwner {
 # registered"/"already exists" error to a no-op (idempotency).
 function Cfgms-AddClusterVMRole {
     param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$VMName)
-    Add-ClusterVirtualMachineRole -Cluster $ClusterName -VirtualMachine $VMName | Out-Null
+    # Cluster by -VMId, NOT -VirtualMachine <name>: the by-name path makes
+    # Add-ClusterVirtualMachineRole resolve the VM via a cross-node WMI
+    # enumeration (ViridianVirtualMachine.GetAllVirtualMachinesByName ->
+    # ManagementScope.Initialize), which fails "Access is denied" when the module
+    # runs as the LocalSystem steward. Get-VM -Name is a local WMI call that
+    # succeeds; clustering by the resolved -VMId skips the enumeration.
+    $vmid = (Get-VM -Name $VMName -ErrorAction Stop).Id
+    Add-ClusterVirtualMachineRole -Cluster $ClusterName -VMId $vmid | Out-Null
 }
 
 # Cfgms-RemoveClusterResource mirrors psRemoveClusterResource: remove a clustered
@@ -564,6 +571,12 @@ function Cfgms-AddClusterVMRole {
 # true) has confirmed the operator opted in.
 function Cfgms-RemoveClusterResource {
     param([Parameter(Mandatory)][string]$Name)
-    Remove-ClusterResource -Name $Name -Force
+    # Remove the clustered VM ROLE by its GROUP name. Add-ClusterVirtualMachineRole
+    # creates a cluster group named after the VM whose resources are named
+    # "Virtual Machine <name>" / "Virtual Machine Configuration <name>" — so
+    # Remove-ClusterResource -Name <VMname> is ObjectNotFound (that is the group
+    # name, not a resource name). Remove-ClusterGroup -RemoveResources removes the
+    # group and all its resources (unclustering the VM; the VM itself persists).
+    Remove-ClusterGroup -Name $Name -RemoveResources -Force
 }
 `


### PR DESCRIPTION
## Summary

Live-validates the merged #2202 promote-to-HA cluster path against the real 3-node cfg-lab failover cluster (epic #2306, V1). Running these tests against a real cluster for the first time surfaced — and this PR fixes — three latent bugs that unit tests with a mock transport could never catch. The full cycle now passes live as the LocalSystem steward.

Fixes #2309

## What changed

**V1 assertion:** `TestClusterHA_CreateFailoverReconverge` now asserts `status.CNOOwnerNode` is non-empty after clustering.

**Bug 1 — test helper (`psTestOtherUpNode`):** piped `Get-ClusterNode | … | Select-Object -First 1`, which cancels the upstream pipeline; the FailoverClusters provider surfaces that as a terminal "The pipeline has been stopped" error, failing every live HA test before any clustering. Now materializes the node set into an array and indexes `[0]`.

**Bug 2 — `Add-ClusterVirtualMachineRole` by name (module):** `-VirtualMachine <name>` resolves the VM via a cross-node WMI enumeration (`ViridianVirtualMachine.GetAllVirtualMachinesByName → ManagementScope.Initialize`) that returns **"Access is denied"** when the module runs as the LocalSystem steward. Now resolves the VM to its Id locally (`Get-VM -Name` is a local WMI call that succeeds) and clusters by **`-VMId`**, skipping the enumeration.

**Bug 3 — destructive teardown (module):** `Remove-ClusterResource -Name <VMname>` is `ObjectNotFound` — clustering a VM creates a **group** named after the VM whose *resources* are named `"Virtual Machine <name>"`. Teardown now uses **`Remove-ClusterGroup -RemoveResources -Force`** (matches the test helper), which unclusters the VM cleanly.

**Behavioral envelope (`module.yaml`):** updated for the cmdlet changes (`Remove-ClusterResource` → `Remove-ClusterGroup`, `+Get-VM`). ⚠️ This is an ADR-006 material change — the bundle must be publisher re-signed + re-approved before `module_trust: strict` stewards accept it.

## Identity model (resolved)

`Add-ClusterVirtualMachineRole` clustering works with the steward as **LocalSystem** — no gMSA, no run-as — provided the **node computer accounts hold cluster access** (`Grant-ClusterAccess -User "LAB\<node>$" -Full`, a one-time cluster-onboarding step). The earlier "Access is denied" was Bug 2 (cross-node WMI by name), not a privilege gap.

## Live proof (cfg-lab, run as the SYSTEM steward via `cfg steward exec`)

```
=== RUN   TestClusterHA_CreateFailoverReconverge
--- PASS: TestClusterHA_CreateFailoverReconverge (24.34s)
PASS
```

Full cycle proven: standalone VM → clustered HA role (`-VMId`) → CNO-owner-gated → forced failover → DNA ChangeEvent → idempotent reconverge → `allow_destructive` teardown. Hyperv unit tests (mock transport, integration excluded) pass.

## Scope note

V1 was scoped as "add an assertion"; making its live [REQUIRED TEST] pass required fixing the two real #2202 module bugs above — folded in here since V1's purpose is proving the promote-to-HA path actually works. Sibling stories V2–V4 build on the same identity model + fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
