### PR TITLE
docs(adr): ADR-016 steward module foundation + ADR-017 DNA composition & sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ A module commits to exactly one kind via `executors:` in `module.yaml`. Cross-ki
 
 **Packaging and trust (#1877, ADR-006):** modules are out-of-process gRPC binaries cached by the controller and pulled by hosts. Bundles are publisher-signed; the controller verifies, runs an approval workflow, and stages. End-to-end signing — the controller forwards module signatures intact, never strips and re-signs. `steward.cfg` `module_trust.mode`: `strict` (steward verifies independently), `controller` (default), `bypass` (dev only). CFGMS publisher identity is baked into the steward binary at build time and cannot be changed via cfg push.
 
-**Stdlib** (`file`, `service`, `package`, `script`, `firewall`, `patch`) ships in the steward installer using the same module contract. Stdlib is governance (installer payload), not implementation (never compiled-in).
+**Stdlib** ships in the steward installer using the same module contract; it is governance (installer payload), not implementation (never compiled-in). **What qualifies as stdlib:** a module is stdlib only if it's part of the declared baseline for *nearly every managed machine* — usage across the fleet, not capability; execution primitives (`script`) and platform-scoped baselines also qualify. Everything else is an `extended` module, pulled on demand. The closed set (`file`, `service`, `package`, `script`, `firewall`, `patch`, `user`, `cert_trust`, `time`, `hostname`) and the criterion are authoritative in ADR-016; see `docs/architecture/modules/README.md`.
 
 **Four execution paths on a steward** — every byte of code that runs on a steward arrives through exactly one of these:
 

--- a/docs/architecture/decisions/016-steward-module-foundation.md
+++ b/docs/architecture/decisions/016-steward-module-foundation.md
@@ -1,0 +1,187 @@
+# ADR-016: Steward Module Foundation — stdlib set, repository layout, and DNA-fragment contract
+
+**Status:** Proposed
+**Date:** 2026-07-04
+**Issue:** (to be assigned at decomposition)
+**Epic:** (module-foundation epic — to be filed)
+
+---
+
+## Context
+
+ADR-006 established the module *packaging and distribution* model: out-of-process signed bundles, controller-cached and pulled by hosts, with stdlib defined as "the installer payload using the same module contract." It did **not** pin down three things that are now on the critical path:
+
+1. **Which modules constitute the standard library**, and how we keep that set complete and compliant over time.
+2. **How the module source tree is organised** so that the stdlib (installer payload) is physically separable from non-stdlib modules (pulled on demand).
+3. **What a module's `Get` must emit for DNA**, and **how a module declares the objects it authoritatively owns** — the two clauses the forthcoming DNA composition ADR (ADR-017) depends on.
+
+### Current state
+
+All modules live flat in `features/modules/`, mixing stdlib and non-stdlib:
+
+```
+features/modules/
+  file/  service/  package/  script/  firewall/  patch/          ← stdlib
+  acme/  activedirectory/  hyperv/  github_runner/  network_activedirectory/  ← non-stdlib
+```
+
+There is no build-level or directory-level boundary between "ships in the installer" and "pulled on demand." A survey done for this ADR found:
+
+- All six stdlib modules build (`cmd/main.go` present in each).
+- **`patch` has no `module.yaml`** — the only stdlib module missing a manifest, so it is not a fully-declared bundle under ADR-006. It also carries a `stub_patch_manager.go` whose real-vs-placeholder status is unverified.
+
+"Builds" is therefore not the same as "is a compliant, fully-declared, installer-shipped bundle." We need an enforceable definition of stdlib completeness, not a one-time cleanup.
+
+### Why the DNA clauses belong here
+
+The DNA model assembles a deterministic, hashable object from per-object fragments so steward and controller can validate full sync after a partial update. The intended sourcing is: **managed resources contribute their DNA fragment from the managing module's `Get`; unmanaged-but-stable host facts come from osquery.** For that to work, the module contract must require `Get` to emit a canonical fragment, and each module must declare which object identities it owns so the steward's DNA assembler can resolve authority. The resolver, the osquery fact list, and the hash/sync mechanics are ADR-017's; the two *contract clauses* are foundational to the module and belong here.
+
+---
+
+## Decision
+
+### 1. The canonical standard library
+
+**Inclusion test.** A module is stdlib iff it is part of the **declared baseline for nearly every managed machine** — it would be configured on essentially all endpoints to bring them to, and hold them in, a managed/compliant state — *or* it is a core **execution primitive** (one of the four execution paths). It must also be **CFGMS-published** (signed by the build keys compiled into the steward per ADR-006) and **ship in the installer payload**. The test is *usage across the fleet*, not capability: a module used on only a subset of machines — however powerful — is `extended`, not stdlib. "Declared baseline" includes **declare-once identity** (e.g. hostname), not only continuously-corrected state.
+
+The standard library is exactly these **ten** modules:
+
+| Module | Baseline role | Status |
+|---|---|---|
+| `file` | Files and directories (content, ownership, permissions/ACLs) | exists |
+| `service` | OS services (systemd, Windows Service, launchd) | exists |
+| `package` | OS package installation/removal | exists |
+| `script` | Staged, signed script execution — **execution primitive** (path 2) | exists |
+| `firewall` | Host firewall rules | exists |
+| `patch` | OS patch/update compliance | exists (no `module.yaml`, stub unverified) |
+| `user` | Local users & groups, membership, password/lock state, disable defaults | **net-new** |
+| `cert_trust` | System trust store — install/trust CA & certs; keeps the CFGMS mTLS chain healthy fleet-wide | **net-new** |
+| `time` | Timezone + NTP/time-sync (skew breaks Kerberos, cert validation, log correlation) | **net-new** |
+| `hostname` | System/computer name & workgroup (domain join → `extended/activedirectory`) | **net-new** |
+
+`script` is stdlib as an execution primitive rather than by the usage test. Four modules (`user`, `cert_trust`, `time`, `hostname`) have **no management code today** — only read-only DNA-collection fragments exist for users/hostname under `features/steward/dna/`, which fold into the new modules' `Get`. Building these is real cross-platform implementation work, not relocation.
+
+This set is **closed**: adding an eleventh stdlib module is an ADR-level decision, not an incidental addition.
+
+**Deliberately excluded from stdlib** (→ `extended/`, because each is used on only a subset of the fleet): `registry` and `scheduled_task` (not touched on typical endpoints), `network` (major OSes default to DHCP, so static config is a minority of machines), and `mount` / `sysctl` / `env` (server- or scenario-specific). Their exclusion is a usage-frequency call, not a judgment on importance; any may be built as an `extended` module when needed.
+
+### 2. Repository and build layout
+
+Modules are separated in the source tree by distribution class:
+
+```
+features/modules/
+  stdlib/     <name>/   ← the six above; installer payload
+  extended/   <name>/   ← CFGMS-authored, non-stdlib; built as standalone bundles, NOT in the installer
+  adapter/              ← shared module runtime/contract code (unchanged)
+```
+
+- `stdlib/` is the **only** set compiled into / shipped with the installer.
+- `extended/` modules (today: `acme`, `activedirectory`, `hyperv`, `github_runner`, `network_activedirectory`) are built as standalone signed bundles, published to the controller cache, and pulled on demand exactly as ADR-006 describes. They are **absent from a fresh steward** until a cfg references them.
+
+The `stdlib` / `extended` names are chosen to pair with the "standard library" concept and to name the distinguishing axis (installer-payload vs on-demand). `extended` is used rather than `contrib` because these modules are CFGMS-authored, not third-party contributions. Relocation is mechanical but touches import paths; each module's move is a discrete story, and an actively-developed module (e.g. `hyperv`) may migrate as part of its own epic to avoid mid-flight churn.
+
+Extracting `extended/` modules into separate repositories is **out of scope**; they remain in-repo under `extended/` for now.
+
+### 3. Installer payload boundary
+
+The installer payload manifest lists exactly the `stdlib/` bundles. The build fails if the payload manifest and the `stdlib/` directory disagree. This makes the "stdlib = installer payload" statement from ADR-006 mechanically true rather than conventional.
+
+### 4. Module `Get` emits a canonical DNA fragment
+
+Every module's `Get` returns, for each object it manages, a **canonical, deterministically-serialisable DNA fragment**:
+
+- Addressed by a stable **object identity** (see clause 5).
+- **Canonical serialisation** — fixed field ordering, normalised value encoding — so the same observed state always produces the same bytes and therefore the same hash on both steward and controller.
+- **Stable desired-comparable fields only** — no ephemeral/runtime fields (live PIDs, current CPU/memory, timestamps). Ephemeral telemetry is not DNA and is out of scope for this contract.
+
+The fragment is the module's authoritative DNA contribution for its objects. Its shape and the aggregation are defined in ADR-017; this ADR requires only that `Get` produce it.
+
+### 5. Modules declare the object identities they own — atomic, object-level
+
+Every module declares in `module.yaml` the **object-identity namespace** it authoritatively owns, e.g.:
+
+```yaml
+# module.yaml — DNA ownership declaration
+owns:
+  - kind: service          # authority over service:* objects this module manages
+```
+
+Authority is **atomic at the object level**: when an active module owns an object, it owns that object's **entire** DNA fragment — every property of it. A single object's properties are **never** split across two sources. At DNA assembly the steward excludes any object claimed by an active module from osquery's DNA contribution; on module uninstall, authority reverts (to osquery if the object's facts are in the curated allowlist, else the fragment disappears). The resolver that performs this is ADR-017's; this ADR requires the **declaration** that makes it possible.
+
+Sub-property co-authorship of one object (module owns some fields, osquery others) is explicitly rejected — it re-introduces the two-sources-one-fragment non-determinism that breaks partial-sync hash validation.
+
+### 6. Stdlib completeness is an enforced gate
+
+A CI/build check (Makefile target) asserts, for every module under `stdlib/`, that it:
+
+1. is present in the `stdlib/` directory **and** the installer payload manifest (clause 3),
+2. builds a bundle with a valid `module.yaml` (executors, behavioral envelope, signing metadata),
+3. exposes a `Get` that emits a canonical DNA fragment (clause 4),
+4. declares its owned object identities (clause 5),
+5. contains no unresolved stub in its enforcement path (no `stub_*` / `panic("TODO")` / `ErrNotImplemented` in the `Set`/`Get` code path).
+
+This converts "make sure they are all built" from a one-time audit into a standing invariant. The immediate consequence: `patch` must gain a `module.yaml`, and its `stub_patch_manager` must be verified real (or completed) before the gate passes.
+
+---
+
+## Out of Scope
+
+Deferred to ADR-017 (DNA composition & sync) or later work:
+
+- The **DNA assembly + hash + partial-sync** mechanics and the **authority resolver** runtime.
+- The **curated osquery DNA-fact query list** — deliberately deferred until the stdlib set is confirmed, because the managed surface determines what osquery should cover.
+- **Observe-only vs managed fragment tagging** and its interaction with drift modes (`auto_correct` / `report_only`).
+- **Ephemeral telemetry / monitor streams** (live process and resource views) — a separate, unhashed pipe, not DNA.
+- **Separate-repo extraction** of `extended/` modules.
+
+---
+
+## Consequences
+
+### Positive
+
+1. **Enforceable stdlib**: completeness and compliance are a CI invariant, not a hope. The `patch` manifest gap would have shipped silently under the old flat layout.
+2. **Clean distribution boundary**: the source tree mirrors the installer-payload-vs-on-demand split, so "what ships in the installer" is unambiguous.
+3. **DNA on a firm contract**: modules produce deterministic fragments and declare ownership, giving ADR-017 a stable foundation and keeping authority single-sourced per object.
+4. **Non-stdlib room to grow**: `extended/` can accumulate CFGMS modules without diluting the stdlib or the installer.
+
+### Negative
+
+1. **Relocation churn**: moving ~5 modules to `extended/` and 6 to `stdlib/` touches import paths across the tree; must be sequenced to avoid colliding with active module work (notably `hyperv`).
+2. **Net-new stdlib build**: `user`, `cert_trust`, `time`, and `hostname` do not exist yet and must be built cross-platform before the completeness gate passes — a real implementation effort, not just relocation. Plus `patch` needs a `module.yaml` and its stub resolved. This makes the module-foundation work a build epic, not an audit; it likely splits into (a) reorg + contract + gate + `patch`, and (b) the four new modules.
+3. **Contract surface on every module**: the `Get`→fragment and `owns:` clauses add required surface to every module, stdlib and extended alike.
+
+### Neutral
+
+- The `stdlib` / `extended` names are a convention; renaming later is a mechanical move.
+- `adapter/` (shared runtime) is unaffected by the split.
+
+---
+
+## Alternatives Considered
+
+### Keep the flat layout, distinguish by a manifest tag
+
+Mark each `module.yaml` with `tier: stdlib|extended` and leave the directory flat.
+
+**Rejected:** the installer-payload boundary stays a convention enforced only by reading manifests; nothing physically prevents a non-stdlib module from being swept into the payload. A directory boundary is checkable by the build with no manifest parsing.
+
+### Sub-property (field-level) DNA authority
+
+Let a module own some fields of an object while osquery contributes the rest.
+
+**Rejected:** two sources contributing one object's fragment can disagree by a field and make the fragment hash non-deterministic, breaking exactly the partial-sync completeness validation DNA exists to provide. Object-level atomic authority keeps every fragment single-sourced.
+
+### Define the osquery fact list now, in parallel with stdlib
+
+**Rejected (deferred):** the set of facts osquery should feed into DNA is the complement of the managed surface. Defining it before the stdlib set is confirmed risks osquery and modules both claiming the same objects. The list is authored in ADR-017 once clause 1 here is settled.
+
+---
+
+## References
+
+- [ADR-006](006-module-packaging-and-distribution.md) — Module Packaging and Distribution (this ADR extends it)
+- ADR-017 — DNA Composition & Sync (forthcoming; depends on clauses 4 and 5)
+- `CLAUDE.md` — Modules section, four execution paths, banned patterns
+- `docs/product/roadmap.md` — Captured Backlog (module foundation, OSquery, controller baseline DNA)

--- a/docs/architecture/decisions/017-dna-composition-and-sync.md
+++ b/docs/architecture/decisions/017-dna-composition-and-sync.md
@@ -1,0 +1,184 @@
+# ADR-017: DNA Composition & Sync — fragment model, authority resolution, and partial-sync validation
+
+**Status:** Proposed
+**Date:** 2026-07-04
+**Issue:** (to be assigned at decomposition)
+**Epic:** (controller-baseline-DNA / DNA-composition epic — to be filed)
+
+---
+
+## Context
+
+DNA is CFGMS's deterministic, hashable representation of a host's state. Its purpose is mutual validation: the steward assembles DNA, the controller holds a copy, and after a **partial** update both sides must be able to confirm the controller's copy is **fully in sync** with the steward's actual state — cheaply, without re-transferring everything.
+
+### Current implementation
+
+Today DNA is a **flat `map[string]string`** assembled by a monolithic `Collector` (`features/steward/dna/dna.go`) whose platform-specific gatherers (`hardware_*.go`, `network_*.go`, `security_*.go`, `software_*.go`) fill categories of attributes. A single `ComputeHash(attributes)` hashes the entire map; heartbeats carry that fingerprint. `commonpb.DNA` is the wire type.
+
+This model has three structural limits:
+
+1. **No per-object addressing.** A single whole-map hash means any change rehashes everything. The controller cannot validate or request an individual object; partial sync cannot prove that applying a delta brought its copy fully into sync at object granularity.
+2. **Bespoke gathering that duplicates modules and osquery.** The monolithic collector re-reads state that managed modules already compute in `Get`, and re-implements per-platform host-fact collection that osquery does natively — the "build our own osquery" duplication.
+3. **No notion of source or authority.** An attribute has no owner, so there is no way to say "this object is managed (enforce drift)" vs "this is an observed fact (report only)."
+
+### What ADR-016 provides
+
+ADR-016 requires every module's `Get` to emit a **canonical DNA fragment** per managed object, and requires modules to **declare the object identities they own**. This ADR defines how those fragments — plus curated osquery facts — **compose** into DNA, how **authority** resolves between them, and how **sync + partial validation** work.
+
+### Pre-production posture
+
+CFGMS has no production deployments. The `commonpb.DNA` wire type is redefined cleanly (flat map → fragment set); no migration shims or dual-format support are built (per the project's pre-release breaking-change policy).
+
+---
+
+## Decision
+
+### 1. DNA is a set of addressable fragments
+
+DNA is redefined from a flat attribute map to a **set of fragments**. Each fragment is:
+
+```
+fragment = (fragment_id, authority, canonical_bytes, fragment_hash)
+```
+
+- **`fragment_id`** — the **object-canonical identity**, stable regardless of which source produced it: `service:sshd`, `file:/etc/hosts`, `user:svc-cfgms`, `host:cpu`, `host:memory`, `host:os`. A service is `service:sshd` whether osquery observed it or the `service` module manages it.
+- **`authority`** — the source that produced this fragment on this host right now: a module identity, or `osquery`.
+- **`canonical_bytes`** — the fragment's state under the canonical serialization (clause 5).
+- **`fragment_hash`** — SHA-256 of `canonical_bytes`.
+
+### 2. Two sources, single authority per fragment — the resolver
+
+A fragment's `authority` is resolved at assembly time, per object, **atomically** (whole fragment, never per-field — ADR-016 clause 5):
+
+```
+for each object the host exposes:
+    if an ACTIVE module declares ownership of this fragment_id → module is authority (module.Get)
+    else if fragment_id is in the curated osquery stable-fact allowlist → osquery is authority
+    else → no fragment
+```
+
+**Module authority preempts osquery.** Installing a module that owns `service:sshd` makes it the authority; osquery stops contributing `service:sshd` **to DNA** (osquery may still be queried ad-hoc). Uninstalling reverts authority to osquery if the fact is in the allowlist, else the fragment disappears. Because `fragment_id` is object-canonical, the handoff is a source swap on the same id — the fragment's content and hash legitimately change (observed view → managed view), and that change is a real, desirable "this is now managed" transition the controller should see.
+
+The resolver runs in the steward's DNA assembler and consults the **active-module registry** for the ownership declarations ADR-016 requires.
+
+### 2a. Managed objects source their fragment from the module — not a second reader
+
+For a managed object, the fragment **is** the module's `Get` output. The steward does not also read that object through a separate path and reconcile. Single source of truth = the enforcer. This is what keeps the fragment deterministic and avoids the two-readers-disagree failure that breaks hash validation.
+
+### 3. Fragment class: managed vs observe-only — gates drift
+
+Every fragment carries its class, derived from `authority`:
+
+| Class | Authority | Drift behavior |
+|---|---|---|
+| **managed** | a module | Drift modes apply (`auto_correct` / `report_only`) — the object has a desired state to enforce |
+| **observe-only** | osquery | No drift correction — you cannot "correct" total RAM or CPU model; report only |
+
+The class is not bookkeeping: the convergence loop uses it to decide which fragments are enforceable. Only managed fragments enter drift correction.
+
+### 4. Stable state only — telemetry is excluded
+
+DNA fragments contain **only stable, desired-comparable state**. Ephemeral runtime values — live PIDs, current CPU/memory utilisation, uptime, per-process resource use — are **not DNA**. They belong to the monitor-stream / telemetry pipe (a separate, unhashed channel; the asset-page live views), which is out of scope here.
+
+Consequently osquery contributes to DNA **only** through a curated **stable-fact allowlist** (e.g. `host:cpu` model, `host:memory` total, `host:bios`, `host:os` build) — never its dynamic tables (`processes`, live counters). Its dynamic tables serve ad-hoc queries and telemetry, both outside DNA. This is the rule that keeps the aggregate hash stable instead of flapping every second.
+
+### 5. Canonical serialization
+
+Both module and osquery fragments serialise under one canonical scheme: **fixed field ordering, normalised value encoding, no host-local or run-local noise** (timestamps, ordering artifacts). The requirement is: identical observed state ⇒ identical `canonical_bytes` ⇒ identical `fragment_hash` on the steward and independently on the controller. Without this, the two sides cannot agree on a hash and sync validation is impossible.
+
+### 6. Two-level hash — per-fragment + aggregate root
+
+DNA has a **two-level (Merkle-style) hash**:
+
+- **Per-fragment hash** — `fragment_hash` over each fragment's `canonical_bytes`.
+- **Aggregate root** — a hash over the **manifest**: the set of `(fragment_id, fragment_hash)` pairs, sorted by `fragment_id`.
+
+The aggregate root is what heartbeats carry (replacing today's whole-map fingerprint). It changes iff any fragment's content, or the set of fragments, changes.
+
+### 7. Partial-sync protocol
+
+```
+1. Steward heartbeat carries the aggregate root (and, on request or by policy, the manifest:
+   the list of (fragment_id, fragment_hash)).
+2. Controller compares the root to its stored copy.
+   - match → in sync, done.
+   - mismatch → controller diffs manifests to find changed/added/removed fragment_ids,
+     requests only those fragments' canonical_bytes over the data plane.
+3. Controller applies the delta, recomputes the aggregate root over its updated manifest,
+   and confirms it equals the steward's root.
+```
+
+Step 3 is the **partial-sync validation** the model exists for: because both sides compute the root identically from identical fragments (clause 5), a matching recomputed root proves the controller's copy is now **fully in sync** with the steward — validated by the delta alone, no full re-transfer. "Completeness" here means *the controller's view equals the steward's view*, which is exactly what a partial sync must guarantee.
+
+### 8. The curated osquery fact list is deferred, but its contract is fixed here
+
+The specific osquery queries that populate `host:*` fragments are **not** enumerated in this ADR — they are defined after the stdlib set is confirmed (ADR-016 clause 1), because the managed surface determines the unmanaged remainder. What is fixed here is the **contract**: osquery facts enter DNA only via a curated **stable-fact allowlist**, each mapped to an object-canonical `host:*` `fragment_id`, each **observe-only**, never from dynamic tables.
+
+---
+
+## Out of Scope
+
+- **The enumerated osquery query list** — a story deliverable gated on ADR-016 clause 1.
+- **Monitor-stream / telemetry design** — the live process/service/resource views (asset page); a separate unhashed pipe.
+- **Drift-correction mechanics** — the existing drift subsystem (`features/steward/dna/drift`); this ADR only gates it by the managed/observe-only class.
+- **Module `Get` fragment wire shape** — ADR-016 owns the requirement; the proto/serialization detail is an implementation concern of that epic.
+
+---
+
+## Consequences
+
+### Positive
+
+1. **Cheap, provable partial sync**: object-level deltas plus an aggregate root that validates the controller's copy is fully in sync — no whole-DNA re-transfer.
+2. **Single-authority determinism**: every fragment has exactly one source; the object-canonical id + atomic resolution make the hash reproducible on both sides.
+3. **No duplicated gathering**: managed state comes from module `Get`, host facts from osquery; the bespoke per-platform collector is retired rather than extended (kills the "build our own osquery" risk).
+4. **Managed/observed separation**: drift correction is cleanly gated to enforceable fragments.
+5. **DNA richness scales with stdlib**: each stdlib module added (ADR-016) contributes managed fragments, shrinking the osquery-fact remainder.
+
+### Negative
+
+1. **Breaking proto redesign**: `commonpb.DNA` changes from flat map to fragment set — acceptable pre-production, done as a clean break with no shims. Everything reading/writing DNA (heartbeat, controller store, delta transfer) changes with it.
+2. **Collector decomposition**: the monolithic `Collector`'s gatherers must be reclassified — managed categories migrate into module `Get` (`user`, `hostname`, etc. per ADR-016), unmanaged host facts migrate to the osquery allowlist. Real refactoring, not a rename.
+3. **New steward + controller machinery**: the assembler, the authority resolver, fragment-addressable controller-side DNA storage, and the delta protocol are new.
+4. **Depends on osquery + stdlib**: the `host:*` fragment layer needs the osquery integration (#2), and authority resolution needs the module ownership declarations (#3 / ADR-016). This epic sits downstream of both.
+
+### Neutral
+
+- The existing `hardware/network/security/software` gatherers are reclassified (→ module `Get` or osquery fact), not deleted — the logic mostly relocates.
+- Read-only DNA fragments that ADR-016 noted (users/hostname under `features/steward/dna/`) become the seed for the corresponding modules' `Get`.
+
+---
+
+## Alternatives Considered
+
+### Keep the flat map + single hash, add map-diff partial sync
+
+Diff the two attribute maps to compute a delta.
+
+**Rejected:** no per-object authority, no managed/observed distinction, a single change still rehashes the whole map, and the source duplication (modules + bespoke collector both reading state) persists. Map-diffing transfers less but proves nothing about object-level completeness.
+
+### Field-level (sub-fragment) authority
+
+Let a module own some fields of an object and osquery the rest.
+
+**Rejected (ADR-016 clause 5):** two sources on one fragment can disagree by a field, making its hash non-deterministic and breaking sync validation. Authority is atomic per object.
+
+### osquery as the sole DNA source, including managed objects
+
+Read everything — even managed objects — from osquery.
+
+**Rejected:** osquery cannot enforce, so the module is already the source of truth for what it manages; sourcing the same object from osquery too creates the two-readers-disagree hazard and demotes the enforcer's own view. Modules own managed fragments; osquery owns the unmanaged remainder.
+
+### Keep a bespoke per-platform fact collector instead of osquery
+
+**Rejected:** reinvents osquery per platform (the clone risk that motivated sequencing osquery before baseline DNA), with a perpetual per-OS maintenance burden and no ad-hoc query surface.
+
+---
+
+## References
+
+- [ADR-016](016-steward-module-foundation.md) — Steward Module Foundation (provides `Get`→fragment + `owns:` declarations)
+- [ADR-006](006-module-packaging-and-distribution.md) — Module Packaging and Distribution
+- `features/steward/dna/dna.go` — current `Collector`, `ComputeHash` (redefined by this ADR)
+- `features/steward/dna/drift` — drift subsystem gated by the managed/observe-only class
+- `docs/product/roadmap.md` — Captured Backlog (OSquery, controller baseline DNA)

--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -65,16 +65,37 @@ The `executors` field must contain exactly one element. `kind` is computed at pa
 
 ## Available Modules
 
-**Stdlib** (shipped in the steward installer, all `executors: [steward]`):
+### What belongs in stdlib
+
+The standard library is not an open-ended collection. A module is **stdlib** only if it meets this test:
+
+> A module is stdlib if it is part of the **declared baseline for nearly every managed machine** — configured on essentially all endpoints to bring them to, and hold them in, a managed/compliant state. The test is **usage across the fleet, not capability**: a powerful module used on only a subset of machines is `extended`, not stdlib.
+
+Two carve-outs:
+
+- **Execution primitives** (e.g. `script`) are stdlib regardless of the usage test — they are core paths through which cfg reaches a host.
+- **Platform-scoped** resources qualify where the resource exists (a Windows-only baseline module is still stdlib).
+
+Everything else — however useful — is an `extended` module, built as a standalone bundle and pulled on demand (see [distribution.md](distribution.md) and [ADR-006](../decisions/006-module-packaging-and-distribution.md)). Changing the stdlib set is an ADR-level decision. **[ADR-016](../decisions/016-steward-module-foundation.md) is authoritative** for the criterion, the current members, and the `stdlib/` ↔ `extended/` repository split.
+
+### Current stdlib members
+
+Shipped in the steward installer, all `executors: [steward]` (closed set — see ADR-016):
 
 - `file` - File content, directory creation, and permissions (`type: file` / `type: directory` / `type: symlink`)
-- `firewall` - Firewall rules and policies
-- `package` - Software package management
-- `patch` - OS patch management (Windows Update COM API on Windows; stub on other platforms)
-- `script` - Cross-platform script execution (file-based, no inline eval)
 - `service` - OS service state management
+- `package` - Software package management
+- `script` - Cross-platform script execution (file-based, no inline eval) — *execution primitive*
+- `firewall` - Firewall rules and policies
+- `patch` - OS patch management (Windows Update COM API on Windows; stub on other platforms)
+- `user` - Local users & groups, membership, password/lock state — *planned (net-new)*
+- `cert_trust` - System trust store: install/trust CA & certs; keeps the CFGMS mTLS chain healthy — *planned (net-new)*
+- `time` - Timezone + NTP/time-sync — *planned (net-new)*
+- `hostname` - System/computer name & workgroup — *planned (net-new)*
 
-**Non-stdlib steward modules:**
+### Extended steward modules (non-stdlib)
+
+CFGMS-authored but used on only a subset of the fleet; built as standalone bundles, pulled on demand:
 
 - `acme` - ACME/Let's Encrypt certificate management
 - `activedirectory` - Local Active Directory integration (steward)


### PR DESCRIPTION
Two **Proposed** ADRs plus the living-doc updates that put their framing where it's used. Docs-only.

### ADR-016 — Steward Module Foundation
Extends ADR-006 with:
- Closed **10-module stdlib set** — file, service, package, script, firewall, patch, **user, cert_trust, time, hostname** (usage-frequency inclusion test; `script` carved out as an execution primitive)
- `stdlib/` ↔ `extended/` repository split + build-enforced installer-payload boundary
- **`Get` → canonical DNA fragment** contract + **atomic object-level `owns:`** declaration
- stdlib **completeness gate** (manifest, bundle, fragment, ownership, no-stub)
- Excluded → `extended/` with rationale: registry, scheduled_task, network, mount, sysctl, env

`user`/`cert_trust`/`time`/`hostname` are **net-new builds**; `patch` needs a `module.yaml`.

### ADR-017 — DNA Composition & Sync
Redefines DNA from a flat attribute map to a **fragment set**:
- Object-canonical `fragment_id`; **module-preempts-osquery** authority resolver, atomic per object
- **managed vs observe-only** class gates drift correction
- **Stable-state only** — telemetry excluded; osquery feeds DNA via a curated stable-fact allowlist
- **Two-level hash** (per-fragment + aggregate root) enabling **delta-based partial-sync validation**
- Clean **breaking proto redesign** of `commonpb.DNA`, no shims (pre-prod)

### Living-doc framing (README + CLAUDE.md)
The stdlib inclusion **criterion** previously lived only in the ADR. These docs now **lead with the test** (the generative knowledge) and treat the member list as a subordinate lookup catalog:
- `docs/architecture/modules/README.md` — new "What belongs in stdlib" section; member list updated to the closed 10-set; non-stdlib retitled "Extended steward modules"
- `CLAUDE.md` — bare six-module list replaced with the criterion + closed set + pointer to ADR-016 / README

Both ADRs **Status: Proposed** — epics unassigned, pending review. ADR-017 depends on ADR-016's fragment/ownership clauses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCGY8RsDRKaXskDYMNLMTJ