### PR TITLE
build: wire ldflags injection for publisher-key + version stamping across steward build scripts (Issue #2377)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,22 @@ fix-git-bare:
 # Build settings
 GO_BUILD_FLAGS=-trimpath -ldflags="-s -w"
 
-# Steward controller URL baked in at build time (security: no runtime override).
-# Override for MSP builds: make build-steward STEWARD_CONTROLLER_URL=https://ctrl.mymsp.com
+# Steward build flags: controller URL, version, and publisher-key baked in at build time
+# (security: no runtime override for controller URL or publisher key).
+#
+# Scope boundary: STEWARD_PUBLISHER_KEY wires the ldflags injection mechanism; a build
+# using the placeholder key (all-zero) cannot verify genuine signed upgrades. The all-zero
+# key is a small-order Ed25519 point, so ed25519.Verify does NOT fail against it (it accepts
+# attacker-forged signatures). Fail-closed behavior is enforced in code, not by the crypto:
+# pkg/modules/trust rejects the all-zero/small-order placeholder (ErrUntrustedPublisherKey),
+# so a placeholder-key build refuses ALL bundles. The real production key is deferred to the
+# code-signing pipeline (ADR-013 §5).
+#
+# Override for MSP builds:
+#   make build-steward STEWARD_CONTROLLER_URL=https://ctrl.mymsp.com VERSION=v1.0.0
+#   make build-steward STEWARD_PUBLISHER_KEY=<base64-ed25519-pub>
 STEWARD_CONTROLLER_URL ?= https://localhost:9080
-STEWARD_BUILD_FLAGS=-trimpath -ldflags="-s -w -X main.ControllerURL=$(STEWARD_CONTROLLER_URL)"
+STEWARD_BUILD_FLAGS=-trimpath -ldflags="-s -w -X main.ControllerURL=$(STEWARD_CONTROLLER_URL) -X github.com/cfgis/cfgms/pkg/version.Version=$(or $(VERSION),0.5.0-dev) -X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=$(or $(STEWARD_PUBLISHER_KEY),AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=)"
 
 # Binary names
 STEWARD_BINARY=cfgms-steward
@@ -216,7 +228,7 @@ build-steward-cross:
 # This target cross-compiles the binary and packages it into an MSI.
 # For production builds, provide a code-signing certificate:
 #   make build-msi-windows STEWARD_CONTROLLER_URL=https://ctrl.example.com \
-#        VERSION=v1.0.0 SIGNING_CERT_THUMBPRINT=<thumbprint>
+#        VERSION=v1.0.0 SIGNING_CERT_THUMBPRINT=<thumbprint> PUBLISHER_KEY=<base64-ed25519-pub>
 build-msi-windows:
 	@echo "🪟 Building Windows MSI installer"
 	@echo "==================================="
@@ -235,10 +247,15 @@ build-msi-windows:
 	if [ -n "$(SIGNING_CERT_THUMBPRINT)" ]; then \
 		SIGN_ARG="-SigningCertThumbprint '$(SIGNING_CERT_THUMBPRINT)'"; \
 	fi; \
+	KEY_ARG=""; \
+	if [ -n "$(PUBLISHER_KEY)" ]; then \
+		KEY_ARG="-PublisherKey '$(PUBLISHER_KEY)'"; \
+	fi; \
 	pwsh -NonInteractive -File build/windows/build-msi.ps1 \
 		$$URL_ARG \
 		-Version "$(or $(VERSION),0.0.0)" \
-		$$SIGN_ARG
+		$$SIGN_ARG \
+		$$KEY_ARG
 	@echo "✅ MSI built: bin/cfgms-steward-windows-amd64.msi"
 
 # Build macOS .pkg installer for cfgms-steward (amd64 and arm64).
@@ -252,7 +269,7 @@ build-msi-windows:
 # Examples:
 #   make build-pkg-darwin VERSION=v1.0.0
 #   APPLE_SIGNING_IDENTITY="Developer ID Installer: Acme (XXXXXXXXXX)" \
-#     make build-pkg-darwin VERSION=v1.0.0
+#     make build-pkg-darwin VERSION=v1.0.0 PUBLISHER_KEY=<base64-ed25519-pub>
 build-pkg-darwin:
 	@echo "🍎 Building macOS .pkg installer"
 	@echo "================================="
@@ -260,8 +277,12 @@ build-pkg-darwin:
 		echo "❌ build-pkg-darwin must be run on macOS (pkgbuild requires macOS)."; \
 		exit 1; \
 	fi
-	@bash build/darwin/build-pkg.sh --arch amd64 --version "$(or $(VERSION),0.0.0)"
-	@bash build/darwin/build-pkg.sh --arch arm64 --version "$(or $(VERSION),0.0.0)"
+	@KEY_ARG=""; \
+	if [ -n "$(PUBLISHER_KEY)" ]; then \
+		KEY_ARG="--publisher-key $(PUBLISHER_KEY)"; \
+	fi; \
+	bash build/darwin/build-pkg.sh --arch amd64 --version "$(or $(VERSION),0.0.0)" $$KEY_ARG; \
+	bash build/darwin/build-pkg.sh --arch arm64 --version "$(or $(VERSION),0.0.0)" $$KEY_ARG
 	@echo "✅ Packages built: bin/cfgms-steward-darwin-amd64.pkg  bin/cfgms-steward-darwin-arm64.pkg"
 
 # Run Linux install.sh tests (Story #1708)

--- a/build/darwin/build-pkg.sh
+++ b/build/darwin/build-pkg.sh
@@ -44,6 +44,7 @@ ARCH="amd64"
 VERSION="0.0.0"
 BINARY_PATH=""
 CONTROLLER_URL=""
+PUBLISHER_KEY=""
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -53,6 +54,7 @@ while [[ $# -gt 0 ]]; do
         --version)       VERSION="$2";        shift 2 ;;
         --binary-path)   BINARY_PATH="$2";    shift 2 ;;
         --controller-url) CONTROLLER_URL="$2"; shift 2 ;;
+        --publisher-key) PUBLISHER_KEY="$2";  shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 1 ;;
     esac
 done
@@ -67,6 +69,7 @@ echo "=== CFGMS Steward macOS .pkg Build ==="
 echo "Version:        $VERSION"
 echo "Pkg version:    $PKG_VERSION"
 echo "ControllerURL:  ${CONTROLLER_URL:-(not set — generic build)}"
+echo "PublisherKey:   ${PUBLISHER_KEY:+(set)}${PUBLISHER_KEY:-(not set — placeholder key)}"
 echo "Arch:           $ARCH"
 
 # ── Step 1: Build the binary (when not pre-supplied) ─────────────────────────
@@ -84,6 +87,9 @@ if [[ -z "$BINARY_PATH" ]]; then
         LD_FLAGS="-s -w -X main.ControllerURL=$CONTROLLER_URL $VERSION_FLAG"
     else
         LD_FLAGS="-s -w $VERSION_FLAG"
+    fi
+    if [[ -n "$PUBLISHER_KEY" ]]; then
+        LD_FLAGS="$LD_FLAGS -X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=$PUBLISHER_KEY"
     fi
 
     GOOS=darwin GOARCH="$ARCH" CGO_ENABLED=0 go build \

--- a/build/linux/install_test.sh
+++ b/build/linux/install_test.sh
@@ -204,6 +204,54 @@ else
 fi
 rm -rf "$T7" "$T7_PREFIX"
 
+# ── Test 8 & 9: Version-stamping ldflags round-trip ──────────────────────────
+#
+# Builds cfgms-steward twice using the same ldflags pattern as STEWARD_BUILD_FLAGS:
+# once with VERSION injected, once with the pre-story default (0.5.0-dev).
+# Requires: go toolchain available on PATH.
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VERSION_BIN_DIR="$(mktemp -d)"
+
+TEST_VERSION="v1.9.9-test-stamp"
+PLACEHOLDER_KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+# Test 8: build with injected VERSION and assert --version reports it.
+STAMPED_LDFLAGS="-s -w -X main.ControllerURL=https://localhost:9080 -X github.com/cfgis/cfgms/pkg/version.Version=${TEST_VERSION} -X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=${PLACEHOLDER_KEY}"
+if go build \
+    -trimpath \
+    -ldflags "$STAMPED_LDFLAGS" \
+    -o "$VERSION_BIN_DIR/cfgms-steward-stamped" \
+    "$REPO_ROOT/cmd/steward" 2>/dev/null; then
+    VERSION_OUT="$("$VERSION_BIN_DIR/cfgms-steward-stamped" --version 2>/dev/null || true)"
+    if echo "$VERSION_OUT" | grep -q "$TEST_VERSION"; then
+        pass "test8: injected VERSION stamps into --version output"
+    else
+        fail "test8: --version should contain '$TEST_VERSION' (got: '$VERSION_OUT')"
+    fi
+else
+    fail "test8: go build failed for stamped binary"
+fi
+
+# Test 9: build with default VERSION (0.5.0-dev) and assert --version is unchanged.
+DEFAULT_LDFLAGS="-s -w -X main.ControllerURL=https://localhost:9080 -X github.com/cfgis/cfgms/pkg/version.Version=0.5.0-dev -X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=${PLACEHOLDER_KEY}"
+if go build \
+    -trimpath \
+    -ldflags "$DEFAULT_LDFLAGS" \
+    -o "$VERSION_BIN_DIR/cfgms-steward-default" \
+    "$REPO_ROOT/cmd/steward" 2>/dev/null; then
+    DEFAULT_OUT="$("$VERSION_BIN_DIR/cfgms-steward-default" --version 2>/dev/null || true)"
+    if echo "$DEFAULT_OUT" | grep -q "0.5.0-dev"; then
+        pass "test9: default build version matches pre-story baseline (0.5.0-dev)"
+    else
+        fail "test9: --version should contain '0.5.0-dev' for default build (got: '$DEFAULT_OUT')"
+    fi
+else
+    fail "test9: go build failed for default binary"
+fi
+
+rm -rf "$VERSION_BIN_DIR"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 echo ""

--- a/build/windows/build-msi.ps1
+++ b/build/windows/build-msi.ps1
@@ -60,7 +60,16 @@ param(
     # When provided, signtool.exe signs the MSI using SHA-256 with a timestamp.
     # When omitted, the MSI is built unsigned with a warning.
     [Parameter(Mandatory = $false)]
-    [string]$SigningCertThumbprint = ""
+    [string]$SigningCertThumbprint = "",
+
+    # Base64-encoded Ed25519 public key for the CFGMS module publisher.
+    # When non-empty, baked into the binary via ldflags so the steward verifies
+    # module/upgrade bundles against this key. When omitted, the binary keeps the
+    # compiled-in all-zero placeholder from pkg/modules/trust/identity.go — a
+    # placeholder-key build cannot verify genuine signed upgrades (fail-closed dev
+    # behavior). The real key is supplied by the code-signing pipeline (ADR-013 §5).
+    [Parameter(Mandatory = $false)]
+    [string]$PublisherKey = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -79,6 +88,7 @@ Write-Host "=== CFGMS Steward MSI Build ===" -ForegroundColor Cyan
 Write-Host "Version:        $Version"
 Write-Host "MSI Version:    $MsiVersion"
 Write-Host "ControllerURL:  $(if ($ControllerURL -ne '') { $ControllerURL } else { '(not set — generic build)' })"
+Write-Host "PublisherKey:   $(if ($PublisherKey -ne '') { '(set)' } else { '(not set — placeholder key)' })"
 Write-Host "Arch:           $Arch"
 
 # ── Step 1: Build the binary (when not pre-supplied) ─────────────────────────
@@ -104,6 +114,9 @@ if ($BinaryPath -eq "") {
         "-s -w -X main.ControllerURL=$ControllerURL $VersionFlag"
     } else {
         "-s -w $VersionFlag"
+    }
+    if ($PublisherKey -ne "") {
+        $LdFlags += " -X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=$PublisherKey"
     }
     $BuildArgs = @(
         "build",

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -251,8 +251,9 @@ func buildRootCommand() *cobra.Command {
 	)
 
 	root := &cobra.Command{
-		Use:   "cfgms-steward",
-		Short: "CFGMS Steward — endpoint configuration management agent",
+		Use:     "cfgms-steward",
+		Version: version.Short(),
+		Short:   "CFGMS Steward — endpoint configuration management agent",
 		Long: fmt.Sprintf(`CFGMS Steward %s
 
 Manages the local endpoint configuration on behalf of a CFGMS controller.

--- a/pkg/modules/trust/identity.go
+++ b/pkg/modules/trust/identity.go
@@ -8,7 +8,15 @@ import (
 )
 
 // cfgmsPublisherPublicKey is the base64-encoded Ed25519 public key for the CFGMS
-// publisher. This is a placeholder (32 zero bytes) for development builds.
+// publisher. This default is a placeholder (32 zero bytes) for development builds
+// that have not been configured with a real publisher key.
+//
+// SECURITY: the all-zero placeholder is a small-order Ed25519 point, NOT a safe
+// "no-op" key. ed25519.Verify does not fail closed against it — it accepts forged
+// signatures. VerifyBundleSignature therefore explicitly rejects small-order and
+// placeholder keys (see isUnsafePublisherKey / ErrUntrustedPublisherKey in verify.go),
+// so a build that ships this placeholder refuses ALL bundles rather than accepting
+// attacker-forged ones. Do not treat the placeholder as a trusted anchor anywhere.
 //
 // The real key is injected by the release pipeline at build time:
 //

--- a/pkg/modules/trust/identity_test.go
+++ b/pkg/modules/trust/identity_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust_test
+
+import (
+	"encoding/base64"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCFGMSPublisherKey_LdflagsRoundTrip verifies that the ldflags injection path
+// for cfgmsPublisherPublicKey actually round-trips: build the probe binary with a
+// non-placeholder key baked in via -ldflags, run it, and assert the output equals
+// the injected key — proving the injection path works end to end, not just that the
+// Makefile string is syntactically well-formed.
+func TestCFGMSPublisherKey_LdflagsRoundTrip(t *testing.T) {
+	// Use a known 32-byte test key (all 0xAB bytes — distinct from the all-zero placeholder).
+	testKey := make([]byte, 32)
+	for i := range testKey {
+		testKey[i] = 0xAB
+	}
+	testKeyB64 := base64.StdEncoding.EncodeToString(testKey)
+
+	tmpDir := t.TempDir()
+	probePath := filepath.Join(tmpDir, "probe")
+
+	ldflags := "-X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=" + testKeyB64
+
+	// Build the probe binary with the test key baked in via ldflags.
+	buildOut, err := exec.Command("go", "build",
+		"-ldflags", ldflags,
+		"-o", probePath,
+		"github.com/cfgis/cfgms/pkg/modules/trust/testdata/probe",
+	).CombinedOutput()
+	require.NoError(t, err, "probe build failed: %s", buildOut)
+
+	// Run the probe and assert it prints back the injected key exactly.
+	out, err := exec.Command(probePath).Output()
+	require.NoError(t, err, "probe run failed")
+
+	assert.Equal(t, testKeyB64, string(out),
+		"CFGMSPublisherIdentity().PublicKey should equal the injected ldflags key")
+}

--- a/pkg/modules/trust/identity_test.go
+++ b/pkg/modules/trust/identity_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,11 @@ func TestCFGMSPublisherKey_LdflagsRoundTrip(t *testing.T) {
 	testKeyB64 := base64.StdEncoding.EncodeToString(testKey)
 
 	tmpDir := t.TempDir()
-	probePath := filepath.Join(tmpDir, "probe")
+	probeName := "probe"
+	if runtime.GOOS == "windows" {
+		probeName = "probe.exe"
+	}
+	probePath := filepath.Join(tmpDir, probeName)
 
 	ldflags := "-X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=" + testKeyB64
 

--- a/pkg/modules/trust/testdata/probe/main.go
+++ b/pkg/modules/trust/testdata/probe/main.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+//
+// probe prints the base64-encoded Ed25519 public key from CFGMSPublisherIdentity()
+// to stdout. Used only by the publisher-key ldflags round-trip test in identity_test.go;
+// not part of any shipped binary or public API.
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+func main() {
+	fmt.Print(base64.StdEncoding.EncodeToString(trust.CFGMSPublisherIdentity().PublicKey))
+}

--- a/pkg/modules/trust/trust_test.go
+++ b/pkg/modules/trust/trust_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -161,6 +162,114 @@ func TestVerifyBundleSignature_MalformedStoredKey(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, trust.ErrKeyMismatch),
 		"expected ErrKeyMismatch for malformed stored key, got: %v", err)
+}
+
+// forgedSigOverAnyMessage builds an Ed25519 signature (R || S) that ed25519.Verify
+// accepts against the all-zero public key for an arbitrary message: R is a small-order
+// point (the p-1 / order-2 encoding) and S is the zero scalar. No private key is used.
+func forgedSigOverAnyMessage() []byte {
+	r := make([]byte, ed25519.PublicKeySize)
+	r[0] = 0xec
+	for i := 1; i < ed25519.PublicKeySize-1; i++ {
+		r[i] = 0xff
+	}
+	r[ed25519.PublicKeySize-1] = 0x7f
+	s := make([]byte, ed25519.PublicKeySize) // zero scalar
+	return append(append([]byte{}, r...), s...)
+}
+
+// TestVerifyBundleSignature_AllZeroPlaceholderKeyRejected proves the placeholder-key
+// footgun is closed. The all-zero key is a small-order Ed25519 point: raw ed25519.Verify
+// ACCEPTS an attacker-forged signature over an attacker-chosen message against it. A
+// trust store holding that key must therefore refuse the bundle, not accept the forgery.
+func TestVerifyBundleSignature_AllZeroPlaceholderKeyRejected(t *testing.T) {
+	allZeroKey := make([]byte, ed25519.PublicKeySize)
+	forged := forgedSigOverAnyMessage()
+
+	// Whether the primitive accepts this fixed small-order R || S=0 forgery depends on
+	// the hash of (R, A, message) landing on the right residue, so search for a content
+	// hash the raw primitive accepts. This makes the footgun concrete and deterministic.
+	var message string
+	var accepted bool
+	for i := 0; i < 4096; i++ {
+		candidate := fmt.Sprintf("attacker-chosen-content-hash-%d", i)
+		if ed25519.Verify(ed25519.PublicKey(allZeroKey), []byte(candidate), forged) {
+			message = candidate
+			accepted = true
+			break
+		}
+	}
+	require.True(t, accepted,
+		"precondition: ed25519.Verify must accept the forgery against the all-zero key for some message")
+
+	store := trust.NewInMemoryTrustStore()
+	require.NoError(t, store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: allZeroKey,
+		Algorithm: "ed25519",
+	}))
+
+	b := makeBundle(message)
+	sig := bundle.BundleSignature{Publisher: "cfgms", Algorithm: "ed25519", Signature: forged}
+
+	err := trust.VerifyBundleSignature(b, sig, store)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrUntrustedPublisherKey),
+		"placeholder all-zero key must be rejected as ErrUntrustedPublisherKey, got: %v", err)
+}
+
+// TestVerifyBundleSignature_SmallOrderKeyRejected verifies that a non-zero small-order
+// public key (an order-8 point) is also rejected, independent of the signature bytes.
+func TestVerifyBundleSignature_SmallOrderKeyRejected(t *testing.T) {
+	// An order-8 small-order point encoding.
+	smallOrderKey := []byte{
+		0x26, 0xe8, 0x95, 0x8f, 0xc2, 0xb2, 0x27, 0xb0, 0x45, 0xc3, 0xf4,
+		0x89, 0xf2, 0xef, 0x98, 0xf0, 0xd5, 0xdf, 0xac, 0x05, 0xd3, 0xc6,
+		0x33, 0x39, 0xb1, 0x38, 0x02, 0x88, 0x6d, 0x53, 0xfc, 0x05,
+	}
+	require.Len(t, smallOrderKey, ed25519.PublicKeySize)
+
+	store := trust.NewInMemoryTrustStore()
+	require.NoError(t, store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: smallOrderKey,
+		Algorithm: "ed25519",
+	}))
+
+	b := makeBundle("some-content-hash")
+	sig := bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: make([]byte, ed25519.SignatureSize),
+	}
+
+	err := trust.VerifyBundleSignature(b, sig, store)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrUntrustedPublisherKey),
+		"small-order key must be rejected as ErrUntrustedPublisherKey, got: %v", err)
+}
+
+// TestVerifyBundleSignature_CFGMSPlaceholderIdentityRejectsBundles verifies that a build
+// carrying the unconfigured placeholder identity (all-zero key) refuses bundles rather
+// than accepting forgeries, exercising the exact runtime trust anchor.
+func TestVerifyBundleSignature_CFGMSPlaceholderIdentityRejectsBundles(t *testing.T) {
+	id := trust.CFGMSPublisherIdentity() // default build: all-zero placeholder key
+
+	store := trust.NewInMemoryTrustStore()
+	require.NoError(t, store.AddPublisher(id))
+
+	message := "attacker-chosen-content-hash"
+	b := makeBundle(message)
+	sig := bundle.BundleSignature{
+		Publisher: id.Name,
+		Algorithm: "ed25519",
+		Signature: forgedSigOverAnyMessage(),
+	}
+
+	err := trust.VerifyBundleSignature(b, sig, store)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrUntrustedPublisherKey),
+		"placeholder CFGMS identity must refuse all bundles, got: %v", err)
 }
 
 // TestInMemoryTrustStore_Operations tests the basic operations of InMemoryTrustStore.

--- a/pkg/modules/trust/verify.go
+++ b/pkg/modules/trust/verify.go
@@ -22,7 +22,71 @@ var (
 	// ErrInvalidSignature is returned when the Ed25519 signature does not verify
 	// against the bundle's ContentHash and the publisher's public key.
 	ErrInvalidSignature = errors.New("invalid bundle signature")
+
+	// ErrUntrustedPublisherKey is returned when the stored publisher public key is not
+	// a safe, prime-order Ed25519 point — specifically the all-zero placeholder key
+	// baked into unconfigured builds or any known small-order point. Such keys must
+	// never be treated as a trust anchor: a small-order public key lets an attacker
+	// forge a signature over an arbitrary message with no private key (ed25519.Verify
+	// accepts a signature with S=0 and a small-order R against it). A build carrying
+	// such a key therefore refuses ALL bundles instead of failing open.
+	ErrUntrustedPublisherKey = errors.New("publisher public key is not a valid prime-order Ed25519 key")
 )
+
+// smallOrderEncodings is the set of Ed25519 public-key encodings (sign bit cleared)
+// that decode to a point of small order — order 1, 2, 4, or 8. It includes the
+// all-zero placeholder key used by unconfigured builds (which encodes an order-4
+// point). Any public key matching one of these, ignoring the sign bit, permits
+// signature forgery and must be rejected as a trust anchor. This is the canonical
+// small-order point set (equivalent to libsodium's ed25519 small-order blocklist).
+var smallOrderEncodings = buildSmallOrderEncodings()
+
+func buildSmallOrderEncodings() [][ed25519.PublicKeySize]byte {
+	set := [][ed25519.PublicKeySize]byte{
+		// 0 — order 4 (also the all-zero placeholder key of unconfigured builds)
+		{},
+		// 1 — order 1 (identity)
+		{0x01},
+		// order-8 point
+		{0x26, 0xe8, 0x95, 0x8f, 0xc2, 0xb2, 0x27, 0xb0, 0x45, 0xc3, 0xf4,
+			0x89, 0xf2, 0xef, 0x98, 0xf0, 0xd5, 0xdf, 0xac, 0x05, 0xd3, 0xc6,
+			0x33, 0x39, 0xb1, 0x38, 0x02, 0x88, 0x6d, 0x53, 0xfc, 0x05},
+		// order-8 point
+		{0xc7, 0x17, 0x6a, 0x70, 0x3d, 0x4d, 0xd8, 0x4f, 0xba, 0x3c, 0x0b,
+			0x76, 0x0d, 0x10, 0x67, 0x0f, 0x2a, 0x20, 0x53, 0xfa, 0x2c, 0x39,
+			0xcc, 0xc6, 0x4e, 0xc7, 0xfd, 0x77, 0x92, 0xac, 0x03, 0x7a},
+	}
+	// p-1 (order 2), p (order 4), p+1 (order 1): first byte varies, then 0xff…, 0x7f.
+	for _, first := range []byte{0xec, 0xed, 0xee} {
+		var e [ed25519.PublicKeySize]byte
+		e[0] = first
+		for i := 1; i < ed25519.PublicKeySize-1; i++ {
+			e[i] = 0xff
+		}
+		e[ed25519.PublicKeySize-1] = 0x7f
+		set = append(set, e)
+	}
+	return set
+}
+
+// isUnsafePublisherKey reports whether pub is a small-order Ed25519 point (including
+// the all-zero placeholder key). Such a key cannot serve as a trust anchor because it
+// permits signature forgery. The sign bit (high bit of the last byte) is masked before
+// comparison so both sign variants of each small-order point are caught.
+func isUnsafePublisherKey(pub []byte) bool {
+	if len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	var masked [ed25519.PublicKeySize]byte
+	copy(masked[:], pub)
+	masked[ed25519.PublicKeySize-1] &= 0x7f
+	for i := range smallOrderEncodings {
+		if masked == smallOrderEncodings[i] {
+			return true
+		}
+	}
+	return false
+}
 
 // VerifyBundleSignature verifies that sig is a valid Ed25519 signature over the
 // bundle's ContentHash bytes, produced by a publisher known to store.
@@ -41,6 +105,16 @@ func VerifyBundleSignature(b *bundle.Bundle, sig bundle.BundleSignature, store T
 	if len(id.PublicKey) != ed25519.PublicKeySize {
 		return fmt.Errorf("%w: stored key for %q has wrong length %d (expected %d)",
 			ErrKeyMismatch, sig.Publisher, len(id.PublicKey), ed25519.PublicKeySize)
+	}
+
+	// Reject small-order/placeholder public keys before calling ed25519.Verify. The
+	// all-zero placeholder baked into unconfigured builds is a small-order point, and
+	// ed25519.Verify does NOT fail closed against it — it accepts an attacker-forged
+	// signature (S=0, small-order R) over any message. Refusing the key here makes a
+	// placeholder-key build reject every bundle instead of accepting forgeries.
+	if isUnsafePublisherKey(id.PublicKey) {
+		return fmt.Errorf("%w: stored key for %q is a small-order/placeholder point and cannot anchor trust",
+			ErrUntrustedPublisherKey, sig.Publisher)
 	}
 
 	message := []byte(b.ContentHash)


### PR DESCRIPTION
## Summary

- **`STEWARD_BUILD_FLAGS`** now bakes `pkg/version.Version` and `pkg/modules/trust.cfgmsPublisherPublicKey` via `-X` ldflags alongside the existing `ControllerURL`. Defaults exactly match current in-source values, so a bare `make build-steward` is a no-op change in stamped output (ADR-013 §#1517 regression guard).
- **`build-msi-windows` / `build-pkg-darwin`** Makefile targets gain optional `PUBLISHER_KEY` pass-through to `build-msi.ps1` (`-PublisherKey`) and `build-pkg.sh` (`--publisher-key`), conditionally passed only when non-empty — mirroring the existing `SIGN_ARG`/`URL_ARG` pattern.
- **`cmd/steward/main.go`**: adds `Version: version.Short()` to the cobra root command, enabling `--version` (consistent with `cmd/cfg` which already does this).
- **`build/linux/install_test.sh`**: two new tests (8 & 9) — version-stamping round-trip via injected `VERSION` and default `0.5.0-dev` baseline.
- **`pkg/modules/trust/testdata/probe/main.go`** (NEW): minimal binary that prints `base64(CFGMSPublisherIdentity().PublicKey)` to stdout; used only by the ldflags round-trip test.
- **`pkg/modules/trust/identity_test.go`** (NEW): publisher-key ldflags round-trip test — builds the probe with a non-placeholder key baked in, runs it, asserts output equals the injected key.
- **Security fix** (surfaced during review): the all-zero placeholder key is a small-order Ed25519 point that `ed25519.Verify` does NOT fail closed against. `VerifyBundleSignature` now rejects small-order/placeholder keys via `isUnsafePublisherKey()` + `ErrUntrustedPublisherKey`, so a placeholder-key build refuses ALL bundles instead of accepting forgeries. Tests prove the footgun is closed with a concrete forgery.

## Specialist Review Results

| Lens | Round 1 | Round 2 |
|------|---------|---------|
| Code review | PASS | — |
| Test quality | FAIL → fix applied | PASS |
| Security | FAIL → fix applied | PASS |

Workflow result: **passed: true** (2 review rounds, 1 fix round, 0 remaining findings)

## Test plan

- [x] `go test ./pkg/modules/trust/...` — all 11 tests pass including 3 new small-order key rejection tests and ldflags round-trip test
- [x] `bash build/linux/install_test.sh` — tests 8 & 9 (version stamping) pass
- [x] `make build-steward` — builds with correct default stamps (`0.5.0-dev`, all-zero placeholder)
- [x] `make build-steward VERSION=v1.2.3` — stamps `v1.2.3` into `--version` output
- [x] `make check-architecture` — no central provider violations
- [x] `make lint-log-injection` — no log injection findings

Fixes #2377

🤖 Generated with [Claude Code](https://claude.com/claude-code)