### PR TITLE
steward: set CFGMS_LOG_DIR to canonical per-platform paths in every installer (Issue #2378)

### DIFF
--- a/cmd/steward/service/manager_darwin.go
+++ b/cmd/steward/service/manager_darwin.go
@@ -187,6 +187,11 @@ func generateLaunchdPlist(token, controllerURL string) string {
   <true/>
   <key>KeepAlive</key>
   <true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CFGMS_LOG_DIR</key>
+    <string>/usr/local/var/log/cfgms</string>
+  </dict>
   <key>StandardOutPath</key>
   <string>/var/log/cfgms-steward.log</string>
   <key>StandardErrorPath</key>
@@ -195,4 +200,3 @@ func generateLaunchdPlist(token, controllerURL string) string {
 </plist>
 `, darwinServiceName, darwinInstallPath, token, urlArgs)
 }
-

--- a/cmd/steward/service/manager_darwin_test.go
+++ b/cmd/steward/service/manager_darwin_test.go
@@ -142,3 +142,13 @@ func TestDarwinManagerNew(t *testing.T) {
 	_, ok := m.(*darwinManager)
 	assert.True(t, ok, "New() should return a *darwinManager on macOS")
 }
+
+// TestGenerateLaunchdPlistSetsLogDir: the installer-managed steward must log to
+// the platform-conventional path (#2378) — never the /tmp/cfgms fallback.
+func TestGenerateLaunchdPlistSetsLogDir(t *testing.T) {
+	plist := generateLaunchdPlist("tok_test", "")
+	assert.Contains(t, plist, "<key>EnvironmentVariables</key>")
+	assert.Contains(t, plist, "<key>CFGMS_LOG_DIR</key>")
+	assert.Contains(t, plist, "<string>/usr/local/var/log/cfgms</string>",
+		"launchd plist must set the platform-conventional log directory")
+}

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -250,6 +250,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=CFGMS_LOG_DIR=/var/log/cfgms
 ExecStart=%s
 Restart=always
 RestartSec=10

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -169,3 +169,11 @@ func TestSystemdUnitFilePermissions(t *testing.T) {
 	// 0600: owner rw (root only); systemd reads as root, group read exposes the token
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }
+
+// TestGenerateSystemdUnitSetsLogDir: the installer-managed steward must log to
+// the platform-conventional path (#2378) — never the /tmp/cfgms fallback.
+func TestGenerateSystemdUnitSetsLogDir(t *testing.T) {
+	unit := generateSystemdUnit("tok_test", "")
+	assert.Contains(t, unit, "Environment=CFGMS_LOG_DIR=/var/log/cfgms",
+		"systemd unit must set the platform-conventional log directory")
+}

--- a/cmd/steward/service/manager_windows.go
+++ b/cmd/steward/service/manager_windows.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/sys/windows/registry"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
@@ -37,6 +38,44 @@ func platformCACertPath() string {
 		return filepath.Join(prefix, dest[len(vol):])
 	}
 	return dest
+}
+
+// platformLogDir returns the platform-conventional steward log directory
+// (docs/architecture/steward-operating-model.md), mirroring
+// platformCACertPath's ProgramData-with-fallback resolution including the
+// CFGMS_INSTALL_PREFIX test isolation.
+func platformLogDir() string {
+	programData := os.Getenv("ProgramData")
+	if programData == "" {
+		programData = `C:\ProgramData`
+	}
+	dest := filepath.Join(programData, "CFGMS", "logs")
+	if prefix := os.Getenv("CFGMS_INSTALL_PREFIX"); prefix != "" {
+		vol := filepath.VolumeName(dest)
+		return filepath.Join(prefix, dest[len(vol):])
+	}
+	return dest
+}
+
+// setServiceEnvironment writes a service's REG_MULTI_SZ Environment value —
+// the native SCM mechanism for per-service environment variables (Windows has
+// no systemd-style inline Environment= line; the SCM reads this value at
+// service start). In-process registry access, never a reg.exe/sc.exe
+// shell-out. root and keyPath are parameters so the round-trip unit test can
+// target a scratch HKCU key (writing the real HKLM service key requires
+// Administrator, which unit tests do not have). The access mask must include
+// SET_VALUE — the read-only QUERY_VALUE mask used by read paths yields
+// access-denied on SetStringsValue.
+func setServiceEnvironment(root registry.Key, keyPath, logDir string) error {
+	key, err := registry.OpenKey(root, keyPath, registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("open service key %s: %w", keyPath, err)
+	}
+	defer key.Close()
+	if err := key.SetStringsValue("Environment", []string{"CFGMS_LOG_DIR=" + logDir}); err != nil {
+		return fmt.Errorf("set Environment value on %s: %w", keyPath, err)
+	}
+	return nil
 }
 
 func newManager(binaryPath string) Manager {
@@ -149,6 +188,15 @@ func (m *windowsManager) Install(token, controllerURL, caCertPEM, expectedFinger
 		return fmt.Errorf("failed to create Windows service: %w", err)
 	}
 	defer newSvc.Close()
+
+	// Point CFGMS_LOG_DIR at the platform-conventional log directory so an
+	// installed steward never falls back to the undiscoverable /tmp/cfgms
+	// (#2378). Written after CreateService (the service key must exist) and
+	// before Start so the very first start picks it up.
+	if err := setServiceEnvironment(registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Services\`+windowsServiceName, platformLogDir()); err != nil {
+		return fmt.Errorf("failed to set service environment: %w", err)
+	}
 
 	// Configure automatic restart on failure (3 escalating delays, 1-day reset).
 	recoveryActions := []mgr.RecoveryAction{
@@ -266,4 +314,3 @@ func waitForStop(s *mgr.Service, timeout time.Duration) error {
 	}
 	return fmt.Errorf("service did not stop within %s", timeout)
 }
-

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -7,10 +7,13 @@ package service
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 func TestWindowsManagerInstallPath(t *testing.T) {
@@ -97,5 +100,42 @@ func TestWindowsManagerNew(t *testing.T) {
 	assert.True(t, ok, "New() should return a *windowsManager on Windows")
 }
 
+// TestSetServiceEnvironmentRoundTrip is the REQUIRED TEST for #2378: the
+// registry-write helper round-trips the CFGMS_LOG_DIR Environment value. It
+// targets a scratch HKCU key — writing the real HKLM service key requires
+// Administrator, which unit tests do not have (the helper's root/keyPath
+// parameters exist exactly for this).
+func TestSetServiceEnvironmentRoundTrip(t *testing.T) {
+	const scratch = `Software\CFGMS-test-svcenv`
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, scratch, registry.ALL_ACCESS)
+	require.NoError(t, err)
+	require.NoError(t, key.Close())
+	t.Cleanup(func() { _ = registry.DeleteKey(registry.CURRENT_USER, scratch) })
 
+	logDir := `C:\ProgramData\CFGMS\logs`
+	require.NoError(t, setServiceEnvironment(registry.CURRENT_USER, scratch, logDir))
 
+	rk, err := registry.OpenKey(registry.CURRENT_USER, scratch, registry.QUERY_VALUE)
+	require.NoError(t, err)
+	defer rk.Close()
+	vals, valType, err := rk.GetStringsValue("Environment")
+	require.NoError(t, err)
+	assert.Equal(t, uint32(registry.MULTI_SZ), valType, "Environment must be REG_MULTI_SZ — the only type the SCM accepts")
+	assert.Equal(t, []string{"CFGMS_LOG_DIR=" + logDir}, vals)
+}
+
+// TestPlatformLogDir verifies the ProgramData-with-fallback resolution mirrors
+// platformCACertPath, including CFGMS_INSTALL_PREFIX test isolation.
+func TestPlatformLogDir(t *testing.T) {
+	t.Setenv("ProgramData", `C:\ProgramData`)
+	t.Setenv("CFGMS_INSTALL_PREFIX", "")
+	assert.Equal(t, filepath.Join(`C:\ProgramData`, "CFGMS", "logs"), platformLogDir())
+
+	t.Setenv("ProgramData", "")
+	assert.Equal(t, filepath.Join(`C:\ProgramData`, "CFGMS", "logs"), platformLogDir(),
+		`unset ProgramData falls back to C:\ProgramData`)
+
+	t.Setenv("CFGMS_INSTALL_PREFIX", `D:\scratch`)
+	assert.Equal(t, filepath.Join(`D:\scratch`, `ProgramData`, "CFGMS", "logs"), platformLogDir(),
+		"CFGMS_INSTALL_PREFIX nests the path under the prefix")
+}

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -412,7 +412,7 @@ The steward writes structured logs using the file logging provider. This is the 
 
 Log level is controlled by the `CFGMS_LOG_LEVEL` environment variable (default `INFO`). Accepted values are `debug`, `info`, `warn`, and `error` (case-insensitive). Invalid or empty values fall back to `INFO`.
 
-Log directory is controlled by `CFGMS_LOG_DIR` (default `/tmp/cfgms` with a warning; set this for production deployments).
+Log directory is controlled by `CFGMS_LOG_DIR`. The three native installers set it automatically to the platform-conventional paths listed under *Log locations* above (Linux `/var/log/cfgms/` via the systemd unit's `Environment=` line, Windows `C:\ProgramData\CFGMS\logs\` via the service's registry `Environment` value, macOS `/usr/local/var/log/cfgms/` via the launchd plist's `EnvironmentVariables` dict) — an installed steward never falls back silently. A steward run bare (no installer — dev/manual/e2e) keeps the `/tmp/cfgms`-with-a-warning fallback.
 
 ## Controller-Connected Capabilities
 


### PR DESCRIPTION
## Summary

A steward installed via any of the three native installers now runs with `CFGMS_LOG_DIR` set to the platform-conventional path from `docs/architecture/steward-operating-model.md` — never silently falling back to the undiscoverable `/tmp/cfgms`. Bare (no-installer) stewards keep today's warning fallback. The `cmd/steward/main.go` read-and-fallback logic is untouched per story scope.

## Changes

- **Linux** — `generateSystemdUnit()`: `Environment=CFGMS_LOG_DIR=/var/log/cfgms` under `[Service]`; `TestGenerateSystemdUnitSetsLogDir` asserts the exact line.
- **macOS** — `generateLaunchdPlist()`: `EnvironmentVariables` dict with `/usr/local/var/log/cfgms`; `TestGenerateLaunchdPlistSetsLogDir` asserts key + value.
- **Windows** — `Install()` writes the service's `REG_MULTI_SZ` `Environment` value (`CFGMS_LOG_DIR=<ProgramData>\CFGMS\logs`) via `golang.org/x/sys/windows/registry` — the native SCM mechanism, no `reg.exe`/`sc.exe` shell-out — after `CreateService` succeeds and before `Start()` so the first start picks it up. `setServiceEnvironment(root, keyPath, logDir)` is parameterized (story note: HKLM writes need Administrator) so the **[REQUIRED TEST]** `TestSetServiceEnvironmentRoundTrip` round-trips against a scratch HKCU key, asserting value and `REG_MULTI_SZ` type (`SET_VALUE` access mask per the story's mask warning). `platformLogDir()` mirrors `platformCACertPath()`'s ProgramData fallback + `CFGMS_INSTALL_PREFIX` isolation, with `TestPlatformLogDir` covering all three resolutions.
- **Docs** — `steward-operating-model.md` `CFGMS_LOG_DIR` paragraph updated as specified.

## Validation

- `go test ./cmd/steward/service/` green natively on Windows (this host), including both new Windows tests
- Linux/darwin test files compile-verified via `GOOS=linux`/`GOOS=darwin go vet` (they execute on their native CI runners per the package's existing convention)
- `make check-architecture` clean; no new dependencies (registry package already in go.mod, precedent `features/steward/dna/security_windows.go`)

Fixes #2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SUVZR6kTwcXDNwjgq8ygn