### PR TITLE
hyperv/provision: fix Windows autounattend --ca-cert → --controller-ca (parallel to #2353)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -261,9 +261,9 @@ tool added to the host):
    controller CA) is attached as a data disk. cloud-init **auto-detects the
    `CIDATA` volume by label on first boot — no kernel command line, no boot-media
    repack.** Its `user-data` `runcmd` (list/exec form only — no shell-string
-   composition) runs `cfgms-steward install --regtoken … --ca-cert … --fingerprint
-   …`, which on a live system stages the binary, writes the systemd unit, and
-   starts enrollment.
+   composition) runs `cfgms-steward install --regtoken … --controller-ca … --fingerprint
+   …`, which on a live system stages the binary (launcher-managed), writes the
+   systemd unit, and starts enrollment.
 3. The seed is detached at `finalizing`; the OS disk is the first boot device.
 
 **Host prerequisite:** the cloud image (`source.image`) must already be on the
@@ -299,7 +299,17 @@ required on the host.
 The enrollment join token and CA fingerprint are supplied via the module's
 controller-synced config (`enroll_token`, `enroll_ca_fingerprint`), and the
 steward binary + CA are staged from `enroll_steward_path` / `enroll_ca_path` (the
-linux steward built for the guest). See [ADR-009](../../../docs/architecture/decisions/009-vm-from-iso-managed-endpoint.md).
+linux steward built for the guest). For a launcher-managed (push-upgradeable)
+guest steward, also set `enroll_launcher_path` to the host path of
+`cfgms-steward-launcher` — it is staged alongside the steward and the guest install
+requires it. See [ADR-009](../../../docs/architecture/decisions/009-vm-from-iso-managed-endpoint.md).
+
+Optional provisioning-debug config:
+
+| Key | Purpose |
+|-----|---------|
+| `enroll_launcher_path` | Host path to `cfgms-steward-launcher`, staged onto the seed so the guest performs a launcher-managed (push-upgradeable) install. |
+| `debug_ssh_authorized_key` | An SSH **public** key added to a provisioned Linux guest's `authorized_keys` so an operator can log in and diagnose a failed enrollment. Public key only (not a secret); omit to disable (production default). |
 
 ### Annotated Linux example (legacy netinst ISO + preseed)
 

--- a/features/modules/hyperv/windows_profile.go
+++ b/features/modules/hyperv/windows_profile.go
@@ -69,7 +69,7 @@ func randomAdminPassword() (string, error) {
 // Enrollment runs first-boot via <FirstLogonCommands>: an AutoLogon of the local
 // Administrator triggers a single cmd.exe /c command that locates the FAT32
 // CFGMS_SEED volume (staged with cfgms-steward.exe + controller-ca.crt next to
-// autounattend.xml) and runs `cfgms-steward install --regtoken … --ca-cert …
+// autounattend.xml) and runs `cfgms-steward install --regtoken … --controller-ca …
 // --fingerprint …`, which self-copies the binary to the platform path and
 // registers as a service. The steward's controller URL is baked in at build
 // time (ldflags). A fixed argument list with declared paths — no iex /
@@ -188,7 +188,7 @@ const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
         <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
           <Order>1</Order>
           <Description>Install and enroll the CFGMS steward from the seed volume</Description>
-          <CommandLine>cmd.exe /c for %i in (D E F G H I J K) do @if exist "%i:\cfgms-steward.exe" "%i:\cfgms-steward.exe" install --regtoken "{{ .EnrollToken }}" --ca-cert "%i:\controller-ca.crt" --fingerprint "{{ .CAFingerprint }}"</CommandLine>
+          <CommandLine>cmd.exe /c for %i in (D E F G H I J K) do @if exist "%i:\cfgms-steward.exe" "%i:\cfgms-steward.exe" install --regtoken "{{ .EnrollToken }}" --controller-ca "%i:\controller-ca.crt" --fingerprint "{{ .CAFingerprint }}"</CommandLine>
         </SynchronousCommand>
       </FirstLogonCommands>
     </component>

--- a/features/modules/hyperv/windows_profile_test.go
+++ b/features/modules/hyperv/windows_profile_test.go
@@ -94,8 +94,10 @@ func TestAutounattend_NoBannedPatterns(t *testing.T) {
 	// present (locate the seed volume, run cfgms-steward install).
 	assert.Contains(t, rendered, `cfgms-steward.exe" install --regtoken`,
 		"enrollment must self-install the steward via install --regtoken")
-	assert.Contains(t, rendered, "--ca-cert",
-		"enrollment must pass the staged controller CA via --ca-cert")
+	assert.Contains(t, rendered, "--controller-ca",
+		"enrollment must pass the staged controller CA via --controller-ca (the real steward install flag)")
+	assert.NotContains(t, rendered, "--ca-cert",
+		"the steward install command has no --ca-cert flag (aborts enrollment: 'unknown flag')")
 	assert.Contains(t, rendered, "--fingerprint",
 		"enrollment must pass the CA fingerprint via --fingerprint")
 }


### PR DESCRIPTION
## Problem
The PR review of #2353 found the **identical `--ca-cert` bug on the Windows path**. The autounattend `FirstLogonCommands` install line (`windows_profile.go:191`) ran `cfgms-steward install … --ca-cert …`, but the steward install command registers only `--controller-ca` (`cmd/steward/main.go`). So **Windows VM-from-ISO enrollment aborts at flag parsing** ("unknown flag: --ca-cert") — the same live-breaking defect #2353 fixed for Linux. Worse, `TestAutounattend_NoBannedPatterns` asserted `--ca-cert` was *present*, encoding the bug as expected.

## Change
- `windows_profile.go`: `--ca-cert` → `--controller-ca` (autounattend command + doc comment)
- `windows_profile_test.go`: assert `--controller-ca` present **and** `--ca-cert` absent (regression guard, corrects the test that encoded the bug)
- `README.md`: fix the stale `--ca-cert` mention; document `enroll_launcher_path` (#2349) and `debug_ssh_authorized_key` (#2353) which were undocumented

## Test
`TestAutounattend*` green; full `features/modules/hyperv` package green; `GOOS=windows` build clean. (Linux equivalent was validated live via a real auto-provisioned VM under #2353.)

Follow-up to #2353 (epic #2257).

🤖 Generated with [Claude Code](https://claude.com/claude-code)