### PR TITLE
deps: bump docker/build-push-action v7 → v7.3.0 (Issue #2393)

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -69,7 +69,7 @@ jobs:
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
     - name: Build Controller Image
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
         file: ./cmd/controller/Dockerfile
@@ -158,7 +158,7 @@ jobs:
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
     - name: Build Steward Image
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
         file: ./cmd/steward/Dockerfile


### PR DESCRIPTION
## Summary

Bump `docker/build-push-action` from `v7 (f9f3042f)` to `v7.3.0 (53b7df96)` in `.github/workflows/docker-security.yml`.

- Both occurrences updated (lines 72 and 161 — controller and steward build steps)
- Same major version (v7), routine minor bump, no security advisory

Fixes #2393

## Verification

- Old SHA absent: `grep -rE "f9f3042f" .github/workflows/docker-security.yml` → 0 matches
- New SHA present: `grep -rE "53b7df96" .github/workflows/docker-security.yml` → 2 matches
- `make test` passed locally

## Specialist Review Results

- **Code Review:** PASS
- **Test Quality:** PASS
- **Security:** PASS

Story-review workflow: `passed: true` (2 review rounds, 1 fix round, 0 remaining findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)