### PR TITLE
api: steward connection/transport monitoring read API (Issue #2367)

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -245,6 +245,71 @@ Refresh the mTLS credentials for a steward. Called when the steward's certificat
 
 - `id` (path): Steward ID
 
+#### GET /api/v1/stewards/{id}/connection
+
+Get transport-level connection detail for a specific steward: whether it is currently streaming, when it connected, its remote network address, and the last-activity timestamp. Sourced from the live connection registry.
+
+Returns `connected: false` (HTTP 200) for a known steward that is not currently streaming. Returns 404 for an unknown steward ID.
+
+**Authentication:** Required  
+**Required permission:** `steward:read`
+
+**Parameters:**
+
+- `id` (path): Steward ID
+
+**Response (connected):**
+
+```json
+{
+  "data": {
+    "steward_id": "steward-001",
+    "connected": true,
+    "connected_at": "2026-01-12T10:29:00Z",
+    "remote_addr": "198.51.100.42:54321",
+    "last_activity": "2026-01-12T10:30:00Z"
+  },
+  "timestamp": "2026-01-12T10:30:05Z"
+}
+```
+
+**Response (known but not connected):**
+
+```json
+{
+  "data": {
+    "steward_id": "steward-001",
+    "connected": false
+  },
+  "timestamp": "2026-01-12T10:30:05Z"
+}
+```
+
+#### GET /api/v1/stewards/connections/all
+
+List all currently-connected stewards from the live connection registry, filtered to the authenticated caller's tenant. Returns transport-level connection detail for each connected steward.
+
+**Authentication:** Required  
+**Required permission:** `steward:read`
+
+**Response:**
+
+```json
+{
+  "data": {
+    "connections": [
+      {
+        "steward_id": "steward-001",
+        "connected_at": "2026-01-12T10:29:00Z",
+        "remote_addr": "198.51.100.42:54321",
+        "last_activity": "2026-01-12T10:30:00Z"
+      }
+    ]
+  },
+  "timestamp": "2026-01-12T10:30:05Z"
+}
+```
+
 ### Configuration Management
 
 #### GET /api/v1/stewards/{id}/config

--- a/features/controller/api/handlers_connections.go
+++ b/features/controller/api/handlers_connections.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// StewardConnectionDetail is the response body for GET /api/v1/stewards/{id}/connection.
+type StewardConnectionDetail struct {
+	StewardID    string     `json:"steward_id"`
+	Connected    bool       `json:"connected"`
+	ConnectedAt  *time.Time `json:"connected_at,omitempty"`
+	RemoteAddr   string     `json:"remote_addr,omitempty"`
+	LastActivity *time.Time `json:"last_activity,omitempty"`
+}
+
+// StewardConnectionItem is one entry in the bulk connections list.
+type StewardConnectionItem struct {
+	StewardID    string    `json:"steward_id"`
+	ConnectedAt  time.Time `json:"connected_at"`
+	RemoteAddr   string    `json:"remote_addr"`
+	LastActivity time.Time `json:"last_activity"`
+}
+
+// handleGetStewardConnection handles GET /api/v1/stewards/{id}/connection.
+//
+// Returns transport-level connection detail (ConnectedAt, RemoteAddr, last-activity)
+// for one steward, sourced from the live connection registry. Distinguishes
+// "unknown steward" (404) from "known but not currently connected" (200, connected:false).
+//
+// Tenant isolation is enforced explicitly: requirePermission's path-var tenant check
+// does not apply to a steward-ID path variable (only "tenant" resourceType qualifies),
+// so the handler compares steward.TenantID against the caller's tenant directly.
+// Admin principals (empty TenantID from context) have global access.
+func (s *Server) handleGetStewardConnection(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	stewardID := vars["id"]
+	stewardIDForLog := logging.SanitizeLogValue(stewardID)
+
+	if stewardID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Steward ID is required", "MISSING_STEWARD_ID")
+		return
+	}
+
+	s.mu.RLock()
+	reg := s.registry
+	s.mu.RUnlock()
+	if reg == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "connection registry not available", "REGISTRY_UNAVAILABLE")
+		return
+	}
+
+	// Confirm the steward exists (mirrors handleGetSteward existence check).
+	stewardInfo, exists := s.controllerService.GetStewardInfo(stewardID)
+	if !exists {
+		s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+		return
+	}
+
+	// Tenant isolation: API-key principals carry a non-empty TenantID; admin mTLS
+	// principals have TenantID="" meaning no scope restriction.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" && stewardInfo.TenantID != callerTenant {
+		// 404 instead of 403 to avoid disclosing steward existence across tenants.
+		s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+		return
+	}
+
+	conn, connected := reg.Get(stewardID)
+	if !connected {
+		s.logger.Debug("Steward known but not currently connected", "steward_id", stewardIDForLog)
+		s.writeSuccessResponse(w, StewardConnectionDetail{
+			StewardID: stewardID,
+			Connected: false,
+		})
+		return
+	}
+
+	connectedAt := conn.ConnectedAt
+	lastActivity := conn.GetLastActivity()
+	s.writeSuccessResponse(w, StewardConnectionDetail{
+		StewardID:    stewardID,
+		Connected:    true,
+		ConnectedAt:  &connectedAt,
+		RemoteAddr:   conn.RemoteAddr,
+		LastActivity: &lastActivity,
+	})
+}
+
+// handleListAllConnections handles GET /api/v1/stewards/connections/all.
+//
+// Returns all currently-connected stewards from the registry, filtered to the
+// caller's tenant. Cross-references registry entries against GetAllStewards() to
+// enforce tenant isolation (registry entries carry no TenantID directly).
+//
+// The path /stewards/connections/all (2 segments under the stewards subrouter) cannot
+// collide with the existing /{id} pattern (1 segment) or /{id}/connection (2 segments
+// with a different second-segment literal), so registration order does not matter here.
+func (s *Server) handleListAllConnections(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	reg := s.registry
+	s.mu.RUnlock()
+	if reg == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "connection registry not available", "REGISTRY_UNAVAILABLE")
+		return
+	}
+
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
+	// Build the set of steward IDs visible to the caller (mirrors deriveStewardDeploymentStatus).
+	allStewards := s.controllerService.GetAllStewards()
+	allowedIDs := make(map[string]bool, len(allStewards))
+	for _, st := range allStewards {
+		if callerTenant == "" || st.TenantID == callerTenant {
+			allowedIDs[st.ID] = true
+		}
+	}
+
+	allConns := reg.GetAll()
+	items := make([]StewardConnectionItem, 0, len(allConns))
+	for _, conn := range allConns {
+		if !allowedIDs[conn.StewardID] {
+			continue
+		}
+		lastActivity := conn.GetLastActivity()
+		items = append(items, StewardConnectionItem{
+			StewardID:    conn.StewardID,
+			ConnectedAt:  conn.ConnectedAt,
+			RemoteAddr:   conn.RemoteAddr,
+			LastActivity: lastActivity,
+		})
+	}
+
+	s.logger.Info("Listed active connections", "count", len(items))
+	s.writeSuccessResponse(w, map[string]interface{}{"connections": items})
+}

--- a/features/controller/api/handlers_connections_test.go
+++ b/features/controller/api/handlers_connections_test.go
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+)
+
+// registerTestConnection registers a live StewardConnection in reg for the given steward ID.
+// ConnectedAt and RemoteAddr are populated so response fields can be asserted.
+func registerTestConnection(t *testing.T, reg *registry.InMemoryRegistry, stewardID string) {
+	t.Helper()
+	require.NoError(t, reg.Register(&registry.StewardConnection{
+		StewardID:   stewardID,
+		Sender:      &noopSender{},
+		ConnectedAt: time.Now().UTC().Truncate(time.Second),
+		RemoteAddr:  "10.0.0.1:12345",
+	}))
+}
+
+// registerStewardUnderTenant registers a steward in the controller service scoped
+// to a specific tenant. Mirrors registerTestSteward but accepts an explicit tenantID.
+func registerStewardUnderTenant(t *testing.T, server *Server, tenantID, hostname string) string {
+	t.Helper()
+	req := &controller.RegisterRequest{
+		Version: "v1.0",
+		InitialDna: &common.DNA{
+			Id:         "dna-" + hostname,
+			Attributes: map[string]string{"hostname": hostname, "os": "linux"},
+		},
+	}
+	ctx := context.WithValue(context.Background(), ctxkeys.TenantID, tenantID)
+	resp, err := server.controllerService.AcceptRegistration(ctx, req)
+	require.NoError(t, err)
+	return resp.StewardId
+}
+
+// ---- handleGetStewardConnection tests ----
+
+func TestHandleGetStewardConnection_Connected(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "connected-host", "os": "linux",
+	})
+
+	reg := registry.NewRegistry()
+	registerTestConnection(t, reg, stewardID)
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID+"/connection", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardConnectionDetail `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.StewardID)
+	assert.True(t, resp.Data.Connected)
+	require.NotNil(t, resp.Data.ConnectedAt)
+	assert.False(t, resp.Data.ConnectedAt.IsZero())
+	assert.Equal(t, "10.0.0.1:12345", resp.Data.RemoteAddr)
+	require.NotNil(t, resp.Data.LastActivity)
+}
+
+func TestHandleGetStewardConnection_KnownButDisconnected(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "disconnected-host", "os": "linux",
+	})
+
+	// Registry is wired but steward has no live connection entry.
+	reg := registry.NewRegistry()
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID+"/connection", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardConnectionDetail `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.StewardID)
+	assert.False(t, resp.Data.Connected)
+	assert.Nil(t, resp.Data.ConnectedAt)
+	assert.Empty(t, resp.Data.RemoteAddr)
+	assert.Nil(t, resp.Data.LastActivity)
+}
+
+func TestHandleGetStewardConnection_UnknownSteward_Returns404(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	reg := registry.NewRegistry()
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/does-not-exist/connection", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestHandleGetStewardConnection_WrongTenant_Returns404 is a REQUIRED acceptance-criteria test.
+// It verifies that the handler enforces tenant isolation explicitly: requirePermission's
+// path-var check does not apply to a steward-ID path variable (only "tenant" resourceType
+// qualifies), so the handler must compare TenantIDs itself. A caller from one tenant must
+// receive 404 (not the connection record) when the steward belongs to a different tenant.
+func TestHandleGetStewardConnection_WrongTenant_Returns404(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Register steward under "test-tenant" (the default for registerTestSteward).
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "tenant-a-host", "os": "linux",
+	})
+
+	reg := registry.NewRegistry()
+	registerTestConnection(t, reg, stewardID)
+	server.SetRegistry(reg)
+
+	// Caller is scoped to "other-tenant" — must not see this steward.
+	wrongTenantKey := NewEphemeralTestKey(t, server, []string{"steward:read"}, "other-tenant", 5*time.Minute)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID+"/connection", nil)
+	req.Header.Set("X-API-Key", wrongTenantKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	// Must be 404, not 200 with connection data — avoids cross-tenant steward existence disclosure.
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleGetStewardConnection_NilRegistry_Returns503(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	// registry is nil by default in setupTestServer — no SetRegistry call.
+
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "host-no-registry", "os": "linux",
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID+"/connection", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// ---- handleListAllConnections tests ----
+
+// TestHandleListAllConnections_Reachable verifies that GET /api/v1/stewards/connections/all
+// is actually served by handleListAllConnections and not captured by the earlier /{id} pattern.
+// A 404 with STEWARD_NOT_FOUND would indicate the /{id} route captured the request.
+func TestHandleListAllConnections_Reachable(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	reg := registry.NewRegistry()
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/connections/all", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	// Must be 200 with a connections list, NOT a STEWARD_NOT_FOUND error.
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			Connections []StewardConnectionItem `json:"connections"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotNil(t, resp.Data.Connections)
+}
+
+func TestHandleListAllConnections_ReturnsConnectedStewards(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	stewardID1 := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "host-1", "os": "linux",
+	})
+	stewardID2 := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "host-2", "os": "linux",
+	})
+
+	reg := registry.NewRegistry()
+	registerTestConnection(t, reg, stewardID1)
+	registerTestConnection(t, reg, stewardID2)
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/connections/all", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			Connections []StewardConnectionItem `json:"connections"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Len(t, resp.Data.Connections, 2)
+	seen := make(map[string]bool)
+	for _, item := range resp.Data.Connections {
+		seen[item.StewardID] = true
+		assert.False(t, item.ConnectedAt.IsZero())
+		assert.Equal(t, "10.0.0.1:12345", item.RemoteAddr)
+	}
+	assert.True(t, seen[stewardID1])
+	assert.True(t, seen[stewardID2])
+}
+
+// TestHandleListAllConnections_ReturnsOnlyCallerTenant is a REQUIRED acceptance-criteria test.
+// It verifies that a connected steward belonging to a different tenant never appears in the
+// caller's list response, even when that steward is currently connected and in the registry.
+func TestHandleListAllConnections_ReturnsOnlyCallerTenant(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Register one steward under "test-tenant" (default for registerTestSteward).
+	ownStewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "own-host", "os": "linux",
+	})
+	// Register a steward under a different tenant.
+	otherStewardID := registerStewardUnderTenant(t, server, "other-tenant", "other-host")
+
+	reg := registry.NewRegistry()
+	registerTestConnection(t, reg, ownStewardID)
+	registerTestConnection(t, reg, otherStewardID)
+	server.SetRegistry(reg)
+
+	// API key scoped to "test-tenant" must not reveal "other-tenant" steward.
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/connections/all", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			Connections []StewardConnectionItem `json:"connections"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	// Only the steward belonging to "test-tenant" must appear.
+	require.Len(t, resp.Data.Connections, 1)
+	assert.Equal(t, ownStewardID, resp.Data.Connections[0].StewardID)
+}
+
+func TestHandleListAllConnections_NilRegistry_Returns503(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	// registry is nil by default in setupTestServer — no SetRegistry call.
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/connections/all", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleListAllConnections_EmptyWhenNoConnections(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	reg := registry.NewRegistry()
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/connections/all", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			Connections []StewardConnectionItem `json:"connections"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Data.Connections)
+}
+
+// TestHandleListAllConnections_DisconnectedStewardNotIncluded verifies that a steward
+// known to the controller service but with no live registry entry is absent from the list.
+func TestHandleListAllConnections_DisconnectedStewardNotIncluded(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	// Steward is registered in the controller service but not in the live registry.
+	registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "offline-host", "os": "linux",
+	})
+
+	reg := registry.NewRegistry()
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/connections/all", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			Connections []StewardConnectionItem `json:"connections"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Data.Connections)
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -471,6 +471,10 @@ func (s *Server) setupRouter() {
 	stewards.Handle("/{id}/config/validate", s.requirePermission("steward", "validate-config")(http.HandlerFunc(s.handleValidateConfig))).Methods("POST")
 	stewards.Handle("/{id}/config/effective", s.requirePermission("steward", "read-config")(http.HandlerFunc(s.handleGetEffectiveConfig))).Methods("GET")
 
+	// Connection monitoring endpoints (Issue #2367)
+	stewards.Handle("/connections/all", s.requirePermission("steward", "read")(http.HandlerFunc(s.handleListAllConnections))).Methods("GET")
+	stewards.Handle("/{id}/connection", s.requirePermission("steward", "read")(http.HandlerFunc(s.handleGetStewardConnection))).Methods("GET")
+
 	// QUIC connection management endpoints
 	// Script management endpoints
 	stewards.Handle("/{id}/scripts/executions", s.requirePermission("steward", "read-scripts")(http.HandlerFunc(s.handleGetScriptExecutions))).Methods("GET")


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/stewards/{id}/connection` — single-steward transport detail (ConnectedAt, RemoteAddr, LastActivity, connected bool) from the live registry; distinguishes unknown-steward 404 from known-but-disconnected 200
- Adds `GET /api/v1/stewards/connections/all` — bulk snapshot of all currently-connected stewards filtered to the caller's tenant
- Both endpoints guard nil registry with 503, are GET-only under `steward:read`, and enforce explicit tenant isolation (requirePermission's path-var check doesn't apply to steward-ID path variables)

Fixes #2367

## Specialist review results

- **Code review**: PASS
- **Test quality**: PASS
- **Security**: PASS

All 4 lenses clean in round 1, 0 fix rounds required.

## Test plan

- [x] `TestHandleGetStewardConnection_Connected` — all detail fields populated when connected
- [x] `TestHandleGetStewardConnection_KnownButDisconnected` — 200/connected:false, no detail fields
- [x] `TestHandleGetStewardConnection_UnknownSteward_Returns404` — 404 for unknown steward (distinct from disconnected)
- [x] `TestHandleGetStewardConnection_WrongTenant_Returns404` — [REQUIRED] explicit tenant isolation
- [x] `TestHandleGetStewardConnection_NilRegistry_Returns503` — 503 when registry not wired
- [x] `TestHandleListAllConnections_Reachable` — route actually reached (not captured by `/{id}`)
- [x] `TestHandleListAllConnections_ReturnsConnectedStewards` — correct fields in list items
- [x] `TestHandleListAllConnections_ReturnsOnlyCallerTenant` — [REQUIRED] cross-tenant isolation
- [x] `TestHandleListAllConnections_NilRegistry_Returns503`
- [x] `TestHandleListAllConnections_EmptyWhenNoConnections`
- [x] `TestHandleListAllConnections_DisconnectedStewardNotIncluded`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)