### PR TITLE
hyperv: cluster-access self-check + controller onboarding alert (Issue #2319)

### DIFF
--- a/docs/operations/hyperv-cluster-access-onboarding.md
+++ b/docs/operations/hyperv-cluster-access-onboarding.md
@@ -1,0 +1,73 @@
+# Hyper-V Cluster-Management Access Onboarding
+
+The CFGMS steward runs as **LocalSystem**. To manage failover-cluster HA VM roles
+(`hyperv.cluster` resources), the node's **computer account** must hold cluster
+administrative access — LocalSystem authenticates to the cluster as that computer
+account, and it has no cluster access by default. This is a one-time, privileged
+grant per node.
+
+The steward **detects** the missing grant and raises a controller-visible alert so
+you know which nodes still need it — designed for fleet deployment where the
+steward is installed by automation (RMM script, GPO startup script, image) across
+many endpoints and the grants are done afterward.
+
+## How the alert works
+
+On every cluster read, the hyperv module runs a **read-only self-check**
+(`Get-ClusterAccess`) asking: *does this node's computer account hold cluster
+access?* The result is surfaced on the module's DNA:
+
+| DNA key | Meaning |
+|---|---|
+| `cluster_access_ok` | `true` when this node holds cluster access (or is a standalone host, or the probe could not determine access — unknown never alerts); `false` on a confirmed missing grant |
+| `cluster_access_remediation` | the exact `Grant-ClusterAccess` command to run, when `cluster_access_ok` is `false` |
+
+`cluster_access_ok` is part of the cluster DNA signature, so a grant/revoke
+**transitions the value and emits a DNA change** — the alert raises when access is
+missing and **clears automatically** on the next check once the grant lands. No
+manual reset.
+
+A confirmed missing grant (`cluster_access_ok: false`) is the onboarding alert:
+the node is a cluster member but cannot perform HA role operations until granted.
+
+## Remediating (the one-time grant)
+
+Run the remediation command from the alert on **any** cluster node, in a
+cluster-admin session (the grant modifies the cluster security descriptor):
+
+```powershell
+Grant-ClusterAccess -Cluster <cluster> -User "<DOMAIN>\<NODE>$" -Full
+```
+
+- The account is the node's **computer account** (`DOMAIN\NODE$`) — LocalSystem
+  presents as this over the network. No new identity, no gMSA, no stored
+  credential: the steward stays LocalSystem.
+- It's `-Full` because the module both reads and writes cluster state. The
+  blast-radius controls are app-layer (CNO-owner gating, `allow_destructive` for
+  teardown, per-op audit, `module_trust: strict`), not the identity.
+- Effect is immediate for a direct computer-account grant (no Kerberos-ticket
+  refresh needed, unlike an AD-group grant).
+
+After the grant, the next cluster read flips `cluster_access_ok` to `true` and the
+alert clears.
+
+## Revocation
+
+When a node is retired from cluster management, revoke its access so a
+decommissioned node loses cluster admin:
+
+```powershell
+Remove-ClusterAccess -Cluster <cluster> -User "<DOMAIN>\<NODE>$"
+```
+
+Full machine decommission (disabling/deleting the computer account) revokes all of
+its access instantly. See the cluster-access lifecycle work for the controller-
+orchestrated grant/revoke tied to node lifecycle.
+
+## Notes
+
+- **Grant-ClusterAccess is never run by routine steward convergence** — it is a
+  privileged onboarding/decommission action, deliberately kept out of the module's
+  cfg path (it is a lateral-movement primitive). The module only *reads* access and
+  *alerts*; a human/operator (or the controller's lifecycle orchestration) grants.
+- Standalone (non-cluster) hosts never raise this alert.

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -165,6 +165,15 @@ type ClusterStatus struct {
 	CSVPaths []string
 	// Found reports whether the cluster exists / was queryable on the host.
 	Found bool
+	// ClusterAccessOK reports whether this node's computer account holds the
+	// cluster-management access HA role operations require (#2306). True on a
+	// standalone host (no cluster to gate) and when the probe cannot determine
+	// access (unknown ⇒ no false alert). False only on a confirmed missing grant.
+	ClusterAccessOK bool
+	// ClusterAccessRemediation is the exact operator command to grant this node
+	// cluster access when ClusterAccessOK is false; empty otherwise. Surfaced as a
+	// controller-visible onboarding alert.
+	ClusterAccessRemediation string
 }
 
 // Validate implements modules.ConfigState. Observed status carries no operator
@@ -184,12 +193,14 @@ func (s *ClusterStatus) AsMap() map[string]interface{} {
 		owners[k] = v
 	}
 	return map[string]interface{}{
-		"name":           s.Name,
-		"cno_owner_node": s.CNOOwnerNode,
-		"member_nodes":   members,
-		"resource_owner": owners,
-		"csv_paths":      csv,
-		"found":          s.Found,
+		"name":                       s.Name,
+		"cno_owner_node":             s.CNOOwnerNode,
+		"member_nodes":               members,
+		"resource_owner":             owners,
+		"csv_paths":                  csv,
+		"found":                      s.Found,
+		"cluster_access_ok":          s.ClusterAccessOK,
+		"cluster_access_remediation": s.ClusterAccessRemediation,
 	}
 }
 
@@ -204,7 +215,7 @@ func (s *ClusterStatus) FromYAML(_ []byte) error { return nil }
 
 // GetManagedFields implements modules.ConfigState.
 func (s *ClusterStatus) GetManagedFields() []string {
-	return []string{"name", "cno_owner_node", "member_nodes", "resource_owner", "csv_paths"}
+	return []string{"name", "cno_owner_node", "member_nodes", "resource_owner", "csv_paths", "cluster_access_ok"}
 }
 
 // psGetCluster reads the cluster identity, member node names, and CSV friendly
@@ -246,6 +257,12 @@ const psAddClusterVMRole = `$vmid = (Get-VM -Name $VMName -ErrorAction Stop).Id;
 // Remove-ClusterGroup -RemoveResources (the VM role's GROUP name, not a resource
 // name — see that function). Reached only after the Go destructive gate.
 const psRemoveClusterResource = `Remove-ClusterGroup -Name $Name -RemoveResources -Force`
+
+// psGetClusterAccessSelf reads whether THIS node's computer account holds
+// cluster-management access (#2306 onboarding). Read-only; a denied/absent read
+// (Get-ClusterAccess SilentlyContinue) yields access_ok:false. The account and
+// the exact remediation grant come from PowerShell, never Go string composition.
+const psGetClusterAccessSelf = `$me = '{0}\{1}$' -f $env:USERDOMAIN, $env:COMPUTERNAME; $acl = @(Get-ClusterAccess -Cluster $ClusterName -ErrorAction SilentlyContinue); $ok = @($acl | Where-Object { $_.IdentityReference -ieq $me }).Count -gt 0; ConvertTo-Json @{ account=$me; access_ok=$ok; remediation=("Grant-ClusterAccess -Cluster {0} -User '{1}' -Full" -f $ClusterName, $me) } -Compress`
 
 // Declarative cluster-role property set commands (#2306). These consts are
 // dispatch KEYS — the executed PowerShell lives in the Cfgms-Set* preamble
@@ -309,7 +326,8 @@ func (m *hypervModule) getCluster(ctx context.Context, name string) (modules.Con
 		return nil, fmt.Errorf("hyperv: parse get-cluster response for %q: %w", name, jsonErr)
 	}
 	if !parsed.Found {
-		return &ClusterStatus{Name: name, Found: false}, nil
+		// Standalone host: no cluster to gate access on — never alert.
+		return &ClusterStatus{Name: name, Found: false, ClusterAccessOK: true}, nil
 	}
 
 	status := &ClusterStatus{
@@ -337,10 +355,44 @@ func (m *hypervModule) getCluster(ctx context.Context, name string) (modules.Con
 		status.CNOOwnerNode = m.readCNOOwner(ctx, name)
 	}
 
+	// Cluster-access self-check (#2306 onboarding): does this node's computer
+	// account hold the cluster-management access HA role ops require? A missing
+	// grant surfaces (via the DNA cluster_access_ok field + the Monitor) as a
+	// controller-visible onboarding alert with the exact remediation command.
+	status.ClusterAccessOK, status.ClusterAccessRemediation = m.probeClusterAccess(ctx, name)
+
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 		"Get-Cluster", "cluster:"+name, nil, nil, nil)
 
 	return status, nil
+}
+
+// probeClusterAccess reports whether this node's computer account holds
+// cluster-management access, and (when it does not) the exact operator command
+// to grant it. Read-only. A transport or parse error is treated as UNKNOWN —
+// access OK, no remediation — so a transient probe failure never raises a false
+// onboarding alert (only a confirmed missing grant does).
+func (m *hypervModule) probeClusterAccess(ctx context.Context, name string) (bool, string) {
+	out, err := m.transport.ExecutePS(ctx, psGetClusterAccessSelf, map[string]string{"ClusterName": name})
+	if err != nil {
+		if logger, ok := m.GetLogger(); ok {
+			logger.Warn("hyperv: cluster-access self-check probe failed; treating as access OK",
+				"cluster", logging.SanitizeLogValue(name))
+		}
+		return true, ""
+	}
+	var r struct {
+		Account     string `json:"account"`
+		AccessOK    bool   `json:"access_ok"`
+		Remediation string `json:"remediation"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &r); jsonErr != nil {
+		return true, ""
+	}
+	if r.AccessOK {
+		return true, ""
+	}
+	return false, r.Remediation
 }
 
 // readCNOOwner queries the current CNO owner node name, returning "" on any

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -205,13 +205,14 @@ func TestGetCluster_FoundPopulatesDNA(t *testing.T) {
 	assert.Equal(t, "NODE1", owners["web-01"])
 	assert.Equal(t, "NODE2", owners["db-01"])
 
-	// This node owns the CNO, so getCluster issues exactly three PS queries
-	// (Get-Cluster, the CNO-owner read, the resource-owner read) and no second
-	// CNO-owner read. A regression that adds or drops a PS call is caught here.
+	// This node owns the CNO, so getCluster issues exactly four PS queries
+	// (Get-Cluster, the CNO-owner read, the resource-owner read, the cluster-access
+	// self-check) and no second CNO-owner read. A regression that adds or drops a
+	// PS call is caught here.
 	transport.mu.Lock()
 	callCount := len(transport.calls)
 	transport.mu.Unlock()
-	assert.Equal(t, 3, callCount, "owner node issues exactly three PS queries")
+	assert.Equal(t, 4, callCount, "owner node issues exactly four PS queries")
 }
 
 // TestClusterScopeCap_OwnershipHelper verifies the scope cap is ALSO enforced in
@@ -338,13 +339,78 @@ func TestGetCluster_FoundNonCNOOwner(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "NODE2", owners["web-01"])
 
-	// Non-owner path issues four PS queries: Get-Cluster, the helper's CNO read,
-	// the resource-owner read, and the second CNO read in getCluster's else
-	// branch.
+	// Non-owner path issues five PS queries: Get-Cluster, the helper's CNO read,
+	// the resource-owner read, the second CNO read in getCluster's else branch,
+	// and the cluster-access self-check.
 	transport.mu.Lock()
 	callCount := len(transport.calls)
 	transport.mu.Unlock()
-	assert.Equal(t, 4, callCount, "non-owner path issues exactly four PS queries")
+	assert.Equal(t, 5, callCount, "non-owner path issues exactly five PS queries")
+}
+
+// TestGetCluster_ClusterAccessOK is the [REQUIRED TEST] (#2306 onboarding): when
+// the node's computer account holds cluster access, getCluster reports
+// ClusterAccessOK=true, no remediation, and surfaces cluster_access_ok on the DNA.
+func TestGetCluster_ClusterAccessOK(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"lab-hv","MemberNodes":["NODE1","NODE2"],"CsvPaths":["C:\\ClusterStorage\\CSV01"]}`,
+			`{"owner":"NODE1"}`, // CNO owner (this node)
+			`{"owners":{}}`,     // resource owners
+			`{"account":"LAB\\NODE1$","access_ok":true,"remediation":"Grant-ClusterAccess -Cluster lab-hv -User 'LAB\\NODE1$' -Full"}`,
+		},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.NoError(t, err)
+	status := state.(*ClusterStatus)
+	assert.True(t, status.ClusterAccessOK, "a granted node reports access OK")
+	assert.Empty(t, status.ClusterAccessRemediation, "no remediation when access is OK")
+	assert.Equal(t, true, status.AsMap()["cluster_access_ok"], "DNA exposes cluster_access_ok=true")
+}
+
+// TestGetCluster_ClusterAccessMissing is the [REQUIRED TEST] (#2306 onboarding):
+// when the node lacks cluster access, getCluster reports ClusterAccessOK=false and
+// an actionable remediation naming the Grant-ClusterAccess command.
+func TestGetCluster_ClusterAccessMissing(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"lab-hv","MemberNodes":["NODE1"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			`{"account":"LAB\\NODE1$","access_ok":false,"remediation":"Grant-ClusterAccess -Cluster lab-hv -User 'LAB\\NODE1$' -Full"}`,
+		},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.NoError(t, err)
+	status := state.(*ClusterStatus)
+	assert.False(t, status.ClusterAccessOK, "an ungranted node reports access missing")
+	assert.Contains(t, status.ClusterAccessRemediation, "Grant-ClusterAccess", "remediation names the grant command")
+	assert.Equal(t, false, status.AsMap()["cluster_access_ok"], "DNA exposes cluster_access_ok=false")
+}
+
+// TestGetCluster_Standalone_NoAccessAlert is the [REQUIRED TEST] (#2306
+// onboarding): a standalone (non-cluster) host never raises a cluster-access
+// alert and skips the probe entirely.
+func TestGetCluster_Standalone_NoAccessAlert(t *testing.T) {
+	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.NoError(t, err)
+	status := state.(*ClusterStatus)
+	assert.False(t, status.Found)
+	assert.True(t, status.ClusterAccessOK, "a standalone host never raises a cluster-access alert")
+	transport.mu.Lock()
+	n := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 1, n, "a standalone host skips the access probe (one Get-Cluster query only)")
 }
 
 // TestGetCluster_NilTransport verifies #7: with no transport wired, getCluster

--- a/features/modules/hyperv/cluster_windows.go
+++ b/features/modules/hyperv/cluster_windows.go
@@ -142,6 +142,10 @@ func clusterSignature(s *ClusterStatus) string {
 	var b strings.Builder
 	b.WriteString("found=")
 	b.WriteString(strconv.FormatBool(s.Found))
+	b.WriteString(";access=")
+	// cluster_access_ok is part of the signature so a grant/revoke transition
+	// emits a DNA change and the onboarding alert clears/raises (#2306).
+	b.WriteString(strconv.FormatBool(s.ClusterAccessOK))
 	b.WriteString(";cno=")
 	b.WriteString(s.CNOOwnerNode)
 	b.WriteString(";members=")

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -50,8 +50,10 @@ behavioral_envelope:
   lolbin_usage_justification: >-
     Hyper-V and Failover Clustering are managed exclusively through their
     PowerShell modules; there is no in-process managed API. The read-only
-    failover-cluster cmdlets (#2199 S1) are: Get-Cluster, Get-ClusterNode,
-    Get-ClusterGroup, Get-ClusterSharedVolume. The failover-cluster WRITE
+    failover-cluster cmdlets (#2199 S1, #2306) are: Get-Cluster, Get-ClusterNode,
+    Get-ClusterGroup, Get-ClusterSharedVolume, Get-ClusterAccess (the last is the
+    onboarding self-check reading whether this node's computer account holds
+    cluster-management access). The failover-cluster WRITE
     cmdlets (#2202 S2) are: Add-ClusterVirtualMachineRole (cluster an existing
     VM as a highly-available role — invoked only by the CNO-owner node, gated
     exactly-once; the VM is resolved to its Id via a local Get-VM and clustered

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -174,6 +174,8 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 		return t.run(ctx, "Cfgms-GetClusterOwnerNode -ClusterName "+quoteArg(psArgs, "ClusterName"))
 	case psGetClusterResourceOwner:
 		return t.run(ctx, "Cfgms-GetClusterResourceOwner -ClusterName "+quoteArg(psArgs, "ClusterName"))
+	case psGetClusterAccessSelf:
+		return t.run(ctx, "Cfgms-GetClusterAccessSelf -ClusterName "+quoteArg(psArgs, "ClusterName"))
 
 	// ── Failover cluster (write, #2202 S2) ──────────────────────────
 	case psAddClusterVMRole:

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -543,6 +543,18 @@ function Cfgms-GetClusterResourceOwner {
     ConvertTo-Json @{ owners = $owners } -Compress -Depth 4
 }
 
+# Cfgms-GetClusterAccessSelf mirrors psGetClusterAccessSelf: reports whether THIS
+# node's computer account holds cluster-management access (#2306 onboarding).
+# Read-only; a denied/absent Get-ClusterAccess read yields access_ok=false. The
+# account and the exact remediation grant come from here, never composed in Go.
+function Cfgms-GetClusterAccessSelf {
+    param([Parameter(Mandatory)][string]$ClusterName)
+    $me = '{0}\{1}$' -f $env:USERDOMAIN, $env:COMPUTERNAME
+    $acl = @(Get-ClusterAccess -Cluster $ClusterName -ErrorAction SilentlyContinue)
+    $ok = @($acl | Where-Object { $_.IdentityReference -ieq $me }).Count -gt 0
+    ConvertTo-Json @{ account = $me; access_ok = $ok; remediation = ("Grant-ClusterAccess -Cluster {0} -User '{1}' -Full" -f $ClusterName, $me) } -Compress
+}
+
 # ── Failover cluster write (#2202 S2) ─────────────────────────────────
 # Each function wraps a single write cmdlet; the exactly-once coordination
 # (only the CNO-owner node calls these), the existence/idempotency check, and


### PR DESCRIPTION
## Summary
Epic #2306. The steward runs as **LocalSystem**; the node's **computer account** needs a one-time `Grant-ClusterAccess` to manage cluster HA roles. This adds a read-only self-check so a cluster member lacking the grant raises a **controller-visible alert** with the exact remediation — for fleet deploy-by-automation where grants happen afterward.

Fixes #2319

## What changed
- `ClusterStatus` gains `cluster_access_ok` + `cluster_access_remediation` (DNA keys). `getCluster` probes access on a cluster member, **skips on a standalone host**, and treats a probe error as **unknown → no false alert**.
- `cluster_access_ok` is in the cluster **DNA signature**, so a grant/revoke transition emits a DNA change and the alert **clears/raises automatically**.
- New `Cfgms-GetClusterAccessSelf` preamble + dispatch; `module.yaml` envelope adds `Get-ClusterAccess` (read-only). Account + remediation come from PowerShell, never Go string composition.
- **`Grant-ClusterAccess` stays OUT of the module** (privileged onboarding action / lateral-movement primitive) — the module only reads + alerts.
- Unit tests: access-OK, access-missing (+remediation), standalone-skip; call-count assertions updated for the probe. Runbook: `docs/operations/hyperv-cluster-access-onboarding.md`.

Unit tests + `go vet` + `check-architecture` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)