### PR TITLE
tooling: po-live session lifecycle — resume/continue reattach + fresh sessions reset to clean develop

### DIFF
--- a/.claude/commands/po-live.md
+++ b/.claude/commands/po-live.md
@@ -32,7 +32,7 @@ Inspect the exit code:
 
 Confirm to the founder:
 - Container name `cfg-agent-live-po`
-- Initial prompt: `/po $ARGUMENTS` (or just `/po` if no args)
+- Session: a fresh session seeds `/po $ARGUMENTS` (or `/po` with no args); `--continue` / `--resume [<id>]` instead reattach to an existing session (no `/po` prompt is sent)
 - Workspace: `worktrees/po-live` (shared across PO live sessions)
 - Resume later: relaunch with `/po-live --resume` (most recent) or `/po-live --resume <session-id>`; the session transcript persists on the host-mounted `~/.claude`. See [Resuming a previous session](#resuming-a-previous-session).
 

--- a/.claude/commands/po-live.md
+++ b/.claude/commands/po-live.md
@@ -3,7 +3,7 @@ name: po-live
 description: PO Live — launch a Product Owner session in a docker container in a new tmux pane, pre-seeded with /po <args>
 parameters:
   - name: subcommand
-    description: "Args to pass to /po inside the live container (e.g., 'intent certificate rotation', 'next', 'status')"
+    description: "Args to pass to /po inside the live container (e.g., 'intent certificate rotation', 'next', 'status'), or '--resume [session-id]' to reattach to a past session"
     required: false
 ---
 
@@ -34,7 +34,7 @@ Confirm to the founder:
 - Container name `cfg-agent-live-po`
 - Initial prompt: `/po $ARGUMENTS` (or just `/po` if no args)
 - Workspace: `worktrees/po-live` (shared across PO live sessions)
-- Resume later: `claude --continue` inside the container, or `claude --resume <session-id>` from any host (sessions are mounted via `~/.claude`)
+- Resume later: relaunch with `/po-live --resume` (most recent) or `/po-live --resume <session-id>`; the session transcript persists on the host-mounted `~/.claude`. See [Resuming a previous session](#resuming-a-previous-session).
 
 ### Exit 1 with stderr message "po-live requires an interactive tmux session"
 
@@ -75,6 +75,26 @@ Surface the script's stderr to the founder verbatim and stop. Don't auto-fall-ba
 - `/po-live next` — opens a new pane and asks PO for the single highest-leverage next action
 - `/po-live` (no args) — opens a new pane at the PO dashboard
 - `/po-live unblock #501` — opens a new pane to handle a targeted unblock conversation
+- `/po-live --resume` — opens a new pane and **reattaches to the most recent** PO session in the workspace (instead of seeding a fresh `/po`)
+- `/po-live --resume 79f06f1d-6d1c-4001-afeb-0618432d81a8` — reattaches to that **specific** session by id
+
+## Resuming a previous session
+
+`po-live --resume` reattaches to an existing Claude conversation in the shared
+`worktrees/po-live` clone instead of starting a fresh `/po`. This is how you pick
+up after closing the pane, a reboot, or a power loss — the container is
+ephemeral (`--rm`) but the session transcript lives on the host-mounted
+`~/.claude`, so it survives.
+
+- **`--resume <session-id>`** → runs `claude --resume <session-id>` in the
+  container: resumes that exact conversation.
+- **`--resume`** (bare) → runs `claude --continue`: resumes the most recent
+  session for the workspace.
+
+To find a session id, look under `~/.claude/projects/-workspace/` on the host
+(the container runs Claude at `/workspace`), or use bare `--resume` to grab the
+latest. The workspace clone is reused as-is (same branch, same uncommitted
+files) — see [Cleaning up](#cleaning-up).
 
 ## Behavior inside the live container
 

--- a/.claude/commands/po-live.md
+++ b/.claude/commands/po-live.md
@@ -3,7 +3,7 @@ name: po-live
 description: PO Live — launch a Product Owner session in a docker container in a new tmux pane, pre-seeded with /po <args>
 parameters:
   - name: subcommand
-    description: "Args to pass to /po inside the live container (e.g., 'intent certificate rotation', 'next', 'status'), or '--resume [session-id]' to reattach to a past session"
+    description: "Args to pass to /po inside the live container (e.g., 'intent certificate rotation', 'next', 'status'), or '--continue' / '--resume [session-id]' to reattach to a past session"
     required: false
 ---
 
@@ -75,21 +75,23 @@ Surface the script's stderr to the founder verbatim and stop. Don't auto-fall-ba
 - `/po-live next` — opens a new pane and asks PO for the single highest-leverage next action
 - `/po-live` (no args) — opens a new pane at the PO dashboard
 - `/po-live unblock #501` — opens a new pane to handle a targeted unblock conversation
-- `/po-live --resume` — opens a new pane and **reattaches to the most recent** PO session in the workspace (instead of seeding a fresh `/po`)
+- `/po-live --continue` — opens a new pane and **continues the most recent** PO session in the workspace (instead of seeding a fresh `/po`)
 - `/po-live --resume 79f06f1d-6d1c-4001-afeb-0618432d81a8` — reattaches to that **specific** session by id
+- `/po-live --resume` — bare alias for `--continue` (most recent session)
 
 ## Resuming a previous session
 
-`po-live --resume` reattaches to an existing Claude conversation in the shared
-`worktrees/po-live` clone instead of starting a fresh `/po`. This is how you pick
-up after closing the pane, a reboot, or a power loss — the container is
-ephemeral (`--rm`) but the session transcript lives on the host-mounted
-`~/.claude`, so it survives.
+`po-live --continue` / `po-live --resume` reattach to an existing Claude
+conversation in the shared `worktrees/po-live` clone instead of starting a fresh
+`/po`. This is how you pick up after closing the pane, a reboot, or a power loss
+— the container is ephemeral (`--rm`) but the session transcript lives on the
+host-mounted `~/.claude`, so it survives. These forward Claude's own flags:
 
-- **`--resume <session-id>`** → runs `claude --resume <session-id>` in the
-  container: resumes that exact conversation.
-- **`--resume`** (bare) → runs `claude --continue`: resumes the most recent
-  session for the workspace.
+- **`--continue`** → runs `claude --continue`: resumes the most recent session
+  for the workspace.
+- **`--resume <session-id>`** → runs `claude --resume <session-id>`: resumes
+  that exact conversation.
+- **`--resume`** (bare) → convenience alias for `--continue`.
 
 To find a session id, look under `~/.claude/projects/-workspace/` on the host
 (the container runs Claude at `/workspace`), or use bare `--resume` to grab the

--- a/.claude/commands/po-live.md
+++ b/.claude/commands/po-live.md
@@ -108,4 +108,17 @@ The container uses `--rm` and removes itself on exit. To exit:
 - Type `/exit` or `exit` in the live Claude session, then `exit` the bash shell
 - Or close the tmux pane (`Ctrl-b x`) — Docker will clean up
 
-The shared `worktrees/po-live` clone persists between sessions; remove manually with `rm -rf worktrees/po-live` if you want a fresh workspace.
+The shared `worktrees/po-live` clone persists between sessions.
+
+**Workspace freshness:**
+- A **fresh** `/po` session (bare `po-live`, `po-live intent …`, etc.) always
+  resets the clone to a **clean, up-to-date `develop`** first, so a stale branch
+  left by a prior session can't leak in. Uncommitted changes are **stashed, not
+  discarded** (`git -C worktrees/po-live stash list` to recover); committed work
+  is already safe on its own branch.
+- A **resume** session (`--continue` / `--resume`) does **not** touch the branch
+  or working tree — it deliberately reattaches to the workspace exactly as the
+  session left it.
+
+Remove the clone manually with `rm -rf worktrees/po-live` if you want it fully
+re-cloned from scratch.

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -1099,12 +1099,17 @@ case "$cmd" in
     # so we never mutate the shared clone underneath a live session.
     if [[ "${1:-}" != "--resume" && "${1:-}" != "--continue" ]]; then
       echo "Refreshing po-live workspace to a clean, up-to-date develop..."
-      git -C "$clone_dir" fetch --quiet origin develop || true
+      git -C "$clone_dir" fetch --quiet origin develop \
+        || echo "  ! warning: fetch of origin/develop failed; refreshing against last-known origin/develop" >&2
       if [[ -n "$(git -C "$clone_dir" status --porcelain 2>/dev/null)" ]]; then
         stash_label="po-live-autobackup-$(date -u +%Y%m%dT%H%M%SZ)"
         if git -C "$clone_dir" stash push -u -m "$stash_label" >/dev/null 2>&1; then
           echo "  ! Stashed uncommitted changes as '${stash_label}'"
           echo "    (recover with: git -C '${clone_dir}' stash list)"
+        else
+          echo "ERROR: could not stash uncommitted changes in ${clone_dir}; refusing to refresh to develop." >&2
+          echo "       Resolve manually (commit/stash/clean the clone), then relaunch." >&2
+          exit 1
         fi
       fi
       git -C "$clone_dir" checkout -q -B develop origin/develop

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -1095,11 +1095,16 @@ case "$cmd" in
     # Build the initial prompt without trailing space when args are empty.
     # Trailing space leaves Claude's input box mid-word and shows the slash-
     # command autocomplete dropdown instead of submitting on Enter.
-    # Resume mode: `po-live --resume [<session-id>]` reattaches to an existing
-    # Claude session in the same /workspace clone instead of seeding a fresh
-    # /po. With an id it resumes that exact session; bare, it continues the
-    # most recent session for the workspace (the last PO conversation).
-    if [[ "${1:-}" == "--resume" ]]; then
+    # Resume mode: reattach to an existing Claude session in the same /workspace
+    # clone instead of seeding a fresh /po. These forward Claude's own flags:
+    #   --continue          -> claude --continue  (most recent session)
+    #   --resume            -> claude --continue  (bare: convenience alias)
+    #   --resume <session-id> -> claude --resume <session-id>  (that exact one)
+    # The session transcript persists on the host-mounted ~/.claude.
+    if [[ "${1:-}" == "--continue" ]]; then
+      claude_args=( --continue )
+      session_desc="continue last session"
+    elif [[ "${1:-}" == "--resume" ]]; then
       if [[ -n "${2:-}" ]]; then
         claude_args=( --resume "$2" )
         session_desc="resume session ${2}"

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -1092,6 +1092,24 @@ case "$cmd" in
     # Remove stale container with the same name (only one PO live at a time)
     docker rm -f "$container_name" 2>/dev/null || true
 
+    # Fresh /po sessions (i.e. NOT --resume/--continue) always start on a clean,
+    # up-to-date develop so a stale branch left by a prior session can't leak in.
+    # Any uncommitted work is stashed, not discarded (committed work is already
+    # safe on its own branch). This runs only after the old container is gone,
+    # so we never mutate the shared clone underneath a live session.
+    if [[ "${1:-}" != "--resume" && "${1:-}" != "--continue" ]]; then
+      echo "Refreshing po-live workspace to a clean, up-to-date develop..."
+      git -C "$clone_dir" fetch --quiet origin develop || true
+      if [[ -n "$(git -C "$clone_dir" status --porcelain 2>/dev/null)" ]]; then
+        stash_label="po-live-autobackup-$(date -u +%Y%m%dT%H%M%SZ)"
+        if git -C "$clone_dir" stash push -u -m "$stash_label" >/dev/null 2>&1; then
+          echo "  ! Stashed uncommitted changes as '${stash_label}'"
+          echo "    (recover with: git -C '${clone_dir}' stash list)"
+        fi
+      fi
+      git -C "$clone_dir" checkout -q -B develop origin/develop
+    fi
+
     # Build the initial prompt without trailing space when args are empty.
     # Trailing space leaves Claude's input box mid-word and shows the slash-
     # command autocomplete dropdown instead of submitting on Enter.

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -1095,25 +1095,37 @@ case "$cmd" in
     # Build the initial prompt without trailing space when args are empty.
     # Trailing space leaves Claude's input box mid-word and shows the slash-
     # command autocomplete dropdown instead of submitting on Enter.
-    if [[ -n "$args" ]]; then
-      po_prompt="/po ${args}"
-      po_name="PO: ${args}"
+    # Resume mode: `po-live --resume [<session-id>]` reattaches to an existing
+    # Claude session in the same /workspace clone instead of seeding a fresh
+    # /po. With an id it resumes that exact session; bare, it continues the
+    # most recent session for the workspace (the last PO conversation).
+    if [[ "${1:-}" == "--resume" ]]; then
+      if [[ -n "${2:-}" ]]; then
+        claude_args=( --resume "$2" )
+        session_desc="resume session ${2}"
+      else
+        claude_args=( --continue )
+        session_desc="resume last session"
+      fi
+    elif [[ -n "$args" ]]; then
+      claude_args=( --name "PO: ${args}" "/po ${args}" )
+      session_desc="/po ${args}"
     else
-      po_prompt="/po"
-      po_name="PO"
+      claude_args=( --name "PO" "/po" )
+      session_desc="/po"
     fi
 
     echo "================================================"
     echo " CFGMS PO Live Session"
-    echo " Initial prompt: ${po_prompt}"
+    echo " Session:        ${session_desc}"
     echo " Clone:          ${real_path}"
     echo "================================================"
 
     host_claude_dir="$HOME/.claude"
     host_claude_json="$HOME/.claude.json"
 
-    # Pass $1 (display name) and $2 (initial prompt) via bash -c positional
-    # args to avoid shell-quote escaping pain when args contain special chars.
+    # Pass the resolved claude args via bash -c positional args ("$@") to avoid
+    # shell-quote escaping pain when args contain special characters.
     exec docker run -it --rm \
       --name "$container_name" \
       --label "cfg-agent=true" \
@@ -1132,10 +1144,9 @@ case "$cmd" in
       --cap-add NET_ADMIN \
       --entrypoint /bin/bash \
       cfg-agent:latest \
-      -c 'setup-env.sh && exec claude --dangerously-skip-permissions --name "$1" "$2"' \
-      cfg-agent-live-po \
-      "$po_name" \
-      "$po_prompt"
+      -c 'setup-env.sh && exec claude --dangerously-skip-permissions "$@"' \
+      _ \
+      "${claude_args[@]}"
     ;;
 
   launch-interactive)


### PR DESCRIPTION
## What

Rounds out the `po-live` session lifecycle so the shared `worktrees/po-live` clone behaves predictably across sessions.

**Reattach to a past session** (the container is `--rm`, but the transcript persists on host-mounted `~/.claude`):
| Command | Runs in the container |
|---|---|
| `po-live --continue` | `claude --continue` (most recent session) |
| `po-live --resume <id>` | `claude --resume <id>` (that exact session) |
| `po-live --resume` | `claude --continue` (bare convenience alias) |

**Fresh sessions always start clean:** for seed sessions (bare `po-live`, `po-live intent …`, etc. — *not* `--resume`/`--continue`), the launcher resets the clone to a clean, up-to-date `develop` first, so a stale branch left by a prior session can't leak in.

## Why

- Resuming previously meant manually running `claude --resume …`; now it's a first-class launcher flag (motivated by recovering a real session after a power outage).
- Fresh `/po` sessions were inheriting whatever branch the last session left behind — a repeated foot-gun.

## How / safety

- Seed refresh = `fetch origin develop` → `checkout -B develop origin/develop`, run **only after** the prior container is removed (never mutates the clone under a live session).
- Uncommitted work is **stashed** (`po-live-autobackup-<ts>`), never discarded; committed work stays on its own branch. `--resume`/`--continue` skip the refresh entirely and reattach to the workspace as-is.
- Resolved `claude` args pass through the `bash -c` positional `"$@"`, so special characters stay safe.

## Validation

- `bash -n` clean.
- Arg resolution exercised for all shapes (`--continue`, `--resume <id>`, bare `--resume`, `intent …`, empty).
- Develop-refresh functional-tested in a throwaway repo: dirty feature branch → clean `develop` at `origin/develop` tip, work stashed + recoverable, prior branch preserved; **resume mode leaves the clone untouched**.
- `--resume <id>` also exercised live end-to-end (launched a pane + container and resumed the correct conversation).

## Notes

- Touches only `.claude/scripts/agent-dispatch.sh` and `.claude/commands/po-live.md` — no Go surface, no deps.
- Pre-approved permission glob `Bash(...agent-dispatch.sh po-live *)` already covers the new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
