### PR TITLE
steward/dna: set exec WaitDelay on darwin security/software/hardware collectors (Issue #2361)

### DIFF
--- a/features/steward/dna/exec_darwin.go
+++ b/features/steward/dna/exec_darwin.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// darwinCmdWaitDelay bounds how long Output()/Run() will wait for a killed
+// command's I/O to drain before the pipes are force-closed. On macOS CI runners
+// a DNA-collection tool (e.g. dscl, netstat) can get stuck in a kernel call that
+// survives the context-driven SIGKILL while a grandchild keeps the stdout pipe
+// open; without WaitDelay, Output() blocks on that pipe indefinitely and leaks a
+// goroutine per collection cycle. WaitDelay guarantees the call returns.
+const darwinCmdWaitDelay = 5 * time.Second
+
+// darwinRunCmd runs an external command with a timeout context and WaitDelay so
+// that a child stuck after SIGKILL cannot block collection forever. It is the
+// generalization of network_darwin.go's darwinRunNetCmd, shared by every darwin
+// DNA collector. Callers keep their existing `err == nil` gating; on timeout or
+// a stuck-pipe drain the returned error is non-nil and output should be ignored.
+func darwinRunCmd(ctx context.Context, timeout time.Duration, name string, args ...string) ([]byte, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, name, args...)
+	cmd.WaitDelay = darwinCmdWaitDelay
+	return cmd.Output()
+}

--- a/features/steward/dna/exec_darwin_test.go
+++ b/features/steward/dna/exec_darwin_test.go
@@ -1,0 +1,40 @@
+//go:build darwin
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDarwinRunCmd_StuckChildDoesNotHang is the regression guard for the macOS CI
+// hang that ejected PRs from the merge queue (Issue #2361). It reproduces the
+// failure mode directly: a shell that backgrounds a long-lived grandchild which
+// inherits the stdout pipe, then exits. The grandchild keeps the write end open,
+// so Output()'s stdout copy cannot see EOF. Without cmd.WaitDelay this blocks for
+// the full grandchild lifetime (here 120s); with WaitDelay it must return within
+// roughly darwinCmdWaitDelay.
+func TestDarwinRunCmd_StuckChildDoesNotHang(t *testing.T) {
+	// A long grandchild lifetime makes a regression unmistakable: a hang would run
+	// ~120s (until the go test alarm), a healthy path returns in ~darwinCmdWaitDelay.
+	start := time.Now()
+	_, _ = darwinRunCmd(context.Background(), 2*time.Second, "sh", "-c", "sleep 120 &")
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 30*time.Second,
+		"darwinRunCmd must return within WaitDelay when a grandchild holds the stdout pipe open, not block on it")
+}
+
+// TestDarwinRunCmd_NormalCommandSucceeds confirms the WaitDelay wrapper does not
+// disturb ordinary fast commands: output is returned intact with no error.
+func TestDarwinRunCmd_NormalCommandSucceeds(t *testing.T) {
+	out, err := darwinRunCmd(context.Background(), darwinCmdWaitDelay, "echo", "cfgms")
+	require.NoError(t, err)
+	require.Equal(t, "cfgms", string(out[:len(out)-1])) // strip trailing newline
+}

--- a/features/steward/dna/hardware_darwin.go
+++ b/features/steward/dna/hardware_darwin.go
@@ -8,7 +8,6 @@ package dna
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -76,10 +75,7 @@ func (d *DarwinHardwareCollector) CollectMemory(ctx context.Context, attributes 
 	}
 
 	// Additional memory info from vm_stat if available
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinHwCmdTimeout)
-	defer cancel()
-
-	if vmstat, err := exec.CommandContext(cmdCtx, "vm_stat").Output(); err == nil {
+	if vmstat, err := darwinRunCmd(ctx, darwinHwCmdTimeout, "vm_stat"); err == nil {
 		d.parseVMStat(string(vmstat), attributes)
 	}
 
@@ -89,19 +85,14 @@ func (d *DarwinHardwareCollector) CollectMemory(ctx context.Context, attributes 
 // CollectDisk gathers disk and storage information on macOS
 func (d *DarwinHardwareCollector) CollectDisk(ctx context.Context, attributes map[string]string) error {
 	// Get disk information using diskutil
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinHwCmdTimeout)
-	if _, err := exec.CommandContext(cmdCtx, "diskutil", "list", "-plist").Output(); err == nil {
+	if _, err := darwinRunCmd(ctx, darwinHwCmdTimeout, "diskutil", "list", "-plist"); err == nil {
 		// diskutil plist output is available; set presence flag (detailed parsing is deferred).
 		attributes["disk_info_available"] = "true"
 		attributes["disk_collection_method"] = "diskutil"
 	}
-	cancel()
 
 	// Get filesystem information using df
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinHwCmdTimeout)
-	defer cancel2()
-
-	if output, err := exec.CommandContext(cmdCtx2, "df", "-h").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinHwCmdTimeout, "df", "-h"); err == nil {
 		d.parseDiskUsage(string(output), attributes)
 	}
 
@@ -116,23 +107,17 @@ func (d *DarwinHardwareCollector) CollectMotherboard(ctx context.Context, attrib
 	}
 
 	// System version
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinHwCmdTimeout)
-	if version, err := exec.CommandContext(cmdCtx, "sw_vers", "-productVersion").Output(); err == nil {
+	if version, err := darwinRunCmd(ctx, darwinHwCmdTimeout, "sw_vers", "-productVersion"); err == nil {
 		attributes["os_version"] = strings.TrimSpace(string(version))
 	}
-	cancel()
 
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinHwCmdTimeout)
-	if build, err := exec.CommandContext(cmdCtx2, "sw_vers", "-buildVersion").Output(); err == nil {
+	if build, err := darwinRunCmd(ctx, darwinHwCmdTimeout, "sw_vers", "-buildVersion"); err == nil {
 		attributes["os_build"] = strings.TrimSpace(string(build))
 	}
-	cancel2()
 
-	cmdCtx3, cancel3 := context.WithTimeout(ctx, darwinHwCmdTimeout)
-	if name, err := exec.CommandContext(cmdCtx3, "sw_vers", "-productName").Output(); err == nil {
+	if name, err := darwinRunCmd(ctx, darwinHwCmdTimeout, "sw_vers", "-productName"); err == nil {
 		attributes["os_name"] = strings.TrimSpace(string(name))
 	}
-	cancel3()
 
 	// Hardware UUID (if available)
 	if uuid, err := d.getSysctl(ctx, "kern.uuid"); err == nil {
@@ -149,10 +134,7 @@ func (d *DarwinHardwareCollector) CollectMotherboard(ctx context.Context, attrib
 
 // getSysctl executes sysctl to get system information
 func (d *DarwinHardwareCollector) getSysctl(ctx context.Context, key string) (string, error) {
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinHwCmdTimeout)
-	defer cancel()
-
-	output, err := exec.CommandContext(cmdCtx, "sysctl", "-n", key).Output()
+	output, err := darwinRunCmd(ctx, darwinHwCmdTimeout, "sysctl", "-n", key)
 	if err != nil {
 		return "", err
 	}

--- a/features/steward/dna/network_darwin.go
+++ b/features/steward/dna/network_darwin.go
@@ -9,18 +9,11 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os/exec"
 	"strings"
 	"time"
 )
 
 const darwinNetCmdTimeout = 30 * time.Second
-
-// darwinNetCmdWaitDelay is the maximum time WaitDelay allows for a killed command's
-// I/O to drain before Output() is forced to return. On macOS CI runners, netstat can
-// get stuck in a kernel call that survives SIGKILL at the process level but leaves
-// the stdout pipe open; WaitDelay guarantees Output() returns regardless.
-const darwinNetCmdWaitDelay = 5 * time.Second
 
 // CollectInterfaces gathers detailed network interface information on macOS
 func (d *DarwinNetworkCollector) CollectInterfaces(ctx context.Context, attributes map[string]string) error {
@@ -48,12 +41,9 @@ func (d *DarwinNetworkCollector) CollectInterfaces(ctx context.Context, attribut
 // darwinRunNetCmd runs a command with a timeout context and WaitDelay so that
 // processes stuck in kernel calls (e.g. netstat on CI macOS) do not block
 // Output() indefinitely after SIGKILL. Returns nil output on timeout or error.
+// It is a nil-on-error convenience wrapper over the shared darwinRunCmd helper.
 func darwinRunNetCmd(ctx context.Context, timeout time.Duration, name string, args ...string) []byte {
-	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	cmd := exec.CommandContext(cmdCtx, name, args...)
-	cmd.WaitDelay = darwinNetCmdWaitDelay
-	output, err := cmd.Output()
+	output, err := darwinRunCmd(ctx, timeout, name, args...)
 	if err != nil {
 		return nil
 	}

--- a/features/steward/dna/security_darwin.go
+++ b/features/steward/dna/security_darwin.go
@@ -8,7 +8,6 @@ package dna
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -19,11 +18,9 @@ const darwinSecCmdTimeout = 30 * time.Second
 // CollectUsers gathers user account information on macOS
 func (d *DarwinSecurityCollector) CollectUsers(ctx context.Context, attributes map[string]string) error {
 	// System users using dscl
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "dscl", ".", "-list", "/Users").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "dscl", ".", "-list", "/Users"); err == nil {
 		d.parseSystemUsers(ctx, string(output), attributes)
 	}
-	cancel()
 
 	// User account details
 	d.collectUserDetails(ctx, attributes)
@@ -37,18 +34,14 @@ func (d *DarwinSecurityCollector) CollectUsers(ctx context.Context, attributes m
 // CollectGroups gathers group information on macOS
 func (d *DarwinSecurityCollector) CollectGroups(ctx context.Context, attributes map[string]string) error {
 	// System groups using dscl
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "dscl", ".", "-list", "/Groups").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "dscl", ".", "-list", "/Groups"); err == nil {
 		d.parseSystemGroups(ctx, string(output), attributes)
 	}
-	cancel()
 
 	// Administrative users
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "dseditgroup", "-o", "checkmember", "-m", "admin").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "dseditgroup", "-o", "checkmember", "-m", "admin"); err == nil {
 		d.parseAdminUsers(ctx, string(output), attributes)
 	}
-	cancel2()
 
 	return nil
 }
@@ -59,8 +52,7 @@ func (d *DarwinSecurityCollector) CollectPermissions(ctx context.Context, attrib
 	d.collectSystemPermissions(ctx, attributes)
 
 	// SIP (System Integrity Protection) status
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "csrutil", "status").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "csrutil", "status"); err == nil {
 		sipStatus := strings.TrimSpace(string(output))
 		if strings.Contains(sipStatus, "enabled") {
 			attributes["sip_status"] = "enabled"
@@ -70,14 +62,11 @@ func (d *DarwinSecurityCollector) CollectPermissions(ctx context.Context, attrib
 			attributes["sip_status"] = "unknown"
 		}
 	}
-	cancel()
 
 	// Gatekeeper status
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "spctl", "--status").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "spctl", "--status"); err == nil {
 		attributes["gatekeeper_status"] = strings.TrimSpace(string(output))
 	}
-	cancel2()
 
 	// File system permissions on key directories
 	d.collectKeyDirectoryPermissions(ctx, attributes)
@@ -94,12 +83,10 @@ func (d *DarwinSecurityCollector) CollectCertificates(ctx context.Context, attri
 	d.collectKeychainCertificates(ctx, attributes, "login")
 
 	// System roots
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "security", "list-keychains").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "security", "list-keychains"); err == nil {
 		keychains := strings.Split(strings.TrimSpace(string(output)), "\n")
 		attributes["keychain_count"] = fmt.Sprintf("%d", len(keychains))
 	}
-	cancel()
 
 	// Code signing certificates
 	d.collectCodeSigningCertificates(ctx, attributes)
@@ -120,8 +107,7 @@ func (d *DarwinSecurityCollector) parseSystemUsers(ctx context.Context, output s
 		}
 
 		// Get user ID to distinguish system vs regular users
-		cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-		if uidOutput, err := exec.CommandContext(cmdCtx, "id", "-u", user).Output(); err == nil {
+		if uidOutput, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "id", "-u", user); err == nil {
 			uidStr := strings.TrimSpace(string(uidOutput))
 			if uid, parseErr := strconv.Atoi(uidStr); parseErr == nil {
 				if uid >= 500 && uid < 65534 { // Regular user range on macOS
@@ -131,7 +117,6 @@ func (d *DarwinSecurityCollector) parseSystemUsers(ctx context.Context, output s
 				}
 			}
 		}
-		cancel()
 	}
 
 	attributes["total_user_count"] = fmt.Sprintf("%d", len(users))
@@ -153,8 +138,7 @@ func (d *DarwinSecurityCollector) parseSystemUsers(ctx context.Context, output s
 // collectUserDetails collects detailed user information
 func (d *DarwinSecurityCollector) collectUserDetails(ctx context.Context, attributes map[string]string) {
 	// Currently logged in users
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "who").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "who"); err == nil {
 		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 		var loggedInUsers []string
 		for _, line := range lines {
@@ -171,11 +155,9 @@ func (d *DarwinSecurityCollector) collectUserDetails(ctx context.Context, attrib
 			attributes["logged_in_users"] = strings.Join(loggedInUsers, ",")
 		}
 	}
-	cancel()
 
 	// Last login information
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "last", "-10").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "last", "-10"); err == nil {
 		lines := strings.Split(string(output), "\n")
 		var recentLogins []string
 		for i, line := range lines {
@@ -194,16 +176,12 @@ func (d *DarwinSecurityCollector) collectUserDetails(ctx context.Context, attrib
 			attributes["recent_login_users"] = strings.Join(recentLogins, ",")
 		}
 	}
-	cancel2()
 }
 
 // collectLoginShells collects login shell information
 func (d *DarwinSecurityCollector) collectLoginShells(ctx context.Context, attributes map[string]string) {
 	// Available shells
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "cat", "/etc/shells").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "cat", "/etc/shells"); err == nil {
 		shells := strings.Split(string(output), "\n")
 		var validShells []string
 		for _, shell := range shells {
@@ -232,8 +210,7 @@ func (d *DarwinSecurityCollector) parseSystemGroups(ctx context.Context, output 
 		}
 
 		// Get group ID to distinguish system vs regular groups
-		cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-		if gidOutput, err := exec.CommandContext(cmdCtx, "dscl", ".", "-read", "/Groups/"+group, "PrimaryGroupID").Output(); err == nil {
+		if gidOutput, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "dscl", ".", "-read", "/Groups/"+group, "PrimaryGroupID"); err == nil {
 			gidLine := strings.TrimSpace(string(gidOutput))
 			if strings.Contains(gidLine, ":") {
 				parts := strings.SplitN(gidLine, ":", 2)
@@ -249,7 +226,6 @@ func (d *DarwinSecurityCollector) parseSystemGroups(ctx context.Context, output 
 				}
 			}
 		}
-		cancel()
 	}
 
 	attributes["total_group_count"] = fmt.Sprintf("%d", len(groups))
@@ -271,10 +247,7 @@ func (d *DarwinSecurityCollector) parseSystemGroups(ctx context.Context, output 
 // parseAdminUsers parses administrative users
 func (d *DarwinSecurityCollector) parseAdminUsers(ctx context.Context, _ string, attributes map[string]string) {
 	// This is a simple approach - in practice, we'd want to list admin group members
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "dseditgroup", "-o", "read", "-t", "user", "admin").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "dseditgroup", "-o", "read", "-t", "user", "admin"); err == nil {
 		adminOutput := string(output)
 		// Count admin users by looking for "Users:" line
 		lines := strings.Split(adminOutput, "\n")
@@ -299,8 +272,7 @@ func (d *DarwinSecurityCollector) collectSystemPermissions(ctx context.Context, 
 	keyDirs := []string{"/System", "/usr", "/bin", "/sbin", "/Applications"}
 
 	for _, dir := range keyDirs {
-		cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-		if output, err := exec.CommandContext(cmdCtx, "ls", "-ld", dir).Output(); err == nil {
+		if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "ls", "-ld", dir); err == nil {
 			permLine := strings.TrimSpace(string(output))
 			fields := strings.Fields(permLine)
 			if len(fields) > 0 {
@@ -312,44 +284,37 @@ func (d *DarwinSecurityCollector) collectSystemPermissions(ctx context.Context, 
 				attributes["permissions_"+dirName] = perms
 			}
 		}
-		cancel()
 	}
 }
 
 // collectKeyDirectoryPermissions collects permissions on key directories
 func (d *DarwinSecurityCollector) collectKeyDirectoryPermissions(ctx context.Context, attributes map[string]string) {
 	// Check /etc permissions
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "ls", "-ld", "/etc").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "ls", "-ld", "/etc"); err == nil {
 		permLine := strings.TrimSpace(string(output))
 		fields := strings.Fields(permLine)
 		if len(fields) > 0 {
 			attributes["etc_permissions"] = fields[0]
 		}
 	}
-	cancel()
 
 	// Check /tmp permissions
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "ls", "-ld", "/tmp").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "ls", "-ld", "/tmp"); err == nil {
 		permLine := strings.TrimSpace(string(output))
 		fields := strings.Fields(permLine)
 		if len(fields) > 0 {
 			attributes["tmp_permissions"] = fields[0]
 		}
 	}
-	cancel2()
 
 	// Check /var permissions
-	cmdCtx3, cancel3 := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx3, "ls", "-ld", "/var").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "ls", "-ld", "/var"); err == nil {
 		permLine := strings.TrimSpace(string(output))
 		fields := strings.Fields(permLine)
 		if len(fields) > 0 {
 			attributes["var_permissions"] = fields[0]
 		}
 	}
-	cancel3()
 }
 
 // collectKeychainCertificates collects certificates from keychains
@@ -360,10 +325,7 @@ func (d *DarwinSecurityCollector) collectKeychainCertificates(ctx context.Contex
 		args = append(args, "-s", keychainName)
 	}
 
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "security", args...).Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "security", args...); err == nil {
 		certOutput := string(output)
 		// Count certificate entries
 		certCount := strings.Count(certOutput, "keychain:")
@@ -404,8 +366,7 @@ func (d *DarwinSecurityCollector) extractCertificateNames(output string, attribu
 // collectCodeSigningCertificates collects code signing certificate information
 func (d *DarwinSecurityCollector) collectCodeSigningCertificates(ctx context.Context, attributes map[string]string) {
 	// List code signing identities
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "security", "find-identity", "-v", "-p", "codesigning").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "security", "find-identity", "-v", "-p", "codesigning"); err == nil {
 		lines := strings.Split(string(output), "\n")
 		var validCerts int
 
@@ -418,11 +379,9 @@ func (d *DarwinSecurityCollector) collectCodeSigningCertificates(ctx context.Con
 
 		attributes["code_signing_certificates"] = fmt.Sprintf("%d", validCerts)
 	}
-	cancel()
 
 	// Check for Developer ID certificates specifically
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSecCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "security", "find-identity", "-v", "-s", "Developer ID").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSecCmdTimeout, "security", "find-identity", "-v", "-s", "Developer ID"); err == nil {
 		lines := strings.Split(string(output), "\n")
 		var devIDCerts int
 
@@ -437,5 +396,4 @@ func (d *DarwinSecurityCollector) collectCodeSigningCertificates(ctx context.Con
 			attributes["developer_id_certificates"] = fmt.Sprintf("%d", devIDCerts)
 		}
 	}
-	cancel2()
 }

--- a/features/steward/dna/software_darwin.go
+++ b/features/steward/dna/software_darwin.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -28,43 +27,31 @@ func (d *DarwinSoftwareCollector) CollectOS(ctx context.Context, attributes map[
 	attributes["runtime_compiler"] = runtime.Compiler
 
 	// macOS-specific OS information
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	if version, err := exec.CommandContext(cmdCtx, "sw_vers", "-productVersion").Output(); err == nil {
+	if version, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "sw_vers", "-productVersion"); err == nil {
 		attributes["macos_version"] = strings.TrimSpace(string(version))
 	}
-	cancel()
 
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	if build, err := exec.CommandContext(cmdCtx2, "sw_vers", "-buildVersion").Output(); err == nil {
+	if build, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "sw_vers", "-buildVersion"); err == nil {
 		attributes["macos_build"] = strings.TrimSpace(string(build))
 	}
-	cancel2()
 
-	cmdCtx3, cancel3 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	if name, err := exec.CommandContext(cmdCtx3, "sw_vers", "-productName").Output(); err == nil {
+	if name, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "sw_vers", "-productName"); err == nil {
 		attributes["macos_product_name"] = strings.TrimSpace(string(name))
 	}
-	cancel3()
 
 	// Kernel information
-	cmdCtx4, cancel4 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	if kernelVersion, err := exec.CommandContext(cmdCtx4, "uname", "-r").Output(); err == nil {
+	if kernelVersion, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "uname", "-r"); err == nil {
 		attributes["kernel_version"] = strings.TrimSpace(string(kernelVersion))
 	}
-	cancel4()
 
-	cmdCtx5, cancel5 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	if kernelName, err := exec.CommandContext(cmdCtx5, "uname", "-s").Output(); err == nil {
+	if kernelName, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "uname", "-s"); err == nil {
 		attributes["kernel_name"] = strings.TrimSpace(string(kernelName))
 	}
-	cancel5()
 
 	// System uptime
-	cmdCtx6, cancel6 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	if uptime, err := exec.CommandContext(cmdCtx6, "uptime").Output(); err == nil {
+	if uptime, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "uptime"); err == nil {
 		attributes["system_uptime"] = strings.TrimSpace(string(uptime))
 	}
-	cancel6()
 
 	return nil
 }
@@ -95,10 +82,7 @@ func (d *DarwinSoftwareCollector) CollectServices(ctx context.Context, attribute
 	d.collectLaunchAgents(ctx, attributes)
 
 	// Running processes count as a service indicator
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "ps", "aux").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "ps", "aux"); err == nil {
 		lines := strings.Split(string(output), "\n")
 		attributes["running_process_count"] = fmt.Sprintf("%d", len(lines)-1) // -1 for header
 	}
@@ -130,10 +114,7 @@ func (d *DarwinSoftwareCollector) CollectProcesses(ctx context.Context, attribut
 	attributes["goroutine_count"] = fmt.Sprintf("%d", runtime.NumGoroutine())
 
 	// Process statistics
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "ps", "-eo", "pid,ppid,user,comm").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "ps", "-eo", "pid,ppid,user,comm"); err == nil {
 		d.parseProcessStats(string(output), attributes)
 	}
 
@@ -142,10 +123,7 @@ func (d *DarwinSoftwareCollector) CollectProcesses(ctx context.Context, attribut
 
 // collectHomebrewPackages collects installed Homebrew packages
 func (d *DarwinSoftwareCollector) collectHomebrewPackages(ctx context.Context, attributes map[string]string) {
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "brew", "list", "--formula").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "brew", "list", "--formula"); err == nil {
 		packages := strings.Fields(string(output))
 		attributes["homebrew_formula_count"] = fmt.Sprintf("%d", len(packages))
 
@@ -159,10 +137,7 @@ func (d *DarwinSoftwareCollector) collectHomebrewPackages(ctx context.Context, a
 		}
 	}
 
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel2()
-
-	if output, err := exec.CommandContext(cmdCtx2, "brew", "list", "--cask").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "brew", "list", "--cask"); err == nil {
 		casks := strings.Fields(string(output))
 		attributes["homebrew_cask_count"] = fmt.Sprintf("%d", len(casks))
 
@@ -179,10 +154,7 @@ func (d *DarwinSoftwareCollector) collectHomebrewPackages(ctx context.Context, a
 
 // collectMacPortsPackages collects installed MacPorts packages
 func (d *DarwinSoftwareCollector) collectMacPortsPackages(ctx context.Context, attributes map[string]string) {
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "port", "installed").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "port", "installed"); err == nil {
 		lines := strings.Split(string(output), "\n")
 		var packageCount int
 		for _, line := range lines {
@@ -198,10 +170,7 @@ func (d *DarwinSoftwareCollector) collectMacPortsPackages(ctx context.Context, a
 
 // collectApplications collects applications in /Applications
 func (d *DarwinSoftwareCollector) collectApplications(ctx context.Context, attributes map[string]string) {
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "find", "/Applications", "-name", "*.app", "-maxdepth", "2").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "find", "/Applications", "-name", "*.app", "-maxdepth", "2"); err == nil {
 		apps := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(apps) > 0 && apps[0] != "" {
 			attributes["applications_count"] = fmt.Sprintf("%d", len(apps))
@@ -232,10 +201,7 @@ func (d *DarwinSoftwareCollector) collectApplications(ctx context.Context, attri
 // collectSystemLibraries collects information about system libraries
 func (d *DarwinSoftwareCollector) collectSystemLibraries(ctx context.Context, attributes map[string]string) {
 	// Count dylibs in /usr/lib
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "find", "/usr/lib", "-name", "*.dylib", "-type", "f").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "find", "/usr/lib", "-name", "*.dylib", "-type", "f"); err == nil {
 		libs := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(libs) > 0 && libs[0] != "" {
 			attributes["system_dylib_count"] = fmt.Sprintf("%d", len(libs))
@@ -243,10 +209,7 @@ func (d *DarwinSoftwareCollector) collectSystemLibraries(ctx context.Context, at
 	}
 
 	// Count frameworks in /System/Library/Frameworks
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel2()
-
-	if output, err := exec.CommandContext(cmdCtx2, "find", "/System/Library/Frameworks", "-name", "*.framework", "-maxdepth", "1").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "find", "/System/Library/Frameworks", "-name", "*.framework", "-maxdepth", "1"); err == nil {
 		frameworks := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(frameworks) > 0 && frameworks[0] != "" {
 			attributes["system_framework_count"] = fmt.Sprintf("%d", len(frameworks))
@@ -256,20 +219,14 @@ func (d *DarwinSoftwareCollector) collectSystemLibraries(ctx context.Context, at
 
 // collectLaunchDaemons collects system launch daemons
 func (d *DarwinSoftwareCollector) collectLaunchDaemons(ctx context.Context, attributes map[string]string) {
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "find", "/System/Library/LaunchDaemons", "-name", "*.plist").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "find", "/System/Library/LaunchDaemons", "-name", "*.plist"); err == nil {
 		daemons := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(daemons) > 0 && daemons[0] != "" {
 			attributes["system_launch_daemon_count"] = fmt.Sprintf("%d", len(daemons))
 		}
 	}
 
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel2()
-
-	if output, err := exec.CommandContext(cmdCtx2, "find", "/Library/LaunchDaemons", "-name", "*.plist").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "find", "/Library/LaunchDaemons", "-name", "*.plist"); err == nil {
 		daemons := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(daemons) > 0 && daemons[0] != "" {
 			attributes["user_launch_daemon_count"] = fmt.Sprintf("%d", len(daemons))
@@ -279,20 +236,14 @@ func (d *DarwinSoftwareCollector) collectLaunchDaemons(ctx context.Context, attr
 
 // collectLaunchAgents collects user launch agents
 func (d *DarwinSoftwareCollector) collectLaunchAgents(ctx context.Context, attributes map[string]string) {
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel()
-
-	if output, err := exec.CommandContext(cmdCtx, "find", "/System/Library/LaunchAgents", "-name", "*.plist").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "find", "/System/Library/LaunchAgents", "-name", "*.plist"); err == nil {
 		agents := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(agents) > 0 && agents[0] != "" {
 			attributes["system_launch_agent_count"] = fmt.Sprintf("%d", len(agents))
 		}
 	}
 
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinSwCmdTimeout)
-	defer cancel2()
-
-	if output, err := exec.CommandContext(cmdCtx2, "find", "/Library/LaunchAgents", "-name", "*.plist").Output(); err == nil {
+	if output, err := darwinRunCmd(ctx, darwinSwCmdTimeout, "find", "/Library/LaunchAgents", "-name", "*.plist"); err == nil {
 		agents := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(agents) > 0 && agents[0] != "" {
 			attributes["user_launch_agent_count"] = fmt.Sprintf("%d", len(agents))


### PR DESCRIPTION
## Problem

`features/steward` intermittently hangs 5 minutes and panics with `test timed out after 5m0s` on the **macOS CI runner**, failing the required `Cross-Platform Build Validation` / `Build Gate` and ejecting whatever PR is under merge-queue validation. PR #2347 (docs-only) was bounced this way on 2026-07-06 21:40Z.

Grounded from the goroutine dump, the stuck frame is background DNA collection, not the test's own 30s `require.Eventually`:
```
DarwinSecurityCollector.parseSystemGroups   security_darwin.go:236
  exec.CommandContext(cmdCtx, "dscl", ".", "-read", "/Groups/"+group, "PrimaryGroupID").Output()
  from CollectGroups -> collectSecurityInfo (dna.go:347) -> runBackgroundCollection (dna.go:197)
```

## Root cause

The darwin DNA collectors called `exec.CommandContext(...).Output()` with a per-command timeout but **never set `cmd.WaitDelay`**. On macOS CI, a tool like `dscl` can get stuck in a kernel call that survives the context-driven SIGKILL while a grandchild keeps the stdout pipe open. Without `WaitDelay`, `Output()` blocks forever on `io.Copy` and leaks a goroutine per collection cycle; the accumulated leaks then block steward `Stop()` until the 5-minute package alarm.

This exact failure mode was **already fixed in `network_darwin.go`** (`darwinRunNetCmd` sets `WaitDelay = 5s`). The sibling collectors never got the same treatment:

| collector | exec.CommandContext sites | WaitDelay (before) |
|---|---|---|
| network  | 1 (via helper) | yes |
| security | 19 (incl. the dscl loop that hung) | no |
| software | 18 | no |
| hardware | 7  | no |

## Fix

- New shared helper `darwinRunCmd(ctx, timeout, name, args...)` (`exec_darwin.go`) that sets `cmd.WaitDelay` — the generalization of `darwinRunNetCmd`.
- Routed all security/software/hardware exec sites through it; `darwinRunNetCmd` now delegates to it too (removes the duplicated const + helper). Net −46 lines.
- Regression test (`exec_darwin_test.go`, darwin-tagged): a shell that backgrounds a 120s grandchild holding the stdout pipe open must return within `WaitDelay`, not hang.

## Validation

- `GOOS=darwin` build + vet + `go test -c` compile: pass
- Windows host build, linux (CGO=0) build: pass
- gofmt clean, `make check-architecture` clean
- Darwin-only files (`//go:build darwin`); no behavior change on Linux/Windows. The macOS native build in CI is the real proof — it is the job that was hanging.

Fixes #2361

🤖 Generated with [Claude Code](https://claude.com/claude-code)