### PR TITLE
workflow: fix storage-provider import violation breaking develop (Issue #2339)

### DIFF
--- a/features/workflow/nodes/providers_test.go
+++ b/features/workflow/nodes/providers_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package nodes
+
+import (
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
+)
+
+// newTestUpgradeStore returns a memory-backed UpgradeStore for tests.
+//
+// The concrete pkg/storage/providers/memory import lives here — an allowlisted
+// */providers_test.go file (see scripts/check-providers.sh) — so the rest of the
+// nodes test suite depends only on the business.UpgradeStore interface and stays
+// free of direct storage-provider imports.
+func newTestUpgradeStore() business.UpgradeStore {
+	return memory.NewUpgradeStore()
+}

--- a/features/workflow/nodes/ring_health_node_test.go
+++ b/features/workflow/nodes/ring_health_node_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/features/workflow"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	"github.com/cfgis/cfgms/pkg/storage/providers/memory"
 )
 
 // makeRingTestSteward creates a StewardData record for ring health tests.
@@ -81,7 +80,7 @@ func TestRingHealthNode_OnVersionFailedPending(t *testing.T) {
 
 	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: stewards})
 
-	upgradeStore := memory.NewUpgradeStore()
+	upgradeStore := newTestUpgradeStore()
 
 	// Populate dispatched (pending) upgrade records.
 	for _, id := range []string{"s-pend-1", "s-pend-2", "s-pend-3"} {
@@ -270,7 +269,7 @@ func TestRingHealthNode_RolledBackCounted_AsFailed(t *testing.T) {
 	}
 
 	fleetQuery := fleet.NewMemoryQuery(&testStewardProvider{stewards: stewards})
-	upgradeStore := memory.NewUpgradeStore()
+	upgradeStore := newTestUpgradeStore()
 
 	rec := newTestUpgradeRecordForRing("upg-rollback", "s-rollback", desiredVersion)
 	require.NoError(t, upgradeStore.CreateUpgrade(ctx, rec))


### PR DESCRIPTION
## Problem

`make check-architecture` fails on `develop` — `features/workflow/nodes/ring_health_node_test.go:16` directly imports `pkg/storage/providers/memory`, a storage-provider import violation. It merged via PR #2364 (`go build` passes, so the Build Gate didn't catch it; `check-architecture` is not a required CI gate). This broke the pipeline code-health preflight and **held all dispatch + blocked the merge queue**.

## Fix

Follow the established allowlist pattern (`features/controller/batchjob/providers_test.go`): the concrete provider import lives in an allowlisted `*/providers_test.go` helper that returns the `business.UpgradeStore` interface; the ring-health test depends only on that interface.

- **add** `features/workflow/nodes/providers_test.go` — `newTestUpgradeStore() business.UpgradeStore`
- **edit** `ring_health_node_test.go` — drop the `providers/memory` import, use `newTestUpgradeStore()` at both call sites

No product code changed; this is a test-wiring fix only. The RolloutStore + query_ring_health functionality delivered in #2339 is unchanged.

## Verification

- `go vet ./features/workflow/nodes/` — clean
- `go test ./features/workflow/nodes/ -run TestRingHealthNode` — pass
- `make check-architecture` — **no violations**
- repo-wide `go build ./...` — clean

Fixes #2339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzgEq4v2eUsKcFw92SkbmL