### PR TITLE
design: web UI design system — warm-terminal identity, tokens, login + fleet-overview + cockpit mockups (Issue #2344)

### DIFF
--- a/docs/design/mockups/README.md
+++ b/docs/design/mockups/README.md
@@ -1,0 +1,22 @@
+# Web UI — Reference Mockups
+
+Self-contained HTML mockups for the CFGMS web UI design direction (Epic #2344).
+Open any file directly in a browser — no build step, no external assets. Each
+file wraps its mockup in a small preview harness:
+
+- **Desktop / Tablet / Mobile** viewport toggle (renders the mockup in an
+  iframe so its responsive breakpoints fire off the framed width, letting you
+  review the desktop layout from a phone).
+- The cockpit adds an **Auto / Light / Dark** theme toggle.
+
+See [`../web-ui-design-system.md`](../web-ui-design-system.md) for the identity,
+principles, and token rationale these mockups express.
+
+| File | What it is | Status |
+|------|------------|--------|
+| [`troubleshooting-cockpit.html`](troubleshooting-cockpit.html) | The chosen direction — agentic troubleshooting cockpit: case bar, dense ticket quick-reference, tabbed Investigation/Chat rail, and an evidence→cause→action canvas (drift-diff, blast-radius graph, change timeline, remediation). Brand-aligned, both themes. | **Reference** |
+| [`fleet-overview-generic-v0.html`](fleet-overview-generic-v0.html) | The initial generic management dashboard, before brand alignment. Kept for provenance only. | Superseded |
+
+> These are design references, not production code. The shipped UI is
+> React + TypeScript + Vite (Epic #2344), built against
+> [`../web-ui-design-tokens.css`](../web-ui-design-tokens.css) as the source of truth.

--- a/docs/design/mockups/README.md
+++ b/docs/design/mockups/README.md
@@ -7,7 +7,10 @@ file wraps its mockup in a small preview harness:
 - **Desktop / Tablet / Mobile** viewport toggle (renders the mockup in an
   iframe so its responsive breakpoints fire off the framed width, letting you
   review the desktop layout from a phone).
-- The cockpit adds an **Auto / Light / Dark** theme toggle.
+- The cockpit, login, and fleet-overview add an **Auto / Light / Dark** theme
+  toggle. The fleet-overview also carries a small **preview state** strip
+  (Ready / Loading / Error / Empty) so its data-state screens can be reviewed
+  from one file; that strip is a harness affordance, not product UI.
 
 See [`../web-ui-design-system.md`](../web-ui-design-system.md) for the identity,
 principles, and token rationale these mockups express.
@@ -15,6 +18,8 @@ principles, and token rationale these mockups express.
 | File | What it is | Status |
 |------|------------|--------|
 | [`troubleshooting-cockpit.html`](troubleshooting-cockpit.html) | The chosen direction — agentic troubleshooting cockpit: case bar, dense ticket quick-reference, tabbed Investigation/Chat rail, and an evidence→cause→action canvas (drift-diff, blast-radius graph, change timeline, remediation). Brand-aligned, both themes. | **Reference** |
+| [`login.html`](login.html) | The authentication screen — terminal-window framing, single mTLS/session sign-in, with `signin` / `loading` / `invalid` / `expired` states and a **passkey/WebAuthn MFA seam** (`mfa` state) designed now, built later. Both themes. | **Reference** |
+| [`fleet-overview.html`](fleet-overview.html) | The read-only fleet overview inside the app shell — tenant-scope switcher, live-filter search, sort, saved views, selectable **device-DNA columns**, scale-aware pagination, and a row drill-in **asset-DNA drawer**. Both themes; Ready / Loading / Error / Empty states. | **Reference** |
 | [`fleet-overview-generic-v0.html`](fleet-overview-generic-v0.html) | The initial generic management dashboard, before brand alignment. Kept for provenance only. | Superseded |
 
 > These are design references, not production code. The shipped UI is

--- a/docs/design/mockups/fleet-overview-generic-v0.html
+++ b/docs/design/mockups/fleet-overview-generic-v0.html
@@ -1,0 +1,519 @@
+<style>
+  :root {
+    --bg: #EFF2F7;
+    --chrome: #FFFFFF;
+    --chrome-2: #F4F6FA;
+    --border: #D8DFEA;
+    --text: #1A2230;
+    --text-dim: #5C6678;
+    --accent: #3B62E8;
+    --accent-ink: #FFFFFF;
+    --accent-weak: #E6ECFD;
+    --shadow: 0 18px 50px -22px rgba(20,32,60,.45);
+    --radius: 14px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #090C12;
+      --chrome: #141922;
+      --chrome-2: #1B212C;
+      --border: #29323F;
+      --text: #E7ECF3;
+      --text-dim: #8593A5;
+      --accent: #6188F6;
+      --accent-ink: #0A0E15;
+      --accent-weak: #1A2540;
+      --shadow: 0 22px 60px -26px rgba(0,0,0,.7);
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #EFF2F7; --chrome: #FFFFFF; --chrome-2: #F4F6FA; --border: #D8DFEA;
+    --text: #1A2230; --text-dim: #5C6678; --accent: #3B62E8; --accent-ink: #FFFFFF;
+    --accent-weak: #E6ECFD; --shadow: 0 18px 50px -22px rgba(20,32,60,.45);
+  }
+  :root[data-theme="dark"] {
+    --bg: #090C12; --chrome: #141922; --chrome-2: #1B212C; --border: #29323F;
+    --text: #E7ECF3; --text-dim: #8593A5; --accent: #6188F6; --accent-ink: #0A0E15;
+    --accent-weak: #1A2540; --shadow: 0 22px 60px -26px rgba(0,0,0,.7);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100dvh;
+    background: var(--bg);
+    color: var(--text);
+    font-family: ui-sans-serif, system-ui, -apple-system, "SF Pro Text", "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+    padding: 12px 16px;
+    background: var(--chrome);
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    z-index: 5;
+  }
+  .brand {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-right: auto;
+  }
+  .brand b {
+    font-size: 15px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    font-weight: 700;
+  }
+  .brand span {
+    font-size: 11px;
+    color: var(--text-dim);
+    letter-spacing: .04em;
+  }
+
+  .seg {
+    display: inline-flex;
+    position: relative;
+    background: var(--chrome-2);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 3px;
+  }
+  .seg button {
+    position: relative;
+    z-index: 1;
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: var(--text-dim);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 7px 14px;
+    border-radius: 7px;
+    cursor: pointer;
+    transition: color .18s ease;
+  }
+  .seg button[aria-pressed="true"] { color: var(--accent-ink); }
+  .seg .thumb {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    height: calc(100% - 6px);
+    background: var(--accent);
+    border-radius: 7px;
+    transition: transform .22s cubic-bezier(.4,.9,.3,1), width .22s cubic-bezier(.4,.9,.3,1);
+    z-index: 0;
+  }
+  .seg button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  .dims {
+    font-family: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, monospace;
+    font-size: 12px;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .stage {
+    flex: 1;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 22px 16px 40px;
+    overflow: auto;
+  }
+  .frame-wrap {
+    position: relative;
+    margin: 0 auto;
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    border: 1px solid var(--border);
+    background: var(--chrome);
+    transition: width .22s ease, height .22s ease;
+  }
+  .frame {
+    display: block;
+    border: 0;
+    transform-origin: 0 0;
+    background: transparent;
+  }
+
+  .hint {
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 12.5px;
+    line-height: 1.6;
+    padding: 0 20px 30px;
+    max-width: 520px;
+    margin: 0 auto;
+  }
+  .hint kbd {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    background: var(--chrome);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    padding: 1px 6px;
+    color: var(--text);
+  }
+</style>
+
+<div class="topbar">
+  <div class="brand">
+    <b>CFGMS</b><span>preview harness</span>
+  </div>
+  <div class="seg" role="group" aria-label="Preview viewport">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-dev="desktop" aria-pressed="true">Desktop</button>
+    <button data-dev="tablet" aria-pressed="false">Tablet</button>
+    <button data-dev="mobile" aria-pressed="false">Mobile</button>
+  </div>
+  <div class="dims" id="dims">—</div>
+</div>
+
+<div class="stage">
+  <div class="frame-wrap" id="wrap">
+    <iframe class="frame" id="frame" title="CFGMS console mockup"></iframe>
+  </div>
+</div>
+
+<p class="hint">
+  Tap <b>Desktop</b> to see the full-width layout scaled to fit — <b>pinch to zoom</b> to inspect detail.
+  Toggle <b>Mobile</b> to see the responsive breakpoint. The console below is a live CFGMS mockup, not a screenshot.
+</p>
+
+<script>
+  const DEVICES = {
+    desktop: { w: 1280, h: 840 },
+    tablet:  { w: 834,  h: 1120 },
+    mobile:  { w: 390,  h: 780 },
+  };
+  let current = "desktop";
+
+  const frame = document.getElementById("frame");
+  const wrap  = document.getElementById("wrap");
+  const stage = document.querySelector(".stage");
+  const dims  = document.getElementById("dims");
+  const seg   = document.querySelector(".seg");
+  const thumb = document.querySelector(".seg .thumb");
+  const btns  = [...document.querySelectorAll(".seg button")];
+
+  const MOCK_CSS = `
+    :root{
+      --bg:#EFF2F7; --panel:#FFFFFF; --panel-2:#F4F6FA; --border:#DCE3EC;
+      --text:#1B2431; --dim:#5C6678; --faint:#8B96A6;
+      --accent:#3B62E8; --accent-weak:#E7ECFD;
+      --ok:#1F9D57; --ok-weak:#E1F3E8; --warn:#B7791F; --warn-weak:#F7EED9;
+      --crit:#D23B3B; --crit-weak:#FBE4E4; --neutral:#5C6678; --neutral-weak:#EAEEF4;
+    }
+    :root[data-theme="dark"]{
+      --bg:#0B0F16; --panel:#141A23; --panel-2:#1B222D; --border:#28313E;
+      --text:#E7ECF3; --dim:#8B98AA; --faint:#5F6C7D;
+      --accent:#6188F6; --accent-weak:#1B2740;
+      --ok:#3FBE74; --ok-weak:#12281D; --warn:#D9A441; --warn-weak:#2A2413;
+      --crit:#F0645F; --crit-weak:#2C1717; --neutral:#8B98AA; --neutral-weak:#1E252F;
+    }
+    *{box-sizing:border-box;}
+    html,body{margin:0;height:100%;}
+    body{
+      background:var(--bg); color:var(--text);
+      font-family:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+      -webkit-font-smoothing:antialiased; font-size:14px; line-height:1.45;
+    }
+    .app{display:grid; grid-template-columns:1fr; height:100%;}
+    .side{display:none;}
+    .side .logo{display:flex; align-items:baseline; gap:7px; padding:18px 18px 14px;}
+    .side .logo b{font-size:15px; letter-spacing:.12em; text-transform:uppercase;}
+    .side .logo i{font-style:normal; font-size:10px; color:var(--faint); letter-spacing:.05em;}
+    .tenant{margin:0 14px 14px; padding:8px 10px; background:var(--panel-2); border:1px solid var(--border);
+      border-radius:9px; font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:11.5px; color:var(--dim);}
+    .tenant b{color:var(--text); font-weight:600;}
+    nav{display:flex; flex-direction:column; gap:2px; padding:4px 10px;}
+    nav a{display:flex; align-items:center; gap:11px; padding:9px 11px; border-radius:8px;
+      color:var(--dim); text-decoration:none; font-weight:500; font-size:13.5px;}
+    nav a .ico{width:16px; height:16px; flex:none; opacity:.85;}
+    nav a.active{background:var(--accent-weak); color:var(--accent); font-weight:600;}
+    nav a.active .ico{opacity:1;}
+    .side .foot{margin-top:auto; padding:14px; display:flex; align-items:center; gap:10px; border-top:1px solid var(--border);}
+    .avatar{width:30px; height:30px; border-radius:50%; background:var(--accent); color:#fff;
+      display:grid; place-items:center; font-size:12px; font-weight:700; flex:none;}
+    .who small{display:block; color:var(--faint); font-size:11px;}
+    .who b{font-size:13px; font-weight:600;}
+
+    .main{display:flex; flex-direction:column; min-width:0; overflow:auto;}
+    .head{position:sticky; top:0; z-index:2; display:flex; align-items:center; gap:12px;
+      padding:12px 16px; background:color-mix(in srgb,var(--bg) 88%, transparent);
+      backdrop-filter:blur(8px); border-bottom:1px solid var(--border);}
+    .head .mlogo{display:flex; align-items:baseline; gap:6px;}
+    .head .mlogo b{font-size:14px; letter-spacing:.1em; text-transform:uppercase;}
+    .crumb{display:none; font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:12px; color:var(--dim);}
+    .crumb b{color:var(--text);}
+    .search{margin-left:auto; display:flex; align-items:center; gap:8px; padding:7px 11px;
+      background:var(--panel); border:1px solid var(--border); border-radius:9px; color:var(--faint); font-size:12.5px;}
+    .search .k{margin-left:6px; font-family:ui-monospace,Menlo,monospace; font-size:10px; border:1px solid var(--border);
+      border-radius:4px; padding:0 4px; color:var(--faint);}
+    .hpill{display:flex; align-items:center; gap:7px; padding:6px 10px; border-radius:20px;
+      background:var(--ok-weak); color:var(--ok); font-size:12px; font-weight:600;}
+    .dot{width:7px; height:7px; border-radius:50%; background:currentColor;}
+
+    .body{padding:18px 16px 32px; display:flex; flex-direction:column; gap:18px;}
+    .htitle{display:flex; align-items:flex-end; justify-content:space-between; gap:12px; flex-wrap:wrap;}
+    .htitle h1{margin:0; font-size:19px; font-weight:700; letter-spacing:-.01em;}
+    .htitle p{margin:3px 0 0; color:var(--dim); font-size:13px;}
+    .btn{appearance:none; border:1px solid var(--border); background:var(--panel); color:var(--text);
+      font:inherit; font-size:13px; font-weight:600; padding:8px 14px; border-radius:9px;}
+    .btn.pri{background:var(--accent); border-color:var(--accent); color:#fff;}
+
+    .tiles{display:grid; grid-template-columns:1fr 1fr; gap:12px;}
+    .tile{background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:14px;}
+    .tile .lbl{font-size:11px; letter-spacing:.07em; text-transform:uppercase; color:var(--faint); font-weight:600;}
+    .tile .num{font-size:26px; font-weight:700; margin-top:6px; font-variant-numeric:tabular-nums; letter-spacing:-.02em;}
+    .tile .sub{font-size:12px; margin-top:3px; font-variant-numeric:tabular-nums;}
+    .up{color:var(--ok);} .down{color:var(--crit);} .muted{color:var(--dim);}
+    .spark{display:flex; align-items:flex-end; gap:3px; height:26px; margin-top:10px;}
+    .spark i{flex:1; background:var(--accent-weak); border-radius:2px;}
+    .spark i.hi{background:var(--accent);}
+
+    .cols{display:grid; grid-template-columns:1fr; gap:14px;}
+    .panel{background:var(--panel); border:1px solid var(--border); border-radius:12px; overflow:hidden;}
+    .panel > h2{margin:0; padding:13px 15px; font-size:13px; font-weight:700; letter-spacing:.01em;
+      border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center;}
+    .panel > h2 small{color:var(--faint); font-weight:500; font-size:11.5px;}
+
+    .rings{padding:6px 15px 14px;}
+    .ring{padding:11px 0; border-bottom:1px solid var(--border);}
+    .ring:last-child{border-bottom:0;}
+    .ring .top{display:flex; justify-content:space-between; align-items:baseline; margin-bottom:7px;}
+    .ring .top b{font-size:13.5px;} .ring .top span{font-size:12px; color:var(--dim); font-variant-numeric:tabular-nums;}
+    .bar{height:7px; border-radius:5px; background:var(--panel-2); overflow:hidden;}
+    .bar i{display:block; height:100%; border-radius:5px; background:var(--accent);}
+    .bar i.done{background:var(--ok);} .bar i.queue{background:var(--neutral); opacity:.5;}
+
+    .tbl{width:100%; border-collapse:collapse; font-size:13px;}
+    .tbl th{text-align:left; font-size:10.5px; letter-spacing:.06em; text-transform:uppercase; color:var(--faint);
+      font-weight:600; padding:10px 15px; border-bottom:1px solid var(--border);}
+    .tbl td{padding:12px 15px; border-bottom:1px solid var(--border); vertical-align:middle;}
+    .tbl tr:last-child td{border-bottom:0;}
+    .host{font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:12.5px; font-weight:600;}
+    .os{color:var(--dim); font-size:12.5px;}
+    .ago{color:var(--faint); font-size:12px; font-variant-numeric:tabular-nums; text-align:right;}
+    .ringtag{font-size:11px; color:var(--dim); font-family:ui-monospace,Menlo,monospace;}
+    .pill{display:inline-flex; align-items:center; gap:6px; padding:4px 9px; border-radius:20px;
+      font-size:11.5px; font-weight:600; white-space:nowrap;}
+    .pill.ok{background:var(--ok-weak); color:var(--ok);}
+    .pill.warn{background:var(--warn-weak); color:var(--warn);}
+    .pill.crit{background:var(--crit-weak); color:var(--crit);}
+    .pill.neu{background:var(--neutral-weak); color:var(--neutral);}
+
+    /* mobile-first table -> cards */
+    .tbl thead{display:none;}
+    .tbl, .tbl tbody, .tbl tr, .tbl td{display:block; width:100%;}
+    .tbl tr{padding:12px 15px; border-bottom:1px solid var(--border); display:grid;
+      grid-template-columns:1fr auto; gap:4px 10px; align-items:center;}
+    .tbl td{padding:0; border:0;}
+    .tbl td.c-state{grid-row:1; grid-column:2; text-align:right;}
+    .tbl td.c-host{grid-row:1; grid-column:1;}
+    .tbl td.c-os{grid-row:2; grid-column:1;}
+    .tbl td.c-ring{grid-row:2; grid-column:1; justify-self:end;}
+    .tbl td.c-ago{grid-row:3; grid-column:1/3;}
+
+    @media (min-width:720px){
+      .tiles{grid-template-columns:repeat(4,1fr);}
+      .crumb{display:block;}
+      /* restore real table */
+      .tbl thead{display:table-header-group;}
+      .tbl{display:table;} .tbl tbody{display:table-row-group;}
+      .tbl tr{display:table-row; padding:0;}
+      .tbl td{display:table-cell; padding:12px 15px; border-bottom:1px solid var(--border);}
+      .tbl td.c-ago{text-align:right;}
+    }
+    @media (min-width:1024px){
+      .app{grid-template-columns:238px 1fr;}
+      .side{display:flex; flex-direction:column; background:var(--panel); border-right:1px solid var(--border);}
+      .head .mlogo{display:none;}
+      .cols{grid-template-columns:1.05fr 1.4fr;}
+      .body{padding:22px 24px 40px;}
+      .head{padding:14px 24px;}
+    }
+  `;
+
+  const ICO = {
+    fleet: '<path d="M3 4h18M3 10h18M3 16h18" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>',
+    mods:  '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>',
+    cfg:   '<path d="M4 6h16M4 12h10M4 18h16" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/><circle cx="17" cy="12" r="2.4" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+    rings: '<circle cx="12" cy="12" r="8.5" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.4" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+    audit: '<path d="M6 3h9l4 4v14H6V3z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M9 12h6M9 16h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>',
+    set:   '<circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M19 5l-2 2M7 17l-2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>',
+  };
+  const navItem = (k, label, active) =>
+    `<a class="${active?'active':''}"><svg class="ico" viewBox="0 0 24 24" fill="none">${ICO[k]}</svg>${label}</a>`;
+
+  const row = (host, os, ring, state, cls, ago) => `
+    <tr>
+      <td class="c-host"><span class="host">${host}</span></td>
+      <td class="c-os"><span class="os">${os}</span></td>
+      <td class="c-ring"><span class="ringtag">${ring}</span></td>
+      <td class="c-state"><span class="pill ${cls}"><span class="dot"></span>${state}</span></td>
+      <td class="c-ago"><span class="ago">${ago}</span></td>
+    </tr>`;
+
+  const MOCK_HTML = `
+  <div class="app">
+    <aside class="side">
+      <div class="logo"><b>CFGMS</b><i>controller</i></div>
+      <div class="tenant">root / <b>msp-a</b> / client-1</div>
+      <nav>
+        ${navItem('fleet','Fleet',true)}
+        ${navItem('mods','Modules',false)}
+        ${navItem('cfg','Config',false)}
+        ${navItem('rings','Rings',false)}
+        ${navItem('audit','Audit',false)}
+        ${navItem('set','Settings',false)}
+      </nav>
+      <div class="foot">
+        <div class="avatar">JR</div>
+        <div class="who"><b>jrdn</b><small>operator · msp-a</small></div>
+      </div>
+    </aside>
+
+    <div class="main">
+      <div class="head">
+        <div class="mlogo"><b>CFGMS</b></div>
+        <div class="crumb">root / <b>msp-a</b> / client-1 / <b>fleet</b></div>
+        <div class="search">Search endpoints<span class="k">/</span></div>
+        <div class="hpill"><span class="dot"></span>All systems nominal</div>
+      </div>
+
+      <div class="body">
+        <div class="htitle">
+          <div>
+            <h1>Fleet overview</h1>
+            <p>48,210 managed endpoints across 3 platforms · last sync 12s ago</p>
+          </div>
+          <button class="btn pri">Push config</button>
+        </div>
+
+        <div class="tiles">
+          <div class="tile">
+            <div class="lbl">Endpoints</div>
+            <div class="num">48,210</div>
+            <div class="sub up">▲ 320 this week</div>
+            <div class="spark"><i style="height:40%"></i><i style="height:55%"></i><i style="height:48%"></i><i style="height:70%"></i><i style="height:62%"></i><i style="height:80%"></i><i class="hi" style="height:95%"></i></div>
+          </div>
+          <div class="tile">
+            <div class="lbl">Converged</div>
+            <div class="num">97.3%</div>
+            <div class="sub up">▲ 0.4 pts</div>
+            <div class="spark"><i style="height:80%"></i><i style="height:78%"></i><i style="height:85%"></i><i style="height:82%"></i><i style="height:88%"></i><i style="height:90%"></i><i class="hi" style="height:97%"></i></div>
+          </div>
+          <div class="tile">
+            <div class="lbl">Drift</div>
+            <div class="num">1,190</div>
+            <div class="sub down">▲ 60 vs. yesterday</div>
+            <div class="spark"><i style="height:30%"></i><i style="height:44%"></i><i style="height:38%"></i><i style="height:50%"></i><i style="height:42%"></i><i style="height:46%"></i><i class="hi" style="height:58%"></i></div>
+          </div>
+          <div class="tile">
+            <div class="lbl">Errors</div>
+            <div class="num">140</div>
+            <div class="sub muted">stable</div>
+            <div class="spark"><i style="height:22%"></i><i style="height:26%"></i><i style="height:20%"></i><i style="height:24%"></i><i style="height:22%"></i><i style="height:23%"></i><i class="hi" style="height:24%"></i></div>
+          </div>
+        </div>
+
+        <div class="cols">
+          <section class="panel">
+            <h2>Rollout rings <small>config r2291 · staged</small></h2>
+            <div class="rings">
+              <div class="ring">
+                <div class="top"><b>canary</b><span>2% · complete</span></div>
+                <div class="bar"><i class="done" style="width:100%"></i></div>
+              </div>
+              <div class="ring">
+                <div class="top"><b>early</b><span>10% · rolling · 62%</span></div>
+                <div class="bar"><i style="width:62%"></i></div>
+              </div>
+              <div class="ring">
+                <div class="top"><b>broad</b><span>38% · rolling · 24%</span></div>
+                <div class="bar"><i style="width:24%"></i></div>
+              </div>
+              <div class="ring">
+                <div class="top"><b>prod</b><span>50% · queued</span></div>
+                <div class="bar"><i class="queue" style="width:100%"></i></div>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel">
+            <h2>Endpoints <small>6 of 48,210</small></h2>
+            <table class="tbl">
+              <thead>
+                <tr><th>Host</th><th>OS</th><th>Ring</th><th>State</th><th style="text-align:right">Last check-in</th></tr>
+              </thead>
+              <tbody>
+                ${row('web-ingest-04','Linux','broad','Converged','ok','41s ago')}
+                ${row('dc-01','Windows','early','Drift','warn','2m ago')}
+                ${row('build-mac-11','macOS','canary','Converged','ok','8s ago')}
+                ${row('sql-primary','Windows','broad','Error','crit','1m ago')}
+                ${row('edge-fw-02','Linux','prod','Queued','neu','5m ago')}
+                ${row('kiosk-lobby','Linux','early','Converged','ok','33s ago')}
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>`;
+
+  function currentTheme() {
+    const d = document.documentElement.getAttribute("data-theme");
+    if (d) return d;
+    return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  function srcdoc(theme) {
+    return '<!doctype html><html lang="en" data-theme="' + theme + '"><head>' +
+      '<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">' +
+      '<style>' + MOCK_CSS + '</style></head><body>' + MOCK_HTML + '</body></html>';
+  }
+  function layout() {
+    const d = DEVICES[current];
+    frame.style.width = d.w + "px";
+    frame.style.height = d.h + "px";
+    const avail = stage.clientWidth - 32;
+    const scale = Math.min(1, avail / d.w);
+    frame.style.transform = "scale(" + scale + ")";
+    wrap.style.width = (d.w * scale) + "px";
+    wrap.style.height = (d.h * scale) + "px";
+    dims.textContent = d.w + " × " + d.h + " · " + Math.round(scale * 100) + "%";
+  }
+  function moveThumb() {
+    const active = btns.find(b => b.dataset.dev === current);
+    thumb.style.width = active.offsetWidth + "px";
+    thumb.style.transform = "translateX(" + (active.offsetLeft - 3) + "px)";
+  }
+  function render() { frame.srcdoc = srcdoc(currentTheme()); layout(); }
+
+  btns.forEach(b => b.addEventListener("click", () => {
+    current = b.dataset.dev;
+    btns.forEach(x => x.setAttribute("aria-pressed", x === b ? "true" : "false"));
+    moveThumb();
+    layout();
+  }));
+
+  new MutationObserver(render).observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", render);
+  window.addEventListener("resize", () => { layout(); moveThumb(); });
+  window.addEventListener("orientationchange", () => setTimeout(() => { layout(); moveThumb(); }, 200));
+
+  render();
+  moveThumb();
+</script>

--- a/docs/design/mockups/fleet-overview.html
+++ b/docs/design/mockups/fleet-overview.html
@@ -1,0 +1,495 @@
+<style>
+  :root {
+    --bg:#f0ebe4; --chrome:#f7f4ef; --chrome-2:#ffffff; --border:#d4cfc4;
+    --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff;
+    --shadow:0 18px 50px -22px rgba(60,45,30,.4); --radius:14px;
+  }
+  @media (prefers-color-scheme: dark){ :root{
+    --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
+    --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a;
+    --shadow:0 22px 60px -26px rgba(0,0,0,.8); } }
+  :root[data-theme="light"]{ --bg:#f0ebe4; --chrome:#f7f4ef; --chrome-2:#ffffff; --border:#d4cfc4;
+    --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff; --shadow:0 18px 50px -22px rgba(60,45,30,.4); }
+  :root[data-theme="dark"]{ --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
+    --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a; --shadow:0 22px 60px -26px rgba(0,0,0,.8); }
+  *{box-sizing:border-box;}
+  body{margin:0; min-height:100dvh; background:var(--bg); color:var(--text); display:flex; flex-direction:column;
+    font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased;}
+  .topbar{display:flex; align-items:center; gap:14px; flex-wrap:wrap; padding:11px 16px; background:var(--chrome);
+    border-bottom:1px solid var(--border); position:sticky; top:0; z-index:5;}
+  .brand{display:flex; align-items:baseline; gap:8px; margin-right:auto;}
+  .brand b{font-size:14px; letter-spacing:.13em; text-transform:uppercase; font-weight:700;}
+  .brand span{font-size:11px; color:var(--text-dim); letter-spacing:.04em;}
+  .seg{display:inline-flex; position:relative; background:var(--chrome-2); border:1px solid var(--border); border-radius:10px; padding:3px;}
+  .seg button{position:relative; z-index:1; appearance:none; border:0; background:transparent; color:var(--text-dim);
+    font:inherit; font-size:12.5px; font-weight:600; padding:6px 13px; border-radius:7px; cursor:pointer; transition:color .18s ease;}
+  .seg button[aria-pressed="true"]{color:var(--accent-ink);}
+  .seg .thumb{position:absolute; top:3px; left:3px; height:calc(100% - 6px); background:var(--accent); border-radius:7px;
+    transition:transform .22s cubic-bezier(.4,.9,.3,1), width .22s cubic-bezier(.4,.9,.3,1); z-index:0;}
+  .seg button:focus-visible{outline:2px solid var(--accent); outline-offset:2px;}
+  .dims{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace; font-size:12px; color:var(--text-dim);
+    font-variant-numeric:tabular-nums; white-space:nowrap;}
+  .stage{flex:1; display:flex; align-items:flex-start; justify-content:center; padding:22px 16px 30px; overflow:auto;}
+  .frame-wrap{position:relative; margin:0 auto; border-radius:var(--radius); overflow:hidden; box-shadow:var(--shadow);
+    border:1px solid var(--border); background:var(--chrome); transition:width .22s ease, height .22s ease;}
+  .frame{display:block; border:0; transform-origin:0 0; background:transparent;}
+  .hint{text-align:center; color:var(--text-dim); font-size:12.5px; line-height:1.6; padding:0 20px 30px; max-width:640px; margin:0 auto;}
+</style>
+
+<div class="topbar">
+  <div class="brand"><b>CFGMS</b><span>app shell v3 · fleet</span></div>
+  <div class="seg" role="group" aria-label="Preview viewport">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-dev="desktop" aria-pressed="true">Desktop</button>
+    <button data-dev="tablet" aria-pressed="false">Tablet</button>
+    <button data-dev="mobile" aria-pressed="false">Mobile</button>
+  </div>
+  <div class="seg themeseg" role="group" aria-label="Theme">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-theme-mode="auto" aria-pressed="true">Auto</button>
+    <button data-theme-mode="light" aria-pressed="false">Light</button>
+    <button data-theme-mode="dark" aria-pressed="false">Dark</button>
+  </div>
+  <div class="dims" id="dims">—</div>
+</div>
+
+<div class="stage">
+  <div class="frame-wrap" id="wrap"><iframe class="frame" id="frame" title="CFGMS fleet v3 mockup"></iframe></div>
+</div>
+
+<p class="hint">
+  Fleet v3 — <b>type in the search box to live-filter</b> rows, <b>click a column header to sort</b>, use <b>Views</b> for saved filters,
+  <b>Columns</b> to pick DNA, and <b>click any steward</b> to open its full-DNA detail. Pagination bottom. ☰ = mobile nav.
+</p>
+
+<script>
+  const DEVICES = { desktop:{w:1400,h:900}, tablet:{w:900,h:1060}, mobile:{w:390,h:1220} };
+  let current = "desktop", themeMode = "auto";
+  const frame = document.getElementById("frame"), wrap = document.getElementById("wrap");
+  const stage = document.querySelector(".stage"), dims = document.getElementById("dims");
+  const devSeg = document.querySelector(".seg:not(.themeseg)"), themeSeg = document.querySelector(".themeseg");
+  const devBtns = [...devSeg.querySelectorAll("button")], themeBtns = [...themeSeg.querySelectorAll("button")];
+  function posThumb(seg){ const t=seg.querySelector(".thumb"); const a=seg.querySelector('button[aria-pressed="true"]')||seg.querySelector("button"); t.style.width=a.offsetWidth+"px"; t.style.transform="translateX("+(a.offsetLeft-3)+"px)"; }
+
+  const MOCK_CSS = `
+    :root{
+      --bg:#f7f4ef; --panel:#ffffff; --elev:#f0ebe4; --sunk:#f0ebe4; --border:#d4cfc4;
+      --text:#6b5a4a; --dim:#7a6a5a; --faint:#8f7d66;
+      --accent:#4a6b7c; --accent-ink:#ffffff; --accent-weak:#e6eef2;
+      --ok:#507055; --ok-bg:#e8f0e9; --warn:#a05a35; --warn-bg:#f7e8db; --crit:#b56a5a; --crit-bg:#f2e5e3;
+      --neu:#7a6a5a; --neu-bg:#e8e0d8; --pop-sh:0 16px 44px -20px rgba(50,40,25,.4);
+    }
+    :root[data-theme="dark"]{
+      --bg:#1e1e1e; --panel:#252526; --elev:#2d2d2d; --sunk:#1a1a1a; --border:#3c3c3c;
+      --text:#c4b4a4; --dim:#a89888; --faint:#8a7a68;
+      --accent:#7b9fb0; --accent-ink:#16202a; --accent-weak:#1e2528;
+      --ok:#6d9472; --ok-bg:#1a2e1d; --warn:#d4864f; --warn-bg:#332518; --crit:#c97a6a; --crit-bg:#2d1f1c;
+      --neu:#a89888; --neu-bg:#2a2520; --pop-sh:0 16px 44px -18px rgba(0,0,0,.7);
+    }
+    *{box-sizing:border-box;}
+    html,body{margin:0; height:100%;}
+    body{background:var(--bg); color:var(--text); font-size:13.5px; line-height:1.45;
+      font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased;}
+    .mono{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace; font-variant-numeric:tabular-nums;}
+    .lbl{font-size:10px; letter-spacing:.09em; text-transform:uppercase; color:var(--faint); font-weight:600;}
+    .dot{width:7px; height:7px; border-radius:50%; background:currentColor; flex:none;}
+    .pill{display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:20px; font-size:11.5px; font-weight:600; white-space:nowrap;}
+    .pill.ok{background:var(--ok-bg); color:var(--ok);} .pill.warn{background:var(--warn-bg); color:var(--warn);}
+    .pill.crit{background:var(--crit-bg); color:var(--crit);} .pill.neu{background:var(--neu-bg); color:var(--neu);}
+    .icobtn{appearance:none; border:1px solid var(--border); background:var(--panel); color:var(--dim); border-radius:9px; width:34px; height:34px; display:grid; place-items:center; cursor:pointer; position:relative; flex:none;}
+    .icobtn:hover{color:var(--text);} svg{display:block;}
+
+    .shell{display:grid; grid-template-columns:1fr; height:100%; position:relative;}
+    .side{display:flex; flex-direction:column; background:var(--panel); border-right:1px solid var(--border);
+      position:fixed; top:0; bottom:0; left:0; width:250px; z-index:40; transform:translateX(-105%); transition:transform .22s ease;}
+    body.drawer .side{transform:translateX(0);}
+    .scrim{position:fixed; inset:0; background:rgba(0,0,0,.4); z-index:35; opacity:0; pointer-events:none; transition:opacity .2s;}
+    body.drawer .scrim, body.det .scrim{opacity:1; pointer-events:auto;}
+    .side .logo{display:flex; align-items:center; justify-content:space-between; padding:16px 16px 12px;}
+    .side .logo .l{display:flex; align-items:baseline; gap:7px;}
+    .side .logo b{font-size:15px; letter-spacing:.13em; text-transform:uppercase;} .side .logo i{font-style:normal; font-size:10px; color:var(--faint); letter-spacing:.05em;}
+    nav{display:flex; flex-direction:column; gap:2px; padding:6px 10px;}
+    nav a{display:flex; align-items:center; gap:11px; padding:9px 11px; border-radius:8px; color:var(--dim); text-decoration:none; font-weight:500; font-size:13.5px; cursor:pointer;}
+    nav a .ico{width:16px; height:16px; flex:none; opacity:.8;}
+    nav a.active{background:var(--accent-weak); color:var(--accent); font-weight:600;} nav a.active .ico{opacity:1;}
+    nav a.soon{opacity:.5;} nav a.soon .tag{margin-left:auto; font-size:9px; letter-spacing:.06em; text-transform:uppercase; color:var(--faint);}
+    .side .cfoot{margin-top:auto; padding:12px 14px; border-top:1px solid var(--border); display:flex; align-items:center; gap:9px; font-size:12px; color:var(--dim); cursor:pointer;}
+    .side .cfoot .cn{font-weight:600; color:var(--text); font-family:'JetBrains Mono',Menlo,monospace; font-size:12px;} .side .cfoot small{display:block; color:var(--faint); font-size:10.5px;}
+
+    .main{display:flex; flex-direction:column; min-width:0; overflow:auto; height:100%;}
+    .appbar{position:sticky; top:0; z-index:20; display:flex; align-items:center; gap:10px; padding:10px 14px;
+      background:color-mix(in srgb,var(--bg) 90%, transparent); backdrop-filter:blur(8px); border-bottom:1px solid var(--border);}
+    .scope{display:flex; align-items:center; gap:8px; padding:7px 10px; background:var(--panel); border:1px solid var(--border); border-radius:9px; cursor:pointer; font-size:12.5px; white-space:nowrap;}
+    .scope .path{font-family:'JetBrains Mono',Menlo,monospace; color:var(--dim);} .scope .path b{color:var(--text);} .scope .cv{color:var(--faint);}
+    .searchbox{flex:1; min-width:0; display:flex; align-items:center; gap:9px; padding:0 12px; background:var(--panel); border:1px solid var(--border); border-radius:9px; max-width:440px;}
+    .searchbox svg{color:var(--faint); flex:none;}
+    .searchbox input{flex:1; min-width:0; border:0; background:transparent; color:var(--text); font:inherit; font-size:13px; padding:9px 0; outline:none;}
+    .searchbox input::placeholder{color:var(--faint);}
+    .abspacer{flex:1;}
+    .badge{position:absolute; top:-5px; right:-5px; min-width:16px; height:16px; padding:0 4px; border-radius:9px; background:var(--crit); color:#fff; font-size:9.5px; font-weight:700; display:grid; place-items:center;}
+    .uav{width:34px; height:34px; border-radius:50%; background:var(--accent); color:var(--accent-ink); display:grid; place-items:center; font-size:12px; font-weight:700; cursor:pointer; flex:none;}
+
+    .pop{position:absolute; z-index:60; background:var(--panel); border:1px solid var(--border); border-radius:12px; box-shadow:var(--pop-sh); padding:6px; min-width:230px; display:none;}
+    .pop.open{display:block;}
+    .pop h4{margin:2px 8px 6px; font-size:10px; letter-spacing:.08em; text-transform:uppercase; color:var(--faint);}
+    .pop .row{display:flex; align-items:center; gap:10px; padding:8px 9px; border-radius:8px; font-size:13px; cursor:pointer; color:var(--text);}
+    .pop .row:hover{background:var(--elev);} .pop .row .sub{color:var(--faint); font-size:11px;}
+    .pop .row.cur{background:var(--accent-weak); color:var(--accent); font-weight:600;}
+    .pop .sep{height:1px; background:var(--border); margin:5px 4px;} .pop .row .r{margin-left:auto; font-size:11px; color:var(--faint); font-family:'JetBrains Mono',Menlo,monospace;}
+    .pop.right{right:14px;}
+    .ck{display:flex; align-items:center; gap:9px; padding:7px 9px; border-radius:7px; font-size:12.5px; cursor:pointer;}
+    .ck:hover{background:var(--elev);} .ck input{accent-color:var(--accent); width:15px; height:15px;} .ck.dis{opacity:.55; cursor:not-allowed;}
+    .miniseg{display:flex; gap:3px; margin:2px 8px 6px;}
+    .miniseg button{flex:1; font:inherit; font-size:11px; font-weight:600; border:1px solid var(--border); background:var(--panel); color:var(--dim); border-radius:6px; padding:5px; cursor:pointer;}
+    .miniseg button.on{background:var(--accent); color:var(--accent-ink); border-color:var(--accent);}
+
+    .content{padding:18px; display:flex; flex-direction:column; gap:16px;}
+    .htitle h1{margin:0; font-size:20px; font-weight:700; letter-spacing:-.01em;}
+    .htitle p{margin:3px 0 0; color:var(--dim); font-size:13px;}
+    .tiles{display:grid; grid-template-columns:1fr 1fr; gap:12px;}
+    .tile{background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:12px 15px; display:flex; flex-direction:column; gap:4px;}
+    .tile .n{font-size:22px; font-weight:700; font-variant-numeric:tabular-nums; letter-spacing:-.02em; display:flex; align-items:center; gap:8px;}
+    .tile .n .sw{width:9px; height:9px; border-radius:50%;}
+
+    .panel{background:var(--panel); border:1px solid var(--border); border-radius:13px; overflow:hidden;}
+    .ptool{display:flex; align-items:center; gap:9px; padding:10px 13px; border-bottom:1px solid var(--border); position:relative; flex-wrap:wrap;}
+    .vbtn,.colbtn{display:flex; align-items:center; gap:7px; padding:7px 11px; background:var(--panel); border:1px solid var(--border); border-radius:8px; font-size:12px; font-weight:600; color:var(--text); cursor:pointer;}
+    .ptool .cnt{margin-left:auto; font-size:11.5px; color:var(--faint); font-variant-numeric:tabular-nums;}
+
+    table.tbl{width:100%; border-collapse:collapse; font-size:13px;}
+    .tbl th{text-align:left; font-size:10.5px; letter-spacing:.05em; text-transform:uppercase; color:var(--faint); font-weight:600; padding:10px 14px; border-bottom:1px solid var(--border); white-space:nowrap; cursor:pointer; user-select:none;}
+    .tbl th .ar{opacity:0; margin-left:4px; font-size:9px;} .tbl th.sort .ar{opacity:1; color:var(--accent);}
+    .tbl td{padding:11px 14px; border-bottom:1px solid var(--border); vertical-align:middle; white-space:nowrap;}
+    .tbl tbody tr:last-child td{border-bottom:0;}
+    .nm{font-family:'JetBrains Mono',Menlo,monospace; font-size:12.5px; font-weight:600;}
+    .mut{color:var(--dim); font-size:12.5px;} .mono2{font-family:'JetBrains Mono',Menlo,monospace; color:var(--dim); font-size:12px;}
+    .seen{color:var(--faint); font-size:12px; font-variant-numeric:tabular-nums;}
+    .tbl tbody tr{cursor:pointer;} .tbl tbody tr:hover td{background:var(--elev);}
+    .tbl tbody tr.hide{display:none;}
+
+    .tbl.h-company .c-company,.tbl.h-user .c-user,.tbl.h-ip .c-ip,.tbl.h-os .c-os,.tbl.h-agent .c-agent,
+    .tbl.h-health .c-health,.tbl.h-seen .c-seen,.tbl.h-serial .c-serial,.tbl.h-model .c-model,.tbl.h-mac .c-mac,.tbl.h-ring .c-ring{display:none;}
+
+    .pager{display:flex; align-items:center; gap:10px; padding:11px 14px; border-top:1px solid var(--border); font-size:12px; color:var(--dim); flex-wrap:wrap;}
+    .pager .pg{display:flex; gap:3px; margin-left:auto;}
+    .pager .pg button{appearance:none; min-width:28px; height:28px; padding:0 7px; border:1px solid var(--border); background:var(--panel); color:var(--dim); border-radius:7px; font:inherit; font-size:12px; cursor:pointer;}
+    .pager .pg button.on{background:var(--accent); color:var(--accent-ink); border-color:var(--accent);}
+    .pager .pg button:disabled{opacity:.4; cursor:default;} .pager .sz{font-family:'JetBrains Mono',Menlo,monospace;}
+
+    .state-block{display:none;}
+    body[data-state="ready"] .s-ready{display:block;} body[data-state="ready"] .s-ready.tiles{display:grid;}
+    body[data-state="loading"] .s-loading{display:block;} body[data-state="loading"] .s-loading.tiles{display:grid;}
+    body[data-state="error"] .s-error{display:block;} body[data-state="empty"] .s-empty{display:block;}
+    .skel{background:linear-gradient(90deg,var(--elev) 25%,var(--sunk) 37%,var(--elev) 63%); background-size:400% 100%; animation:sh 1.3s ease infinite; border-radius:6px; height:12px;}
+    @keyframes sh{0%{background-position:100% 50%;}100%{background-position:0 50%;}}
+    @media (prefers-reduced-motion:reduce){.skel{animation:none;} .side,.det{transition:none;}}
+    .skrow{display:grid; grid-template-columns:1.4fr 1fr 1fr .8fr .8fr; gap:14px; padding:14px; border-bottom:1px solid var(--border);}
+    .notice{padding:38px 24px; text-align:center; display:flex; flex-direction:column; align-items:center; gap:9px;}
+    .notice .ic{width:44px; height:44px; border-radius:12px; display:grid; place-items:center; font-size:22px;}
+    .notice.err .ic{background:var(--crit-bg); color:var(--crit);} .notice.empty .ic{background:var(--elev); color:var(--faint);}
+    .notice h3{margin:0; font-size:15px; font-weight:700;} .notice p{margin:0; color:var(--dim); font-size:13px; max-width:340px;}
+    .notice .btn{margin-top:6px; appearance:none; border:1px solid var(--accent); background:var(--accent); color:var(--accent-ink); font:inherit; font-size:13px; font-weight:600; padding:8px 16px; border-radius:9px; cursor:pointer;}
+    .notice.err .mono{font-size:11px; color:var(--faint);}
+
+    .det{position:fixed; top:0; right:0; bottom:0; width:400px; max-width:92%; background:var(--panel); border-left:1px solid var(--border);
+      z-index:45; transform:translateX(103%); transition:transform .24s ease; display:flex; flex-direction:column; box-shadow:var(--pop-sh);}
+    body.det .det{transform:translateX(0);}
+    .det .dh{display:flex; align-items:center; gap:10px; padding:15px 16px; border-bottom:1px solid var(--border);}
+    .det .dh .nm{font-size:15px;} .det .dh .x{margin-left:auto;}
+    .det .db{flex:1; overflow:auto; padding:6px 0 20px;}
+    .det .grp{padding:12px 16px 4px;} .det .grp .lbl{margin-bottom:2px;}
+    .det .kv{display:flex; justify-content:space-between; gap:14px; padding:6px 16px; font-size:12.5px; align-items:baseline;}
+    .det .kv .k{color:var(--dim); flex:none;} .det .kv .v{text-align:right; word-break:break-word;}
+    .det .gsep{height:1px; background:var(--border); margin:8px 16px;}
+    .det .raw{margin:10px 16px 0;} .det .raw summary{font-size:11.5px; color:var(--accent); font-weight:600; cursor:pointer;}
+    .det .raw pre{margin:8px 0 0; padding:12px; background:var(--sunk); border:1px solid var(--border); border-radius:9px; font-size:11px; color:var(--dim); white-space:pre-wrap; line-height:1.55;}
+    .det .dact{padding:12px 16px; border-top:1px solid var(--border); display:flex; gap:9px;}
+    .det .dact .btn{flex:1; appearance:none; border:1px solid var(--border); background:var(--panel); color:var(--text); font:inherit; font-size:12.5px; font-weight:600; padding:9px; border-radius:9px; cursor:pointer;}
+
+    .tbl thead{display:none;} .tbl,.tbl tbody,.tbl tr,.tbl td{display:block; width:100%;}
+    .tbl tbody tr{padding:12px 14px; border-bottom:1px solid var(--border); display:grid; grid-template-columns:1fr 148px; gap:3px 10px;}
+    .tbl td{padding:0; border:0; white-space:normal;}
+    /* right column left-aligns to one gutter so status/time/IP scan cleanly down a shared edge */
+    .tbl td.c-name{grid-column:1; grid-row:1;} .tbl td.c-health{grid-column:2; grid-row:1; justify-self:start;}
+    .tbl td.c-company{grid-column:1; grid-row:2;} .tbl td.c-seen{grid-column:2; grid-row:2; justify-self:start;}
+    .tbl td.c-user{grid-column:1; grid-row:3;} .tbl td.c-ip{grid-column:2; grid-row:3; justify-self:start;}
+    .tbl td.c-os,.tbl td.c-agent,.tbl td.c-serial,.tbl td.c-model,.tbl td.c-mac,.tbl td.c-ring,.tbl td.c-spacer{display:none;}
+
+    @media (min-width:720px){
+      .tiles{grid-template-columns:repeat(4,1fr);}
+      .tbl thead{display:table-header-group;} .tbl{display:table; table-layout:auto;} .tbl tbody{display:table-row-group;}
+      /* reset BOTH header and body rows — the base card rule blocks every <tr> */
+      .tbl thead tr,.tbl tbody tr{display:table-row; padding:0;} .tbl td{display:table-cell; padding:11px 14px; border-bottom:1px solid var(--border); white-space:nowrap;}
+      .tbl td.c-os,.tbl td.c-agent,.tbl td.c-serial,.tbl td.c-model,.tbl td.c-mac,.tbl td.c-ring{display:table-cell;}
+      /* trailing spacer eats all slack so data columns hug content and NAME can't balloon */
+      .tbl th.c-spacer,.tbl td.c-spacer{display:table-cell; width:100%; padding:0; border-bottom:1px solid var(--border); cursor:default;}
+    }
+    @media (min-width:1024px){ .shell{grid-template-columns:250px 1fr;} .side{position:static; transform:none;} body.drawer .scrim{opacity:0; pointer-events:none;} .ham{display:none;} .content{padding:22px 24px;} }
+    @media (max-width:1023px){ .ham{display:grid;} }
+    /* phones: the search box can't share a row with scope + icons — give it its own full-width line */
+    @media (max-width:719px){
+      .appbar{flex-wrap:wrap; row-gap:10px;}
+      .searchbox{order:6; flex-basis:100%; max-width:none;}
+      .searchbox input{padding:11px 0; font-size:15px;}
+    }
+  `;
+
+  const STEW = [
+    {name:'web-ingest-04', company:'acme-corp', user:'svc_deploy', ip:'10.20.4.14', os:'Ubuntu 24.04', agent:'v0.42', serial:'5CD82', model:'PowerEdge R650', mac:'a4:bb:6d:2f:19:07', ring:'broad', st:'Healthy', cls:'ok', seen:'12s ago', fqdn:'web-ingest-04.acme.internal', cpu:'16 vCPU', ram:'64 GB', uptime:'23d 4h', enrolled:'2026-03-11', trust:'controller', conv:'ok - 41s ago'},
+    {name:'dc-01', company:'acme-corp', user:'ACME\\administrator', ip:'10.20.1.5', os:'Win Server 2022', agent:'v0.42', serial:'7GH21', model:'PowerEdge R750', mac:'a4:bb:6d:11:52:c3', ring:'early', st:'Healthy', cls:'ok', seen:'40s ago', fqdn:'dc-01.acme.internal', cpu:'32 vCPU', ram:'128 GB', uptime:'61d 9h', enrolled:'2026-02-02', trust:'strict', conv:'ok - 1m ago'},
+    {name:'reception-07', company:'client-1', user:'jdoe', ip:'192.168.1.42', os:'Windows 11', agent:'v0.42', serial:'JJ9F2', model:'OptiPlex 7010', mac:'e8:6a:64:8b:20:11', ring:'broad', st:'Healthy', cls:'ok', seen:'18s ago', fqdn:'reception-07.client1.lan', cpu:'8 vCPU', ram:'16 GB', uptime:'2d 1h', enrolled:'2026-05-19', trust:'controller', conv:'ok - 22s ago'},
+    {name:'build-mac-11', company:'globex', user:'ci-runner', ip:'10.30.9.11', os:'macOS 14.5', agent:'v0.41', serial:'C02XK', model:'Mac mini M2', mac:'f0:18:98:1a:44:9e', ring:'canary', st:'Degraded', cls:'warn', seen:'3m ago', fqdn:'build-mac-11.globex.dev', cpu:'8 core', ram:'24 GB', uptime:'14d 7h', enrolled:'2026-04-08', trust:'controller', conv:'warn - module slow'},
+    {name:'sql-primary', company:'acme-corp', user:'ACME\\svc_sql', ip:'10.20.1.9', os:'Win Server 2019', agent:'v0.42', serial:'7GH04', model:'PowerEdge R740', mac:'a4:bb:6d:11:40:88', ring:'broad', st:'Unreachable', cls:'crit', seen:'6m ago', fqdn:'sql-primary.acme.internal', cpu:'48 vCPU', ram:'256 GB', uptime:'-', enrolled:'2026-01-28', trust:'strict', conv:'stale - 6m ago'},
+    {name:'edge-fw-02', company:'initech', user:'root', ip:'10.40.0.2', os:'Debian 12', agent:'v0.42', serial:'FW220', model:'Protectli VP2420', mac:'64:9d:99:03:2a:1c', ring:'prod', st:'Healthy', cls:'ok', seen:'22s ago', fqdn:'edge-fw-02.initech.net', cpu:'4 core', ram:'8 GB', uptime:'112d 3h', enrolled:'2025-12-15', trust:'strict', conv:'ok - 30s ago'},
+    {name:'kiosk-lobby', company:'client-1', user:'kiosk', ip:'192.168.1.88', os:'Pop!_OS 22.04', agent:'v0.40', serial:'KSK07', model:'NUC 13 Pro', mac:'1c:69:7a:6d:33:52', ring:'early', st:'Healthy', cls:'ok', seen:'51s ago', fqdn:'kiosk-lobby.client1.lan', cpu:'4 core', ram:'8 GB', uptime:'8d 12h', enrolled:'2026-05-30', trust:'controller', conv:'ok - 51s ago'},
+    {name:'laptop-sales-3', company:'globex', user:'mrivera', ip:'10.30.5.23', os:'Windows 11', agent:'v0.41', serial:'LT773', model:'Latitude 7440', mac:'8c:16:45:9d:71:e0', ring:'broad', st:'Degraded', cls:'warn', seen:'2m ago', fqdn:'laptop-sales-3.globex.dev', cpu:'12 vCPU', ram:'32 GB', uptime:'1d 5h', enrolled:'2026-06-21', trust:'controller', conv:'warn - patch pending'}
+  ];
+  const sk = `<div class="skrow"><span class="skel" style="width:75%"></span><span class="skel" style="width:60%"></span><span class="skel" style="width:70%"></span><span class="skel" style="width:50%"></span><span class="skel" style="width:55%"></span></div>`;
+  const colCk = (key,name,on,dis)=>`<label class="ck ${dis?'dis':''}"><input type="checkbox" data-col="${key}" ${on?'checked':''} ${dis?'disabled':''}>${name}</label>`;
+
+  const MOCK_HTML = `
+  <div class="scrim" data-close></div>
+  <div class="shell">
+    <aside class="side">
+      <div class="logo"><div class="l"><b>CFGMS</b><i>controller</i></div><button class="icobtn" data-drawer-close style="width:30px;height:30px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></button></div>
+      <nav>
+        <a class="active"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M3 4h18M3 10h18M3 16h18" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>Fleet</a>
+        <a class="soon"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>Modules<span class="tag">soon</span></a>
+        <a class="soon"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M4 6h16M4 12h10M4 18h16" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>Config<span class="tag">soon</span></a>
+        <a class="soon"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M6 3h9l4 4v14H6V3z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>Audit<span class="tag">soon</span></a>
+      </nav>
+      <div class="cfoot" data-pop="pop-ctrl"><span class="dot" style="color:var(--ok)"></span><div><span class="cn">controller-01</span><small>healthy · v0.42</small></div><svg width="14" height="14" viewBox="0 0 24 24" fill="none" style="margin-left:auto;color:var(--faint)"><path d="M8 10l4 4 4-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
+    </aside>
+
+    <div class="main">
+      <div class="appbar">
+        <button class="icobtn ham" data-drawer-open><svg width="17" height="17" viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></button>
+        <button class="scope" data-pop="pop-tenant"><span class="cv">scope</span><span class="path">root / <b>msp-a</b></span><svg width="13" height="13" viewBox="0 0 24 24" fill="none"><path d="M8 10l4 4 4-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+        <div class="searchbox"><svg width="15" height="15" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="1.7"/><path d="M20 20l-3-3" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg><input id="filter" type="text" placeholder="Filter stewards by name, user, IP, company…"></div>
+        <div class="abspacer"></div>
+        <button class="icobtn" data-pop="pop-notif"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9a6 6 0 1112 0c0 5 2 6 2 6H4s2-1 2-6z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M10 20a2 2 0 004 0" stroke="currentColor" stroke-width="1.6"/></svg><span class="badge">3</span></button>
+        <button class="uav" data-pop="pop-user">AD</button>
+      </div>
+
+      <div class="pop" id="pop-tenant" style="left:14px; top:52px;">
+        <h4>Switch scope</h4>
+        <div class="row cur"><span class="mono">root / msp-a</span><span class="r">this MSP</span></div>
+        <div class="row"><span class="mono">└ acme-corp</span><span class="r">1,204</span></div>
+        <div class="row"><span class="mono">└ client-1</span><span class="r">318</span></div>
+        <div class="row"><span class="mono">└ globex</span><span class="r">88</span></div>
+        <div class="row"><span class="mono">└ initech</span><span class="r">42</span></div>
+      </div>
+      <div class="pop right" id="pop-notif" style="top:52px; min-width:300px;">
+        <h4>Notifications · 3</h4>
+        <div class="row"><span class="dot" style="color:var(--crit)"></span><div><div>sql-primary unreachable</div><div class="sub">acme-corp · 6m ago</div></div></div>
+        <div class="row"><span class="dot" style="color:var(--warn)"></span><div><div>2 stewards degraded</div><div class="sub">build-mac-11, laptop-sales-3</div></div></div>
+        <div class="row"><span class="dot" style="color:var(--ok)"></span><div><div>Config r2291 rolled out</div><div class="sub">ring: broad · 12m ago</div></div></div>
+      </div>
+      <div class="pop right" id="pop-user" style="top:52px; min-width:240px;">
+        <div class="row" style="cursor:default"><div class="uav" style="width:30px;height:30px;font-size:11px">AD</div><div><div>admin@msp-a</div><div class="sub">operator · msp-a</div></div></div>
+        <div class="sep"></div><h4>Theme</h4>
+        <div class="miniseg"><button>Light</button><button class="on">Auto</button><button>Dark</button></div>
+        <div class="sep"></div>
+        <div class="row"><span>Account &amp; security</span></div>
+        <div class="row"><span>Session</span><span class="r">expires 11h58m</span></div>
+        <div class="sep"></div>
+        <div class="row" style="color:var(--crit)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M15 4h3v16h-3M11 8l-4 4 4 4M7 12h9" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>Sign out</div>
+      </div>
+      <div class="pop" id="pop-ctrl" style="left:14px; bottom:14px; min-width:250px;">
+        <h4>Controller</h4>
+        <div class="row" style="cursor:default"><span class="dot" style="color:var(--ok)"></span><div><div class="mono">controller-01</div><div class="sub">healthy</div></div></div>
+        <div class="row" style="cursor:default"><span>Endpoint</span><span class="r">cfg.is:8443</span></div>
+        <div class="row" style="cursor:default"><span>Version</span><span class="r">v0.42.1</span></div>
+      </div>
+
+      <div class="content">
+        <div class="demobar" role="group" aria-label="Mockup preview state — harness control, not part of the product UI">
+          <span class="dlbl">preview state</span>
+          <div class="sw2"><button data-state="ready" class="on">Ready</button><button data-state="loading">Loading</button><button data-state="error">Error</button><button data-state="empty">Empty</button></div>
+          <span class="dhint">harness only — not product UI</span>
+        </div>
+        <div class="htitle"><h1>Fleet</h1><p>Stewards enrolled to this controller, with the device DNA you choose.</p></div>
+
+        <div class="tiles s-ready state-block">
+          <div class="tile"><span class="lbl">Stewards</span><span class="n">48,210</span></div>
+          <div class="tile"><span class="lbl">Healthy</span><span class="n"><span class="sw" style="background:var(--ok)"></span>46,880</span></div>
+          <div class="tile"><span class="lbl">Degraded</span><span class="n"><span class="sw" style="background:var(--warn)"></span>1,190</span></div>
+          <div class="tile"><span class="lbl">Unreachable</span><span class="n"><span class="sw" style="background:var(--crit)"></span>140</span></div>
+        </div>
+        <div class="tiles s-loading state-block">
+          <div class="tile"><span class="lbl">Stewards</span><span class="skel" style="width:50%;height:22px"></span></div>
+          <div class="tile"><span class="lbl">Healthy</span><span class="skel" style="width:50%;height:22px"></span></div>
+          <div class="tile"><span class="lbl">Degraded</span><span class="skel" style="width:50%;height:22px"></span></div>
+          <div class="tile"><span class="lbl">Unreachable</span><span class="skel" style="width:50%;height:22px"></span></div>
+        </div>
+
+        <section class="panel">
+          <div class="ptool">
+            <button class="vbtn" data-pop="pop-views"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M4 6h16M7 12h10M10 18h4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>View: <span id="viewname">All stewards</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M8 10l4 4 4-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            <div class="pop" id="pop-views" style="left:13px; top:44px; min-width:220px;">
+              <h4>Saved views</h4>
+              <div class="row" data-view="All stewards" data-filter=""><span>All stewards</span><span class="r">48,210</span></div>
+              <div class="row" data-view="Unreachable" data-filter="unreachable"><span>Unreachable</span><span class="r">140</span></div>
+              <div class="row" data-view="acme-corp" data-filter="acme-corp"><span>acme-corp servers</span><span class="r">1,204</span></div>
+              <div class="row" data-view="Stale agents" data-filter="v0.40"><span>Stale agents</span><span class="r">312</span></div>
+              <div class="sep"></div>
+              <div class="row"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>Save current view…</div>
+            </div>
+            <button class="colbtn" data-pop="pop-cols"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M4 5h16v14H4zM10 5v14M16 5v14" stroke="currentColor" stroke-width="1.6"/></svg>Columns</button>
+            <div class="pop" id="pop-cols" style="left:150px; top:44px; min-width:210px;">
+              <h4>Device DNA columns</h4>
+              ${colCk('name','Name',true,true)}${colCk('company','Company',true,false)}${colCk('user','Last logged-in user',true,false)}${colCk('ip','IP address',true,false)}${colCk('health','Health',true,false)}${colCk('seen','Last check-in',true,false)}
+              <div class="sep"></div>
+              ${colCk('os','OS / platform',false,false)}${colCk('agent','Agent version',false,false)}${colCk('ring','Ring',false,false)}${colCk('model','Model',false,false)}${colCk('serial','Serial',false,false)}${colCk('mac','MAC address',false,false)}
+            </div>
+            <span class="cnt" id="count">48,210 stewards</span>
+          </div>
+
+          <div class="s-ready state-block">
+            <table class="tbl" id="fleet-tbl">
+              <thead><tr>
+                <th class="c-name" data-sort="name">Name<span class="ar">▼</span></th><th class="c-company" data-sort="company">Company<span class="ar">▼</span></th>
+                <th class="c-user" data-sort="user">Last user<span class="ar">▼</span></th><th class="c-ip" data-sort="ip">IP<span class="ar">▼</span></th>
+                <th class="c-os" data-sort="os">OS<span class="ar">▼</span></th><th class="c-agent" data-sort="agent">Agent<span class="ar">▼</span></th>
+                <th class="c-serial" data-sort="serial">Serial<span class="ar">▼</span></th><th class="c-model" data-sort="model">Model<span class="ar">▼</span></th>
+                <th class="c-mac" data-sort="mac">MAC<span class="ar">▼</span></th><th class="c-ring" data-sort="ring">Ring<span class="ar">▼</span></th>
+                <th class="c-health" data-sort="st">Health<span class="ar">▼</span></th><th class="c-seen" data-sort="seen">Last check-in<span class="ar">▼</span></th>
+                <th class="c-spacer" aria-hidden="true"></th>
+              </tr></thead>
+              <tbody id="fleet-body"></tbody>
+            </table>
+            <div class="pager">
+              <span>Showing <b id="pgfrom">1</b>–<b id="pgto">8</b> of <b id="pgtot">48,210</b> stewards</span>
+              <span class="sz" style="margin-left:14px">50 / page ▾</span>
+              <div class="pg"><button disabled>‹</button><button class="on">1</button><button>2</button><button>3</button><button>…</button><button>965</button><button>›</button></div>
+            </div>
+          </div>
+          <div class="s-loading state-block">${sk}${sk}${sk}${sk}${sk}${sk}</div>
+          <div class="s-error state-block"><div class="notice err"><div class="ic">!</div><h3>Couldn't reach the controller</h3><p>The fleet list request failed. Check your connection and try again.</p><span class="mono">GET /api/v1/stewards — 503 Service Unavailable</span><button class="btn">Retry</button></div></div>
+          <div class="s-empty state-block"><div class="notice empty"><div class="ic">◍</div><h3>No stewards enrolled yet</h3><p>Once you install a steward and it registers with this controller, it'll appear here with live health.</p><button class="btn">View enrollment guide</button></div></div>
+        </section>
+      </div>
+    </div>
+  </div>
+
+  <aside class="det">
+    <div class="dh"><span class="pill ok" id="d-health"><span class="dot"></span>Healthy</span><span class="nm" id="d-name">—</span><button class="icobtn x" data-close style="width:30px;height:30px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></button></div>
+    <div class="db" id="d-body"></div>
+    <div class="dact"><button class="btn">Open full asset</button><button class="btn">Export DNA</button></div>
+  </aside>
+
+  <style>
+    .demobar{display:flex; align-items:center; gap:10px; padding:7px 12px; background:var(--sunk); border:1px dashed var(--border); border-radius:10px; flex-wrap:wrap;}
+    .demobar .dlbl{font-size:10px; text-transform:uppercase; letter-spacing:.08em; color:var(--faint); font-weight:700;}
+    .demobar .dhint{margin-left:auto; font-size:10.5px; color:var(--faint);}
+    .sw2{display:inline-flex; gap:2px;}
+    .sw2 button{appearance:none;border:0;background:transparent;font:inherit;font-size:11px;font-weight:600;color:var(--dim);padding:5px 9px;border-radius:6px;cursor:pointer;}
+    .sw2 button.on{background:var(--accent);color:var(--accent-ink);}
+  </style>
+  `;
+
+  const MOCK_JS = "var STEW = " + JSON.stringify(STEW) + ";\n" + `
+    var body=document.getElementById('fleet-body'), tbl=document.getElementById('fleet-tbl');
+    function esc(x){return String(x).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+    function rowHTML(s,i){
+      return '<tr data-i="'+i+'">'+
+        '<td class="c-name"><span class="nm">'+esc(s.name)+'</span></td>'+
+        '<td class="c-company"><span class="mut">'+esc(s.company)+'</span></td>'+
+        '<td class="c-user"><span class="mono2">'+esc(s.user)+'</span></td>'+
+        '<td class="c-ip"><span class="mono2">'+esc(s.ip)+'</span></td>'+
+        '<td class="c-os"><span class="mut">'+esc(s.os)+'</span></td>'+
+        '<td class="c-agent"><span class="mono2">'+esc(s.agent)+'</span></td>'+
+        '<td class="c-serial"><span class="mono2">'+esc(s.serial)+'</span></td>'+
+        '<td class="c-model"><span class="mut">'+esc(s.model)+'</span></td>'+
+        '<td class="c-mac"><span class="mono2">'+esc(s.mac)+'</span></td>'+
+        '<td class="c-ring"><span class="mono2">'+esc(s.ring)+'</span></td>'+
+        '<td class="c-health"><span class="pill '+s.cls+'"><span class="dot"></span>'+esc(s.st)+'</span></td>'+
+        '<td class="c-seen"><span class="seen">'+esc(s.seen)+'</span></td>'+
+        '<td class="c-spacer"></td></tr>';
+    }
+    function renderRows(list){ body.innerHTML = list.map(function(s){ return rowHTML(s, STEW.indexOf(s)); }).join(''); applyFilter(); }
+
+    function closeAll(){ var l=document.querySelectorAll('.pop.open'); for(var i=0;i<l.length;i++) l[i].classList.remove('open'); }
+    document.addEventListener('click', function(e){
+      var t=e.target.closest('[data-pop]');
+      if(t){ var p=document.getElementById(t.getAttribute('data-pop')); var was=p.classList.contains('open'); closeAll(); if(!was) p.classList.add('open'); e.stopPropagation(); return; }
+      if(e.target.closest('[data-drawer-open]')){ document.body.classList.add('drawer'); return; }
+      if(e.target.closest('[data-drawer-close]')){ document.body.classList.remove('drawer'); return; }
+      if(e.target.closest('[data-close]')){ document.body.classList.remove('det'); document.body.classList.remove('drawer'); return; }
+      var vr=e.target.closest('#pop-views .row[data-view]');
+      if(vr){ setView(vr.getAttribute('data-view'), vr.getAttribute('data-filter')); closeAll(); return; }
+      var tr=e.target.closest('#fleet-body tr');
+      if(tr){ openDetail(parseInt(tr.getAttribute('data-i'),10)); return; }
+      if(!e.target.closest('.pop')) closeAll();
+    });
+    document.addEventListener('keydown', function(e){ if(e.key==='Escape'){ document.body.classList.remove('det'); document.body.classList.remove('drawer'); closeAll(); } });
+
+    var filter=document.getElementById('filter');
+    function applyFilter(){
+      var q=filter.value.trim().toLowerCase(), shown=0, rows=body.querySelectorAll('tr');
+      for(var i=0;i<rows.length;i++){ var s=STEW[parseInt(rows[i].getAttribute('data-i'),10)];
+        var hay=(s.name+' '+s.company+' '+s.user+' '+s.ip+' '+s.os+' '+s.st+' '+s.ring+' '+s.agent).toLowerCase();
+        var hit=hay.indexOf(q)>-1; rows[i].classList.toggle('hide', !hit); if(hit) shown++; }
+      document.getElementById('count').textContent = q ? (shown+' of 48,210 match') : '48,210 stewards';
+      document.getElementById('pgfrom').textContent = shown ? 1 : 0;
+      document.getElementById('pgto').textContent = q ? shown : 8;
+      document.getElementById('pgtot').textContent = q ? shown : '48,210';
+    }
+    filter.addEventListener('input', applyFilter);
+    function setView(name, f){ document.getElementById('viewname').textContent=name; filter.value=f||''; applyFilter(); }
+
+    var sortKey=null, sortDir=1;
+    var ths=tbl.querySelectorAll('th[data-sort]');
+    for(var j=0;j<ths.length;j++){ (function(th){ th.addEventListener('click', function(){
+      var k=th.getAttribute('data-sort'); if(sortKey===k){ sortDir=-sortDir; } else { sortKey=k; sortDir=1; }
+      var all=tbl.querySelectorAll('th'); for(var m=0;m<all.length;m++) all[m].classList.remove('sort');
+      th.classList.add('sort'); th.querySelector('.ar').textContent = sortDir>0?'▼':'▲';
+      var arr=STEW.slice().sort(function(a,b){ var av=(''+a[k]).toLowerCase(), bv=(''+b[k]).toLowerCase(); return av<bv?-sortDir:av>bv?sortDir:0; });
+      renderRows(arr);
+    }); })(ths[j]); }
+
+    var cbs=document.querySelectorAll('[data-col]');
+    for(var c=0;c<cbs.length;c++){ (function(cb){ function ap(){ if(cb.disabled) return; tbl.classList.toggle('h-'+cb.getAttribute('data-col'), !cb.checked); } cb.addEventListener('change', ap); ap(); })(cbs[c]); }
+
+    var ms=document.querySelectorAll('#pop-user .miniseg button');
+    for(var u=0;u<ms.length;u++){ (function(b){ b.addEventListener('click', function(){ for(var x=0;x<ms.length;x++) ms[x].classList.toggle('on', ms[x]===b); }); })(ms[u]); }
+    var sb=document.querySelectorAll('.sw2 button');
+    for(var v=0;v<sb.length;v++){ (function(b){ b.addEventListener('click', function(){ document.body.dataset.state=b.getAttribute('data-state'); for(var x=0;x<sb.length;x++) sb[x].classList.toggle('on', sb[x]===b); }); })(sb[v]); }
+    document.body.dataset.state='ready';
+
+    function kv(k,v){ return '<div class="kv"><span class="k">'+k+'</span><span class="v mono">'+esc(v)+'</span></div>'; }
+    function openDetail(i){ var s=STEW[i];
+      document.getElementById('d-name').textContent=s.name;
+      var hp=document.getElementById('d-health'); hp.className='pill '+s.cls; hp.innerHTML='<span class="dot"></span>'+esc(s.st);
+      document.getElementById('d-body').innerHTML =
+        '<div class="grp"><div class="lbl">Identity</div></div>'+kv('Company / tenant',s.company)+kv('Ring',s.ring)+kv('FQDN',s.fqdn)+kv('Enrolled',s.enrolled)+
+        '<div class="gsep"></div><div class="grp"><div class="lbl">Network</div></div>'+kv('IP address',s.ip)+kv('MAC',s.mac)+
+        '<div class="gsep"></div><div class="grp"><div class="lbl">System</div></div>'+kv('OS / platform',s.os)+kv('Model',s.model)+kv('Serial',s.serial)+kv('CPU',s.cpu)+kv('RAM',s.ram)+kv('Uptime',s.uptime)+
+        '<div class="gsep"></div><div class="grp"><div class="lbl">Session & agent</div></div>'+kv('Last logged-in user',s.user)+kv('Last check-in',s.seen)+kv('Agent version',s.agent)+kv('Module trust',s.trust)+kv('Last convergence',s.conv)+
+        '<details class="raw"><summary>View all DNA (raw)</summary><pre>'+esc(JSON.stringify(s,null,2))+'</pre></details>';
+      document.body.classList.add('det');
+    }
+
+    renderRows(STEW);
+  `;
+
+  function currentTheme(){ if(themeMode!=="auto") return themeMode; const d=document.documentElement.getAttribute("data-theme"); return d || (matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"); }
+  function srcdoc(t){ return '<!doctype html><html lang="en" data-theme="'+t+'"><head><meta charset="utf-8">'+
+    '<meta name="viewport" content="width=device-width,initial-scale=1"><style>'+MOCK_CSS+'</style></head><body>'+
+    MOCK_HTML+'<script>'+MOCK_JS+'<\/script></body></html>'; }
+  function layout(){ const d=DEVICES[current]; frame.style.width=d.w+"px"; frame.style.height=d.h+"px";
+    const avail=stage.clientWidth-32; const s=Math.min(1,avail/d.w); frame.style.transform="scale("+s+")";
+    wrap.style.width=(d.w*s)+"px"; wrap.style.height=(d.h*s)+"px"; dims.textContent=d.w+" × "+d.h+" · "+Math.round(s*100)+"%"; }
+  function render(){ frame.srcdoc=srcdoc(currentTheme()); layout(); }
+  devBtns.forEach(b=>b.addEventListener("click",()=>{ current=b.dataset.dev;
+    devBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(devSeg); layout(); }));
+  themeBtns.forEach(b=>b.addEventListener("click",()=>{ themeMode=b.dataset.themeMode;
+    themeBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(themeSeg);
+    if(themeMode==="auto"){ document.documentElement.removeAttribute("data-theme"); render(); }
+    else { document.documentElement.setAttribute("data-theme",themeMode); } }));
+  new MutationObserver(render).observe(document.documentElement,{attributes:true,attributeFilter:["data-theme"]});
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change",()=>{ if(themeMode==="auto") render(); });
+  window.addEventListener("resize",()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); });
+  window.addEventListener("orientationchange",()=>setTimeout(()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); },200));
+  render(); posThumb(devSeg); posThumb(themeSeg);
+</script>

--- a/docs/design/mockups/login.html
+++ b/docs/design/mockups/login.html
@@ -1,0 +1,240 @@
+<style>
+  :root {
+    --bg:#f0ebe4; --chrome:#f7f4ef; --chrome-2:#ffffff; --border:#d4cfc4;
+    --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff;
+    --shadow:0 18px 50px -22px rgba(60,45,30,.4); --radius:14px;
+  }
+  @media (prefers-color-scheme: dark){ :root{
+    --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
+    --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a;
+    --shadow:0 22px 60px -26px rgba(0,0,0,.8); } }
+  :root[data-theme="light"]{ --bg:#f0ebe4; --chrome:#f7f4ef; --chrome-2:#ffffff; --border:#d4cfc4;
+    --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff; --shadow:0 18px 50px -22px rgba(60,45,30,.4); }
+  :root[data-theme="dark"]{ --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
+    --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a; --shadow:0 22px 60px -26px rgba(0,0,0,.8); }
+  *{box-sizing:border-box;}
+  body{margin:0; min-height:100dvh; background:var(--bg); color:var(--text); display:flex; flex-direction:column;
+    font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased;}
+  .topbar{display:flex; align-items:center; gap:14px; flex-wrap:wrap; padding:11px 16px; background:var(--chrome);
+    border-bottom:1px solid var(--border); position:sticky; top:0; z-index:5;}
+  .brand{display:flex; align-items:baseline; gap:8px; margin-right:auto;}
+  .brand b{font-size:14px; letter-spacing:.13em; text-transform:uppercase; font-weight:700;}
+  .brand span{font-size:11px; color:var(--text-dim); letter-spacing:.04em;}
+  .seg{display:inline-flex; position:relative; background:var(--chrome-2); border:1px solid var(--border); border-radius:10px; padding:3px;}
+  .seg button{position:relative; z-index:1; appearance:none; border:0; background:transparent; color:var(--text-dim);
+    font:inherit; font-size:12.5px; font-weight:600; padding:6px 13px; border-radius:7px; cursor:pointer; transition:color .18s ease;}
+  .seg button[aria-pressed="true"]{color:var(--accent-ink);}
+  .seg .thumb{position:absolute; top:3px; left:3px; height:calc(100% - 6px); background:var(--accent); border-radius:7px;
+    transition:transform .22s cubic-bezier(.4,.9,.3,1), width .22s cubic-bezier(.4,.9,.3,1); z-index:0;}
+  .seg button:focus-visible{outline:2px solid var(--accent); outline-offset:2px;}
+  .dims{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace; font-size:12px; color:var(--text-dim);
+    font-variant-numeric:tabular-nums; white-space:nowrap;}
+  .stage{flex:1; display:flex; align-items:flex-start; justify-content:center; padding:22px 16px 30px; overflow:auto;}
+  .frame-wrap{position:relative; margin:0 auto; border-radius:var(--radius); overflow:hidden; box-shadow:var(--shadow);
+    border:1px solid var(--border); background:var(--chrome); transition:width .22s ease, height .22s ease;}
+  .frame{display:block; border:0; transform-origin:0 0; background:transparent;}
+  .hint{text-align:center; color:var(--text-dim); font-size:12.5px; line-height:1.6; padding:0 20px 30px; max-width:560px; margin:0 auto;}
+</style>
+
+<div class="topbar">
+  <div class="brand"><b>CFGMS</b><span>login screen</span></div>
+  <div class="seg" role="group" aria-label="Preview viewport">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-dev="desktop" aria-pressed="true">Desktop</button>
+    <button data-dev="tablet" aria-pressed="false">Tablet</button>
+    <button data-dev="mobile" aria-pressed="false">Mobile</button>
+  </div>
+  <div class="seg themeseg" role="group" aria-label="Theme">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-theme-mode="auto" aria-pressed="true">Auto</button>
+    <button data-theme-mode="light" aria-pressed="false">Light</button>
+    <button data-theme-mode="dark" aria-pressed="false">Dark</button>
+  </div>
+  <div class="dims" id="dims">—</div>
+</div>
+
+<div class="stage">
+  <div class="frame-wrap" id="wrap"><iframe class="frame" id="frame" title="CFGMS login mockup"></iframe></div>
+</div>
+
+<p class="hint">
+  Login screen · session-token credential auth (Epic #2344). Use the <b>state</b> switcher in the mockup to see
+  <b>Sign in / Invalid credentials / Session expired</b>. Auto/Light/Dark + Desktop/Mobile toggles above.
+</p>
+
+<script>
+  const DEVICES = { desktop:{w:1280,h:760}, tablet:{w:834,h:900}, mobile:{w:390,h:780} };
+  let current = "desktop", themeMode = "auto";
+  const frame = document.getElementById("frame"), wrap = document.getElementById("wrap");
+  const stage = document.querySelector(".stage"), dims = document.getElementById("dims");
+  const devSeg = document.querySelector(".seg:not(.themeseg)"), themeSeg = document.querySelector(".themeseg");
+  const devBtns = [...devSeg.querySelectorAll("button")], themeBtns = [...themeSeg.querySelectorAll("button")];
+  function posThumb(seg){ const t=seg.querySelector(".thumb"); const a=seg.querySelector('button[aria-pressed="true"]')||seg.querySelector("button"); t.style.width=a.offsetWidth+"px"; t.style.transform="translateX("+(a.offsetLeft-3)+"px)"; }
+
+  const MOCK_CSS = `
+    :root{
+      --bg:#f0ebe4; --panel:#ffffff; --elev:#f7f4ef; --sunk:#f0ebe4; --border:#d4cfc4;
+      --text:#6b5a4a; --dim:#7a6a5a; --faint:#8f7d66;
+      --accent:#4a6b7c; --accent-ink:#ffffff;
+      --ok:#507055; --warn:#a05a35; --warn-bg:#f7e8db; --crit:#b56a5a; --crit-bg:#f2e5e3;
+      --tl-red:#e6564c; --tl-yellow:#d9a441; --tl-green:#5a9367;
+    }
+    :root[data-theme="dark"]{
+      --bg:#181817; --panel:#1e1e1e; --elev:#252526; --sunk:#161616; --border:#3c3c3c;
+      --text:#c4b4a4; --dim:#a89888; --faint:#8a7a68;
+      --accent:#7b9fb0; --accent-ink:#16202a;
+      --ok:#6d9472; --warn:#d4864f; --warn-bg:#332518; --crit:#c97a6a; --crit-bg:#2d1f1c;
+      --tl-red:#ff5f56; --tl-yellow:#ffbd2e; --tl-green:#6d9472;
+    }
+    *{box-sizing:border-box;}
+    html,body{margin:0; height:100%;}
+    body{background:var(--bg); color:var(--text); font-size:14px; line-height:1.45;
+      font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased;
+      display:flex; flex-direction:column; align-items:center; justify-content:center; padding:24px 18px; gap:16px;}
+    .mono{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace;}
+
+    /* demo-only preview-state switch (not part of the real screen) */
+    .demo{display:flex; align-items:center; gap:8px; font-size:11px; color:var(--faint);}
+    .demo .lbl{letter-spacing:.06em; text-transform:uppercase; font-weight:600;}
+    .demo .sw{display:inline-flex; background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:2px;}
+    .demo .sw button{appearance:none; border:0; background:transparent; font:inherit; font-size:11px; font-weight:600;
+      color:var(--dim); padding:4px 9px; border-radius:6px; cursor:pointer;}
+    .demo .sw button.on{background:var(--accent); color:var(--accent-ink);}
+
+    /* terminal-window login card */
+    .win{width:100%; max-width:400px; background:var(--panel); border:1px solid var(--border); border-radius:12px;
+      overflow:hidden; box-shadow:0 24px 60px -30px rgba(0,0,0,.45);}
+    .titlebar{display:flex; align-items:center; gap:8px; padding:10px 13px; background:var(--elev); border-bottom:1px solid var(--border);}
+    .lights{display:flex; gap:6px;}
+    .lights i{width:11px; height:11px; border-radius:50%; display:block;}
+    .lights .r{background:var(--tl-red);} .lights .y{background:var(--tl-yellow);} .lights .g{background:var(--tl-green);}
+    .titlebar .tt{font-size:11.5px; color:var(--faint); margin:0 auto; letter-spacing:.02em;}
+
+    .body{padding:26px 26px 22px; display:flex; flex-direction:column; gap:16px;}
+    .wordmark{display:flex; flex-direction:column; gap:3px; align-items:center; text-align:center; margin-bottom:2px;}
+    .wordmark b{font-size:22px; font-weight:700; letter-spacing:.16em; text-transform:uppercase;}
+    .wordmark span{font-size:11px; color:var(--faint); letter-spacing:.06em; text-transform:uppercase;}
+    .lead{text-align:center; font-size:13px; color:var(--dim); margin:-4px 0 4px;}
+
+    .expired{display:none; align-items:flex-start; gap:9px; padding:10px 12px; border-radius:9px;
+      background:var(--warn-bg); border:1px solid var(--warn); font-size:12.5px; color:var(--warn);}
+    body[data-state="expired"] .expired{display:flex;}
+
+    .field{display:flex; flex-direction:column; gap:6px;}
+    .field label{font-size:11px; letter-spacing:.06em; text-transform:uppercase; color:var(--faint); font-weight:600;}
+    .field .inp{display:flex; align-items:center; gap:9px; padding:11px 13px; background:var(--sunk);
+      border:1px solid var(--border); border-radius:9px;}
+    .field .inp .val{font-size:14px; color:var(--text); font-family:'JetBrains Mono',Menlo,monospace;}
+    .field .inp .val.ph{color:var(--faint);}
+    body[data-state="invalid"] .field .inp{border-color:var(--crit); background:var(--crit-bg);}
+
+    .err{display:none; align-items:center; gap:8px; font-size:12.5px; color:var(--crit); margin-top:-4px;}
+    .err .dot{width:6px; height:6px; border-radius:50%; background:currentColor;}
+    body[data-state="invalid"] .err{display:flex;}
+
+    .signin{appearance:none; border:0; width:100%; padding:12px; border-radius:9px; background:var(--accent);
+      color:var(--accent-ink); font:inherit; font-size:14px; font-weight:600; cursor:pointer; display:flex;
+      align-items:center; justify-content:center; gap:9px; margin-top:2px;}
+    .signin .spin{width:14px; height:14px; border:2px solid currentColor; border-right-color:transparent; border-radius:50%; display:none;}
+    body[data-state="loading"] .signin .spin{display:block; animation:sp .7s linear infinite;}
+    body[data-state="loading"] .signin .txt{opacity:.85;}
+    @keyframes sp{to{transform:rotate(360deg);}}
+    @media (prefers-reduced-motion:reduce){.signin .spin{animation:none;}}
+
+    .mfa{display:none; flex-direction:column; gap:12px; align-items:center; text-align:center; padding:4px 0;}
+    body[data-state="mfa"] .mfa{display:flex;}
+    body[data-state="mfa"] .lead, body[data-state="mfa"] .field, body[data-state="mfa"] .err, body[data-state="mfa"] .signin{display:none;}
+    .mfa .mic{width:52px; height:52px; border-radius:14px; background:var(--sunk); color:var(--accent); display:grid; place-items:center;}
+    .mfa h3{margin:0; font-size:16px; font-weight:700;}
+    .mfa p{margin:0; font-size:12.5px; color:var(--dim); max-width:290px;}
+    .mbtn{appearance:none; border:0; width:100%; padding:12px; border-radius:9px; background:var(--accent); color:var(--accent-ink);
+      font:inherit; font-size:14px; font-weight:600; cursor:pointer; display:flex; align-items:center; justify-content:center; gap:9px;}
+    .mfa .alt{font-size:12px; color:var(--accent); font-weight:600; cursor:pointer;}
+
+    .foot{display:flex; justify-content:space-between; align-items:center; padding-top:4px; font-size:11px; color:var(--faint);}
+    .foot a{color:var(--accent); text-decoration:none; font-weight:600;}
+    .foot .ep{font-family:'JetBrains Mono',Menlo,monospace;}
+  `;
+
+  const MOCK_HTML = `
+    <div class="demo">
+      <span class="lbl">Preview state</span>
+      <div class="sw" role="group" aria-label="Preview state">
+        <button data-state="signin" class="on">Sign in</button>
+        <button data-state="invalid">Invalid</button>
+        <button data-state="mfa">MFA</button>
+        <button data-state="expired">Expired</button>
+      </div>
+    </div>
+
+    <div class="win">
+      <div class="titlebar">
+        <span class="lights"><i class="r"></i><i class="y"></i><i class="g"></i></span>
+        <span class="tt mono">cfgms · secure session</span>
+      </div>
+      <div class="body">
+        <div class="wordmark"><b>CFGMS</b><span>config management</span></div>
+        <p class="lead">Sign in to the controller</p>
+
+        <div class="expired"><span class="mono">⚠</span><span>Your session expired. Sign in again to continue.</span></div>
+
+        <div class="field">
+          <label>Username</label>
+          <div class="inp"><span class="val">admin@msp-a</span></div>
+        </div>
+        <div class="field">
+          <label>Password</label>
+          <div class="inp"><span class="val">••••••••••••</span></div>
+        </div>
+        <div class="err"><span class="dot"></span>Invalid username or password.</div>
+
+        <button class="signin"><span class="spin"></span><span class="txt">Sign in</span></button>
+
+        <div class="mfa">
+          <div class="mic"><svg width="26" height="26" viewBox="0 0 24 24" fill="none"><path d="M12 2a7 7 0 00-7 7v2M12 2a7 7 0 017 7v2M8 11h8v9a1 1 0 01-1 1H9a1 1 0 01-1-1v-9z" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="15.5" r="1.4" fill="currentColor"/></svg></div>
+          <h3>Verify it's you</h3>
+          <p>Signing in as <b class="mono">admin@msp-a</b>. Use your passkey or security key to finish.</p>
+          <button class="mbtn"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M7.5 13.5a3.5 3.5 0 113.5-3.5M11 10h9l-2 2 2 2-3 3" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>Verify with passkey</button>
+          <span class="alt">Use a recovery code</span>
+        </div>
+
+        <div class="foot">
+          <a>Trouble signing in?</a>
+          <span class="ep">controller · v0.42</span>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const MOCK_JS = `
+    var sb=[].slice.call(document.querySelectorAll('.demo .sw button'));
+    sb.forEach(function(b){b.addEventListener('click',function(){
+      document.body.dataset.state=b.dataset.state;
+      sb.forEach(function(x){x.classList.toggle('on',x===b);});});});
+    document.body.dataset.state='signin';
+    var btn=document.querySelector('.signin');
+    if(btn){btn.addEventListener('click',function(){
+      var prev=document.body.dataset.state; document.body.dataset.state='loading';
+      setTimeout(function(){document.body.dataset.state=prev==='loading'?'signin':prev;},1300);});}
+  `;
+
+  function currentTheme(){ if(themeMode!=="auto") return themeMode; const d=document.documentElement.getAttribute("data-theme"); return d || (matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"); }
+  function srcdoc(t){ return '<!doctype html><html lang="en" data-theme="'+t+'"><head><meta charset="utf-8">'+
+    '<meta name="viewport" content="width=device-width,initial-scale=1"><style>'+MOCK_CSS+'</style></head><body>'+
+    MOCK_HTML+'<script>'+MOCK_JS+'<\/script></body></html>'; }
+  function layout(){ const d=DEVICES[current]; frame.style.width=d.w+"px"; frame.style.height=d.h+"px";
+    const avail=stage.clientWidth-32; const s=Math.min(1,avail/d.w); frame.style.transform="scale("+s+")";
+    wrap.style.width=(d.w*s)+"px"; wrap.style.height=(d.h*s)+"px"; dims.textContent=d.w+" × "+d.h+" · "+Math.round(s*100)+"%"; }
+  function render(){ frame.srcdoc=srcdoc(currentTheme()); layout(); }
+  devBtns.forEach(b=>b.addEventListener("click",()=>{ current=b.dataset.dev;
+    devBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(devSeg); layout(); }));
+  themeBtns.forEach(b=>b.addEventListener("click",()=>{ themeMode=b.dataset.themeMode;
+    themeBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(themeSeg);
+    if(themeMode==="auto"){ document.documentElement.removeAttribute("data-theme"); render(); }
+    else { document.documentElement.setAttribute("data-theme",themeMode); } }));
+  new MutationObserver(render).observe(document.documentElement,{attributes:true,attributeFilter:["data-theme"]});
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change",()=>{ if(themeMode==="auto") render(); });
+  window.addEventListener("resize",()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); });
+  window.addEventListener("orientationchange",()=>setTimeout(()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); },200));
+  render(); posThumb(devSeg); posThumb(themeSeg);
+</script>

--- a/docs/design/mockups/troubleshooting-cockpit.html
+++ b/docs/design/mockups/troubleshooting-cockpit.html
@@ -1,0 +1,470 @@
+<style>
+  :root {
+    --bg: #f0ebe4; --chrome: #f7f4ef; --chrome-2: #ffffff; --border: #d4cfc4;
+    --text: #6b5a4a; --text-dim: #7a6a5a; --accent: #4a6b7c; --accent-ink: #ffffff;
+    --shadow: 0 18px 50px -22px rgba(60,45,30,.4); --radius: 14px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #181817; --chrome: #1e1e1e; --chrome-2: #252526; --border: #3c3c3c;
+      --text: #c4b4a4; --text-dim: #a89888; --accent: #7b9fb0; --accent-ink: #16202a;
+      --shadow: 0 22px 60px -26px rgba(0,0,0,.8);
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #f0ebe4; --chrome: #f7f4ef; --chrome-2: #ffffff; --border: #d4cfc4;
+    --text: #6b5a4a; --text-dim: #7a6a5a; --accent: #4a6b7c; --accent-ink: #ffffff;
+    --shadow: 0 18px 50px -22px rgba(60,45,30,.4);
+  }
+  :root[data-theme="dark"] {
+    --bg: #181817; --chrome: #1e1e1e; --chrome-2: #252526; --border: #3c3c3c;
+    --text: #c4b4a4; --text-dim: #a89888; --accent: #7b9fb0; --accent-ink: #16202a;
+    --shadow: 0 22px 60px -26px rgba(0,0,0,.8);
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100dvh; background: var(--bg); color: var(--text);
+    font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased; display: flex; flex-direction: column;
+  }
+  .topbar {
+    display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    padding: 11px 16px; background: var(--chrome); border-bottom: 1px solid var(--border);
+    position: sticky; top: 0; z-index: 5;
+  }
+  .brand { display: flex; align-items: baseline; gap: 8px; margin-right: auto; }
+  .brand b { font-size: 14px; letter-spacing: .13em; text-transform: uppercase; font-weight: 700; }
+  .brand span { font-size: 11px; color: var(--text-dim); letter-spacing: .04em; }
+  .seg { display: inline-flex; position: relative; background: var(--chrome-2); border: 1px solid var(--border); border-radius: 10px; padding: 3px; }
+  .seg button {
+    position: relative; z-index: 1; appearance: none; border: 0; background: transparent;
+    color: var(--text-dim); font: inherit; font-size: 12.5px; font-weight: 600;
+    padding: 6px 13px; border-radius: 7px; cursor: pointer; transition: color .18s ease;
+  }
+  .seg button[aria-pressed="true"] { color: var(--accent-ink); }
+  .seg .thumb { position: absolute; top: 3px; left: 3px; height: calc(100% - 6px); background: var(--accent); border-radius: 7px; transition: transform .22s cubic-bezier(.4,.9,.3,1), width .22s cubic-bezier(.4,.9,.3,1); z-index: 0; }
+  .seg button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .dims { font-family: 'JetBrains Mono', ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: var(--text-dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .stage { flex: 1; display: flex; align-items: flex-start; justify-content: center; padding: 22px 16px 30px; overflow: auto; }
+  .frame-wrap { position: relative; margin: 0 auto; border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); border: 1px solid var(--border); background: var(--chrome); transition: width .22s ease, height .22s ease; }
+  .frame { display: block; border: 0; transform-origin: 0 0; background: transparent; }
+  .hint { text-align: center; color: var(--text-dim); font-size: 12.5px; line-height: 1.6; padding: 0 20px 30px; max-width: 580px; margin: 0 auto; }
+</style>
+
+<div class="topbar">
+  <div class="brand"><b>CFGMS</b><span>troubleshooting cockpit</span></div>
+  <div class="seg" role="group" aria-label="Preview viewport">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-dev="desktop" aria-pressed="true">Desktop</button>
+    <button data-dev="tablet" aria-pressed="false">Tablet</button>
+    <button data-dev="mobile" aria-pressed="false">Mobile</button>
+  </div>
+  <div class="seg themeseg" role="group" aria-label="Theme">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-theme-mode="auto" aria-pressed="true">Auto</button>
+    <button data-theme-mode="light" aria-pressed="false">Light</button>
+    <button data-theme-mode="dark" aria-pressed="false">Dark</button>
+  </div>
+  <div class="dims" id="dims">—</div>
+</div>
+
+<div class="stage">
+  <div class="frame-wrap" id="wrap"><iframe class="frame" id="frame" title="CFGMS cockpit mockup"></iframe></div>
+</div>
+
+<p class="hint">
+  Brand-aligned to <b>cfg.is/style-guide</b> · use the <b>Auto / Light / Dark</b> toggle to compare themes,
+  flip intake <b>Email / Live</b>, tab <b>Investigation / Chat</b>, and try <b>Caller-ID lookup</b>. Pinch to zoom.
+</p>
+
+<script>
+  const DEVICES = { desktop:{w:1440,h:940}, tablet:{w:900,h:1180}, mobile:{w:390,h:1620} };
+  let current = "desktop", themeMode = "auto";
+  const frame = document.getElementById("frame"), wrap = document.getElementById("wrap");
+  const stage = document.querySelector(".stage"), dims = document.getElementById("dims");
+  const devSeg = document.querySelector(".seg:not(.themeseg)"), themeSeg = document.querySelector(".themeseg");
+  const devBtns = [...devSeg.querySelectorAll("button")], themeBtns = [...themeSeg.querySelectorAll("button")];
+  function posThumb(seg){ const t=seg.querySelector(".thumb"); const a=seg.querySelector('button[aria-pressed="true"]')||seg.querySelector("button"); t.style.width=a.offsetWidth+"px"; t.style.transform="translateX("+(a.offsetLeft-3)+"px)"; }
+
+  const MOCK_CSS = `
+    :root{
+      --bg:#f7f4ef; --panel:#ffffff; --elev:#f0ebe4; --sunk:#f0ebe4; --border:#d4cfc4;
+      --text:#6b5a4a; --dim:#7a6a5a; --faint:#8f7d66;
+      --accent:#4a6b7c; --accent-ink:#ffffff;
+      --ok:#507055; --ok-bg:#e8f0e9; --warn:#a05a35; --warn-bg:#f7e8db;
+      --crit:#b56a5a; --crit-bg:#f2e5e3; --mauve:#7a5f6e; --neu:#7a6a5a; --neu-bg:#e8e0d8;
+      --tint-red:#f2e5e3; --tint-green:#e8f0e9; --tint-orange:#f7e8db; --tint-blue:#e6eef2;
+      --tint-brown:#e8e0d8; --tint-cream:#faf8f5;
+    }
+    :root[data-theme="dark"]{
+      --bg:#1e1e1e; --panel:#252526; --elev:#2d2d2d; --sunk:#1a1a1a; --border:#3c3c3c;
+      --text:#c4b4a4; --dim:#a89888; --faint:#8a7a68;
+      --accent:#7b9fb0; --accent-ink:#16202a;
+      --ok:#6d9472; --ok-bg:#1a2e1d; --warn:#d4864f; --warn-bg:#332518;
+      --crit:#c97a6a; --crit-bg:#2d1f1c; --mauve:#a58198; --neu:#a89888; --neu-bg:#2a2520;
+      --tint-red:#2d1f1c; --tint-green:#1a2e1d; --tint-orange:#332518; --tint-blue:#1e2528;
+      --tint-brown:#2a2520; --tint-cream:#252321;
+    }
+    *{box-sizing:border-box;}
+    html,body{margin:0;height:100%;}
+    body{background:var(--bg); color:var(--text); font-size:13.5px; line-height:1.45;
+      font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased;}
+    .mono{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace; font-variant-numeric:tabular-nums;}
+    .lbl{font-size:10px; letter-spacing:.09em; text-transform:uppercase; color:var(--faint); font-weight:600;}
+    .dot{width:7px; height:7px; border-radius:50%; background:currentColor; flex:none;}
+    .pill{display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:20px; font-size:11px; font-weight:600; white-space:nowrap;}
+    .pill.ok{background:var(--ok-bg); color:var(--ok);} .pill.warn{background:var(--warn-bg); color:var(--warn);}
+    .pill.crit{background:var(--crit-bg); color:var(--crit);} .pill.neu{background:var(--neu-bg); color:var(--neu);}
+    .pill.acc{background:var(--accent); color:var(--accent-ink);}
+
+    .cockpit{display:flex; flex-direction:column; height:100%;}
+    .cbar{display:flex; align-items:center; gap:12px; flex-wrap:wrap; padding:10px 16px;
+      background:var(--panel); border-bottom:1px solid var(--border); position:sticky; top:0; z-index:4;}
+    .cid{display:flex; align-items:center; gap:10px; flex-wrap:wrap;}
+    .cid .num{font-size:12px; font-weight:700; letter-spacing:.05em; color:var(--accent);}
+    .cid .asset{font-size:14px; font-weight:700;}
+    .cid .path{font-size:11.5px; color:var(--dim);}
+    .intakeseg{display:inline-flex; position:relative; background:var(--elev); border:1px solid var(--border);
+      border-radius:9px; padding:3px; margin-left:auto;}
+    .intakeseg button{position:relative; z-index:1; border:0; background:transparent; color:var(--dim);
+      font:inherit; font-size:12px; font-weight:600; padding:6px 12px; border-radius:6px; cursor:pointer;}
+    .intakeseg button.on{color:var(--accent-ink);}
+    .intakeseg .ithumb{position:absolute; top:3px; left:3px; height:calc(100% - 6px); border-radius:6px; background:var(--accent); transition:transform .2s ease, width .2s ease; z-index:0;}
+
+    .work{flex:1; display:grid; grid-template-columns:1fr; min-height:0;}
+    .leftcol{display:flex; flex-direction:column; min-height:0;}
+
+    /* ===== rail (tabbed) ===== */
+    .rail{display:flex; flex-direction:column; min-height:0; background:var(--panel); border-bottom:1px solid var(--border);}
+    .tabs{display:flex; align-items:center; gap:2px; padding:0 12px; border-bottom:1px solid var(--border); position:relative;}
+    .tabs button{appearance:none; border:0; background:transparent; font:inherit; font-size:12.5px; font-weight:600;
+      color:var(--dim); padding:12px 12px; cursor:pointer; position:relative;}
+    .tabs button.on{color:var(--text);}
+    .tabs button.on::after{content:""; position:absolute; left:8px; right:8px; bottom:-1px; height:2px; background:var(--accent); border-radius:2px;}
+    .tabs .ctx{margin-left:auto; display:flex; align-items:center; gap:7px; font-size:11px;}
+    .live-ind{display:flex; align-items:center; gap:6px; color:var(--crit); font-weight:600;}
+    .live-ind .dot{animation:pulse 1.4s infinite;}
+    @keyframes pulse{0%,100%{opacity:1;} 50%{opacity:.25;}}
+    @media (prefers-reduced-motion:reduce){.live-ind .dot{animation:none;}}
+    .tabpane{display:none; flex:1; min-height:0; flex-direction:column;}
+    .tabpane.on{display:flex;}
+    .rbody{flex:1; overflow:auto; padding:14px 15px; display:flex; flex-direction:column; gap:12px;}
+
+    .intake{display:flex; flex-wrap:wrap; gap:6px 10px; align-items:center; font-size:11.5px; color:var(--dim);}
+    .subj{font-size:14px; font-weight:600; line-height:1.3;}
+    .finds{display:flex; flex-direction:column;}
+    .find{display:grid; grid-template-columns:16px 1fr; gap:10px; padding:8px 0; position:relative;}
+    .find:not(:last-child)::before{content:""; position:absolute; left:7px; top:21px; bottom:-8px; width:1.5px; background:var(--border);}
+    .find .mk{width:15px; height:15px; border-radius:50%; border:2px solid var(--ok); display:grid; place-items:center; margin-top:1px;}
+    .find .mk::after{content:""; width:5px; height:5px; border-radius:50%; background:var(--ok);}
+    .find.q .mk{border-color:var(--accent);} .find.q .mk::after{background:var(--accent);}
+    .find p{margin:0; font-size:12.5px;} .find p b{font-weight:600;}
+    .verdict{margin-top:2px; padding:10px 12px; background:var(--tint-cream); border:1px solid var(--border);
+      border-radius:10px; display:flex; align-items:center; gap:10px; font-size:12px;}
+
+    .msgs{display:flex; flex-direction:column; gap:11px;}
+    .msg{display:flex; gap:9px;}
+    .msg .av{width:26px; height:26px; border-radius:7px; flex:none; display:grid; place-items:center; font-size:10px; font-weight:700;
+      font-family:'JetBrains Mono',Menlo,monospace;}
+    .msg .av.you{background:var(--neu-bg); color:var(--text);}
+    .msg .av.sys{background:var(--accent); color:var(--accent-ink);}
+    .msg .av.bot{background:var(--warn-bg); color:var(--warn); border:1px solid var(--warn);}
+    .msg .bub .who{font-size:11px; color:var(--faint); font-weight:600; margin-bottom:2px;}
+    .msg .bub p{margin:0; font-size:12.5px; line-height:1.4;}
+    .mention{color:var(--accent); font-weight:600; font-family:'JetBrains Mono',Menlo,monospace;}
+    .composer{display:flex; align-items:center; gap:9px; padding:11px 15px; border-top:1px solid var(--border); background:var(--panel);}
+    .composer .box{flex:1; padding:9px 12px; background:var(--sunk); border:1px solid var(--border); border-radius:9px; color:var(--faint); font-size:12.5px;}
+    .composer .send{width:34px; height:34px; border-radius:9px; background:var(--accent); color:var(--accent-ink); border:0; display:grid; place-items:center; flex:none; cursor:pointer;}
+
+    /* ===== quick reference ===== */
+    .qref{background:var(--tint-brown); border-bottom:1px solid var(--border); display:flex; flex-direction:column; flex:none;}
+    .qref .qhead{display:flex; align-items:center; gap:9px; padding:9px 13px; border-bottom:1px solid var(--border);}
+    .qref .qhead b{font-size:12px; font-weight:700; letter-spacing:.03em;}
+    .qref .qhead .count{margin-left:auto; font-size:11px; font-weight:700;}
+    .qref.ready .qhead .state{background:var(--ok-bg); color:var(--ok);}
+    .qref .qhead .state{background:var(--warn-bg); color:var(--warn);}
+    .qtools{display:flex; gap:6px; flex-wrap:wrap; padding:8px 13px 2px;}
+    .qbtn{appearance:none; font:inherit; font-size:11px; font-weight:600; padding:5px 9px; border-radius:7px; cursor:pointer;
+      background:var(--panel); border:1px solid var(--border); color:var(--text);}
+    .qbtn.pri{background:var(--accent); border-color:var(--accent); color:var(--accent-ink);}
+    .qfields{padding:4px 13px 9px; display:flex; flex-direction:column;}
+    .qfield{display:flex; justify-content:space-between; gap:10px; align-items:baseline; padding:6px 0; border-bottom:1px solid var(--border);}
+    .qfield:last-child{border-bottom:0;}
+    .qfield .lbl{flex:none; padding-top:1px;}
+    .qf-v{font-size:12.5px; font-weight:600; text-align:right; line-height:1.3;}
+    .qf-v .src{font-size:9px; letter-spacing:.04em; text-transform:uppercase; color:var(--faint); font-weight:600; margin-left:5px;}
+    .qf-v .src.ok{color:var(--ok);}
+    .qfield.miss{background:var(--warn-bg); margin:0 -13px; padding:6px 13px; border-bottom:1px solid var(--border);}
+    .qfield.miss .lbl{color:var(--warn);}
+    .qfield.miss .qf-v{color:var(--warn);}
+    .qf-v .add{font-size:11px; font-weight:600; color:var(--accent); cursor:pointer; margin-left:4px;}
+
+    /* ===== canvas ===== */
+    .canvas{overflow:auto; padding:16px; display:grid; grid-template-columns:1fr; gap:14px; align-content:start;}
+    .card{background:var(--panel); border:1px solid var(--border); border-radius:13px; overflow:hidden;}
+    .card > h3{margin:0; padding:11px 15px; font-size:12.5px; font-weight:700; border-bottom:1px solid var(--border);
+      display:flex; align-items:center; justify-content:space-between; gap:10px;}
+    .card > h3 .rt{font-size:11px; font-weight:600; color:var(--accent); cursor:pointer;}
+    .card > h3 .sub{color:var(--faint); font-weight:500; font-size:11px;}
+
+    .diff{background:var(--tint-red);}
+    .diff .grid{display:grid; grid-template-columns:1fr; gap:1px; background:var(--border);}
+    .diff .col{background:var(--panel); padding:12px 15px;}
+    .diff .col .lbl{margin-bottom:8px;}
+    .diff .kv{display:flex; justify-content:space-between; gap:12px; padding:5px 0; font-size:12.5px; align-items:center;}
+    .diff .kv .k{color:var(--dim);}
+    .diff .kv .v{font-weight:600;}
+    .diff .kv.bad{background:var(--crit-bg); margin:0 -15px; padding:5px 15px;}
+    .diff .kv.bad .v{color:var(--crit);}
+    .diff .kv.good .v{color:var(--ok);}
+    .diff .note{padding:10px 15px; font-size:12px; color:var(--dim); display:flex; gap:8px; align-items:flex-start;}
+    .diff .raw{display:none; padding:12px 15px; border-top:1px solid var(--border); background:var(--sunk);}
+    .diff .raw.show{display:block;}
+    .diff .raw pre{margin:0; font-size:11px; color:var(--dim); white-space:pre-wrap; line-height:1.5;}
+    .diff .raw .cur{color:var(--ok);}
+
+    .graph{background:var(--tint-orange);} .graph .gwrap{padding:10px; display:grid; place-items:center; background:var(--panel);}
+    .graph svg{width:100%; height:auto; max-width:340px;}
+    .timeline{background:var(--tint-blue);}
+    .tl{padding:8px 15px 12px; background:var(--panel);}
+    .tl .ev{display:grid; grid-template-columns:52px 14px 1fr; gap:10px; padding:7px 0; position:relative; align-items:start;}
+    .tl .ev:not(:last-child)::before{content:""; position:absolute; left:58px; top:19px; bottom:-7px; width:1.5px; background:var(--border);}
+    .tl .ev .t{font-size:11px; color:var(--faint); text-align:right; padding-top:1px;}
+    .tl .ev .m{width:9px; height:9px; border-radius:50%; background:var(--neu); margin:4px auto 0;}
+    .tl .ev.crit .m{background:var(--crit);} .tl .ev.now .m{background:var(--accent); box-shadow:0 0 0 4px var(--accent-bg,rgba(122,159,176,.2));}
+    .tl .ev p{margin:0; font-size:12.5px;} .tl .ev p b{font-weight:600;} .tl .ev small{color:var(--faint); font-size:11px;}
+
+    .remedy{background:var(--tint-green); border-color:var(--ok);}
+    .remedy > h3{color:var(--ok); border-bottom-color:var(--border);}
+    .remedy .rbdy{padding:13px 15px; display:flex; flex-direction:column; gap:11px; background:var(--panel);}
+    .remedy .plan{font-size:13.5px; font-weight:600;}
+    .remedy .facts{display:flex; flex-wrap:wrap; gap:7px;}
+    .remedy .fact{font-size:11.5px; color:var(--dim); background:var(--elev); border:1px solid var(--border); border-radius:7px; padding:4px 9px;}
+    .remedy .acts{display:flex; gap:9px; flex-wrap:wrap;}
+    .btn{appearance:none; font:inherit; font-size:13px; font-weight:600; padding:9px 16px; border-radius:9px; cursor:pointer;}
+    .btn.pri{background:var(--ok); color:#fff; border:1px solid var(--ok);}
+    .btn.ghost{background:transparent; color:var(--text); border:1px solid var(--border);}
+
+    @media (min-width:720px){
+      .work{grid-template-columns:320px 1fr;}
+      .leftcol{height:100%; border-right:1px solid var(--border);}
+      .rail{flex:1; min-height:0; border-bottom:0;}
+    }
+    @media (min-width:1024px){
+      .work{grid-template-columns:340px 1fr;}
+      .canvas{grid-template-columns:1fr 1fr; padding:18px;}
+      .diff, .remedy{grid-column:1 / -1;}
+      .diff .grid{grid-template-columns:1fr 1fr;}
+    }
+  `;
+
+  const graphSVG = `
+    <svg viewBox="0 0 320 190" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dependency graph">
+      <line x1="160" y1="95" x2="60" y2="40" stroke="var(--crit)" stroke-width="2"/>
+      <line x1="160" y1="95" x2="60" y2="150" stroke="var(--crit)" stroke-width="2"/>
+      <line x1="160" y1="95" x2="270" y2="95" stroke="var(--border)" stroke-width="2"/>
+      <g font-family="'JetBrains Mono',Menlo,monospace" font-size="9">
+        <circle cx="160" cy="95" r="26" fill="var(--crit-bg)" stroke="var(--crit)" stroke-width="2"/>
+        <text x="160" y="98" text-anchor="middle" fill="var(--crit)" font-weight="700">sql-primary</text>
+        <circle cx="60" cy="40" r="20" fill="var(--warn-bg)" stroke="var(--warn)" stroke-width="1.5"/>
+        <text x="60" y="43" text-anchor="middle" fill="var(--warn)">api-02</text>
+        <circle cx="60" cy="150" r="20" fill="var(--warn-bg)" stroke="var(--warn)" stroke-width="1.5"/>
+        <text x="60" y="153" text-anchor="middle" fill="var(--warn)">reports-01</text>
+        <circle cx="270" cy="95" r="20" fill="var(--ok-bg)" stroke="var(--ok)" stroke-width="1.5"/>
+        <text x="270" y="98" text-anchor="middle" fill="var(--ok)">web-04</text>
+      </g>
+      <text x="103" y="58" fill="var(--crit)" font-family="'JetBrains Mono',Menlo,monospace" font-size="8.5">×4 lat</text>
+      <text x="103" y="132" fill="var(--crit)" font-family="'JetBrains Mono',Menlo,monospace" font-size="8.5">×4 lat</text>
+    </svg>`;
+
+  const MOCK_HTML = `
+  <div class="cockpit">
+    <div class="cbar">
+      <div class="cid">
+        <span class="num mono">CASE 4821</span>
+        <span class="asset mono">sql-primary</span>
+        <span class="path mono">root / msp-a / client-1</span>
+      </div>
+      <div class="intakeseg" role="group" aria-label="Intake">
+        <span class="ithumb" aria-hidden="true"></span>
+        <button data-intake="email" class="on">Email</button>
+        <button data-intake="live">Live call</button>
+      </div>
+      <span class="pill warn"><span class="dot"></span>SLA 46m</span>
+    </div>
+
+    <div class="work">
+      <div class="leftcol">
+      <!-- QUICK REFERENCE -->
+      <aside class="qref">
+        <div class="qhead">
+          <b>Ticket</b>
+          <span class="pill state" style="padding:2px 8px;"><span class="dot"></span><span id="qstate">2 needed</span></span>
+          <span class="count mono" id="qcount">3 / 5</span>
+        </div>
+        <div class="qtools">
+          <button class="qbtn pri" id="cidLookup">Caller-ID lookup</button>
+          <button class="qbtn">Match ticket</button>
+          <button class="qbtn">Edit</button>
+        </div>
+        <div class="qfields">
+          <div class="qfield" data-field="title"><span class="lbl">Title</span><span class="qf-v">SQL app slow since 9am <span class="src ok">email</span></span></div>
+          <div class="qfield" data-field="client"><span class="lbl">Client</span><span class="qf-v mono">client-1 <span class="src ok">caller-ID</span></span></div>
+          <div class="qfield" data-field="priority"><span class="lbl">Priority</span><span class="qf-v">High · P2 <span class="src ok">email</span></span></div>
+          <div class="qfield miss" data-field="contact"><span class="lbl">Contact</span><span class="qf-v">— <span class="add">add</span></span></div>
+          <div class="qfield miss" data-field="category"><span class="lbl">Category</span><span class="qf-v">— <span class="add">add</span></span></div>
+        </div>
+      </aside>
+
+      <!-- RAIL: tabbed Investigation / Chat -->
+      <aside class="rail">
+        <div class="tabs">
+          <button data-tab="inv" class="on">Investigation</button>
+          <button data-tab="chat">Chat</button>
+          <div class="ctx">
+            <span class="ctx-email pill neu" style="padding:2px 8px;"><span class="dot"></span>Email · #4821</span>
+            <span class="ctx-live live-ind" style="display:none;"><span class="dot"></span>LIVE · <span class="mono">02:14</span></span>
+          </div>
+        </div>
+
+        <div class="tabpane on" data-pane="inv">
+          <div class="rbody">
+            <div class="intake mono"><span>#4821</span><span>·</span><span id="intakeSrc">Email</span><span>·</span><span>08:52</span></div>
+            <div class="subj">"SQL app has been crawling since about 9am"</div>
+            <div class="lbl">Prepared by CFGMS</div>
+            <div class="finds">
+              <div class="find"><span class="mk"></span><p>Correlated onset with config push <b class="mono">r2291</b> at <b class="mono">08:41</b></p></div>
+              <div class="find"><span class="mk"></span><p><b class="mono">sql-primary</b> drifted — <b>max server memory</b> reverted to 2 GB default</p></div>
+              <div class="find"><span class="mk"></span><p>Blast radius: <b>2 of 3</b> dependent app servers at <b class="mono">×4</b> latency</p></div>
+              <div class="find q"><span class="mk"></span><p>Remediation staged &amp; validated — awaiting approval</p></div>
+            </div>
+            <div class="verdict"><span class="pill crit"><span class="dot"></span>Cause found</span><b>1 action · ~30s · reversible</b></div>
+          </div>
+        </div>
+
+        <div class="tabpane" data-pane="chat">
+          <div class="rbody">
+            <div class="msgs">
+              <div class="msg"><div class="av you">YOU</div><div class="bub"><div class="who">Dispatcher</div><p>Customer's on the line — app's been crawling for the whole floor since ~9am.</p></div></div>
+              <div class="msg"><div class="av sys">CF</div><div class="bub"><div class="who">CFGMS</div><p>On it — pulling <span class="mention">sql-primary</span> and its dependents…</p></div></div>
+              <div class="msg"><div class="av sys">CF</div><div class="bub"><div class="who">CFGMS</div><p>Found it: memory config reverted during the <span class="mention">r2291</span> push at 08:41. Canvas updated →</p></div></div>
+              <div class="msg"><div class="av you">YOU</div><div class="bub"><div class="who">Dispatcher</div><p><span class="mention">@sql-bot</span> confirm blast radius before I promise a fix time.</p></div></div>
+              <div class="msg"><div class="av bot">SQ</div><div class="bub"><div class="who mono">@sql-bot</div><p>3 dependents; <span class="mention">api-02</span> + <span class="mention">reports-01</span> at ×4 latency. web-04 nominal.</p></div></div>
+              <div class="msg"><div class="av sys">CF</div><div class="bub"><div class="who">CFGMS</div><p>Fix staged → approve on the canvas. Tell them ~2 minutes.</p></div></div>
+            </div>
+          </div>
+          <div class="composer">
+            <div class="box">Message, or <b class="mono">@bot</b> to summon…</div>
+            <button class="send" aria-label="Send"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M4 12l16-8-6 16-3-6-7-2z" fill="currentColor"/></svg></button>
+          </div>
+        </div>
+      </aside>
+      </div>
+
+      <!-- CANVAS -->
+      <main class="canvas">
+        <section class="card diff">
+          <h3><span>Desired vs actual · <span class="mono" style="font-weight:700">sql-primary</span></span><span class="rt" data-raw>⌄ raw</span></h3>
+          <div class="grid">
+            <div class="col">
+              <div class="lbl">Desired — intent r2291</div>
+              <div class="kv"><span class="k mono">max_server_memory</span><span class="v mono">12288 MB</span></div>
+              <div class="kv"><span class="k mono">max_worker_threads</span><span class="v mono">640</span></div>
+              <div class="kv"><span class="k mono">cost_threshold_par</span><span class="v mono">50</span></div>
+            </div>
+            <div class="col">
+              <div class="lbl">Actual — observed 08:44</div>
+              <div class="kv bad"><span class="k mono">max_server_memory</span><span class="v mono">2048 MB ⚠</span></div>
+              <div class="kv good"><span class="k mono">max_worker_threads</span><span class="v mono">640 ✓</span></div>
+              <div class="kv good"><span class="k mono">cost_threshold_par</span><span class="v mono">50 ✓</span></div>
+            </div>
+          </div>
+          <div class="note"><span class="pill crit"><span class="dot"></span>drift</span><span>Memory section of r2291 failed to apply — service reverted to install default, starving the buffer pool.</span></div>
+          <div class="raw"><pre class="mono">$ cfg steward inspect sql-primary --module mssql.config
+<span class="cur">➜</span> desired.max_server_memory = 12288
+  actual.max_server_memory  = 2048   (source: registry default)
+  last_apply = r2291 partial (section 'memory' err: lock timeout)
+  drift_detected = 2026-07-03T08:44:11Z</pre></div>
+        </section>
+
+        <section class="card graph">
+          <h3><span>Blast radius</span><span class="sub">3 dependents</span></h3>
+          <div class="gwrap">${graphSVG}</div>
+        </section>
+
+        <section class="card timeline">
+          <h3><span>Change timeline</span><span class="sub">today</span></h3>
+          <div class="tl">
+            <div class="ev"><span class="t mono">08:41</span><span class="m"></span><p><b>Config push r2291</b><br><small class="mono">by controller · ring: broad</small></p></div>
+            <div class="ev crit"><span class="t mono">08:44</span><span class="m"></span><p><b>Drift detected</b> on sql-primary<br><small class="mono">memory section not applied</small></p></div>
+            <div class="ev"><span class="t mono">08:52</span><span class="m"></span><p><b>Ticket #4821</b> opened<br><small class="mono">email · client-1</small></p></div>
+            <div class="ev now"><span class="t mono">now</span><span class="m"></span><p><b>Remediation staged</b><br><small class="mono">awaiting approval</small></p></div>
+          </div>
+        </section>
+
+        <section class="card remedy">
+          <h3><span>Remediation plan</span><span class="pill ok" style="background:transparent;border:1px solid currentColor;">validated</span></h3>
+          <div class="rbdy">
+            <div class="plan">Re-apply the <b class="mono">memory</b> section of r2291 to <b class="mono">sql-primary</b></div>
+            <div class="facts"><span class="fact">1 host</span><span class="fact">~30s</span><span class="fact">no restart</span><span class="fact">reversible</span><span class="fact mono">module: mssql.config</span></div>
+            <div class="acts"><button class="btn pri">Approve &amp; run</button><button class="btn ghost">Preview diff</button><button class="btn ghost">Hand to L2</button></div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>`;
+
+  const MOCK_JS = `
+    var ibtns=[].slice.call(document.querySelectorAll('.intakeseg button'));
+    var ithumb=document.querySelector('.intakeseg .ithumb');
+    var tabs=[].slice.call(document.querySelectorAll('.tabs button'));
+    function moveI(){var a=ibtns.filter(function(b){return b.classList.contains('on');})[0]||ibtns[0];
+      ithumb.style.width=a.offsetWidth+'px';ithumb.style.transform='translateX('+(a.offsetLeft-3)+'px)';}
+    function setTab(id){tabs.forEach(function(t){t.classList.toggle('on',t.dataset.tab===id);});
+      [].slice.call(document.querySelectorAll('.tabpane')).forEach(function(p){p.classList.toggle('on',p.dataset.pane===id);});}
+    tabs.forEach(function(t){t.addEventListener('click',function(){setTab(t.dataset.tab);});});
+    ibtns.forEach(function(b){b.addEventListener('click',function(){
+      document.body.dataset.intake=b.dataset.intake;
+      ibtns.forEach(function(x){x.classList.toggle('on',x===b);});moveI();
+      var live=b.dataset.intake==='live';
+      document.querySelector('.ctx-email').style.display=live?'none':'inline-flex';
+      document.querySelector('.ctx-live').style.display=live?'inline-flex':'none';
+      document.getElementById('intakeSrc').textContent=live?'Live call':'Email';
+      setTab(live?'chat':'inv');
+    });});
+    var lookup=document.getElementById('cidLookup');
+    function fill(f,val,src){var el=document.querySelector('.qfield[data-field="'+f+'"]');if(!el)return;
+      el.classList.remove('miss');
+      el.querySelector('.qf-v').innerHTML=val+' <span class="src ok">'+src+'</span>';}
+    if(lookup){lookup.addEventListener('click',function(){
+      fill('contact','M. Rivera · IT mgr','caller-ID');
+      fill('category','Database / Perf','auto');
+      document.getElementById('qcount').textContent='5 / 5';
+      document.getElementById('qstate').textContent='complete';
+      document.querySelector('.qref').classList.add('ready');});}
+    var rt=document.querySelector('[data-raw]');if(rt){rt.addEventListener('click',function(){
+      var r=document.querySelector('.diff .raw');r.classList.toggle('show');
+      rt.textContent=r.classList.contains('show')?'⌃ hide':'⌄ raw';});}
+    window.addEventListener('load',moveI);moveI();
+  `;
+
+  function currentTheme(){ if(themeMode!=="auto") return themeMode; const d=document.documentElement.getAttribute("data-theme"); return d || (matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"); }
+  function srcdoc(t){ return '<!doctype html><html lang="en" data-theme="'+t+'"><head><meta charset="utf-8">'+
+    '<meta name="viewport" content="width=device-width,initial-scale=1"><style>'+MOCK_CSS+'</style></head><body>'+
+    MOCK_HTML+'<script>'+MOCK_JS+'<\/script></body></html>'; }
+  function layout(){ const d=DEVICES[current]; frame.style.width=d.w+"px"; frame.style.height=d.h+"px";
+    const avail=stage.clientWidth-32; const s=Math.min(1,avail/d.w); frame.style.transform="scale("+s+")";
+    wrap.style.width=(d.w*s)+"px"; wrap.style.height=(d.h*s)+"px"; dims.textContent=d.w+" × "+d.h+" · "+Math.round(s*100)+"%"; }
+  function render(){ frame.srcdoc=srcdoc(currentTheme()); layout(); }
+  devBtns.forEach(b=>b.addEventListener("click",()=>{ current=b.dataset.dev;
+    devBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(devSeg); layout(); }));
+  themeBtns.forEach(b=>b.addEventListener("click",()=>{ themeMode=b.dataset.themeMode;
+    themeBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(themeSeg);
+    if(themeMode==="auto"){ document.documentElement.removeAttribute("data-theme"); render(); }
+    else { document.documentElement.setAttribute("data-theme",themeMode); } }));
+  new MutationObserver(render).observe(document.documentElement,{attributes:true,attributeFilter:["data-theme"]});
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change",()=>{ if(themeMode==="auto") render(); });
+  window.addEventListener("resize",()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); });
+  window.addEventListener("orientationchange",()=>setTimeout(()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); },200));
+  render(); posThumb(devSeg); posThumb(themeSeg);
+</script>

--- a/docs/design/web-ui-design-system.md
+++ b/docs/design/web-ui-design-system.md
@@ -1,12 +1,11 @@
 # CFGMS Web UI — Design System
 
-> **Status: WORK IN PROGRESS (checkpoint).** This document captures the
-> founder-owned, in-session design direction for the CFGMS web UI. It is the
-> `docs/design/web-ui-design-system.md` deliverable named in Epic #2344, but it
-> is **not yet complete** — the login screen and a finalized fleet-overview
-> screen in this identity are still pending. Do not treat the epic's
-> "design system merged" success criterion as satisfied until those exist and
-> this banner is removed.
+This document is the founder-owned design direction for the CFGMS web UI and the
+`docs/design/web-ui-design-system.md` deliverable named in Epic #2344. It defines
+the visual identity, the working principle, the case model, and the reference
+screens (login, fleet overview, troubleshooting cockpit) that the shipped
+React + TypeScript + Vite app is built to match. It is a design reference, not
+production code; the mockups express intent, the tokens are the source of truth.
 
 Machine-readable tokens live in [`web-ui-design-tokens.css`](web-ui-design-tokens.css).
 Reference mockups live in [`mockups/`](mockups/).
@@ -134,7 +133,64 @@ assembled answer; any card can be peeled back to raw telemetry for deeper tiers.
 
 ---
 
-## 5. Provenance — directions considered
+## 5. Screens (established in the mockups)
+
+Three reference screens fix the identity for the parts of the app that gate
+early development. Each mockup is responsive (Desktop / Tablet / Mobile) and
+ships both themes.
+
+### 5.1 Login — [`mockups/login.html`](mockups/login.html)
+
+A single, quiet authentication surface framed as a **terminal window** (the one
+place the Ubuntu-Mono terminal accent is spent). One credential path to start —
+the mTLS/session sign-in that mirrors `cfg` — with the full set of states the
+screen must handle already drawn:
+
+- `signin` (default), `loading`, `invalid` (bad credential), and `expired`
+  (session timed out — re-authenticate), so error and lifecycle copy are
+  designed, not left to implementation.
+- An **MFA seam**: a `mfa` state carrying a passkey/WebAuthn challenge. The
+  layout, copy, and control are designed **now** so the flow has a home; the
+  actual second-factor enforcement is built later (see [ADR-015](../architecture/decisions/015-web-session-semantics.md)
+  for the session model this feeds).
+
+### 5.2 App shell + fleet overview — [`mockups/fleet-overview.html`](mockups/fleet-overview.html)
+
+The **app shell** every authenticated screen lives in: left sidebar, a top
+**app bar** with a **tenant-scope switcher** (the `root / msp-a` path selector),
+global **search**, an **alert/notification center**, and a **user menu**. On
+phones the search drops to its own full-width row; the sidebar becomes an
+off-canvas drawer.
+
+The first screen inside the shell is the **read-only fleet overview** — stewards
+enrolled to the controller — carrying the patterns early development needs:
+
+- **Live-filter search**, not a command bar: typing narrows the visible rows in
+  place (name, company, last user, IP, OS, health, ring, agent) and updates the
+  match count and pager live. Clearing restores the full list.
+- **Selectable device-DNA columns.** A column picker chooses which DNA a
+  technician sees. Defaults are Name, Company, Last user, IP, Health, Last
+  check-in; additional DNA (OS, Agent, Ring, Model, Serial, MAC) is opt-in. Name
+  is pinned. A trailing spacer column absorbs slack so columns hug their content
+  and the name column never balloons as DNA is added.
+- **Sort, saved views, and scale-aware pagination** — the count and pager are
+  written for 48k+ stewards, not a demo-sized list.
+- **Row drill-in → asset-DNA drawer.** Selecting a steward opens a side drawer
+  showing the **full device DNA** for that host (the early-development need for
+  "view all asset DNA" before deeper asset screens exist), with a raw-values
+  disclosure and export.
+- **Ready / Loading (skeleton) / Error / Empty** states are all drawn; the
+  mockup's `preview state` strip is a harness affordance for reviewing them and
+  is not part of the product UI.
+
+### 5.3 Troubleshooting cockpit — [`mockups/troubleshooting-cockpit.html`](mockups/troubleshooting-cockpit.html)
+
+The differentiator described in §3–§4: the agentic case surface. This is the
+primary working screen the fleet overview and login lead into.
+
+---
+
+## 6. Provenance — directions considered
 
 Three interface directions were explored in-session before converging:
 
@@ -149,11 +205,8 @@ Three interface directions were explored in-session before converging:
 
 ---
 
-## 6. Open items (before this can drop its WIP status)
+## 7. Open items
 
-- [ ] **Login screen** in this identity (Epic #2344's other gating screen).
-- [ ] **Finalized read-only fleet-overview** screen in this identity
-      (the generic v0 mockup is a placeholder, not the reference).
 - [ ] **Converge the app identity with the public-site style guide.** The app
       currently *derives from* the published guide; at some point the two style
       guides should be reconciled into one source of truth. (Founder note,
@@ -167,10 +220,11 @@ Three interface directions were explored in-session before converging:
 
 ---
 
-## 7. How to view the mockups
+## 8. How to view the mockups
 
 The mockups are self-contained HTML — open any file in [`mockups/`](mockups/)
 directly in a browser. Each is wrapped in a small preview harness with a
-**Desktop / Tablet / Mobile** viewport toggle and (for the cockpit) an
-**Auto / Light / Dark** theme toggle, so both responsive breakpoints and both
-themes can be reviewed from a single file — including from a phone.
+**Desktop / Tablet / Mobile** viewport toggle; the cockpit, login, and
+fleet-overview add an **Auto / Light / Dark** theme toggle, so both responsive
+breakpoints and both themes can be reviewed from a single file — including from
+a phone.

--- a/docs/design/web-ui-design-system.md
+++ b/docs/design/web-ui-design-system.md
@@ -1,0 +1,176 @@
+# CFGMS Web UI — Design System
+
+> **Status: WORK IN PROGRESS (checkpoint).** This document captures the
+> founder-owned, in-session design direction for the CFGMS web UI. It is the
+> `docs/design/web-ui-design-system.md` deliverable named in Epic #2344, but it
+> is **not yet complete** — the login screen and a finalized fleet-overview
+> screen in this identity are still pending. Do not treat the epic's
+> "design system merged" success criterion as satisfied until those exist and
+> this banner is removed.
+
+Machine-readable tokens live in [`web-ui-design-tokens.css`](web-ui-design-tokens.css).
+Reference mockups live in [`mockups/`](mockups/).
+
+---
+
+## 1. Identity: a warm terminal
+
+Every other tool in the operations/RMM category dresses as a cold blue-black
+control panel. CFGMS goes the other way on purpose: a **warm terminal** — a
+calm, dense, instrument-grade surface that reads as purpose-built tooling, not
+a generic SaaS dashboard. The identity is derived directly from the public
+brand style guide (https://cfg.is/style-guide) and amplifies its most
+distinctive traits.
+
+**The four pillars:**
+
+1. **Warm grounds, warm text.** Near-black `#1e1e1e` / warm-paper `#f7f4ef`
+   grounds with **warm taupe** body text (`#c4b4a4` / `#6b5a4a`), never a cool
+   grey or stark off-white. This is the single most identity-defining choice.
+2. **Colour is information.** Semantic **state** (converged / drift / error /
+   queued) owns the colour budget. When everything is coloured, nothing
+   signals — so most surfaces stay warm-neutral and let a red *mean* a problem.
+3. **The accent is for interaction only.** The muted slate-blue accent
+   (`#7b9fb0` / `#4a6b7c`) marks what is interactive — focus, selection, links,
+   primary actions — and is never spent on decoration or on conveying state.
+4. **Mono carries machine data.** Every hostname, hash, timestamp, config key,
+   ring name, and identifier is set in JetBrains Mono. Used heavily, it gives
+   the UI its instrument texture and makes machine values unambiguous.
+
+### Semantics (desaturated earth tones)
+
+| Meaning              | Token           | Light     | Dark      |
+|----------------------|-----------------|-----------|-----------|
+| Converged / success  | `--state-ok`    | `#507055` | `#6d9472` |
+| Drift / warning      | `--state-warn`  | `#a05a35` | `#d4864f` |
+| Error (terracotta)   | `--state-crit`  | `#b56a5a` | `#c97a6a` |
+| Error (mauve, alt)   | `--state-mauve` | `#7a5f6e` | `#a58198` |
+| Queued / inert       | `--state-neutral`| `#7a6a5a`| `#a89888` |
+
+### Card tints encode meaning, not decoration
+
+The style guide's muted card-tint palette is used to give a card a **role at a
+glance**: the problem card wears the red tint, the remediation card the green
+tint, dependency/attention the orange, neutral context the blue, reference the
+brown, summary the cream. A tint is never applied for visual variety alone.
+
+### Typography
+
+- **Inter** — UI and body (weights 400/500/600/700).
+- **JetBrains Mono** — all machine data (400/500/700).
+- **Ubuntu Mono** — reserved for logo / terminal accents.
+- Uppercase micro-labels carry `letter-spacing: 0.09em`; numeric columns use
+  `font-variant-numeric: tabular-nums`.
+- Font delivery for the shipped app is an open item (see §6) — the mockups use
+  a progressive stack that falls back to the platform UI/mono faces when the
+  brand webfonts are not present.
+
+### Theme model
+
+Light is the default token set; dark is supplied under
+`@media (prefers-color-scheme: dark)`; and `:root[data-theme="…"]` overrides the
+media query in both directions so an in-app theme control can force either
+theme. Both themes are first-class and equally tuned — dark is not a naive
+inversion of light.
+
+---
+
+## 2. Working principle: Lean Six Sigma (reduce motion)
+
+The UI is designed to get a technician to the information they need in far less
+time than any other platform, by eliminating the classic wastes of RMM work:
+
+| Waste           | Where it hides                              | Our answer                                            |
+|-----------------|---------------------------------------------|-------------------------------------------------------|
+| Transportation  | Swivel-chair across RMM / PSA / docs / remote | One surface; the case *is* the ticket *is* the asset |
+| Motion          | Clicking down client→site→device→tab trees   | Info comes to the work; keyboard/command-palette entry |
+| Waiting         | Page loads, agent check-ins, script runs     | Live/streaming; desired state already known           |
+| Over-processing | Manually correlating drift ↔ change ↔ alert  | The system pre-correlates before the tech arrives     |
+| Inventory       | Alert/ticket pile-up as WIP                  | Auto-triage; only actionable items surface            |
+| Defects         | Wrong asset, stale data, fat-fingered fix    | Desired-state guardrails + preview/approve            |
+| Non-used talent | Senior techs doing L1 triage                 | Automation handles rote; escalates only the novel     |
+
+**The thesis:** other tools make you *browse to* the problem; CFGMS brings the
+**assembled case** to you. Navigation itself is the waste to remove.
+
+---
+
+## 3. The case model and two intake modes
+
+The atomic unit of work is a **case** (alert- or ticket-triggered). The same
+case model and the same canvas cards serve two intake modes; only the direction
+that evidence flows differs:
+
+- **Email ticket (asynchronous).** CFGMS pre-investigates and the case *arrives
+  with the evidence assembled*. The rail opens on the **Investigation** tab
+  showing prepared findings; the technician confirms and resolves. Evidence
+  flows agent → canvas.
+- **Live call (synchronous).** The technician's hands and attention are on the
+  phone, so the conversation leads. The rail opens on the **Chat** tab where the
+  dispatcher narrates the call or `@`-summons specialist bots, and the canvas
+  populates from the conversation. Evidence flows conversation → canvas.
+
+Progressive disclosure serves both L1 and L2/L3 on one surface: L1 sees the
+assembled answer; any card can be peeled back to raw telemetry for deeper tiers.
+
+---
+
+## 4. Component patterns (established in the mockups)
+
+- **Case bar** — sticky header: case id + asset + tenant path (mono), intake
+  toggle (Email / Live), SLA state.
+- **Ticket quick-reference** — dense, top-left, always glanceable on a call.
+  Mandatory fields (Title, Client, Primary contact, Priority, Category) show
+  their source (`email`, `caller-ID`); missing fields stay highlighted until
+  collected and can be filled from an existing ticket, a caller-ID / PSA lookup,
+  chat input, or direct edit.
+- **Tabbed rail** — Investigation and Chat share one column; the intake mode
+  sets the default tab.
+- **Evidence canvas** — reads top-to-bottom as **evidence → cause → action**:
+  a desired-vs-actual **drift-diff** hero (the CFGMS-native object), a
+  **dependency/blast-radius graph**, a **change timeline**, and a
+  **remediation plan** with preview/approve.
+- **State pills, stat tiles, sparklines** — semantic colour only.
+
+---
+
+## 5. Provenance — directions considered
+
+Three interface directions were explored in-session before converging:
+
+1. **Modern management dashboard** — competent but generic; rejected as not
+   memorable ([`mockups/fleet-overview-generic-v0.html`](mockups/fleet-overview-generic-v0.html),
+   pre-brand-alignment).
+2. **Traditional RMM asset-browser** — easy asset browsing, but browsing is the
+   motion waste we want to remove; retained only as a fast *finder*, not the
+   primary surface.
+3. **Agentic troubleshooting cockpit** — chosen. The differentiator, and where
+   the Lean payoff is largest ([`mockups/troubleshooting-cockpit.html`](mockups/troubleshooting-cockpit.html)).
+
+---
+
+## 6. Open items (before this can drop its WIP status)
+
+- [ ] **Login screen** in this identity (Epic #2344's other gating screen).
+- [ ] **Finalized read-only fleet-overview** screen in this identity
+      (the generic v0 mockup is a placeholder, not the reference).
+- [ ] **Converge the app identity with the public-site style guide.** The app
+      currently *derives from* the published guide; at some point the two style
+      guides should be reconciled into one source of truth. (Founder note,
+      2026-07-03 — "good enough for now.")
+- [ ] **Webfont delivery decision** — ship/subset Inter + JetBrains Mono vs.
+      rely on the progressive platform-font fallback used in the mockups.
+- [ ] **Remediation authority model** — how much can be one-click *Approve &
+      run* at L1 vs. always routed through preview / second-eye.
+- [ ] Translate the mockups into the React + TypeScript + Vite component library
+      (the stack fixed for Epic #2344) with these tokens as the source of truth.
+
+---
+
+## 7. How to view the mockups
+
+The mockups are self-contained HTML — open any file in [`mockups/`](mockups/)
+directly in a browser. Each is wrapped in a small preview harness with a
+**Desktop / Tablet / Mobile** viewport toggle and (for the cockpit) an
+**Auto / Light / Dark** theme toggle, so both responsive breakpoints and both
+themes can be reviewed from a single file — including from a phone.

--- a/docs/design/web-ui-design-system.md
+++ b/docs/design/web-ui-design-system.md
@@ -151,7 +151,7 @@ screen must handle already drawn:
   designed, not left to implementation.
 - An **MFA seam**: a `mfa` state carrying a passkey/WebAuthn challenge. The
   layout, copy, and control are designed **now** so the flow has a home; the
-  actual second-factor enforcement is built later (see **ADR-015 — web-session
+  actual second-factor enforcement is built later (see **ADR-018 — web-session
   semantics**, PR #2350, for the session model this feeds).
 
 ### 5.2 App shell + fleet overview — [`mockups/fleet-overview.html`](mockups/fleet-overview.html)

--- a/docs/design/web-ui-design-system.md
+++ b/docs/design/web-ui-design-system.md
@@ -151,8 +151,8 @@ screen must handle already drawn:
   designed, not left to implementation.
 - An **MFA seam**: a `mfa` state carrying a passkey/WebAuthn challenge. The
   layout, copy, and control are designed **now** so the flow has a home; the
-  actual second-factor enforcement is built later (see [ADR-015](../architecture/decisions/015-web-session-semantics.md)
-  for the session model this feeds).
+  actual second-factor enforcement is built later (see **ADR-015 — web-session
+  semantics**, PR #2350, for the session model this feeds).
 
 ### 5.2 App shell + fleet overview — [`mockups/fleet-overview.html`](mockups/fleet-overview.html)
 

--- a/docs/design/web-ui-design-tokens.css
+++ b/docs/design/web-ui-design-tokens.css
@@ -1,0 +1,128 @@
+/*
+ * CFGMS Web UI — Design Tokens
+ * ----------------------------------------------------------------------------
+ * Machine-readable token layer for the controller-served web app (Epic #2344).
+ * Values are lifted verbatim from the public brand style guide
+ * (https://cfg.is/style-guide) so the app and the marketing site share one
+ * source of truth for colour. See docs/design/web-ui-design-system.md for the
+ * rationale, usage rules, and open items.
+ *
+ * Identity in one line: a WARM TERMINAL — warm near-black grounds, warm taupe
+ * text, muted slate-blue accent, desaturated earth-tone semantics, and a
+ * palette of muted card tints. State owns the colour budget; the accent is
+ * reserved for interaction; mono carries all machine data.
+ *
+ * Theme model: default tokens are light. `@media (prefers-color-scheme: dark)`
+ * supplies dark. `:root[data-theme="light"|"dark"]` overrides the media query
+ * in both directions (the app's own theme control stamps data-theme on :root).
+ * ==========================================================================*/
+
+:root {
+  /* --- Background & structure --- */
+  --bg-primary:   #f7f4ef;  /* app ground */
+  --bg-surface:   #ffffff;  /* panels, cards */
+  --bg-elevated:  #f0ebe4;  /* raised / inset chrome */
+  --bg-sunk:      #f0ebe4;  /* wells, code blocks */
+  --border:       #d4cfc4;
+
+  /* --- Text & accent --- */
+  --text-primary:   #6b5a4a; /* warm taupe */
+  --text-secondary: #7a6a5a;
+  --text-faint:     #8f7d66; /* micro-labels (contrast-tuned vs guide) */
+  --accent:         #4a6b7c; /* muted slate blue — INTERACTION ONLY */
+  --accent-ink:     #ffffff; /* text/icon on accent fill */
+
+  /* --- Semantic state (desaturated earth tones) --- */
+  --state-ok:        #507055;  --state-ok-bg:    #e8f0e9; /* converged / success */
+  --state-warn:      #a05a35;  --state-warn-bg:  #f7e8db; /* drift / warning */
+  --state-crit:      #b56a5a;  --state-crit-bg:  #f2e5e3; /* error (terracotta) */
+  --state-mauve:     #7a5f6e;                              /* alt error (guide) */
+  --state-neutral:   #7a6a5a;  --state-neutral-bg:#e8e0d8; /* queued / inert */
+
+  /* --- Card tints (background only; meaning-encoding, not decoration) --- */
+  --tint-red:    #f2e5e3;  /* a problem / failing surface */
+  --tint-green:  #e8f0e9;  /* a fix / resolved surface */
+  --tint-orange: #f7e8db;  /* attention / dependency */
+  --tint-blue:   #e6eef2;  /* neutral context / timeline */
+  --tint-brown:  #e8e0d8;  /* metadata / reference */
+  --tint-cream:  #faf8f5;  /* summary / verdict */
+
+  /* --- Type --- */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, "SF Mono", "SFMono-Regular", Menlo, monospace;
+  --font-display: 'Ubuntu Mono', var(--font-mono); /* logo / terminal accent */
+
+  /* Type scale (1.20 minor-third, 13.5px base) */
+  --text-xs:   10px;   /* uppercase micro-labels */
+  --text-sm:   11.5px;
+  --text-base: 13.5px;
+  --text-md:   14px;
+  --text-lg:   16px;
+  --text-xl:   19px;
+  --text-2xl:  26px;   /* stat numerals */
+  --tracking-label: 0.09em; /* uppercase labels */
+
+  /* --- Spacing (4px base) --- */
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px;
+  --space-4: 16px; --space-5: 20px; --space-6: 24px;
+
+  /* --- Radii --- */
+  --radius-sm: 7px;   /* pills-in-buttons, chips */
+  --radius:    9px;   /* buttons, inputs */
+  --radius-lg: 13px;  /* cards */
+  --radius-pill: 20px;
+
+  /* --- Elevation --- */
+  --shadow: 0 18px 50px -22px rgba(60, 45, 30, 0.40);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-primary:  #1e1e1e;
+    --bg-surface:  #252526;
+    --bg-elevated: #2d2d2d;
+    --bg-sunk:     #1a1a1a;
+    --border:      #3c3c3c;
+
+    --text-primary:   #c4b4a4;
+    --text-secondary: #a89888;
+    --text-faint:     #8a7a68;
+    --accent:         #7b9fb0;
+    --accent-ink:     #16202a;
+
+    --state-ok:      #6d9472;  --state-ok-bg:     #1a2e1d;
+    --state-warn:    #d4864f;  --state-warn-bg:   #332518;
+    --state-crit:    #c97a6a;  --state-crit-bg:   #2d1f1c;
+    --state-mauve:   #a58198;
+    --state-neutral: #a89888;  --state-neutral-bg:#2a2520;
+
+    --tint-red:    #2d1f1c;
+    --tint-green:  #1a2e1d;
+    --tint-orange: #332518;
+    --tint-blue:   #1e2528;
+    --tint-brown:  #2a2520;
+    --tint-cream:  #252321;
+
+    --shadow: 0 22px 60px -26px rgba(0, 0, 0, 0.80);
+  }
+}
+
+/* Explicit overrides — the app's theme control stamps data-theme on :root and
+   must win over the OS media query in BOTH directions. */
+:root[data-theme="light"] {
+  --bg-primary: #f7f4ef; --bg-surface: #ffffff; --bg-elevated: #f0ebe4; --bg-sunk: #f0ebe4; --border: #d4cfc4;
+  --text-primary: #6b5a4a; --text-secondary: #7a6a5a; --text-faint: #8f7d66; --accent: #4a6b7c; --accent-ink: #ffffff;
+  --state-ok: #507055; --state-ok-bg: #e8f0e9; --state-warn: #a05a35; --state-warn-bg: #f7e8db;
+  --state-crit: #b56a5a; --state-crit-bg: #f2e5e3; --state-mauve: #7a5f6e; --state-neutral: #7a6a5a; --state-neutral-bg: #e8e0d8;
+  --tint-red: #f2e5e3; --tint-green: #e8f0e9; --tint-orange: #f7e8db; --tint-blue: #e6eef2; --tint-brown: #e8e0d8; --tint-cream: #faf8f5;
+  --shadow: 0 18px 50px -22px rgba(60, 45, 30, 0.40);
+}
+
+:root[data-theme="dark"] {
+  --bg-primary: #1e1e1e; --bg-surface: #252526; --bg-elevated: #2d2d2d; --bg-sunk: #1a1a1a; --border: #3c3c3c;
+  --text-primary: #c4b4a4; --text-secondary: #a89888; --text-faint: #8a7a68; --accent: #7b9fb0; --accent-ink: #16202a;
+  --state-ok: #6d9472; --state-ok-bg: #1a2e1d; --state-warn: #d4864f; --state-warn-bg: #332518;
+  --state-crit: #c97a6a; --state-crit-bg: #2d1f1c; --state-mauve: #a58198; --state-neutral: #a89888; --state-neutral-bg: #2a2520;
+  --tint-red: #2d1f1c; --tint-green: #1a2e1d; --tint-orange: #332518; --tint-blue: #1e2528; --tint-brown: #2a2520; --tint-cream: #252321;
+  --shadow: 0 22px 60px -26px rgba(0, 0, 0, 0.80);
+}


### PR DESCRIPTION
## What this is

The founder-owned, in-session web UI design direction for Epic #2344's
**design-system deliverable**, now **complete**. Per the epic, look-and-feel is
decided by the founder in-session and frozen into the repo — this PR is that
capture, not agent-originated design. (Opened as a checkpoint; finalized once
the login and fleet-overview screens landed.)

## What's captured

- **`docs/design/web-ui-design-system.md`** — the **warm-terminal identity**
  derived from and amplifying the public style guide: warm grounds + warm taupe
  text, colour-is-information (state owns the palette), slate-blue accent
  reserved for interaction, mono for all machine data. Plus the Lean Six Sigma
  working principle, the **case model + two intake modes** (email /
  prepared-evidence vs live-call / chat), component patterns, a **§5 Screens**
  section (login, app shell + fleet overview, cockpit), direction provenance,
  and remaining open items.
- **`docs/design/web-ui-design-tokens.css`** — machine-readable tokens for
  **both light and dark themes**, values lifted verbatim from `cfg.is/style-guide`.
- **`docs/design/mockups/`** — the reference screens, all brand-aligned, both
  themes, Desktop/Tablet/Mobile responsive:
  - **`login.html`** — terminal-framed auth: signin / loading / invalid /
    expired states + a **passkey/WebAuthn MFA seam** (designed now, built later;
    feeds ADR-015).
  - **`fleet-overview.html`** — app shell (tenant-scope switcher, search,
    notifications, user menu) + read-only fleet overview: live-filter search,
    sort, saved views, **selectable device-DNA columns**, scale-aware
    pagination, and a **row drill-in asset-DNA drawer** (view all device DNA per
    steward). Ready / Loading / Error / Empty states.
  - **`troubleshooting-cockpit.html`** — the chosen direction: case bar, dense
    ticket quick-reference, tabbed Investigation/Chat rail, evidence→cause→action
    canvas.
  - **`fleet-overview-generic-v0.html`** — superseded pre-brand dashboard, kept
    for provenance.

## Epic impact

This satisfies Epic #2344's design-system prerequisite: UI-visible stories may
now be decomposed and cite the design system in their acceptance criteria.
Epic #2344's scope + success criteria were updated in tandem to include the fleet
patterns these mockups fix (selectable DNA columns, live-filter/sort/saved-views,
scale-aware pagination, row drill-in to full asset DNA) and the app-shell chrome.

## How to review

Open any file in `docs/design/mockups/` in a browser — self-contained, no build.
Use the Desktop/Tablet/Mobile toggle and the Auto/Light/Dark toggle to review
both breakpoints and both themes from one file, including from a phone.

## Notes

- Docs/design assets only — no Go surface, no dependency changes.
- Open item recorded in the design doc: eventually **converge the app identity
  with the public-site style guide** into one source of truth ("good enough for
  now", 2026-07-03).
