### PR TITLE
ci: bump docker/setup-buildx-action v4 → v4.2.0 (Issue #2394)

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -66,7 +66,7 @@ jobs:
           trivy-db-${{ runner.os }}-
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Build Controller Image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -155,7 +155,7 @@ jobs:
           trivy-db-${{ runner.os }}-
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Build Steward Image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0


### PR DESCRIPTION
## Summary

- Bump `docker/setup-buildx-action` from `d7f5e7f5` (v4) to `bb05f3f5` (v4.2.0) in `.github/workflows/docker-security.yml`
- Two occurrences updated in lockstep: controller scan job (line 69) and steward scan job (line 158)
- Same major version (v4), no breaking changes; released 2026-07-02, 5 days past 3-day cooldown threshold

Fixes #2394

## Specialist Review Results

- **Security Review**: PASS — SHA-pinned CI dependency bump, no Go code, no secrets, no TLS/cert surfaces affected. Verified tag v4.2.0 resolves to commit `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c`
- **QA Code Review**: PASS — workflow-only change, no test quality issues
- **`make test`**: PASS — 196 passed, 0 failed

## Verification

- Old SHA (`d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5`): 0 matches in file
- New SHA (`bb05f3f5519dd87d3ba754cc423b652a5edd6d2c`): 2 matches in file

🤖 Generated with [Claude Code](https://claude.com/claude-code)