### PR TITLE
hyperv: clean up seed VHDX + staged answer media after enrollment (Issue #2081)

### DIFF
--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -93,6 +93,8 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 				" -CASrc "+quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:
 		return t.runFresh(ctx, "Cfgms-DetachSeedVHD -Path "+quoteArg(psArgs, "Path"))
+	case psDeleteSeedMedia:
+		return t.run(ctx, "Cfgms-DeleteSeedMedia -Path "+quoteArg(psArgs, "Path"))
 	case psAttachSeedDisk:
 		// runFresh: Add-VMHardDiskDrive opens the seed VHD, which hits the same
 		// async-VHD deadlock as Mount-VHD in the persistent -Command - host.

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -146,6 +146,8 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 		return emit("Cfgms-GetClusterOwnerNode -ClusterName " + quoteArg(psArgs, "ClusterName"))
 	case psGetClusterResourceOwner:
 		return emit("Cfgms-GetClusterResourceOwner -ClusterName " + quoteArg(psArgs, "ClusterName"))
+	case psGetClusterAccessSelf:
+		return emit("Cfgms-GetClusterAccessSelf -ClusterName " + quoteArg(psArgs, "ClusterName"))
 	case psAddClusterVMRole:
 		return emit("Cfgms-AddClusterVMRole -ClusterName " + quoteArg(psArgs, "ClusterName") +
 			" -VMName " + quoteArg(psArgs, "VMName"))
@@ -526,6 +528,7 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psGetCluster", psGetCluster, map[string]string{"ClusterName": "lab-hv"}},
 		{"psGetClusterOwnerNode", psGetClusterOwnerNode, map[string]string{"ClusterName": "lab-hv"}},
 		{"psGetClusterResourceOwner", psGetClusterResourceOwner, map[string]string{"ClusterName": "lab-hv"}},
+		{"psGetClusterAccessSelf", psGetClusterAccessSelf, map[string]string{"ClusterName": "lab-hv"}},
 		// Failover cluster write verbs (cluster.go, #2202 S2)
 		{"psAddClusterVMRole", psAddClusterVMRole, map[string]string{"ClusterName": "lab-hv", "VMName": "web-01"}},
 		{"psRemoveClusterResource", psRemoveClusterResource, map[string]string{"Name": "web-01"}},

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -78,6 +78,8 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 			" -CASrc " + quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:
 		return emit("Cfgms-DetachSeedVHD -Path " + quoteArg(psArgs, "Path"))
+	case psDeleteSeedMedia:
+		return emit("Cfgms-DeleteSeedMedia -Path " + quoteArg(psArgs, "Path"))
 	case psPrepCloudBootDisk:
 		return emit("Cfgms-PrepCloudBootDisk -ImagePath " + quoteArg(psArgs, "ImagePath") +
 			" -VhdPath " + quoteArg(psArgs, "VhdPath") +
@@ -498,6 +500,7 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psMountSeedVHD", psMountSeedVHD, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
 		{"psCopyToSeedVHD", psCopyToSeedVHD, map[string]string{"SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx", "FileName": "preseed.cfg", "Content": "# placeholder preseed"}},
 		{"psDetachSeedVHD", psDetachSeedVHD, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
+		{"psDeleteSeedMedia", psDeleteSeedMedia, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
 		{"psAttachSeedDisk", psAttachSeedDisk, map[string]string{"Name": "cfgms-t__web-01", "SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
 		{"psAttachDVD", psAttachDVD, map[string]string{"Name": "cfgms-t__web-01", "ISOPath": "C:\\ISO\\server.iso"}},
 		{"psSetVMFirmware", psSetVMFirmware, map[string]string{"Name": "cfgms-t__web-01", "Template": "MicrosoftWindows"}},
@@ -571,6 +574,25 @@ func TestPreamble_RemoveVMStopsRunningVMFirst(t *testing.T) {
 	require.NotEqual(t, -1, removeIdx)
 	assert.Less(t, stopIdx, removeIdx,
 		"Stop-VM must be ordered before Remove-VM, otherwise the running VM blocks its own deletion")
+}
+
+// TestPreamble_DeleteSeedMediaUsesLiteralPathAndSilentContinue guards the
+// security and idempotency properties of the Cfgms-DeleteSeedMedia preamble
+// function (ADR-010 §5 / Issue #2081). Dispatch tests assert routing only;
+// this test asserts the function body itself:
+//   - -LiteralPath prevents wildcard/glob expansion — a crafted path like
+//     "C:\seeds\*" or "C:\seeds\[vol]*.vhdx" must not expand.
+//   - -ErrorAction SilentlyContinue makes the delete idempotent — removing an
+//     already-absent file is not an error.
+func TestPreamble_DeleteSeedMediaUsesLiteralPathAndSilentContinue(t *testing.T) {
+	body := preambleFunctionBody(t, "Cfgms-DeleteSeedMedia")
+
+	assert.Contains(t, body, "-LiteralPath",
+		"Cfgms-DeleteSeedMedia must use -LiteralPath to prevent wildcard glob expansion on the seed path")
+	assert.Contains(t, body, "SilentlyContinue",
+		"Cfgms-DeleteSeedMedia must use -ErrorAction SilentlyContinue for idempotency (absent file is not an error)")
+	assert.Contains(t, body, "Remove-Item",
+		"Cfgms-DeleteSeedMedia must call Remove-Item")
 }
 
 // preambleFunctionBody extracts the body of a `function <name> { ... }` block

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -267,6 +267,15 @@ function Cfgms-DetachSeedVHD {
     Dismount-VHD -Path $Path -ErrorAction SilentlyContinue
 }
 
+# Cfgms-DeleteSeedMedia removes the seed VHDX or answer ISO file after
+# enrollment (ADR-010 §5). Idempotent — SilentlyContinue means an absent file
+# is not an error. The path travels via ArgumentList only; it is never
+# interpolated into the script text.
+function Cfgms-DeleteSeedMedia {
+    param([Parameter(Mandatory)][string]$Path)
+    Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+}
+
 # Cfgms-AttachSeedDisk attaches the seed VHDX to the VM as a secondary hard
 # disk. $SeedPath travels via ArgumentList.
 function Cfgms-AttachSeedDisk {

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -1046,6 +1046,11 @@ func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName st
 	if err := m.finalizeProvision(ctx, vmName, hostName, cfg); err != nil {
 		return err
 	}
+	// TTL sweep: clean up orphaned seed media for any stale provision records
+	// (ADR-010 §5). Called after finalizeProvision so the just-advanced record
+	// (UpdatedAt = now) is naturally excluded by the TTL check. Best-effort —
+	// a sweep failure does not block convergence.
+	m.sweepStaleSeedMedia(ctx)
 	return m.applyVMState(ctx, vmName, hostName, cfg, currentVM, state)
 }
 

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -66,6 +66,12 @@ const (
 	// create path this story implements).
 	psDetachSeedVHD = `Dismount-VHD -Path $Path -ErrorAction SilentlyContinue`
 
+	// psDeleteSeedMedia removes a staged seed file (seed VHDX or answer ISO)
+	// after enrollment. Idempotent — SilentlyContinue means an already-absent
+	// file is not an error. The path travels via ArgumentList only; it is never
+	// interpolated into the script text.
+	psDeleteSeedMedia = `Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue`
+
 	// psAttachSeedDisk wraps Add-VMHardDiskDrive: attach the seed VHDX as the
 	// VM's secondary disk.
 	psAttachSeedDisk = `Add-VMHardDiskDrive -VMName $Name -Path $SeedPath`
@@ -117,6 +123,14 @@ const (
 // gibibyte is 1024^3, used to convert source.resize_gb into a byte count for the
 // cloud boot-disk resize (0 means "leave at native size").
 const gibibyte = int64(1) << 30
+
+// seedMediaTTL is the maximum time staged seed media (seed VHDX, answer ISO)
+// may remain on disk after the provision record's last update. The TTL sweep
+// (sweepStaleSeedMedia) catches orphaned media from failed or aborted
+// provisions — bounding the on-disk join-token window even when the per-VM
+// finalizeProvision delete was never reached (e.g. the VM was deleted
+// mid-install).
+const seedMediaTTL = 24 * time.Hour
 
 // secureBootTemplate returns the Gen2 secure-boot firmware template for the
 // given os_family. Windows guests use the Microsoft Windows template; Linux
@@ -708,6 +722,27 @@ func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName s
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", "vm:"+vmName, nil, nil, nil)
 
+	// Delete the seed VHDX and the answer ISO (ADR-010 §5). Both calls are
+	// idempotent — psDeleteSeedMedia uses SilentlyContinue so an absent file
+	// is not an error. For linux/cloud-init VMs the seed VHDX exists; the ISO
+	// path is a no-op. For windows VMs the seed VHDX never existed; the ISO
+	// path deletes the answer ISO built by psBuildAnswerIso.
+	isoPath := answerISOPath(vmName, cfg.VHDPath, m.seedDir)
+	for _, mediaPath := range []string{seedPath, isoPath} {
+		if _, psErr := m.transport.ExecutePS(ctx, psDeleteSeedMedia, map[string]string{
+			"Path": mediaPath,
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-Item", "vm:"+vmName, nil, nil, psErr)
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: seed media delete failed; TTL sweep will retry",
+					"vm_name", logging.SanitizeLogValue(vmName),
+					"path", logging.SanitizeLogValue(mediaPath))
+			}
+			continue
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-Item", "vm:"+vmName, nil, nil, nil)
+	}
+
 	// Advance installing → finalizing. ready is controller-side (#2050).
 	return m.advanceProvision(ctx, vmName, record, ProvisionStateFinalizing)
 }
@@ -737,4 +772,58 @@ func (m *hypervModule) vmIsRunning(ctx context.Context, vmName string) (bool, er
 		return false, err
 	}
 	return strings.EqualFold(current.State, "running"), nil
+}
+
+// sweepStaleSeedMedia deletes staged seed media (seed VHDX + answer ISO) for
+// any provision record whose UpdatedAt is older than seedMediaTTL. This is a
+// safety net that bounds the on-disk join-token window for orphaned media left
+// by failed or aborted provisions — e.g. a VM deleted mid-install, or a
+// finalizeProvision delete that failed transiently. All Remove-Item calls use
+// psDeleteSeedMedia (SilentlyContinue), so absent files are not errors. Paths
+// are derived from seedVHDPath / answerISOPath; if neither seedDir is set nor
+// the VM's VHD path is known from the module cache, the path fails validation
+// and that file is silently skipped.
+func (m *hypervModule) sweepStaleSeedMedia(ctx context.Context) {
+	if m.provisionStore == nil || m.transport == nil {
+		return
+	}
+	records, err := m.provisionStore.ListProvisions(ctx)
+	if err != nil {
+		return
+	}
+	for _, rec := range records {
+		if rec.State == ProvisionStateAbsent {
+			continue
+		}
+		if time.Since(rec.UpdatedAt) < seedMediaTTL {
+			continue
+		}
+		// Derive the VHD path from the module's VM cache. Unknown VMs (deleted
+		// mid-provision) get an empty vhdPath, which is fine when seedDir is set.
+		m.vmsMu.RLock()
+		cachedCfg, ok := m.vms[rec.VMName]
+		m.vmsMu.RUnlock()
+		vhdPath := ""
+		if ok {
+			vhdPath = cachedCfg.VHDPath
+		}
+		for _, mediaPath := range []string{
+			seedVHDPath(rec.VMName, vhdPath, m.seedDir),
+			answerISOPath(rec.VMName, vhdPath, m.seedDir),
+		} {
+			if validateSeedPath(mediaPath) != nil {
+				// Path not derivable (seedDir unset and VM absent from cache); skip.
+				continue
+			}
+			if _, psErr := m.transport.ExecutePS(ctx, psDeleteSeedMedia, map[string]string{
+				"Path": mediaPath,
+			}); psErr != nil {
+				if logger, ok := m.GetLogger(); ok {
+					logger.Warn("hyperv: TTL sweep seed media delete failed",
+						"vm_name", logging.SanitizeLogValue(rec.VMName),
+						"path", logging.SanitizeLogValue(mediaPath))
+				}
+			}
+		}
+	}
 }

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -762,7 +762,7 @@ func TestProvision_FinalizeDeletesSeedMediaPostDetach(t *testing.T) {
 	// Remove-Item is issued for both the seed VHDX and the answer ISO — both
 	// paths travel via args only. SilentlyContinue makes it idempotent.
 	deletes := callsContaining(calls, "Remove-Item")
-	require.GreaterOrEqual(t, len(deletes), 1, "finalizing must issue at least one Remove-Item for seed media")
+	require.GreaterOrEqual(t, len(deletes), 2, "finalizing must issue Remove-Item for both seed VHDX and answer ISO")
 	seedPaths := make([]string, 0, len(deletes))
 	for _, d := range deletes {
 		for _, a := range d.args {

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -4,6 +4,7 @@ package hyperv
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -710,4 +711,289 @@ func TestProvisionVM_NoSourceSkipsProvisioning(t *testing.T) {
 
 	_, err := store.GetProvision(context.Background(), "plain-vm")
 	assert.ErrorIs(t, err, ErrProvisionNotFound, "no source: no provisioning record")
+}
+
+// ── REQUIRED TEST: seed VHDX + answer media deleted post-finalizing ──────────
+
+// TestProvision_FinalizeDeletesSeedMediaPostDetach is the REQUIRED TEST
+// (ADR-010 §5 / Issue #2081). It proves that when a VM's installing record
+// passes the settle window and the VM is running, finalizeProvision:
+//  1. Issues Dismount-VHD (detach) before Remove-Item (delete).
+//  2. Issues Remove-Item for BOTH the seed VHDX path and the answer ISO path
+//     — idempotent, so a non-existent file is not an error.
+//  3. Advances the record to finalizing (not ready — that is controller-side).
+//
+// The delete is issued post-finalizing in the sense that it is part of the
+// same convergence cycle that advances the record to finalizing, bounding the
+// on-disk join-token window to that single cycle. A second convergence cycle
+// on the same (now-finalizing) record issues no further Remove-Item calls,
+// proving system-level idempotency.
+func TestProvision_FinalizeDeletesSeedMediaPostDetach(t *testing.T) {
+	transport := &testWinRMTransport{
+		output: runningSourceVMJSON(),
+	}
+	store := NewMemProvisionStore()
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stw-01",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "stw-01",
+		StartedAt:     time.Now().Add(-2 * time.Hour),
+	}))
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	// Detach must precede delete — both path values travel via args, never the
+	// script text (ADR-009 §5 — no user-controlled value in script).
+	detach := callsContaining(calls, "Dismount-VHD")
+	require.Len(t, detach, 1, "finalizing must issue exactly one Dismount-VHD")
+	assert.True(t, argsContain(detach[0], `C:\ClusterStorage\CSV01\cfgms-seed-stw-01.vhdx`),
+		"seed path must travel via args")
+	assert.NotContains(t, detach[0].scriptBlock, "cfgms-seed-stw-01",
+		"seed path must not be interpolated into the script text")
+
+	// Remove-Item is issued for both the seed VHDX and the answer ISO — both
+	// paths travel via args only. SilentlyContinue makes it idempotent.
+	deletes := callsContaining(calls, "Remove-Item")
+	require.GreaterOrEqual(t, len(deletes), 1, "finalizing must issue at least one Remove-Item for seed media")
+	seedPaths := make([]string, 0, len(deletes))
+	for _, d := range deletes {
+		for _, a := range d.args {
+			if s, ok := a.(string); ok && strings.Contains(s, "cfgms-") {
+				seedPaths = append(seedPaths, s)
+			}
+		}
+	}
+	assert.Contains(t, seedPaths, `C:\ClusterStorage\CSV01\cfgms-seed-stw-01.vhdx`,
+		"seed VHDX must be deleted via args")
+	for _, d := range deletes {
+		assert.Contains(t, d.scriptBlock, "SilentlyContinue",
+			"seed media delete must be idempotent (SilentlyContinue)")
+		assert.NotContains(t, d.scriptBlock, "cfgms-seed-stw-01",
+			"path must not be interpolated into the delete script text")
+	}
+
+	// Detach must precede the first Remove-Item in the recorded call sequence.
+	detachIdx := -1
+	firstDeleteIdx := -1
+	for i, c := range calls {
+		if strings.Contains(c.scriptBlock, "Dismount-VHD") && detachIdx < 0 {
+			detachIdx = i
+		}
+		if strings.Contains(c.scriptBlock, "Remove-Item") && firstDeleteIdx < 0 {
+			firstDeleteIdx = i
+		}
+	}
+	require.Greater(t, detachIdx, -1, "Dismount-VHD must be recorded")
+	require.Greater(t, firstDeleteIdx, -1, "Remove-Item must be recorded")
+	assert.Less(t, detachIdx, firstDeleteIdx, "Dismount-VHD must precede Remove-Item")
+
+	// Record must be at finalizing after the cycle.
+	rec, err := store.GetProvision(context.Background(), "stw-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateFinalizing, rec.State,
+		"record must advance to finalizing after detach+delete")
+
+	// ── Idempotency: a second convergence cycle on the now-finalizing record
+	// must NOT issue another Dismount-VHD or Remove-Item.
+	transport.mu.Lock()
+	transport.calls = nil
+	transport.mu.Unlock()
+
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls2 := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls2, "Dismount-VHD"),
+		"second cycle on finalizing record must not re-detach the seed")
+	assert.Empty(t, callsContaining(calls2, "Remove-Item"),
+		"second cycle on finalizing record must not re-delete seed media")
+}
+
+// TestProvision_WindowsFinalizeDeletesAnswerISO asserts the Windows path
+// (answer ISO, not seed VHDX) issues Remove-Item for the answer ISO path on
+// finalization. The seed VHDX path is also attempted (idempotent no-op since
+// it never existed for Windows VMs).
+func TestProvision_WindowsFinalizeDeletesAnswerISO(t *testing.T) {
+	vmJSON := `{"found":true,"Name":"stw-01","MemoryStartupBytes":4294967296,` +
+		`"ProcessorCount":2,"Generation":2,"Path":"C:\\ClusterStorage\\CSV01\\stw-01.vhdx",` +
+		`"SwitchName":"HVSwitch_1G","SwitchNames":["HVSwitch_1G"],"State":"Running"}`
+	transport := &testWinRMTransport{output: vmJSON}
+	store := NewMemProvisionStore()
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stw-01",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "stw-01",
+		StartedAt:     time.Now().Add(-2 * time.Hour),
+	}))
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	deletes := callsContaining(calls, "Remove-Item")
+	require.GreaterOrEqual(t, len(deletes), 1, "windows finalization must issue Remove-Item for answer ISO")
+
+	isoPaths := make([]string, 0)
+	for _, d := range deletes {
+		for _, a := range d.args {
+			if s, ok := a.(string); ok && strings.Contains(s, "cfgms-answer") {
+				isoPaths = append(isoPaths, s)
+			}
+		}
+	}
+	assert.Contains(t, isoPaths, `C:\ClusterStorage\CSV01\cfgms-answer-stw-01.iso`,
+		"answer ISO path must be deleted for the windows path")
+}
+
+// TestProvision_FinalizeDeleteSeedMediaErrorDoesNotBlockAdvance asserts that a
+// transient ExecutePS failure on psDeleteSeedMedia does NOT fail the provision
+// or block the record from advancing to finalizing. The detach (psDetachSeedVHD)
+// already removed the answer file from the guest's visible media; the delete is
+// a best-effort on-disk cleanup, and the TTL sweep is the safety net for any
+// failed deletes. A failed delete must log a warning and continue.
+func TestProvision_FinalizeDeleteSeedMediaErrorDoesNotBlockAdvance(t *testing.T) {
+	// Call sequence when an installing record is past the settle window and the VM
+	// is running:
+	//   0: getVM (existence check in setVM)        → Running
+	//   1: getVM (vmIsRunning in finalizeProvision) → Running
+	//   2: psDetachSeedVHD                          → success
+	//   3: psDeleteSeedMedia (seed VHDX path)       → ERROR (simulated transient failure)
+	//   4: psDeleteSeedMedia (answer ISO path)      → success (continue after error)
+	deleteErr := fmt.Errorf("PS host: Remove-Item failed (access denied)")
+	transport := &testWinRMTransport{
+		output:        runningSourceVMJSON(),
+		perCallErrors: []error{nil, nil, nil, deleteErr},
+	}
+	store := NewMemProvisionStore()
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stw-01",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "stw-01",
+		StartedAt:     time.Now().Add(-2 * time.Hour),
+		UpdatedAt:     time.Now().Add(-2 * time.Hour),
+	}))
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
+	// Must succeed — a failed seed-media delete is non-fatal.
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg),
+		"failed seed-media delete must not propagate as a provision failure")
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	// Detach must still run.
+	require.Len(t, callsContaining(calls, "Dismount-VHD"), 1)
+	// Both Remove-Item calls must be issued (error on first does not skip second).
+	require.Len(t, callsContaining(calls, "Remove-Item"), 2,
+		"both seed VHDX and answer ISO Remove-Item calls must be attempted even after error on first")
+
+	// Record must advance to finalizing despite the failed delete.
+	rec, err := store.GetProvision(context.Background(), "stw-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateFinalizing, rec.State,
+		"record must still advance to finalizing when seed-media delete fails")
+}
+
+// TestProvision_SweepNilGuardsAreNoop asserts that sweepStaleSeedMedia returns
+// silently when the provision store or transport are nil, without panicking.
+func TestProvision_SweepNilGuardsAreNoop(t *testing.T) {
+	// nil provisionStore
+	m1 := &hypervModule{
+		transport:      &testWinRMTransport{},
+		provisionStore: nil,
+		vms:            make(map[string]VMConfig),
+	}
+	require.NotPanics(t, func() { m1.sweepStaleSeedMedia(context.Background()) },
+		"nil provisionStore must not panic")
+
+	// nil transport
+	m2 := &hypervModule{
+		transport:      nil,
+		provisionStore: NewMemProvisionStore(),
+		vms:            make(map[string]VMConfig),
+	}
+	require.NotPanics(t, func() { m2.sweepStaleSeedMedia(context.Background()) },
+		"nil transport must not panic")
+}
+
+// TestProvision_SweepDeletesStaleSeedMedia asserts that sweepStaleSeedMedia
+// issues Remove-Item for a stale provision record's seed paths when the record
+// is older than seedMediaTTL, without affecting a fresh record.
+func TestProvision_SweepDeletesStaleSeedMedia(t *testing.T) {
+	transport := &testWinRMTransport{output: runningSourceVMJSON()}
+	store := NewMemProvisionStore()
+
+	// Stale record: updated 48h ago — well past seedMediaTTL.
+	stalePast := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stale-vm",
+		State:         ProvisionStateFinalizing,
+		CorrelationID: "stale-vm",
+		StartedAt:     stalePast,
+		UpdatedAt:     stalePast,
+	}))
+
+	// Fresh record: updated just now — within the TTL window, must not be swept.
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "fresh-vm",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "fresh-vm",
+		StartedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}))
+
+	// Wire a VHD path for stale-vm so the sweep can derive the media path.
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+	m.seedDir = `C:\cfgms-seeds`
+	m.vmsMu.Lock()
+	m.vms["stale-vm"] = VMConfig{VHDPath: `C:\VMs\stale-vm.vhdx`}
+	m.vmsMu.Unlock()
+
+	m.sweepStaleSeedMedia(context.Background())
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	deletes := callsContaining(calls, "Remove-Item")
+	require.GreaterOrEqual(t, len(deletes), 1, "sweep must issue Remove-Item for the stale record")
+
+	// The stale-vm seed paths must appear in the delete args.
+	var deletedPaths []string
+	for _, d := range deletes {
+		for _, a := range d.args {
+			if s, ok := a.(string); ok && strings.Contains(s, "stale-vm") {
+				deletedPaths = append(deletedPaths, s)
+			}
+		}
+	}
+	assert.NotEmpty(t, deletedPaths, "stale-vm seed media paths must be deleted by the sweep")
+
+	// The fresh-vm paths must NOT appear in the delete args.
+	for _, d := range deletes {
+		for _, a := range d.args {
+			if s, ok := a.(string); ok {
+				assert.NotContains(t, s, "fresh-vm",
+					"fresh record must not be swept before TTL expires")
+			}
+		}
+	}
 }

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -18,7 +18,8 @@ import (
 // real in-memory SecretStore is injected so the windows create path can resolve
 // the .ppkg host-path secret ({{ secret "ppkg-path-key" }}) when rendering the
 // autounattend answer file (#2047) — no mock framework is used.
-func provisionModuleWithTransport(transport winrmTransport) *hypervModule {
+func provisionModuleWithTransport(t *testing.T, transport winrmTransport) *hypervModule {
+	t.Helper()
 	m := &hypervModule{
 		executor:       &stubHypervExecutor{},
 		transport:      transport,
@@ -37,10 +38,10 @@ func provisionModuleWithTransport(transport winrmTransport) *hypervModule {
 	// user password. The Windows autounattend (ADR-010) no longer reads secrets
 	// (token + CA fingerprint are controller-supplied ProfileVars), so it needs
 	// no store entries.
-	_ = m.SetSecretStore(newInlineStore(
+	require.NoError(t, m.SetSecretStore(newInlineStore(
 		"hyperv/enroll/regtoken", "reg-token-stub-value",
 		"hyperv/enroll/user-password-crypted", "$6$rounds=4096$stub$cryptedstub",
-	))
+	)))
 	return m
 }
 
@@ -85,7 +86,7 @@ func TestProvisionVM_Gen1SkipsFirmware(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`}, // getVM → absent
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(1, "linux")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -200,7 +201,7 @@ func TestProvisionVM_Gen2WindowsFirmwareTemplate(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`},
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -226,7 +227,7 @@ func TestProvisionVM_Gen2LinuxFirmwareTemplate(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`},
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -253,7 +254,7 @@ func TestProvisionVM_SeedVHDBuildAndAttachSequence(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`},
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -303,7 +304,7 @@ func TestProvisionVM_SeedVHDBuildAndAttachSequence(t *testing.T) {
 // seed VHDX.
 func TestProvisionVM_WindowsBuildsAnswerISO(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -330,7 +331,7 @@ func TestProvisionVM_AttachesInstallISOFromHostPath(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`},
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -381,7 +382,7 @@ func cloudInitVMConfigMap(generation int) map[string]interface{} {
 // boot device; and there is NO install ISO, NO answer ISO, and NO boot keypress.
 func TestProvisionVM_CloudInitPath(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	// The linux steward + launcher binaries + CA host paths the seed stages (ADR-010).
 	// The launcher is required for a launcher-managed (push-upgradeable) install.
 	m.enrollStewardPath = `C:\seed-assets\cfgms-steward-linux`
@@ -432,7 +433,7 @@ func TestProvisionVM_CloudInitPath(t *testing.T) {
 // firmware boot device — same Gen1 contract as the install-media path).
 func TestProvisionVM_CloudInitGen1SkipsHddFirstBoot(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: cloudInitVMConfigMap(1)}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -457,7 +458,7 @@ func TestProvisionVM_CloudInitGen1SkipsHddFirstBoot(t *testing.T) {
 // runcmd and no banned patterns.
 func TestProvision_CloudInitUserDataRenderedToSeed(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: cloudInitVMConfigMap(2)}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
@@ -521,7 +522,7 @@ func TestProvision_InstallingToFinalizingDetachesSeed(t *testing.T) {
 		CorrelationID: "stw-01",
 		StartedAt:     time.Now().Add(-2 * time.Hour),
 	}))
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
@@ -560,7 +561,7 @@ func TestProvision_InstallingNotSettledDoesNotDetach(t *testing.T) {
 		CorrelationID: "stw-01",
 		StartedAt:     time.Now(), // just started — well within the settle window
 	}))
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
@@ -587,7 +588,7 @@ func TestProvision_RealPreseedRenderedToSeed(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`}, // getVM → absent
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	require.NoError(t, m.SetSecretStore(preseedTestStore()))
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
@@ -630,7 +631,7 @@ func TestProvisionVM_AdvancesRecordAbsentToInstalling(t *testing.T) {
 		perCallOutputs: []string{`{"found":false}`},
 	}
 	store := NewMemProvisionStore()
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
@@ -658,7 +659,7 @@ func TestProvisionVM_ResumeFromInstallingDoesNotRestart(t *testing.T) {
 		State:         ProvisionStateInstalling,
 		CorrelationID: "stw-01",
 	}))
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
@@ -687,7 +688,7 @@ func TestProvisionVM_NoSourceSkipsProvisioning(t *testing.T) {
 		perCallOutputs: []string{`{"found":false}`},
 	}
 	store := NewMemProvisionStore()
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: map[string]interface{}{
@@ -739,7 +740,7 @@ func TestProvision_FinalizeDeletesSeedMediaPostDetach(t *testing.T) {
 		CorrelationID: "stw-01",
 		StartedAt:     time.Now().Add(-2 * time.Hour),
 	}))
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
@@ -834,7 +835,7 @@ func TestProvision_WindowsFinalizeDeletesAnswerISO(t *testing.T) {
 		CorrelationID: "stw-01",
 		StartedAt:     time.Now().Add(-2 * time.Hour),
 	}))
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
@@ -886,7 +887,7 @@ func TestProvision_FinalizeDeleteSeedMediaErrorDoesNotBlockAdvance(t *testing.T)
 		StartedAt:     time.Now().Add(-2 * time.Hour),
 		UpdatedAt:     time.Now().Add(-2 * time.Hour),
 	}))
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
@@ -960,7 +961,7 @@ func TestProvision_SweepDeletesStaleSeedMedia(t *testing.T) {
 	}))
 
 	// Wire a VHD path for stale-vm so the sweep can derive the media path.
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	m.provisionStore = store
 	m.seedDir = `C:\cfgms-seeds`
 	m.vmsMu.Lock()

--- a/features/modules/hyperv/vm_reconcile_integration_test.go
+++ b/features/modules/hyperv/vm_reconcile_integration_test.go
@@ -271,7 +271,7 @@ func TestExistenceGating_ExistingVMNotRecreatedByDefault(t *testing.T) {
 	transport := &testWinRMTransport{
 		output: existingSourceVMJSON("stw-01", "Running"),
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")} // on_existing: never
 
@@ -299,7 +299,7 @@ func TestExistenceGating_ExistingStoppedVMNotRecreatedByDefault(t *testing.T) {
 	transport := &testWinRMTransport{
 		output: existingSourceVMJSON("stw-01", "Off"),
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")} // desired running, on_existing: never
 
@@ -324,7 +324,7 @@ func TestExistenceGating_BrokenVMSurfacesAsDegraded(t *testing.T) {
 	transport := &testWinRMTransport{
 		output: existingSourceVMJSON("stw-01", "Critical"),
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")} // on_existing: never
 
@@ -354,7 +354,7 @@ func TestExistenceGating_RecreateOnlyWhenExplicit(t *testing.T) {
 	transport := &testWinRMTransport{
 		output: existingSourceVMJSON("stw-01", "Running"),
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 
 	configMap := sourceVMConfigMap(2, "linux")
 	src := configMap["source"].(map[string]interface{})
@@ -393,7 +393,7 @@ func TestExistenceGating_OwnIncompleteAttemptDoesNotAutoRetry(t *testing.T) {
 	transport := &testWinRMTransport{
 		output: `{"found":false}`, // host reports the VM absent
 	}
-	m := provisionModuleWithTransport(transport)
+	m := provisionModuleWithTransport(t, transport)
 	require.NoError(t, m.provisionStore.SetProvision(context.Background(), &ProvisionRecord{
 		VMName:        "stw-01",
 		State:         ProvisionStateInstalling,

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -1457,3 +1457,89 @@ func TestSetVM_HARole_RegistersClusteredRole(t *testing.T) {
 			"an already-registered role must not be added again (S2 idempotency)")
 	})
 }
+
+// TestParseHARoleMap exercises the executor-supplied map decode path directly:
+// a standalone VM (no ha_role, or a malformed/empty block) yields a nil HARole,
+// while a well-formed ha_role map is decoded into an HARoleConfig. This is the
+// map-shaped runtime input the generic executor delivers (not the *VMConfig
+// short-circuit), so it must be covered independently of the typed create path.
+func TestParseHARoleMap(t *testing.T) {
+	// Standalone / absent-or-malformed inputs → nil (no clustered registration).
+	assert.Nil(t, parseHARoleMap(nil), "absent ha_role → standalone VM")
+	assert.Nil(t, parseHARoleMap("not-a-map"), "non-map ha_role → standalone VM")
+	assert.Nil(t, parseHARoleMap(map[string]interface{}{}), "empty ha_role map → standalone VM")
+	assert.Nil(t, parseHARoleMap(map[string]interface{}{"resource_group_name": "rg-only"}),
+		"ha_role without cluster_name → standalone VM (cluster_name is the anchor)")
+	assert.Nil(t, parseHARoleMap(map[string]interface{}{"cluster_name": "   "}),
+		"whitespace-only cluster_name → standalone VM")
+
+	// cluster_name only → HARole with an empty resource_group_name.
+	role := parseHARoleMap(map[string]interface{}{"cluster_name": "lab-hv"})
+	require.NotNil(t, role, "a cluster_name must decode into an HARoleConfig")
+	assert.Equal(t, "lab-hv", role.ClusterName)
+	assert.Equal(t, "", role.ResourceGroupName)
+
+	// Full block → both fields decoded.
+	role = parseHARoleMap(map[string]interface{}{
+		"cluster_name":        "lab-hv",
+		"resource_group_name": "rg-ha",
+	})
+	require.NotNil(t, role)
+	assert.Equal(t, "lab-hv", role.ClusterName)
+	assert.Equal(t, "rg-ha", role.ResourceGroupName)
+}
+
+// TestSetVM_HARole_MapShapeRegistersClusteredRole drives the create path with an
+// executor-shaped config MAP carrying a nested ha_role block (the generic runtime
+// input), rather than a typed *VMConfig. This proves parseHARoleMap wires the
+// decoded HARole into setVM and that registerClusteredRole then delegates to
+// setCluster — the map-shaped path the *VMConfig short-circuit (vm.go) bypasses.
+func TestSetVM_HARole_MapShapeRegistersClusteredRole(t *testing.T) {
+	const vmName = "ha-map-vm"
+	const cluster = "lab-hv"
+
+	mapCfg := rawConfigState{m: map[string]interface{}{
+		"name":        vmName,
+		"memory_mb":   4096,
+		"cpu_count":   2,
+		"vhd_path":    `C:\VMs\ha-map-vm.vhdx`, // non-CSV: seed-dir rule not triggered
+		"switch_name": "Default Switch",
+		"generation":  2,
+		"state":       "stopped",
+		"ha_role": map[string]interface{}{
+			"cluster_name":        cluster,
+			"resource_group_name": "rg-ha",
+		},
+	}}
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"found":false}`,   // getVM: VM absent
+		``,                  // New-VM: create succeeds
+		`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)
+		`{"owners":{}}`,     // ownership helper: resource owners (role absent)
+		`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read
+		``,                  // Add-ClusterVirtualMachineRole: success
+	}}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "vm:"+vmName, mapCfg))
+
+	// The decoded HARole must drive exactly one clustered-role registration.
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"a map-shaped ha_role must register the clustered role exactly once")
+
+	addArgs := psArgsForCmd(transport, psAddClusterVMRole)
+	require.NotNil(t, addArgs, "the Add call's psArgs must be recorded")
+	assert.Equal(t, cluster, addArgs["ClusterName"])
+	assert.Equal(t, vmName, addArgs["VMName"])
+
+	// Names travel via psArgs only, never composed into the scriptBlock (S3).
+	for _, sb := range scriptBlocks(transport) {
+		assert.NotContains(t, sb, vmName,
+			"VM/role name must travel via ArgumentList, never the scriptBlock")
+		assert.NotContains(t, sb, cluster,
+			"cluster name must travel via ArgumentList, never the scriptBlock")
+	}
+}

--- a/features/modules/hyperv/windows_profile_test.go
+++ b/features/modules/hyperv/windows_profile_test.go
@@ -192,7 +192,7 @@ func TestRandomAdminPassword_ComplexAndUnique(t *testing.T) {
 // renders a real autounattend (not the placeholder), with the CorrelationID
 // baked in and a generated AdminPassword present.
 func TestRenderSeedAnswerFile_WindowsRendersAutounattend(t *testing.T) {
-	m := provisionModuleWithTransport(&testWinRMTransport{})
+	m := provisionModuleWithTransport(t, &testWinRMTransport{})
 	src := &SourceConfig{ISO: `C:\iso\ws2025.iso`, OSFamily: "windows"}
 
 	content, err := m.renderSeedAnswerFile(context.Background(), "stw-win-09", src, "stw-win-09")


### PR DESCRIPTION
## Summary

- Deletes the seed VHDX immediately after `Dismount-VHD` in `finalizeProvision` (installing → finalizing) to minimize the on-disk join-token window (ADR-010 §5)
- Deletes the answer ISO in the same pass
- Adds `sweepStaleSeedMedia` TTL sweep (24 h) as a safety net for any delete failures — called after `finalizeProvision` so the just-advanced record is naturally excluded
- New `Cfgms-DeleteSeedMedia` PS preamble uses `-LiteralPath` and `-ErrorAction SilentlyContinue` for idempotency
- All PS values travel via `ArgumentList`, never interpolated into script text

## Test plan

- [x] `TestProvision_FinalizeDeletesSeedMediaPostDetach` — REQUIRED: recording transport proves Remove-Item is issued after Dismount-VHD, idempotent on repeat
- [x] `TestProvision_WindowsFinalizeDeletesAnswerISO` — answer ISO deleted in same finalizeProvision pass
- [x] `TestProvision_FinalizeDeleteSeedMediaErrorDoesNotBlockAdvance` — delete failure is non-fatal, provision advances normally
- [x] `TestProvision_SweepNilGuardsAreNoop` — nil transport/store guards
- [x] `TestProvision_SweepDeletesStaleSeedMedia` — TTL sweep issues Remove-Item for stale records
- [x] `TestPreamble_DeleteSeedMediaUsesLiteralPathAndSilentContinue` — preamble body verified
- [x] `TestDispatch_AllKnownCommands` — psDeleteSeedMedia dispatch entry
- [x] `make test-agent-complete` — all pre-commit, fast, production-critical, and cross-platform compilation checks pass
- [x] `make security-scan` — all security tools passed

Fixes #2081
Part of #2077

🤖 Generated with [Claude Code](https://claude.com/claude-code)