### PR TITLE
api: admin session monitoring read API (Issue #2368)

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -858,6 +858,80 @@ Delete an API key. The key is immediately invalidated.
 
 - `id` (path): API key ID
 
+### Session Management
+
+Admin auth sessions are zero-standing-privilege bearer-token sessions issued to `cfg` CLI users holding an admin mTLS bundle (ADR-014). The raw token is returned once at creation and never re-stored; the controller holds only a SHA-256 hash. Sessions have an idle TTL (15 min) and an absolute cap (8 h). These endpoints require an admin principal (`IsAdmin == true`).
+
+#### POST /api/v1/sessions
+
+Create a new admin session. The caller must present an admin mTLS certificate. Returns a one-time bearer token — store it securely in the OS keychain.
+
+**Authentication:** admin mTLS certificate
+
+**Request body:**
+
+```json
+{
+  "connection_name": "my-ctrl"
+}
+```
+
+**Response (201 Created):**
+
+```json
+{
+  "session_id": "abc123",
+  "token": "<43-char base64url bearer token>",
+  "issued_at": "2026-07-07T00:00:00Z",
+  "idle_ttl": 900,
+  "absolute_expiry": "2026-07-07T08:00:00Z"
+}
+```
+
+#### GET /api/v1/sessions
+
+List currently active admin sessions. A session is active if it is not revoked and has not exceeded its idle TTL or absolute cap. Tenant-scoped admins see only sessions belonging to their tenant; global admins (no tenant) see all tenants' sessions.
+
+**Authentication:** admin mTLS certificate or bearer token (`Authorization: Bearer <token>`)
+
+**Response (200 OK):**
+
+```json
+{
+  "sessions": [
+    {
+      "session_id": "abc123",
+      "principal_id": "alice",
+      "connection_name": "my-ctrl",
+      "issued_at": "2026-07-07T00:00:00Z",
+      "last_activity": "2026-07-07T00:10:00Z",
+      "absolute_expiry": "2026-07-07T08:00:00Z"
+    }
+  ]
+}
+```
+
+Fields returned: `session_id`, `principal_id`, `connection_name`, `issued_at`, `last_activity`, `absolute_expiry`. The bearer token is never included.
+
+#### DELETE /api/v1/sessions/{id}
+
+Revoke a session by ID. Accepts either a valid bearer token or an admin mTLS certificate as credentials, so an admin can revoke sessions even if a token is unavailable.
+
+**Authentication:** admin mTLS certificate or bearer token
+
+**Parameters:**
+
+- `id` (path): session ID
+
+**Response (200 OK):**
+
+```json
+{
+  "id": "abc123",
+  "revoked": true
+}
+```
+
 ### Registration Token Management
 
 Registration tokens authorise steward self-registration. The token encodes the target tenant and is consumed by `POST /api/v1/register`.

--- a/features/controller/api/handlers_sessions.go
+++ b/features/controller/api/handlers_sessions.go
@@ -76,6 +76,70 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// sessionListItem is the allow-listed per-session payload for GET /api/v1/sessions.
+// Fields are named explicitly so a future field added to session.Session cannot
+// silently leak through this endpoint via a raw json.Marshal passthrough.
+type sessionListItem struct {
+	SessionID      string    `json:"session_id"`
+	PrincipalID    string    `json:"principal_id"`
+	ConnectionName string    `json:"connection_name"`
+	IssuedAt       time.Time `json:"issued_at"`
+	LastActivity   time.Time `json:"last_activity"`
+	AbsoluteExpiry time.Time `json:"absolute_expiry"`
+}
+
+// sessionListResponse wraps the active-session listing for GET /api/v1/sessions.
+type sessionListResponse struct {
+	Sessions []sessionListItem `json:"sessions"`
+}
+
+// handleSessionList handles GET /api/v1/sessions.
+// Requires an admin principal (principal.IsAdmin == true).
+// Tenant-scoped admins see only sessions whose TenantID matches their own;
+// global admins (TenantID == "") see every tenant's sessions.
+func (s *Server) handleSessionList(w http.ResponseWriter, r *http.Request) {
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil || !principal.IsAdmin {
+		s.writeErrorResponse(w, http.StatusForbidden, "Admin mTLS certificate required", "NOT_ADMIN")
+		return
+	}
+	if s.sessionManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Session management not available", "SESSION_UNAVAILABLE")
+		return
+	}
+
+	all, err := s.sessionManager.List(r.Context())
+	if err != nil {
+		s.logger.Error("Failed to list sessions",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list sessions", "SESSION_LIST_ERROR")
+		return
+	}
+
+	items := make([]sessionListItem, 0, len(all))
+	for _, sess := range all {
+		if principal.TenantID != "" && sess.TenantID != principal.TenantID {
+			continue
+		}
+		items = append(items, sessionListItem{
+			SessionID:      sess.ID,
+			PrincipalID:    sess.PrincipalID,
+			ConnectionName: sess.ConnectionName,
+			IssuedAt:       sess.IssuedAt,
+			LastActivity:   sess.LastActivity,
+			AbsoluteExpiry: sess.AbsoluteExpiresAt,
+		})
+	}
+
+	s.logger.Info("Sessions listed",
+		"principal_id", logging.SanitizeLogValue(principal.ID),
+		"count", len(items))
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sessionListResponse{Sessions: items})
+}
+
 // handleSessionRevoke handles DELETE /api/v1/sessions/{id}.
 // Accepts either a valid session token or an admin mTLS cert as credentials.
 // Returns HTTP 200 on success or HTTP 404 if the session does not exist.

--- a/features/controller/api/handlers_sessions_test.go
+++ b/features/controller/api/handlers_sessions_test.go
@@ -443,3 +443,234 @@ func TestHandleSessionCreate_NoSessionManager(t *testing.T) {
 		t.Errorf("status = %d, want 503 when sessionManager is nil", rec.Code)
 	}
 }
+
+// injectAdminPrincipalWithTenant returns a request with an admin Principal scoped to a specific tenant.
+func injectAdminPrincipalWithTenant(r *http.Request, principalID, tenantID string) *http.Request {
+	p := &Principal{
+		ID:       principalID,
+		Name:     "mtls-admin:" + principalID,
+		IsAdmin:  true,
+		TenantID: tenantID,
+	}
+	return r.WithContext(context.WithValue(r.Context(), principalContextKey, p))
+}
+
+// TestHandleSessionList_NonAdminReturns403 verifies that a non-admin caller receives 403.
+func TestHandleSessionList_NonAdminReturns403(t *testing.T) {
+	srv, _, _ := setupTestServerWithSession(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	req = injectNonAdminPrincipal(req)
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionList(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+// TestHandleSessionList_TenantIsolation verifies that a tenant-scoped admin sees only
+// sessions belonging to their tenant, while a global admin sees all tenants' sessions.
+func TestHandleSessionList_TenantIsolation(t *testing.T) {
+	srv, mgr, _ := setupTestServerWithSession(t)
+	ctx := context.Background()
+
+	// Issue sessions in two different tenants and one without a tenant.
+	_, _, err := mgr.Issue(ctx, "alice", "ctrl-a", "tenant-x")
+	if err != nil {
+		t.Fatalf("Issue tenant-x: %v", err)
+	}
+	_, _, err = mgr.Issue(ctx, "bob", "ctrl-b", "tenant-y")
+	if err != nil {
+		t.Fatalf("Issue tenant-y: %v", err)
+	}
+	_, _, err = mgr.Issue(ctx, "carol", "ctrl-c", "tenant-x")
+	if err != nil {
+		t.Fatalf("Issue tenant-x second: %v", err)
+	}
+
+	// Tenant-scoped admin for tenant-x: must see only tenant-x sessions (alice + carol).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	req = injectAdminPrincipalWithTenant(req, "alice", "tenant-x")
+	rec := httptest.NewRecorder()
+	srv.handleSessionList(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("tenant-x admin: status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var tenantResp struct {
+		Sessions []struct {
+			SessionID string `json:"session_id"`
+		} `json:"sessions"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&tenantResp); err != nil {
+		t.Fatalf("decode tenant-x response: %v", err)
+	}
+	if len(tenantResp.Sessions) != 2 {
+		t.Errorf("tenant-x admin: got %d sessions, want 2 (alice + carol)", len(tenantResp.Sessions))
+	}
+
+	// Global admin (TenantID == ""): must see all three sessions.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	req2 = injectAdminPrincipal(req2, "global-admin") // no TenantID → global
+	rec2 := httptest.NewRecorder()
+	srv.handleSessionList(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("global admin: status = %d, want 200; body: %s", rec2.Code, rec2.Body.String())
+	}
+	var globalResp struct {
+		Sessions []struct {
+			SessionID string `json:"session_id"`
+		} `json:"sessions"`
+	}
+	if err := json.NewDecoder(rec2.Body).Decode(&globalResp); err != nil {
+		t.Fatalf("decode global response: %v", err)
+	}
+	if len(globalResp.Sessions) != 3 {
+		t.Errorf("global admin: got %d sessions, want 3 (all tenants)", len(globalResp.Sessions))
+	}
+}
+
+// TestHandleSessionList_NoTokenDisclosure verifies that the raw bearer token, its SHA-256
+// hash, and any other secret-equivalent value are absent from the GET /api/v1/sessions
+// response body. The assertion is against raw response bytes, not the response struct.
+func TestHandleSessionList_NoTokenDisclosure(t *testing.T) {
+	srv, mgr, _ := setupTestServerWithSession(t)
+	ctx := context.Background()
+
+	_, token, err := mgr.Issue(ctx, "dave", "ctrl-d", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	tokenHash := session.HashToken(token)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	req = injectAdminPrincipal(req, "dave")
+	rec := httptest.NewRecorder()
+	srv.handleSessionList(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, token) {
+		t.Errorf("response body contains raw bearer token — must not be disclosed\nbody:\n%s", body)
+	}
+	if strings.Contains(body, tokenHash) {
+		t.Errorf("response body contains token hash — must not be disclosed\nbody:\n%s", body)
+	}
+}
+
+// TestHandleSessionList_IdleExpiredExcluded verifies that a session that has gone
+// idle-expired (per Validate's IdleTimeout rule) is excluded from the listing, even
+// if the store record has not yet been physically reaped.
+func TestHandleSessionList_IdleExpiredExcluded(t *testing.T) {
+	srv := setupTestServer(t)
+	cfg := session.Config{
+		IdleTimeout:     100 * time.Millisecond,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     10 * time.Millisecond,
+	}
+	clock := &testClock{t: time.Now()}
+	store := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(store.Close)
+	mgr := session.NewManager(cfg, store, clock.Now)
+	srv.SetSessionManager(mgr)
+
+	ctx := context.Background()
+	// Issue a session; it will become idle-expired when the clock advances past IdleTimeout.
+	_, _, err := mgr.Issue(ctx, "eve", "ctrl-e", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Advance past idle TTL; the MemStore sweep has not yet reaped the record.
+	clock.advance(200 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	req = injectAdminPrincipal(req, "eve")
+	rec := httptest.NewRecorder()
+	srv.handleSessionList(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Sessions []interface{} `json:"sessions"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Sessions) != 0 {
+		t.Errorf("idle-expired session still in listing: got %d sessions, want 0", len(resp.Sessions))
+	}
+}
+
+// TestHandleSessionList_ResponseFields verifies the response contains exactly the
+// allow-listed fields and no extras.
+func TestHandleSessionList_ResponseFields(t *testing.T) {
+	srv, mgr, _ := setupTestServerWithSession(t)
+	ctx := context.Background()
+
+	_, _, err := mgr.Issue(ctx, "frank", "ctrl-f", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	req = injectAdminPrincipal(req, "frank")
+	rec := httptest.NewRecorder()
+	srv.handleSessionList(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	// Decode as a generic map to inspect raw field names.
+	var raw struct {
+		Sessions []map[string]interface{} `json:"sessions"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(raw.Sessions) != 1 {
+		t.Fatalf("want 1 session, got %d", len(raw.Sessions))
+	}
+	item := raw.Sessions[0]
+	allowed := map[string]bool{
+		"session_id":      true,
+		"principal_id":    true,
+		"connection_name": true,
+		"issued_at":       true,
+		"last_activity":   true,
+		"absolute_expiry": true,
+	}
+	for k := range item {
+		if !allowed[k] {
+			t.Errorf("unexpected field %q in session list item", k)
+		}
+	}
+	for k := range allowed {
+		if _, ok := item[k]; !ok {
+			t.Errorf("required field %q missing from session list item", k)
+		}
+	}
+}
+
+// TestHandleSessionList_NoSessionManager returns 503 when no manager is wired.
+func TestHandleSessionList_NoSessionManager(t *testing.T) {
+	srv := setupTestServer(t) // no SetSessionManager call
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	req = injectAdminPrincipal(req, "alice")
+	rec := httptest.NewRecorder()
+
+	srv.handleSessionList(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 when sessionManager is nil", rec.Code)
+	}
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -534,11 +534,12 @@ func (s *Server) setupRouter() {
 	apiKeys.Handle("/{id}", s.requirePermission("api-key", "read")(http.HandlerFunc(s.handleGetAPIKey))).Methods("GET")
 	apiKeys.Handle("/{id}", s.requireTier(TierMTLSOnly)(s.requirePermission("api-key", "delete")(http.HandlerFunc(s.handleDeleteAPIKey)))).Methods("DELETE")
 
-	// Admin session endpoints (Issue #2232). POST requires an admin principal (IsAdmin==true);
-	// DELETE accepts either a valid session token or an admin mTLS cert.
-	// Both handlers check principal.IsAdmin internally — no tier-3 wrapper needed because
+	// Admin session endpoints (Issue #2232, #2368). POST requires an admin principal (IsAdmin==true);
+	// DELETE accepts either a valid session token or an admin mTLS cert; GET lists active sessions.
+	// All handlers check principal.IsAdmin internally — no tier-3 wrapper needed because
 	// session-token principals also have IsAdmin==true.
 	api.Handle("/sessions", http.HandlerFunc(s.handleSessionCreate)).Methods("POST")
+	api.Handle("/sessions", http.HandlerFunc(s.handleSessionList)).Methods("GET")
 	api.Handle("/sessions/{id}", http.HandlerFunc(s.handleSessionRevoke)).Methods("DELETE")
 
 	// Registration token management endpoints (Story #264)

--- a/pkg/session/contract.go
+++ b/pkg/session/contract.go
@@ -77,11 +77,16 @@ func DefaultConfig() Config {
 //
 // Revoke invalidates a session by ID. Accepts a valid session token or an admin mTLS cert
 // so a client holding an expired token can still clean up server-side.
+//
+// List returns copies of all currently-live sessions across all tenants. A session is live
+// if it is not revoked, not absolute-expired, and not idle-expired — the same three checks
+// Validate applies. Tenant scoping is the caller's responsibility.
 type Manager interface {
 	Issue(ctx context.Context, principalID, connectionName, tenantID string) (*Session, string, error)
 	Validate(ctx context.Context, token string) (*Session, error)
 	Renew(ctx context.Context, token string) (*Session, string, error)
 	Revoke(ctx context.Context, id string) error
+	List(ctx context.Context) ([]*Session, error)
 }
 
 // Store is the in-memory backing store for the session Manager (ADR-014 §2, v1).

--- a/pkg/session/contract_test.go
+++ b/pkg/session/contract_test.go
@@ -38,7 +38,8 @@ func (s *stubManager) Validate(_ context.Context, _ string) (*session.Session, e
 func (s *stubManager) Renew(_ context.Context, _ string) (*session.Session, string, error) {
 	return nil, "", nil
 }
-func (s *stubManager) Revoke(_ context.Context, _ string) error { return nil }
+func (s *stubManager) Revoke(_ context.Context, _ string) error           { return nil }
+func (s *stubManager) List(_ context.Context) ([]*session.Session, error) { return nil, nil }
 
 // stubStore satisfies Store for compile-time interface verification.
 type stubStore struct{}

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -184,6 +184,42 @@ func (m *manager) Renew(ctx context.Context, token string) (*Session, string, er
 	return &out, newToken, nil
 }
 
+// List returns copies of all currently-live sessions. A session is live if it is not
+// revoked, not absolute-expired, and not idle-expired — the same three checks Validate
+// applies. Tenant scoping is the caller's responsibility. Results are copies so callers
+// cannot mutate manager-internal state through the returned pointers.
+func (m *manager) List(_ context.Context) ([]*Session, error) {
+	now := m.clockFn()
+	// Snapshot the managedSession pointers under m.mu, then release m.mu BEFORE
+	// acquiring any per-session ms.mu. Holding m.mu while taking ms.mu would invert
+	// the lock order used by Renew (ms.mu then m.mu), producing an ABBA deadlock
+	// under concurrent List/Renew on the same session.
+	m.mu.RLock()
+	snapshot := make([]*managedSession, 0, len(m.sessions))
+	for _, ms := range m.sessions {
+		snapshot = append(snapshot, ms)
+	}
+	m.mu.RUnlock()
+
+	out := make([]*Session, 0, len(snapshot))
+	for _, ms := range snapshot {
+		ms.mu.Lock()
+		live := !ms.revoked &&
+			now.Before(ms.session.AbsoluteExpiresAt) &&
+			now.Before(ms.session.LastActivity.Add(m.cfg.IdleTimeout))
+		var copy *Session
+		if live {
+			c := *ms.session
+			copy = &c
+		}
+		ms.mu.Unlock()
+		if copy != nil {
+			out = append(out, copy)
+		}
+	}
+	return out, nil
+}
+
 // Revoke immediately invalidates the session identified by id. Subsequent Validate
 // or Renew calls for any token belonging to this session return ErrSessionRevoked.
 func (m *manager) Revoke(ctx context.Context, id string) error {

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -307,3 +307,238 @@ func TestRevokeUnknownSession(t *testing.T) {
 		t.Errorf("Revoke unknown: got %v, want ErrSessionNotFound", err)
 	}
 }
+
+// TestManagerList_ActiveSessionsOnly verifies that List returns only genuinely-live
+// sessions — not revoked, not absolute-expired, not idle-expired — and returns copies.
+func TestManagerList_ActiveSessionsOnly(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     200 * time.Millisecond,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	// Issue three sessions: one to keep active, one to revoke, one to let idle-expire.
+	activeSess, activeToken, err := mgr.Issue(ctx, "alice", "ctrl-a", "tenantA")
+	if err != nil {
+		t.Fatalf("Issue active: %v", err)
+	}
+	revokedSess, _, err := mgr.Issue(ctx, "bob", "ctrl-b", "tenantA")
+	if err != nil {
+		t.Fatalf("Issue revoked: %v", err)
+	}
+	_, _, err = mgr.Issue(ctx, "carol", "ctrl-c", "tenantA")
+	if err != nil {
+		t.Fatalf("Issue idle: %v", err)
+	}
+
+	// Revoke bob's session.
+	if err := mgr.Revoke(ctx, revokedSess.ID); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	// Advance to T=100ms (inside idle TTL) and validate alice's token to refresh
+	// her LastActivity. Carol's token is never validated.
+	clock.advance(100 * time.Millisecond)
+	if _, err := mgr.Validate(ctx, activeToken); err != nil {
+		t.Fatalf("Validate alice inside idle window: %v", err)
+	}
+
+	// Advance to T=250ms: carol's LastActivity is still T=0 → idle-expired at T=200ms;
+	// alice's LastActivity was reset to T=100ms → idle-expires at T=300ms → still alive.
+	clock.advance(150 * time.Millisecond)
+
+	sessions, err := mgr.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	// Only alice's session should be returned.
+	if len(sessions) != 1 {
+		t.Fatalf("List returned %d sessions, want 1 (active only); got IDs: %v",
+			len(sessions), sessionIDs(sessions))
+	}
+	if sessions[0].ID != activeSess.ID {
+		t.Errorf("List returned session %q, want %q", sessions[0].ID, activeSess.ID)
+	}
+}
+
+// sessionIDs extracts session IDs for error messages.
+func sessionIDs(sessions []*session.Session) []string {
+	ids := make([]string, len(sessions))
+	for i, s := range sessions {
+		ids[i] = s.ID
+	}
+	return ids
+}
+
+// TestManagerList_AbsoluteExpiredExcluded verifies that a session past its absolute
+// expiry is excluded from List even if the store has not yet reaped it.
+func TestManagerList_AbsoluteExpiredExcluded(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     1 * time.Hour,
+		AbsoluteTimeout: 100 * time.Millisecond,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	_, _, err := mgr.Issue(ctx, "dave", "ctrl-d", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Advance past absolute timeout.
+	clock.advance(200 * time.Millisecond)
+
+	sessions, err := mgr.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("List returned %d sessions after absolute expiry, want 0", len(sessions))
+	}
+}
+
+// TestManagerList_ReturnsCopies verifies that mutating a returned *Session does not
+// affect the manager's internal state (subsequent List calls return the original value).
+func TestManagerList_ReturnsCopies(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	_, _, err := mgr.Issue(ctx, "eve", "ctrl-e", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	sessions, err := mgr.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("List returned %d sessions, want 1", len(sessions))
+	}
+
+	originalID := sessions[0].ID
+	// Mutate the returned pointer.
+	sessions[0].ID = "mutated-id"
+	sessions[0].PrincipalID = "mutated-principal"
+
+	// A fresh List must still see the original values.
+	sessions2, err := mgr.List(ctx)
+	if err != nil {
+		t.Fatalf("second List: %v", err)
+	}
+	if len(sessions2) != 1 {
+		t.Fatalf("second List returned %d sessions, want 1", len(sessions2))
+	}
+	if sessions2[0].ID != originalID {
+		t.Errorf("mutation leaked: ID = %q, want %q", sessions2[0].ID, originalID)
+	}
+}
+
+// TestManagerList_ConcurrentWithRenew stresses List() and Renew() from parallel
+// goroutines on the same set of sessions. Its purpose is to expose lock-ordering
+// bugs that -race cannot: -race detects data races, not deadlocks. List() snapshots
+// the sessions map under m.mu and releases it before taking any per-session ms.mu,
+// while Renew() takes ms.mu then m.mu; if List instead held m.mu across ms.mu the two
+// paths would form an ABBA deadlock and this test would hang. A watchdog fails the
+// test rather than letting the whole suite block if that regression returns.
+func TestManagerList_ConcurrentWithRenew(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     1 * time.Hour,
+		AbsoluteTimeout: 24 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	const (
+		numSessions = 8
+		listWorkers = 8
+		iterations  = 500
+	)
+	initialTokens := make([]string, numSessions)
+	for i := 0; i < numSessions; i++ {
+		_, tok, err := mgr.Issue(ctx, "user", "ctrl", "tenant")
+		if err != nil {
+			t.Fatalf("Issue %d: %v", i, err)
+		}
+		initialTokens[i] = tok
+	}
+
+	var wg sync.WaitGroup
+
+	// One renew goroutine per session: each goroutine owns its session's rolling
+	// token, so it always renews with the current token (never a grace-window token
+	// that a competing renewer could have evicted). This keeps the test focused on
+	// the List/Renew lock interaction rather than token-rotation bookkeeping, while
+	// still driving Renew's ms.mu→m.mu ordering against List concurrently.
+	for i := 0; i < numSessions; i++ {
+		wg.Add(1)
+		go func(tok string) {
+			defer wg.Done()
+			for n := 0; n < iterations; n++ {
+				_, newTok, err := mgr.Renew(ctx, tok)
+				if err != nil {
+					t.Errorf("Renew: %v", err)
+					return
+				}
+				if newTok != "" {
+					tok = newTok
+				}
+			}
+		}(initialTokens[i])
+	}
+
+	// List workers: enumerate all live sessions concurrently with the rotations,
+	// exercising List's m.mu→ms.mu path against Renew's ms.mu→m.mu path.
+	for w := 0; w < listWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := 0; n < iterations; n++ {
+				if _, err := mgr.List(ctx); err != nil {
+					t.Errorf("List: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent List/Renew workload did not complete within 10s: " +
+			"likely an ABBA deadlock between List (m.mu→ms.mu) and Renew (ms.mu→m.mu)")
+	}
+}
+
+// TestManagerList_EmptyWhenNoSessions verifies List returns an empty slice (not nil
+// or an error) when no sessions have been issued.
+func TestManagerList_EmptyWhenNoSessions(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sessions, err := mgr.List(ctx)
+	if err != nil {
+		t.Fatalf("List on empty manager: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(sessions))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `List(ctx)` to the `session.Manager` interface and implements it on the concrete `manager` by iterating `m.sessions` and applying the same revoked/absolute-expiry/idle-expiry liveness checks `Validate` uses — only genuinely-active sessions are returned, each as a shallow copy.
- Adds `GET /api/v1/sessions` handler with inline admin check, tenant-scoped filtering (TenantID != "" → own tenant; "" → all), and an explicit allow-list response struct so future `Session` fields cannot silently leak.
- Registers the new `GET` method on the existing `/sessions` path in `server.go`.
- Documents `POST`, `GET`, and `DELETE /api/v1/sessions` in `docs/api/rest-api.md` under a new Session Management section.

## Specialist Review Results

| Lens | Round 1 | Round 2 |
|------|---------|---------|
| Code Review | FAIL → fixed (lock-order deadlock in List) | PASS |
| Test Quality | FAIL → fixed | PASS |
| Security | PASS | — |

All three lenses passed. `story-review` workflow: `passed: true`, 2 review rounds, 1 fix round, 0 remaining findings.

## Security properties

- No bearer token or token-hash field exists on `Session`; the allow-list response struct (`sessionListItem`) is defence-in-depth against future struct additions leaking through this endpoint.
- Tenant isolation is enforced in the handler; `requirePermission` provides no tenant filter for bare collection endpoints (per Implementation Notes).
- All logged values wrapped with `logging.SanitizeLogValue`.
- Lock ordering in `List`: snapshot `m.sessions` under `m.mu`, release `m.mu`, then take per-session `ms.mu` — avoids ABBA deadlock with `Renew` (which takes `ms.mu` then `m.mu`).

## Test plan

- [x] `TestManagerList_ActiveSessionsOnly` — revoked and idle-expired sessions excluded
- [x] `TestManagerList_AbsoluteExpiredExcluded` — absolute-expired sessions excluded
- [x] `TestManagerList_ReturnsCopies` — mutation of returned pointer does not affect manager state
- [x] `TestManagerList_EmptyWhenNoSessions` — empty slice (not error) on empty manager
- [x] `TestHandleSessionList_NonAdminReturns403` — inline IsAdmin check
- [x] `TestHandleSessionList_TenantIsolation` — tenant-scoped vs global admin
- [x] `TestHandleSessionList_NoTokenDisclosure` — raw body scan for token and hash
- [x] `TestHandleSessionList_IdleExpiredExcluded` — idle-expired session not in listing
- [x] `TestHandleSessionList_ResponseFields` — exact field allow-list verified
- [x] `TestHandleSessionList_NoSessionManager` — 503 when manager not wired

Fixes #2368

🤖 Generated with [Claude Code](https://claude.com/claude-code)