### PR TITLE
infra: provision Windows ci-runner VM live + fix register script service start (Issue #2336)

### DIFF
--- a/docs/development/ci-runner-github-app-setup.md
+++ b/docs/development/ci-runner-github-app-setup.md
@@ -170,7 +170,7 @@ Measured timings:
 | Registration token mint | 0.50 s |
 | Runner agent download (100 MB zip, in-guest) | 7.2 s |
 | Runner agent extract | 14.2 s |
-| Registration script (`config.cmd` remove + re-register + service install/start) | 4.8 s |
+| Registration script v1.1.0 (`config.cmd` register + service install/start; operator ran `config.cmd remove` first to clear the v1.0.0 registration) | 4.8 s |
 | Runner `online` in GitHub API after service start | first poll (< 60 s) |
 | Hyper-V checkpoint create (`Checkpoint-VM`, running VM) | 7.05 s |
 | Hyper-V checkpoint revert (`Restore-VMCheckpoint`) | 5.82 s |

--- a/docs/development/ci-runner-github-app-setup.md
+++ b/docs/development/ci-runner-github-app-setup.md
@@ -151,6 +151,61 @@ GitHub API (same endpoint the App-based provider calls) and delivered over an
 operator SSH session — never composed into a CFGMS command string. Sequence and
 timings otherwise mirror the workflow's steps 1–4.
 
+### Windows runner (Issue #2336, measured 2026-07-07 on cfg-lab)
+
+Windows CI runner provisioned on the same cluster: VM `cfgms-ci-win-01`
+(4 vCPU / 8 GB, Windows Server 2025 SERVERSTANDARD from the eval ISO) on host
+CFG-70-02 via the hyperv module autounattend path (ADR-009 §6), steward v0.9.10
+enrolled to tenant `gh-ci-runners`, registered to `cfg-is/cfgms` as runner
+**`CFGMS-CI-WIN-01`** with labels **`self-hosted, Windows, X64, cfgms`** (runner
+id 23, status `online`; GitHub canonicalizes the OS/arch label case, as with the
+Linux runner).
+
+Measured timings:
+
+| Phase | Measured |
+|-------|----------|
+| VM provision, autounattend path (`cfg config upload` → VM created + answer ISO staged) | 43 s |
+| Full provision (`cfg config upload` → unattended install → steward `active` on controller) | 7 m 16 s |
+| Registration token mint | 0.50 s |
+| Runner agent download (100 MB zip, in-guest) | 7.2 s |
+| Runner agent extract | 14.2 s |
+| Registration script (`config.cmd` remove + re-register + service install/start) | 4.8 s |
+| Runner `online` in GitHub API after service start | first poll (< 60 s) |
+| Hyper-V checkpoint create (`Checkpoint-VM`, running VM) | 7.05 s |
+| Hyper-V checkpoint revert (`Restore-VMCheckpoint`) | 5.82 s |
+| Revert → `Start-VM` → runner `online` in GitHub API | 137 s |
+
+A production checkpoint (the Server 2025 default) restores the VM to `Off`, so the
+revert-pool cycle on Windows is revert (5.8 s) + boot to runner-online (137 s,
+including the runner service's delayed auto-start) — viable for Phase 2 ephemeral
+runners, with a materially longer recovery than the Linux VM's 36 s.
+
+**Script fix confirmed live:** the shipped `register-github-runner-windows.yaml`
+(v1.0.0) ran verbatim and registered the runner (`√ Runner successfully added`,
+`√ Settings Saved.`, token never echoed — a recursive literal-token search over
+the runner work dir, including the agent's `_diag` logs, found zero hits), but the
+runner stayed `offline`: `config.cmd --unattended --replace` only writes settings.
+v1.1.0 adds `--runasservice`, which installs and starts the runner's Windows
+service (`actions.runner.cfg-is-cfgms.CFGMS-CI-WIN-01`, NETWORK SERVICE, delayed
+auto-start) — runner `online` at the first API poll after the script exits.
+
+**Deviations for this run:** same workflow-path gaps as the Linux run above (token
+minted directly against the GitHub API; agent staged operator-side because the
+`github_runner` module is still not in the steward factory). Two additional lab
+findings recorded for follow-up: (1) the deployed v0.9.9 hyperv module rendered the
+pre-#2355 `--ca-cert` install flag, which no current steward accepts — resolved by
+push-upgrading the HV-host steward to v0.9.10 and staging a matching guest
+`cfgms-steward.exe` (both sides must agree on the rendered flag); (2) a steward
+`exec` job that runs a Windows batch file (`config.cmd`) completes its work but the
+job harness never observes process exit (descendant console handles hold the output
+stream open), the completion event never fires, and the controller's per-device
+dispatch lock (`features/controller/dispatcher/dispatcher.go`) is then held
+indefinitely — `run-cancel` does not release it, and a steward reboot makes the
+completion event permanently impossible (controller restart required). Runner
+registration on Windows therefore ran over PowerShell Direct rather than the
+steward exec channel.
+
 ---
 
 ## 7. What the founder does vs what the agent builds

--- a/templates/scripts/cirunner/register-github-runner-windows.yaml
+++ b/templates/scripts/cirunner/register-github-runner-windows.yaml
@@ -4,13 +4,15 @@ metadata:
   description: >
     Registers this already-enrolled Windows host as a GitHub Actions self-hosted
     runner by invoking the runner's own config.cmd against the on-disk
-    actions-runner directory. The single-use registration token is supplied by
-    the provisioning workflow's staging step as the secret env var
+    actions-runner directory, installing and starting the runner's Windows
+    service (--runasservice) so the runner comes Online without a separate
+    service step. The single-use registration token is supplied by the
+    provisioning workflow's staging step as the secret env var
     CFGMS_SECRET_RUNNER_TOKEN (secret-store param binding); it is never written
     into this file nor composed into a command string.
   version:
     major: 1
-    minor: 0
+    minor: 1
     patch: 0
   author: cfgms-team@cfg.is
   tags:
@@ -40,7 +42,7 @@ metadata:
         — never passed on the command line or stored in this file.
       required: true
   created_at: 2026-06-29T00:00:00Z
-  updated_at: 2026-06-29T00:00:00Z
+  updated_at: 2026-07-07T00:00:00Z
 content: |
   #Requires -Version 5.1
   Set-StrictMode -Version Latest
@@ -57,5 +59,11 @@ content: |
   if ([string]::IsNullOrWhiteSpace($repoUrl)) { throw 'REPO_URL is required' }
   $runnerLabels = if ($env:CFGMS_PARAM_RUNNER_LABELS) { $env:CFGMS_PARAM_RUNNER_LABELS } else { 'self-hosted,windows,cfgms' }
 
+  # --runasservice installs and starts the runner's Windows service so the
+  # runner is Online immediately after registration. Without it config.cmd only
+  # writes settings and the runner stays offline until something runs run.cmd
+  # (confirmed live on cfgms-ci-win-01, Issue #2336). The Linux sibling leaves
+  # service management to the github_runner module; on Windows the service is
+  # created by config.cmd itself, so the flag belongs here.
   Set-Location .\actions-runner
-  .\config.cmd --url $repoUrl --token $env:CFGMS_SECRET_RUNNER_TOKEN --labels $runnerLabels --unattended --replace
+  .\config.cmd --url $repoUrl --token $env:CFGMS_SECRET_RUNNER_TOKEN --labels $runnerLabels --unattended --replace --runasservice


### PR DESCRIPTION
## Summary

Second self-hosted CI runner is live (epic #565): `cfgms-ci-win-01` (Windows Server 2025) provisioned on cfg-lab via the hyperv module **autounattend path** (ADR-009 §6 — first full live run of this path), steward v0.9.10 enrolled to `gh-ci-runners`, and runner **`CFGMS-CI-WIN-01` online** in cfg-is/cfgms. The Windows registration script gained a live-confirmed fix (`--runasservice`).

## AC evidence

**AC1 — runner Online with labels (GitHub API):**
```json
{"busy":false,"id":23,"labels":["self-hosted","X64","cfgms","Windows"],"name":"CFGMS-CI-WIN-01","status":"online"}
```
(GitHub canonicalizes the OS/arch label case, same as the Linux runner's `Linux, X64`.)

**AC2 — script verified against the live run; issue found + fixed:** the shipped v1.0.0 script ran **verbatim** on the VM (staged byte-identical, sha `a52e84f7…`) — registered the runner (`√ Runner successfully added`, `√ Settings Saved.`) but the runner stayed `offline`: `config.cmd --unattended --replace` only writes settings; nothing installs/starts the service. Fix (v1.1.0): add `--runasservice` — service `actions.runner.cfg-is-cfgms.CFGMS-CI-WIN-01` installed (NT AUTHORITY\NETWORK SERVICE, delayed auto-start) and started by the script; runner online at the first API poll after exit.

**AC3 — token never logged/echoed:** recursive literal-token search over the entire runner work dir (`C:\runner`, including the agent's `_diag` logs, `.credentials`, and both runs' captured stdout/stderr) found **zero hits**, for both the verbatim v1.0.0 run and the fixed v1.1.0 run. The script references the token only as `$env:CFGMS_SECRET_RUNNER_TOKEN`.

**AC4 — docs:** Windows subsection added to "Lab Provisioning Results" with measured timings — upload→VM created 43 s; upload→steward active **7 m 16 s**; agent download 7.2 s / extract 14.2 s; registration script 4.8 s; checkpoint create **7.05 s** / revert **5.82 s**; revert (production checkpoint → VM Off) → `Start-VM` → runner online **137 s**.

**AC5 — `make test-complete`:** exit 0 on the story branch (Windows host).

## Review team (adversarial, pre-PR)

- **Acceptance checker: PASS** — all ACs verified incl. live GitHub API; diff-scope check confirms only the two in-scope files changed, all out-of-scope paths untouched.
- **QA test runner: PASS** — story-relevant surface green (incl. `TestRegisterScriptsBannedPatterns`); the only failures are the previously-documented Windows-host environment limitations (Unix-perm `cmd/*` tests, cross-CGO toolchains, gitignored local artifact) that pass in Linux CI.
- **QA code review: PASS** — 0 blocking; flag correctness, metadata (v1.1.0, updated_at), docs/ADR references verified.
- **Security: PASS** — 0 blocking; no new secret exposure, no banned patterns; NETWORK SERVICE + delayed auto-start judged a sound low-privilege default for a dedicated CI VM.

## Deficiencies found live (documented in the docs section; follow-up story candidates)

1. **Controller dispatch lock leak:** a steward exec job that runs a Windows batch (`config.cmd`) completes its work (output mtime proves 21 s) but the job harness never observes exit (descendant console handles hold the output stream), no completion event fires, and the per-device dispatch lock (`features/controller/dispatcher/dispatcher.go`) is held **forever** — `run-cancel` doesn't release it, steward reboot makes the event permanently impossible; recovery required a controller restart. Registration therefore ran over PowerShell Direct.
2. **Flag-consistency prereq:** deployed v0.9.9 hyperv module rendered the pre-#2355 `--ca-cert` install flag which no current steward accepts — resolved by push-upgrading the HV-host steward to v0.9.10 and staging a matching guest `cfgms-steward.exe` (renderer and guest binary must agree).
3. Carried-forward advisories from review: runner-service crash-recovery settings unset (persistent-runner reliability); both register scripts pass the token as a child-process argv (pre-existing, both platforms).

Same workflow-path deviations as #2335 (token minted directly against the GitHub API; agent staged operator-side — `github_runner` module still not in the steward factory).

Fixes #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SUVZR6kTwcXDNwjgq8ygn