### PR TITLE
steward/install: launcher-managed Linux install so stewards are push-upgradeable

### DIFF
--- a/build/linux/install.sh
+++ b/build/linux/install.sh
@@ -9,6 +9,12 @@
 # use), and delegates to cfgms-steward install for cert placement and systemd
 # service registration.
 #
+# The bundle MUST also contain the cfgms-steward-launcher binary alongside
+# cfgms-steward: `cfgms-steward install` performs a launcher-managed install
+# (steward supervised by cfgms-launcher, staged under /opt/cfgms/versions/), which
+# is what makes the steward upgradeable via the control plane. It fails with a
+# clear error if the launcher binary is missing.
+#
 # Usage:
 #   sudo bash install.sh --regtoken TOKEN [--controller-url URL] \
 #       [--fingerprint HEX] [--controller-ca PATH]

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -11,9 +11,24 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/cfgis/cfgms/pkg/version"
 )
 
 const (
+	// linuxLauncherPath is where the launcher binary is installed. The steward's
+	// push-upgrade handler execs "cfgms-launcher swap" at this exact path
+	// (features/steward/client launcherPath()), so a launcher-managed install is
+	// what makes a Linux steward upgradeable via the control plane. It must not change.
+	linuxLauncherPath = "/usr/local/bin/cfgms-launcher"
+	// linuxLauncherRoot is the launcher install root holding versions/ and
+	// state.json. Matches the launcher's defaultRoot() on Linux.
+	linuxLauncherRoot = "/opt/cfgms"
+	// linuxLauncherBinaryName is the launcher binary as shipped in the install
+	// bundle, expected alongside the cfgms-steward binary being installed.
+	linuxLauncherBinaryName = "cfgms-steward-launcher"
+	// linuxInstallPath is the legacy bare-steward binary path. Retained only so
+	// Uninstall(purge) also cleans up pre-launcher (direct-service) installs.
 	linuxInstallPath = "/usr/local/bin/cfgms-steward"
 	linuxSystemdUnit = "/etc/systemd/system/cfgms-steward.service"
 	linuxServiceName = "cfgms-steward"
@@ -68,9 +83,33 @@ func (m *linuxManager) Install(token, controllerURL, caCertPEM, expectedFingerpr
 	// Stop existing service if running (idempotent: ignore failure if not running).
 	_ = exec.Command("systemctl", "stop", linuxServiceName).Run()
 
-	fmt.Printf("Installing to %s...\n", linuxInstallPath)
-	if err := copyBinary(m.binaryPath, linuxInstallPath); err != nil {
-		return fmt.Errorf("failed to copy binary: %w", err)
+	// A launcher-managed install (steward supervised by cfgms-launcher, staged
+	// under /opt/cfgms/versions/) is what makes the steward upgradeable via the
+	// control plane: the push-upgrade handler execs "cfgms-launcher swap" and
+	// requires the launcher at linuxLauncherPath. A bare direct-service steward
+	// cannot be push-upgraded. The launcher binary ships alongside the steward
+	// binary in the install bundle.
+	launcherSrc := filepath.Join(filepath.Dir(m.binaryPath), linuxLauncherBinaryName)
+	if _, err := os.Stat(launcherSrc); err != nil {
+		return fmt.Errorf("launcher binary %q not found next to the steward binary: %w\n"+
+			"  a launcher-managed install requires %s in the install bundle",
+			launcherSrc, err, linuxLauncherBinaryName)
+	}
+
+	ver := version.Short()
+
+	fmt.Printf("Installing launcher to %s...\n", linuxLauncherPath)
+	if err := copyBinary(launcherSrc, linuxLauncherPath); err != nil {
+		return fmt.Errorf("failed to install launcher: %w", err)
+	}
+
+	// Bootstrap the launcher layout: stage the steward binary as the current
+	// version under /opt/cfgms/versions/<ver>/ and record it in state.json. This
+	// reuses the launcher's own "swap" surface, so the on-disk layout is identical
+	// to what a subsequent push-upgrade produces.
+	fmt.Printf("Staging steward %s under %s...\n", ver, linuxLauncherRoot)
+	if out, err := exec.Command(linuxLauncherPath, "swap", "--root", linuxLauncherRoot, ver, m.binaryPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stage steward binary via launcher: %w\n%s", err, out)
 	}
 
 	// Write CA cert before registering the service so the service finds it on first start.
@@ -130,6 +169,20 @@ func (m *linuxManager) Uninstall(purge bool) error {
 	}
 
 	if purge {
+		// Launcher binary + layout (versions/, state.json) for launcher-managed installs.
+		if _, err := os.Stat(linuxLauncherPath); err == nil {
+			fmt.Printf("Removing %s...\n", linuxLauncherPath)
+			if err := os.Remove(linuxLauncherPath); err != nil {
+				return fmt.Errorf("failed to remove launcher: %w", err)
+			}
+		}
+		if _, err := os.Stat(linuxLauncherRoot); err == nil {
+			fmt.Printf("Removing %s...\n", linuxLauncherRoot)
+			if err := os.RemoveAll(linuxLauncherRoot); err != nil {
+				return fmt.Errorf("failed to remove launcher root: %w", err)
+			}
+		}
+		// Legacy bare-steward binary (pre-launcher direct-service installs).
 		if _, err := os.Stat(linuxInstallPath); err == nil {
 			fmt.Printf("Removing %s...\n", linuxInstallPath)
 			if err := os.Remove(linuxInstallPath); err != nil {
@@ -147,7 +200,7 @@ func (m *linuxManager) Uninstall(purge bool) error {
 func (m *linuxManager) Status() (*ServiceStatus, error) {
 	status := &ServiceStatus{
 		ServiceName: linuxServiceName,
-		InstallPath: linuxInstallPath,
+		InstallPath: linuxLauncherPath,
 	}
 
 	// Service is installed if the unit file exists.
@@ -180,10 +233,15 @@ func writeSystemdUnit(path string, content []byte) error {
 // mirrors the behaviour of --regtoken in ps output. The token is a one-time
 // registration credential — after registration the steward uses mTLS certs.
 func generateSystemdUnit(token, controllerURL string) string {
-	execStart := fmt.Sprintf(`%s --regtoken "%s"`, linuxInstallPath, token)
+	// The launcher supervises the steward and forwards --child-args to it. Args
+	// are space-separated (the launcher splits on whitespace); the registration
+	// token is validated to be free of spaces/quotes, so no per-arg quoting is
+	// needed inside the child-args string.
+	childArgs := fmt.Sprintf(`--regtoken %s`, token)
 	if controllerURL != "" {
-		execStart += fmt.Sprintf(` --controller-url "%s"`, controllerURL)
+		childArgs += fmt.Sprintf(` --controller-url %s`, controllerURL)
 	}
+	execStart := fmt.Sprintf(`%s run --root %s --child-args "%s"`, linuxLauncherPath, linuxLauncherRoot, childArgs)
 	return fmt.Sprintf(`[Unit]
 Description=CFGMS Steward
 Documentation=https://docs.cfg.is/steward

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -110,8 +110,8 @@ func TestGenerateSystemdUnit(t *testing.T) {
 	// Launcher-managed: ExecStart runs the launcher, which supervises the steward
 	// and forwards the token via --child-args. This is what makes the steward
 	// push-upgradeable.
-	assert.Contains(t, unit, linuxLauncherPath)
-	assert.Contains(t, unit, "run --child-args")
+	assert.Contains(t, unit, linuxLauncherPath+" run ")
+	assert.Contains(t, unit, "--child-args")
 	assert.NotContains(t, unit, linuxInstallPath+" --regtoken", "ExecStart must run the launcher, not the bare steward")
 	assert.Contains(t, unit, "WantedBy=multi-user.target")
 

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -94,7 +94,7 @@ func TestLinuxManagerStatusNotInstalled(t *testing.T) {
 		assert.False(t, status.Running, "should not be running when unit file is absent")
 	}
 	assert.Equal(t, linuxServiceName, status.ServiceName)
-	assert.Equal(t, linuxInstallPath, status.InstallPath)
+	assert.Equal(t, linuxLauncherPath, status.InstallPath)
 }
 
 func TestGenerateSystemdUnit(t *testing.T) {
@@ -106,8 +106,13 @@ func TestGenerateSystemdUnit(t *testing.T) {
 	assert.Contains(t, unit, "[Install]")
 	assert.Contains(t, unit, "Restart=always")
 	assert.Contains(t, unit, "RestartSec=10")
-	assert.Contains(t, unit, `--regtoken "`+token+`"`)
-	assert.Contains(t, unit, linuxInstallPath)
+	assert.Contains(t, unit, "--regtoken "+token)
+	// Launcher-managed: ExecStart runs the launcher, which supervises the steward
+	// and forwards the token via --child-args. This is what makes the steward
+	// push-upgradeable.
+	assert.Contains(t, unit, linuxLauncherPath)
+	assert.Contains(t, unit, "run --child-args")
+	assert.NotContains(t, unit, linuxInstallPath+" --regtoken", "ExecStart must run the launcher, not the bare steward")
 	assert.Contains(t, unit, "WantedBy=multi-user.target")
 
 	// Verify token appears exactly once (no duplication).
@@ -128,9 +133,9 @@ func TestGenerateSystemdUnitWithControllerURL(t *testing.T) {
 	controllerURL := "https://ctrl.example.com"
 	unit := generateSystemdUnit(token, controllerURL)
 
-	assert.Contains(t, unit, `--controller-url "`+controllerURL+`"`)
-	assert.Contains(t, unit, `--regtoken "`+token+`"`)
-	assert.Contains(t, unit, linuxInstallPath)
+	assert.Contains(t, unit, "--controller-url "+controllerURL)
+	assert.Contains(t, unit, "--regtoken "+token)
+	assert.Contains(t, unit, linuxLauncherPath)
 
 	// Verify token and URL each appear exactly once.
 	assert.Equal(t, 1, strings.Count(unit, token), "token should appear exactly once")


### PR DESCRIPTION
## Problem
The Linux installer produced a **bare** direct-service steward (`ExecStart=/usr/local/bin/cfgms-steward --regtoken`) — no launcher, no `versions/` layout. The push-upgrade handler execs `cfgms-launcher swap` and requires the launcher at `/usr/local/bin/cfgms-launcher`, so a bare steward **can never be upgraded via the control plane**. Discovered during the v0.9.6 fleet rollout: deb-ci-02 is bare and un-upgradeable, and a tear-down/rebuild via the current bootstrap just recreates the same dead-end. The launcher is already cross-platform (`lifecycle_posix.go`, `service_other.go`, built by `build-cross-platform`) — only Windows wired it up.

## Change
`cfgms-steward install` (Linux) now performs a **launcher-managed** install:
- installs the bundled `cfgms-steward-launcher` → `/usr/local/bin/cfgms-launcher`
- bootstraps the layout via the launcher's own `swap` (stages the steward under `/opt/cfgms/versions/<version>/`, writes `state.json`) — identical on-disk shape to a push-upgrade
- writes a systemd unit whose `ExecStart` runs the launcher: `cfgms-launcher run --root /opt/cfgms --child-args "--regtoken ..."`
- fails with a clear error if the launcher binary isn't bundled alongside the steward
- `Uninstall(purge)` also removes the launcher + `/opt/cfgms`; `Status` reports the launcher path

Result: a freshly-installed (or steward-rebuilt) Linux endpoint is push-upgradeable via `cfg steward upgrade` — no manual launcher-swap.

## Tests
`generateSystemdUnit` tests updated for the launcher-based unit (asserts ExecStart runs the launcher, not the bare steward). `GOOS=linux` vet + test-compile clean; full run on CI. `install.sh` is functionally unchanged (mock-based `install_test.sh` unaffected); documents the launcher bundle requirement.

Deficiency story #2 under epic #2257. Prerequisite for tearing down + rebuilding deb-ci-02 into an upgradeable steward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)