### PR TITLE
hyperv: cluster-role property PS transport + live validation (Issue #2327)

### DIFF
--- a/features/modules/hyperv/cluster_integration_test.go
+++ b/features/modules/hyperv/cluster_integration_test.go
@@ -123,6 +123,13 @@ const psTestOtherUpNode = `$n = @(Get-ClusterNode -Cluster $env:CFGMS_T_CLUSTER 
 // SilentlyContinue throughout so cleanup never fails a passing test.
 const psTestRemoveClusteredVM = `$g = Get-ClusterGroup -Cluster $env:CFGMS_T_CLUSTER -Name $env:CFGMS_T_VM -ErrorAction SilentlyContinue; if ($g) { Remove-ClusterGroup -Cluster $env:CFGMS_T_CLUSTER -Name $env:CFGMS_T_VM -RemoveResources -Force -ErrorAction SilentlyContinue }; $vm = Get-VM -Name $env:CFGMS_T_VM -ErrorAction SilentlyContinue; if ($vm) { Stop-VM -Name $env:CFGMS_T_VM -Force -ErrorAction SilentlyContinue; Remove-VM -Name $env:CFGMS_T_VM -Force -ErrorAction SilentlyContinue }; 'ok'`
 
+// psTestReadGroupPriority reads the clustered role group's Priority (#2306 PROP-B).
+const psTestReadGroupPriority = `(Get-ClusterGroup -Cluster $env:CFGMS_T_CLUSTER -Name $env:CFGMS_T_VM -ErrorAction Stop).Priority`
+
+// psTestReadPreferredOwners reads the role group's ordered preferred owner nodes,
+// comma-joined (#2306 PROP-B).
+const psTestReadPreferredOwners = `(Get-ClusterOwnerNode -Cluster $env:CFGMS_T_CLUSTER -Group $env:CFGMS_T_VM -ErrorAction Stop).OwnerNodes.Name -join ','`
+
 // runTestPS executes a test-local PS helper in a freshly-spawned powershell.exe
 // (NOT the module's closed-dispatch ps-host transport, which would reject an
 // arbitrary script with "unknown psCommand"). Names are passed via CFGMS_T_*
@@ -475,6 +482,41 @@ func TestClusterHA_DestructiveGate(t *testing.T) {
 		"re-add after true-path removal must succeed")
 	assert.NotEmptyf(t, getClusterStatus(t, m, p.cluster).RoleOwners[role],
 		"role %q must reappear in RoleOwners after re-add", role)
+}
+
+// TestClusterHA_RoleProperties is the [REQUIRED TEST] (#2306 PROPERTIES-B): on the
+// CNO-owner node, a Set that declares role properties (preferred_owners + priority)
+// reconciles them onto the live clustered group, verified by reading the group back.
+func TestClusterHA_RoleProperties(t *testing.T) {
+	p := requireClusterEnv(t)
+	const role = "cfgms-ha-props-test"
+
+	m, _ := newClusterHAModule(t, p, []string{role})
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		runTestPS(t, psTestRemoveClusteredVM, map[string]string{"CFGMS_T_CLUSTER": p.cluster, "CFGMS_T_VM": role})
+	})
+
+	local := m.nodeHostname
+	runTestPS(t, psTestEnsureCNOOwner, map[string]string{"CFGMS_T_CLUSTER": p.cluster, "CFGMS_T_NODE": local})
+	runTestPS(t, psTestCreateClusteredCapableVM, map[string]string{"CFGMS_T_VM": role, "CFGMS_T_CSV": p.csvPath})
+
+	// Cluster the VM AND reconcile properties in a single owner-node Set.
+	require.NoError(t, m.Set(ctx, "cluster:"+p.cluster, &ClusterConfig{
+		Name:      p.cluster,
+		RoleNames: []string{role},
+		State:     "present",
+		Roles: map[string]ClusterRoleProperties{
+			role: {PreferredOwners: []string{local}, Priority: intPtr(2000)},
+		},
+	}), "clustering + property reconcile must succeed on the CNO owner")
+
+	// Read the live group back and assert the declared properties applied.
+	prio := strings.TrimSpace(runTestPS(t, psTestReadGroupPriority, map[string]string{"CFGMS_T_CLUSTER": p.cluster, "CFGMS_T_VM": role}))
+	assert.Equal(t, "2000", prio, "the cluster group Priority must reflect the declared value")
+	owners := runTestPS(t, psTestReadPreferredOwners, map[string]string{"CFGMS_T_CLUSTER": p.cluster, "CFGMS_T_VM": role})
+	assert.Containsf(t, owners, local, "preferred owners %q must include the declared node %q", owners, local)
 }
 
 // auditEntriesByAction returns the captured entries whose Action matches, in order.

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -60,7 +60,11 @@ behavioral_envelope:
     by -VMId, avoiding a cross-node WMI name-enumeration that is denied when the
     module runs as the LocalSystem steward) and Remove-ClusterGroup
     -RemoveResources (remove a clustered VM role group by name — gated behind
-    allow_destructive: true, default off). All arguments travel via
+    allow_destructive: true, default off). The cluster-role PROPERTY write
+    cmdlets (#2306) are: Set-ClusterOwnerNode (preferred owners on the role group,
+    possible owners on the VM resource) and Set-ClusterGroup group-property
+    assignment (Priority, AutoStart, AntiAffinityClassNames) — reconciled only on
+    the CNO-owner node after the role exists, idempotent. All arguments travel via
     ArgumentList (never string-composed). Cluster FORMATION cmdlets
     (New-Cluster, Add-ClusterNode, Remove-ClusterNode, quorum) are NOT declared
     and out of scope. This envelope change requires ADR-006 module re-signing

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -184,6 +184,23 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 				" -VMName "+quoteArg(psArgs, "VMName"))
 	case psRemoveClusterResource:
 		return t.run(ctx, "Cfgms-RemoveClusterResource -Name "+quoteArg(psArgs, "Name"))
+
+	// ── Failover cluster-role properties (write, #2306 PROPERTIES-B) ─
+	case psSetClusterRolePreferredOwners:
+		return t.run(ctx, "Cfgms-SetClusterRolePreferredOwners -ClusterName "+quoteArg(psArgs, "ClusterName")+
+			" -GroupName "+quoteArg(psArgs, "GroupName")+" -Owners "+quoteArg(psArgs, "Owners"))
+	case psSetClusterRolePossibleOwners:
+		return t.run(ctx, "Cfgms-SetClusterRolePossibleOwners -ClusterName "+quoteArg(psArgs, "ClusterName")+
+			" -ResourceName "+quoteArg(psArgs, "ResourceName")+" -Owners "+quoteArg(psArgs, "Owners"))
+	case psSetClusterGroupPriority:
+		return t.run(ctx, "Cfgms-SetClusterGroupPriority -ClusterName "+quoteArg(psArgs, "ClusterName")+
+			" -GroupName "+quoteArg(psArgs, "GroupName")+" -Priority "+quoteArg(psArgs, "Priority"))
+	case psSetClusterGroupAutoStart:
+		return t.run(ctx, "Cfgms-SetClusterGroupAutoStart -ClusterName "+quoteArg(psArgs, "ClusterName")+
+			" -GroupName "+quoteArg(psArgs, "GroupName")+" -AutoStart "+quoteArg(psArgs, "AutoStart"))
+	case psSetClusterGroupAntiAffinity:
+		return t.run(ctx, "Cfgms-SetClusterGroupAntiAffinity -ClusterName "+quoteArg(psArgs, "ClusterName")+
+			" -GroupName "+quoteArg(psArgs, "GroupName")+" -ClassName "+quoteArg(psArgs, "ClassName"))
 	}
 
 	return "", fmt.Errorf("hyperv-ps-host: unknown psCommand (not in dispatch table); add a Cfgms-* function and a case here")

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -149,6 +149,21 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 			" -VMName " + quoteArg(psArgs, "VMName"))
 	case psRemoveClusterResource:
 		return emit("Cfgms-RemoveClusterResource -Name " + quoteArg(psArgs, "Name"))
+	case psSetClusterRolePreferredOwners:
+		return emit("Cfgms-SetClusterRolePreferredOwners -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -GroupName " + quoteArg(psArgs, "GroupName") + " -Owners " + quoteArg(psArgs, "Owners"))
+	case psSetClusterRolePossibleOwners:
+		return emit("Cfgms-SetClusterRolePossibleOwners -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -ResourceName " + quoteArg(psArgs, "ResourceName") + " -Owners " + quoteArg(psArgs, "Owners"))
+	case psSetClusterGroupPriority:
+		return emit("Cfgms-SetClusterGroupPriority -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -GroupName " + quoteArg(psArgs, "GroupName") + " -Priority " + quoteArg(psArgs, "Priority"))
+	case psSetClusterGroupAutoStart:
+		return emit("Cfgms-SetClusterGroupAutoStart -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -GroupName " + quoteArg(psArgs, "GroupName") + " -AutoStart " + quoteArg(psArgs, "AutoStart"))
+	case psSetClusterGroupAntiAffinity:
+		return emit("Cfgms-SetClusterGroupAntiAffinity -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -GroupName " + quoteArg(psArgs, "GroupName") + " -ClassName " + quoteArg(psArgs, "ClassName"))
 	}
 	// Mirror production ExecutePS: an unknown psCommand is an error, not a
 	// silent success — keeps this test mirror honest to the production contract.
@@ -402,6 +417,36 @@ func TestPSDispatch_ClusterVerbs(t *testing.T) {
 			psCommand: psRemoveClusterResource,
 			psArgs:    map[string]string{"Name": "web-01"},
 			want:      "Cfgms-RemoveClusterResource -Name 'web-01'",
+		},
+		{
+			name:      "SetClusterRolePreferredOwners",
+			psCommand: psSetClusterRolePreferredOwners,
+			psArgs:    map[string]string{"ClusterName": "lab-hv", "GroupName": "web-01", "Owners": "NODE1,NODE2"},
+			want:      "Cfgms-SetClusterRolePreferredOwners -ClusterName 'lab-hv' -GroupName 'web-01' -Owners 'NODE1,NODE2'",
+		},
+		{
+			name:      "SetClusterRolePossibleOwners",
+			psCommand: psSetClusterRolePossibleOwners,
+			psArgs:    map[string]string{"ClusterName": "lab-hv", "ResourceName": "web-01", "Owners": "NODE1"},
+			want:      "Cfgms-SetClusterRolePossibleOwners -ClusterName 'lab-hv' -ResourceName 'web-01' -Owners 'NODE1'",
+		},
+		{
+			name:      "SetClusterGroupPriority",
+			psCommand: psSetClusterGroupPriority,
+			psArgs:    map[string]string{"ClusterName": "lab-hv", "GroupName": "web-01", "Priority": "2000"},
+			want:      "Cfgms-SetClusterGroupPriority -ClusterName 'lab-hv' -GroupName 'web-01' -Priority '2000'",
+		},
+		{
+			name:      "SetClusterGroupAutoStart",
+			psCommand: psSetClusterGroupAutoStart,
+			psArgs:    map[string]string{"ClusterName": "lab-hv", "GroupName": "web-01", "AutoStart": "1"},
+			want:      "Cfgms-SetClusterGroupAutoStart -ClusterName 'lab-hv' -GroupName 'web-01' -AutoStart '1'",
+		},
+		{
+			name:      "SetClusterGroupAntiAffinity",
+			psCommand: psSetClusterGroupAntiAffinity,
+			psArgs:    map[string]string{"ClusterName": "lab-hv", "GroupName": "web-01", "ClassName": "db-tier"},
+			want:      "Cfgms-SetClusterGroupAntiAffinity -ClusterName 'lab-hv' -GroupName 'web-01' -ClassName 'db-tier'",
 		},
 	}
 

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -591,4 +591,43 @@ function Cfgms-RemoveClusterResource {
     # group and all its resources (unclustering the VM; the VM itself persists).
     Remove-ClusterGroup -Name $Name -RemoveResources -Force
 }
+
+# ── Failover cluster-role properties (#2306 PROPERTIES-B) ──────────────
+# Declarative placement/scheduling properties for a clustered VM role. Reconciled
+# only on the CNO-owner node, after the role exists (Go gate in setCluster). All
+# args travel via ArgumentList; comma-joined owner lists are split here, never
+# composed into the command text.
+
+function Cfgms-SetClusterRolePreferredOwners {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$GroupName, [Parameter(Mandatory)][string]$Owners)
+    Set-ClusterOwnerNode -Cluster $ClusterName -Group $GroupName -Owners ($Owners -split ',')
+}
+
+function Cfgms-SetClusterRolePossibleOwners {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$ResourceName, [Parameter(Mandatory)][string]$Owners)
+    # Possible owners apply to the VM RESOURCE inside the role group; $ResourceName
+    # is the role (group) name — resolve its Virtual Machine resource. Materialise
+    # the match into an array (no Select -First, which trips the FailoverClusters
+    # provider with "pipeline has been stopped").
+    $res = @(Get-ClusterResource -Cluster $ClusterName -ErrorAction SilentlyContinue | Where-Object { $_.OwnerGroup.Name -eq $ResourceName -and $_.ResourceType.Name -eq 'Virtual Machine' })
+    if ($res.Count -gt 0) { Set-ClusterOwnerNode -Cluster $ClusterName -Resource $res[0].Name -Owners ($Owners -split ',') }
+}
+
+function Cfgms-SetClusterGroupPriority {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$GroupName, [Parameter(Mandatory)][int]$Priority)
+    $g = Get-ClusterGroup -Cluster $ClusterName -Name $GroupName -ErrorAction Stop
+    $g.Priority = $Priority
+}
+
+function Cfgms-SetClusterGroupAutoStart {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$GroupName, [Parameter(Mandatory)][int]$AutoStart)
+    $g = Get-ClusterGroup -Cluster $ClusterName -Name $GroupName -ErrorAction Stop
+    $g.AutoStart = $AutoStart
+}
+
+function Cfgms-SetClusterGroupAntiAffinity {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$GroupName, [Parameter(Mandatory)][string]$ClassName)
+    $g = Get-ClusterGroup -Cluster $ClusterName -Name $GroupName -ErrorAction Stop
+    $g.AntiAffinityClassNames = if ($ClassName) { @($ClassName) } else { @() }
+}
 `


### PR DESCRIPTION
## Summary
PROPERTIES-B of epic #2306 — the PS-transport half of the declarative cluster-role property reconcile (types + Go reconcile landed in PROPERTIES-A #2314). Completes the property capability.

Fixes #2327

## What changed
- Five `Cfgms-Set*` preamble functions + dispatch cases for the property consts: preferred owners (`Set-ClusterOwnerNode -Group`), possible owners (VM resource in the group), priority / auto-start / anti-affinity (`(Get-ClusterGroup).<prop>`). Comma-joined owner lists split in PowerShell; all args via **ArgumentList**.
- `module.yaml` envelope adds `Set-ClusterOwnerNode` + `Set-ClusterGroup` property writes (**ADR-006 re-sign** before strict stewards accept the bundle).
- Dispatch-table tests assert each const routes to the right `Cfgms-Set*` call with quoted args.

## Live proof (cfg-lab, SYSTEM steward via cfg exec)
```
--- PASS: TestClusterHA_RoleProperties (13.82s)
PASS
```
A Set declaring `preferred_owners` + `priority` reconciles onto the clustered group; verified by reading Priority (=2000) and the preferred owners back. Unit tests + check-architecture green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)