### PR TITLE
fleet/storage: idempotent DNA-history upsert on (device_id, version) collision

### DIFF
--- a/features/controller/fleet/storage/backends.go
+++ b/features/controller/fleet/storage/backends.go
@@ -703,11 +703,19 @@ func (b *DatabaseBackend) prepareStatements() error {
 		return fmt.Errorf("failed to prepare PostgreSQL insert record statement: %w", err)
 	}
 
-	// Insert reference statement
+	// Insert reference statement. Same idempotency rationale as insertRecord:
+	// dna_references also has UNIQUE(device_id, version), and the dedup branch
+	// (storeReference) is the likely path when a duplicate/concurrent publish
+	// republishes identical DNA (a dedup hit). ON CONFLICT keeps it from failing
+	// the constraint; the latest reference wins.
 	b.stmts.insertReference, err = b.db.Prepare(`
-		INSERT INTO dna_references 
+		INSERT INTO dna_references
 		(device_id, content_hash, version, timestamp, shard_id)
 		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (device_id, version) DO UPDATE SET
+			content_hash=EXCLUDED.content_hash,
+			timestamp=EXCLUDED.timestamp,
+			shard_id=EXCLUDED.shard_id
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare PostgreSQL insert reference statement: %w", err)

--- a/features/controller/fleet/storage/backends.go
+++ b/features/controller/fleet/storage/backends.go
@@ -675,12 +675,29 @@ func (b *DatabaseBackend) prepareStatements() error {
 	var err error
 
 	// Insert DNA record statement
+	// ON CONFLICT keeps the write idempotent when two DNA snapshots for the same
+	// device resolve to the same version (GetNextVersion runs outside this insert's
+	// transaction, so a duplicate/concurrent publish can collide on the
+	// UNIQUE(device_id, version) constraint). The latest snapshot wins.
 	b.stmts.insertRecord, err = b.db.Prepare(`
 		INSERT INTO dna_history
 		(device_id, timestamp, version, dna_json, content_hash,
 		 original_size, compressed_size, compression_ratio, shard_id,
 		 tenant_id, os, architecture, hostname, status)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		ON CONFLICT (device_id, version) DO UPDATE SET
+			timestamp=EXCLUDED.timestamp,
+			dna_json=EXCLUDED.dna_json,
+			content_hash=EXCLUDED.content_hash,
+			original_size=EXCLUDED.original_size,
+			compressed_size=EXCLUDED.compressed_size,
+			compression_ratio=EXCLUDED.compression_ratio,
+			shard_id=EXCLUDED.shard_id,
+			tenant_id=EXCLUDED.tenant_id,
+			os=EXCLUDED.os,
+			architecture=EXCLUDED.architecture,
+			hostname=EXCLUDED.hostname,
+			status=EXCLUDED.status
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare PostgreSQL insert record statement: %w", err)

--- a/features/controller/fleet/storage/sqlite_backend.go
+++ b/features/controller/fleet/storage/sqlite_backend.go
@@ -398,11 +398,19 @@ func (b *SQLiteBackend) prepareStatements() error {
 		return fmt.Errorf("failed to prepare insert record statement: %w", err)
 	}
 
-	// Insert reference statement
+	// Insert reference statement. Same idempotency rationale as insertRecord:
+	// dna_references also has UNIQUE(device_id, version), and the dedup branch
+	// (storeReference) is the likely path when a duplicate/concurrent publish
+	// republishes identical DNA (a dedup hit). ON CONFLICT keeps it from failing
+	// the constraint; the latest reference wins.
 	b.stmts.insertReference, err = b.db.Prepare(`
-		INSERT INTO dna_references 
+		INSERT INTO dna_references
 		(device_id, content_hash, version, timestamp, shard_id)
 		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(device_id, version) DO UPDATE SET
+			content_hash=excluded.content_hash,
+			timestamp=excluded.timestamp,
+			shard_id=excluded.shard_id
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare insert reference statement: %w", err)

--- a/features/controller/fleet/storage/sqlite_backend.go
+++ b/features/controller/fleet/storage/sqlite_backend.go
@@ -367,12 +367,32 @@ func (b *SQLiteBackend) prepareStatements() error {
 	var err error
 
 	// Insert DNA record statement
+	// ON CONFLICT keeps the write idempotent when two DNA snapshots for the same
+	// device resolve to the same version. GetNextVersion (MAX(version)+1) runs
+	// outside this insert's lock, so a duplicate/concurrent publish — e.g. the
+	// heartbeat path and the ring-subscription path both firing on reconnect — can
+	// assign the same (device_id, version); without the upsert the second insert
+	// fails the UNIQUE constraint, crashing DNA persist and churning the control
+	// channel. The latest snapshot wins.
 	b.stmts.insertRecord, err = b.db.Prepare(`
 		INSERT INTO dna_history
 		(device_id, timestamp, version, dna_json, content_hash,
 		 original_size, compressed_size, compression_ratio, shard_id,
 		 tenant_id, os, architecture, hostname, status)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(device_id, version) DO UPDATE SET
+			timestamp=excluded.timestamp,
+			dna_json=excluded.dna_json,
+			content_hash=excluded.content_hash,
+			original_size=excluded.original_size,
+			compressed_size=excluded.compressed_size,
+			compression_ratio=excluded.compression_ratio,
+			shard_id=excluded.shard_id,
+			tenant_id=excluded.tenant_id,
+			os=excluded.os,
+			architecture=excluded.architecture,
+			hostname=excluded.hostname,
+			status=excluded.status
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare insert record statement: %w", err)

--- a/features/controller/fleet/storage/version_collision_test.go
+++ b/features/controller/fleet/storage/version_collision_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestSQLiteBackend_DuplicateVersionUpserts reproduces the DNA-persist regression
+// where two DNA snapshots for the same device land on the same (device_id, version).
+// GetNextVersion (MAX(version)+1) is computed outside the backend insert lock, so a
+// concurrent/duplicate publish — e.g. the heartbeat path and the ring-subscription
+// store path both firing on reconnect — assigns the same version to two snapshots.
+// The plain INSERT then failed with
+//
+//	UNIQUE constraint failed: dna_history.device_id, dna_history.version
+//
+// which crashed the DNA persist ("Failed to persist DNA to fleet storage") and churned
+// the steward control channel fleet-wide. StoreRecord must be idempotent on
+// (device_id, version): upsert the latest snapshot rather than erroring.
+func TestSQLiteBackend_DuplicateVersionUpserts(t *testing.T) {
+	logger := logging.NewLogger("error")
+	config := createTestConfig(t, BackendSQLite)
+
+	backend, err := NewBackend(BackendSQLite, config, logger)
+	if err != nil {
+		t.Fatalf("failed to create sqlite backend: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+
+	ctx := context.Background()
+	const device = "collision-device"
+
+	mk := func(hash string) *DNARecord {
+		return &DNARecord{
+			DeviceID:         device,
+			DNA:              createTestDNA(device, map[string]string{"os": "linux", "hostname": "h-" + hash}),
+			StoredAt:         time.Now(),
+			ContentHash:      hash,
+			CompressedSize:   100,
+			OriginalSize:     200,
+			CompressionRatio: 0.5,
+			Version:          1, // identical version — the racing/duplicate publish
+			ShardID:          "default",
+		}
+	}
+
+	if err := backend.StoreRecord(ctx, mk("hash-A"), []byte("A")); err != nil {
+		t.Fatalf("first store failed: %v", err)
+	}
+
+	// Second snapshot lands on the same (device_id, version). Before the fix this
+	// returned the UNIQUE constraint violation that crashed the live fleet.
+	if err := backend.StoreRecord(ctx, mk("hash-B"), []byte("B")); err != nil {
+		t.Fatalf("duplicate (device_id, version) must upsert, not error: %v", err)
+	}
+
+	// Upsert semantics: the latest snapshot wins; the row now carries hash-B, and the
+	// superseded hash-A row must be gone (one row per (device_id, version)).
+	if _, err := backend.GetRecord(ctx, "hash-B", "default"); err != nil {
+		t.Fatalf("record with latest content hash-B not found after upsert: %v", err)
+	}
+	if _, err := backend.GetRecord(ctx, "hash-A", "default"); err == nil {
+		t.Fatalf("superseded hash-A row still present — upsert should have replaced it")
+	}
+}

--- a/features/controller/fleet/storage/version_collision_test.go
+++ b/features/controller/fleet/storage/version_collision_test.go
@@ -68,3 +68,42 @@ func TestSQLiteBackend_DuplicateVersionUpserts(t *testing.T) {
 		t.Fatalf("superseded hash-A row still present — upsert should have replaced it")
 	}
 }
+
+// TestSQLiteBackend_DuplicateReferenceVersionUpserts covers the deduplication path:
+// dna_references carries the same UNIQUE(device_id, version) constraint, and
+// Manager.Store takes the storeReference branch when a republished snapshot's content
+// already exists — the likely collision path on reconnect double-fires (identical DNA
+// = dedup hit). StoreReference must be idempotent on (device_id, version) too.
+func TestSQLiteBackend_DuplicateReferenceVersionUpserts(t *testing.T) {
+	logger := logging.NewLogger("error")
+	config := createTestConfig(t, BackendSQLite)
+
+	backend, err := NewBackend(BackendSQLite, config, logger)
+	if err != nil {
+		t.Fatalf("failed to create sqlite backend: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+
+	ctx := context.Background()
+	const device = "collision-ref-device"
+
+	ref := func(hash string) *DNARecord {
+		return &DNARecord{
+			DeviceID:    device,
+			DNA:         createTestDNA(device, map[string]string{"os": "linux"}),
+			StoredAt:    time.Now(),
+			ContentHash: hash,
+			Version:     1, // identical version — the racing/duplicate dedup publish
+			ShardID:     "default",
+		}
+	}
+
+	if err := backend.StoreReference(ctx, ref("ref-hash-A")); err != nil {
+		t.Fatalf("first StoreReference failed: %v", err)
+	}
+	// Second reference lands on the same (device_id, version). Before the fix this
+	// returned "UNIQUE constraint failed: dna_references.device_id, dna_references.version".
+	if err := backend.StoreReference(ctx, ref("ref-hash-B")); err != nil {
+		t.Fatalf("duplicate (device_id, version) reference must upsert, not error: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem
Advancing the controller to current `develop` regressed the live lab fleet: DNA persist crashed with
```
Failed to persist DNA to fleet storage: UNIQUE constraint failed: dna_history.device_id, dna_history.version (2067)
```
alongside constant `steward ControlChannel closed (context canceled)` churn — `cfg steward exec` stopped completing fleet-wide. Reproduced live; rolled the lab controller back to the prior build to restore service.

## Root cause
`Manager.Store` computes `version` via `GetNextVersion` (`MAX(version)+1`) **outside** the backend insert lock, then does a plain `INSERT` with no conflict handling. A duplicate/concurrent publish for the same device (e.g. the heartbeat path and the ring-subscription store path from #2271 both firing on reconnect) assigns the **same** `(device_id, version)` to two snapshots, and the second `INSERT` violates `UNIQUE(device_id, version)`.

## Fix
Make the insert idempotent with `ON CONFLICT (device_id, version) DO UPDATE` on both the SQLite and Postgres backends — matching the upsert convention used across the other stores (config, ip-trust, rbac). Latest snapshot wins.

## Test
`TestSQLiteBackend_DuplicateVersionUpserts` reproduces the exact constraint failure (fails before the fix) and asserts upsert semantics (one row per `(device_id, version)`, latest content). Full `features/controller/fleet/storage` package green.

Found during fleet-ops cleanup under epic #2257 (fleet steward version rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)