### PR TITLE
ci: bump actions/cache v5 → v6.1.0 across all workflows (Issue #2392)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -85,7 +85,7 @@ jobs:
     # or a non-Go change in the same series get a fast restore + analyze.
     # Cache scope: the CodeQL action stores its DB under runner.temp by default.
     - name: Cache CodeQL database
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/codeql_databases
         key: ${{ runner.os }}-codeql-db-${{ matrix.language }}-${{ hashFiles('**/*.go', '**/go.sum') }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -39,7 +39,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
@@ -126,7 +126,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -58,7 +58,7 @@ jobs:
         cache: true
 
     - name: Cache Trivy vulnerability database
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ github.workspace }}/.cache/trivy
         key: trivy-db-${{ runner.os }}-${{ github.run_id }}
@@ -147,7 +147,7 @@ jobs:
         cache: true
 
     - name: Cache Trivy vulnerability database
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ github.workspace }}/.cache/trivy
         key: trivy-db-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -32,7 +32,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Cache Go modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -44,7 +44,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-licenses-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -117,7 +117,7 @@ jobs:
 
     # Cache disabled due to parallel job conflicts causing tar extraction failures
     # - name: Cache Go modules
-    #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+    #   uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     #   with:
     #     path: ~/go/pkg/mod
     #     key: ${{ runner.os }}-nancy-${{ hashFiles('**/go.sum') }}
@@ -163,7 +163,7 @@ jobs:
 
     # Cache disabled due to parallel job conflicts causing tar extraction failures
     # - name: Cache Go modules
-    #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+    #   uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     #   with:
     #     path: ~/go/pkg/mod
     #     key: ${{ runner.os }}-gosec-${{ hashFiles('**/go.sum') }}
@@ -242,7 +242,7 @@ jobs:
 
     # Cache disabled due to parallel job conflicts causing tar extraction failures
     # - name: Cache Go modules
-    #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+    #   uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     #   with:
     #     path: ~/go/pkg/mod
     #     key: ${{ runner.os }}-staticcheck-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -46,7 +46,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
@@ -87,7 +87,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
@@ -138,7 +138,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
@@ -193,7 +193,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
@@ -249,7 +249,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     
     - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
## Summary

- Bumps `actions/cache` from `v5` (`27d5ce7f107fe9357f9df03efb73ab90386fccae`) to `v6.1.0` (`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`) published 2026-06-26 — 11 days past the 3-day cooldown threshold
- All **15 occurrences** updated in lockstep across 7 workflow files (including 3 commented-out disabled steps in `security-scan.yml`)
- Trailing version comments updated from `# v5` → `# v6.1.0` on every line

Fixes #2392

## Major version notes (v5 → v6)

The v6 release updates the Node.js runtime used by the action. Cache key semantics, restore-key resolution, and save/restore behavior are unchanged — this is a runtime upgrade, not a behavioral change.

## Verification

| Check | Result |
|-------|--------|
| Old SHA grep (`27d5ce7f...`) | **0 matches** |
| New SHA grep (`55cc8345...`) | **15 matches** |
| `make test` | **196/196 passed** |
| story-review (code / tests / security / acceptance) | **PASS — 0 findings** |

## Files changed

- `.github/workflows/codeql-analysis.yml` — 1 active step
- `.github/workflows/cross-platform-build.yml` — 2 active steps
- `.github/workflows/docker-security.yml` — 2 active steps
- `.github/workflows/fleet-e2e.yml` — 1 active step
- `.github/workflows/license-check.yml` — 1 active step
- `.github/workflows/test-suite.yml` — 5 active steps
- `.github/workflows/security-scan.yml` — 3 commented-out (disabled) steps

## Test plan

- [x] `grep -rE "27d5ce7f107fe9357f9df03efb73ab90386fccae" .github/workflows/` → 0 matches
- [x] `grep -rE "55cc8345863c7cc4c66a329aec7e433d2d1c52a9" .github/workflows/` → 15 matches
- [x] `make test` passes locally
- [ ] CI required checks pass (unit-tests, integration-tests, Build Gate, security-deployment-gate)
- [ ] Acceptance reviewer: fetch latest docker-security workflow run for this PR and grep Trivy SARIF for `"Installed Version"` to confirm new version reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)