### PR TITLE
deps: bump trufflehog v3.95.6 → v3.95.8 (Issue #2391)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,7 +90,7 @@ RUN GOPATH=$(go env GOPATH) \
     && chmod +x "$GOPATH/bin/nancy"
 
 # truffleHog (optional, best-effort secret scanning — pinned version, not @main)
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.6/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.6 || true
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.8/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.8 || true
 
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -120,7 +120,7 @@ jobs:
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.1.0"
-        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.6"
+        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.8"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.72.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"


### PR DESCRIPTION
## Summary

- Bumps trufflehog from `v3.95.6` to `v3.95.8` in `.devcontainer/Dockerfile` (both the install.sh URL path and trailing version arg)
- Updates the matching `check_version` guard in `.github/workflows/dependency-pin-check.yml`

Fixes #2391

## Acceptance Criteria Verification

- AC1: Both locations updated from v3.95.6 to v3.95.8 ✓
- AC2: `grep -rE "v3\.95\.6" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile` → 0 matches ✓
- AC3: `grep -rE "v3\.95\.8" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile` → 2 matches ✓
- AC4: `make test` passes ✓

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| Code Review | PASS (Round 2, after commit) |
| Security Review | PASS — no CVEs, install URL pinned to official trufflesecurity repo at version tag |
| Test Quality | PASS — infrastructure-only change, no test code affected |
| Test Runner | PASS — all gates (unit+race, lint, license, production-critical, cross-platform compile, Docker integration) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)