### PR TITLE
deps: bump trivy v0.71.2 → v0.72.0 (Issue #2390)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,8 +73,8 @@ RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1 \
 # fetched at install time and can be tampered with). See
 # docs/runbooks/trivy-rollback.md for rollback procedure.
 RUN set -eu; \
-    TRIVY_VERSION='v0.71.2'; \
-    TRIVY_SHA256='0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'; \
+    TRIVY_VERSION='v0.72.0'; \
+    TRIVY_SHA256='bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea'; \
     ARCHIVE="trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz"; \
     curl -sSfL -o "/tmp/${ARCHIVE}" \
       "https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/${ARCHIVE}"; \

--- a/.github/scripts/install-trivy.sh
+++ b/.github/scripts/install-trivy.sh
@@ -4,7 +4,7 @@
 # versions per the GHSA-69fq-xp46-6x23 advisory (CVE-2026-33634).
 #
 # Usage: install-trivy.sh <version> <sha256> [dest_dir]
-#   version    Trivy version tag (e.g. "v0.71.2")
+#   version    Trivy version tag (e.g. "v0.72.0")
 #   sha256     Expected SHA-256 of trivy_<v>_Linux-64bit.tar.gz from the
 #              upstream release's checksums.txt — pinned in caller's env.
 #   dest_dir   Install directory (default: /usr/local/bin)

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -50,7 +50,7 @@ jobs:
           echo "" >&2
           echo "ERROR: a known-compromised Trivy version (v0.69.4 - v0.69.6) was found in a pin-usage context." >&2
           echo "These releases are part of the CVE-2026-33634 supply-chain compromise." >&2
-          echo "Use v0.71.2 (post-incident clean release) or v0.69.3 (pre-incident)." >&2
+          echo "Use v0.72.0 (post-incident clean release) or v0.69.3 (pre-incident)." >&2
           echo "See docs/runbooks/trivy-rollback.md for context." >&2
           exit 1
         fi
@@ -121,7 +121,7 @@ jobs:
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.1.0"
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.6"
-        check_version "trivy"       "aquasecurity/trivy"                      "v0.71.2"
+        check_version "trivy"       "aquasecurity/trivy"                      "v0.72.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"
 

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -32,7 +32,7 @@ env:
   GO_VERSION: '1.26.4'
   REGISTRY: ghcr.io
   IMAGE_PREFIX: cfg-is/cfgms
-  TRIVY_VERSION: 'v0.71.2'
+  TRIVY_VERSION: 'v0.72.0'
 
 jobs:
   # Scan Controller Docker Image

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -60,10 +60,10 @@ jobs:
         echo "=============================================="
         
         # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
-        # v0.71.2 is the post-incident clean release. The install helper
+        # v0.72.0 is the post-incident clean release. The install helper
         # verifies the archive SHA-256 against the pinned value before
         # extraction. See docs/runbooks/trivy-rollback.md for rollback.
-        sudo .github/scripts/install-trivy.sh 'v0.71.2' '0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'
+        sudo .github/scripts/install-trivy.sh 'v0.72.0' 'bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea'
 
         # Install other security tools
         make install-nancy

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -53,12 +53,12 @@ jobs:
 
     - name: Install Trivy
       env:
-        # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.71.2 is
+        # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.72.0 is
         # the post-incident clean release. The install helper verifies the
         # archive SHA-256 against this pinned value before extraction. See
         # docs/runbooks/trivy-rollback.md for rollback procedure.
-        TRIVY_VERSION: 'v0.71.2'
-        TRIVY_SHA256: '0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'
+        TRIVY_VERSION: 'v0.72.0'
+        TRIVY_SHA256: 'bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea'
       run: sudo .github/scripts/install-trivy.sh "$TRIVY_VERSION" "$TRIVY_SHA256"
 
     - name: Run Trivy Scan
@@ -324,10 +324,10 @@ jobs:
         make install-nancy
         
         # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
-        # v0.71.2 is the post-incident clean release. The install helper
+        # v0.72.0 is the post-incident clean release. The install helper
         # verifies the archive SHA-256 against the pinned value before
         # extraction. See docs/runbooks/trivy-rollback.md for rollback.
-        sudo .github/scripts/install-trivy.sh 'v0.71.2' '0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'
+        sudo .github/scripts/install-trivy.sh 'v0.72.0' 'bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea'
 
         # Install gosec and staticcheck
         go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1


### PR DESCRIPTION
## Summary

- Advances the pinned Trivy release from v0.71.2 to v0.72.0 across all five lockstep locations
- Updates the SHA-256 supply-chain pin to `bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea`, verified against the official upstream `checksums.txt` for `trivy_0.72.0_Linux-64bit.tar.gz`
- Updates the usage-comment example in `install-trivy.sh` for consistency (cosmetic, outside AC scope)

## Files changed

| File | Change |
|------|--------|
| `.devcontainer/Dockerfile` | version + SHA256 pin |
| `.github/workflows/dependency-pin-check.yml` | denylist message + version check |
| `.github/workflows/docker-security.yml` | `TRIVY_VERSION` env var |
| `.github/workflows/production-gates.yml` | comment + install call |
| `.github/workflows/security-scan.yml` | env var + comment + install call (×2) |
| `.github/scripts/install-trivy.sh` | usage docstring example (cosmetic) |

## Specialist review results

- **Code review**: PASS — coordinated CI/DevOps config bump, no Go source changes
- **Security review**: PASS — SHA-256 verified against upstream `checksums.txt`; v0.72.0 is clear of the compromised v0.69.4–v0.69.6 range (CVE-2026-33634); gitleaks clean; check-architecture clean
- **Acceptance check**: PASS — AC#2 (0 old-version matches) and AC#3 (exactly 10 new-version matches) both verified

## Test plan

- [x] `make test` — 196 passed, 0 failed
- [x] `grep -rE "v0\.71\.2"` on the 5 scoped files → 0 matches
- [x] `grep -rE "v0\.72\.0"` on the 5 scoped files → 10 matches
- [x] SHA-256 `bbb64b96...` confirmed against upstream checksums.txt

Fixes #2390

🤖 Generated with [Claude Code](https://claude.com/claude-code)