### PR TITLE
hyperv: single-surface ha_role convergence — promote/demote on hyperv.vm for all paths (Issue #2372)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -115,12 +115,19 @@ The resource type is selected via the `module` field as `hyperv.<type>`
 ### Highly-available (clustered) VM
 
 Add an optional `ha_role` block to register the VM as a clustered HA role on a
-failover cluster after it is created. The primary VHDX lives on a Cluster Shared
-Volume (`C:\ClusterStorage\...`) so it is reachable from every node; after
-`New-VM`, the module registers the VM as a clustered role via the cluster write
-path, reusing the **CNO ownership gate** and **existence idempotency** — the role
-is added exactly once cluster-wide and a non-owner node is a no-op. Standalone
-(non-HA) VMs omit `ha_role` and behave exactly as before.
+failover cluster. `ha_role` is **fully convergent on every path** (#2372): it
+promotes a freshly-created VM, an already-existing VM (on the next converge),
+and a source-provisioned VM (during provisioning finalize) — and **removing**
+the block demotes the VM (the clustered role is removed; the VM is never
+touched, so no destructive opt-in is needed). Registration and demotion reuse
+the **CNO ownership gate** and **existence idempotency** — mutations run exactly
+once cluster-wide and a non-owner node is a no-op. Standalone (non-HA) VMs omit
+`ha_role` and behave exactly as before. This is the **single surface** for VM
+cluster-role membership — see *Single surface* under the cluster section below;
+promote/demote drift detection requires the module-level `cluster_name` scope
+cap. The primary VHDX lives on a Cluster Shared Volume
+(`C:\ClusterStorage\...`) so it is reachable from every node — required for real
+failover.
 
 ```yaml
 - name: ci-runner-01
@@ -541,32 +548,64 @@ two write cmdlets `Add-ClusterVirtualMachineRole` and `Remove-ClusterResource`
 (S2) are declared in `module.yaml`'s `behavioral_envelope`. No cluster-formation
 cmdlet (`New-Cluster`/`Add-ClusterNode`/`Remove-ClusterNode`/quorum) is declared.
 
-### Managing clustered VM roles (`Set`)
+### Single surface: VM cluster-role membership lives on `hyperv.vm` (#2372)
 
-`Set("cluster:<name>", config)` reconciles the **declared** clustered-VM-role set
-(`role_names`). Its decision order is:
+**All VM-scoped settings — including promoting a VM to a clustered HA role and
+demoting it back — are `hyperv.vm` settings.** `hyperv.cluster` never creates or
+removes VM roles; there is exactly one config surface:
+
+- **Promote:** declare `ha_role:` on the vm resource. Convergent on **every**
+  path — a plain-lifecycle create, an already-existing VM (registered on the
+  next converge), and a source-provisioned VM (registered during finalize, no
+  later than the record's `finalizing` transition).
+- **Demote:** remove `ha_role:` from the vm resource. The clustered role is
+  removed; **the VM itself is never touched**. Because demotion is role-only,
+  it needs no separate destructive opt-in — it converges by default.
+- **Idempotent both ways:** an already-registered member is not re-added; an
+  already-standalone VM is not re-removed. An *already configured / already
+  exists* error from `Add-ClusterVirtualMachineRole` (a post-failover
+  existence-check↔Add race) is normalised to `nil`; every other PS error
+  surfaces.
+- **CNO gate (S1) unchanged:** only the CNO-owner node mutates; a non-owner
+  records an *ownership-gated-skip* audit event and returns `nil` —
+  coordination, not authorization.
+- **Moving a registered VM to a different cluster in one step is undefined** —
+  demote first (remove `ha_role`), converge, then promote with the new cluster.
+
+**Drift detection requires the module-level `cluster_name` scope cap.** `Get`
+reports a VM's current cluster-role membership by probing the scope-capped
+cluster's role-owner map — on demote the desired config no longer carries
+`ha_role`, so the module-level `cluster_name` is the only cluster it may ask.
+Set `cluster_name` at the hyperv module level (matching each VM's
+`ha_role.cluster_name`) or promote/demote drift is not observable and `ha_role`
+convergence on existing VMs does not run.
+
+### Reconciling role properties (`Set` on `hyperv.cluster`)
+
+`Set("cluster:<name>", config)` is **cluster-scoped only**: it reconciles the
+placement/scheduling **properties** of roles named in `role_names` that already
+exist (#2306). Its decision order is:
 
 | Step | Behaviour |
 |------|-----------|
 | **Scope cap (S5)** | An out-of-scope `<name>` returns `ErrClusterNotDeclared` **before** any cmdlet runs. |
 | **CNO gate (S1)** | Only the **CNO-owner** node mutates. A non-owner records an *ownership-gated-skip* audit event and returns `nil` (coordination, not authorization — never an error, never a PS write). |
-| **Existence check (idempotency)** | Before clustering a role, the owner checks the live per-role owner map (the same `Get-ClusterGroup` read the ownership gate already performs — no extra PS function). An already-clustered role is a no-op. |
-| **Create** | An absent declared role is clustered with `Add-ClusterVirtualMachineRole`. If the cmdlet still reports *already configured / already exists* (a post-failover existence-check↔Add race), that error is normalised to `nil`. **Only** that error class is treated as idempotent — every other PS error surfaces. |
-| **Destructive gate (S6)** | `state: absent` removes the role with `Remove-ClusterResource`, but **only** when `allow_destructive: true`. With the default `allow_destructive: false` it returns `ErrDestructiveOpBlocked` **without** invoking any write cmdlet. |
-| **Drift-not-adopted (S1)** | Only roles named in `role_names` are ever passed to Add/Remove. A role present on the cluster but absent from the config is **never** created, removed, or adopted — even with `allow_destructive: true`. |
+| **Membership is not managed here (#2372)** | A role named in `role_names` that does not exist on the cluster is skipped with a warning and an audit event — it is **not** created; declare `ha_role` on the `hyperv.vm` resource instead. `state: absent` returns `ErrRoleMembershipNotClusterManaged` without any PS write — demotion is `ha_role` removal on the vm resource. |
+| **Property reconcile (#2306)** | Roles that exist get their declared placement/scheduling properties converged. |
+| **Drift-not-adopted (S1)** | Only roles named in `role_names` are ever property-reconciled. A role present on the cluster but absent from the config is never touched. |
 
-Every `Set` path (create / gated-skip / idempotent no-op / destructive / drift)
-records a `pkg/audit` event via the same audit path as `Get`, carrying the node
-identity, the CNO-owner decision, the role, and before/after state maps, with a
-Go receipt-time `Timestamp` (S8).
+Every `Set` path records a `pkg/audit` event via the same audit path as `Get`,
+carrying the node identity, the CNO-owner decision, the role, and before/after
+state maps, with a Go receipt-time `Timestamp` (S8).
 
 ```yaml
 - name: lab-hv
   module: hyperv.cluster
   config:
-    role_names: [web-01, db-01]   # cluster these existing VMs as HA roles
-    # state: absent                # opt into teardown of the named roles, AND:
-    # allow_destructive: true      # ...required for any role removal (default false)
+    role_names: [web-01, db-01]   # property-reconcile targets (must already exist)
+    roles:
+      web-01:
+        preferred_owners: [NODE1, NODE2]
 ```
 
 ### Ownership gate (coordination, not authorization)

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -154,6 +154,19 @@ failover.
 > `ErrInvalidHARoleSeedDir`. Set `seed_dir` to a per-node path such as
 > `C:\ProgramData\cfgms\seed`.
 
+> **VM configuration files must also be on cluster storage.** `New-VM` places
+> the VM's configuration files at the host default (the local system drive)
+> unless told otherwise, and `Add-ClusterVirtualMachineRole` refuses a VM whose
+> configuration lives on non-clustered storage — the promote then fails each
+> converge with *"The clustered role was not successfully created"* (the module
+> retries convergently; the error is in the steward log with the cluster report
+> path). The module does not yet expose a VM configuration-path setting, so for
+> a VM that will carry `ha_role`, either provision it with everything on the
+> CSV or move it once with
+> `Move-VMStorage <vm> -DestinationStoragePath C:\ClusterStorage\<csv>\<vm>` —
+> the next converge completes the registration (verified live on cfg-lab,
+> #2372).
+
 ### Create an external virtual switch
 
 ```yaml

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -37,6 +37,13 @@ var ErrTransportNotConfigured = errors.New("hyperv: cluster transport not config
 // role even if the steward owns the CNO.
 var ErrDestructiveOpBlocked = errors.New("hyperv: destructive cluster operation blocked — set allow_destructive: true to proceed")
 
+// ErrRoleMembershipNotClusterManaged is returned by setCluster when a
+// hyperv.cluster resource attempts to remove VM-role membership (state: absent
+// on role_names). VM cluster-role membership is a hyperv.vm setting (ha_role) —
+// the single config surface for VM-scoped settings (#2372). Declaring or
+// removing ha_role on the vm resource is the only way to promote or demote.
+var ErrRoleMembershipNotClusterManaged = errors.New("hyperv: VM cluster-role membership is managed via the hyperv.vm ha_role setting, not hyperv.cluster role_names")
+
 // ClusterConfig is the DESIRED state of a Hyper-V failover cluster as declared
 // by an operator. S1 manages no cluster mutation; the desired-state struct
 // exists so the executor and DNA layers have a stable ConfigState shape (Set /
@@ -665,79 +672,41 @@ func (m *hypervModule) setCluster(ctx context.Context, resourceID string, config
 		resourceOwners = map[string]string{}
 	}
 
-	// (4) Owner path. Mutate ONLY roles named in cfg (drift-not-adopted, S1).
+	// (4) Owner path. hyperv.cluster is cluster-scoped only (#2372): it never
+	// mutates VM-role membership. Creating and removing clustered VM roles is
+	// the hyperv.vm ha_role setting — the single config surface for VM-scoped
+	// settings. Roles named in role_names are property-reconcile targets ONLY.
+	if strings.EqualFold(strings.TrimSpace(cfg.State), "absent") {
+		// The pre-#2372 destructive role-removal surface. Hard-removed: demotion
+		// is ha_role removal on the vm resource. Refused before any PS mutation.
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-remove-refused", "cluster:"+cfg.Name,
+			map[string]interface{}{"roles": append([]string(nil), cfg.RoleNames...)},
+			map[string]interface{}{"refused": true, "cno_owner": cnoOwner}, ErrRoleMembershipNotClusterManaged)
+		return fmt.Errorf("hyperv: set cluster %q: %w", cfg.Name, ErrRoleMembershipNotClusterManaged)
+	}
+
 	for _, role := range cfg.RoleNames {
 		if strings.TrimSpace(role) == "" {
 			continue
 		}
-		_, exists := resourceOwners[role]
-
-		if strings.EqualFold(strings.TrimSpace(cfg.State), "absent") {
-			// S6 destructive gate. Default off: NO PS write cmdlet is issued.
-			if !cfg.AllowDestructive {
-				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-					"cluster-set-remove-blocked", "cluster:"+cfg.Name,
-					map[string]interface{}{"role": role, "exists": exists},
-					map[string]interface{}{"allow_destructive": false, "blocked": true}, ErrDestructiveOpBlocked)
-				return fmt.Errorf("hyperv: set cluster %q role %q: %w", cfg.Name, role, ErrDestructiveOpBlocked)
-			}
-			if !exists {
-				// Already gone — idempotent no-op for the destructive path.
-				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-					"cluster-set-remove-noop", "cluster:"+cfg.Name,
-					map[string]interface{}{"role": role, "exists": false},
-					map[string]interface{}{"removed": false, "cno_owner": cnoOwner}, nil)
-				continue
-			}
-			if _, rmErr := m.transport.ExecutePS(ctx, psRemoveClusterResource, map[string]string{"Name": role}); rmErr != nil {
-				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-					"cluster-set-remove", "cluster:"+cfg.Name,
-					map[string]interface{}{"role": role, "exists": true},
-					map[string]interface{}{"removed": false}, rmErr)
-				return fmt.Errorf("hyperv: set cluster %q remove role %q: %w", cfg.Name, role, rmErr)
+		if _, exists := resourceOwners[role]; !exists {
+			// Not a clustered role: hyperv.cluster no longer creates it. The
+			// role converges when its hyperv.vm resource declares ha_role; its
+			// properties reconcile on a later cycle once it exists.
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: cluster role not present — hyperv.cluster does not create VM roles; declare ha_role on the hyperv.vm resource",
+					"cluster", logging.SanitizeLogValue(cfg.Name),
+					"role", logging.SanitizeLogValue(role))
 			}
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-				"cluster-set-remove", "cluster:"+cfg.Name,
-				map[string]interface{}{"role": role, "exists": true},
-				map[string]interface{}{"removed": true, "cno_owner": cnoOwner}, nil)
+				"cluster-set-membership-skip", "cluster:"+cfg.Name,
+				map[string]interface{}{"role": role, "exists": false},
+				map[string]interface{}{"created": false, "single_surface": "hyperv.vm ha_role", "cno_owner": cnoOwner}, nil)
 			continue
 		}
 
-		// Present (default): existence check BEFORE the Add (idempotency).
-		if exists {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-				"cluster-set-noop", "cluster:"+cfg.Name,
-				map[string]interface{}{"role": role, "exists": true},
-				map[string]interface{}{"created": false, "cno_owner": cnoOwner}, nil)
-		} else {
-			_, addErr := m.transport.ExecutePS(ctx, psAddClusterVMRole, map[string]string{
-				"ClusterName": cfg.Name,
-				"VMName":      role,
-			})
-			switch {
-			case addErr == nil:
-				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-					"cluster-set-create", "cluster:"+cfg.Name,
-					map[string]interface{}{"role": role, "exists": false},
-					map[string]interface{}{"created": true, "cno_owner": cnoOwner}, nil)
-			case isAlreadyRegistered(addErr):
-				// Idempotency: an "already registered"/"already exists" error means a
-				// concurrent owner (or a stale existence read post-failover) created
-				// the role — normalise to nil. Only this text class is idempotent.
-				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-					"cluster-set-noop", "cluster:"+cfg.Name,
-					map[string]interface{}{"role": role, "exists": false},
-					map[string]interface{}{"created": false, "already_registered": true, "cno_owner": cnoOwner}, nil)
-			default:
-				recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
-					"cluster-set-create", "cluster:"+cfg.Name,
-					map[string]interface{}{"role": role, "exists": false},
-					map[string]interface{}{"created": false}, addErr)
-				return fmt.Errorf("hyperv: set cluster %q add role %q: %w", cfg.Name, role, addErr)
-			}
-		}
-
-		// Declarative property reconcile (#2306): the role now exists on this
+		// Declarative property reconcile (#2306): the role exists on this
 		// (CNO-owner) node — converge its placement/scheduling properties. A role
 		// with no cfg.Roles entry is left at cluster defaults (no dispatch).
 		if props, ok := cfg.Roles[role]; ok {
@@ -747,6 +716,132 @@ func (m *hypervModule) setCluster(ctx context.Context, resourceID string, config
 		}
 	}
 
+	return nil
+}
+
+// reconcileRoleMembership converges ONE VM's clustered-role membership — the
+// single internal engine behind the hyperv.vm ha_role setting (#2372). It is
+// called only by registerClusteredRole (promote, state "present") and
+// demoteClusteredRole (demote, state "absent"); hyperv.cluster's operator
+// surface never reaches it. Gates mirror setCluster: scope cap (S5), transport,
+// CNO ownership (S1 — a non-owner audits a skip and returns nil; coordination,
+// not authorization). Membership mutations are idempotent: an existing member
+// is not re-added, an absent member is not re-removed, and Add's
+// "already registered" error class is normalised to nil (post-failover
+// existence-check↔Add race).
+//
+// allowDestructive gates the absent path exactly as S6 does for the old
+// surface. The vm-side demote passes true unconditionally: demotion only ever
+// removes the ROLE (Remove-ClusterGroup) — the VM itself is never touched — so
+// the S6 opt-in protects nothing on this path and requiring a second operator
+// flag would break AC1's convergent demote.
+func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName, role, state string, allowDestructive bool) error {
+	// (1) Scope cap (S5): reject an out-of-scope cluster name before the transport.
+	if m.clusterName != "" && clusterName != m.clusterName {
+		if logger, ok := m.GetLogger(); ok {
+			logger.Warn("hyperv: declining role-membership reconcile — not in declared cluster_name scope",
+				"requested", logging.SanitizeLogValue(clusterName),
+				"declared", logging.SanitizeLogValue(m.clusterName))
+		}
+		return fmt.Errorf("hyperv: reconcile role membership %q/%q: %w", clusterName, role, ErrClusterNotDeclared)
+	}
+
+	// (2) Transport wired.
+	if m.transport == nil {
+		return fmt.Errorf("hyperv: reconcile role membership %q/%q: %w", clusterName, role, ErrTransportNotConfigured)
+	}
+
+	// (3) CNO gate (S1). The helper audits the ownership decision and returns
+	// the role-owner map, which doubles as the existence oracle below.
+	ownsCNO, resourceOwners, err := m.clusterOwnershipHelper(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("hyperv: reconcile role membership %q/%q: %w", clusterName, role, err)
+	}
+
+	cnoOwner := m.readCNOOwner(ctx, clusterName)
+
+	if !ownsCNO {
+		// Non-owner: record an ownership-gated-skip and return nil.
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-skip", "cluster:"+clusterName, nil,
+			map[string]interface{}{
+				"owns_cno":  false,
+				"cno_owner": cnoOwner,
+				"skipped":   true,
+				"roles":     []string{role},
+			}, nil)
+		return nil
+	}
+
+	if resourceOwners == nil {
+		resourceOwners = map[string]string{}
+	}
+	_, exists := resourceOwners[role]
+
+	if strings.EqualFold(strings.TrimSpace(state), "absent") {
+		// S6 destructive gate. Default off: NO PS write cmdlet is issued.
+		if !allowDestructive {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-set-remove-blocked", "cluster:"+clusterName,
+				map[string]interface{}{"role": role, "exists": exists},
+				map[string]interface{}{"allow_destructive": false, "blocked": true}, ErrDestructiveOpBlocked)
+			return fmt.Errorf("hyperv: reconcile role membership %q role %q: %w", clusterName, role, ErrDestructiveOpBlocked)
+		}
+		if !exists {
+			// Already gone — idempotent no-op for the destructive path.
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-set-remove-noop", "cluster:"+clusterName,
+				map[string]interface{}{"role": role, "exists": false},
+				map[string]interface{}{"removed": false, "cno_owner": cnoOwner}, nil)
+			return nil
+		}
+		if _, rmErr := m.transport.ExecutePS(ctx, psRemoveClusterResource, map[string]string{"Name": role}); rmErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"cluster-set-remove", "cluster:"+clusterName,
+				map[string]interface{}{"role": role, "exists": true},
+				map[string]interface{}{"removed": false}, rmErr)
+			return fmt.Errorf("hyperv: reconcile role membership %q remove role %q: %w", clusterName, role, rmErr)
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-remove", "cluster:"+clusterName,
+			map[string]interface{}{"role": role, "exists": true},
+			map[string]interface{}{"removed": true, "cno_owner": cnoOwner}, nil)
+		return nil
+	}
+
+	// Present (default): existence check BEFORE the Add (idempotency).
+	if exists {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-noop", "cluster:"+clusterName,
+			map[string]interface{}{"role": role, "exists": true},
+			map[string]interface{}{"created": false, "cno_owner": cnoOwner}, nil)
+		return nil
+	}
+	_, addErr := m.transport.ExecutePS(ctx, psAddClusterVMRole, map[string]string{
+		"ClusterName": clusterName,
+		"VMName":      role,
+	})
+	switch {
+	case addErr == nil:
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-create", "cluster:"+clusterName,
+			map[string]interface{}{"role": role, "exists": false},
+			map[string]interface{}{"created": true, "cno_owner": cnoOwner}, nil)
+	case isAlreadyRegistered(addErr):
+		// Idempotency: an "already registered"/"already exists" error means a
+		// concurrent owner (or a stale existence read post-failover) created
+		// the role — normalise to nil. Only this text class is idempotent.
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-noop", "cluster:"+clusterName,
+			map[string]interface{}{"role": role, "exists": false},
+			map[string]interface{}{"created": false, "already_registered": true, "cno_owner": cnoOwner}, nil)
+	default:
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+			"cluster-set-create", "cluster:"+clusterName,
+			map[string]interface{}{"role": role, "exists": false},
+			map[string]interface{}{"created": false}, addErr)
+		return fmt.Errorf("hyperv: reconcile role membership %q add role %q: %w", clusterName, role, addErr)
+	}
 	return nil
 }
 

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -597,8 +597,11 @@ func (m *hypervModule) readResourceOwners(ctx context.Context, clusterName strin
 	return parsed.Owners, nil
 }
 
-// setCluster reconciles the declared clustered-VM-role set on a failover
-// cluster (S2). It is the Set("cluster:<name>", config) write path.
+// setCluster reconciles the placement/scheduling PROPERTIES of existing
+// clustered VM roles (#2306). It is the Set("cluster:<name>", config) write
+// path — cluster-scoped only since #2372: it never creates or removes VM-role
+// membership (that is the hyperv.vm ha_role setting, via
+// reconcileRoleMembership below).
 //
 // Decision order (each step short-circuits BEFORE any transport call where it
 // can):
@@ -609,16 +612,15 @@ func (m *hypervModule) readResourceOwners(ctx context.Context, clusterName strin
 //  3. CNO gate (S1): clusterOwnershipHelper decides which node acts. A NON-owner
 //     records an ownership-gated-skip audit event and returns nil — ownership is
 //     coordination, not authorization, so a non-owner never errors or blocks.
-//  4. On the owner, for each role NAMED in the declared RoleNames set
-//     (drift-not-adopted, S1 — roles absent from cfg are never mutated):
-//     - state: absent + allow_destructive=false → ErrDestructiveOpBlocked,
-//     with NO PS write cmdlet (S6 destructive gate, default off).
-//     - state: absent + allow_destructive=true  → Remove-ClusterResource.
-//     - present (default): existence check via the helper's resource-owner
-//     map (reuses S1's readResourceOwners output — no 4th PS function). If
-//     the role already exists → idempotent no-op. Otherwise
-//     Add-ClusterVirtualMachineRole; an "already"/"exists" error is
-//     normalised to nil (post-failover existence-check↔Add race).
+//  4. On the owner:
+//     - state: absent → ErrRoleMembershipNotClusterManaged with NO PS write —
+//     the pre-#2372 destructive role-removal surface is hard-removed
+//     (demote by removing ha_role on the vm resource).
+//     - present (default): for each role NAMED in RoleNames
+//     (drift-not-adopted, S1 — roles absent from cfg are never touched):
+//     a role missing from the cluster is skipped with a warn + audit (it is
+//     NOT created); an existing role gets its declared placement properties
+//     reconciled via reconcileRoleProperties.
 //
 // Every path (create / gated-skip / idempotent no-op / destructive / drift)
 // records a pkg/audit event via recordHypervOp with the node identity

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -698,26 +698,25 @@ func TestSetCluster_NonOwnerSkipsProperties(t *testing.T) {
 	assert.True(t, skip, "a non-owner must record cluster-set-skip")
 }
 
-// TestClusterSet_CNOOwner_Create verifies the AC: the CNO-owner node calls
-// Cfgms-AddClusterVMRole (psAddClusterVMRole) exactly once when the named role
-// is absent, and records a create audit event with the owner node identity and
-// a Go receipt-time Timestamp (S8).
-func TestClusterSet_CNOOwner_Create(t *testing.T) {
+// TestRoleMembership_CNOOwner_Create verifies the AC on the membership engine
+// (reconcileRoleMembership — the internal path behind hyperv.vm ha_role, #2372):
+// the CNO-owner node calls Cfgms-AddClusterVMRole (psAddClusterVMRole) exactly
+// once when the named role is absent, and records a create audit event with the
+// owner node identity and a Go receipt-time Timestamp (S8).
+func TestRoleMembership_CNOOwner_Create(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
 			`{"owner":"NODE1"}`, // helper: CNO owner read → this node (NODE1) owns it
 			`{"owners":{}}`,     // helper: resource owners → role absent
-			`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read
+			`{"owner":"NODE1"}`, // engine: cnoOwner re-read
 			``,                  // Add-ClusterVirtualMachineRole → success (empty output)
 		},
 	}
 	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1", clusterName == "lab-hv"
 	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-	cfg := &ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"}
-
 	start := time.Now()
-	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "present", false)
 	require.NoError(t, err)
 
 	// Exactly one Add cmdlet, and the user-supplied role name never appears in the
@@ -794,12 +793,12 @@ func TestClusterSet_NonOwner_Skip(t *testing.T) {
 	assert.Equal(t, false, skipEvt.Changes.After["owns_cno"])
 }
 
-// TestClusterSet_Idempotent verifies the idempotency Technical Decision two ways:
-// (a) when the role already exists, the existence check short-circuits the Add
-// (no PS mutation), and (b) when the existence read missed it but Add returns an
-// "already registered" error, that error is normalised to nil. Both converges
-// succeed and leave no error.
-func TestClusterSet_Idempotent(t *testing.T) {
+// TestRoleMembership_Idempotent verifies the idempotency Technical Decision on
+// the membership engine two ways: (a) when the role already exists, the
+// existence check short-circuits the Add (no PS mutation), and (b) when the
+// existence read missed it but Add returns an "already registered" error, that
+// error is normalised to nil. Both converges succeed and leave no error.
+func TestRoleMembership_Idempotent(t *testing.T) {
 	// (a) Existence-check short-circuit: role already present in the owners map.
 	t.Run("existence-check short-circuit", func(t *testing.T) {
 		transport := &testWinRMTransport{
@@ -812,8 +811,7 @@ func TestClusterSet_Idempotent(t *testing.T) {
 		m, _ := clusterTestModule(t, transport)
 		defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-		err := m.setCluster(context.Background(), "cluster:lab-hv",
-			&ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"})
+		err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "present", false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
 			"an already-existing role must short-circuit BEFORE the Add (no PS mutation)")
@@ -836,8 +834,7 @@ func TestClusterSet_Idempotent(t *testing.T) {
 		m, _ := clusterTestModule(t, transport)
 		defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-		err := m.setCluster(context.Background(), "cluster:lab-hv",
-			&ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"})
+		err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "present", false)
 		require.NoError(t, err,
 			"an 'already configured' error from Add must be normalised to nil (idempotent)")
 		assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
@@ -861,17 +858,18 @@ func TestClusterSet_Idempotent(t *testing.T) {
 		m, _ := clusterTestModule(t, transport)
 		defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-		err := m.setCluster(context.Background(), "cluster:lab-hv",
-			&ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"})
+		err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "present", false)
 		require.Error(t, err, "a non-idempotent PS error must surface, not be swallowed")
 		assert.Contains(t, err.Error(), "Access is denied")
 	})
 }
 
-// TestClusterSet_DestructiveGate verifies S6: state: absent with
-// allow_destructive: false returns ErrDestructiveOpBlocked WITHOUT invoking any
-// PS write cmdlet (zero Add/Remove calls).
-func TestClusterSet_DestructiveGate(t *testing.T) {
+// TestRoleMembership_DestructiveGate verifies S6 on the membership engine:
+// state "absent" with allowDestructive false returns ErrDestructiveOpBlocked
+// WITHOUT invoking any PS write cmdlet (zero Add/Remove calls). The vm-side
+// demote passes true (role-only removal); the gate still protects any future
+// internal caller that does not.
+func TestRoleMembership_DestructiveGate(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
 			`{"owner":"NODE1"}`,             // helper CNO owner (this node owns it)
@@ -882,13 +880,7 @@ func TestClusterSet_DestructiveGate(t *testing.T) {
 	m, _ := clusterTestModule(t, transport)
 	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-	cfg := &ClusterConfig{
-		Name:             "lab-hv",
-		RoleNames:        []string{"web-01"},
-		State:            "absent",
-		AllowDestructive: false,
-	}
-	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "absent", false)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrDestructiveOpBlocked,
 		"state: absent without allow_destructive must return ErrDestructiveOpBlocked")
@@ -899,12 +891,12 @@ func TestClusterSet_DestructiveGate(t *testing.T) {
 		"the destructive gate must issue no Add either")
 }
 
-// TestClusterSet_DriftNotAdopted verifies S1: Set on a cfg naming only role A,
-// with an undeclared role B also present on the cluster, issues no Add or Remove
-// targeting B — only declared roles are mutated. Here role A ("web-01") is
-// absent (gets created) while role B ("db-99") is present but undeclared and
-// must be left untouched, even though state is the default "present".
-func TestClusterSet_DriftNotAdopted(t *testing.T) {
+// TestRoleMembership_DriftNotAdopted verifies S1 on the membership engine: a
+// reconcile naming only role A, with an undeclared role B also present on the
+// cluster, issues no Add or Remove targeting B — only the named role is
+// mutated. Here role A ("web-01") is absent (gets created) while role B
+// ("db-99") is present but unnamed and must be left untouched.
+func TestRoleMembership_DriftNotAdopted(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
 			`{"owner":"NODE1"}`,            // helper CNO owner (this node)
@@ -916,8 +908,7 @@ func TestClusterSet_DriftNotAdopted(t *testing.T) {
 	m, _ := clusterTestModule(t, transport)
 	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-	cfg := &ClusterConfig{Name: "lab-hv", RoleNames: []string{"web-01"}, State: "present"}
-	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "present", false)
 	require.NoError(t, err)
 
 	// Exactly one Add (for the declared web-01); zero Removes (db-99 is never adopted).
@@ -939,13 +930,13 @@ func TestClusterSet_DriftNotAdopted(t *testing.T) {
 	}
 }
 
-// ─── B2: setCluster destructive REMOVE success path (state: absent + allow_destructive) ─
+// ─── B2: membership-engine REMOVE path (the hyperv.vm ha_role demote engine) ───
 
-// TestClusterSet_Remove_Success verifies B2(a): on the CNO-owner node, a
-// declared role that EXISTS, with state: absent + allow_destructive: true,
-// triggers Remove-ClusterResource exactly once and records a
-// cluster-set-remove audit event with removed: true.
-func TestClusterSet_Remove_Success(t *testing.T) {
+// TestRoleMembership_Remove_Success verifies B2(a): on the CNO-owner node, a
+// named role that EXISTS, with state "absent" + allowDestructive true (exactly
+// what demoteClusteredRole passes), triggers Remove-ClusterResource exactly
+// once and records a cluster-set-remove audit event with removed: true.
+func TestRoleMembership_Remove_Success(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
 			`{"owner":"NODE1"}`,             // helper CNO owner → this node (NODE1) owns it
@@ -957,15 +948,8 @@ func TestClusterSet_Remove_Success(t *testing.T) {
 	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
 	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-	cfg := &ClusterConfig{
-		Name:             "lab-hv",
-		RoleNames:        []string{"web-01"},
-		State:            "absent",
-		AllowDestructive: true,
-	}
-
 	start := time.Now()
-	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "absent", true)
 	require.NoError(t, err, "removing an existing role with allow_destructive must succeed")
 
 	// (a) Exactly one Remove cmdlet; zero Adds.
@@ -1002,11 +986,11 @@ func TestClusterSet_Remove_Success(t *testing.T) {
 		"the remove audit must record removed: true")
 }
 
-// TestClusterSet_Remove_TransportError verifies B2(b): when the
-// Remove-ClusterResource transport call FAILS, setCluster wraps and returns the
+// TestRoleMembership_Remove_TransportError verifies B2(b): when the
+// Remove-ClusterResource transport call FAILS, the engine wraps and returns the
 // error (it does NOT swallow it) — isAlreadyRegistered must NOT be applied to
 // the remove path, so even an "already"-bearing error surfaces.
-func TestClusterSet_Remove_TransportError(t *testing.T) {
+func TestRoleMembership_Remove_TransportError(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
 			`{"owner":"NODE1"}`,             // helper CNO owner (this node owns it)
@@ -1024,13 +1008,7 @@ func TestClusterSet_Remove_TransportError(t *testing.T) {
 	m, store := clusterTestModule(t, transport)
 	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-	cfg := &ClusterConfig{
-		Name:             "lab-hv",
-		RoleNames:        []string{"web-01"},
-		State:            "absent",
-		AllowDestructive: true,
-	}
-	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "absent", true)
 	require.Error(t, err, "a failed Remove must surface, never be swallowed")
 	assert.Contains(t, err.Error(), "could not be deleted",
 		"the underlying Remove error must be wrapped, not normalised away")
@@ -1052,11 +1030,11 @@ func TestClusterSet_Remove_TransportError(t *testing.T) {
 		"a failed remove must record removed: false")
 }
 
-// TestClusterSet_Remove_AlreadyGone verifies B2(c): a declared role that is NOT
-// present in the resource-owner map, with state: absent + allow_destructive:
+// TestRoleMembership_Remove_AlreadyGone verifies B2(c): a named role that is
+// NOT present in the resource-owner map, with state "absent" + allowDestructive
 // true, is an idempotent no-op — zero Remove-ClusterResource calls, a
 // cluster-set-remove-noop audit event, and no error.
-func TestClusterSet_Remove_AlreadyGone(t *testing.T) {
+func TestRoleMembership_Remove_AlreadyGone(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
 			`{"owner":"NODE1"}`, // helper CNO owner (this node owns it)
@@ -1067,13 +1045,7 @@ func TestClusterSet_Remove_AlreadyGone(t *testing.T) {
 	m, store := clusterTestModule(t, transport)
 	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
-	cfg := &ClusterConfig{
-		Name:             "lab-hv",
-		RoleNames:        []string{"web-01"},
-		State:            "absent",
-		AllowDestructive: true,
-	}
-	err := m.setCluster(context.Background(), "cluster:lab-hv", cfg)
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "absent", true)
 	require.NoError(t, err, "removing an already-absent role is an idempotent no-op")
 
 	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -59,8 +59,12 @@ behavioral_envelope:
     exactly-once; the VM is resolved to its Id via a local Get-VM and clustered
     by -VMId, avoiding a cross-node WMI name-enumeration that is denied when the
     module runs as the LocalSystem steward) and Remove-ClusterGroup
-    -RemoveResources (remove a clustered VM role group by name — gated behind
-    allow_destructive: true, default off). The cluster-role PROPERTY write
+    -RemoveResources (remove a clustered VM role group by name — reached only
+    by the hyperv.vm ha_role demote path since #2372: removing ha_role from a
+    previously-HA vm resource converges by removing the ROLE, never the VM;
+    both cmdlets are CNO-owner-gated and scope-capped, and the pre-#2372
+    operator-facing hyperv.cluster role teardown surface is hard-refused). The
+    cluster-role PROPERTY write
     cmdlets (#2306) are: Set-ClusterOwnerNode (preferred owners on the role group,
     possible owners on the VM resource) and Set-ClusterGroup group-property
     assignment (Priority, AutoStart, AntiAffinityClassNames) — reconciled only on

--- a/features/modules/hyperv/schema.yaml
+++ b/features/modules/hyperv/schema.yaml
@@ -156,11 +156,12 @@ resources:
 
   cluster:
     description: >
-      Hyper-V failover-cluster HA VM role management. Declares which VMs are
-      clustered as highly-available roles on the named cluster and their
-      placement/scheduling properties. Mutation is CNO-owner-gated and
-      idempotent; role teardown requires allow_destructive. Cluster formation is
-      out of scope.
+      Hyper-V failover-cluster role property management (cluster-scoped only).
+      Reconciles placement/scheduling properties of existing clustered VM
+      roles. VM cluster-role membership (promote/demote) is a hyperv.vm
+      setting (ha_role) — the single surface for VM-scoped settings; this
+      resource never creates or removes roles. Mutation is CNO-owner-gated and
+      idempotent. Cluster formation is out of scope.
     required:
       - name
     properties:
@@ -169,16 +170,24 @@ resources:
         description: Failover cluster (CNO) name; must equal the module's declared cluster_name.
       role_names:
         type: array
-        description: Bounded set of clustered VM role names this resource manages. Empty means all roles in scope.
+        description: >
+          Bounded set of existing clustered VM role names whose properties this
+          resource reconciles. Roles are never created or removed here — VM
+          cluster-role membership is the hyperv.vm ha_role setting.
         items:
           type: string
       allow_destructive:
         type: boolean
-        description: Opt in to destructive cluster operations (role teardown). Default false.
+        description: >
+          Retained for the internal destructive gate; the operator-facing role
+          teardown surface is removed — state absent is refused regardless
+          (demote via removing ha_role on the hyperv.vm resource).
         default: false
       state:
         type: string
-        description: Desired lifecycle. Cluster formation/teardown is out of scope.
+        description: >
+          Desired lifecycle. absent is refused (role membership is managed via
+          hyperv.vm ha_role); cluster formation/teardown is out of scope.
         enum:
           - present
           - absent

--- a/features/modules/hyperv/schema.yaml
+++ b/features/modules/hyperv/schema.yaml
@@ -101,13 +101,19 @@ resources:
       ha_role:
         type: object
         description: >
-          When present, registers the VM as a clustered HA role on the named
-          failover cluster after creation (reuses the cluster CNO ownership gate
-          and existence-based idempotency). Absent: the VM is a standalone
-          (non-HA) resource. When the primary vhd_path is on a Cluster Shared
-          Volume (C:\ClusterStorage\...), the module-level seed_dir must be set
-          and host-local (not under CSV) or the resource is rejected at validate
-          time.
+          Convergent cluster-role membership — the single surface for VM HA
+          state (#2372). Present: the VM is registered as a clustered HA role
+          on the named failover cluster, on every path (plain create, an
+          already-existing VM on the next converge, a source-provisioned VM at
+          provisioning finalize). REMOVING this block from a previously-HA vm
+          resource DEMOTES the VM on the next converge: the clustered role is
+          removed (the VM itself is never touched) with no separate opt-in
+          flag. Both directions reuse the cluster CNO ownership gate and
+          existence-based idempotency. Promote/demote drift detection requires
+          the module-level cluster_name scope cap. When the primary vhd_path is
+          on a Cluster Shared Volume (C:\ClusterStorage\...), the module-level
+          seed_dir must be set and host-local (not under CSV) or the resource
+          is rejected at validate time.
         required:
           - cluster_name
         properties:

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -701,6 +701,29 @@ func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, err
 		}
 	}
 
+	// Cluster-role membership probe (#2372): report whether this VM is a
+	// clustered HA role so drift detection covers promote AND demote. The probe
+	// requires the module-level cluster_name scope cap (S5) — on demote the
+	// desired config no longer carries ha_role, so the scope cap is the only
+	// cluster the module may ask. It reuses the same scope-capped
+	// readResourceOwners read as setCluster's owner path; a read needs no CNO
+	// ownership gate. Without a configured scope no HA-role drift is observable
+	// — skip entirely, never error. A failing probe degrades to HARole=nil
+	// (promote is idempotent, so a missed membership converges next cycle)
+	// rather than failing every VM read on a transient cluster-service error.
+	if m.clusterName != "" {
+		if owners, roErr := m.readResourceOwners(ctx, m.clusterName); roErr == nil {
+			if _, isMember := owners[vmName]; isMember {
+				cfg.HARole = &HARoleConfig{ClusterName: m.clusterName}
+			}
+		} else if logger, ok := m.GetLogger(); ok {
+			logger.Warn("hyperv: cluster-role membership probe failed; reporting no HA role this cycle",
+				"vm_name", logging.SanitizeLogValue(vmName),
+				"cluster", logging.SanitizeLogValue(m.clusterName),
+				"error", roErr.Error())
+		}
+	}
+
 	// Write-through: update cache on successful read
 	m.vmsMu.Lock()
 	m.vms[vmName] = *cfg
@@ -939,12 +962,18 @@ func parseHARoleMap(v interface{}) *HARoleConfig {
 // CNO ownership gate, and existence-based idempotency — so the role is added
 // exactly once cluster-wide and re-converges are no-ops.
 func (m *hypervModule) registerClusteredRole(ctx context.Context, cfg *VMConfig) error {
-	cc := &ClusterConfig{
-		Name:      cfg.HARole.ClusterName,
-		RoleNames: []string{cfg.Name},
-		State:     "present",
-	}
-	return m.setCluster(ctx, "cluster:"+cfg.HARole.ClusterName, cc)
+	return m.reconcileRoleMembership(ctx, cfg.HARole.ClusterName, cfg.Name, "present", false)
+}
+
+// demoteClusteredRole removes a VM's clustered-role membership — the demote
+// half of the single-surface ha_role setting (#2372): an ha_role removed from a
+// previously-HA vm resource converges by removing the ROLE, never the VM.
+// allowDestructive is passed true unconditionally: this path only ever issues
+// Remove-ClusterGroup against the role, so the S6 destructive gate (which
+// protects hyperv.cluster's standalone destructive surface) has nothing to
+// protect here, and demote must not require a second operator opt-in (AC1).
+func (m *hypervModule) demoteClusteredRole(ctx context.Context, cfg *VMConfig, clusterName string) error {
+	return m.reconcileRoleMembership(ctx, clusterName, cfg.Name, "absent", true)
 }
 
 // applySourceGated enforces the ADR-009 §2 existence-gating safety invariant for
@@ -1152,6 +1181,32 @@ func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string
 	// the cache write at the end of this function reflects the converged set.
 	if err := m.reconcileNetwork(ctx, cfgResourceID, vmName, hostName, desired, current); err != nil {
 		return err
+	}
+
+	// Cluster-role membership reconcile (#2372): ha_role is convergent on the
+	// existing-VM path, not create-only. current.HARole comes from getVM's
+	// membership probe; both mutations run before any power-state transition,
+	// mirroring the create path's register-before-start ordering.
+	//
+	//   nil → non-nil  promote (register the clustered role)
+	//   non-nil → nil  demote (remove the role — the VM is never touched)
+	//   both non-nil   no-op: already a member; moving a registered VM to a
+	//                  different cluster in one step has no defined semantics
+	//                  (out of scope, #2372) and the same-cluster case is
+	//                  already converged.
+	switch {
+	case desired.HARole != nil && current.HARole == nil:
+		promoteCfg := *desired
+		promoteCfg.Name = vmName
+		if err := m.registerClusteredRole(ctx, &promoteCfg); err != nil {
+			return err
+		}
+	case desired.HARole == nil && current.HARole != nil:
+		demoteCfg := *desired
+		demoteCfg.Name = vmName
+		if err := m.demoteClusteredRole(ctx, &demoteCfg, current.HARole.ClusterName); err != nil {
+			return err
+		}
 	}
 
 	needsCPUResize := desired.CPUCount != 0 && desired.CPUCount != current.CPUCount

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -709,8 +709,10 @@ func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, err
 	// readResourceOwners read as setCluster's owner path; a read needs no CNO
 	// ownership gate. Without a configured scope no HA-role drift is observable
 	// — skip entirely, never error. A failing probe degrades to HARole=nil
-	// (promote is idempotent, so a missed membership converges next cycle)
-	// rather than failing every VM read on a transient cluster-service error.
+	// rather than failing every VM read on a transient cluster-service error;
+	// the degradation defers BOTH directions one cycle (a missed membership
+	// re-promotes idempotently; a pending demote reads current as nil→nil and
+	// simply waits) — each converges on the next cycle once the probe recovers.
 	if m.clusterName != "" {
 		if owners, roErr := m.readResourceOwners(ctx, m.clusterName); roErr == nil {
 			if _, isMember := owners[vmName]; isMember {
@@ -954,13 +956,16 @@ func parseHARoleMap(v interface{}) *HARoleConfig {
 	return &HARoleConfig{ClusterName: cluster, ResourceGroupName: rg}
 }
 
-// registerClusteredRole registers a just-created VM as a clustered HA role by
-// delegating to the cluster module's setCluster write path. The clustered role
-// name is the VM name (the default cluster group name Add-ClusterVirtualMachineRole
-// assigns); resource_group_name is reserved for an explicit group name and
-// currently defaults to the VM name. setCluster applies the S5 scope cap, the
-// CNO ownership gate, and existence-based idempotency — so the role is added
-// exactly once cluster-wide and re-converges are no-ops.
+// registerClusteredRole registers a VM as a clustered HA role — the promote
+// half of the single-surface ha_role setting (#2372), called from every path a
+// VM can converge through (plain create, applyVMState on an existing VM, and
+// finalizeProvision for a source-provisioned VM). It delegates to
+// reconcileRoleMembership, which applies the S5 scope cap, the CNO ownership
+// gate, and existence-based idempotency — so the role is added exactly once
+// cluster-wide and re-converges are no-ops. The clustered role name is the VM
+// name (the default cluster group name Add-ClusterVirtualMachineRole assigns);
+// resource_group_name is reserved for an explicit group name and currently
+// defaults to the VM name.
 func (m *hypervModule) registerClusteredRole(ctx context.Context, cfg *VMConfig) error {
 	return m.reconcileRoleMembership(ctx, cfg.HARole.ClusterName, cfg.Name, "present", false)
 }

--- a/features/modules/hyperv/vm_harole_convergence_test.go
+++ b/features/modules/hyperv/vm_harole_convergence_test.go
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Issue #2372: single-surface ha_role convergence ───────────────────────────
+//
+// A VM's cluster-role membership is a fully convergent hyperv.vm setting:
+// declaring ha_role promotes on any path (existing VM, plain create,
+// source-provisioned), removing it demotes (role removed, VM intact), and
+// hyperv.cluster no longer offers a second membership surface.
+
+// ─── getVM cluster-role membership probe ───────────────────────────────────────
+
+// TestGetVM_ClusterRoleProbe_MemberReported verifies getVM populates HARole on
+// the returned VMConfig when the module-level cluster_name scope is configured
+// and the VM appears in the cluster's VirtualMachine group owner map.
+func TestGetVM_ClusterRoleProbe_MemberReported(t *testing.T) {
+	const vmName = "ha-probe-vm"
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "running", 2, 4096), // psGetVM
+		`{"owners":{"ha-probe-vm":"NODE1"}}`,   // membership probe
+	}}
+	m := vmModuleWithTransport(transport, "t-probe")
+	m.clusterName = "lab-hv"
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.HARole, "a clustered VM must report HARole from the probe")
+	assert.Equal(t, "lab-hv", cfg.HARole.ClusterName)
+}
+
+// TestGetVM_ClusterRoleProbe_NonMemberNil verifies a VM absent from the owner
+// map reports a nil HARole.
+func TestGetVM_ClusterRoleProbe_NonMemberNil(t *testing.T) {
+	const vmName = "plain-vm"
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "running", 2, 4096),
+		`{"owners":{}}`,
+	}}
+	m := vmModuleWithTransport(transport, "t-probe")
+	m.clusterName = "lab-hv"
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.HARole)
+}
+
+// TestGetVM_ClusterRoleProbe_SkippedWithoutScope verifies the probe is skipped
+// entirely (no extra transport call) when no module-level cluster_name is set —
+// no HA-role drift is observable without a cluster scope, and non-cluster hosts
+// must not issue cluster queries.
+func TestGetVM_ClusterRoleProbe_SkippedWithoutScope(t *testing.T) {
+	const vmName = "standalone-vm"
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "running", 2, 4096),
+	}}
+	m := vmModuleWithTransport(transport, "t-probe")
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.HARole)
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	assert.Len(t, transport.calls, 1, "no cluster probe without a cluster_name scope")
+}
+
+// TestGetVM_ClusterRoleProbe_ErrorDegrades verifies a failing membership probe
+// degrades to HARole=nil without failing the VM read: promote is idempotent, so
+// a missed membership converges on a later cycle rather than breaking Get.
+func TestGetVM_ClusterRoleProbe_ErrorDegrades(t *testing.T) {
+	const vmName = "degraded-vm"
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{hostVMJSON(vmName, "running", 2, 4096), ``},
+		perCallErrors:  []error{nil, errors.New("cluster service down")},
+	}
+	m := vmModuleWithTransport(transport, "t-probe")
+	m.clusterName = "lab-hv"
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err, "a probe failure must not fail the VM read")
+	assert.Nil(t, cfg.HARole)
+}
+
+// ─── AC1 (REQUIRED TEST): promote / demote an existing VM, idempotent ─────────
+
+// TestSetVM_HARole_PromoteExistingVM: adding ha_role to an already-created VM
+// registers the clustered role on the next converge.
+func TestSetVM_HARole_PromoteExistingVM(t *testing.T) {
+	const vmName = "ha-promote-vm"
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
+		`{"owners":{}}`,                        // getVM probe: not a member
+		`{"owner":"NODE1"}`,                    // ownership helper: CNO owner
+		`{"owners":{}}`,                        // ownership helper: role owners
+		`{"owner":"NODE1"}`,                    // audit cnoOwner re-read
+		``,                                     // Add-ClusterVirtualMachineRole
+	}}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "vm:"+vmName, mapConfigState{
+		"name":      vmName,
+		"memory_mb": 4096,
+		"cpu_count": 2,
+		"vhd_path":  `C:\VMs\ha-promote-vm.vhdx`,
+		"state":     "stopped",
+		"ha_role":   map[string]interface{}{"cluster_name": cluster},
+	}))
+
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"ha_role on an existing VM must register the clustered role")
+	assert.Equal(t, 0, countCmd(transport, psRemoveVM), "promote must not touch the VM")
+}
+
+// TestSetVM_HARole_DemoteRemovesRoleOnly: removing ha_role from a previously-HA
+// vm resource demotes — the clustered role is removed, the VM is untouched, and
+// no operator opt-in flag is required (the demote path never deletes the VM).
+func TestSetVM_HARole_DemoteRemovesRoleOnly(t *testing.T) {
+	const vmName = "ha-demote-vm"
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
+		`{"owners":{"ha-demote-vm":"NODE1"}}`,  // getVM probe: member
+		`{"owner":"NODE1"}`,                    // ownership helper: CNO owner
+		`{"owners":{"ha-demote-vm":"NODE1"}}`,  // ownership helper: role owners
+		`{"owner":"NODE1"}`,                    // audit cnoOwner re-read
+		``,                                     // Remove-ClusterGroup
+	}}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "vm:"+vmName, mapConfigState{
+		"name":      vmName,
+		"memory_mb": 4096,
+		"cpu_count": 2,
+		"vhd_path":  `C:\VMs\ha-demote-vm.vhdx`,
+		"state":     "stopped",
+		// no ha_role key — desired state is standalone
+	}))
+
+	assert.Equal(t, 1, countCmd(transport, psRemoveClusterResource),
+		"removing ha_role must remove the clustered role")
+	assert.Equal(t, 0, countCmd(transport, psRemoveVM),
+		"demote is role-only — the VM must never be deleted")
+}
+
+// TestSetVM_HARole_PromoteIdempotent: an already-registered member with ha_role
+// still declared performs no membership mutation (and no ownership reads).
+func TestSetVM_HARole_PromoteIdempotent(t *testing.T) {
+	const vmName = "ha-steady-vm"
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
+		`{"owners":{"ha-steady-vm":"NODE1"}}`,  // getVM probe: already a member
+	}}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "vm:"+vmName, mapConfigState{
+		"name":      vmName,
+		"memory_mb": 4096,
+		"cpu_count": 2,
+		"vhd_path":  `C:\VMs\ha-steady-vm.vhdx`,
+		"state":     "stopped",
+		"ha_role":   map[string]interface{}{"cluster_name": cluster},
+	}))
+
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"an already-registered member must not re-register")
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource))
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	assert.Len(t, transport.calls, 2,
+		"steady state must be exactly getVM + probe — no membership machinery")
+}
+
+// TestSetVM_HARole_DemoteIdempotent: a VM that is already standalone with no
+// ha_role declared performs no membership mutation.
+func TestSetVM_HARole_DemoteIdempotent(t *testing.T) {
+	const vmName = "plain-steady-vm"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "stopped", 2, 4096),
+		`{"owners":{}}`,
+	}}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = "lab-hv"
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "vm:"+vmName, mapConfigState{
+		"name":      vmName,
+		"memory_mb": 4096,
+		"cpu_count": 2,
+		"vhd_path":  `C:\VMs\plain-steady-vm.vhdx`,
+		"state":     "stopped",
+	}))
+
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource))
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole))
+}
+
+// ─── AC3 (REQUIRED TEST): non-CNO-owner nodes no-op ────────────────────────────
+
+// TestSetVM_HARole_NonOwnerNoop: promote on a non-CNO-owner node performs no
+// membership mutation and returns nil — coordination, not authorization.
+func TestSetVM_HARole_NonOwnerNoop(t *testing.T) {
+	const vmName = "ha-nonowner-vm"
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
+		`{"owners":{}}`,                        // getVM probe: not a member
+		`{"owner":"NODE2"}`,                    // ownership helper: another node owns CNO
+		`{"owners":{}}`,                        // ownership helper: role owners
+		`{"owner":"NODE2"}`,                    // audit cnoOwner re-read
+	}}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "vm:"+vmName, mapConfigState{
+		"name":      vmName,
+		"memory_mb": 4096,
+		"cpu_count": 2,
+		"vhd_path":  `C:\VMs\ha-nonowner-vm.vhdx`,
+		"state":     "stopped",
+		"ha_role":   map[string]interface{}{"cluster_name": cluster},
+	}))
+
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"a non-owner node must not mutate cluster membership")
+}
+
+// ─── AC2 (REQUIRED TEST): source-provisioned VM registered by finalizing ──────
+
+// TestFinalizeProvision_HARole_RegistersBeforeFinalizing: a source-provisioned
+// VM with ha_role declared is registered as a clustered role during finalize —
+// no later than the record's installing → finalizing transition (ready is
+// controller-side, #2050, and never observed here).
+func TestFinalizeProvision_HARole_RegistersBeforeFinalizing(t *testing.T) {
+	ctx := context.Background()
+	const vmName = "ha-src-vm"
+	const cluster = "lab-hv"
+
+	store := NewMemProvisionStore()
+	started := time.Now().UTC().Add(-10 * time.Minute)
+	require.NoError(t, store.SetProvision(ctx, &ProvisionRecord{
+		VMName:        vmName,
+		State:         ProvisionStateInstalling,
+		CorrelationID: vmName,
+		StartedAt:     started,
+		UpdatedAt:     started,
+	}))
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSON(vmName, "running", 2, 4096), // vmIsRunning → getVM
+		`{"owners":{}}`,                        // getVM probe (cluster scope set)
+		``,                                     // Dismount-VHD (detach seed)
+		``,                                     // Remove-Item (seed VHDX)
+		``,                                     // Remove-Item (answer ISO)
+		`{"owner":"NODE1"}`,                    // ownership helper: CNO owner
+		`{"owners":{}}`,                        // ownership helper: role owners
+		`{"owner":"NODE1"}`,                    // audit cnoOwner re-read
+		``,                                     // Add-ClusterVirtualMachineRole
+	}}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+	m.provisionStore = store
+
+	cfg := &VMConfig{
+		Name:    vmName,
+		VHDPath: `C:\VMs\ha-src-vm.vhdx`,
+		HARole:  &HARoleConfig{ClusterName: cluster},
+		Source: &SourceConfig{
+			Image:      `C:\images\debian.raw`,
+			OSFamily:   "linux",
+			Completion: CompletionConfig{Mode: "steward-registration", Timeout: "10m"},
+		},
+	}
+
+	require.NoError(t, m.finalizeProvision(ctx, vmName, vmName, cfg))
+
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"finalize must register the declared ha_role")
+
+	rec, err := store.GetProvision(ctx, vmName)
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateFinalizing, rec.State,
+		"registration happens no later than the finalizing transition")
+}
+
+// TestFinalizeProvision_HARole_RegistrationFailureRetries: a failed registration
+// keeps the record at installing so the next converge cycle retries finalize —
+// the record must not advance past a VM that should be HA but is not.
+func TestFinalizeProvision_HARole_RegistrationFailureRetries(t *testing.T) {
+	ctx := context.Background()
+	const vmName = "ha-src-fail-vm"
+	const cluster = "lab-hv"
+
+	store := NewMemProvisionStore()
+	started := time.Now().UTC().Add(-10 * time.Minute)
+	require.NoError(t, store.SetProvision(ctx, &ProvisionRecord{
+		VMName:        vmName,
+		State:         ProvisionStateInstalling,
+		CorrelationID: vmName,
+		StartedAt:     started,
+		UpdatedAt:     started,
+	}))
+
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			hostVMJSON(vmName, "running", 2, 4096), // vmIsRunning → getVM
+			`{"owners":{}}`,                        // getVM probe
+			``,                                     // Dismount-VHD
+			``,                                     // Remove-Item (seed)
+			``,                                     // Remove-Item (iso)
+			`{"owner":"NODE1"}`,                    // CNO owner
+			`{"owners":{}}`,                        // role owners
+			`{"owner":"NODE1"}`,                    // audit re-read
+			``,                                     // Add — errors below
+		},
+		perCallErrors: []error{nil, nil, nil, nil, nil, nil, nil, nil, errors.New("cluster add failed")},
+	}
+	m := vmModuleWithTransport(transport, "t-ha")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+	m.provisionStore = store
+
+	cfg := &VMConfig{
+		Name:    vmName,
+		VHDPath: `C:\VMs\ha-src-fail-vm.vhdx`,
+		HARole:  &HARoleConfig{ClusterName: cluster},
+		Source: &SourceConfig{
+			Image:      `C:\images\debian.raw`,
+			OSFamily:   "linux",
+			Completion: CompletionConfig{Mode: "steward-registration", Timeout: "10m"},
+		},
+	}
+
+	require.Error(t, m.finalizeProvision(ctx, vmName, vmName, cfg))
+
+	rec, err := store.GetProvision(ctx, vmName)
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, rec.State,
+		"a failed HA registration must keep the record at installing for retry")
+}
+
+// ─── AC4: hyperv.cluster no longer offers a second membership surface ─────────
+
+// TestSetCluster_RoleNamesNoLongerAddRoles: a hyperv.cluster resource naming a
+// role that does not exist performs NO membership mutation — role creation
+// lives exclusively on hyperv.vm ha_role.
+func TestSetCluster_RoleNamesNoLongerAddRoles(t *testing.T) {
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"owner":"NODE1"}`, // ownership helper: CNO owner
+		`{"owners":{}}`,     // ownership helper: role owners (role absent)
+		`{"owner":"NODE1"}`, // audit cnoOwner re-read
+	}}
+	m := vmModuleWithTransport(transport, "t-cluster")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "cluster:"+cluster, mapConfigState{
+		"name":       cluster,
+		"role_names": []interface{}{"some-vm"},
+	}))
+
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"hyperv.cluster must no longer create VM roles — ha_role on hyperv.vm is the single surface")
+}
+
+// TestSetCluster_AbsentMembershipSurfaceRemoved: the destructive role-removal
+// surface on hyperv.cluster is gone — state:absent on role_names errors with
+// the single-surface sentinel and issues no PS mutation.
+func TestSetCluster_AbsentMembershipSurfaceRemoved(t *testing.T) {
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"owner":"NODE1"}`,
+		`{"owners":{"some-vm":"NODE1"}}`,
+		`{"owner":"NODE1"}`,
+	}}
+	m := vmModuleWithTransport(transport, "t-cluster")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	err := m.Set(context.Background(), "cluster:"+cluster, mapConfigState{
+		"name":              cluster,
+		"role_names":        []interface{}{"some-vm"},
+		"state":             "absent",
+		"allow_destructive": true,
+	})
+	require.ErrorIs(t, err, ErrRoleMembershipNotClusterManaged)
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),
+		"the removed surface must not issue Remove-ClusterGroup")
+}
+
+// TestSetCluster_PropertiesStillReconciledForExistingRole: narrowing the surface
+// keeps hyperv.cluster's cluster-scoped concern — placement/scheduling property
+// reconcile (#2306) — for roles that already exist.
+func TestSetCluster_PropertiesStillReconciledForExistingRole(t *testing.T) {
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"owner":"NODE1"}`,              // ownership helper: CNO owner
+		`{"owners":{"some-vm":"NODE1"}}`, // ownership helper: role exists
+		`{"owner":"NODE1"}`,              // audit cnoOwner re-read
+		``,                               // Set-ClusterOwnerNode (preferred owners)
+	}}
+	m := vmModuleWithTransport(transport, "t-cluster")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "cluster:"+cluster, mapConfigState{
+		"name":       cluster,
+		"role_names": []interface{}{"some-vm"},
+		"roles": map[string]interface{}{
+			"some-vm": map[string]interface{}{
+				"preferred_owners": []interface{}{"NODE1", "NODE2"},
+			},
+		},
+	}))
+
+	assert.Equal(t, 1, countCmd(transport, psSetClusterRolePreferredOwners),
+		"property reconcile for existing roles stays on hyperv.cluster")
+}

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -743,6 +743,21 @@ func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName s
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-Item", "vm:"+vmName, nil, nil, nil)
 	}
 
+	// Cluster-role registration for a source-provisioned VM (#2372): ha_role is
+	// convergent on every path, so a VM born via source: is registered here —
+	// no later than the installing → finalizing transition (ready is
+	// controller-side, #2050, never observed by this steward-side code). A
+	// registration failure returns BEFORE the record advances, keeping it at
+	// installing so the next converge cycle retries the finalize (transient CNO
+	// failover must not strand a should-be-HA VM as standalone).
+	if cfg.HARole != nil {
+		roleCfg := *cfg
+		roleCfg.Name = vmName
+		if err := m.registerClusteredRole(ctx, &roleCfg); err != nil {
+			return fmt.Errorf("hyperv: register clustered role for provisioned VM %q: %w", vmName, err)
+		}
+	}
+
 	// Advance installing → finalizing. ready is controller-side (#2050).
 	return m.advanceProvision(ctx, vmName, record, ProvisionStateFinalizing)
 }


### PR DESCRIPTION
## Summary

Implements the founder direction: **one config surface for VM-scoped settings**. A VM's cluster-role membership is now a fully convergent `hyperv.vm` setting — declaring `ha_role:` promotes on every path (plain create, existing VM, source-provisioned VM); removing it demotes (role removed, VM never touched, no extra opt-in). `hyperv.cluster` is narrowed to cluster-scoped concerns (role placement properties) and no longer creates or removes VM roles.

## Changes

- `getVM` probes the scope-capped cluster role-owner map so drift detection covers promote **and** demote (skipped without `cluster_name`; degrades to nil + Warn on transient probe error — both directions self-heal next cycle)
- `applyVMState` reconciles `ha_role` on existing VMs before power transitions; both-non-nil is a no-op (no cross-cluster move semantics, documented)
- `finalizeProvision` registers a source-provisioned VM's role **before** the `installing → finalizing` advance; a failed registration keeps the record at `installing` for convergent retry
- Membership engine extracted verbatim to `reconcileRoleMembership` (scope cap S5, CNO gate S1, existence idempotency, already-registered normalisation, S6 gate); `registerClusteredRole`/`demoteClusteredRole` delegate to it
- Public `setCluster`: `state: absent` → `ErrRoleMembershipNotClusterManaged` (no PS write); missing roles skipped with warn + audit; property reconcile (#2306) unchanged
- README, `schema.yaml`, and `module.yaml` behavioral envelope updated for the single-surface rule + the module-level `cluster_name` drift-detection requirement (envelope text change → bundle re-sign per ADR-006)
- Legacy `setCluster` membership tests retargeted at the engine (coverage preserved); 13 new tests cover AC1-AC4

## Live validation (cfg-lab, steward v0.9.11 built from this branch)

- **Promote existing VM:** `ha_role` added to a scratch VM → drift `added_fields:[ha_role]` → `Add-ClusterVirtualMachineRole` fired. First attempt exposed a real cluster constraint (VM config files on the local system drive — pre-existing `New-VM` limitation, now documented in README with the `Move-VMStorage` remedy); the convergent retry registered the role on the next cycle after the storage move. Role live at 13:14:28Z.
- **Demote:** `ha_role` removed → next converge removed the role; `ROLE_EXISTS=False, VM_EXISTS=True`.
- **Idempotence:** steady-state cycles show no membership churn.
- Scratch VM cleaned up via `state: absent`; runner config restored.

## Review team (adversarial, pre-PR)

- **Acceptance checker: PASS** — all 6 ACs verified with file:line evidence; diff-scope exactly the 7 in-scope files.
- **QA code review: PASS after one fix round** — 3 blocking doc-accuracy findings (stale pre-extraction comments in `cluster.go`/`vm.go`, `schema.yaml` demote semantics) fixed in 9ee7797a and re-verified RESOLVED; the `module.yaml` envelope staleness warning also fixed.
- **Security: PASS** — S3 injection safety clean (all names via psArgs); the unconditional internal `AllowDestructive` on demote assessed as within the threat model (role-only blast radius, S5+S1 gates ahead of it, controller-signed config, and the old broad `hyperv.cluster` teardown surface is now hard-refused — net surface reduction); gosec/staticcheck/check-architecture clean for changed files.
- **QA test runner:** story package **PASS 276/276**; `make check-architecture` + `test-integration-docker` PASS. Remaining suite failures are the documented Windows-host environment set (cmd/* Unix-permission tests from #2221, CGO cross-toolchain gaps, gitleaks/golangci-lint absent — all covered by Linux CI), plus two single-run e2e observations on this host (docker.sock Unix-path expectation under Windows Docker Desktop; one controller-startup timeout) — host-class, not reproduced, flagged rather than dismissed; CI runs these natively.

Non-blocking follow-up suggestions recorded by review: per-converge caching of the role-owner probe for many-VM configs; the harmless duplicate idempotent registration on the finalize→promote overlap cycle; an `applyVMState`-level error-path test.

Fixes #2372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SUVZR6kTwcXDNwjgq8ygn