### PR TITLE
config: json tags on steward-settings structs so cfg config show round-trips

### DIFF
--- a/features/config/stewardtypes/json_roundtrip_test.go
+++ b/features/config/stewardtypes/json_roundtrip_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package stewardtypes
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStewardConfig_JSONKeysAreSnakeCase guards against the round-trip regression
+// where StewardSettings (and its nested config structs) carried yaml tags but no
+// json tags — so json.Marshal (what `cfg config show` uses) fell back to Go field
+// names and leaked PascalCase (e.g. "ConvergeInterval") to the wire, while
+// `cfg config upload` parses snake_case yaml ("converge_interval"). The two must
+// use the same wire keys so a config round-trips: show -> edit -> upload.
+func TestStewardConfig_JSONKeysAreSnakeCase(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:                          "steward-1",
+			Mode:                        ModeController,
+			ModulePaths:                 []string{"/opt/cfgms/modules"},
+			Logging:                     LoggingConfig{Level: "info", Format: "json"},
+			ErrorHandling:               ErrorHandlingConfig{ModuleLoadFailure: ActionWarn, ResourceFailure: ActionFail, ConfigurationError: ActionFail},
+			Secrets:                     SecretsConfig{SecretsDir: "/var/lib/cfgms/secrets", Provider: "sops"},
+			ConvergeInterval:            "30m",
+			ScriptSigning:               ScriptSigningConfig{Policy: ScriptSigningPolicyRequired, TrustMode: TrustModeTrustedKeys, TrustedKeys: []TrustedKeyRef{{Name: "k1", Thumbprint: "ab", PublicKeyRef: "ref"}}, AllowPublicCA: true, RequireSignedAdhoc: true},
+			ModuleTrust:                 ModuleTrustConfig{Mode: ModuleTrustModeStrict, AdditionalPublishers: []string{"acme"}},
+			SignedCommandReplayWindow:   5 * time.Minute,
+			SignedCommandMaxParamsBytes: 4096,
+			DriftMode:                   DriftModeApply,
+			Upgrade:                     UpgradeConfig{DesiredVersion: "v0.9.7"},
+			RegistrationPollTimeout:     time.Hour,
+			DNARefreshInterval:          "30m",
+		},
+		Resources: []ResourceConfig{{Name: "r1", Module: "file", Config: map[string]interface{}{"path": "/tmp/x"}}},
+	}
+
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+
+	// Every leaf field must serialise under its snake_case key.
+	wantKeys := []string{
+		`"id"`, `"mode"`, `"module_paths"`, `"logging"`, `"level"`, `"format"`,
+		`"error_handling"`, `"module_load_failure"`, `"resource_failure"`, `"configuration_error"`,
+		`"secrets"`, `"secrets_dir"`, `"provider"`, `"converge_interval"`,
+		`"script_signing"`, `"policy"`, `"trust_mode"`, `"trusted_keys"`, `"public_key_ref"`,
+		`"allow_public_ca"`, `"require_signed_adhoc"`, `"module_trust"`, `"additional_publishers"`,
+		`"signed_command_replay_window"`, `"signed_command_max_params_bytes"`, `"drift_mode"`,
+		`"upgrade"`, `"desired_version"`, `"registration_poll_timeout"`, `"dna_refresh_interval"`,
+	}
+	for _, k := range wantKeys {
+		if !strings.Contains(got, k) {
+			t.Errorf("JSON output missing snake_case key %s\ngot: %s", k, got)
+		}
+	}
+
+	// No Go field name (PascalCase) may leak into the JSON keys.
+	leaked := []string{
+		`"ConvergeInterval"`, `"DriftMode"`, `"Mode"`, `"ModulePaths"`, `"ErrorHandling"`,
+		`"ModuleLoadFailure"`, `"ResourceFailure"`, `"ConfigurationError"`, `"ScriptSigning"`,
+		`"ModuleTrust"`, `"SecretsDir"`, `"DesiredVersion"`, `"RegistrationPollTimeout"`,
+		`"DNARefreshInterval"`, `"AllowPublicCA"`, `"TrustMode"`, `"PublicKeyRef"`,
+	}
+	for _, k := range leaked {
+		if strings.Contains(got, k) {
+			t.Errorf("JSON output leaked PascalCase Go field name %s (missing json tag)\ngot: %s", k, got)
+		}
+	}
+}

--- a/features/config/stewardtypes/types.go
+++ b/features/config/stewardtypes/types.go
@@ -20,46 +20,46 @@ type StewardConfig struct {
 
 // StewardSettings contains steward-specific configuration options.
 type StewardSettings struct {
-	ID          string        `yaml:"id"`
-	Mode        OperationMode `yaml:"mode"`
-	ModulePaths []string      `yaml:"module_paths,omitempty"`
-	Logging     LoggingConfig `yaml:"logging"`
+	ID          string        `yaml:"id" json:"id"`
+	Mode        OperationMode `yaml:"mode" json:"mode"`
+	ModulePaths []string      `yaml:"module_paths,omitempty" json:"module_paths,omitempty"`
+	Logging     LoggingConfig `yaml:"logging" json:"logging"`
 
-	ErrorHandling ErrorHandlingConfig `yaml:"error_handling"`
-	Secrets       SecretsConfig       `yaml:"secrets,omitempty"`
+	ErrorHandling ErrorHandlingConfig `yaml:"error_handling" json:"error_handling"`
+	Secrets       SecretsConfig       `yaml:"secrets,omitempty" json:"secrets,omitempty"`
 
 	// ConvergeInterval is how often the steward re-converges (e.g. "30m").
-	ConvergeInterval string `yaml:"converge_interval,omitempty"`
+	ConvergeInterval string `yaml:"converge_interval,omitempty" json:"converge_interval,omitempty"`
 
 	// ScriptSigning configures script signing policy and trusted keys.
 	// Child tenants may only tighten (not loosen) the inherited policy.
-	ScriptSigning ScriptSigningConfig `yaml:"script_signing,omitempty"`
+	ScriptSigning ScriptSigningConfig `yaml:"script_signing,omitempty" json:"script_signing,omitempty"`
 
 	// ModuleTrust configures module trust policy and additional trusted publishers.
-	ModuleTrust ModuleTrustConfig `yaml:"module_trust,omitempty"`
+	ModuleTrust ModuleTrustConfig `yaml:"module_trust,omitempty" json:"module_trust,omitempty"`
 
 	// SignedCommandReplayWindow is the maximum age of an accepted command timestamp.
-	SignedCommandReplayWindow time.Duration `yaml:"signed_command_replay_window,omitempty"`
+	SignedCommandReplayWindow time.Duration `yaml:"signed_command_replay_window,omitempty" json:"signed_command_replay_window,omitempty"`
 
 	// SignedCommandMaxParamsBytes is the maximum JSON-serialized size of Command.Params.
-	SignedCommandMaxParamsBytes int `yaml:"signed_command_max_params_bytes,omitempty"`
+	SignedCommandMaxParamsBytes int `yaml:"signed_command_max_params_bytes,omitempty" json:"signed_command_max_params_bytes,omitempty"`
 
 	// DriftMode controls how the steward responds to detected configuration drift.
 	// Must be sourced exclusively from the controller-delivered cfg.
-	DriftMode DriftMode `yaml:"drift_mode,omitempty"`
+	DriftMode DriftMode `yaml:"drift_mode,omitempty" json:"drift_mode,omitempty"`
 
 	// Upgrade configures the steward upgrade policy. (Issue #1943)
-	Upgrade UpgradeConfig `yaml:"upgrade,omitempty"`
+	Upgrade UpgradeConfig `yaml:"upgrade,omitempty" json:"upgrade,omitempty"`
 
 	// RegistrationPollTimeout is the maximum time to wait for manual registration
 	// approval when the controller uses registration.workflow: manual (Issue #1899).
 	// Default is 24h. Set to 0 to use the default.
-	RegistrationPollTimeout time.Duration `yaml:"registration_poll_timeout,omitempty"`
+	RegistrationPollTimeout time.Duration `yaml:"registration_poll_timeout,omitempty" json:"registration_poll_timeout,omitempty"`
 
 	// DNARefreshInterval is how often the steward re-collects and publishes DNA
 	// attribute deltas while connected to the controller (Issue #1915).
 	// Accepts Go duration strings (e.g. "30m", "1h"). Default: 30m.
-	DNARefreshInterval string `yaml:"dna_refresh_interval,omitempty"`
+	DNARefreshInterval string `yaml:"dna_refresh_interval,omitempty" json:"dna_refresh_interval,omitempty"`
 }
 
 // UpgradeConfig holds upgrade-related steward policy settings. (Issue #1943)
@@ -78,8 +78,8 @@ type UpgradeConfig struct {
 
 // SecretsConfig defines configuration for steward-side secret storage.
 type SecretsConfig struct {
-	SecretsDir string `yaml:"secrets_dir,omitempty"`
-	Provider   string `yaml:"provider,omitempty"`
+	SecretsDir string `yaml:"secrets_dir,omitempty" json:"secrets_dir,omitempty"`
+	Provider   string `yaml:"provider,omitempty" json:"provider,omitempty"`
 }
 
 // ScriptSigningPolicy defines the enforcement level for script signatures.
@@ -102,9 +102,9 @@ const (
 
 // TrustedKeyRef identifies a trusted signing key by name, thumbprint, or key reference.
 type TrustedKeyRef struct {
-	Name         string `yaml:"name"`
-	Thumbprint   string `yaml:"thumbprint,omitempty"`
-	PublicKeyRef string `yaml:"public_key_ref,omitempty"`
+	Name         string `yaml:"name" json:"name"`
+	Thumbprint   string `yaml:"thumbprint,omitempty" json:"thumbprint,omitempty"`
+	PublicKeyRef string `yaml:"public_key_ref,omitempty" json:"public_key_ref,omitempty"`
 }
 
 // ScriptSigningConfig defines the steward-level script signing policy.
@@ -112,14 +112,14 @@ type TrustedKeyRef struct {
 // Child tenants inherit parent config via MergeScriptSigningConfig and may only
 // tighten policy (none→optional→required), never loosen it.
 type ScriptSigningConfig struct {
-	Policy        ScriptSigningPolicy `yaml:"policy,omitempty"`
-	TrustMode     ScriptTrustMode     `yaml:"trust_mode,omitempty"`
-	TrustedKeys   []TrustedKeyRef     `yaml:"trusted_keys,omitempty"`
-	AllowPublicCA bool                `yaml:"allow_public_ca,omitempty"`
+	Policy        ScriptSigningPolicy `yaml:"policy,omitempty" json:"policy,omitempty"`
+	TrustMode     ScriptTrustMode     `yaml:"trust_mode,omitempty" json:"trust_mode,omitempty"`
+	TrustedKeys   []TrustedKeyRef     `yaml:"trusted_keys,omitempty" json:"trusted_keys,omitempty"`
+	AllowPublicCA bool                `yaml:"allow_public_ca,omitempty" json:"allow_public_ca,omitempty"`
 
 	// RequireSignedAdhoc requires a valid signature on all ad-hoc script commands.
 	// Incompatible with policy: none.
-	RequireSignedAdhoc bool `yaml:"require_signed_adhoc,omitempty"`
+	RequireSignedAdhoc bool `yaml:"require_signed_adhoc,omitempty" json:"require_signed_adhoc,omitempty"`
 }
 
 // ResourceConfig defines a single resource to be managed by the steward.
@@ -148,15 +148,15 @@ const (
 
 // LoggingConfig defines logging output settings.
 type LoggingConfig struct {
-	Level  string `yaml:"level"`
-	Format string `yaml:"format"`
+	Level  string `yaml:"level" json:"level"`
+	Format string `yaml:"format" json:"format"`
 }
 
 // ErrorHandlingConfig defines how to handle various error conditions.
 type ErrorHandlingConfig struct {
-	ModuleLoadFailure  ErrorAction `yaml:"module_load_failure"`
-	ResourceFailure    ErrorAction `yaml:"resource_failure"`
-	ConfigurationError ErrorAction `yaml:"configuration_error"`
+	ModuleLoadFailure  ErrorAction `yaml:"module_load_failure" json:"module_load_failure"`
+	ResourceFailure    ErrorAction `yaml:"resource_failure" json:"resource_failure"`
+	ConfigurationError ErrorAction `yaml:"configuration_error" json:"configuration_error"`
 }
 
 // ErrorAction defines the available error handling strategies.


### PR DESCRIPTION
## Problem
`cfg config show` renders JSON, but `StewardSettings` + its nested structs (`LoggingConfig`, `ErrorHandlingConfig`, `SecretsConfig`, `ScriptSigningConfig`, `TrustedKeyRef`) had `yaml:` tags but **no `json:` tags**. `json.Marshal` fell back to Go field names → leaked PascalCase (`ConvergeInterval`, `DriftMode`, `ModuleLoadFailure`, …), while `cfg config upload` + storage use snake_case YAML (`converge_interval`). So `cfg config show` output was **not re-uploadable** — the show → edit → upload round-trip broke. (Surfaced while editing a live hyperv VM config.)

## Fix
Add matching `json:"snake_case"` tags to every affected field. **Storage + upload are unaffected** — both use `yaml.Marshal`/`Unmarshal`; this only fixes the JSON display path so its keys match the YAML wire format.

## Test
`TestStewardConfig_JSONKeysAreSnakeCase` asserts all expected snake_case keys are present and no PascalCase Go field name leaks. Package green; `features/config/...`, `features/controller/...`, `cmd/cfg/...` build clean; `check-architecture` clean.

Aligns with the new [Casing Conventions](docs/development/standards/casing-conventions.md) doc (#2351). Deficiency story filed under epic #2257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)