### PR TITLE
hyperv/provision: stage launcher on linux cloud-init seed (fixes #2346 provisioning regression)

### DIFF
--- a/features/modules/hyperv/linux_profile.go
+++ b/features/modules/hyperv/linux_profile.go
@@ -163,11 +163,14 @@ const linuxCloudInitProfileName = "debian-cloudinit-base"
 // image (source.image). cloud-init auto-detects the CIDATA-labelled seed on
 // first boot — no kernel cmdline, no boot-media repack — and runs runcmd as root.
 //
-// The seed volume (built host-side) carries the steward binary (cfgms-steward)
-// and controller CA (controller-ca.crt) next to this user-data. runcmd copies the
-// binary off the vfat seed (which has no Unix exec bit), makes it executable, and
-// runs `cfgms-steward install --regtoken … --ca-cert … --fingerprint …`, which on
-// a live (non-chroot) system stages the binary, writes the CA + systemd unit
+// The seed volume (built host-side) carries the steward binary (cfgms-steward),
+// the launcher binary (cfgms-steward-launcher), and controller CA
+// (controller-ca.crt) next to this user-data. runcmd copies the binaries off the
+// vfat seed (which has no Unix exec bit), makes them executable, and runs
+// `cfgms-steward install --regtoken … --ca-cert … --fingerprint …`. On Linux that
+// install is launcher-managed and REQUIRES cfgms-steward-launcher next to the
+// steward binary (so the resulting steward is push-upgradeable); on
+// a live (non-chroot) system it stages the binary, writes the CA + systemd unit
 // (token baked in), and `systemctl enable --now` starts enrollment. The
 // controller URL is baked into the binary at build time (ldflags).
 //
@@ -187,6 +190,8 @@ runcmd:
   - [ mount, /dev/disk/by-label/CIDATA, /mnt/cidata ]
   - [ cp, /mnt/cidata/cfgms-steward, /opt/cfgms-steward ]
   - [ chmod, "0755", /opt/cfgms-steward ]
+  - [ cp, /mnt/cidata/cfgms-steward-launcher, /opt/cfgms-steward-launcher ]
+  - [ chmod, "0755", /opt/cfgms-steward-launcher ]
   - [ /opt/cfgms-steward, install, --regtoken, "{{ .EnrollToken }}", --ca-cert, /mnt/cidata/controller-ca.crt, --fingerprint, "{{ .CAFingerprint }}" ]
   - [ umount, /mnt/cidata ]
 `

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -95,10 +95,14 @@ type hypervModule struct {
 	// enrollCAFingerprint is the controller CA's SHA-256 for the guest's
 	// install-time TOFU; enrollStewardPath / enrollCAPath are host paths to the
 	// steward binary and CA cert staged onto the seed VHDX so the guest can
-	// self-install without guest network/installer infra.
+	// self-install without guest network/installer infra. enrollLauncherPath is
+	// the host path to the cfgms-steward-launcher binary, staged alongside the
+	// steward so the guest performs a launcher-managed (push-upgradeable) install
+	// — Linux `cfgms-steward install` requires the launcher next to it.
 	enrollToken         string
 	enrollCAFingerprint string
 	enrollStewardPath   string
+	enrollLauncherPath  string
 	enrollCAPath        string
 
 	// seedDir is a host-local directory for the ephemeral provisioning seed
@@ -265,6 +269,7 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.enrollToken, _ = configMap["enroll_token"].(string)
 	m.enrollCAFingerprint, _ = configMap["enroll_ca_fingerprint"].(string)
 	m.enrollStewardPath, _ = configMap["enroll_steward_path"].(string)
+	m.enrollLauncherPath, _ = configMap["enroll_launcher_path"].(string)
 	m.enrollCAPath, _ = configMap["enroll_ca_path"].(string)
 	m.seedDir, _ = configMap["seed_dir"].(string)
 

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -87,6 +87,8 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 				optArg(psArgs, "FileName2", "FileName2")+
 				optArg(psArgs, "Content2", "Content2")+
 				optArg(psArgs, "StewardDest", "StewardDest")+
+				optArg(psArgs, "LauncherSrc", "LauncherSrc")+
+				optArg(psArgs, "LauncherDest", "LauncherDest")+
 				" -StewardSrc "+quoteArg(psArgs, "StewardSrc")+
 				" -CASrc "+quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -510,7 +510,7 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psSetHddFirstBoot", psSetHddFirstBoot, map[string]string{"Name": "cfgms-t__web-01", "VHDPath": "C:\\VMs\\web-01.vhdx"}},
 		// cloud-init CIDATA seed reuses psMountSeedVHD/psCopyToSeedVHD with extra optional args
 		{"psMountSeedVHD/cidata", psMountSeedVHD, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx", "Label": "CIDATA"}},
-		{"psCopyToSeedVHD/cidata", psCopyToSeedVHD, map[string]string{"SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx", "Label": "CIDATA", "FileName": "user-data", "Content": "#cloud-config", "FileName2": "meta-data", "Content2": "instance-id: x", "StewardSrc": "C:\\s\\cfgms-steward-linux", "StewardDest": "cfgms-steward", "CASrc": "C:\\s\\ca.crt"}},
+		{"psCopyToSeedVHD/cidata", psCopyToSeedVHD, map[string]string{"SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx", "Label": "CIDATA", "FileName": "user-data", "Content": "#cloud-config", "FileName2": "meta-data", "Content2": "instance-id: x", "StewardSrc": "C:\\s\\cfgms-steward-linux", "StewardDest": "cfgms-steward", "LauncherSrc": "C:\\s\\cfgms-steward-launcher-linux", "LauncherDest": "cfgms-steward-launcher", "CASrc": "C:\\s\\ca.crt"}},
 		// VSwitch verbs (vswitch.go)
 		{"psGetVSwitch", psGetVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},
 		{"psRemoveVSwitch", psRemoveVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -244,6 +244,8 @@ function Cfgms-CopyToSeedVHD {
         [string]$Content2 = '',
         [string]$StewardSrc = '',
         [string]$StewardDest = 'cfgms-steward.exe',
+        [string]$LauncherSrc = '',
+        [string]$LauncherDest = 'cfgms-steward-launcher',
         [string]$CASrc = ''
     )
     $disk = Mount-VHD -Path $SeedPath -Passthru
@@ -253,6 +255,7 @@ function Cfgms-CopyToSeedVHD {
     Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline
     if ($FileName2) { Set-Content -Path ($letter + ':\' + $FileName2) -Value $Content2 -NoNewline }
     if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\' + $StewardDest) -Force }
+    if ($LauncherSrc -and (Test-Path -LiteralPath $LauncherSrc)) { Copy-Item -LiteralPath $LauncherSrc -Destination ($letter + ':\' + $LauncherDest) -Force }
     if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }
     Cfgms-DismountAndVerify -Path $SeedPath
 }

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -60,7 +60,7 @@ const (
 	// travel via ArgumentList; empty optional params fall back to their defaults.
 	// WinRM-transport variant of the preamble's Cfgms-CopyToSeedVHD — same parameter
 	// contract; the preamble adds the verify-dismount hardening (see psMountSeedVHD).
-	psCopyToSeedVHD = `$disk = Mount-VHD -Path $SeedPath -Passthru; $label = $(if ($Label) { $Label } else { 'CFGMS_SEED' }); $letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq $label } | Select-Object -First 1).DriveLetter; Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline; if ($FileName2) { Set-Content -Path ($letter + ':\' + $FileName2) -Value $Content2 -NoNewline }; if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\' + $(if ($StewardDest) { $StewardDest } else { 'cfgms-steward.exe' })) -Force }; if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }; Dismount-VHD -Path $SeedPath`
+	psCopyToSeedVHD = `$disk = Mount-VHD -Path $SeedPath -Passthru; $label = $(if ($Label) { $Label } else { 'CFGMS_SEED' }); $letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq $label } | Select-Object -First 1).DriveLetter; Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline; if ($FileName2) { Set-Content -Path ($letter + ':\' + $FileName2) -Value $Content2 -NoNewline }; if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\' + $(if ($StewardDest) { $StewardDest } else { 'cfgms-steward.exe' })) -Force }; if ($LauncherSrc -and (Test-Path -LiteralPath $LauncherSrc)) { Copy-Item -LiteralPath $LauncherSrc -Destination ($letter + ':\' + $(if ($LauncherDest) { $LauncherDest } else { 'cfgms-steward-launcher' })) -Force }; if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }; Dismount-VHD -Path $SeedPath`
 
 	// psDetachSeedVHD wraps Dismount-VHD (called at finalizing, not in the
 	// create path this story implements).
@@ -580,15 +580,17 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, nil)
 	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
-		"SeedPath":    seedPath,
-		"Label":       cidataVolumeLabel,
-		"FileName":    "user-data",
-		"Content":     userData,
-		"FileName2":   "meta-data",
-		"Content2":    metaData,
-		"StewardSrc":  m.enrollStewardPath,
-		"StewardDest": "cfgms-steward",
-		"CASrc":       m.enrollCAPath,
+		"SeedPath":     seedPath,
+		"Label":        cidataVolumeLabel,
+		"FileName":     "user-data",
+		"Content":      userData,
+		"FileName2":    "meta-data",
+		"Content2":     metaData,
+		"StewardSrc":   m.enrollStewardPath,
+		"StewardDest":  "cfgms-steward",
+		"LauncherSrc":  m.enrollLauncherPath,
+		"LauncherDest": "cfgms-steward-launcher",
+		"CASrc":        m.enrollCAPath,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write cloud-init seed for VM %q: %w", vmName, psErr))

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -381,8 +381,10 @@ func cloudInitVMConfigMap(generation int) map[string]interface{} {
 func TestProvisionVM_CloudInitPath(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
 	m := provisionModuleWithTransport(transport)
-	// The linux steward binary + CA host paths the seed stages (ADR-010).
+	// The linux steward + launcher binaries + CA host paths the seed stages (ADR-010).
+	// The launcher is required for a launcher-managed (push-upgradeable) install.
 	m.enrollStewardPath = `C:\seed-assets\cfgms-steward-linux`
+	m.enrollLauncherPath = `C:\seed-assets\cfgms-steward-launcher-linux`
 	m.enrollCAPath = `C:\seed-assets\controller-ca.crt`
 
 	cfg := rawConfigState{m: cloudInitVMConfigMap(2)}
@@ -411,6 +413,8 @@ func TestProvisionVM_CloudInitPath(t *testing.T) {
 	assert.True(t, argsContain(copyCall, "user-data"), "seed carries user-data")
 	assert.True(t, argsContain(copyCall, "meta-data"), "seed carries meta-data")
 	assert.True(t, argsContain(copyCall, "cfgms-steward"), "seed stages the linux steward (dest cfgms-steward)")
+	assert.True(t, argsContain(copyCall, "cfgms-steward-launcher"),
+		"seed stages the launcher so the guest performs a launcher-managed (push-upgradeable) install")
 
 	// OS disk made first boot; no installer media; no keypress.
 	require.Len(t, callsContaining(calls, "Cfgms-SetHddFirstBoot"), 1,
@@ -471,6 +475,7 @@ func TestProvision_CloudInitUserDataRenderedToSeed(t *testing.T) {
 	require.NotEmpty(t, userData, "rendered cloud-config user-data must be present in the copy args")
 	assert.Contains(t, userData, "runcmd", "user-data must carry runcmd")
 	assert.Contains(t, userData, "cfgms-steward", "user-data must install the steward")
+	assert.Contains(t, userData, "/opt/cfgms-steward-launcher", "user-data must stage the launcher for a launcher-managed install")
 	assert.Contains(t, userData, "install", "user-data must run the steward install command")
 	assert.Contains(t, userData, "reg-token-stub-value", "controller-supplied token must be rendered into user-data")
 	assert.Contains(t, userData, "abc123fingerprint", "CA fingerprint must be rendered into user-data")


### PR DESCRIPTION
## Problem
#2346 made `cfgms-steward install` on Linux **require** the launcher next to the steward binary (launcher-managed = push-upgradeable). But the hyperv cloud-init seed only stages `cfgms-steward`, so a **new Linux VM provisioned via the hyperv module would now fail at install** ("launcher binary not found"). Discovered while planning the deb-ci-02 rebuild.

## Change
- New module config `enroll_launcher_path` (host path to `cfgms-steward-launcher`), staged onto the CIDATA seed as `cfgms-steward-launcher`.
- `Cfgms-CopyToSeedVHD` preamble + WinRM const + dispatch gain optional `LauncherSrc`/`LauncherDest` (mirrors `StewardSrc`/`StewardDest`).
- cloud-init `runcmd` copies the launcher to `/opt/cfgms-steward-launcher` (next to `/opt/cfgms-steward`) + `chmod` before `cfgms-steward install`, so the resulting steward is **launcher-managed and push-upgradeable** via `cfg steward upgrade`.

## Tests
`TestProvisionVM_CloudInitPath` asserts the launcher is staged onto the seed; the user-data test asserts the runcmd stages `/opt/cfgms-steward-launcher`; the dispatch roundtrip covers the launcher args. Full `features/modules/hyperv` package green; `check-architecture` clean; `GOOS=windows` vet + `GOOS=linux` build clean. No new cmdlet (Copy-Item already in the module envelope) → no ADR-006 re-sign needed.

Completes the launcher-managed install story (deficiency #2 under epic #2257) for provisioned Linux VMs — prerequisite for the deb-ci-02 tear-down/rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)