### PR TITLE
hyperv: cluster-access lifecycle reconcile — grant on join / revoke on retire (Issue #2330)

### DIFF
--- a/docs/operations/hyperv-cluster-access-onboarding.md
+++ b/docs/operations/hyperv-cluster-access-onboarding.md
@@ -61,8 +61,30 @@ Remove-ClusterAccess -Cluster <cluster> -User "<DOMAIN>\<NODE>$"
 ```
 
 Full machine decommission (disabling/deleting the computer account) revokes all of
-its access instantly. See the cluster-access lifecycle work for the controller-
-orchestrated grant/revoke tied to node lifecycle.
+its access instantly.
+
+## Controller-orchestrated lifecycle (option 3)
+
+Beyond the manual grant, the controller can **reconcile** cluster-management access
+to the cluster's member set automatically. The hyperv module exposes a privileged
+`ReconcileClusterAccess(cluster, desiredMembers)` action that:
+
+1. reads the node computer accounts currently in the cluster ACL,
+2. computes **grants** (a desired member whose account is not in the ACL) and
+   **revokes** (an account whose node is no longer a member — drift, e.g. a
+   retired or evicted node),
+3. applies them via `Grant-ClusterAccess` / `Remove-ClusterAccess`, auditing each.
+
+The controller invokes this as a **privileged lifecycle action** on a node whose
+steward already holds cluster access (bootstrap: the first grant is manual, driven
+by the onboarding alert above). It is **not** reachable from routine `hyperv.cluster`
+Set convergence — `Grant-ClusterAccess` is a lateral-movement primitive and is kept
+out of the cfg path deliberately. Grant/revoke of an already-consistent account is a
+no-op, so the reconcile is idempotent and safe to run repeatedly.
+
+Node retirement therefore revokes access two ways: the reconcile removes a
+no-longer-member account from the ACL, and full machine decommission
+(disabling/deleting the computer account) is the immediate, total revoke.
 
 ## Notes
 

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -264,6 +264,22 @@ const psRemoveClusterResource = `Remove-ClusterGroup -Name $Name -RemoveResource
 // the exact remediation grant come from PowerShell, never Go string composition.
 const psGetClusterAccessSelf = `$me = '{0}\{1}$' -f $env:USERDOMAIN, $env:COMPUTERNAME; $acl = @(Get-ClusterAccess -Cluster $ClusterName -ErrorAction SilentlyContinue); $ok = @($acl | Where-Object { $_.IdentityReference -ieq $me }).Count -gt 0; ConvertTo-Json @{ account=$me; access_ok=$ok; remediation=("Grant-ClusterAccess -Cluster {0} -User '{1}' -Full" -f $ClusterName, $me) } -Compress`
 
+// Cluster-access lifecycle commands (#2306 PROPERTIES/lifecycle, option 3).
+// These are PRIVILEGED, controller-orchestrated grant/revoke primitives — NOT
+// reachable from routine hyperv.cluster Set convergence. $NodeName is a cluster
+// node's short name; the computer account (DOMAIN\<node>$) is built in PowerShell
+// from $env:USERDOMAIN, never composed in Go. Dispatch keys.
+const (
+	// psListClusterAccessNodes returns the node short-names of the computer
+	// accounts currently granted cluster access (drift-detection source).
+	psListClusterAccessNodes = `ConvertTo-Json @{ nodes = @(Get-ClusterAccess -Cluster $ClusterName -ErrorAction SilentlyContinue | Where-Object { $_.IdentityReference -match '\$$' } | ForEach-Object { ($_.IdentityReference -replace '.*\\','') -replace '\$$','' }) } -Compress`
+	// psGrantClusterAccess grants $NodeName's computer account Full cluster access
+	// (the DOMAIN\<node>$ account is built in the preamble from $env:USERDOMAIN).
+	psGrantClusterAccess = `Grant-ClusterAccess -Cluster $ClusterName -User (DOMAIN\$NodeName$) -Full`
+	// psRevokeClusterAccess removes $NodeName's computer account from the cluster ACL.
+	psRevokeClusterAccess = `Remove-ClusterAccess -Cluster $ClusterName -User (DOMAIN\$NodeName$)`
+)
+
 // Declarative cluster-role property set commands (#2306). These consts are
 // dispatch KEYS — the executed PowerShell lives in the Cfgms-Set* preamble
 // functions wired by the PS-transport story (PROPERTIES-B); the reconcile below
@@ -393,6 +409,101 @@ func (m *hypervModule) probeClusterAccess(ctx context.Context, name string) (boo
 		return true, ""
 	}
 	return false, r.Remediation
+}
+
+// ClusterAccessReconcile is the outcome of a cluster-access lifecycle reconcile:
+// the node computer accounts granted and revoked to make the cluster ACL match
+// the desired member set.
+type ClusterAccessReconcile struct {
+	Granted []string
+	Revoked []string
+}
+
+// computeClusterAccessReconcile computes, case-insensitively, which member nodes
+// need a grant (a desired member whose computer account is not in the ACL) and
+// which granted nodes need a revoke (in the ACL but no longer a desired member —
+// drift, e.g. a retired node). Pure: no I/O, deterministic sets.
+func computeClusterAccessReconcile(desiredMembers, currentGranted []string) (grants, revokes []string) {
+	cur := map[string]string{} // lower(node) -> original
+	for _, n := range currentGranted {
+		if s := strings.TrimSpace(n); s != "" {
+			cur[strings.ToLower(s)] = s
+		}
+	}
+	des := map[string]struct{}{}
+	for _, n := range desiredMembers {
+		s := strings.TrimSpace(n)
+		if s == "" {
+			continue
+		}
+		des[strings.ToLower(s)] = struct{}{}
+		if _, ok := cur[strings.ToLower(s)]; !ok {
+			grants = append(grants, s)
+		}
+	}
+	for lower, orig := range cur {
+		if _, ok := des[lower]; !ok {
+			revokes = append(revokes, orig)
+		}
+	}
+	return grants, revokes
+}
+
+// ReconcileClusterAccess is the PRIVILEGED cluster-access lifecycle reconcile
+// (#2306 option 3): make the cluster ACL's node computer-account grants match the
+// desired member set. It reads the current grants, computes grants (desired
+// members lacking access) + revokes (granted nodes no longer members), applies
+// them via Grant-/Remove-ClusterAccess, and audits each. It is invoked by the
+// CONTROLLER's cluster-access lifecycle — NOT by routine hyperv.cluster Set
+// convergence — and runs on a node whose steward already holds cluster access.
+// Grant/revoke of an already-consistent account is a no-op (idempotent).
+func (m *hypervModule) ReconcileClusterAccess(ctx context.Context, clusterName string, desiredMembers []string) (ClusterAccessReconcile, error) {
+	var result ClusterAccessReconcile
+	if m.transport == nil {
+		return result, fmt.Errorf("hyperv: reconcile cluster access %q: %w", clusterName, ErrTransportNotConfigured)
+	}
+	out, err := m.transport.ExecutePS(ctx, psListClusterAccessNodes, map[string]string{"ClusterName": clusterName})
+	if err != nil {
+		return result, fmt.Errorf("hyperv: list cluster access %q: %w", clusterName, err)
+	}
+	var parsed struct {
+		Nodes []string `json:"nodes"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); jsonErr != nil {
+		return result, fmt.Errorf("hyperv: parse cluster access list %q: %w", clusterName, jsonErr)
+	}
+
+	grants, revokes := computeClusterAccessReconcile(desiredMembers, parsed.Nodes)
+
+	for _, node := range grants {
+		if _, err := m.transport.ExecutePS(ctx, psGrantClusterAccess, map[string]string{"ClusterName": clusterName, "NodeName": node}); err != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-access-grant", "cluster:"+clusterName,
+				map[string]interface{}{"node": logging.SanitizeLogValue(node)},
+				map[string]interface{}{"granted": false}, err)
+			return result, fmt.Errorf("hyperv: grant cluster access to %q: %w", node, err)
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-access-grant", "cluster:"+clusterName,
+			map[string]interface{}{"node": logging.SanitizeLogValue(node)},
+			map[string]interface{}{"granted": true}, nil)
+		result.Granted = append(result.Granted, node)
+	}
+	for _, node := range revokes {
+		if _, err := m.transport.ExecutePS(ctx, psRevokeClusterAccess, map[string]string{"ClusterName": clusterName, "NodeName": node}); err != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-access-revoke", "cluster:"+clusterName,
+				map[string]interface{}{"node": logging.SanitizeLogValue(node)},
+				map[string]interface{}{"revoked": false}, err)
+			return result, fmt.Errorf("hyperv: revoke cluster access from %q: %w", node, err)
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-access-revoke", "cluster:"+clusterName,
+			map[string]interface{}{"node": logging.SanitizeLogValue(node)},
+			map[string]interface{}{"revoked": true}, nil)
+		result.Revoked = append(result.Revoked, node)
+	}
+	return result, nil
 }
 
 // readCNOOwner queries the current CNO owner node name, returning "" on any

--- a/features/modules/hyperv/cluster_integration_test.go
+++ b/features/modules/hyperv/cluster_integration_test.go
@@ -519,6 +519,25 @@ func TestClusterHA_RoleProperties(t *testing.T) {
 	assert.Containsf(t, owners, local, "preferred owners %q must include the declared node %q", owners, local)
 }
 
+// TestClusterHA_AccessReconcileNoOp validates the cluster-access lifecycle reconcile
+// live (#2306 option 3) without mutating the ACL: reconciling against the CURRENT
+// member set on a fully-onboarded cluster must be a no-op — zero grants, zero
+// revokes — exercising the live ACL read + compute path.
+func TestClusterHA_AccessReconcileNoOp(t *testing.T) {
+	p := requireClusterEnv(t)
+	m, _ := newClusterHAModule(t, p, nil)
+	t.Cleanup(func() { _ = m.Close() })
+	ctx := context.Background()
+
+	status := getClusterStatus(t, m, p.cluster)
+	require.NotEmpty(t, status.MemberNodes, "cluster must report members")
+
+	res, err := m.ReconcileClusterAccess(ctx, p.cluster, status.MemberNodes)
+	require.NoError(t, err)
+	assert.Emptyf(t, res.Granted, "a fully-onboarded cluster needs no grants, got %v", res.Granted)
+	assert.Emptyf(t, res.Revoked, "reconciling against the current member set revokes nothing, got %v", res.Revoked)
+}
+
 // auditEntriesByAction returns the captured entries whose Action matches, in order.
 func auditEntriesByAction(entries []*business.AuditEntry, action string) []*business.AuditEntry {
 	var out []*business.AuditEntry

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -413,6 +413,59 @@ func TestGetCluster_Standalone_NoAccessAlert(t *testing.T) {
 	assert.Equal(t, 1, n, "a standalone host skips the access probe (one Get-Cluster query only)")
 }
 
+// TestComputeClusterAccessReconcile is the [REQUIRED TEST] (#2306 lifecycle): the
+// pure reconcile computes the correct grant-set (desired members lacking access)
+// and revoke-set (granted nodes no longer members — drift), case-insensitively.
+func TestComputeClusterAccessReconcile(t *testing.T) {
+	// Desired A,B,C; ACL holds A, c (different case), X (retired drift).
+	grants, revokes := computeClusterAccessReconcile(
+		[]string{"CFG-A", "CFG-B", "CFG-C"}, []string{"CFG-A", "cfg-c", "CFG-X"})
+	assert.ElementsMatch(t, []string{"CFG-B"}, grants, "a desired member absent from the ACL is granted")
+	assert.ElementsMatch(t, []string{"CFG-X"}, revokes, "a granted node no longer a member is revoked (drift)")
+
+	// Steady state: desired == current (any case/order) → no changes.
+	g, r := computeClusterAccessReconcile([]string{"CFG-A", "CFG-B"}, []string{"cfg-b", "CFG-A"})
+	assert.Empty(t, g, "steady state grants nothing")
+	assert.Empty(t, r, "steady state revokes nothing")
+}
+
+// TestReconcileClusterAccess drives the reconcile through the transport: it reads
+// the ACL, grants the missing member and revokes the drift node, exactly once each.
+func TestReconcileClusterAccess(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"nodes":["NODE1","NODE3"]}`, // current ACL: NODE1, NODE3
+			``,                            // grant NODE2
+			``,                            // revoke NODE3
+		},
+	}
+	m, store := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	res, err := m.ReconcileClusterAccess(context.Background(), "lab-hv", []string{"NODE1", "NODE2"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"NODE2"}, res.Granted)
+	assert.ElementsMatch(t, []string{"NODE3"}, res.Revoked)
+	assert.Equal(t, 1, countCmd(transport, psGrantClusterAccess), "one grant issued")
+	assert.Equal(t, 1, countCmd(transport, psRevokeClusterAccess), "one revoke issued")
+
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	assert.Len(t, auditEntriesByActionCT(store.captured(), "cluster-access-grant"), 1)
+	assert.Len(t, auditEntriesByActionCT(store.captured(), "cluster-access-revoke"), 1)
+}
+
+// auditEntriesByActionCT counts captured audit entries by action (unit-test copy;
+// the integration file has its own auditEntriesByAction under a different tag).
+func auditEntriesByActionCT(entries []*business.AuditEntry, action string) []*business.AuditEntry {
+	var out []*business.AuditEntry
+	for _, e := range entries {
+		if e.Action == action {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // TestGetCluster_NilTransport verifies #7: with no transport wired, getCluster
 // returns the distinct ErrTransportNotConfigured sentinel (a misconfiguration),
 // NOT the ErrClusterNotDeclared scope-cap sentinel.

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -64,7 +64,12 @@ behavioral_envelope:
     cmdlets (#2306) are: Set-ClusterOwnerNode (preferred owners on the role group,
     possible owners on the VM resource) and Set-ClusterGroup group-property
     assignment (Priority, AutoStart, AntiAffinityClassNames) — reconciled only on
-    the CNO-owner node after the role exists, idempotent. All arguments travel via
+    the CNO-owner node after the role exists, idempotent. The cluster-ACCESS
+    lifecycle cmdlets (#2306 option 3) are: Grant-ClusterAccess and
+    Remove-ClusterAccess (grant/revoke a node computer account's cluster-management
+    access) — a PRIVILEGED, controller-orchestrated action tied to node lifecycle,
+    NOT reachable from routine cluster cfg convergence (a lateral-movement
+    primitive). All arguments travel via
     ArgumentList (never string-composed). Cluster FORMATION cmdlets
     (New-Cluster, Add-ClusterNode, Remove-ClusterNode, quorum) are NOT declared
     and out of scope. This envelope change requires ADR-006 module re-signing

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -201,6 +201,16 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 	case psSetClusterGroupAntiAffinity:
 		return t.run(ctx, "Cfgms-SetClusterGroupAntiAffinity -ClusterName "+quoteArg(psArgs, "ClusterName")+
 			" -GroupName "+quoteArg(psArgs, "GroupName")+" -ClassName "+quoteArg(psArgs, "ClassName"))
+
+	// ── Cluster-access lifecycle (write, #2306 option 3, privileged) ─
+	case psListClusterAccessNodes:
+		return t.run(ctx, "Cfgms-ListClusterAccessNodes -ClusterName "+quoteArg(psArgs, "ClusterName"))
+	case psGrantClusterAccess:
+		return t.run(ctx, "Cfgms-GrantClusterAccess -ClusterName "+quoteArg(psArgs, "ClusterName")+
+			" -NodeName "+quoteArg(psArgs, "NodeName"))
+	case psRevokeClusterAccess:
+		return t.run(ctx, "Cfgms-RevokeClusterAccess -ClusterName "+quoteArg(psArgs, "ClusterName")+
+			" -NodeName "+quoteArg(psArgs, "NodeName"))
 	}
 
 	return "", fmt.Errorf("hyperv-ps-host: unknown psCommand (not in dispatch table); add a Cfgms-* function and a case here")

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -164,6 +164,14 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 	case psSetClusterGroupAntiAffinity:
 		return emit("Cfgms-SetClusterGroupAntiAffinity -ClusterName " + quoteArg(psArgs, "ClusterName") +
 			" -GroupName " + quoteArg(psArgs, "GroupName") + " -ClassName " + quoteArg(psArgs, "ClassName"))
+	case psListClusterAccessNodes:
+		return emit("Cfgms-ListClusterAccessNodes -ClusterName " + quoteArg(psArgs, "ClusterName"))
+	case psGrantClusterAccess:
+		return emit("Cfgms-GrantClusterAccess -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -NodeName " + quoteArg(psArgs, "NodeName"))
+	case psRevokeClusterAccess:
+		return emit("Cfgms-RevokeClusterAccess -ClusterName " + quoteArg(psArgs, "ClusterName") +
+			" -NodeName " + quoteArg(psArgs, "NodeName"))
 	}
 	// Mirror production ExecutePS: an unknown psCommand is an error, not a
 	// silent success — keeps this test mirror honest to the production contract.

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -630,4 +630,28 @@ function Cfgms-SetClusterGroupAntiAffinity {
     $g = Get-ClusterGroup -Cluster $ClusterName -Name $GroupName -ErrorAction Stop
     $g.AntiAffinityClassNames = if ($ClassName) { @($ClassName) } else { @() }
 }
+
+# ── Cluster-access lifecycle (#2306 option 3, PRIVILEGED) ──────────────
+# Controller-orchestrated grant/revoke of node computer accounts, tied to node
+# lifecycle. NOT reachable from routine cluster cfg convergence. $NodeName is a
+# short node name; the DOMAIN\<node>$ computer account is built here from
+# $env:USERDOMAIN, never composed in Go.
+
+function Cfgms-ListClusterAccessNodes {
+    param([Parameter(Mandatory)][string]$ClusterName)
+    $nodes = @(Get-ClusterAccess -Cluster $ClusterName -ErrorAction SilentlyContinue | Where-Object { $_.IdentityReference -match '\$$' } | ForEach-Object { ($_.IdentityReference -replace '.*\\','') -replace '\$$','' })
+    ConvertTo-Json @{ nodes = $nodes } -Compress
+}
+
+function Cfgms-GrantClusterAccess {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$NodeName)
+    $acct = '{0}\{1}$' -f $env:USERDOMAIN, $NodeName
+    Grant-ClusterAccess -Cluster $ClusterName -User $acct -Full
+}
+
+function Cfgms-RevokeClusterAccess {
+    param([Parameter(Mandatory)][string]$ClusterName, [Parameter(Mandatory)][string]$NodeName)
+    $acct = '{0}\{1}$' -f $env:USERDOMAIN, $NodeName
+    Remove-ClusterAccess -Cluster $ClusterName -User $acct
+}
 `


### PR DESCRIPTION
## Summary
The final story of epic #2306 — the cluster-access **lifecycle** (**option 3**): the controller reconciles which node computer accounts hold cluster-management access to match the cluster's member set, via **direct per-node** `Grant-ClusterAccess`/`Remove-ClusterAccess` — no AD group, no directory-provider dependency (the AD provider's group writes proved to be read-only stubs; a security review confirmed the computer-account grant model).

Fixes #2330

## What changed
- `ReconcileClusterAccess(cluster, desiredMembers)`: reads the current ACL, computes **grants** (desired member lacking access) + **revokes** (granted node no longer a member — drift), applies + audits each. A **privileged, controller-orchestrated** action — **not** reachable from routine `hyperv.cluster` Set convergence (`Grant-ClusterAccess` is a lateral-movement primitive). Idempotent.
- `computeClusterAccessReconcile`: pure, case-insensitive grant/revoke set computation.
- `Cfgms-ListClusterAccessNodes` / `-GrantClusterAccess` / `-RevokeClusterAccess` preamble + dispatch; the `DOMAIN\<node>$` account is built in PowerShell from `$env:USERDOMAIN`, never in Go. Envelope adds `Grant`/`Remove-ClusterAccess` (ADR-006 re-sign).
- Unit tests (compute + reconcile-via-mock + audit). Runbook lifecycle section.

## Live proof (cfg-lab, SYSTEM steward via cfg exec)
```
--- PASS: TestClusterHA_AccessReconcileNoOp (2.02s)
PASS
```
Reconciling against the current member set on the fully-onboarded cluster no-ops (0 grants/revokes) — validates the live ACL read + compute path without mutating the ACL. Unit tests + check-architecture green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)