### PR TITLE
storage: add RefreshPolicyStore + PendingRefreshStore on Postgres provider + migrator coverage (Issue #2329)

### DIFF
--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -178,6 +178,27 @@ cfg storage migrate --from git --to flatfile \
 
 See [docs/operations/backend-migration.md](../operations/backend-migration.md) for the full offline-cutover procedure and downtime envelope.
 
+### Stores covered by the storage migrator
+
+The `cfg migrate --provider storage` pathway covers the following store kinds. Each row shows whether the OSS (flatfile+SQLite) and database (PostgreSQL) backends support export and import for that kind.
+
+| Store kind | OSS | PostgreSQL | Notes |
+|---|---|---|---|
+| `tenant` | ✓ | ✓ | Tenant tree |
+| `config` | ✓ | ✓ | Config entries |
+| `audit` | ✓ | ✓ | Audit log entries |
+| `registration_token` | ✓ | ✓ | Steward registration tokens |
+| `session` | ✓ | ✓ | Admin sessions |
+| `steward` | ✓ | ✓ | Steward fleet records |
+| `command` | ✓ | ✓ | Command records |
+| `trigger` | ✓ | — | OSS only; Postgres backend does not expose a `TriggerStore` |
+| `push` | ✓ | — | OSS only; Postgres backend does not expose a `PushStore` |
+| `ip_trust` | ✓ | ✓ | Trusted IP ranges per tenant |
+| `refresh_policy` | ✓ | ✓ | Per-tenant DNA refresh approval policy (Issue #2329) |
+| `pending_refresh` | ✓ | ✓ | Pending DNA refresh requests (Issue #2329) |
+
+Kinds marked `—` are silently skipped when the destination backend does not support that store. The integrity check at the end of a `Run` only compares kinds that both source and destination support, so a cross-backend migration (OSS → Postgres) will not fail on `trigger` or `push` records.
+
 **Config update required after migration.** Replace the old single-provider block with OSS composite:
 
 ```yaml

--- a/pkg/migrate/storage/helpers_test.go
+++ b/pkg/migrate/storage/helpers_test.go
@@ -168,4 +168,29 @@ func seedOSSManager(t *testing.T, mgr *interfaces.StorageManager) {
 	ipts := mgr.GetIPTrustStore()
 	require.NotNil(t, ipts, "ip trust store")
 	require.NoError(t, ipts.AddTrustedRange(ctx, "tenant-seed-1", "192.168.1.0/24", false))
+
+	// refresh policy (explicit, non-default)
+	rps := mgr.GetRefreshPolicyStore()
+	require.NotNil(t, rps, "refresh policy store")
+	dormancy := 30
+	require.NoError(t, rps.SetPolicy(ctx, &business.RefreshPolicy{
+		TenantID:        "tenant-seed-1",
+		Mode:            "auto_accept",
+		MaxDormancyDays: &dormancy,
+	}))
+
+	// pending refresh entry
+	prs := mgr.GetPendingRefreshStore()
+	require.NotNil(t, prs, "pending refresh store")
+	require.NoError(t, prs.AddPendingRefresh(ctx, &business.PendingRefreshEntry{
+		PendingID:               "pending-refresh-seed-1",
+		DeviceID:                "device-seed-1",
+		TenantID:                "tenant-seed-1",
+		SourceIP:                "10.0.0.1",
+		ProvenanceMatchedFields: 4,
+		ProvenanceTotalFields:   5,
+		Status:                  business.PendingRefreshStatusPending,
+		CreatedAt:               time.Now(),
+		ExpiresAt:               time.Now().Add(24 * time.Hour),
+	}))
 }

--- a/pkg/migrate/storage/migrate.go
+++ b/pkg/migrate/storage/migrate.go
@@ -129,8 +129,14 @@ func (m *StorageMigrator) Run(ctx context.Context) (migrate.MigrationReport, err
 	}
 	dstCounts := countByKind(dstRecords)
 
+	dstSupported := supportedKindsByManager(m.dst)
+
 	var mismatch []string
 	for kind, srcN := range srcCounts {
+		if !dstSupported[kind] {
+			// Destination backend does not support this store; data skip is expected.
+			continue
+		}
 		if dstN := dstCounts[kind]; dstN != srcN {
 			mismatch = append(mismatch, fmt.Sprintf("%s: want %d got %d", kind, srcN, dstN))
 		}
@@ -161,6 +167,8 @@ const (
 	kindTrigger           = "trigger"
 	kindPush              = "push"
 	kindIPTrust           = "ip_trust"
+	kindRefreshPolicy     = "refresh_policy"
+	kindPendingRefresh    = "pending_refresh"
 )
 
 // ─── export ──────────────────────────────────────────────────────────────────
@@ -243,6 +251,20 @@ func exportAll(ctx context.Context, mgr *interfaces.StorageManager) ([]migrate.R
 		return nil, err
 	}
 	out = append(out, ipRecs...)
+
+	// Refresh-policy records are per-tenant; export after tenants so that the
+	// tenant IDs are available for scoping (FK ordering).
+	rpRecs, err := exportRefreshPolicies(ctx, mgr, tenantIDs)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, rpRecs...)
+
+	prRecs, err := exportPendingRefresh(ctx, mgr)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, prRecs...)
 
 	return out, nil
 }
@@ -575,6 +597,50 @@ func exportIPTrust(ctx context.Context, mgr *interfaces.StorageManager, tenantID
 	return recs, nil
 }
 
+// exportRefreshPolicies exports the per-tenant refresh policy for each known
+// tenant. GetPolicy returns a default when no explicit record exists, so the
+// export is always one record per tenant — the count matches the tenant count.
+func exportRefreshPolicies(ctx context.Context, mgr *interfaces.StorageManager, tenantIDs []string) ([]migrate.Record, error) {
+	store := mgr.GetRefreshPolicyStore()
+	if store == nil {
+		return nil, nil
+	}
+	recs := make([]migrate.Record, 0, len(tenantIDs))
+	for _, tid := range tenantIDs {
+		p, err := store.GetPolicy(ctx, tid)
+		if err != nil {
+			return nil, fmt.Errorf("get refresh policy for tenant %s: %w", tid, err)
+		}
+		data, err := marshal(p)
+		if err != nil {
+			return nil, err
+		}
+		recs = append(recs, migrate.Record{Kind: kindRefreshPolicy, ID: tid, Data: data})
+	}
+	return recs, nil
+}
+
+// exportPendingRefresh exports all pending-refresh entries across all tenants.
+func exportPendingRefresh(ctx context.Context, mgr *interfaces.StorageManager) ([]migrate.Record, error) {
+	store := mgr.GetPendingRefreshStore()
+	if store == nil {
+		return nil, nil
+	}
+	entries, err := store.ListPendingRefresh(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("list pending refresh entries: %w", err)
+	}
+	recs := make([]migrate.Record, 0, len(entries))
+	for _, e := range entries {
+		data, err := marshal(e)
+		if err != nil {
+			return nil, err
+		}
+		recs = append(recs, migrate.Record{Kind: kindPendingRefresh, ID: e.PendingID, Data: data})
+	}
+	return recs, nil
+}
+
 // ─── import ──────────────────────────────────────────────────────────────────
 
 // importAll writes all records to mgr using upsert semantics so that calling
@@ -620,6 +686,10 @@ func importRecord(ctx context.Context, mgr *interfaces.StorageManager, rec migra
 		return importPush(ctx, mgr, rec)
 	case kindIPTrust:
 		return importIPTrust(ctx, mgr, rec)
+	case kindRefreshPolicy:
+		return importRefreshPolicy(ctx, mgr, rec)
+	case kindPendingRefresh:
+		return importPendingRefresh(ctx, mgr, rec)
 	default:
 		return fmt.Errorf("unknown record kind %q", rec.Kind)
 	}
@@ -857,7 +927,7 @@ func importCommand(ctx context.Context, mgr *interfaces.StorageManager, rec migr
 func importTrigger(ctx context.Context, mgr *interfaces.StorageManager, rec migrate.Record) error {
 	store := mgr.GetTriggerStore()
 	if store == nil {
-		return fmt.Errorf("trigger store not available")
+		return nil // backend does not support trigger records — skip silently
 	}
 	var tr business.TriggerRecord
 	if err := json.Unmarshal(rec.Data, &tr); err != nil {
@@ -869,7 +939,7 @@ func importTrigger(ctx context.Context, mgr *interfaces.StorageManager, rec migr
 func importPush(ctx context.Context, mgr *interfaces.StorageManager, rec migrate.Record) error {
 	store := mgr.GetPushStore()
 	if store == nil {
-		return fmt.Errorf("push store not available")
+		return nil // backend does not support push records — skip silently
 	}
 	var p business.PushRecord
 	if err := json.Unmarshal(rec.Data, &p); err != nil {
@@ -910,6 +980,34 @@ func importIPTrust(ctx context.Context, mgr *interfaces.StorageManager, rec migr
 	return nil
 }
 
+func importRefreshPolicy(ctx context.Context, mgr *interfaces.StorageManager, rec migrate.Record) error {
+	store := mgr.GetRefreshPolicyStore()
+	if store == nil {
+		return nil // backend does not support refresh policies — skip silently
+	}
+	var policy business.RefreshPolicy
+	if err := json.Unmarshal(rec.Data, &policy); err != nil {
+		return fmt.Errorf("unmarshal refresh policy: %w", err)
+	}
+	return store.SetPolicy(ctx, &policy)
+}
+
+func importPendingRefresh(ctx context.Context, mgr *interfaces.StorageManager, rec migrate.Record) error {
+	store := mgr.GetPendingRefreshStore()
+	if store == nil {
+		return nil // backend does not support pending refresh — skip silently
+	}
+	var entry business.PendingRefreshEntry
+	if err := json.Unmarshal(rec.Data, &entry); err != nil {
+		return fmt.Errorf("unmarshal pending refresh entry: %w", err)
+	}
+	// Check existence to avoid duplicate-constraint violations on idempotent re-run.
+	if existing, err := store.GetPendingRefreshByID(ctx, entry.PendingID); err == nil && existing != nil {
+		return nil // already present
+	}
+	return store.AddPendingRefresh(ctx, &entry)
+}
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 func countByKind(records []migrate.Record) map[string]int {
@@ -918,4 +1016,30 @@ func countByKind(records []migrate.Record) map[string]int {
 		counts[r.Kind]++
 	}
 	return counts
+}
+
+// supportedKindsByManager returns the set of record kinds the manager's stores
+// can accept. Kinds whose store is nil (backend does not support them) are omitted
+// so that the integrity check does not flag expected data-skip as a mismatch.
+func supportedKindsByManager(mgr *interfaces.StorageManager) map[string]bool {
+	rbac := mgr.GetRBACStore() != nil
+	return map[string]bool{
+		kindConfig:            mgr.GetConfigStore() != nil,
+		kindAudit:             mgr.GetAuditStore() != nil,
+		kindRBACPermission:    rbac,
+		kindRBACRole:          rbac,
+		kindRBACSubject:       rbac,
+		kindRBACAssignment:    rbac,
+		kindTenant:            mgr.GetTenantStore() != nil,
+		kindClientTenant:      mgr.GetClientTenantStore() != nil,
+		kindRegistrationToken: mgr.GetRegistrationTokenStore() != nil,
+		kindSession:           mgr.GetSessionStore() != nil,
+		kindSteward:           mgr.GetStewardStore() != nil,
+		kindCommand:           mgr.GetCommandStore() != nil,
+		kindTrigger:           mgr.GetTriggerStore() != nil,
+		kindPush:              mgr.GetPushStore() != nil,
+		kindIPTrust:           mgr.GetIPTrustStore() != nil,
+		kindRefreshPolicy:     mgr.GetRefreshPolicyStore() != nil,
+		kindPendingRefresh:    mgr.GetPendingRefreshStore() != nil,
+	}
 }

--- a/pkg/migrate/storage/migrate_test.go
+++ b/pkg/migrate/storage/migrate_test.go
@@ -145,7 +145,8 @@ func TestStorageMigrate_DatabasePlan(t *testing.T) {
 }
 
 // assertMigrationCounts checks that all expected store kinds appear in the
-// report with at least one record.
+// report with at least one record. Only kinds that all tested backends support
+// are listed here — trigger and push are OSS-only and intentionally absent.
 func assertMigrationCounts(t *testing.T, counts map[string]int, label string) {
 	t.Helper()
 	wantKinds := []string{
@@ -156,9 +157,9 @@ func assertMigrationCounts(t *testing.T, counts map[string]int, label string) {
 		"session",
 		"steward",
 		"command",
-		"trigger",
-		"push",
 		"ip_trust",
+		"refresh_policy",
+		"pending_refresh",
 	}
 	for _, kind := range wantKinds {
 		c, ok := counts[kind]

--- a/pkg/migrate/storage/migrate_unit_test.go
+++ b/pkg/migrate/storage/migrate_unit_test.go
@@ -101,7 +101,7 @@ func TestStorageMigrator_OSStoOSSRoundTrip(t *testing.T) {
 	require.NoError(t, err, "OSS→OSS migration must succeed")
 
 	// Verify counts for the non-RBAC stores we seeded.
-	wantKinds := []string{"tenant", "config", "audit", "registration_token", "session", "steward", "command", "trigger", "push", "ip_trust"}
+	wantKinds := []string{"tenant", "config", "audit", "registration_token", "session", "steward", "command", "trigger", "push", "ip_trust", "refresh_policy", "pending_refresh"}
 	for _, kind := range wantKinds {
 		c, ok := report.Counts[kind]
 		assert.True(t, ok, "expected kind %q in OSS→OSS report", kind)

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -60,6 +60,14 @@ type BusinessStoreOpener interface {
 	OpenBusinessStores(path string) (*BusinessStoreBundle, error)
 }
 
+// RefreshStoreCreator is an optional StorageProvider extension for backends that
+// support the per-tenant refresh policy and pending-refresh approval queue (Issue #2329).
+// Backends that do not implement this interface leave those stores nil in the manager.
+type RefreshStoreCreator interface {
+	CreateRefreshPolicyStore(config map[string]interface{}) (business.RefreshPolicyStore, error)
+	CreatePendingRefreshStore(config map[string]interface{}) (business.PendingRefreshStore, error)
+}
+
 // StorageProvider defines the interface that all storage backends must implement.
 // Providers now return sub-package types from pkg/storage/interfaces/{business,config}.
 type StorageProvider interface {
@@ -693,6 +701,9 @@ func (sm *StorageManager) Close() error {
 		sm.triggerStore,
 		sm.pushStore,
 		sm.pendingRegistrationStore,
+		sm.ipTrustStore,
+		sm.refreshPolicyStore,
+		sm.pendingRefreshStore,
 	}
 	var firstErr error
 	for _, s := range slots {
@@ -878,6 +889,23 @@ func CreateClusterStorageManager(pgConnStr string, _ map[string]interface{}) (*S
 	}
 	if pendingRegStore != nil {
 		sm.SetPendingRegistrationStore(pendingRegStore)
+	}
+	// Wire refresh stores if the provider implements the optional RefreshStoreCreator extension.
+	if rsc, ok := provider.(RefreshStoreCreator); ok {
+		refreshPolicyStore, err := rsc.CreateRefreshPolicyStore(dbCfg)
+		if err != nil && !errors.Is(err, business.ErrNotSupported) {
+			return nil, fmt.Errorf("cluster storage: failed to create refresh policy store: %w", err)
+		}
+		if refreshPolicyStore != nil {
+			sm.SetRefreshPolicyStore(refreshPolicyStore)
+		}
+		pendingRefreshStore, err := rsc.CreatePendingRefreshStore(dbCfg)
+		if err != nil && !errors.Is(err, business.ErrNotSupported) {
+			return nil, fmt.Errorf("cluster storage: failed to create pending refresh store: %w", err)
+		}
+		if pendingRefreshStore != nil {
+			sm.SetPendingRefreshStore(pendingRefreshStore)
+		}
 	}
 	return sm, nil
 }

--- a/pkg/storage/providers/database/pending_refresh_store.go
+++ b/pkg/storage/providers/database/pending_refresh_store.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package database implements PendingRefreshStore using PostgreSQL (Issue #2329).
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.PendingRefreshStore = (*DatabasePendingRefreshStore)(nil)
+
+// DatabasePendingRefreshStore implements business.PendingRefreshStore using PostgreSQL.
+type DatabasePendingRefreshStore struct {
+	db *sql.DB
+}
+
+// NewDatabasePendingRefreshStore opens a pooled Postgres connection, initialises
+// the schema, and returns a ready-to-use PendingRefreshStore.
+func NewDatabasePendingRefreshStore(dsn string, config map[string]interface{}) (*DatabasePendingRefreshStore, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to open pending refresh store connection: %w", err)
+	}
+	db.SetMaxOpenConns(getIntFromConfig(config, "max_open_connections", 25))
+	db.SetMaxIdleConns(getIntFromConfig(config, "max_idle_connections", 5))
+	db.SetConnMaxLifetime(time.Duration(getIntFromConfig(config, "connection_max_lifetime_minutes", 30)) * time.Minute)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("database: failed to ping pending refresh store: %w", err)
+	}
+	store := &DatabasePendingRefreshStore{db: db}
+	if err := store.initSchema(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("database: failed to initialise pending refresh schema: %w", err)
+	}
+	return store, nil
+}
+
+func (s *DatabasePendingRefreshStore) initSchema() error {
+	ctx := context.Background()
+	const lockID = 41782095 // advisory lock ID unique to pending_refresh_requests schema
+	if _, err := s.db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", lockID); err != nil {
+		return fmt.Errorf("database: failed to acquire pending refresh schema lock: %w", err)
+	}
+	defer func() { _, _ = s.db.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", lockID) }()
+	return NewDatabaseSchemas().CreatePendingRefreshRequestsTable(ctx, s.db)
+}
+
+// Close releases the database connection.
+func (s *DatabasePendingRefreshStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// AddPendingRefresh inserts a new pending-refresh entry.
+// Returns an error if an entry with the same PendingID already exists.
+func (s *DatabasePendingRefreshStore) AddPendingRefresh(ctx context.Context, entry *business.PendingRefreshEntry) error {
+	if entry == nil {
+		return fmt.Errorf("database: pending refresh entry cannot be nil")
+	}
+	if entry.PendingID == "" {
+		return fmt.Errorf("database: pending_id cannot be empty")
+	}
+	if entry.DeviceID == "" {
+		return fmt.Errorf("database: device_id cannot be empty")
+	}
+	if entry.TenantID == "" {
+		return fmt.Errorf("database: tenant_id cannot be empty")
+	}
+
+	createdAt := entry.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	status := entry.Status
+	if status == "" {
+		status = business.PendingRefreshStatusPending
+	}
+	claimBundle := entry.ClaimBundle
+	if claimBundle == nil {
+		claimBundle = []byte{}
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO pending_refresh_requests
+			(pending_id, device_id, tenant_id, source_ip,
+			 provenance_matched_fields, provenance_total_fields,
+			 claim_bundle, status, created_at, expires_at, resolved_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		entry.PendingID,
+		entry.DeviceID,
+		entry.TenantID,
+		entry.SourceIP,
+		entry.ProvenanceMatchedFields,
+		entry.ProvenanceTotalFields,
+		claimBundle,
+		status,
+		createdAt,
+		entry.ExpiresAt,
+		nullableTime(entry.ResolvedAt),
+	)
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return fmt.Errorf("database: pending refresh %s already exists", entry.PendingID)
+		}
+		return fmt.Errorf("database: failed to add pending refresh %s: %w", entry.PendingID, err)
+	}
+	return nil
+}
+
+// GetPendingRefreshByID retrieves the entry for the given pending_id.
+// Returns ErrPendingRefreshNotFound if no record exists.
+func (s *DatabasePendingRefreshStore) GetPendingRefreshByID(ctx context.Context, pendingID string) (*business.PendingRefreshEntry, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT pending_id, device_id, tenant_id, source_ip,
+		       provenance_matched_fields, provenance_total_fields,
+		       claim_bundle, status, created_at, expires_at, resolved_at
+		FROM pending_refresh_requests WHERE pending_id = $1`, pendingID)
+	return scanPendingRefreshDBRow(row)
+}
+
+// UpdateRefreshStatus updates the status of the entry identified by pendingID.
+// For terminal statuses (approved, rejected), resolved_at is also set to now.
+// Returns ErrPendingRefreshNotFound if no record exists.
+func (s *DatabasePendingRefreshStore) UpdateRefreshStatus(ctx context.Context, pendingID, status string) error {
+	var (
+		res sql.Result
+		err error
+	)
+	isTerminal := status == business.PendingRefreshStatusApproved ||
+		status == business.PendingRefreshStatusRejected
+	if isTerminal {
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE pending_refresh_requests
+			SET status = $1, resolved_at = $2
+			WHERE pending_id = $3`,
+			status, time.Now().UTC(), pendingID,
+		)
+	} else {
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE pending_refresh_requests SET status = $1 WHERE pending_id = $2`,
+			status, pendingID,
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("database: failed to update refresh status for %s: %w", pendingID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrPendingRefreshNotFound
+	}
+	return nil
+}
+
+// ListPendingRefresh returns all entries for the given tenantID ordered by
+// created_at ascending. An empty tenantID returns entries for all tenants.
+func (s *DatabasePendingRefreshStore) ListPendingRefresh(ctx context.Context, tenantID string) ([]*business.PendingRefreshEntry, error) {
+	var (
+		query string
+		args  []interface{}
+	)
+	if tenantID == "" {
+		query = `
+			SELECT pending_id, device_id, tenant_id, source_ip,
+			       provenance_matched_fields, provenance_total_fields,
+			       claim_bundle, status, created_at, expires_at, resolved_at
+			FROM pending_refresh_requests ORDER BY created_at ASC`
+	} else {
+		query = `
+			SELECT pending_id, device_id, tenant_id, source_ip,
+			       provenance_matched_fields, provenance_total_fields,
+			       claim_bundle, status, created_at, expires_at, resolved_at
+			FROM pending_refresh_requests WHERE tenant_id = $1 ORDER BY created_at ASC`
+		args = []interface{}{tenantID}
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to list pending refresh requests: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []*business.PendingRefreshEntry
+	for rows.Next() {
+		e, err := scanPendingRefreshDBRows(rows)
+		if err != nil {
+			return nil, fmt.Errorf("database: failed to scan pending refresh row: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// ExpireStaleRefresh marks entries whose expires_at is at or before cutoff and
+// whose status is "pending" as "expired", setting resolved_at to now.
+func (s *DatabasePendingRefreshStore) ExpireStaleRefresh(ctx context.Context, cutoff time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE pending_refresh_requests
+		SET status = $1, resolved_at = $2
+		WHERE status = $3 AND expires_at <= $4`,
+		business.PendingRefreshStatusExpired,
+		time.Now().UTC(),
+		business.PendingRefreshStatusPending,
+		cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("database: failed to expire stale refresh requests: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// StoreClaimBundle persists the proof-of-possession payload for the given pendingID.
+// Returns ErrPendingRefreshNotFound if no record exists.
+func (s *DatabasePendingRefreshStore) StoreClaimBundle(ctx context.Context, pendingID string, bundle []byte) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE pending_refresh_requests SET claim_bundle = $1 WHERE pending_id = $2`,
+		bundle, pendingID,
+	)
+	if err != nil {
+		return fmt.Errorf("database: failed to store claim bundle for %s: %w", pendingID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrPendingRefreshNotFound
+	}
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func scanPendingRefreshDBRow(row *sql.Row) (*business.PendingRefreshEntry, error) {
+	e := &business.PendingRefreshEntry{}
+	var resolvedAt sql.NullTime
+	var claimBundle []byte
+	err := row.Scan(
+		&e.PendingID, &e.DeviceID, &e.TenantID, &e.SourceIP,
+		&e.ProvenanceMatchedFields, &e.ProvenanceTotalFields,
+		&claimBundle, &e.Status, &e.CreatedAt, &e.ExpiresAt, &resolvedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, business.ErrPendingRefreshNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to scan pending refresh: %w", err)
+	}
+	e.ClaimBundle = claimBundle
+	if resolvedAt.Valid {
+		t := resolvedAt.Time
+		e.ResolvedAt = &t
+	}
+	return e, nil
+}
+
+func scanPendingRefreshDBRows(rows *sql.Rows) (*business.PendingRefreshEntry, error) {
+	e := &business.PendingRefreshEntry{}
+	var resolvedAt sql.NullTime
+	var claimBundle []byte
+	if err := rows.Scan(
+		&e.PendingID, &e.DeviceID, &e.TenantID, &e.SourceIP,
+		&e.ProvenanceMatchedFields, &e.ProvenanceTotalFields,
+		&claimBundle, &e.Status, &e.CreatedAt, &e.ExpiresAt, &resolvedAt,
+	); err != nil {
+		return nil, err
+	}
+	e.ClaimBundle = claimBundle
+	if resolvedAt.Valid {
+		t := resolvedAt.Time
+		e.ResolvedAt = &t
+	}
+	return e, nil
+}
+
+// nullableTime converts a *time.Time to an interface value suitable for
+// binding as a nullable TIMESTAMP column: nil pointers produce SQL NULL.
+func nullableTime(t *time.Time) interface{} {
+	if t == nil {
+		return nil
+	}
+	return *t
+}

--- a/pkg/storage/providers/database/pending_refresh_store_test.go
+++ b/pkg/storage/providers/database/pending_refresh_store_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package database provides unit tests for the PostgreSQL PendingRefreshStore (Issue #2329).
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestPendingRefreshStore creates a PendingRefreshStore backed by the test Postgres
+// database. The schema is initialised fresh; the test is skipped when Postgres is unavailable.
+func newTestPendingRefreshStore(t *testing.T) *DatabasePendingRefreshStore {
+	t.Helper()
+	db := setupTestDatabase(t)
+	t.Cleanup(func() { _ = db.Close() })
+	schemas := NewDatabaseSchemas()
+	ctx := context.Background()
+	require.NoError(t, schemas.CreatePendingRefreshRequestsTable(ctx, db))
+
+	store, err := NewDatabasePendingRefreshStore(buildTestDSN(), getTestConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func makeSamplePendingRefresh(pendingID, deviceID, tenantID string) *business.PendingRefreshEntry {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	return &business.PendingRefreshEntry{
+		PendingID:               pendingID,
+		DeviceID:                deviceID,
+		TenantID:                tenantID,
+		SourceIP:                "10.0.0.1",
+		ProvenanceMatchedFields: 3,
+		ProvenanceTotalFields:   5,
+		Status:                  business.PendingRefreshStatusPending,
+		CreatedAt:               now,
+		ExpiresAt:               now.Add(24 * time.Hour),
+	}
+}
+
+// TestDatabasePendingRefreshStore_AddAndGet verifies round-trip for AddPendingRefresh
+// and GetPendingRefreshByID.
+func TestDatabasePendingRefreshStore_AddAndGet(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	entry := makeSamplePendingRefresh("pr-001", "dev-001", "tenant-pr-a")
+	entry.ClaimBundle = []byte(`{"key":"val"}`)
+
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-001")
+	require.NoError(t, err)
+	assert.Equal(t, "pr-001", got.PendingID)
+	assert.Equal(t, "dev-001", got.DeviceID)
+	assert.Equal(t, "tenant-pr-a", got.TenantID)
+	assert.Equal(t, "10.0.0.1", got.SourceIP)
+	assert.Equal(t, 3, got.ProvenanceMatchedFields)
+	assert.Equal(t, 5, got.ProvenanceTotalFields)
+	assert.Equal(t, business.PendingRefreshStatusPending, got.Status)
+	assert.Equal(t, []byte(`{"key":"val"}`), got.ClaimBundle)
+	assert.Nil(t, got.ResolvedAt)
+}
+
+// TestDatabasePendingRefreshStore_NotFound verifies ErrPendingRefreshNotFound is
+// returned when the record does not exist.
+func TestDatabasePendingRefreshStore_NotFound(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	_, err := store.GetPendingRefreshByID(ctx, "nonexistent-pending-id")
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+// TestDatabasePendingRefreshStore_DuplicateAdd verifies that adding an entry with
+// the same PendingID returns a descriptive error.
+func TestDatabasePendingRefreshStore_DuplicateAdd(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	entry := makeSamplePendingRefresh("pr-dup", "dev-dup", "tenant-pr-dup")
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	err := store.AddPendingRefresh(ctx, entry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+// TestDatabasePendingRefreshStore_UpdateStatus verifies UpdateRefreshStatus changes
+// the status for a non-terminal transition.
+func TestDatabasePendingRefreshStore_UpdateStatus(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	entry := makeSamplePendingRefresh("pr-status", "dev-status", "tenant-pr-status")
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	require.NoError(t, store.UpdateRefreshStatus(ctx, "pr-status", business.PendingRefreshStatusExpired))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-status")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusExpired, got.Status)
+	assert.Nil(t, got.ResolvedAt, "non-terminal status must not set resolved_at")
+}
+
+// TestDatabasePendingRefreshStore_TerminalStatusSetsResolvedAt verifies that
+// terminal statuses (approved, rejected) cause resolved_at to be set.
+func TestDatabasePendingRefreshStore_TerminalStatusSetsResolvedAt(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	entry := makeSamplePendingRefresh("pr-terminal", "dev-term", "tenant-pr-term")
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	require.NoError(t, store.UpdateRefreshStatus(ctx, "pr-terminal", business.PendingRefreshStatusApproved))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-terminal")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusApproved, got.Status)
+	require.NotNil(t, got.ResolvedAt, "approved terminal status must set resolved_at")
+}
+
+// TestDatabasePendingRefreshStore_UpdateStatusNotFound verifies ErrPendingRefreshNotFound
+// when updating a non-existent record.
+func TestDatabasePendingRefreshStore_UpdateStatusNotFound(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	err := store.UpdateRefreshStatus(ctx, "nonexistent", business.PendingRefreshStatusApproved)
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+// TestDatabasePendingRefreshStore_ListAll verifies ListPendingRefresh with an empty
+// tenantID returns all entries across tenants.
+func TestDatabasePendingRefreshStore_ListAll(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	for i, tid := range []string{"tenant-list-a", "tenant-list-b"} {
+		e := makeSamplePendingRefresh(
+			"pr-list-all-"+tid,
+			"dev-list-"+tid,
+			tid,
+		)
+		e.CreatedAt = time.Now().UTC().Add(time.Duration(i) * time.Millisecond)
+		require.NoError(t, store.AddPendingRefresh(ctx, e))
+	}
+
+	list, err := store.ListPendingRefresh(ctx, "")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(list), 2)
+}
+
+// TestDatabasePendingRefreshStore_ListByTenant verifies that ListPendingRefresh
+// with a tenantID filters results to that tenant only.
+func TestDatabasePendingRefreshStore_ListByTenant(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	eA := makeSamplePendingRefresh("pr-tenant-filter-a", "dev-fa", "tenant-filter-a")
+	eB := makeSamplePendingRefresh("pr-tenant-filter-b", "dev-fb", "tenant-filter-b")
+	require.NoError(t, store.AddPendingRefresh(ctx, eA))
+	require.NoError(t, store.AddPendingRefresh(ctx, eB))
+
+	listA, err := store.ListPendingRefresh(ctx, "tenant-filter-a")
+	require.NoError(t, err)
+	for _, e := range listA {
+		assert.Equal(t, "tenant-filter-a", e.TenantID)
+	}
+	assert.GreaterOrEqual(t, len(listA), 1)
+
+	listB, err := store.ListPendingRefresh(ctx, "tenant-filter-b")
+	require.NoError(t, err)
+	for _, e := range listB {
+		assert.Equal(t, "tenant-filter-b", e.TenantID)
+	}
+	assert.GreaterOrEqual(t, len(listB), 1)
+}
+
+// TestDatabasePendingRefreshStore_ExpireStale verifies ExpireStaleRefresh marks
+// pending entries with expires_at in the past as expired.
+func TestDatabasePendingRefreshStore_ExpireStale(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	stale := makeSamplePendingRefresh("pr-stale", "dev-stale", "tenant-stale")
+	stale.ExpiresAt = now.Add(-time.Minute) // already expired
+	require.NoError(t, store.AddPendingRefresh(ctx, stale))
+
+	fresh := makeSamplePendingRefresh("pr-fresh", "dev-fresh", "tenant-fresh")
+	fresh.ExpiresAt = now.Add(time.Hour) // not yet expired
+	require.NoError(t, store.AddPendingRefresh(ctx, fresh))
+
+	n, err := store.ExpireStaleRefresh(ctx, now)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, n, 1)
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-stale")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusExpired, got.Status)
+	require.NotNil(t, got.ResolvedAt)
+
+	gotFresh, err := store.GetPendingRefreshByID(ctx, "pr-fresh")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusPending, gotFresh.Status)
+}
+
+// TestDatabasePendingRefreshStore_StoreClaimBundle verifies that StoreClaimBundle
+// updates the claim_bundle field for an existing entry.
+func TestDatabasePendingRefreshStore_StoreClaimBundle(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	entry := makeSamplePendingRefresh("pr-bundle", "dev-bundle", "tenant-bundle")
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	bundle := []byte(`{"proof":"signed-data"}`)
+	require.NoError(t, store.StoreClaimBundle(ctx, "pr-bundle", bundle))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-bundle")
+	require.NoError(t, err)
+	assert.Equal(t, bundle, got.ClaimBundle)
+}
+
+// TestDatabasePendingRefreshStore_StoreClaimBundleNotFound verifies
+// ErrPendingRefreshNotFound when storing a bundle for a non-existent entry.
+func TestDatabasePendingRefreshStore_StoreClaimBundleNotFound(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	err := store.StoreClaimBundle(ctx, "nonexistent-pending", []byte(`{}`))
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}

--- a/pkg/storage/providers/database/plugin.go
+++ b/pkg/storage/providers/database/plugin.go
@@ -204,6 +204,32 @@ func (p *DatabaseProvider) CreatePendingRegistrationStore(config map[string]inte
 	return nil, business.ErrNotSupported
 }
 
+// CreateRefreshPolicyStore creates a PostgreSQL-backed RefreshPolicyStore (Issue #2329).
+func (p *DatabaseProvider) CreateRefreshPolicyStore(config map[string]interface{}) (business.RefreshPolicyStore, error) {
+	dsn, err := p.getDSN(config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid database configuration: %w", err)
+	}
+	store, err := NewDatabaseRefreshPolicyStore(dsn, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create database refresh policy store: %w", err)
+	}
+	return store, nil
+}
+
+// CreatePendingRefreshStore creates a PostgreSQL-backed PendingRefreshStore (Issue #2329).
+func (p *DatabaseProvider) CreatePendingRefreshStore(config map[string]interface{}) (business.PendingRefreshStore, error) {
+	dsn, err := p.getDSN(config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid database configuration: %w", err)
+	}
+	store, err := NewDatabasePendingRefreshStore(dsn, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create database pending refresh store: %w", err)
+	}
+	return store, nil
+}
+
 // CreateIPTrustStore creates a PostgreSQL-backed IPTrustStore.
 func (p *DatabaseProvider) CreateIPTrustStore(config map[string]interface{}) (business.IPTrustStore, error) {
 	dsn, err := p.getDSN(config)

--- a/pkg/storage/providers/database/refresh_policy_store.go
+++ b/pkg/storage/providers/database/refresh_policy_store.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package database implements RefreshPolicyStore using PostgreSQL (Issue #2329).
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.RefreshPolicyStore = (*DatabaseRefreshPolicyStore)(nil)
+
+// DatabaseRefreshPolicyStore implements business.RefreshPolicyStore using PostgreSQL.
+type DatabaseRefreshPolicyStore struct {
+	db *sql.DB
+}
+
+// NewDatabaseRefreshPolicyStore opens a pooled Postgres connection, initialises
+// the schema, and returns a ready-to-use RefreshPolicyStore.
+func NewDatabaseRefreshPolicyStore(dsn string, config map[string]interface{}) (*DatabaseRefreshPolicyStore, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to open refresh policy store connection: %w", err)
+	}
+	db.SetMaxOpenConns(getIntFromConfig(config, "max_open_connections", 25))
+	db.SetMaxIdleConns(getIntFromConfig(config, "max_idle_connections", 5))
+	db.SetConnMaxLifetime(time.Duration(getIntFromConfig(config, "connection_max_lifetime_minutes", 30)) * time.Minute)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("database: failed to ping refresh policy store: %w", err)
+	}
+	store := &DatabaseRefreshPolicyStore{db: db}
+	if err := store.initSchema(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("database: failed to initialise refresh policy schema: %w", err)
+	}
+	return store, nil
+}
+
+func (s *DatabaseRefreshPolicyStore) initSchema() error {
+	ctx := context.Background()
+	const lockID = 53781294 // advisory lock ID unique to refresh_policies schema
+	if _, err := s.db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", lockID); err != nil {
+		return fmt.Errorf("database: failed to acquire refresh policy schema lock: %w", err)
+	}
+	defer func() { _, _ = s.db.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", lockID) }()
+	return NewDatabaseSchemas().CreateRefreshPoliciesTable(ctx, s.db)
+}
+
+// Close releases the database connection.
+func (s *DatabaseRefreshPolicyStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// GetPolicy returns the refresh policy for the given tenant. When no record
+// exists it returns a default policy of {Mode: "require_approval",
+// MaxDormancyDays: nil} without error (ADR-010 §4).
+func (s *DatabaseRefreshPolicyStore) GetPolicy(ctx context.Context, tenantID string) (*business.RefreshPolicy, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT tenant_id, mode, max_dormancy_days
+		FROM refresh_policies WHERE tenant_id = $1`, tenantID)
+
+	p := &business.RefreshPolicy{}
+	var maxDormancy sql.NullInt64
+	err := row.Scan(&p.TenantID, &p.Mode, &maxDormancy)
+	if err == sql.ErrNoRows {
+		return &business.RefreshPolicy{
+			TenantID:        tenantID,
+			Mode:            "require_approval",
+			MaxDormancyDays: nil,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to get refresh policy for tenant %s: %w", tenantID, err)
+	}
+	if maxDormancy.Valid {
+		v := int(maxDormancy.Int64)
+		p.MaxDormancyDays = &v
+	}
+	return p, nil
+}
+
+// SetPolicy creates or replaces the refresh policy for the tenant identified by
+// policy.TenantID using upsert semantics.
+func (s *DatabaseRefreshPolicyStore) SetPolicy(ctx context.Context, policy *business.RefreshPolicy) error {
+	if policy == nil {
+		return fmt.Errorf("database: policy cannot be nil")
+	}
+	if policy.TenantID == "" {
+		return fmt.Errorf("database: policy tenant_id cannot be empty")
+	}
+
+	var maxDormancy interface{}
+	if policy.MaxDormancyDays != nil {
+		maxDormancy = *policy.MaxDormancyDays
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO refresh_policies (tenant_id, mode, max_dormancy_days)
+		VALUES ($1, $2, $3)
+		ON CONFLICT(tenant_id) DO UPDATE SET
+			mode              = EXCLUDED.mode,
+			max_dormancy_days = EXCLUDED.max_dormancy_days`,
+		policy.TenantID,
+		policy.Mode,
+		maxDormancy,
+	)
+	if err != nil {
+		return fmt.Errorf("database: failed to set refresh policy for tenant %s: %w", policy.TenantID, err)
+	}
+	return nil
+}

--- a/pkg/storage/providers/database/refresh_policy_store_test.go
+++ b/pkg/storage/providers/database/refresh_policy_store_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package database provides unit tests for the PostgreSQL RefreshPolicyStore (Issue #2329).
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestRefreshPolicyStore creates a RefreshPolicyStore backed by the test Postgres
+// database. The schema is initialised fresh via the store constructor; the test is
+// skipped when Postgres is unavailable.
+func newTestRefreshPolicyStore(t *testing.T) *DatabaseRefreshPolicyStore {
+	t.Helper()
+	db := setupTestDatabase(t)
+	t.Cleanup(func() { _ = db.Close() })
+	schemas := NewDatabaseSchemas()
+	ctx := context.Background()
+	require.NoError(t, schemas.CreateRefreshPoliciesTable(ctx, db))
+
+	store, err := NewDatabaseRefreshPolicyStore(buildTestDSN(), getTestConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestDatabaseRefreshPolicyStore_GetDefault verifies that GetPolicy returns the
+// default policy when no explicit record exists for the tenant.
+func TestDatabaseRefreshPolicyStore_GetDefault(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	p, err := store.GetPolicy(ctx, "tenant-rp-default")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "tenant-rp-default", p.TenantID)
+	assert.Equal(t, "require_approval", p.Mode)
+	assert.Nil(t, p.MaxDormancyDays)
+}
+
+// TestDatabaseRefreshPolicyStore_SetAndGet verifies that SetPolicy persists the
+// policy and GetPolicy retrieves it correctly.
+func TestDatabaseRefreshPolicyStore_SetAndGet(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	v := 30
+	policy := &business.RefreshPolicy{
+		TenantID:        "tenant-rp-set",
+		Mode:            "auto_accept",
+		MaxDormancyDays: &v,
+	}
+	require.NoError(t, store.SetPolicy(ctx, policy))
+
+	got, err := store.GetPolicy(ctx, "tenant-rp-set")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-rp-set", got.TenantID)
+	assert.Equal(t, "auto_accept", got.Mode)
+	require.NotNil(t, got.MaxDormancyDays)
+	assert.Equal(t, 30, *got.MaxDormancyDays)
+}
+
+// TestDatabaseRefreshPolicyStore_SetNoMaxDormancy verifies that a nil
+// MaxDormancyDays is stored as NULL and returned as nil.
+func TestDatabaseRefreshPolicyStore_SetNoMaxDormancy(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	policy := &business.RefreshPolicy{
+		TenantID:        "tenant-rp-nodorm",
+		Mode:            "reject",
+		MaxDormancyDays: nil,
+	}
+	require.NoError(t, store.SetPolicy(ctx, policy))
+
+	got, err := store.GetPolicy(ctx, "tenant-rp-nodorm")
+	require.NoError(t, err)
+	assert.Equal(t, "reject", got.Mode)
+	assert.Nil(t, got.MaxDormancyDays)
+}
+
+// TestDatabaseRefreshPolicyStore_Upsert verifies that a second SetPolicy call
+// updates the existing record rather than creating a duplicate.
+func TestDatabaseRefreshPolicyStore_Upsert(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{
+		TenantID: "tenant-rp-upsert",
+		Mode:     "auto_accept",
+	}))
+
+	v := 7
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{
+		TenantID:        "tenant-rp-upsert",
+		Mode:            "require_approval",
+		MaxDormancyDays: &v,
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-rp-upsert")
+	require.NoError(t, err)
+	assert.Equal(t, "require_approval", got.Mode)
+	require.NotNil(t, got.MaxDormancyDays)
+	assert.Equal(t, 7, *got.MaxDormancyDays)
+}
+
+// TestDatabaseRefreshPolicyStore_NilPolicyError verifies that SetPolicy rejects a nil policy.
+func TestDatabaseRefreshPolicyStore_NilPolicyError(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+	err := store.SetPolicy(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+// TestDatabaseRefreshPolicyStore_EmptyTenantError verifies that SetPolicy rejects
+// a policy with an empty TenantID.
+func TestDatabaseRefreshPolicyStore_EmptyTenantError(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+	err := store.SetPolicy(ctx, &business.RefreshPolicy{TenantID: "", Mode: "auto_accept"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenant_id")
+}

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -733,6 +733,60 @@ func (s DatabaseSchemas) CreateAllTables(ctx context.Context, db *sql.DB) error 
 		return err
 	}
 
+	if err := s.CreateRefreshPoliciesTable(ctx, db); err != nil {
+		return err
+	}
+
+	if err := s.CreatePendingRefreshRequestsTable(ctx, db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateRefreshPoliciesTable creates the refresh_policies table (Issue #2329).
+func (s DatabaseSchemas) CreateRefreshPoliciesTable(ctx context.Context, db *sql.DB) error {
+	ddl := `
+		CREATE TABLE IF NOT EXISTS refresh_policies (
+			tenant_id           TEXT NOT NULL PRIMARY KEY,
+			mode                TEXT NOT NULL DEFAULT 'require_approval',
+			max_dormancy_days   INTEGER
+		);`
+	if _, err := db.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("failed to create refresh_policies table: %w", err)
+	}
+	return nil
+}
+
+// CreatePendingRefreshRequestsTable creates the pending_refresh_requests table (Issue #2329).
+func (s DatabaseSchemas) CreatePendingRefreshRequestsTable(ctx context.Context, db *sql.DB) error {
+	ddl := `
+		CREATE TABLE IF NOT EXISTS pending_refresh_requests (
+			pending_id                  TEXT NOT NULL PRIMARY KEY,
+			device_id                   TEXT NOT NULL,
+			tenant_id                   TEXT NOT NULL,
+			source_ip                   TEXT NOT NULL DEFAULT '',
+			provenance_matched_fields   INTEGER NOT NULL DEFAULT 0,
+			provenance_total_fields     INTEGER NOT NULL DEFAULT 0,
+			claim_bundle                BYTEA NOT NULL DEFAULT ''::bytea,
+			status                      TEXT NOT NULL DEFAULT 'pending',
+			created_at                  TIMESTAMP WITH TIME ZONE NOT NULL,
+			expires_at                  TIMESTAMP WITH TIME ZONE NOT NULL,
+			resolved_at                 TIMESTAMP WITH TIME ZONE
+		);`
+	if _, err := db.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("failed to create pending_refresh_requests table: %w", err)
+	}
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_pending_refresh_tenant_id  ON pending_refresh_requests(tenant_id);",
+		"CREATE INDEX IF NOT EXISTS idx_pending_refresh_status     ON pending_refresh_requests(status);",
+		"CREATE INDEX IF NOT EXISTS idx_pending_refresh_expires_at ON pending_refresh_requests(expires_at);",
+	}
+	for _, idx := range indexes {
+		if _, err := db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create pending_refresh_requests index: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -963,6 +1017,8 @@ func (s DatabaseSchemas) DropAllTables(ctx context.Context, db *sql.DB) error {
 		"DROP TABLE IF EXISTS rbac_subjects;",
 		"DROP TABLE IF EXISTS rbac_roles;", // Has self-reference foreign key
 		"DROP TABLE IF EXISTS rbac_permissions;",
+		"DROP TABLE IF EXISTS pending_refresh_requests;",
+		"DROP TABLE IF EXISTS refresh_policies;",
 		"DROP TABLE IF EXISTS command_transitions;",
 		"DROP TABLE IF EXISTS command_records;",
 		"DROP TABLE IF EXISTS steward_records;",


### PR DESCRIPTION
## Summary

- Implements `DatabaseRefreshPolicyStore` (`GetPolicy` with default fallback, `SetPolicy` upsert) and `DatabasePendingRefreshStore` (all 6 interface methods including terminal-status `resolved_at` handling) for the PostgreSQL storage provider
- Adds `refresh_policies` and `pending_refresh_requests` tables to `schemas.go` with correct types (`BYTEA` for `claim_bundle`, `TIMESTAMP WITH TIME ZONE` for all timestamp fields)
- Wires both stores into `CreateClusterStorageManager` via a new `RefreshStoreCreator` optional interface (no changes to `StorageProvider` core interface; sqlite/flatfile plugins unchanged)
- Extends the storage migrator with `kindRefreshPolicy`/`kindPendingRefresh` constants, `exportRefreshPolicies`/`exportPendingRefresh`, `importRefreshPolicy`/`importPendingRefresh`, and a `supportedKindsByManager` helper that prevents false integrity-check failures on cross-backend migrations (OSS→Postgres skips `trigger`/`push` silently)
- Fixes a pre-existing connection-pool leak: `StorageManager.Close()` was missing `ipTrustStore`, `refreshPolicyStore`, and `pendingRefreshStore` from its close slots

## Test plan

- [x] `TestDatabaseRefreshPolicyStore_*` — 6 unit tests: default policy, set/get, no max dormancy, upsert, nil policy error, empty tenant error
- [x] `TestDatabasePendingRefreshStore_*` — 11 unit tests: add/get, not found, duplicate, update status, terminal sets `resolved_at`, update not found, list all, list by tenant, expire stale, store claim bundle, store claim bundle not found
- [x] `TestStorageMigrator_OSStoOSSRoundTrip` — includes `refresh_policy` and `pending_refresh` in `wantKinds`
- [x] `TestStorageMigrate_FlatfileToDatabaseRoundTrip` (integration, requires Postgres) — `assertMigrationCounts` verifies both new kinds
- [x] `make test-agent-complete` — all gates green

Fixes #2329

🤖 Generated with [Claude Code](https://claude.ai/claude-code)