### PR TITLE
workflow: rollout foundation — RolloutStore + query_ring_health + RunningVersion (Issue #2339)

### DIFF
--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -33,7 +33,7 @@ func newTestWorkflowHandler(t *testing.T) (*WorkflowHandler, cfgconfig.ConfigSto
 	configStore := storageManager.GetConfigStore()
 
 	logger := logging.NewNoopLogger()
-	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil, nil)
 
 	handler := NewWorkflowHandler(engine, configStore, nil, logger)
 	return handler, configStore
@@ -550,7 +550,7 @@ func TestWorkflowHandler_SpecialCharsInName_HandledSafely(t *testing.T) {
 	_, configStore := newTestWorkflowHandler(t)
 	capLogger := &capturingLogger{}
 
-	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), capLogger, nil)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), capLogger, nil, nil)
 	h := NewWorkflowHandler(engine, configStore, nil, capLogger)
 	router := newWorkflowRouter(h)
 
@@ -582,7 +582,7 @@ func newTestWorkflowHandlerAndEngine(t *testing.T) (*WorkflowHandler, cfgconfig.
 	storageManager := pkgtesting.SetupTestStorage(t)
 	configStore := storageManager.GetConfigStore()
 	logger := logging.NewNoopLogger()
-	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil, nil)
 	handler := NewWorkflowHandler(engine, configStore, nil, logger)
 	return handler, configStore, engine
 }

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -92,7 +92,7 @@ func newTestApprovalHook(t *testing.T) (*WorkflowApprovalHook, cfgconfig.ConfigS
 	configStore := storageManager.GetConfigStore()
 
 	logger := logging.NewNoopLogger()
-	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil, nil)
 
 	hook := NewWorkflowApprovalHook(engine, configStore, logger)
 	return hook, configStore

--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -91,14 +91,15 @@ func ParseTargetSelector(s string) (Filter, error) {
 // StewardResult is a device record returned by a fleet query.
 // Contains enough information for targeting decisions without a full DNA dump.
 type StewardResult struct {
-	ID            string
-	TenantID      string
-	Hostname      string
-	OS            string
-	Architecture  string
-	Status        string
-	LastHeartbeat time.Time
-	DNAAttributes map[string]string
+	ID             string
+	TenantID       string
+	Hostname       string
+	OS             string
+	Architecture   string
+	Status         string
+	LastHeartbeat  time.Time
+	DNAAttributes  map[string]string
+	RunningVersion string // populated from the steward.version DNA attribute (Issue #2260)
 }
 
 // FleetQuery is the single query path for all device filtering.

--- a/features/controller/fleet/memory.go
+++ b/features/controller/fleet/memory.go
@@ -127,13 +127,14 @@ func toStewardResult(s StewardData) StewardResult {
 		attrs = map[string]string{}
 	}
 	return StewardResult{
-		ID:            s.ID,
-		TenantID:      s.TenantID,
-		Hostname:      attrs["hostname"],
-		OS:            attrs["os"],
-		Architecture:  attrs["arch"],
-		Status:        s.Status,
-		LastHeartbeat: s.LastHeartbeat,
-		DNAAttributes: attrs,
+		ID:             s.ID,
+		TenantID:       s.TenantID,
+		Hostname:       attrs["hostname"],
+		OS:             attrs["os"],
+		Architecture:   attrs["arch"],
+		Status:         s.Status,
+		LastHeartbeat:  s.LastHeartbeat,
+		DNAAttributes:  attrs,
+		RunningVersion: attrs["steward.version"],
 	}
 }

--- a/features/controller/fleet/memory_test.go
+++ b/features/controller/fleet/memory_test.go
@@ -286,10 +286,11 @@ func TestMemoryQuery_StewardResult_Fields(t *testing.T) {
 				Status:        "online",
 				LastHeartbeat: now,
 				DNAAttributes: map[string]string{
-					"hostname": "my-host",
-					"os":       "linux",
-					"arch":     "arm64",
-					"custom":   "value",
+					"hostname":       "my-host",
+					"os":             "linux",
+					"arch":           "arm64",
+					"custom":         "value",
+					"steward.version": "v1.5.3",
 				},
 			},
 		},
@@ -309,6 +310,27 @@ func TestMemoryQuery_StewardResult_Fields(t *testing.T) {
 	assert.Equal(t, "online", r.Status)
 	assert.WithinDuration(t, now, r.LastHeartbeat, time.Second)
 	assert.Equal(t, "value", r.DNAAttributes["custom"])
+	assert.Equal(t, "v1.5.3", r.RunningVersion, "RunningVersion must be populated from steward.version DNA attribute")
+}
+
+func TestMemoryQuery_StewardResult_RunningVersionEmpty_WhenDNAAbsent(t *testing.T) {
+	provider := &staticProvider{
+		stewards: []StewardData{
+			{
+				ID:       "no-version",
+				TenantID: "tenant-x",
+				Status:   "online",
+				// No steward.version in DNAAttributes
+				DNAAttributes: map[string]string{"hostname": "host-a"},
+			},
+		},
+	}
+	q := NewMemoryQuery(provider)
+
+	results, err := q.Search(context.Background(), Filter{})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "", results[0].RunningVersion, "RunningVersion must be empty when steward.version DNA attribute is absent")
 }
 
 func TestMemoryQuery_TenantScoping_IsolatesData(t *testing.T) {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -1380,7 +1380,7 @@ func initializeWorkflowHandler(
 	// REST-only deployments that never resolve modules through the engine are unaffected.
 	moduleFactory := workflow.NewWorkflowModuleFactory(moduleCache, workflowRT)
 
-	workflowEngine := workflow.NewEngine(moduleFactory, logger, nil)
+	workflowEngine := workflow.NewEngine(moduleFactory, logger, nil, nil)
 
 	configStore := storageManager.GetConfigStore()
 

--- a/features/workflow/conditional_test.go
+++ b/features/workflow/conditional_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestWorkflowConditionalLogic(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	tests := []struct {
 		name      string
@@ -351,7 +351,7 @@ func TestWorkflowConditionalLogic(t *testing.T) {
 
 func TestWorkflowExpressionConditions(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	tests := []struct {
 		name       string
@@ -464,7 +464,7 @@ func TestWorkflowExpressionConditions(t *testing.T) {
 
 func TestWorkflowConditionalExecution(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "conditional-test",

--- a/features/workflow/debug_test.go
+++ b/features/workflow/debug_test.go
@@ -634,7 +634,7 @@ func TestBreakpointCondition_RespectedOnHit(t *testing.T) {
 func createTestEngineWithDebug(t *testing.T) (*Engine, logging.Logger) {
 	t.Helper()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(createTestFactory(), logger, nil)
+	engine := NewEngine(createTestFactory(), logger, nil, nil)
 	return engine, logger
 }
 

--- a/features/workflow/engine.go
+++ b/features/workflow/engine.go
@@ -29,25 +29,35 @@ type TransformStepExecutor interface {
 	ExecuteTransformStep(ctx context.Context, step Step, execution *WorkflowExecution) (StepResult, error)
 }
 
+// RingHealthStepExecutor executes a workflow step of type query_ring_health.
+//
+// Declared here rather than importing features/workflow/nodes to avoid an
+// import cycle. Concrete callers pass *nodes.RingHealthNodeExecutor.
+type RingHealthStepExecutor interface {
+	ExecuteRingHealthStep(ctx context.Context, step Step, execution *WorkflowExecution) (StepResult, error)
+}
+
 // Engine implements the WorkflowEngine interface
 type Engine struct {
-	moduleFactory     ModuleLoader
-	logger            *logging.ModuleLogger
-	executions        map[string]*WorkflowExecution
-	workflows         map[string]Workflow
-	mutex             sync.RWMutex
-	httpClient        *HTTPClient
-	providerRegistry  *ProviderRegistry
-	errorHandler      ErrorHandler
-	syncManager       *SyncManager
-	debugEngine       *DebugEngineImpl
-	transformExecutor TransformStepExecutor
+	moduleFactory      ModuleLoader
+	logger             *logging.ModuleLogger
+	executions         map[string]*WorkflowExecution
+	workflows          map[string]Workflow
+	mutex              sync.RWMutex
+	httpClient         *HTTPClient
+	providerRegistry   *ProviderRegistry
+	errorHandler       ErrorHandler
+	syncManager        *SyncManager
+	debugEngine        *DebugEngineImpl
+	transformExecutor  TransformStepExecutor
+	ringHealthExecutor RingHealthStepExecutor
 }
 
 // NewEngine creates a new workflow engine instance.
-// transformExecutor handles StepTypeTransform steps; pass nil if transform steps
-// are not used (executeStep will return an error for any transform step encountered).
-func NewEngine(moduleFactory ModuleLoader, logger logging.Logger, transformExecutor TransformStepExecutor) *Engine {
+// transformExecutor handles StepTypeTransform steps; pass nil if transform steps are not used.
+// ringHealthExecutor handles StepTypeQueryRingHealth steps; pass nil if ring-health steps are not used.
+// executeStep returns a clear error for any step type whose executor is nil.
+func NewEngine(moduleFactory ModuleLoader, logger logging.Logger, transformExecutor TransformStepExecutor, ringHealthExecutor RingHealthStepExecutor) *Engine {
 	// Create module logger for structured workflow logging
 	workflowLogger := logging.ForModule("workflow").WithField("component", "engine")
 
@@ -67,15 +77,16 @@ func NewEngine(moduleFactory ModuleLoader, logger logging.Logger, transformExecu
 	providerRegistry := NewProviderRegistry(logger)
 
 	engine := &Engine{
-		moduleFactory:     moduleFactory,
-		logger:            workflowLogger,
-		executions:        make(map[string]*WorkflowExecution),
-		workflows:         make(map[string]Workflow),
-		httpClient:        httpClient,
-		providerRegistry:  providerRegistry,
-		errorHandler:      NewDefaultErrorHandler(),
-		syncManager:       NewSyncManager(),
-		transformExecutor: transformExecutor,
+		moduleFactory:      moduleFactory,
+		logger:             workflowLogger,
+		executions:         make(map[string]*WorkflowExecution),
+		workflows:          make(map[string]Workflow),
+		httpClient:         httpClient,
+		providerRegistry:   providerRegistry,
+		errorHandler:       NewDefaultErrorHandler(),
+		syncManager:        NewSyncManager(),
+		transformExecutor:  transformExecutor,
+		ringHealthExecutor: ringHealthExecutor,
 	}
 
 	// Initialize debug engine
@@ -461,6 +472,14 @@ func (e *Engine) executeStep(ctx context.Context, step Step, execution *Workflow
 			var transformResult StepResult
 			transformResult, err = e.transformExecutor.ExecuteTransformStep(ctx, step, execution)
 			execution.SetStepResult(step.Name, transformResult)
+		}
+	case StepTypeQueryRingHealth:
+		if e.ringHealthExecutor == nil {
+			err = fmt.Errorf("ring health executor not configured")
+		} else {
+			var rhResult StepResult
+			rhResult, err = e.ringHealthExecutor.ExecuteRingHealthStep(ctx, step, execution)
+			execution.SetStepResult(step.Name, rhResult)
 		}
 	default:
 		err = fmt.Errorf("unknown step type: %s", step.Type)

--- a/features/workflow/engine_composition_test.go
+++ b/features/workflow/engine_composition_test.go
@@ -18,7 +18,7 @@ import (
 // sequence value; OutputMappings propagate those values to the parent execution so
 // we can assert all three ran and produced their expected outputs.
 func TestExecuteComponentsDependency_LinearChain(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	// Register three minimal sub-workflows, each with a distinct sequence value.
 	engine.RegisterWorkflow(Workflow{
@@ -105,7 +105,7 @@ func TestExecuteComponentsDependency_LinearChain(t *testing.T) {
 // TestExecuteComponentsDependency_ParallelFanOut verifies that two independent
 // components (neither has DependsOn) both complete when using the dependency strategy.
 func TestExecuteComponentsDependency_ParallelFanOut(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	engine.RegisterWorkflow(Workflow{
 		Name:      "dep-fanout-x",
@@ -172,7 +172,7 @@ func TestExecuteComponentsDependency_ParallelFanOut(t *testing.T) {
 // components form a dependency cycle returns a non-nil error before any component
 // executes, and that the error message names the cycle path.
 func TestExecuteComponentsDependency_CycleDetected(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	// Register the component workflows so loading does not fail before cycle check.
 	engine.RegisterWorkflow(Workflow{
@@ -226,7 +226,7 @@ func TestExecuteComponentsDependency_CycleDetected(t *testing.T) {
 // TestExecuteComponentsDependency_UnknownDependency verifies that a component
 // referencing a non-existent dependency name returns a descriptive error.
 func TestExecuteComponentsDependency_UnknownDependency(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	engine.RegisterWorkflow(Workflow{
 		Name:  "unknown-dep-wf",
@@ -268,7 +268,7 @@ func TestExecuteComponentsDependency_UnknownDependency(t *testing.T) {
 // component runs. The test asserts that the threaded variable carries the exact value
 // set by component 1 — a bare no-error assertion would pass with the old sequential stub.
 func TestExecuteComponentsPipeline_OutputThreaded(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	// comp1 exposes output_val; OutputMappings propagate it to comp1_result in parent execution.
 	engine.RegisterWorkflow(Workflow{
@@ -338,7 +338,7 @@ func TestExecuteComponentsPipeline_OutputThreaded(t *testing.T) {
 // TestExecuteComponentsPipeline_EmptyPipeline verifies that a pipeline with zero
 // components returns nil immediately without error.
 func TestExecuteComponentsPipeline_EmptyPipeline(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	execution := &WorkflowExecution{
 		ID:           "test-empty-pipeline",
@@ -361,7 +361,7 @@ func TestExecuteComponentsPipeline_EmptyPipeline(t *testing.T) {
 // mapping referencing a non-existent FromVariable logs a warning but does not fail;
 // the pipeline completes successfully.
 func TestExecuteComponentsPipeline_MissingDataFlowVariable(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	engine.RegisterWorkflow(Workflow{
 		Name: "pipe-missing-src",
@@ -415,7 +415,7 @@ func TestExecuteComponentsPipeline_MissingDataFlowVariable(t *testing.T) {
 // component fails, handleComponentFailure propagates the error and the workflow
 // reaches StatusFailed — exercising the failure-propagation branch on line 518.
 func TestExecuteComponentsPipeline_ComponentFailure(t *testing.T) {
-	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil, nil)
 
 	// "unregistered-wf" is intentionally not registered so executeComponent fails.
 	workflow := Workflow{

--- a/features/workflow/engine_test.go
+++ b/features/workflow/engine_test.go
@@ -46,7 +46,7 @@ func createTestFactory() *factory.ModuleFactory {
 func TestEngine_ExecuteWorkflow_Simple(t *testing.T) {
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "simple-workflow",
@@ -100,7 +100,7 @@ func TestEngine_ExecuteWorkflow_Simple(t *testing.T) {
 func TestEngine_ExecuteWorkflow_Parallel(t *testing.T) {
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "parallel-workflow",
@@ -154,7 +154,7 @@ func TestEngine_ExecuteWorkflow_Parallel(t *testing.T) {
 func TestEngine_CancelExecution(t *testing.T) {
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "long-running-workflow",
@@ -192,7 +192,7 @@ func TestEngine_CancelExecution(t *testing.T) {
 func TestEngine_ListExecutions(t *testing.T) {
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "list-test-workflow",
@@ -302,7 +302,7 @@ func TestEvaluateCondition(t *testing.T) {
 
 	logger := pkgtesting.NewMockLogger(true)
 	factory := createTestFactory()
-	engine := NewEngine(factory, logger, nil)
+	engine := NewEngine(factory, logger, nil, nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -380,7 +380,7 @@ func TestEngineTransformExecutorWired(t *testing.T) {
 	logger := pkgtesting.NewMockLogger(true)
 	exec := &testTransformExecutor{}
 
-	engine := NewEngine(factory, logger, exec)
+	engine := NewEngine(factory, logger, exec, nil)
 
 	require.NotNil(t, engine.transformExecutor)
 	assert.Equal(t, exec, engine.transformExecutor)
@@ -395,7 +395,7 @@ func TestExecuteStepTransformDispatches(t *testing.T) {
 		varName:  "transform_output",
 		varValue: "hello",
 	}
-	engine := NewEngine(factory, logger, exec)
+	engine := NewEngine(factory, logger, exec, nil)
 
 	wf := Workflow{
 		Name: "transform-dispatch-test",
@@ -424,7 +424,7 @@ func TestContinueWithStepExecution(t *testing.T) {
 	logger := pkgtesting.NewMockLogger(true)
 
 	exec := &testTransformExecutor{err: fmt.Errorf("transform failed")}
-	engine := NewEngine(factory, logger, exec)
+	engine := NewEngine(factory, logger, exec, nil)
 	engine.errorHandler = &testErrorHandler{
 		decision: ErrorHandlingDecision{
 			Action:       ErrorActionContinueWith,
@@ -461,7 +461,7 @@ func TestContinueWithStepNotFound(t *testing.T) {
 	logger := pkgtesting.NewMockLogger(true)
 
 	exec := &testTransformExecutor{err: fmt.Errorf("transform failed")}
-	engine := NewEngine(factory, logger, exec)
+	engine := NewEngine(factory, logger, exec, nil)
 	engine.errorHandler = &testErrorHandler{
 		decision: ErrorHandlingDecision{
 			Action:       ErrorActionContinueWith,
@@ -493,7 +493,7 @@ func TestFallbackStepExecution(t *testing.T) {
 	logger := pkgtesting.NewMockLogger(true)
 
 	exec := &testTransformExecutor{err: fmt.Errorf("transform failed")}
-	engine := NewEngine(factory, logger, exec)
+	engine := NewEngine(factory, logger, exec, nil)
 	engine.errorHandler = &testErrorHandler{
 		decision: ErrorHandlingDecision{Action: ErrorActionFallback},
 	}
@@ -561,7 +561,7 @@ func TestRetryMaxAttempts(t *testing.T) {
 
 	factory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(factory, logger, nil)
+	engine := NewEngine(factory, logger, nil, nil)
 	// Use zero delays so the test runs instantly.
 	engine.errorHandler = &DefaultErrorHandler{
 		MaxRetries:        maxAttempts,
@@ -618,7 +618,7 @@ func TestRetryNilConfig(t *testing.T) {
 		result: StepResult{Status: StatusFailed},
 		err:    fmt.Errorf("step error"),
 	}
-	engine := NewEngine(factory, logger, exec)
+	engine := NewEngine(factory, logger, exec, nil)
 	// ShouldRetry returns true (up to 5 attempts) — without the nil guard this handler
 	// would cause the loop to run, resulting in RetryCount > 0.
 	engine.errorHandler = &testRetryDecisionHandler{
@@ -676,7 +676,7 @@ func TestGenericConfigStateYAMLRoundTrip(t *testing.T) {
 // --- loadWorkflowByName tests ---
 
 func TestEngine_LoadWorkflowByName_Hit(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 
 	want := Workflow{
 		Name: "my-workflow",
@@ -694,7 +694,7 @@ func TestEngine_LoadWorkflowByName_Hit(t *testing.T) {
 }
 
 func TestEngine_LoadWorkflowByName_Miss(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 
 	_, err := engine.loadWorkflowByName("nonexistent-workflow")
 	require.Error(t, err)
@@ -719,7 +719,7 @@ steps:
 	wfPath := filepath.Join(dir, "disk-workflow.yaml")
 	require.NoError(t, os.WriteFile(wfPath, []byte(yamlContent), 0600))
 
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	got, err := engine.loadWorkflowFromPath(wfPath)
 	require.NoError(t, err)
 	assert.Equal(t, "disk-workflow", got.Name)
@@ -729,8 +729,77 @@ steps:
 }
 
 func TestEngine_LoadWorkflowFromPath_Missing(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	_, err := engine.loadWorkflowFromPath("/nonexistent/path/workflow.yaml")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "/nonexistent/path/workflow.yaml")
+}
+
+func TestRingHealthExecutor_NilReturnsError(t *testing.T) {
+	factory := createTestFactory()
+	logger := pkgtesting.NewMockLogger(true)
+	// ringHealthExecutor is nil — engine must return a clear error.
+	engine := NewEngine(factory, logger, nil, nil)
+
+	wf := Workflow{
+		Name: "ring-health-nil-test",
+		Steps: []Step{
+			{Name: "check-ring", Type: StepTypeQueryRingHealth},
+		},
+	}
+
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, wf, nil)
+	require.NoError(t, err)
+
+	waitForWorkflowCompletion(t, execution, 2*time.Second)
+
+	final, err := engine.GetExecution(execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, final.GetStatus(), "workflow must fail when ring health executor is nil")
+	assert.Contains(t, final.GetError(), "ring health executor not configured")
+}
+
+func TestRingHealthExecutor_Injected_IsCalled(t *testing.T) {
+	factory := createTestFactory()
+	logger := pkgtesting.NewMockLogger(true)
+
+	exec := &testRingHealthExecutor{
+		result: StepResult{Status: StatusCompleted, Output: map[string]interface{}{
+			"on_version_pct": 75.0,
+			"failed_pct":     5.0,
+			"pending_count":  3,
+		}},
+	}
+	engine := NewEngine(factory, logger, nil, exec)
+
+	wf := Workflow{
+		Name: "ring-health-dispatch-test",
+		Steps: []Step{
+			{Name: "check-ring", Type: StepTypeQueryRingHealth},
+		},
+	}
+
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, wf, nil)
+	require.NoError(t, err)
+
+	waitForWorkflowCompletion(t, execution, 2*time.Second)
+
+	final, err := engine.GetExecution(execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, final.GetStatus())
+	assert.True(t, exec.called, "ring health executor must have been invoked")
+}
+
+// testRingHealthExecutor is a minimal test-local RingHealthStepExecutor.
+type testRingHealthExecutor struct {
+	result StepResult
+	err    error
+	called bool
+}
+
+func (e *testRingHealthExecutor) ExecuteRingHealthStep(_ context.Context, _ Step, _ *WorkflowExecution) (StepResult, error) {
+	e.called = true
+	return e.result, e.err
 }

--- a/features/workflow/error_handling_test.go
+++ b/features/workflow/error_handling_test.go
@@ -308,7 +308,7 @@ func TestErrorHandlingIntegration(t *testing.T) {
 			result: StepResult{Status: StatusFailed},
 			err:    stepErr,
 		}
-		engine := NewEngine(factory, logger, exec)
+		engine := NewEngine(factory, logger, exec, nil)
 		engine.errorHandler = &testErrorHandler{
 			decision: ErrorHandlingDecision{Action: ErrorActionStop},
 		}

--- a/features/workflow/error_workflow_test.go
+++ b/features/workflow/error_workflow_test.go
@@ -47,7 +47,7 @@ func TestErrorWorkflowStep(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(errorHandlerWorkflow)
 	ctx := context.Background()
 
@@ -107,7 +107,7 @@ steps:
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -163,7 +163,7 @@ func TestErrorWorkflowAsync(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(errorHandlerWorkflow)
 	ctx := context.Background()
 
@@ -199,7 +199,7 @@ func TestErrorWorkflowMissingConfiguration(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -234,7 +234,7 @@ func TestErrorWorkflowMissingWorkflowSpec(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -280,7 +280,7 @@ func TestErrorWorkflowWithRecoveryActions(t *testing.T) {
 			// Create engine and execute workflow
 			moduleFactory := createTestFactory()
 			logger := pkgtesting.NewMockLogger(true)
-			engine := NewEngine(moduleFactory, logger, nil)
+			engine := NewEngine(moduleFactory, logger, nil, nil)
 			engine.RegisterWorkflow(errorHandlerWorkflow)
 			ctx := context.Background()
 
@@ -339,7 +339,7 @@ func TestErrorWorkflowParameterAndOutputMappings(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(errorHandlerWorkflow)
 	ctx := context.Background()
 
@@ -383,7 +383,7 @@ func TestErrorWorkflowTimeout(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(errorHandlerWorkflow)
 	ctx := context.Background()
 

--- a/features/workflow/fanout_fanin_test.go
+++ b/features/workflow/fanout_fanin_test.go
@@ -49,7 +49,7 @@ func TestFanOutStep(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -98,7 +98,7 @@ func TestFanInStep(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -202,7 +202,7 @@ func TestFanInStrategies(t *testing.T) {
 			// Create engine and execute workflow
 			moduleFactory := createTestFactory()
 			logger := pkgtesting.NewMockLogger(true)
-			engine := NewEngine(moduleFactory, logger, nil)
+			engine := NewEngine(moduleFactory, logger, nil, nil)
 			ctx := context.Background()
 
 			execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -251,7 +251,7 @@ func TestFanOutEmptyData(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -289,7 +289,7 @@ func TestFanInEmptyData(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -324,7 +324,7 @@ func TestFanOutMissingConfiguration(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -354,7 +354,7 @@ func TestFanInMissingConfiguration(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -407,7 +407,7 @@ func TestFanOutFanInCombined(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -440,56 +440,56 @@ func getKeys(m map[string]interface{}) []string {
 // --- fanInCustom expression tests ---
 
 func TestFanInCustom_First(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	result, err := engine.fanInCustom([]interface{}{"alpha", "beta", "gamma"}, "first")
 	require.NoError(t, err)
 	assert.Equal(t, "alpha", result)
 }
 
 func TestFanInCustom_First_Empty(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	result, err := engine.fanInCustom([]interface{}{}, "first")
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }
 
 func TestFanInCustom_Last(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	result, err := engine.fanInCustom([]interface{}{"alpha", "beta", "gamma"}, "last")
 	require.NoError(t, err)
 	assert.Equal(t, "gamma", result)
 }
 
 func TestFanInCustom_Last_Empty(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	result, err := engine.fanInCustom([]interface{}{}, "last")
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }
 
 func TestFanInCustom_Count(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	result, err := engine.fanInCustom([]interface{}{"a", "b", "c", "d"}, "count")
 	require.NoError(t, err)
 	assert.Equal(t, 4, result)
 }
 
 func TestFanInCustom_JoinWithSep(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	result, err := engine.fanInCustom([]interface{}{"apple", "banana", "cherry"}, "join:,")
 	require.NoError(t, err)
 	assert.Equal(t, "apple,banana,cherry", result)
 }
 
 func TestFanInCustom_JoinWithMultiCharSep(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	result, err := engine.fanInCustom([]interface{}{"x", "y", "z"}, "join: | ")
 	require.NoError(t, err)
 	assert.Equal(t, "x | y | z", result)
 }
 
 func TestFanInCustom_UnknownExpression(t *testing.T) {
-	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil)
+	engine := NewEngine(createTestFactory(), pkgtesting.NewMockLogger(true), nil, nil)
 	_, err := engine.fanInCustom([]interface{}{"a", "b"}, "unknown")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown")

--- a/features/workflow/http_test.go
+++ b/features/workflow/http_test.go
@@ -113,7 +113,7 @@ func TestEngine_ExecuteHTTPStep(t *testing.T) {
 	// Create engine
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "http-test-workflow",
@@ -178,7 +178,7 @@ func TestEngine_ExecuteAPIStep(t *testing.T) {
 	// Create engine
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	// Mock the Microsoft Graph API URL by overriding the buildMicrosoftGraphRequest method
 	// For this test, we'll create a simpler API config that uses our test server
@@ -239,7 +239,7 @@ func TestEngine_ExecuteWebhookStep(t *testing.T) {
 	// Create engine
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "webhook-test-workflow",
@@ -286,7 +286,7 @@ func TestEngine_ExecuteDelayStep(t *testing.T) {
 	// Create engine
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "delay-test-workflow",
@@ -358,7 +358,7 @@ func TestEngine_ComplexAPIWorkflow(t *testing.T) {
 	// Create engine
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "complex-api-workflow",

--- a/features/workflow/integration.go
+++ b/features/workflow/integration.go
@@ -23,7 +23,7 @@ type Manager struct {
 // NewManager creates a new workflow manager
 func NewManager(moduleFactory *factory.ModuleFactory, logger logging.Logger) *Manager {
 	return &Manager{
-		engine: NewEngine(moduleFactory, logger, nil),
+		engine: NewEngine(moduleFactory, logger, nil, nil),
 		parser: NewParser(),
 		logger: logger,
 		workflowPaths: []string{

--- a/features/workflow/loop_break_test.go
+++ b/features/workflow/loop_break_test.go
@@ -52,7 +52,7 @@ func TestForLoopBreak(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -110,7 +110,7 @@ func TestForLoopContinue(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -173,7 +173,7 @@ func TestWhileLoopBreak(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -230,7 +230,7 @@ func TestForeachLoopBreak(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -268,7 +268,7 @@ func TestBreakContinueOutsideLoop(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)

--- a/features/workflow/loop_test.go
+++ b/features/workflow/loop_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestWorkflowForLoop(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	tests := []struct {
 		name      string
@@ -151,7 +151,7 @@ func TestWorkflowForLoop(t *testing.T) {
 
 func TestWorkflowWhileLoop(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	t.Run("while loop with max iterations safety", func(t *testing.T) {
 		workflow := Workflow{
@@ -217,7 +217,7 @@ func TestWorkflowWhileLoop(t *testing.T) {
 
 func TestWorkflowForeachLoop(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	tests := []struct {
 		name      string
@@ -347,7 +347,7 @@ func TestWorkflowForeachLoop(t *testing.T) {
 
 func TestLoopUtilityFunctions(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	t.Run("resolveLoopValue", func(t *testing.T) {
 		execution := &WorkflowExecution{
@@ -440,7 +440,7 @@ func TestLoopUtilityFunctions(t *testing.T) {
 
 func TestNestedLoops(t *testing.T) {
 	logger := logging.NewLogger("info")
-	engine := NewEngine(nil, logger, nil)
+	engine := NewEngine(nil, logger, nil, nil)
 
 	workflow := Workflow{
 		Name: "nested-loops-test",

--- a/features/workflow/nested_workflow_test.go
+++ b/features/workflow/nested_workflow_test.go
@@ -42,7 +42,7 @@ func TestNestedWorkflowByName(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(testNestedWorkflow)
 	ctx := context.Background()
 
@@ -104,7 +104,7 @@ steps:
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -152,7 +152,7 @@ func TestNestedWorkflowParameterMapping(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(testNestedWorkflow)
 	ctx := context.Background()
 
@@ -187,7 +187,7 @@ func TestNestedWorkflowTimeout(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(testNestedWorkflow)
 	ctx := context.Background()
 
@@ -232,7 +232,7 @@ func TestNestedWorkflowAsync(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(testNestedWorkflow)
 	ctx := context.Background()
 
@@ -263,7 +263,7 @@ func TestNestedWorkflowMissingConfiguration(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -298,7 +298,7 @@ func TestNestedWorkflowMissingWorkflowSpec(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -330,7 +330,7 @@ func TestNestedWorkflowNotFound(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -378,7 +378,7 @@ func TestNestedWorkflowComplexParameterMapping(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	engine.RegisterWorkflow(testNestedWorkflow)
 	ctx := context.Background()
 

--- a/features/workflow/nodes/ring_health_node.go
+++ b/features/workflow/nodes/ring_health_node.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package nodes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	"github.com/cfgis/cfgms/features/workflow"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// ringHealthConfig holds the parsed configuration for a query_ring_health step.
+type ringHealthConfig struct {
+	Ring           string `yaml:"ring"`
+	DesiredVersion string `yaml:"desired_version"`
+	TenantID       string `yaml:"tenant_id"` // required to scope fleet queries to a single tenant
+}
+
+// RingHealthNodeExecutor implements workflow.RingHealthStepExecutor.
+// It queries the fleet for stewards in a deployment ring and classifies each
+// steward as on-version, failed, or pending based on their running version
+// and upgrade record status.
+type RingHealthNodeExecutor struct {
+	fleetQuery   fleet.FleetQuery
+	upgradeStore business.UpgradeStore
+}
+
+// NewRingHealthNodeExecutor constructs a RingHealthNodeExecutor.
+// upgradeStore may be nil; when nil, all non-on-version stewards are counted as pending.
+func NewRingHealthNodeExecutor(fleetQuery fleet.FleetQuery, upgradeStore business.UpgradeStore) *RingHealthNodeExecutor {
+	return &RingHealthNodeExecutor{
+		fleetQuery:   fleetQuery,
+		upgradeStore: upgradeStore,
+	}
+}
+
+// ExecuteRingHealthStep satisfies workflow.RingHealthStepExecutor.
+// It reads ring and desired_version from step.Config, queries the fleet for stewards
+// in that ring, and returns on_version_pct, failed_pct, pending_count as step outputs.
+func (e *RingHealthNodeExecutor) ExecuteRingHealthStep(ctx context.Context, step workflow.Step, execution *workflow.WorkflowExecution) (workflow.StepResult, error) {
+	startTime := time.Now()
+
+	cfg, err := parseRingHealthConfig(step.Config)
+	if err != nil {
+		return failedRingHealthResult(startTime, fmt.Errorf("query_ring_health step %q: %w", step.Name, err)), err
+	}
+
+	if cfg.Ring == "" {
+		err = fmt.Errorf("query_ring_health step %q: ring must not be empty", step.Name)
+		return failedRingHealthResult(startTime, err), err
+	}
+	if cfg.DesiredVersion == "" {
+		err = fmt.Errorf("query_ring_health step %q: desired_version must not be empty", step.Name)
+		return failedRingHealthResult(startTime, err), err
+	}
+	if cfg.TenantID == "" {
+		err = fmt.Errorf("query_ring_health step %q: tenant_id must not be empty — fleet queries must be tenant-scoped to prevent cross-tenant data leakage", step.Name)
+		return failedRingHealthResult(startTime, err), err
+	}
+
+	filter := fleet.Filter{
+		TenantID:      cfg.TenantID,
+		DNAAttributes: map[string]string{"deployment_ring": cfg.Ring},
+	}
+	stewards, err := e.fleetQuery.Search(ctx, filter)
+	if err != nil {
+		err = fmt.Errorf("query_ring_health step %q: fleet query failed: %w", step.Name, err)
+		return failedRingHealthResult(startTime, err), err
+	}
+
+	total := len(stewards)
+	if total == 0 {
+		return completedRingHealthResult(startTime, 0.0, 0.0, 0), nil
+	}
+
+	onVersion := 0
+	failed := 0
+	pending := 0
+
+	for _, s := range stewards {
+		if s.RunningVersion == cfg.DesiredVersion {
+			onVersion++
+			continue
+		}
+		if e.upgradeStore == nil {
+			pending++
+			continue
+		}
+		upgradeStatus, found, queryErr := e.latestUpgradeStatus(ctx, s.ID, cfg.DesiredVersion)
+		if queryErr != nil {
+			err = fmt.Errorf("query_ring_health step %q: upgrade query for steward %q failed: %w", step.Name, s.ID, queryErr)
+			return failedRingHealthResult(startTime, err), err
+		}
+		if found && isTerminalFailure(upgradeStatus) {
+			failed++
+		} else {
+			pending++
+		}
+	}
+
+	onVersionPct := 100.0 * float64(onVersion) / float64(total)
+	failedPct := 100.0 * float64(failed) / float64(total)
+
+	result := completedRingHealthResult(startTime, onVersionPct, failedPct, pending)
+
+	// Store outputs in execution variables so downstream steps can access them.
+	execution.SetVariable(step.Name+"_on_version_pct", onVersionPct)
+	execution.SetVariable(step.Name+"_failed_pct", failedPct)
+	execution.SetVariable(step.Name+"_pending_count", pending)
+
+	return result, nil
+}
+
+// latestUpgradeStatus returns the status of the most recent upgrade record for
+// stewardID targeting desiredVersion. Returns (status, true, nil) when found,
+// ("", false, nil) when no matching record exists, or ("", false, err) on error.
+func (e *RingHealthNodeExecutor) latestUpgradeStatus(ctx context.Context, stewardID, desiredVersion string) (business.UpgradeStatus, bool, error) {
+	records, err := e.upgradeStore.ListUpgradesBySteward(ctx, stewardID)
+	if err != nil {
+		return "", false, err
+	}
+	// Records are ordered by CreatedAt descending; find the most recent for desiredVersion.
+	for _, r := range records {
+		if r.Version == desiredVersion {
+			return r.Status, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// isTerminalFailure returns true for upgrade statuses that represent a definitive
+// upgrade failure — the steward tried and could not complete the upgrade.
+func isTerminalFailure(status business.UpgradeStatus) bool {
+	return status == business.UpgradeStatusFailed || status == business.UpgradeStatusRolledBack
+}
+
+// parseRingHealthConfig extracts ring health configuration from the raw step config map.
+func parseRingHealthConfig(raw map[string]interface{}) (ringHealthConfig, error) {
+	var cfg ringHealthConfig
+	if raw == nil {
+		return cfg, nil
+	}
+	if v, ok := raw["ring"]; ok {
+		if s, ok := v.(string); ok {
+			cfg.Ring = s
+		}
+	}
+	if v, ok := raw["desired_version"]; ok {
+		if s, ok := v.(string); ok {
+			cfg.DesiredVersion = s
+		}
+	}
+	if v, ok := raw["tenant_id"]; ok {
+		if s, ok := v.(string); ok {
+			cfg.TenantID = s
+		}
+	}
+	return cfg, nil
+}
+
+func failedRingHealthResult(startTime time.Time, err error) workflow.StepResult {
+	endTime := time.Now()
+	return workflow.StepResult{
+		Status:    workflow.StatusFailed,
+		StartTime: startTime,
+		EndTime:   &endTime,
+		Duration:  endTime.Sub(startTime),
+		Error:     err.Error(),
+	}
+}
+
+func completedRingHealthResult(startTime time.Time, onVersionPct, failedPct float64, pendingCount int) workflow.StepResult {
+	endTime := time.Now()
+	return workflow.StepResult{
+		Status:    workflow.StatusCompleted,
+		StartTime: startTime,
+		EndTime:   &endTime,
+		Duration:  endTime.Sub(startTime),
+		Output: map[string]interface{}{
+			"on_version_pct": onVersionPct,
+			"failed_pct":     failedPct,
+			"pending_count":  pendingCount,
+		},
+	}
+}

--- a/features/workflow/nodes/ring_health_node_test.go
+++ b/features/workflow/nodes/ring_health_node_test.go
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package nodes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	"github.com/cfgis/cfgms/features/workflow"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
+)
+
+// makeRingTestSteward creates a StewardData record for ring health tests.
+// dna must include "deployment_ring" and optionally "steward.version".
+func makeRingTestSteward(id string, dna map[string]string) fleet.StewardData {
+	return fleet.StewardData{
+		ID:            id,
+		TenantID:      "test-tenant",
+		Status:        "online",
+		LastHeartbeat: time.Now(),
+		DNAAttributes: dna,
+	}
+}
+
+// newRingHealthStep creates a minimal Step for query_ring_health.
+func newRingHealthStep(name, ring, desiredVersion string) workflow.Step {
+	return workflow.Step{
+		Name: name,
+		Type: workflow.StepTypeQueryRingHealth,
+		Config: map[string]interface{}{
+			"ring":            ring,
+			"desired_version": desiredVersion,
+			"tenant_id":       "test-tenant",
+		},
+	}
+}
+
+// newRingExecution creates a fresh WorkflowExecution for testing.
+func newRingExecution() *workflow.WorkflowExecution {
+	return &workflow.WorkflowExecution{
+		ID:           "exec-test",
+		WorkflowName: "test-rollout",
+		Status:       workflow.StatusRunning,
+		StepResults:  make(map[string]workflow.StepResult),
+		Variables:    make(map[string]interface{}),
+		Done:         make(chan struct{}),
+	}
+}
+
+// TestRingHealthNode_OnVersionFailedPending is the required AC test:
+// given a fleet with known on-version/failed/pending stewards, the step
+// returns correct on_version_pct, failed_pct, pending_count.
+func TestRingHealthNode_OnVersionFailedPending(t *testing.T) {
+	ctx := context.Background()
+	const ring = "canary"
+	const desiredVersion = "v2.0.0"
+	const oldVersion = "v1.9.0"
+
+	// Set up 10 stewards in the canary ring:
+	//   5 already on v2.0.0 (on-version)
+	//   3 with old version and dispatched upgrade records (pending)
+	//   2 with old version and failed upgrade records (failed)
+	stewards := []fleet.StewardData{
+		makeRingTestSteward("s-on-1", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+		makeRingTestSteward("s-on-2", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+		makeRingTestSteward("s-on-3", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+		makeRingTestSteward("s-on-4", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+		makeRingTestSteward("s-on-5", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+		makeRingTestSteward("s-pend-1", map[string]string{"deployment_ring": ring, "steward.version": oldVersion}),
+		makeRingTestSteward("s-pend-2", map[string]string{"deployment_ring": ring, "steward.version": oldVersion}),
+		makeRingTestSteward("s-pend-3", map[string]string{"deployment_ring": ring, "steward.version": oldVersion}),
+		makeRingTestSteward("s-fail-1", map[string]string{"deployment_ring": ring, "steward.version": oldVersion}),
+		makeRingTestSteward("s-fail-2", map[string]string{"deployment_ring": ring, "steward.version": oldVersion}),
+	}
+
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: stewards})
+
+	upgradeStore := memory.NewUpgradeStore()
+
+	// Populate dispatched (pending) upgrade records.
+	for _, id := range []string{"s-pend-1", "s-pend-2", "s-pend-3"} {
+		rec := newTestUpgradeRecordForRing("upg-"+id, id, desiredVersion)
+		require.NoError(t, upgradeStore.CreateUpgrade(ctx, rec))
+	}
+
+	// Populate failed upgrade records.
+	for _, id := range []string{"s-fail-1", "s-fail-2"} {
+		rec := newTestUpgradeRecordForRing("upg-"+id, id, desiredVersion)
+		require.NoError(t, upgradeStore.CreateUpgrade(ctx, rec))
+		require.NoError(t, upgradeStore.UpdateUpgradeStatus(ctx, "upg-"+id, business.UpgradeStatusFailed, "health check failed"))
+	}
+
+	executor := NewRingHealthNodeExecutor(fleetQuery, upgradeStore)
+	step := newRingHealthStep("check-canary", ring, desiredVersion)
+	execution := newRingExecution()
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, execution)
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+
+	// Verify step outputs in the StepResult.
+	require.NotNil(t, result.Output)
+	assert.InDelta(t, 50.0, result.Output["on_version_pct"], 0.001, "on_version_pct should be 50%%")
+	assert.InDelta(t, 20.0, result.Output["failed_pct"], 0.001, "failed_pct should be 20%%")
+	assert.Equal(t, 3, result.Output["pending_count"], "pending_count should be 3")
+
+	// Verify outputs are also set as execution variables.
+	onPct, ok := execution.GetVariable("check-canary_on_version_pct")
+	require.True(t, ok)
+	assert.InDelta(t, 50.0, onPct, 0.001)
+
+	failPct, ok := execution.GetVariable("check-canary_failed_pct")
+	require.True(t, ok)
+	assert.InDelta(t, 20.0, failPct, 0.001)
+
+	pendCount, ok := execution.GetVariable("check-canary_pending_count")
+	require.True(t, ok)
+	assert.Equal(t, 3, pendCount)
+}
+
+func TestRingHealthNode_AllOnVersion(t *testing.T) {
+	ctx := context.Background()
+	const ring = "stable"
+	const desiredVersion = "v1.5.0"
+
+	stewards := []fleet.StewardData{
+		makeRingTestSteward("s-1", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+		makeRingTestSteward("s-2", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+	}
+
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: stewards})
+	executor := NewRingHealthNodeExecutor(fleetQuery, nil)
+	step := newRingHealthStep("check-stable", ring, desiredVersion)
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+	assert.InDelta(t, 100.0, result.Output["on_version_pct"], 0.001)
+	assert.InDelta(t, 0.0, result.Output["failed_pct"], 0.001)
+	assert.Equal(t, 0, result.Output["pending_count"])
+}
+
+func TestRingHealthNode_EmptyRing(t *testing.T) {
+	ctx := context.Background()
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: []fleet.StewardData{}})
+	executor := NewRingHealthNodeExecutor(fleetQuery, nil)
+	step := newRingHealthStep("check-empty", "no-such-ring", "v1.0.0")
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+	assert.InDelta(t, 0.0, result.Output["on_version_pct"], 0.001)
+	assert.InDelta(t, 0.0, result.Output["failed_pct"], 0.001)
+	assert.Equal(t, 0, result.Output["pending_count"])
+}
+
+func TestRingHealthNode_NilUpgradeStore_AllNonOnVersionCountedAsPending(t *testing.T) {
+	ctx := context.Background()
+	const ring = "early"
+	const desiredVersion = "v3.0.0"
+
+	stewards := []fleet.StewardData{
+		makeRingTestSteward("s-a", map[string]string{"deployment_ring": ring, "steward.version": desiredVersion}),
+		makeRingTestSteward("s-b", map[string]string{"deployment_ring": ring, "steward.version": "v2.0.0"}),
+		makeRingTestSteward("s-c", map[string]string{"deployment_ring": ring, "steward.version": "v2.0.0"}),
+	}
+
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: stewards})
+	executor := NewRingHealthNodeExecutor(fleetQuery, nil)
+	step := newRingHealthStep("check-early", ring, desiredVersion)
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+	// 1 of 3 on-version = 33.33%
+	assert.InDelta(t, 33.333, result.Output["on_version_pct"], 0.01)
+	// No upgrade store → failed_pct always 0
+	assert.InDelta(t, 0.0, result.Output["failed_pct"], 0.001)
+	// All non-on-version counted as pending
+	assert.Equal(t, 2, result.Output["pending_count"])
+}
+
+func TestRingHealthNode_MissingRingConfig_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: []fleet.StewardData{}})
+	executor := NewRingHealthNodeExecutor(fleetQuery, nil)
+
+	step := workflow.Step{
+		Name: "bad-step",
+		Type: workflow.StepTypeQueryRingHealth,
+		Config: map[string]interface{}{
+			// ring is missing
+			"desired_version": "v1.0.0",
+			"tenant_id":       "test-tenant",
+		},
+	}
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, result.Status)
+	assert.Contains(t, err.Error(), "ring must not be empty")
+}
+
+func TestRingHealthNode_MissingDesiredVersionConfig_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: []fleet.StewardData{}})
+	executor := NewRingHealthNodeExecutor(fleetQuery, nil)
+
+	step := workflow.Step{
+		Name: "bad-step",
+		Type: workflow.StepTypeQueryRingHealth,
+		Config: map[string]interface{}{
+			"ring":      "canary",
+			"tenant_id": "test-tenant",
+			// desired_version is missing
+		},
+	}
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, result.Status)
+	assert.Contains(t, err.Error(), "desired_version must not be empty")
+}
+
+func TestRingHealthNode_MissingTenantIDConfig_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: []fleet.StewardData{}})
+	executor := NewRingHealthNodeExecutor(fleetQuery, nil)
+
+	step := workflow.Step{
+		Name: "bad-step",
+		Type: workflow.StepTypeQueryRingHealth,
+		Config: map[string]interface{}{
+			"ring":            "canary",
+			"desired_version": "v2.0.0",
+			// tenant_id is missing
+		},
+	}
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, result.Status)
+	assert.Contains(t, err.Error(), "tenant_id must not be empty")
+}
+
+func TestRingHealthNode_FleetQueryError_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	executor := NewRingHealthNodeExecutor(&errorFleetQuery{err: errTestFleetError}, nil)
+	step := newRingHealthStep("check-ring", "canary", "v2.0.0")
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, result.Status)
+	assert.Contains(t, err.Error(), "fleet query failed")
+}
+
+func TestRingHealthNode_RolledBackCounted_AsFailed(t *testing.T) {
+	ctx := context.Background()
+	const ring = "canary"
+	const desiredVersion = "v2.0.0"
+
+	stewards := []fleet.StewardData{
+		makeRingTestSteward("s-rollback", map[string]string{"deployment_ring": ring, "steward.version": "v1.0.0"}),
+	}
+
+	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: stewards})
+	upgradeStore := memory.NewUpgradeStore()
+
+	rec := newTestUpgradeRecordForRing("upg-rollback", "s-rollback", desiredVersion)
+	require.NoError(t, upgradeStore.CreateUpgrade(ctx, rec))
+	require.NoError(t, upgradeStore.UpdateUpgradeStatus(ctx, "upg-rollback", business.UpgradeStatusRolledBack, "health check failed after swap"))
+
+	executor := NewRingHealthNodeExecutor(fleetQuery, upgradeStore)
+	step := newRingHealthStep("check-rb", ring, desiredVersion)
+
+	result, err := executor.ExecuteRingHealthStep(ctx, step, newRingExecution())
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+	assert.InDelta(t, 0.0, result.Output["on_version_pct"], 0.001)
+	assert.InDelta(t, 100.0, result.Output["failed_pct"], 0.001)
+	assert.Equal(t, 0, result.Output["pending_count"])
+}
+
+// --- helpers ---
+
+var errTestFleetError = errRingTestStr("fleet query test error")
+
+type errRingTestStr string
+
+func (e errRingTestStr) Error() string { return string(e) }
+
+// newTestUpgradeRecordForRing creates an upgrade record suitable for ring health tests.
+// The record's BundleSignature is non-empty (required by the upgrade store).
+func newTestUpgradeRecordForRing(id, stewardID, version string) *business.UpgradeRecord {
+	return &business.UpgradeRecord{
+		ID:              id,
+		StewardID:       stewardID,
+		TenantID:        "test-tenant",
+		Version:         version,
+		Platform:        "linux",
+		Arch:            "amd64",
+		SHA256:          "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111",
+		Status:          business.UpgradeStatusDispatched,
+		Publisher:       "cfgms",
+		SignatureDigest: "deadbeef",
+		BundleSignature: make([]byte, 64),
+		CreatedAt:       time.Now().UTC(),
+		OperationNonce:  make([]byte, 32),
+		DispatchedAt:    time.Now().UTC(),
+	}
+}

--- a/features/workflow/providers_test.go
+++ b/features/workflow/providers_test.go
@@ -225,7 +225,7 @@ func TestEngine_ExecuteAPIStep_WithProviderRegistry(t *testing.T) {
 	// this test exercises the engine's variable-storage path, not the provider stubs.
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	const providerName = "test-api-provider"
 	err := engine.providerRegistry.RegisterProvider(providerName, &MockProvider{name: providerName})

--- a/features/workflow/switch_test.go
+++ b/features/workflow/switch_test.go
@@ -154,7 +154,7 @@ func TestSwitchStep_BasicFunctionality(t *testing.T) {
 			// Create engine and execute workflow
 			moduleFactory := createTestFactory()
 			logger := pkgtesting.NewMockLogger(true)
-			engine := NewEngine(moduleFactory, logger, nil)
+			engine := NewEngine(moduleFactory, logger, nil, nil)
 			ctx := context.Background()
 
 			execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -235,7 +235,7 @@ func TestSwitchStep_DefaultCase(t *testing.T) {
 
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -289,7 +289,7 @@ func TestSwitchStep_NoMatchNoDefault(t *testing.T) {
 
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -368,7 +368,7 @@ func TestSwitchStep_ExpressionBasedSwitch(t *testing.T) {
 
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -418,7 +418,7 @@ func TestSwitchStep_VariableResolutionError(t *testing.T) {
 
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -498,7 +498,7 @@ func TestSwitchStep_NestedSwitchStatements(t *testing.T) {
 
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)

--- a/features/workflow/sync_test.go
+++ b/features/workflow/sync_test.go
@@ -95,7 +95,7 @@ func TestBarrierStep(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -151,7 +151,7 @@ func TestSemaphoreStep(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -233,7 +233,7 @@ func TestLockStep(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -337,7 +337,7 @@ func TestWaitGroupStep(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -398,7 +398,7 @@ func TestSyncMissingConfiguration(t *testing.T) {
 
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	for _, workflow := range workflows {
@@ -436,7 +436,7 @@ func TestSyncTimeout(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -454,7 +454,7 @@ func TestSyncCleanup(t *testing.T) {
 	// Test that sync manager cleanup works
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 
 	// Create some barriers
 	barrier1, err := engine.syncManager.GetOrCreateBarrier("test-barrier-1", 2)

--- a/features/workflow/trigger/controller_factory_test.go
+++ b/features/workflow/trigger/controller_factory_test.go
@@ -70,7 +70,7 @@ func newRealWorkflowTrigger(tb testing.TB) WorkflowTrigger {
 
 	registry := make(discovery.ModuleRegistry)
 	errCfg := stewardconfig.ErrorHandlingConfig{ModuleLoadFailure: stewardconfig.ActionContinue}
-	eng := workflow.NewEngine(factory.New(registry, errCfg, logging.NewNoopLogger()), logging.NewNoopLogger(), nil)
+	eng := workflow.NewEngine(factory.New(registry, errCfg, logging.NewNoopLogger()), logging.NewNoopLogger(), nil, nil)
 
 	return &workflowEngineAdapter{
 		engine:      eng,

--- a/features/workflow/try_catch_test.go
+++ b/features/workflow/try_catch_test.go
@@ -67,7 +67,7 @@ func TestTrySuccess(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -132,7 +132,7 @@ func TestTryCatchHandled(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -197,7 +197,7 @@ func TestTryCatchNotHandled(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -262,7 +262,7 @@ func TestTryCatchByErrorType(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -313,7 +313,7 @@ func TestTryFinallyWithoutCatch(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -378,7 +378,7 @@ func TestCatchAllErrors(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
@@ -408,7 +408,7 @@ func TestTryMissingConfiguration(t *testing.T) {
 	// Create engine and execute workflow
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
-	engine := NewEngine(moduleFactory, logger, nil)
+	engine := NewEngine(moduleFactory, logger, nil, nil)
 	ctx := context.Background()
 
 	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)

--- a/features/workflow/types.go
+++ b/features/workflow/types.go
@@ -226,6 +226,11 @@ const (
 
 	// StepTypeTransform executes data transformation operations
 	StepTypeTransform StepType = "transform"
+
+	// StepTypeQueryRingHealth queries the health of a deployment ring for rollout gating.
+	// Counts on-version, failed, and pending stewards in the ring and exposes the results
+	// as step outputs (on_version_pct, failed_pct, pending_count).
+	StepTypeQueryRingHealth StepType = "query_ring_health"
 )
 
 // Condition defines execution conditions for conditional steps

--- a/pkg/storage/interfaces/business/rollout_store.go
+++ b/pkg/storage/interfaces/business/rollout_store.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package business defines storage interfaces for the controller business tier.
+package business
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrRolloutNotFound is returned when a rollout record does not exist.
+var ErrRolloutNotFound = errors.New("rollout record not found")
+
+// RolloutStatus is the lifecycle state of a ring-advance rollout orchestration.
+type RolloutStatus string
+
+const (
+	// RolloutStatusInProgress indicates the rollout is actively advancing through rings.
+	RolloutStatusInProgress RolloutStatus = "in-progress"
+
+	// RolloutStatusHalted indicates the rollout was halted due to a health threshold breach
+	// or operator intervention.
+	RolloutStatusHalted RolloutStatus = "halted"
+
+	// RolloutStatusCompleted indicates all rings reached the target version successfully.
+	RolloutStatusCompleted RolloutStatus = "completed"
+)
+
+// RolloutRecord holds the durable state for a ring-advance rollout operation.
+//
+// This is the orchestration-state record for the rollout workflow — it tracks which
+// rings have been completed and which stewards have been deferred for retry. Individual
+// per-steward upgrade state is stored separately in UpgradeStore.
+//
+// The DeferredStewards list holds steward IDs that failed during this rollout and
+// should be retried; this is data on the record, not a DNA mutation.
+type RolloutRecord struct {
+	// ID is the unique rollout operation identifier.
+	ID string
+
+	// TenantID scopes this rollout to a single tenant.
+	TenantID string
+
+	// TargetVersion is the steward binary version this rollout is promoting.
+	TargetVersion string
+
+	// CurrentRing is the ring currently being processed. Empty when completed.
+	CurrentRing string
+
+	// RingsCompleted is the count of rings that have reached the target version.
+	RingsCompleted int
+
+	// RingsTotal is the total number of rings in the rollout plan.
+	RingsTotal int
+
+	// Status is the current lifecycle state of this rollout.
+	Status RolloutStatus
+
+	// StartedAt is when the rollout was initiated.
+	StartedAt time.Time
+
+	// HaltedAt is set when the rollout transitions to RolloutStatusHalted.
+	HaltedAt *time.Time
+
+	// Error holds the halt or failure reason; empty when Status is in-progress or completed.
+	Error string
+
+	// DeferredStewards is the list of steward IDs that failed during this rollout
+	// and are queued for a subsequent retry pass. This list grows monotonically;
+	// it is never cleared automatically.
+	DeferredStewards []string
+}
+
+// RolloutStore defines the storage interface for durable rollout-orchestration-state persistence.
+//
+// This interface is the durability seam between the in-memory workflow engine and any
+// future durable workflow execution backend (ADR-008). All implementations must be safe
+// for concurrent use.
+//
+// Do NOT add rollout types to upgrade_store.go — that file owns the UpgradeRecord/UpgradeStore
+// concern and mixing them would trip make check-architecture.
+type RolloutStore interface {
+	// CreateRollout inserts a new rollout record.
+	// Returns an error if a record with the same ID already exists.
+	CreateRollout(ctx context.Context, record *RolloutRecord) error
+
+	// GetRollout retrieves the rollout record for the given ID.
+	// Returns ErrRolloutNotFound if no record exists.
+	GetRollout(ctx context.Context, id string) (*RolloutRecord, error)
+
+	// UpdateRolloutProgress updates the status, current ring, completed ring count,
+	// and optional halt metadata for a rollout. Pass haltedAt as non-nil only when
+	// transitioning to RolloutStatusHalted.
+	// Returns ErrRolloutNotFound if no record exists for id.
+	UpdateRolloutProgress(ctx context.Context, id string, status RolloutStatus, currentRing string, ringsCompleted int, haltedAt *time.Time, errorMsg string) error
+
+	// AppendDeferredStewards adds steward IDs to the deferred-retry list.
+	// IDs already in the list are not deduplicated — callers are responsible for
+	// ensuring each ID is appended only once per rollout.
+	// Returns ErrRolloutNotFound if no record exists for rolloutID.
+	AppendDeferredStewards(ctx context.Context, rolloutID string, stewardIDs []string) error
+
+	// ListRolloutsByTenant returns all rollout records for the given tenantID.
+	// Returns an empty slice (not an error) when no records exist.
+	ListRolloutsByTenant(ctx context.Context, tenantID string) ([]*RolloutRecord, error)
+
+	// HealthCheck verifies the store is reachable and operational.
+	HealthCheck(ctx context.Context) error
+
+	// Initialize prepares the store (creates directories, tables, etc.).
+	Initialize(ctx context.Context) error
+
+	// Close releases resources held by the store.
+	Close() error
+}

--- a/pkg/storage/interfaces/business/rollout_store_test.go
+++ b/pkg/storage/interfaces/business/rollout_store_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package business_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemRolloutStore is a minimal in-memory RolloutStore used to validate the
+// shared contract harness. It is not a substitute for production implementations —
+// the real memory provider runs the same operations in its own test package.
+type inMemRolloutStore struct {
+	mu      sync.RWMutex
+	records map[string]*business.RolloutRecord
+}
+
+func newInMemRolloutStore() business.RolloutStore {
+	return &inMemRolloutStore{records: make(map[string]*business.RolloutRecord)}
+}
+
+func (s *inMemRolloutStore) CreateRollout(_ context.Context, record *business.RolloutRecord) error {
+	if record == nil {
+		return errRolloutTestNilRecord
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.records[record.ID]; exists {
+		return errRolloutTestDuplicateID
+	}
+	cp := copyRolloutRecord(record)
+	s.records[record.ID] = cp
+	return nil
+}
+
+func (s *inMemRolloutStore) GetRollout(_ context.Context, id string) (*business.RolloutRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[id]
+	if !ok {
+		return nil, business.ErrRolloutNotFound
+	}
+	return copyRolloutRecord(r), nil
+}
+
+func (s *inMemRolloutStore) UpdateRolloutProgress(_ context.Context, id string, status business.RolloutStatus, currentRing string, ringsCompleted int, haltedAt *time.Time, errorMsg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[id]
+	if !ok {
+		return business.ErrRolloutNotFound
+	}
+	r.Status = status
+	r.CurrentRing = currentRing
+	r.RingsCompleted = ringsCompleted
+	if haltedAt != nil {
+		t := *haltedAt
+		r.HaltedAt = &t
+	}
+	r.Error = errorMsg
+	return nil
+}
+
+func (s *inMemRolloutStore) AppendDeferredStewards(_ context.Context, rolloutID string, stewardIDs []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[rolloutID]
+	if !ok {
+		return business.ErrRolloutNotFound
+	}
+	r.DeferredStewards = append(r.DeferredStewards, stewardIDs...)
+	return nil
+}
+
+func (s *inMemRolloutStore) ListRolloutsByTenant(_ context.Context, tenantID string) ([]*business.RolloutRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*business.RolloutRecord
+	for _, r := range s.records {
+		if r.TenantID == tenantID {
+			out = append(out, copyRolloutRecord(r))
+		}
+	}
+	return out, nil
+}
+
+func (s *inMemRolloutStore) HealthCheck(_ context.Context) error { return nil }
+func (s *inMemRolloutStore) Initialize(_ context.Context) error  { return nil }
+func (s *inMemRolloutStore) Close() error                        { return nil }
+
+var _ business.RolloutStore = (*inMemRolloutStore)(nil)
+
+func copyRolloutRecord(r *business.RolloutRecord) *business.RolloutRecord {
+	cp := *r
+	cp.DeferredStewards = append([]string(nil), r.DeferredStewards...)
+	if r.HaltedAt != nil {
+		t := *r.HaltedAt
+		cp.HaltedAt = &t
+	}
+	return &cp
+}
+
+var (
+	errRolloutTestNilRecord   = errRolloutTestStr("nil rollout record")
+	errRolloutTestDuplicateID = errRolloutTestStr("duplicate rollout ID")
+)
+
+type errRolloutTestStr string
+
+func (e errRolloutTestStr) Error() string { return string(e) }
+
+func newTestRolloutRecord(id, tenantID string) *business.RolloutRecord {
+	return &business.RolloutRecord{
+		ID:             id,
+		TenantID:       tenantID,
+		TargetVersion:  "v2.0.0",
+		CurrentRing:    "canary",
+		RingsCompleted: 0,
+		RingsTotal:     4,
+		Status:         business.RolloutStatusInProgress,
+		StartedAt:      time.Now().UTC(),
+		DeferredStewards: []string{},
+	}
+}
+
+func TestRolloutStore_Contract(t *testing.T) {
+	store := newInMemRolloutStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Initialize(ctx))
+	require.NoError(t, store.HealthCheck(ctx))
+
+	t.Run("create and get round-trip", func(t *testing.T) {
+		rec := newTestRolloutRecord("rollout-1", "tenant-1")
+		require.NoError(t, store.CreateRollout(ctx, rec))
+
+		got, err := store.GetRollout(ctx, "rollout-1")
+		require.NoError(t, err)
+		assert.Equal(t, "rollout-1", got.ID)
+		assert.Equal(t, "tenant-1", got.TenantID)
+		assert.Equal(t, "v2.0.0", got.TargetVersion)
+		assert.Equal(t, "canary", got.CurrentRing)
+		assert.Equal(t, 0, got.RingsCompleted)
+		assert.Equal(t, 4, got.RingsTotal)
+		assert.Equal(t, business.RolloutStatusInProgress, got.Status)
+		assert.Nil(t, got.HaltedAt)
+		assert.Empty(t, got.Error)
+		assert.Empty(t, got.DeferredStewards)
+	})
+
+	t.Run("duplicate ID returns error", func(t *testing.T) {
+		rec := newTestRolloutRecord("rollout-dup", "tenant-1")
+		require.NoError(t, store.CreateRollout(ctx, rec))
+		err := store.CreateRollout(ctx, rec)
+		require.Error(t, err)
+	})
+
+	t.Run("get not found returns ErrRolloutNotFound", func(t *testing.T) {
+		_, err := store.GetRollout(ctx, "no-such-id")
+		assert.ErrorIs(t, err, business.ErrRolloutNotFound)
+	})
+
+	t.Run("UpdateRolloutProgress reflects in Get", func(t *testing.T) {
+		rec := newTestRolloutRecord("rollout-progress", "tenant-1")
+		require.NoError(t, store.CreateRollout(ctx, rec))
+
+		require.NoError(t, store.UpdateRolloutProgress(ctx, "rollout-progress", business.RolloutStatusInProgress, "early", 1, nil, ""))
+		got, err := store.GetRollout(ctx, "rollout-progress")
+		require.NoError(t, err)
+		assert.Equal(t, business.RolloutStatusInProgress, got.Status)
+		assert.Equal(t, "early", got.CurrentRing)
+		assert.Equal(t, 1, got.RingsCompleted)
+		assert.Nil(t, got.HaltedAt)
+
+		require.NoError(t, store.UpdateRolloutProgress(ctx, "rollout-progress", business.RolloutStatusCompleted, "", 4, nil, ""))
+		got, err = store.GetRollout(ctx, "rollout-progress")
+		require.NoError(t, err)
+		assert.Equal(t, business.RolloutStatusCompleted, got.Status)
+		assert.Equal(t, 4, got.RingsCompleted)
+	})
+
+	t.Run("UpdateRolloutProgress halted sets HaltedAt and error", func(t *testing.T) {
+		rec := newTestRolloutRecord("rollout-halt", "tenant-1")
+		require.NoError(t, store.CreateRollout(ctx, rec))
+
+		haltTime := time.Now().UTC()
+		require.NoError(t, store.UpdateRolloutProgress(ctx, "rollout-halt", business.RolloutStatusHalted, "canary", 0, &haltTime, "error rate exceeded threshold"))
+
+		got, err := store.GetRollout(ctx, "rollout-halt")
+		require.NoError(t, err)
+		assert.Equal(t, business.RolloutStatusHalted, got.Status)
+		assert.Equal(t, "error rate exceeded threshold", got.Error)
+		require.NotNil(t, got.HaltedAt)
+	})
+
+	t.Run("UpdateRolloutProgress not found", func(t *testing.T) {
+		err := store.UpdateRolloutProgress(ctx, "ghost", business.RolloutStatusHalted, "", 0, nil, "")
+		assert.ErrorIs(t, err, business.ErrRolloutNotFound)
+	})
+
+	t.Run("deferred-retry list persists across appends", func(t *testing.T) {
+		rec := newTestRolloutRecord("rollout-deferred", "tenant-1")
+		require.NoError(t, store.CreateRollout(ctx, rec))
+
+		require.NoError(t, store.AppendDeferredStewards(ctx, "rollout-deferred", []string{"s-1", "s-2"}))
+		require.NoError(t, store.AppendDeferredStewards(ctx, "rollout-deferred", []string{"s-3"}))
+
+		got, err := store.GetRollout(ctx, "rollout-deferred")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"s-1", "s-2", "s-3"}, got.DeferredStewards)
+	})
+
+	t.Run("AppendDeferredStewards not found", func(t *testing.T) {
+		err := store.AppendDeferredStewards(ctx, "ghost-rollout", []string{"s-x"})
+		assert.ErrorIs(t, err, business.ErrRolloutNotFound)
+	})
+
+	t.Run("ListRolloutsByTenant scopes by tenant", func(t *testing.T) {
+		require.NoError(t, store.CreateRollout(ctx, newTestRolloutRecord("rollout-ta-1", "tenant-A")))
+		require.NoError(t, store.CreateRollout(ctx, newTestRolloutRecord("rollout-ta-2", "tenant-A")))
+		require.NoError(t, store.CreateRollout(ctx, newTestRolloutRecord("rollout-tb-1", "tenant-B")))
+
+		listA, err := store.ListRolloutsByTenant(ctx, "tenant-A")
+		require.NoError(t, err)
+		assert.Len(t, listA, 2)
+
+		listB, err := store.ListRolloutsByTenant(ctx, "tenant-B")
+		require.NoError(t, err)
+		assert.Len(t, listB, 1)
+		assert.Equal(t, "rollout-tb-1", listB[0].ID)
+
+		listNone, err := store.ListRolloutsByTenant(ctx, "tenant-unknown")
+		require.NoError(t, err)
+		assert.Empty(t, listNone)
+	})
+
+	require.NoError(t, store.Close())
+}
+
+func TestRolloutStore_StatusConstants(t *testing.T) {
+	assert.Equal(t, business.RolloutStatus("in-progress"), business.RolloutStatusInProgress)
+	assert.Equal(t, business.RolloutStatus("halted"), business.RolloutStatusHalted)
+	assert.Equal(t, business.RolloutStatus("completed"), business.RolloutStatusCompleted)
+}
+
+func TestErrRolloutNotFound(t *testing.T) {
+	assert.NotNil(t, business.ErrRolloutNotFound)
+	assert.Equal(t, "rollout record not found", business.ErrRolloutNotFound.Error())
+}

--- a/pkg/storage/providers/memory/rollout_store.go
+++ b/pkg/storage/providers/memory/rollout_store.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package memory provides in-memory storage implementations for development and testing.
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// RolloutStore is a thread-safe in-memory implementation of business.RolloutStore.
+// Used in tests and development environments where durable rollout-state persistence
+// is not required. All mutations deep-copy the stored record to prevent aliasing.
+type RolloutStore struct {
+	mu      sync.RWMutex
+	records map[string]*business.RolloutRecord
+}
+
+// NewRolloutStore returns an initialised in-memory RolloutStore.
+func NewRolloutStore() *RolloutStore {
+	return &RolloutStore{records: make(map[string]*business.RolloutRecord)}
+}
+
+// CreateRollout inserts a new rollout record.
+// Returns an error if a record with the same ID already exists.
+func (s *RolloutStore) CreateRollout(_ context.Context, record *business.RolloutRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.records[record.ID]; exists {
+		return fmt.Errorf("rollout %q already exists", record.ID)
+	}
+	s.records[record.ID] = copyRollout(record)
+	return nil
+}
+
+// GetRollout retrieves a deep copy of the rollout record identified by id.
+func (s *RolloutStore) GetRollout(_ context.Context, id string) (*business.RolloutRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[id]
+	if !ok {
+		return nil, business.ErrRolloutNotFound
+	}
+	return copyRollout(r), nil
+}
+
+// UpdateRolloutProgress sets the status, current ring, completed ring count, and
+// optional halt metadata.
+func (s *RolloutStore) UpdateRolloutProgress(_ context.Context, id string, status business.RolloutStatus, currentRing string, ringsCompleted int, haltedAt *time.Time, errorMsg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[id]
+	if !ok {
+		return business.ErrRolloutNotFound
+	}
+	r.Status = status
+	r.CurrentRing = currentRing
+	r.RingsCompleted = ringsCompleted
+	if haltedAt != nil {
+		t := *haltedAt
+		r.HaltedAt = &t
+	}
+	r.Error = errorMsg
+	return nil
+}
+
+// AppendDeferredStewards adds steward IDs to the deferred-retry list for a rollout.
+func (s *RolloutStore) AppendDeferredStewards(_ context.Context, rolloutID string, stewardIDs []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[rolloutID]
+	if !ok {
+		return business.ErrRolloutNotFound
+	}
+	r.DeferredStewards = append(r.DeferredStewards, stewardIDs...)
+	return nil
+}
+
+// ListRolloutsByTenant returns deep copies of all rollouts belonging to tenantID.
+func (s *RolloutStore) ListRolloutsByTenant(_ context.Context, tenantID string) ([]*business.RolloutRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*business.RolloutRecord
+	for _, r := range s.records {
+		if r.TenantID == tenantID {
+			out = append(out, copyRollout(r))
+		}
+	}
+	return out, nil
+}
+
+func (s *RolloutStore) HealthCheck(_ context.Context) error { return nil }
+func (s *RolloutStore) Initialize(_ context.Context) error  { return nil }
+func (s *RolloutStore) Close() error                        { return nil }
+
+var _ business.RolloutStore = (*RolloutStore)(nil)
+
+// copyRollout returns a fully independent copy of a RolloutRecord, preventing aliasing
+// between the store's internal state and caller-held pointers.
+func copyRollout(r *business.RolloutRecord) *business.RolloutRecord {
+	cp := *r
+	cp.DeferredStewards = append([]string(nil), r.DeferredStewards...)
+	if r.HaltedAt != nil {
+		t := *r.HaltedAt
+		cp.HaltedAt = &t
+	}
+	return &cp
+}

--- a/pkg/storage/providers/memory/rollout_store_test.go
+++ b/pkg/storage/providers/memory/rollout_store_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package memory_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
+)
+
+func newMemTestRollout(id, tenantID string) *business.RolloutRecord {
+	return &business.RolloutRecord{
+		ID:               id,
+		TenantID:         tenantID,
+		TargetVersion:    "v2.0.0",
+		CurrentRing:      "canary",
+		RingsCompleted:   0,
+		RingsTotal:       4,
+		Status:           business.RolloutStatusInProgress,
+		StartedAt:        time.Now().UTC(),
+		DeferredStewards: []string{},
+	}
+}
+
+func TestRolloutStore_Memory_InitializeAndHealthCheck(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx))
+	require.NoError(t, store.HealthCheck(ctx))
+	require.NoError(t, store.Close())
+}
+
+func TestRolloutStore_Memory_CreateAndGet(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	rec := newMemTestRollout("r-1", "tenant-1")
+	require.NoError(t, store.CreateRollout(ctx, rec))
+
+	got, err := store.GetRollout(ctx, "r-1")
+	require.NoError(t, err)
+	assert.Equal(t, "r-1", got.ID)
+	assert.Equal(t, "tenant-1", got.TenantID)
+	assert.Equal(t, "v2.0.0", got.TargetVersion)
+	assert.Equal(t, "canary", got.CurrentRing)
+	assert.Equal(t, 0, got.RingsCompleted)
+	assert.Equal(t, 4, got.RingsTotal)
+	assert.Equal(t, business.RolloutStatusInProgress, got.Status)
+	assert.Nil(t, got.HaltedAt)
+	assert.Empty(t, got.Error)
+}
+
+func TestRolloutStore_Memory_CreateDuplicateIDReturnsError(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	rec := newMemTestRollout("r-dup", "tenant-1")
+	require.NoError(t, store.CreateRollout(ctx, rec))
+	err := store.CreateRollout(ctx, rec)
+	require.Error(t, err)
+}
+
+func TestRolloutStore_Memory_GetNotFound(t *testing.T) {
+	store := memory.NewRolloutStore()
+	_, err := store.GetRollout(context.Background(), "no-such-id")
+	assert.ErrorIs(t, err, business.ErrRolloutNotFound)
+}
+
+func TestRolloutStore_Memory_UpdateRolloutProgress(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateRollout(ctx, newMemTestRollout("r-prog", "tenant-1")))
+
+	require.NoError(t, store.UpdateRolloutProgress(ctx, "r-prog", business.RolloutStatusInProgress, "early", 1, nil, ""))
+	got, err := store.GetRollout(ctx, "r-prog")
+	require.NoError(t, err)
+	assert.Equal(t, business.RolloutStatusInProgress, got.Status)
+	assert.Equal(t, "early", got.CurrentRing)
+	assert.Equal(t, 1, got.RingsCompleted)
+	assert.Nil(t, got.HaltedAt)
+
+	require.NoError(t, store.UpdateRolloutProgress(ctx, "r-prog", business.RolloutStatusCompleted, "", 4, nil, ""))
+	got, err = store.GetRollout(ctx, "r-prog")
+	require.NoError(t, err)
+	assert.Equal(t, business.RolloutStatusCompleted, got.Status)
+	assert.Equal(t, 4, got.RingsCompleted)
+}
+
+func TestRolloutStore_Memory_UpdateRolloutProgressHalted(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateRollout(ctx, newMemTestRollout("r-halt", "tenant-1")))
+
+	haltTime := time.Now().UTC()
+	require.NoError(t, store.UpdateRolloutProgress(ctx, "r-halt", business.RolloutStatusHalted, "canary", 0, &haltTime, "failure rate exceeded"))
+
+	got, err := store.GetRollout(ctx, "r-halt")
+	require.NoError(t, err)
+	assert.Equal(t, business.RolloutStatusHalted, got.Status)
+	assert.Equal(t, "failure rate exceeded", got.Error)
+	require.NotNil(t, got.HaltedAt)
+}
+
+func TestRolloutStore_Memory_UpdateRolloutProgressNotFound(t *testing.T) {
+	store := memory.NewRolloutStore()
+	err := store.UpdateRolloutProgress(context.Background(), "ghost", business.RolloutStatusHalted, "", 0, nil, "")
+	assert.ErrorIs(t, err, business.ErrRolloutNotFound)
+}
+
+func TestRolloutStore_Memory_AppendDeferredStewards(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateRollout(ctx, newMemTestRollout("r-deferred", "tenant-1")))
+
+	require.NoError(t, store.AppendDeferredStewards(ctx, "r-deferred", []string{"s-1", "s-2"}))
+	require.NoError(t, store.AppendDeferredStewards(ctx, "r-deferred", []string{"s-3"}))
+
+	got, err := store.GetRollout(ctx, "r-deferred")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"s-1", "s-2", "s-3"}, got.DeferredStewards)
+}
+
+func TestRolloutStore_Memory_AppendDeferredStewardsNotFound(t *testing.T) {
+	store := memory.NewRolloutStore()
+	err := store.AppendDeferredStewards(context.Background(), "ghost", []string{"s-x"})
+	assert.ErrorIs(t, err, business.ErrRolloutNotFound)
+}
+
+func TestRolloutStore_Memory_ListRolloutsByTenant(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateRollout(ctx, newMemTestRollout("r-a1", "tenant-A")))
+	require.NoError(t, store.CreateRollout(ctx, newMemTestRollout("r-a2", "tenant-A")))
+	require.NoError(t, store.CreateRollout(ctx, newMemTestRollout("r-b1", "tenant-B")))
+
+	listA, err := store.ListRolloutsByTenant(ctx, "tenant-A")
+	require.NoError(t, err)
+	assert.Len(t, listA, 2)
+
+	listB, err := store.ListRolloutsByTenant(ctx, "tenant-B")
+	require.NoError(t, err)
+	assert.Len(t, listB, 1)
+	assert.Equal(t, "r-b1", listB[0].ID)
+
+	listNone, err := store.ListRolloutsByTenant(ctx, "tenant-unknown")
+	require.NoError(t, err)
+	assert.Empty(t, listNone)
+}
+
+func TestRolloutStore_Memory_ConcurrencySafe(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	const workers = 20
+	errs := make(chan error, workers*4)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := range workers {
+		go func(n int) {
+			defer wg.Done()
+			id := "concurrent-r-" + string(rune('a'+n))
+			tenantID := "tenant-" + string(rune('a'+n%3))
+			rec := newMemTestRollout(id, tenantID)
+			if err := store.CreateRollout(ctx, rec); err != nil {
+				errs <- err
+				return
+			}
+			if _, err := store.GetRollout(ctx, id); err != nil {
+				errs <- err
+			}
+			if err := store.UpdateRolloutProgress(ctx, id, business.RolloutStatusInProgress, "early", 1, nil, ""); err != nil {
+				errs <- err
+			}
+			if _, err := store.ListRolloutsByTenant(ctx, tenantID); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestRolloutStore_Memory_CreateIsolatesFromMutation(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	rec := newMemTestRollout("r-alias", "tenant-1")
+	require.NoError(t, store.CreateRollout(ctx, rec))
+
+	// Mutating original after create must not affect stored copy.
+	rec.Status = business.RolloutStatusHalted
+	rec.DeferredStewards = append(rec.DeferredStewards, "s-injected")
+
+	got, err := store.GetRollout(ctx, "r-alias")
+	require.NoError(t, err)
+	assert.Equal(t, business.RolloutStatusInProgress, got.Status)
+	assert.Empty(t, got.DeferredStewards, "DeferredStewards must be deep-copied on create")
+}
+
+func TestRolloutStore_Memory_GetIsolatesFromMutation(t *testing.T) {
+	store := memory.NewRolloutStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateRollout(ctx, newMemTestRollout("r-get-alias", "tenant-1")))
+
+	got, err := store.GetRollout(ctx, "r-get-alias")
+	require.NoError(t, err)
+
+	// Mutating returned copy must not affect stored value.
+	got.Status = business.RolloutStatusHalted
+	got.DeferredStewards = append(got.DeferredStewards, "s-extra")
+
+	got2, err := store.GetRollout(ctx, "r-get-alias")
+	require.NoError(t, err)
+	assert.Equal(t, business.RolloutStatusInProgress, got2.Status)
+	assert.Empty(t, got2.DeferredStewards, "DeferredStewards must be deep-copied on get")
+}


### PR DESCRIPTION
## Summary

- Adds `RolloutStore` interface (`pkg/storage/interfaces/business/rollout_store.go`) + thread-safe in-memory provider with full contract test coverage (create/get/update/list/deferred-retry round-trips)
- Adds `StepTypeQueryRingHealth` to the workflow engine with a concrete `RingHealthNodeExecutor` that queries fleet health per ring and outputs `on_version_pct`, `failed_pct`, `pending_count` as step variables
- Adds `StewardResult.RunningVersion` populated from the `steward.version` DNA attribute, enabling on-version comparisons without a separate lookup

## Acceptance criteria verified

- [x] `RolloutStore` interface + types in `pkg/storage/interfaces/business/rollout_store.go`; in-memory provider in `pkg/storage/providers/memory/rollout_store.go`; `make check-architecture` passes
- [x] Contract test in `business/rollout_store_test.go` covers create/get/update-status/list round-trips and deferred-retry list persistence
- [x] Unit test in `features/workflow/nodes/ring_health_node_test.go` proves correct `on_version_pct`/`failed_pct`/`pending_count` across on-version/failed/pending steward mix; tenant isolation enforced (missing `tenant_id` returns validation error)
- [x] Engine dispatches `StepTypeQueryRingHealth` to injected `RingHealthStepExecutor`; returns clear error when no executor is injected
- [x] `StewardResult.RunningVersion` populated from `steward.version` DNA attribute; empty when absent

## Specialist review results

- **Security:** PASS — multi-tenant isolation enforced via required `tenant_id` config field; fleet queries always scoped to `Filter.TenantID`; no hardcoded secrets; no cleartext storage; no information disclosure in error messages
- **Test Quality:** PASS — real CFGMS components throughout (fleet.MemoryQuery, memory.UpgradeStore); no mocks; contract test uses local in-memory impl (not imported provider); concurrency test (20 goroutines) in provider tests; error paths all covered
- **Code Review:** PASS — follows batch_job_store.go pattern exactly; `copyRollout()` prevents aliasing; compile-time interface assertions; `NewEngine` extended cleanly with nil-safe guards

## Test plan

- [ ] `go test ./features/workflow/... ./pkg/storage/... ./features/controller/fleet/...` — all pass
- [ ] `make check-architecture` — no violations
- [ ] `go build ./...` — no errors
- [ ] Story B (REST endpoints + rollout_steward.yaml template) can now import this foundation

Fixes #2339

🤖 Generated with [Claude Code](https://claude.com/claude-code)