### PR TITLE
deps: bump github/codeql-action v4.36.2 → v4.36.3 (Issue #2395)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -104,7 +104,7 @@ jobs:
     # run that workflow manually with `--ref <branch>` before re-running
     # this one.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -127,7 +127,7 @@ jobs:
 
     # Perform CodeQL Analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         category: "/language:${{ matrix.language }}"
         # Upload results to GitHub Security tab (SARIF format)

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -95,7 +95,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       if: always()
       with:
         sarif_file: 'trivy-controller-results.sarif'
@@ -184,7 +184,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       if: always()
       with:
         sarif_file: 'trivy-steward-results.sarif'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -81,7 +81,7 @@ jobs:
         fi
     
     - name: Upload Trivy SARIF
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       if: always() && hashFiles('sarif-results/trivy.sarif') != ''
       with:
         sarif_file: sarif-results/trivy.sarif
@@ -206,7 +206,7 @@ jobs:
     # configuration, and results are still available via workflow artifacts.
     #
     # - name: Upload gosec SARIF
-    #   uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+    #   uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
     #   if: always() && hashFiles('sarif-results/gosec.sarif') != ''
     #   with:
     #     sarif_file: sarif-results/gosec.sarif


### PR DESCRIPTION
## What

Last pin of the 2026-07-07 refresh chain (#2390–#2395). Bumps `github/codeql-action` from `v4.36.2` (`8aad20d1`) to `v4.36.3` (`54f647b7`) — routine, past 3-day cooldown, no security advisory.

All 6 occurrences of the shared init/analyze/upload-sarif SHA bumped in lockstep:
- `codeql-analysis.yml:107` (init), `:130` (analyze)
- `docker-security.yml:98`, `:187` (upload-sarif)
- `security-scan.yml:84`, `:209` (upload-sarif; `:209` is the disabled gosec-SARIF block, bumped for lockstep)

## Why applied inline

The dev-agent dispatch for #2395 stalled on the known bg-wait PR-creation ceiling (`feedback_stalled_dispatch_bg_wait_ceiling`) and produced no branch. Applied directly as a pipeline-infra one-liner to complete the chain rather than re-loop the stall.

## Verification
- Old SHA `8aad20d1…`: **0 matches** across `.github/workflows/`
- New SHA `54f647b7…`: **6 matches**
- No `# v4.36.2` codeql comment remains

Fixes #2395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzgEq4v2eUsKcFw92SkbmL