### PR TITLE
hyperv/provision: optional debug_ssh_authorized_key for diagnosing failed enrollment

### DIFF
--- a/features/modules/hyperv/cloudinit_debugssh_test.go
+++ b/features/modules/hyperv/cloudinit_debugssh_test.go
@@ -40,3 +40,20 @@ func TestLinuxCloudInit_DebugSSHKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, string(out2), "ssh_authorized_keys", "no debug SSH access unless explicitly configured")
 }
+
+// TestLinuxCloudInit_InstallUsesControllerCAFlag guards against the flag-name drift
+// that silently broke enrollment: the cloud-init install line must invoke
+// `cfgms-steward install ... --controller-ca ...` (the actual flag registered by
+// the steward install command), NOT the non-existent `--ca-cert`, which aborts the
+// install at flag parsing ("unknown flag: --ca-cert") so the steward never installs.
+func TestLinuxCloudInit_InstallUsesControllerCAFlag(t *testing.T) {
+	profile := defaultLinuxCloudInitProfile()
+	out, err := NewProfileRenderer().Render(context.Background(), profile, ProfileVars{
+		VMName: "stw-lin-01", OSFamily: "linux", CorrelationID: "corr-1",
+		EnrollToken: "tok", CAFingerprint: "abcd", BundleURL: profile.Enroll.BundleURL,
+	}, preseedTestStore())
+	require.NoError(t, err)
+	rendered := string(out)
+	assert.Contains(t, rendered, "--controller-ca", "install must use the real --controller-ca flag")
+	assert.NotContains(t, rendered, "--ca-cert", "the steward install command has no --ca-cert flag (aborts enrollment)")
+}

--- a/features/modules/hyperv/cloudinit_debugssh_test.go
+++ b/features/modules/hyperv/cloudinit_debugssh_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinuxCloudInit_DebugSSHKey verifies the optional operator debug SSH public
+// key is threaded into the cloud-init user-data as an ssh_authorized_keys entry
+// when set, and is entirely absent (production default) when unset.
+func TestLinuxCloudInit_DebugSSHKey(t *testing.T) {
+	profile := defaultLinuxCloudInitProfile()
+	const key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAADEBUGKEY operator@lab"
+
+	base := ProfileVars{
+		VMName:        "stw-lin-01",
+		OSFamily:      "linux",
+		CorrelationID: "stw-corr-1",
+		EnrollToken:   "tok",
+		CAFingerprint: "abcd",
+		BundleURL:     profile.Enroll.BundleURL,
+	}
+
+	// Debug key set → cloud-init adds it to the guest's authorized_keys.
+	withKey := base
+	withKey.DebugSSHKey = key
+	out, err := NewProfileRenderer().Render(context.Background(), profile, withKey, preseedTestStore())
+	require.NoError(t, err)
+	rendered := string(out)
+	assert.Contains(t, rendered, "ssh_authorized_keys:", "cloud-init must carry ssh_authorized_keys when a debug key is set")
+	assert.Contains(t, rendered, key, "the operator's public key must appear verbatim")
+
+	// Unset → no ssh_authorized_keys directive at all (secure default).
+	out2, err := NewProfileRenderer().Render(context.Background(), profile, base, preseedTestStore())
+	require.NoError(t, err)
+	assert.NotContains(t, string(out2), "ssh_authorized_keys", "no debug SSH access unless explicitly configured")
+}

--- a/features/modules/hyperv/linux_profile.go
+++ b/features/modules/hyperv/linux_profile.go
@@ -185,6 +185,14 @@ const cloudInitUserDataTemplate = `#cloud-config
 # CFGMS Linux VM-from-cloud-image enrollment (NoCloud datasource).
 # Rendered for VM {{ .VMName }} (correlation {{ .CorrelationID }}).
 hostname: {{ .CorrelationID }}
+{{- if .DebugSSHKey }}
+# Optional operator debug access (hyperv config: debug_ssh_authorized_key).
+# The value is an SSH PUBLIC key — not a secret. cloud-init adds it to the
+# cloud image's default user so an operator can log in and diagnose a failed
+# enrollment. Omit debug_ssh_authorized_key in production to disable.
+ssh_authorized_keys:
+  - {{ .DebugSSHKey }}
+{{- end }}
 runcmd:
   - [ mkdir, -p, /mnt/cidata ]
   - [ mount, /dev/disk/by-label/CIDATA, /mnt/cidata ]

--- a/features/modules/hyperv/linux_profile.go
+++ b/features/modules/hyperv/linux_profile.go
@@ -167,7 +167,7 @@ const linuxCloudInitProfileName = "debian-cloudinit-base"
 // the launcher binary (cfgms-steward-launcher), and controller CA
 // (controller-ca.crt) next to this user-data. runcmd copies the binaries off the
 // vfat seed (which has no Unix exec bit), makes them executable, and runs
-// `cfgms-steward install --regtoken … --ca-cert … --fingerprint …`. On Linux that
+// `cfgms-steward install --regtoken … --controller-ca … --fingerprint …`. On Linux that
 // install is launcher-managed and REQUIRES cfgms-steward-launcher next to the
 // steward binary (so the resulting steward is push-upgradeable); on
 // a live (non-chroot) system it stages the binary, writes the CA + systemd unit
@@ -200,7 +200,7 @@ runcmd:
   - [ chmod, "0755", /opt/cfgms-steward ]
   - [ cp, /mnt/cidata/cfgms-steward-launcher, /opt/cfgms-steward-launcher ]
   - [ chmod, "0755", /opt/cfgms-steward-launcher ]
-  - [ /opt/cfgms-steward, install, --regtoken, "{{ .EnrollToken }}", --ca-cert, /mnt/cidata/controller-ca.crt, --fingerprint, "{{ .CAFingerprint }}" ]
+  - [ /opt/cfgms-steward, install, --regtoken, "{{ .EnrollToken }}", --controller-ca, /mnt/cidata/controller-ca.crt, --fingerprint, "{{ .CAFingerprint }}" ]
   - [ umount, /mnt/cidata ]
 `
 

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -105,6 +105,12 @@ type hypervModule struct {
 	enrollLauncherPath  string
 	enrollCAPath        string
 
+	// debugSSHAuthorizedKey is an optional SSH PUBLIC key added to a provisioned
+	// Linux guest's authorized_keys so operators can log in to diagnose a failed
+	// enrollment. Empty = disabled (production default). A public key is not a
+	// secret. From config key "debug_ssh_authorized_key".
+	debugSSHAuthorizedKey string
+
 	// seedDir is a host-local directory for the ephemeral provisioning seed
 	// VHDX. It MUST NOT be on a Cluster Shared Volume (C:\ClusterStorage\...):
 	// Mount-VHD against a CSV-resident VHDX hangs on a cluster node. When empty
@@ -271,6 +277,7 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.enrollStewardPath, _ = configMap["enroll_steward_path"].(string)
 	m.enrollLauncherPath, _ = configMap["enroll_launcher_path"].(string)
 	m.enrollCAPath, _ = configMap["enroll_ca_path"].(string)
+	m.debugSSHAuthorizedKey, _ = configMap["debug_ssh_authorized_key"].(string)
 	m.seedDir, _ = configMap["seed_dir"].(string)
 
 	// Failover-cluster scope cap (S5). cluster_name bounds which cluster this

--- a/features/modules/hyperv/profile.go
+++ b/features/modules/hyperv/profile.go
@@ -169,6 +169,12 @@ type ProfileVars struct {
 	// enrollment). It is never persisted or surfaced; the steward manages the
 	// host after enrollment. Empty for non-Windows profiles.
 	AdminPassword string
+	// DebugSSHKey is an optional SSH PUBLIC key added to the provisioned guest's
+	// authorized_keys (Linux cloud-init) so an operator can log in to diagnose a
+	// failed enrollment. A public key is not a secret; the matching private key
+	// never leaves the operator. Empty disables it (production default). Sourced
+	// from the hyperv module's debug_ssh_authorized_key config.
+	DebugSSHKey string
 }
 
 // ProfileRenderer renders an UnattendProfile's template into answer-file bytes,
@@ -235,6 +241,7 @@ func (r *ProfileRenderer) Render(ctx context.Context, profile *UnattendProfile, 
 		BundleURL      string
 		CAFingerprint  string
 		AdminPassword  string
+		DebugSSHKey    string
 	}{
 		VMName:         vars.VMName,
 		OSFamily:       vars.OSFamily,
@@ -244,6 +251,7 @@ func (r *ProfileRenderer) Render(ctx context.Context, profile *UnattendProfile, 
 		BundleURL:      vars.BundleURL,
 		CAFingerprint:  vars.CAFingerprint,
 		AdminPassword:  vars.AdminPassword,
+		DebugSSHKey:    vars.DebugSSHKey,
 	}
 
 	var buf bytes.Buffer

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -229,6 +229,8 @@ func (m *hypervModule) renderSeedAnswerFile(ctx context.Context, vmName string, 
 		// (operator-unwritable) SecretStore for the token (#2077 fix).
 		EnrollToken:   m.enrollToken,
 		CAFingerprint: m.enrollCAFingerprint,
+		// Optional operator-provided debug SSH public key (diagnose failed enroll).
+		DebugSSHKey: m.debugSSHAuthorizedKey,
 	}
 	// A per-VM random password is generated for both families: Windows uses it
 	// for the one-shot AutoLogon that runs enrollment; Linux uses it for the


### PR DESCRIPTION
## Problem
A provisioned Linux VM whose steward install/enroll fails is undiagnosable — the provisioning cloud-init bakes in no SSH key, so a keyless guest rejects all logins and there's no way to read `cloud-init-output.log`. Surfaced when deb-ci-02's launcher-managed rebuild booted + networked but never enrolled, with no way inside.

## Change
Optional operator-provided debug SSH access:
- new hyperv module config **`debug_ssh_authorized_key`** — a **public** key (not a secret; the matching private key stays with the operator). Empty = disabled (production default).
- threaded `ProfileVars.DebugSSHKey` → the Linux cloud-init template renders an `ssh_authorized_keys` entry **only when set**.

## Test
`TestLinuxCloudInit_DebugSSHKey` asserts the key appears verbatim when configured and `ssh_authorized_keys` is entirely absent when not. Full `features/modules/hyperv` package green; `check-architecture` clean; `GOOS=windows`/`linux` build clean.

Debuggability fix for headless provisioning (epic #2257). Note: only a public key lives in config — no secret-storage concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)