### PR TITLE
migrate: generalized cfg storage migrate verb + dry-run/report convention (Issue #2321)

### DIFF
--- a/cmd/cfg/cmd/migrate.go
+++ b/cmd/cfg/cmd/migrate.go
@@ -150,7 +150,7 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func printMigrateReport(out io.Writer, report migrate.Report) error {
+func printMigrateReport(out io.Writer, report migrate.MigrationReport) error {
 	total := 0
 	var totalBytes int64
 	for store, count := range report.Counts {

--- a/cmd/cfg/cmd/migrate_test.go
+++ b/cmd/cfg/cmd/migrate_test.go
@@ -108,7 +108,7 @@ func TestMigrateCmd_DryRunDoesNotWrite(t *testing.T) {
 // TestPrintMigrateReport_WithBytes verifies that printMigrateReport includes
 // byte totals per namespace when report.Bytes is populated.
 func TestPrintMigrateReport_WithBytes(t *testing.T) {
-	report := migrate.Report{
+	report := migrate.MigrationReport{
 		Counts: map[string]int{
 			"installers": 2,
 			"reports":    1,
@@ -136,7 +136,7 @@ func TestPrintMigrateReport_WithBytes(t *testing.T) {
 // TestPrintMigrateReport_WithoutBytes verifies backward compatibility: when Bytes
 // is nil, printMigrateReport omits byte information and still prints record counts.
 func TestPrintMigrateReport_WithoutBytes(t *testing.T) {
-	report := migrate.Report{
+	report := migrate.MigrationReport{
 		Counts: map[string]int{
 			"config_store": 3,
 		},

--- a/cmd/cfg/cmd/storage.go
+++ b/cmd/cfg/cmd/storage.go
@@ -21,11 +21,12 @@ import (
 )
 
 var (
-	migrateFrom         string
-	migrateTo           string
-	migrateGitRoot      string
-	migrateFlatfileRoot string
-	migrateSQLitePath   string
+	migrateFrom           string
+	migrateTo             string
+	migrateGitRoot        string
+	migrateFlatfileRoot   string
+	migrateSQLitePath     string
+	storageMigrateDryRun  bool
 )
 
 // storageCmd represents the storage command group
@@ -50,7 +51,13 @@ The migration reads all data from the source provider and writes it to the
 target provider. The command is idempotent: running it twice produces the same
 record count with no duplicates.
 
+Use --dry-run to preview what would be migrated without writing any data.
+
 Examples:
+  # Preview migration from git to flatfile+sqlite (dry run)
+  cfg storage migrate --from git --to flatfile --git-root /data/cfgms-git \
+    --flatfile-root /data/cfgms-flatfile --sqlite-path /data/cfgms.db --dry-run
+
   # Migrate from git to flatfile+sqlite (OSS composite)
   cfg storage migrate --from git --to flatfile --git-root /data/cfgms-git \
     --flatfile-root /data/cfgms-flatfile --sqlite-path /data/cfgms.db
@@ -67,6 +74,7 @@ func init() {
 	storageMigrateCmd.Flags().StringVar(&migrateGitRoot, "git-root", "", "Path to git repository root (required when --from=git)")
 	storageMigrateCmd.Flags().StringVar(&migrateFlatfileRoot, "flatfile-root", "", "Flatfile root directory (required when --to=flatfile)")
 	storageMigrateCmd.Flags().StringVar(&migrateSQLitePath, "sqlite-path", "", "SQLite database path (used with --to=flatfile for business data)")
+	storageMigrateCmd.Flags().BoolVar(&storageMigrateDryRun, "dry-run", false, "Preview migration plan without writing any data")
 
 	_ = storageMigrateCmd.MarkFlagRequired("from")
 	_ = storageMigrateCmd.MarkFlagRequired("to")
@@ -87,11 +95,20 @@ func runStorageMigrate(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("storage migrator: %w", err)
 		}
 		ctx := context.Background()
-		report, err := m.Run(ctx)
+		var report migrate.MigrationReport
+		if storageMigrateDryRun {
+			report, err = m.Plan(ctx)
+		} else {
+			report, err = m.Run(ctx)
+		}
 		if err != nil {
 			return err
 		}
-		fmt.Println("Migration complete:")
+		if storageMigrateDryRun {
+			fmt.Println("Dry-run complete (no data written):")
+		} else {
+			fmt.Println("Migration complete:")
+		}
 		total := 0
 		for store, count := range report.Counts {
 			fmt.Printf("  %-30s %d records\n", store+":", count)
@@ -163,43 +180,33 @@ func runStorageMigrate(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	counts := make(map[string]int)
-	errors := make(map[string]error)
 
 	switch migrateTo {
 	case "flatfile":
-		if err := migrateToFlatfile(ctx, gitProvider, gitConfig, counts, errors); err != nil {
+		reports, err := migrateToFlatfile(ctx, gitProvider, gitConfig, storageMigrateDryRun)
+		if err != nil {
 			return err
 		}
+		if storageMigrateDryRun {
+			fmt.Println("Dry-run complete (no data written):")
+		} else {
+			fmt.Println("Migration complete:")
+		}
+		migrate.PrintReport(os.Stdout, reports)
 	case "postgres":
 		return fmt.Errorf("postgres migration is not supported; migrate to flatfile first, then switch backend")
-	}
-
-	// Report results
-	fmt.Println("Migration complete:")
-	total := 0
-	for store, count := range counts {
-		fmt.Printf("  %-30s %d records\n", store+":", count)
-		total += count
-	}
-	fmt.Printf("  %-30s %d records\n", "Total:", total)
-
-	if len(errors) > 0 {
-		fmt.Println("\nWarnings (non-fatal):")
-		for store, err := range errors {
-			fmt.Printf("  %s: %v\n", store, err)
-		}
 	}
 
 	return nil
 }
 
 // migrateToFlatfile migrates all compatible stores from the git provider to
-// the flatfile+sqlite OSS composite target.
-func migrateToFlatfile(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, counts map[string]int, errors map[string]error) error {
+// the flatfile+sqlite OSS composite target using step-based execution.
+// When dryRun is true each step reads from source and counts records without writing.
+func migrateToFlatfile(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, dryRun bool) ([]migrate.Report, error) {
 	// Ensure target directories exist
 	if err := os.MkdirAll(migrateFlatfileRoot, 0755); err != nil {
-		return fmt.Errorf("failed to create flatfile root directory: %w", err)
+		return nil, fmt.Errorf("failed to create flatfile root directory: %w", err)
 	}
 
 	sqlitePath := migrateSQLitePath
@@ -210,40 +217,34 @@ func migrateToFlatfile(ctx context.Context, gitProvider interfaces.StorageProvid
 
 	targetManager, err := interfaces.CreateOSSStorageManager(migrateFlatfileRoot, sqlitePath)
 	if err != nil {
-		return fmt.Errorf("failed to initialize target storage: %w", err)
+		return nil, fmt.Errorf("failed to initialize target storage: %w", err)
 	}
 
-	fmt.Println("Migrating config store...")
-	if n, err := migrateConfigStore(ctx, gitProvider, gitConfig, targetManager); err != nil {
-		errors["config_store"] = err
-		fmt.Printf("  WARNING: config store migration incomplete: %v\n", err)
-	} else {
-		counts["config_store"] = n
-		fmt.Printf("  Config store: %d records migrated\n", n)
+	steps := []migrate.Step{
+		{
+			Name: "config_store",
+			Run: func(ctx context.Context, dryRun bool) (int, error) {
+				return migrateConfigStore(ctx, gitProvider, gitConfig, targetManager, dryRun)
+			},
+		},
+		{
+			Name: "registration_token_store",
+			Run: func(ctx context.Context, dryRun bool) (int, error) {
+				return migrateRegistrationTokenStore(ctx, gitProvider, gitConfig, targetManager, dryRun)
+			},
+		},
+		{
+			Name: "tenant_store",
+			Run: func(ctx context.Context, dryRun bool) (int, error) {
+				return migrateTenantStore(ctx, gitProvider, gitConfig, targetManager, dryRun)
+			},
+		},
 	}
 
-	fmt.Println("Migrating registration token store...")
-	if n, err := migrateRegistrationTokenStore(ctx, gitProvider, gitConfig, targetManager); err != nil {
-		errors["registration_token_store"] = err
-		fmt.Printf("  WARNING: registration token store migration incomplete: %v\n", err)
-	} else {
-		counts["registration_token_store"] = n
-		fmt.Printf("  Registration token store: %d records migrated\n", n)
-	}
-
-	fmt.Println("Migrating tenant store...")
-	if n, err := migrateTenantStore(ctx, gitProvider, gitConfig, targetManager); err != nil {
-		errors["tenant_store"] = err
-		fmt.Printf("  WARNING: tenant store migration incomplete: %v\n", err)
-	} else {
-		counts["tenant_store"] = n
-		fmt.Printf("  Tenant store: %d records migrated\n", n)
-	}
-
-	return nil
+	return migrate.RunSteps(ctx, dryRun, steps), nil
 }
 
-func migrateConfigStore(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, target *interfaces.StorageManager) (int, error) {
+func migrateConfigStore(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, target *interfaces.StorageManager, dryRun bool) (int, error) {
 	src, err := gitProvider.CreateConfigStore(gitConfig)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open git config store: %w", err)
@@ -261,6 +262,10 @@ func migrateConfigStore(ctx context.Context, gitProvider interfaces.StorageProvi
 
 	n := 0
 	for _, entry := range entries {
+		if dryRun {
+			n++
+			continue
+		}
 		entry.UpdatedAt = time.Now()
 		if err := dst.StoreConfig(ctx, entry); err != nil {
 			return n, fmt.Errorf("failed to store config %v: %w", entry.Key, err)
@@ -270,7 +275,7 @@ func migrateConfigStore(ctx context.Context, gitProvider interfaces.StorageProvi
 	return n, nil
 }
 
-func migrateRegistrationTokenStore(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, target *interfaces.StorageManager) (int, error) {
+func migrateRegistrationTokenStore(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, target *interfaces.StorageManager, dryRun bool) (int, error) {
 	src, err := gitProvider.CreateRegistrationTokenStore(gitConfig)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open git registration token store: %w", err)
@@ -293,6 +298,10 @@ func migrateRegistrationTokenStore(ctx context.Context, gitProvider interfaces.S
 
 	n := 0
 	for _, token := range tokens {
+		if dryRun {
+			n++
+			continue
+		}
 		if err := dst.SaveToken(ctx, token); err != nil {
 			return n, fmt.Errorf("failed to store token: %w", err)
 		}
@@ -301,7 +310,7 @@ func migrateRegistrationTokenStore(ctx context.Context, gitProvider interfaces.S
 	return n, nil
 }
 
-func migrateTenantStore(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, target *interfaces.StorageManager) (int, error) {
+func migrateTenantStore(ctx context.Context, gitProvider interfaces.StorageProvider, gitConfig map[string]interface{}, target *interfaces.StorageManager, dryRun bool) (int, error) {
 	src, err := gitProvider.CreateTenantStore(gitConfig)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open git tenant store: %w", err)
@@ -329,6 +338,10 @@ func migrateTenantStore(ctx context.Context, gitProvider interfaces.StorageProvi
 
 	n := 0
 	for _, tenantItem := range tenants {
+		if dryRun {
+			n++
+			continue
+		}
 		if err := dst.CreateTenant(ctx, tenantItem); err != nil {
 			// If already exists, try update (idempotency)
 			if err2 := dst.UpdateTenant(ctx, tenantItem); err2 != nil {

--- a/cmd/cfg/cmd/storage.go
+++ b/cmd/cfg/cmd/storage.go
@@ -21,12 +21,12 @@ import (
 )
 
 var (
-	migrateFrom           string
-	migrateTo             string
-	migrateGitRoot        string
-	migrateFlatfileRoot   string
-	migrateSQLitePath     string
-	storageMigrateDryRun  bool
+	migrateFrom          string
+	migrateTo            string
+	migrateGitRoot       string
+	migrateFlatfileRoot  string
+	migrateSQLitePath    string
+	storageMigrateDryRun bool
 )
 
 // storageCmd represents the storage command group
@@ -192,7 +192,9 @@ func runStorageMigrate(cmd *cobra.Command, args []string) error {
 		} else {
 			fmt.Println("Migration complete:")
 		}
-		migrate.PrintReport(os.Stdout, reports)
+		if err := migrate.PrintReport(os.Stdout, reports); err != nil {
+			return err
+		}
 	case "postgres":
 		return fmt.Errorf("postgres migration is not supported; migrate to flatfile first, then switch backend")
 	}

--- a/cmd/cfg/cmd/storage_test.go
+++ b/cmd/cfg/cmd/storage_test.go
@@ -3,10 +3,18 @@
 package cmd
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/migrate"
+	migratestorage "github.com/cfgis/cfgms/pkg/migrate/storage"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
 // TestStorageMigrateValidation verifies that runStorageMigrate returns a clear
@@ -21,6 +29,7 @@ func TestStorageMigrateValidation(t *testing.T) {
 		name           string
 		from           string
 		to             string
+		dryRun         bool
 		wantErrContain string
 	}{
 		{
@@ -52,6 +61,14 @@ func TestStorageMigrateValidation(t *testing.T) {
 			to:             "database",
 			wantErrContain: "CFGMS_STORAGE_FLATFILE_ROOT",
 		},
+		{
+			// --dry-run still validates backend names — an unknown source fails.
+			name:           "dry-run still validates backend",
+			from:           "git",
+			to:             "oss",
+			dryRun:         true,
+			wantErrContain: "git",
+		},
 	}
 
 	for _, tt := range tests {
@@ -64,13 +81,16 @@ func TestStorageMigrateValidation(t *testing.T) {
 			// Save and restore global flags.
 			origFrom := migrateFrom
 			origTo := migrateTo
+			origDryRun := storageMigrateDryRun
 			defer func() {
 				migrateFrom = origFrom
 				migrateTo = origTo
+				storageMigrateDryRun = origDryRun
 			}()
 
 			migrateFrom = tt.from
 			migrateTo = tt.to
+			storageMigrateDryRun = tt.dryRun
 
 			err := runStorageMigrate(nil, nil)
 			require.Error(t, err)
@@ -108,4 +128,103 @@ func TestStorageMigrateGitBackendRejected(t *testing.T) {
 	require.Error(t, err)
 	// The registered storage migrator reports "git" as an unknown backend.
 	assert.Contains(t, err.Error(), "git")
+}
+
+// TestStorageMigrateDryRun_FlatfileSQLiteTargetRemainsEmpty verifies that
+// running cfg storage migrate with --dry-run leaves the target flatfile+sqlite
+// config, registration-token, and tenant stores empty while the migration
+// reports the source record counts (reads all records but writes none).
+//
+// The "storage" migrator factory is temporarily overridden to inject
+// pre-built OSS managers with separate source and target directories so that
+// the target can be inspected independently of the source after the run.
+func TestStorageMigrateDryRun_FlatfileSQLiteTargetRemainsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	// Build a seeded source OSS manager.
+	srcDir := t.TempDir()
+	srcMgr, err := interfaces.CreateOSSStorageManager(srcDir+"/flat", srcDir+"/cfgms.db")
+	require.NoError(t, err, "create source storage manager")
+	t.Cleanup(func() { _ = srcMgr.Close() })
+
+	// Seed source config store.
+	require.NoError(t, srcMgr.GetConfigStore().StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key:       &cfgconfig.ConfigKey{TenantID: "t1", Namespace: "ns", Name: "cfg"},
+		Data:      []byte("key: val"),
+		Version:   1,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+
+	// Seed source tenant store.
+	srcTS := srcMgr.GetTenantStore()
+	require.NoError(t, srcTS.Initialize(ctx))
+	require.NoError(t, srcTS.CreateTenant(ctx, &business.TenantData{
+		ID:        "t1",
+		Name:      "Tenant One",
+		Status:    business.TenantStatusActive,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+
+	// Seed source registration token store.
+	srcRTS := srcMgr.GetRegistrationTokenStore()
+	require.NoError(t, srcRTS.Initialize(ctx))
+	require.NoError(t, srcRTS.SaveToken(ctx, &business.RegistrationTokenData{
+		Token:     "token-1",
+		TenantID:  "t1",
+		CreatedAt: time.Now(),
+	}))
+
+	// Build an empty target OSS manager.
+	dstDir := t.TempDir()
+	dstMgr, err := interfaces.CreateOSSStorageManager(dstDir+"/flat", dstDir+"/cfgms.db")
+	require.NoError(t, err, "create target storage manager")
+	t.Cleanup(func() { _ = dstMgr.Close() })
+
+	// Override the "storage" factory for this test with a real StorageMigrator
+	// using the pre-built managers instead of env-var-configured backends.
+	prevFactory, prevErr := migrate.Lookup("storage")
+	migrate.Register("storage", func(from, to string) (migrate.Migrator, error) {
+		return migratestorage.NewStorageMigrator(srcMgr, dstMgr), nil
+	})
+	t.Cleanup(func() {
+		if prevErr == nil {
+			migrate.Register("storage", prevFactory)
+		}
+	})
+
+	// Save and restore global flag state.
+	origFrom, origTo := migrateFrom, migrateTo
+	origDryRun := storageMigrateDryRun
+	t.Cleanup(func() {
+		migrateFrom, migrateTo = origFrom, origTo
+		storageMigrateDryRun = origDryRun
+	})
+
+	migrateFrom = "oss"
+	migrateTo = "oss"
+	storageMigrateDryRun = true
+
+	err = runStorageMigrate(nil, nil)
+	require.NoError(t, err, "dry-run must succeed")
+
+	// Target config store must remain empty — no writes performed.
+	entries, err := dstMgr.GetConfigStore().ListConfigs(ctx, &cfgconfig.ConfigFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, entries, "dry-run must not write config records to target")
+
+	// Target tenant store must remain empty.
+	dstTS := dstMgr.GetTenantStore()
+	require.NoError(t, dstTS.Initialize(ctx))
+	tenants, err := dstTS.ListTenants(ctx, &business.TenantFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, tenants, "dry-run must not write tenant records to target")
+
+	// Target registration token store must remain empty.
+	dstRTS := dstMgr.GetRegistrationTokenStore()
+	require.NoError(t, dstRTS.Initialize(ctx))
+	tokens, err := dstRTS.ListTokens(ctx, &business.RegistrationTokenFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, tokens, "dry-run must not write registration token records to target")
 }

--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -167,6 +167,17 @@ What this does:
 
 **Idempotent**: running the command twice against the same target produces the same record count with no duplicates. Safe to rehearse against a copy of production data before cutting over.
 
+**Dry-run preview**: pass `--dry-run` to read all source records and report per-store counts without writing anything to the target. Use this to confirm expected counts before scheduling downtime:
+
+```bash
+cfg storage migrate --from git --to flatfile \
+  --git-root /var/lib/cfgms/git-storage \
+  --flatfile-root /var/lib/cfgms/flatfile \
+  --dry-run
+```
+
+See [docs/operations/backend-migration.md](../operations/backend-migration.md) for the full offline-cutover procedure and downtime envelope.
+
 **Config update required after migration.** Replace the old single-provider block with OSS composite:
 
 ```yaml

--- a/docs/operations/backend-migration.md
+++ b/docs/operations/backend-migration.md
@@ -1,0 +1,114 @@
+# Backend Migration — Operator Guide
+
+This guide covers the generic `cfg migrate` and `cfg storage migrate` verb shape used
+to move data between CFGMS provider backends. Per-provider operator guides are linked
+in the [Provider-Specific Guides](#provider-specific-guides) section below.
+
+## Offline-Cutover Requirement
+
+**Stop the controller before migrating any provider it is actively using.**
+
+The migration tools assume exclusive write access to both the source and target backends.
+Running a migration while the controller is live can produce split-brain state: the
+controller continues writing to the source while the migrator reads a moving target,
+yielding an inconsistent snapshot in the destination.
+
+Recommended cutover sequence:
+
+1. Stop the controller (`systemctl stop cfgms-controller` or equivalent).
+2. Verify no other process holds the source backend open (check file locks, DB connections).
+3. Run the migration with `--dry-run` first to confirm expected record counts.
+4. Run the live migration.
+5. Update the controller's backend configuration to point at the new target.
+6. Start the controller and verify it reads the migrated data correctly.
+7. Archive (do not immediately delete) the source backend for a roll-back window.
+
+## Downtime Envelope
+
+| Phase                          | Typical Duration |
+|-------------------------------|-----------------|
+| `--dry-run` validation         | Seconds to minutes (read-only, no writes) |
+| Live migration (storage)       | Minutes to hours depending on record count |
+| Live migration (secrets)       | Seconds to minutes (secrets are small) |
+| Live migration (blobs)         | Minutes to hours depending on total blob size |
+| Controller restart and verify  | 30–120 seconds |
+
+Migration is idempotent: re-running against the same target is safe and produces
+the same record counts with no duplicates.
+
+## Generic Verb Shape
+
+All CFGMS provider migration commands share this flag convention:
+
+```
+cfg migrate --provider <provider> --from <source-backend> --to <target-backend> [--dry-run]
+cfg storage migrate --from <source-backend> --to <target-backend> [--dry-run]
+```
+
+| Flag         | Required | Description |
+|-------------|----------|-------------|
+| `--from`    | Yes      | Source backend name (provider-specific) |
+| `--to`      | Yes      | Target backend name (provider-specific) |
+| `--dry-run` | No       | Read source records and report counts without writing to target |
+
+### `--dry-run`
+
+`--dry-run` performs a read-only preview:
+
+- Reads all records from the source backend.
+- Counts records per store kind.
+- Writes nothing to the target backend.
+- Prints the same per-store count report as a live run.
+
+Use it to confirm record counts before scheduling a maintenance window, and to
+rehearse the migration against a copy of production data.
+
+```bash
+# Preview what would be migrated
+cfg storage migrate --from oss --to database --dry-run
+
+# Execute the live migration
+cfg storage migrate --from oss --to database
+```
+
+A `--dry-run` count that differs from the live run count indicates the source
+backend changed between the two invocations — always migrate with the controller stopped.
+
+### Reporting
+
+After a successful run (live or dry-run) the command prints a per-store summary:
+
+```
+Migration complete:
+  config:                        1 204 records
+  tenant:                          42 records
+  registration_token:               8 records
+  ...
+  Total:                         1 254 records
+```
+
+Non-fatal per-store errors appear as `WARNING:` lines in the summary and do not
+abort the remaining stores. A non-zero exit code is returned only for fatal errors
+that prevent the migration from starting (missing configuration, unreachable backend).
+
+## Provider-Specific Guides
+
+Per-provider operator guides document backend names, required environment variables,
+and provider-specific cutover notes. The following guides are planned as part of the
+backend migration epic (#2256); links will resolve once the corresponding stories merge.
+
+| Provider | Command | Guide |
+|---------|---------|-------|
+| Storage (controller data) | `cfg storage migrate` or `cfg migrate --provider storage` | [`docs/architecture/storage-architecture.md#storage-migration`](../architecture/storage-architecture.md) (S2) |
+| Secrets (CA key + secrets) | `cfg migrate --provider secrets` | `docs/operations/secrets-ca-migration.md` (S3 — file does not exist yet; created by story #2323) |
+| Blobs (installer artifacts) | `cfg migrate --provider blob` | `docs/operations/blob-migration.md` (S4 — file does not exist yet; created by story #2324) |
+
+> **Note on forward references:** The `secrets-ca-migration.md` and `blob-migration.md`
+> links above are intentional forward references to documents that will be created by
+> their respective stories (S3 and S4). A missing file at those paths is expected while
+> only S1 has merged — it is not a broken link bug.
+
+## Related
+
+- [`docs/architecture/storage-architecture.md`](../architecture/storage-architecture.md) — storage provider overview and migration-from-git guide
+- [Roadmap](../product/roadmap.md) — epic #2256 tracking all migration stories

--- a/pkg/migrate/blob/migrate.go
+++ b/pkg/migrate/blob/migrate.go
@@ -132,33 +132,33 @@ func NewBlobMigrator(src, dst blobstore.BlobStore, tenants []string) *BlobMigrat
 
 // Plan lists all blobs from the source and returns per-namespace counts and byte totals.
 // No writes to the target are performed.
-func (m *BlobMigrator) Plan(ctx context.Context) (migrate.Report, error) {
+func (m *BlobMigrator) Plan(ctx context.Context) (migrate.MigrationReport, error) {
 	infos, err := m.listAll(ctx)
 	if err != nil {
-		return migrate.Report{}, fmt.Errorf("blob plan: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("blob plan: %w", err)
 	}
 	counts, bytes := collectNamespaceStats(infos)
-	return migrate.Report{Counts: counts, Bytes: bytes, Errors: make(map[string]error)}, nil
+	return migrate.MigrationReport{Counts: counts, Bytes: bytes, Errors: make(map[string]error)}, nil
 }
 
 // Run copies all blobs from the source to the target, preserving BlobKey, BlobMeta,
 // and checksums. A checksum mismatch on any source blob fails the migration immediately.
 // Run is idempotent: re-running with the same source overwrites with identical content.
-func (m *BlobMigrator) Run(ctx context.Context) (migrate.Report, error) {
+func (m *BlobMigrator) Run(ctx context.Context) (migrate.MigrationReport, error) {
 	infos, err := m.listAll(ctx)
 	if err != nil {
-		return migrate.Report{}, fmt.Errorf("blob run: list failed: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("blob run: list failed: %w", err)
 	}
 
 	for _, info := range infos {
 		if err := m.copyBlob(ctx, info.Key, info.Meta); err != nil {
-			return migrate.Report{}, fmt.Errorf("blob run: copy %s/%s/%s: %w",
+			return migrate.MigrationReport{}, fmt.Errorf("blob run: copy %s/%s/%s: %w",
 				info.Key.TenantID, info.Key.Namespace, info.Key.Name, err)
 		}
 	}
 
 	counts, bytes := collectNamespaceStats(infos)
-	return migrate.Report{Counts: counts, Bytes: bytes, Errors: make(map[string]error)}, nil
+	return migrate.MigrationReport{Counts: counts, Bytes: bytes, Errors: make(map[string]error)}, nil
 }
 
 // listAll enumerates all blobs across all configured tenants from the source.

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -46,16 +46,24 @@ func RunSteps(ctx context.Context, dryRun bool, steps []Step) []Report {
 
 // PrintReport writes a human-readable per-step summary to w. Successful steps
 // show their record count; failed steps show a WARNING line. A Total line
-// sums counts from all successful steps.
-func PrintReport(w io.Writer, reports []Report) {
+// sums counts from all successful steps. It returns the first write error
+// encountered, if any.
+func PrintReport(w io.Writer, reports []Report) error {
 	total := 0
 	for _, r := range reports {
 		if r.Err != nil {
-			fmt.Fprintf(w, "  %-30s WARNING: %v\n", r.Name+":", r.Err)
+			if _, err := fmt.Fprintf(w, "  %-30s WARNING: %v\n", r.Name+":", r.Err); err != nil {
+				return err
+			}
 		} else {
-			fmt.Fprintf(w, "  %-30s %d records\n", r.Name+":", r.Count)
+			if _, err := fmt.Fprintf(w, "  %-30s %d records\n", r.Name+":", r.Count); err != nil {
+				return err
+			}
 			total += r.Count
 		}
 	}
-	fmt.Fprintf(w, "  %-30s %d records\n", "Total:", total)
+	if _, err := fmt.Fprintf(w, "  %-30s %d records\n", "Total:", total); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package migrate provides thin step-based helpers for multi-store migrations.
+//
+// Step, Report, RunSteps, and PrintReport are a minimal utility layer for
+// provider-agnostic migration work. They are not a generic migration engine:
+// no resumability, no parallelism, no retry. Steps run sequentially; a
+// failing step does not stop subsequent steps (non-fatal-warnings semantics).
+//
+// S3 (cfg secrets migrate) and S4 (cfg blob migrate) must follow the same
+// flag/report convention established here: --from, --to, --dry-run, and a
+// PrintReport-shaped summary.
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// Step is a named unit of migration work. Run performs the source read and,
+// when dryRun is false, the destination write. When dryRun is true, Run must
+// read from source and return the source record count without writing.
+type Step struct {
+	Name string
+	Run  func(ctx context.Context, dryRun bool) (count int, err error)
+}
+
+// Report carries the result of a single Step execution.
+type Report struct {
+	Name  string
+	Count int
+	Err   error
+}
+
+// RunSteps executes each step sequentially. A failing step records its error
+// in the corresponding Report and does not prevent subsequent steps from running.
+func RunSteps(ctx context.Context, dryRun bool, steps []Step) []Report {
+	reports := make([]Report, len(steps))
+	for i, step := range steps {
+		count, err := step.Run(ctx, dryRun)
+		reports[i] = Report{Name: step.Name, Count: count, Err: err}
+	}
+	return reports
+}
+
+// PrintReport writes a human-readable per-step summary to w. Successful steps
+// show their record count; failed steps show a WARNING line. A Total line
+// sums counts from all successful steps.
+func PrintReport(w io.Writer, reports []Report) {
+	total := 0
+	for _, r := range reports {
+		if r.Err != nil {
+			fmt.Fprintf(w, "  %-30s WARNING: %v\n", r.Name+":", r.Err)
+		} else {
+			fmt.Fprintf(w, "  %-30s %d records\n", r.Name+":", r.Count)
+			total += r.Count
+		}
+	}
+	fmt.Fprintf(w, "  %-30s %d records\n", "Total:", total)
+}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package migrate_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/migrate"
+)
+
+// TestRunSteps_DryRunSkipsWritePath verifies the dry-run contract:
+// each step's read logic is invoked (returning source counts) while the
+// write path is not reached when dryRun is true. A subsequent live run
+// against the same source must produce identical counts.
+func TestRunSteps_DryRunSkipsWritePath(t *testing.T) {
+	ctx := context.Background()
+
+	writeCount := 0
+	steps := []migrate.Step{
+		{
+			Name: "config_store",
+			Run: func(ctx context.Context, dryRun bool) (int, error) {
+				if !dryRun {
+					writeCount++
+				}
+				return 3, nil
+			},
+		},
+		{
+			Name: "tenant_store",
+			Run: func(ctx context.Context, dryRun bool) (int, error) {
+				if !dryRun {
+					writeCount++
+				}
+				return 2, nil
+			},
+		},
+	}
+
+	// Dry run: read-only, no writes, counts reflect source data.
+	dryReports := migrate.RunSteps(ctx, true, steps)
+	require.Len(t, dryReports, 2)
+	assert.Equal(t, 0, writeCount, "dry-run must not reach write path")
+	assert.Equal(t, "config_store", dryReports[0].Name)
+	assert.Equal(t, 3, dryReports[0].Count, "dry-run must report source record count")
+	assert.NoError(t, dryReports[0].Err)
+	assert.Equal(t, "tenant_store", dryReports[1].Name)
+	assert.Equal(t, 2, dryReports[1].Count, "dry-run must report source record count")
+	assert.NoError(t, dryReports[1].Err)
+
+	// Live run: same counts as dry run, write path is reached.
+	liveReports := migrate.RunSteps(ctx, false, steps)
+	require.Len(t, liveReports, 2)
+	assert.Equal(t, 2, writeCount, "live run must reach write path for each step")
+	assert.Equal(t, dryReports[0].Count, liveReports[0].Count,
+		"live run count must match dry-run count for config_store")
+	assert.Equal(t, dryReports[1].Count, liveReports[1].Count,
+		"live run count must match dry-run count for tenant_store")
+}
+
+// TestRunSteps_FailingStepContinues verifies that a step error does not
+// prevent subsequent steps from executing — matching the non-fatal-warnings
+// semantics of the inline git migration fallback.
+func TestRunSteps_FailingStepContinues(t *testing.T) {
+	ctx := context.Background()
+	secondRan := false
+
+	steps := []migrate.Step{
+		{
+			Name: "failing_step",
+			Run: func(ctx context.Context, dryRun bool) (int, error) {
+				return 0, errors.New("simulated step failure")
+			},
+		},
+		{
+			Name: "succeeding_step",
+			Run: func(ctx context.Context, dryRun bool) (int, error) {
+				secondRan = true
+				return 5, nil
+			},
+		},
+	}
+
+	reports := migrate.RunSteps(ctx, false, steps)
+	require.Len(t, reports, 2)
+	assert.Error(t, reports[0].Err, "failing step must record its error")
+	assert.True(t, secondRan, "succeeding step must run even after a prior failure")
+	assert.NoError(t, reports[1].Err)
+	assert.Equal(t, 5, reports[1].Count)
+}
+
+// TestPrintReport_OutputFormat verifies that PrintReport emits per-step lines
+// and a Total line that sums only successful steps.
+func TestPrintReport_OutputFormat(t *testing.T) {
+	reports := []migrate.Report{
+		{Name: "config_store", Count: 7, Err: nil},
+		{Name: "token_store", Count: 0, Err: errors.New("listing failed")},
+		{Name: "tenant_store", Count: 3, Err: nil},
+	}
+
+	var b strings.Builder
+	migrate.PrintReport(&b, reports)
+	out := b.String()
+
+	assert.Contains(t, out, "config_store", "must include config_store step")
+	assert.Contains(t, out, "7 records", "must show count for config_store")
+	assert.Contains(t, out, "WARNING", "must flag the failed token_store step")
+	assert.Contains(t, out, "listing failed", "must include error message")
+	assert.Contains(t, out, "tenant_store", "must include tenant_store step")
+	assert.Contains(t, out, "Total:", "must include a Total line")
+	// Total must be 7+3=10 (token_store failed, excluded from total).
+	assert.Contains(t, out, "10 records", "Total must sum only successful step counts")
+}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -105,7 +105,7 @@ func TestPrintReport_OutputFormat(t *testing.T) {
 	}
 
 	var b strings.Builder
-	migrate.PrintReport(&b, reports)
+	require.NoError(t, migrate.PrintReport(&b, reports))
 	out := b.String()
 
 	assert.Contains(t, out, "config_store", "must include config_store step")

--- a/pkg/migrate/migrator.go
+++ b/pkg/migrate/migrator.go
@@ -20,9 +20,9 @@ type Record struct {
 	Data []byte
 }
 
-// Report carries per-kind record counts, optional byte totals, and non-fatal errors.
+// MigrationReport carries per-kind record counts, optional byte totals, and non-fatal errors.
 // Bytes is nil for migrators that do not track byte sizes (e.g. storage, secrets).
-type Report struct {
+type MigrationReport struct {
 	Counts map[string]int
 	Bytes  map[string]int64 // per-namespace byte totals; nil when not tracked
 	Errors map[string]error
@@ -43,10 +43,10 @@ type Importer interface {
 // Migrator orchestrates a dry-run plan and an idempotent apply run.
 type Migrator interface {
 	// Plan performs a dry-run: it counts what would be migrated without writing.
-	Plan(ctx context.Context) (Report, error)
+	Plan(ctx context.Context) (MigrationReport, error)
 	// Run applies the migration. Run is idempotent: a second call yields identical
 	// counts and no duplicates in the target backend.
-	Run(ctx context.Context) (Report, error)
+	Run(ctx context.Context) (MigrationReport, error)
 }
 
 // MigratorFactory creates a Migrator for the given source and target backend names.
@@ -71,31 +71,31 @@ func NewBaseMigrator(e Exporter, i Importer) *BaseMigrator {
 }
 
 // Plan exports all records and returns their counts by kind; no writes are performed.
-func (m *BaseMigrator) Plan(ctx context.Context) (Report, error) {
+func (m *BaseMigrator) Plan(ctx context.Context) (MigrationReport, error) {
 	records, err := m.exporter.Export(ctx)
 	if err != nil {
-		return Report{}, fmt.Errorf("export failed: %w", err)
+		return MigrationReport{}, fmt.Errorf("export failed: %w", err)
 	}
 	counts := make(map[string]int, 4)
 	for _, r := range records {
 		counts[r.Kind]++
 	}
-	return Report{Counts: counts, Errors: make(map[string]error)}, nil
+	return MigrationReport{Counts: counts, Errors: make(map[string]error)}, nil
 }
 
 // Run exports all records and imports them into the target; returns counts by kind.
 // A second call to Run must produce identical counts with no duplicates.
-func (m *BaseMigrator) Run(ctx context.Context) (Report, error) {
+func (m *BaseMigrator) Run(ctx context.Context) (MigrationReport, error) {
 	records, err := m.exporter.Export(ctx)
 	if err != nil {
-		return Report{}, fmt.Errorf("export failed: %w", err)
+		return MigrationReport{}, fmt.Errorf("export failed: %w", err)
 	}
 	if err := m.importer.Import(ctx, records); err != nil {
-		return Report{}, fmt.Errorf("import failed: %w", err)
+		return MigrationReport{}, fmt.Errorf("import failed: %w", err)
 	}
 	counts := make(map[string]int, 4)
 	for _, r := range records {
 		counts[r.Kind]++
 	}
-	return Report{Counts: counts, Errors: make(map[string]error)}, nil
+	return MigrationReport{Counts: counts, Errors: make(map[string]error)}, nil
 }

--- a/pkg/migrate/secrets/migrate.go
+++ b/pkg/migrate/secrets/migrate.go
@@ -124,27 +124,27 @@ func NewSecretsMigrator(src, dst secretsinterfaces.SecretStore, caStoragePath, c
 
 // Plan exports secrets from the source and returns per-kind counts.
 // No writes to the target are performed.
-func (m *SecretsMigrator) Plan(ctx context.Context) (migrate.Report, error) {
+func (m *SecretsMigrator) Plan(ctx context.Context) (migrate.MigrationReport, error) {
 	records, err := m.exportSecrets(ctx)
 	if err != nil {
-		return migrate.Report{}, fmt.Errorf("secrets plan: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("secrets plan: %w", err)
 	}
 	counts := countByKind(records)
 	if m.caStoragePath != "" {
 		counts[kindCA] = 1
 	}
-	return migrate.Report{Counts: counts, Errors: make(map[string]error)}, nil
+	return migrate.MigrationReport{Counts: counts, Errors: make(map[string]error)}, nil
 }
 
 // Run migrates all secrets and (if configured) the file-based CA private key.
 // Idempotent: re-running overwrites with identical values using upsert semantics.
-func (m *SecretsMigrator) Run(ctx context.Context) (migrate.Report, error) {
+func (m *SecretsMigrator) Run(ctx context.Context) (migrate.MigrationReport, error) {
 	records, err := m.exportSecrets(ctx)
 	if err != nil {
-		return migrate.Report{}, fmt.Errorf("secrets run: export failed: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("secrets run: export failed: %w", err)
 	}
 	if err := m.importSecrets(ctx, records); err != nil {
-		return migrate.Report{}, fmt.Errorf("secrets run: import failed: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("secrets run: import failed: %w", err)
 	}
 
 	counts := countByKind(records)
@@ -153,7 +153,7 @@ func (m *SecretsMigrator) Run(ctx context.Context) (migrate.Report, error) {
 	if m.caStoragePath != "" {
 		sourceKeyFile, err := m.migrateCA(ctx)
 		if err != nil {
-			return migrate.Report{Counts: counts, Errors: errs},
+			return migrate.MigrationReport{Counts: counts, Errors: errs},
 				fmt.Errorf("secrets run: CA migration failed: %w", err)
 		}
 		counts[kindCA] = 1
@@ -161,7 +161,7 @@ func (m *SecretsMigrator) Run(ctx context.Context) (migrate.Report, error) {
 		errs["ca_source_key_path"] = fmt.Errorf("residual CA private key requires manual removal: %s", sourceKeyFile)
 	}
 
-	return migrate.Report{Counts: counts, Errors: errs}, nil
+	return migrate.MigrationReport{Counts: counts, Errors: errs}, nil
 }
 
 // exportSecrets lists and fetches all secrets from the source store.

--- a/pkg/migrate/storage/migrate.go
+++ b/pkg/migrate/storage/migrate.go
@@ -98,26 +98,26 @@ func NewStorageMigrator(src, dst *interfaces.StorageManager) *StorageMigrator {
 
 // Plan exports all records from the source and returns per-kind counts.
 // No writes to the target are performed.
-func (m *StorageMigrator) Plan(ctx context.Context) (migrate.Report, error) {
+func (m *StorageMigrator) Plan(ctx context.Context) (migrate.MigrationReport, error) {
 	records, err := exportAll(ctx, m.src)
 	if err != nil {
-		return migrate.Report{}, fmt.Errorf("storage plan: export failed: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("storage plan: export failed: %w", err)
 	}
 	counts := countByKind(records)
-	return migrate.Report{Counts: counts, Errors: make(map[string]error)}, nil
+	return migrate.MigrationReport{Counts: counts, Errors: make(map[string]error)}, nil
 }
 
 // Run exports all records from the source, imports them into the target with
 // upsert semantics, and then verifies that per-kind counts match. A count
 // mismatch returns a non-nil error that lists all mismatched kinds.
-func (m *StorageMigrator) Run(ctx context.Context) (migrate.Report, error) {
+func (m *StorageMigrator) Run(ctx context.Context) (migrate.MigrationReport, error) {
 	records, err := exportAll(ctx, m.src)
 	if err != nil {
-		return migrate.Report{}, fmt.Errorf("storage run: export failed: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("storage run: export failed: %w", err)
 	}
 
 	if err := importAll(ctx, m.dst, records); err != nil {
-		return migrate.Report{}, fmt.Errorf("storage run: import failed: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("storage run: import failed: %w", err)
 	}
 
 	srcCounts := countByKind(records)
@@ -125,7 +125,7 @@ func (m *StorageMigrator) Run(ctx context.Context) (migrate.Report, error) {
 	// Integrity check: re-export from target and compare counts.
 	dstRecords, err := exportAll(ctx, m.dst)
 	if err != nil {
-		return migrate.Report{}, fmt.Errorf("storage run: integrity check export failed: %w", err)
+		return migrate.MigrationReport{}, fmt.Errorf("storage run: integrity check export failed: %w", err)
 	}
 	dstCounts := countByKind(dstRecords)
 
@@ -136,11 +136,11 @@ func (m *StorageMigrator) Run(ctx context.Context) (migrate.Report, error) {
 		}
 	}
 	if len(mismatch) > 0 {
-		return migrate.Report{Counts: srcCounts, Errors: make(map[string]error)},
+		return migrate.MigrationReport{Counts: srcCounts, Errors: make(map[string]error)},
 			fmt.Errorf("storage migration integrity check failed: %v", mismatch)
 	}
 
-	return migrate.Report{Counts: srcCounts, Errors: make(map[string]error)}, nil
+	return migrate.MigrationReport{Counts: srcCounts, Errors: make(map[string]error)}, nil
 }
 
 // ─── kind constants ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `pkg/migrate.Step`/`Report`/`RunSteps`/`PrintReport` — a thin utility layer (no resumability, parallelism, or retry) for per-step migration work; renames the existing aggregate `Report` → `MigrationReport` to avoid a naming collision in the same package
- Adds `--dry-run` to `cfg storage migrate`: registered-migrator path calls `m.Plan()`, inline git-fallback path threads `dryRun` through three store functions that skip writes but still count source records; refactors the three call sites into `[]migrate.Step` + `RunSteps`
- Publishes `docs/operations/backend-migration.md` with generic verb shape, offline-cutover requirement, downtime envelope, and forward links to S2/S3/S4 operator guides; extends `docs/architecture/storage-architecture.md` with `--dry-run` example

## Specialist Review Results

| Lens | Result | Findings |
|------|--------|----------|
| Code Review | PASS | 0 findings |
| Test Quality | PASS | 0 findings |
| Security | PASS | 0 findings |

Review completed in 1 round, 0 fix rounds (workflow: `story-review`, run: `wf_72a115d2-d47`).

## Test plan

- [x] `pkg/migrate/migrate_test.go` — [REQUIRED] `RunSteps` dry-run: write path not reached, Count matches live run; failing step continues; `PrintReport` format
- [x] `cmd/cfg/cmd/storage_test.go` — [REQUIRED] `--dry-run` against real flatfile+sqlite target: target config/tenant/token stores empty after run; `TestStorageMigrateValidation` extended with dry-run case
- [x] All existing `pkg/migrate/{storage,secrets,blob}` tests pass (rename-only changes)
- [x] All existing `cmd/cfg/cmd` tests pass
- [x] `make check-architecture` — no central provider violations
- [x] `make lint-log-injection` — clean

Fixes #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)