### PR TITLE
steward: decommission endpoint and CLI command (Issue #2408)

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -225,6 +225,49 @@ Examples:
 	RunE: runStewardMove,
 }
 
+// stewardDecommissionCmd permanently decommissions a steward from the fleet.
+var stewardDecommissionCmd = &cobra.Command{
+	Use:   "decommission <id>",
+	Short: "Decommission a steward from the fleet",
+	Long: `Mark a steward record as deregistered after its host or VM has been torn down.
+
+Requires an admin mTLS certificate. The record is retained in durable storage
+for audit but no longer appears in cfg steward list. Any active connection is dropped.
+
+Examples:
+  cfg steward decommission steward-abc123`,
+	Args: cobra.ExactArgs(1),
+	RunE: runStewardDecommission,
+}
+
+func runStewardDecommission(_ *cobra.Command, args []string) error {
+	stewardID := args[0]
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+	resp, err := client.doRequest(context.Background(), http.MethodDelete,
+		"/api/v1/stewards/"+stewardID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to decommission steward: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		fmt.Printf("Steward %s decommissioned.\n", stewardID)
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("steward %s not found", stewardID)
+	case http.StatusForbidden:
+		return fmt.Errorf("decommission requires an admin mTLS certificate")
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf("fleet store unavailable; retry later")
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+}
+
 // stewardLogsCmd pulls recent log entries from a steward via the controller REST API.
 var stewardLogsCmd = &cobra.Command{
 	Use:   "logs <id>",
@@ -479,11 +522,18 @@ func init() {
 		panic(err)
 	}
 
+	// decommission flags (Issue #2408)
+	stewardDecommissionCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardDecommissionCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardDecommissionCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+	stewardDecommissionCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+
 	stewardCmd.AddCommand(stewardListCmd)
 	stewardCmd.AddCommand(stewardStatusCmd)
 	stewardCmd.AddCommand(stewardDNACmd)
 	stewardCmd.AddCommand(stewardModulesCmd)
 	stewardCmd.AddCommand(stewardMoveCmd)
+	stewardCmd.AddCommand(stewardDecommissionCmd)
 	stewardCmd.AddCommand(stewardRunScriptCmd)
 	stewardCmd.AddCommand(stewardRunCommandCmd)
 	stewardCmd.AddCommand(stewardExecCmd)

--- a/cmd/cfg/cmd/steward_test.go
+++ b/cmd/cfg/cmd/steward_test.go
@@ -843,3 +843,165 @@ func TestStewardMove_FlagsRegistered(t *testing.T) {
 	assert.NotNil(t, stewardMoveCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered")
 	assert.NotNil(t, stewardMoveCmd.Flags().Lookup("to-tenant"), "--to-tenant flag must be registered")
 }
+
+// TestStewardDecommission_CallsDeleteEndpoint verifies that decommission issues an
+// HTTP DELETE to /api/v1/stewards/{id} and reports success on 200.
+func TestStewardDecommission_CallsDeleteEndpoint(t *testing.T) {
+	var requestPath string
+	var requestMethod string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":     "steward-abc123",
+				"status": "deregistered",
+			},
+		})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runStewardDecommission(stewardDecommissionCmd, []string{"steward-abc123"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, http.MethodDelete, requestMethod)
+	assert.Equal(t, "/api/v1/stewards/steward-abc123", requestPath)
+	assert.Contains(t, output, "steward-abc123")
+	assert.Contains(t, output, "decommissioned")
+}
+
+// TestStewardDecommission_NotFound_ReturnsError verifies a 404 surfaces a clear error.
+func TestStewardDecommission_NotFound_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    "STEWARD_NOT_FOUND",
+				"message": "Steward not found",
+			},
+		})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runStewardDecommission(stewardDecommissionCmd, []string{"unknown-steward"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "unknown-steward")
+}
+
+// TestStewardDecommission_Forbidden_ReturnsMTLSError verifies that a 403 (API-key caller
+// rejected at the Tier-3 gate) surfaces an mTLS-specific error.
+func TestStewardDecommission_Forbidden_ReturnsMTLSError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    "MTLS_REQUIRED",
+				"message": "mTLS admin certificate required for this endpoint",
+			},
+		})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runStewardDecommission(stewardDecommissionCmd, []string{"steward-abc123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mTLS")
+}
+
+// TestStewardDecommission_ServiceUnavailable_ReturnsRetryError verifies that a 503
+// (fleet store unavailable) surfaces a retry-later error.
+func TestStewardDecommission_ServiceUnavailable_ReturnsRetryError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    "SERVICE_UNAVAILABLE",
+				"message": "Fleet store unavailable",
+			},
+		})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runStewardDecommission(stewardDecommissionCmd, []string{"steward-abc123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retry")
+}
+
+// TestStewardDecommission_OtherHTTPError_ReturnsStatusAndBody verifies that an unexpected
+// status returns the status and response body.
+func TestStewardDecommission_OtherHTTPError_ReturnsStatusAndBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runStewardDecommission(stewardDecommissionCmd, []string{"steward-abc123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "internal server error")
+}
+
+func TestStewardDecommission_FlagsRegistered(t *testing.T) {
+	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("url"), "--url flag must be registered")
+	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("api-key"), "--api-key flag must be registered")
+	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered")
+	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered")
+}

--- a/features/controller/api/auth_tiers.go
+++ b/features/controller/api/auth_tiers.go
@@ -38,6 +38,7 @@ var tier3Permissions = map[string]struct{}{
 	"refresh:approve":              {}, // POST /stewards/refresh/{pending_id}/approve
 	"refresh:set-policy":           {}, // PUT /tenants/{tenant_path}/refresh-policy
 	"steward:move":                 {}, // POST /stewards/{id}/move
+	"steward:decommission":         {}, // DELETE /stewards/{id}
 }
 
 // requireTier returns middleware that enforces the given authentication tier.

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -5,6 +5,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -84,12 +85,17 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// No filter: existing behavior — return all stewards including registered-but-not-connected.
+	// No filter: return all stewards including registered-but-not-connected.
+	// Deregistered stewards are excluded by default; pass ?include_deregistered=true to restore them.
+	includeDeregistered := r.URL.Query().Get("include_deregistered") == "true"
 	stewards := s.controllerService.GetAllStewards()
 
 	stewardList := make([]StewardInfo, 0, len(stewards))
 
 	for _, steward := range stewards {
+		if !includeDeregistered && steward.Status == string(business.StewardStatusDeregistered) {
+			continue
+		}
 		info := StewardInfo{
 			ID:          steward.ID,
 			Version:     steward.Version,
@@ -623,6 +629,115 @@ func (s *Server) handleDeleteStewardConfig(w http.ResponseWriter, r *http.Reques
 
 	s.logger.Info("Configuration deleted", "steward_id", stewardIDForLog)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDecommissionSteward handles DELETE /api/v1/stewards/{id}.
+// Tombstones the steward's durable record (status: deregistered), updates the in-memory
+// registry, and drops any active QUIC/gRPC session. The record is retained for audit.
+// Requires an admin mTLS certificate (TierMTLSOnly gate). Issue #2408.
+func (s *Server) handleDecommissionSteward(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	stewardID := vars["id"]
+
+	if !identifierRegex.MatchString(stewardID) {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid steward ID format", "INVALID_STEWARD_ID")
+		return
+	}
+
+	if s.stewardStore == nil {
+		s.logger.Error("decommission failed: steward store not configured",
+			"steward_id", logging.SanitizeLogValue(stewardID))
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Fleet store unavailable", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	record, err := s.stewardStore.GetSteward(r.Context(), stewardID)
+	if err != nil {
+		if errors.Is(err, business.ErrStewardNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+			return
+		}
+		s.logger.Error("decommission failed: store lookup error",
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to look up steward", "INTERNAL_ERROR")
+		return
+	}
+
+	// Cross-tenant scope check using the durable record's TenantID as the authoritative source.
+	// Admin mTLS (empty callerTenant) has global scope; API-key callers are rejected at the
+	// TierMTLSOnly gate before reaching here, so callerTenant is always from an mTLS principal.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := record.TenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(record.TenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			// 404 instead of 403 to avoid existence disclosure across tenant boundaries.
+			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+			return
+		}
+	}
+
+	// Tombstone in durable storage — authoritative; must succeed before in-memory updates.
+	if err := s.stewardStore.DeregisterSteward(r.Context(), stewardID); err != nil {
+		s.logger.Error("decommission failed: store write error",
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decommission steward", "INTERNAL_ERROR")
+		return
+	}
+
+	// Update in-memory status — best-effort; durable storage already succeeded.
+	if err := s.controllerService.UpdateStewardStatus(stewardID, string(business.StewardStatusDeregistered)); err != nil {
+		s.logger.Warn("decommission: in-memory status update failed (non-fatal)",
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+	}
+
+	// Drop any active QUIC/gRPC connection.
+	s.mu.RLock()
+	reg := s.registry
+	s.mu.RUnlock()
+	if reg != nil {
+		reg.Unregister(stewardID)
+	}
+
+	// Emit audit event.
+	auditTenantID := callerTenant
+	if auditTenantID == "" {
+		auditTenantID = audit.SystemTenantID
+	}
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	principalID := ""
+	if principal != nil {
+		principalID = principal.ID
+	}
+	s.emitDecommissionAudit(r.Context(), auditTenantID, principalID, stewardID)
+
+	s.logger.Info("Steward decommissioned",
+		"steward_id", logging.SanitizeLogValue(stewardID),
+		"principal_id", logging.SanitizeLogValue(principalID))
+
+	s.writeSuccessResponse(w, map[string]interface{}{
+		"id":     stewardID,
+		"status": string(business.StewardStatusDeregistered),
+	})
+}
+
+// emitDecommissionAudit records a steward-decommission audit event. No-op when auditManager is nil.
+func (s *Server) emitDecommissionAudit(ctx context.Context, tenantID, principalID, stewardID string) {
+	if s.auditManager == nil {
+		return
+	}
+	b := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(business.AuditEventSystemAccess).
+		Action("steward.decommissioned").
+		User(principalID, business.AuditUserTypeHuman).
+		Resource("steward", stewardID, "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityHigh)
+	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
+		s.logger.Warn("Failed to emit decommission audit event",
+			"error", err, "steward_id", logging.SanitizeLogValue(stewardID))
+	}
 }
 
 // handleGetStewardModules handles GET /api/v1/stewards/{id}/modules.

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -680,7 +680,7 @@ func (s *Server) handleDecommissionSteward(w http.ResponseWriter, r *http.Reques
 	// Tombstone in durable storage — authoritative; must succeed before in-memory updates.
 	if err := s.stewardStore.DeregisterSteward(r.Context(), stewardID); err != nil {
 		s.logger.Error("decommission failed: store write error",
-			"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decommission steward", "INTERNAL_ERROR")
 		return
 	}
@@ -688,7 +688,7 @@ func (s *Server) handleDecommissionSteward(w http.ResponseWriter, r *http.Reques
 	// Update in-memory status — best-effort; durable storage already succeeded.
 	if err := s.controllerService.UpdateStewardStatus(stewardID, string(business.StewardStatusDeregistered)); err != nil {
 		s.logger.Warn("decommission: in-memory status update failed (non-fatal)",
-			"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", logging.SanitizeLogValue(err.Error()))
 	}
 
 	// Drop any active QUIC/gRPC connection.

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -30,6 +30,302 @@ import (
 	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
 
+// ---- handleDecommissionSteward tests (Issue #2408) ----
+
+// setupDecommissionServer creates a test server wired with a real flat-file steward
+// store, suitable for decommission handler tests that need durable storage.
+func setupDecommissionServer(t *testing.T) (*Server, business.StewardStore) {
+	t.Helper()
+	server := setupTestServer(t)
+	st, _ := newTestStewardDurableStore(t)
+	server.SetStewardStore(st)
+	return server, st
+}
+
+// deleteDecommissionSteward calls handleDecommissionSteward directly (bypassing the Tier-3
+// middleware) with a root-admin mTLS principal so we can exercise the handler in isolation.
+func deleteDecommissionSteward(server *Server, stewardID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/"+stewardID, nil)
+	req = withPrincipal(req, &Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""})
+	req = withVars(req, map[string]string{"id": stewardID})
+	rec := httptest.NewRecorder()
+	server.handleDecommissionSteward(rec, req)
+	return rec
+}
+
+// TestHandleDecommissionSteward_HappyPath verifies that a known steward is tombstoned
+// with status "deregistered" and the response contains {"id":"...","status":"deregistered"}.
+func TestHandleDecommissionSteward_HappyPath(t *testing.T) {
+	server, st := setupDecommissionServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-decomm-ok",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+	require.NoError(t, server.controllerService.RegisterSteward("s-decomm-ok", "test-tenant", "addr", "active"))
+
+	rec := deleteDecommissionSteward(server, "s-decomm-ok")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "s-decomm-ok", resp.Data["id"])
+	assert.Equal(t, "deregistered", resp.Data["status"])
+
+	// Verify durable store reflects the tombstone.
+	got, err := st.GetSteward(context.Background(), "s-decomm-ok")
+	require.NoError(t, err)
+	assert.Equal(t, business.StewardStatusDeregistered, got.Status)
+}
+
+// TestHandleDecommissionSteward_APIKeyRejected verifies that an API-key caller
+// is rejected with 403 at the Tier-3 gate (via the full router).
+func TestHandleDecommissionSteward_APIKeyRejected(t *testing.T) {
+	server, _ := setupDecommissionServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:decommission"})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/any-steward", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code, "API-key callers must be rejected at Tier-3")
+}
+
+// TestHandleDecommissionSteward_InvalidID verifies 400 for a malformed steward ID.
+func TestHandleDecommissionSteward_InvalidID(t *testing.T) {
+	server, _ := setupDecommissionServer(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/bad.id:here", nil)
+	req = withPrincipal(req, &Principal{ID: "admin", IsAdmin: true, TenantID: ""})
+	req = withVars(req, map[string]string{"id": "bad.id:here"})
+	rec := httptest.NewRecorder()
+	server.handleDecommissionSteward(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "INVALID_STEWARD_ID", errResp.Error.Code)
+}
+
+// TestHandleDecommissionSteward_NilStore verifies 503 when stewardStore is nil.
+func TestHandleDecommissionSteward_NilStore(t *testing.T) {
+	server := setupTestServer(t)
+	// stewardStore is nil in the default setup.
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/some-steward", nil)
+	req = withPrincipal(req, &Principal{ID: "admin", IsAdmin: true, TenantID: ""})
+	req = withVars(req, map[string]string{"id": "some-steward"})
+	rec := httptest.NewRecorder()
+	server.handleDecommissionSteward(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "SERVICE_UNAVAILABLE", errResp.Error.Code)
+}
+
+// TestHandleDecommissionSteward_NotFound verifies 404 for an unknown steward ID.
+func TestHandleDecommissionSteward_NotFound(t *testing.T) {
+	server, _ := setupDecommissionServer(t)
+
+	rec := deleteDecommissionSteward(server, "nonexistent-steward")
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "STEWARD_NOT_FOUND", errResp.Error.Code)
+}
+
+// TestHandleDecommissionSteward_CrossTenant verifies that a scoped admin receives 404
+// when trying to decommission a steward in a different tenant (avoids existence disclosure).
+func TestHandleDecommissionSteward_CrossTenant(t *testing.T) {
+	server, st := setupDecommissionServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-cross-tenant",
+		TenantID: "tenant-b",
+		Status:   business.StewardStatusActive,
+	}))
+
+	// Caller is scoped to "tenant-a"; steward belongs to "tenant-b".
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/s-cross-tenant", nil)
+	req = withPrincipal(req, &Principal{ID: "tenant-a-admin", IsAdmin: true, TenantID: "tenant-a"})
+	req = withVars(req, map[string]string{"id": "s-cross-tenant"})
+	rec := httptest.NewRecorder()
+	server.handleDecommissionSteward(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant decommission must return 404, not 403")
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "STEWARD_NOT_FOUND", errResp.Error.Code)
+}
+
+// TestHandleDecommissionSteward_AuditEmitted verifies that a successful decommission writes
+// an audit entry with action "steward.decommissioned", AuditSeverityHigh, and resource_type "steward".
+func TestHandleDecommissionSteward_AuditEmitted(t *testing.T) {
+	server, st := setupDecommissionServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-audit-decomm",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/s-audit-decomm", nil)
+	req = withPrincipal(req, &Principal{ID: "audit-admin", IsAdmin: true, TenantID: ""})
+	req = withVars(req, map[string]string{"id": "s-audit-decomm"})
+	rec := httptest.NewRecorder()
+	server.handleDecommissionSteward(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, server.auditManager.Flush(context.Background()))
+	entries, err := server.auditManager.QueryEntries(context.Background(), &business.AuditFilter{
+		Actions: []string{"steward.decommissioned"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "decommission audit entry must be written")
+
+	e := entries[0]
+	assert.Equal(t, "steward.decommissioned", e.Action)
+	assert.Equal(t, business.AuditSeverityHigh, e.Severity)
+	assert.Equal(t, "steward", e.ResourceType)
+	assert.Equal(t, "s-audit-decomm", e.ResourceID)
+	assert.Equal(t, business.AuditResultSuccess, e.Result)
+}
+
+// TestHandleDecommissionSteward_RegistryConnectionDropped verifies that after decommission
+// the registry no longer contains the steward's entry (active connection is dropped).
+func TestHandleDecommissionSteward_RegistryConnectionDropped(t *testing.T) {
+	server, st := setupDecommissionServer(t)
+
+	stewardID := "s-conn-drop"
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       stewardID,
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&registry.StewardConnection{
+		StewardID:   stewardID,
+		Sender:      &noopSender{},
+		ConnectedAt: time.Now(),
+	}))
+	server.SetRegistry(reg)
+
+	countBefore := reg.Count()
+	require.Equal(t, 1, countBefore, "registry must have one entry before decommission")
+
+	rec := deleteDecommissionSteward(server, stewardID)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, 0, reg.Count(), "registry must be empty after decommission")
+	_, found := reg.Get(stewardID)
+	assert.False(t, found, "registry.Get must return false for decommissioned steward")
+}
+
+// TestHandleDecommissionSteward_ExcludedFromList verifies that after decommission the steward
+// no longer appears in the unfiltered list, but reappears with ?include_deregistered=true.
+// The handler is called directly (bypassing auth middleware) with an empty TenantID so that
+// isEmptyFilter returns true and the test exercises the unfiltered GetAllStewards path, where
+// the include_deregistered filtering lives (per Issue #2408 implementation notes).
+func TestHandleDecommissionSteward_ExcludedFromList(t *testing.T) {
+	server, st := setupDecommissionServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-list-filter",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+	require.NoError(t, server.controllerService.RegisterSteward("s-list-filter", "test-tenant", "addr", "active"))
+
+	// Decommission via the handler.
+	rec := deleteDecommissionSteward(server, "s-list-filter")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Default list (no TenantID → isEmptyFilter is true → unfiltered GetAllStewards path).
+	// The deregistered steward must be excluded.
+	req := httptest.NewRequest("GET", "/api/v1/stewards", nil)
+	req = withTenant(req, "") // empty tenant → admin global scope → isEmptyFilter true
+	rec = httptest.NewRecorder()
+	server.handleListStewards(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	for _, s := range resp.Data {
+		assert.NotEqual(t, "s-list-filter", s.ID, "deregistered steward must not appear in default list")
+	}
+
+	// With ?include_deregistered=true it must reappear.
+	req2 := httptest.NewRequest("GET", "/api/v1/stewards?include_deregistered=true", nil)
+	req2 = withTenant(req2, "")
+	rec2 := httptest.NewRecorder()
+	server.handleListStewards(rec2, req2)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp2 struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&resp2))
+	found := false
+	for _, s := range resp2.Data {
+		if s.ID == "s-list-filter" {
+			found = true
+			assert.Equal(t, "deregistered", s.Status)
+		}
+	}
+	assert.True(t, found, "deregistered steward must appear with ?include_deregistered=true")
+}
+
+// TestHandleDecommissionSteward_DurableStoreWriteFails verifies that when the durable
+// store write (DeregisterSteward) fails after lookup and scope checks pass, the handler
+// returns 500 INTERNAL_ERROR and does NOT tombstone the record. Per CFGMS standards, the
+// error branch at handlers_stewards.go:681 must be covered, not just the happy path.
+func TestHandleDecommissionSteward_DurableStoreWriteFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not enforce POSIX directory permissions on Windows")
+	}
+	server := setupTestServer(t)
+	st, root := newTestStewardDurableStore(t)
+	server.SetStewardStore(st)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-decomm-writefail",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	// Induce a genuine durable-store write failure: make the flat-file store's backing
+	// directory read-only. The record was already written, so GetSteward (a pure read)
+	// still succeeds and the handler reaches DeregisterSteward, whose atomic write
+	// (temp-file creation in the directory) then fails with a permission error — the
+	// handler must surface a 500. Restore the mode on cleanup so t.TempDir() removal
+	// can delete the tree.
+	stewardDir := filepath.Join(root, "stewards")
+	require.NoError(t, os.Chmod(stewardDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(stewardDir, 0o750) })
+
+	rec := deleteDecommissionSteward(server, "s-decomm-writefail")
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "INTERNAL_ERROR", errResp.Error.Code)
+
+	// The tombstone must not have been persisted: restore write access and confirm the
+	// record is still Active (the failed write left durable state unchanged).
+	require.NoError(t, os.Chmod(stewardDir, 0o750))
+	got, err := st.GetSteward(context.Background(), "s-decomm-writefail")
+	require.NoError(t, err)
+	assert.Equal(t, business.StewardStatusActive, got.Status,
+		"record must remain Active when the durable tombstone write fails")
+}
+
 // ---- buildFleetFilter unit tests (no server required) ----
 
 func TestBuildFleetFilter_Empty(t *testing.T) {

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -21,6 +21,7 @@ var knownPermissions = map[string]bool{
 	"steward:read-modules":    true,
 	"steward:delete-config":   true,
 	"steward:move":            true,
+	"steward:decommission":    true,
 	// Config management
 	"config:list":             true,
 	"config:list-deployments": true,

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -462,7 +462,8 @@ func (s *Server) setupRouter() {
 	stewards.Handle("/{id}/dna", s.requirePermission("steward", "read-dna")(http.HandlerFunc(s.handleGetStewardDNA))).Methods("GET")
 	stewards.Handle("/{id}/logs", s.requirePermission("steward", "read-logs")(http.HandlerFunc(s.handleGetStewardLogs))).Methods("GET")
 	stewards.Handle("/{id}/auth/refresh", s.requirePermission("steward", "auth-refresh")(http.HandlerFunc(s.handleStewardAuthRefresh))).Methods("POST")
-	stewards.Handle("/{id}/move", s.requireTier(TierMTLSOnly)(s.requirePermission("steward", "move")(http.HandlerFunc(s.handleMoveSteward)))).Methods("POST") // Issue #2341: Tier-3 admin move-steward
+	stewards.Handle("/{id}/move", s.requireTier(TierMTLSOnly)(s.requirePermission("steward", "move")(http.HandlerFunc(s.handleMoveSteward)))).Methods("POST")              // Issue #2341: Tier-3 admin move-steward
+	stewards.Handle("/{id}", s.requireTier(TierMTLSOnly)(s.requirePermission("steward", "decommission")(http.HandlerFunc(s.handleDecommissionSteward)))).Methods("DELETE") // Issue #2408: Tier-3 steward decommission
 
 	// Configuration management endpoints
 	stewards.Handle("/{id}/config", s.requirePermission("steward", "read-config")(http.HandlerFunc(s.handleGetStewardConfig))).Methods("GET")

--- a/features/controller/api/tier_enforcement_test.go
+++ b/features/controller/api/tier_enforcement_test.go
@@ -43,7 +43,8 @@ var tier3RouteTable = []tier3RouteEntry{
 	{"POST", "/api/v1/tenants", "tenant:create"},
 	{"POST", "/api/v1/stewards/refresh/pending-123/approve", "refresh:approve"},
 	{"PUT", "/api/v1/tenants/test-tenant/refresh-policy", "refresh:set-policy"},
-	{"POST", "/api/v1/stewards/test-steward-id/move", "steward:move"}, // Issue #2341
+	{"POST", "/api/v1/stewards/test-steward-id/move", "steward:move"},      // Issue #2341
+	{"DELETE", "/api/v1/stewards/test-steward-id", "steward:decommission"}, // Issue #2408
 }
 
 // TestTier3Enforcement_APIKeyWithAdminPermissions_Gets403 verifies that an API-key

--- a/features/rbac/defaults.go
+++ b/features/rbac/defaults.go
@@ -44,6 +44,13 @@ var DefaultPermissions = []*common.Permission{
 		ResourceType: "steward",
 		Actions:      []string{"create", "read", "update", "delete"},
 	},
+	{
+		Id:           "steward.decommission",
+		Name:         "Decommission Steward",
+		Description:  "Permanently decommission a steward from the fleet (tombstones the record; requires mTLS)",
+		ResourceType: "steward",
+		Actions:      []string{"delete"},
+	},
 
 	// Configuration Management Permissions
 	{

--- a/test/integration/steward_controller_detailed_test.go
+++ b/test/integration/steward_controller_detailed_test.go
@@ -3,12 +3,34 @@
 package integration
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	controllerapi "github.com/cfgis/cfgms/features/controller/api"
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/test/integration/testutil"
 )
 
@@ -155,4 +177,143 @@ func (s *DetailedIntegrationTestSuite) TestErrorHandlingAndResilience() {
 
 func TestDetailedIntegration(t *testing.T) {
 	suite.Run(t, new(DetailedIntegrationTestSuite))
+}
+
+// newAdminPeerCert mints a self-signed client certificate carrying the CFGMS admin marker
+// extension. Injected into req.TLS.PeerCertificates, it makes extractAdminPrincipal produce
+// an admin principal. Chain verification is a TLS-layer concern (production uses
+// VerifyClientCertIfGiven + ClientCAs) and is intentionally not exercised here — the handler
+// under test only inspects the admin-marker extension.
+func newAdminPeerCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "integration-admin"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	cert.SetAdminMarker(tmpl)
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return parsed
+}
+
+// TestStewardDecommissionCycle_FullControllerStack exercises the complete steward
+// decommission cycle across the real controller REST stack (Issue #2408). A DELETE
+// /api/v1/stewards/{id} carried by an admin mTLS principal is driven through the production
+// router — authentication middleware → Tier-3 mTLS gate → permission check → handler — and
+// every effect is asserted against real providers (no mocks):
+//
+//  1. durable tombstone      — flat-file steward store record flips to "deregistered"
+//  2. in-memory status update — controller service record reflects "deregistered"
+//  3. audit                   — a high-severity steward.decommissioned event is written
+//
+// The active-connection drop (registry.Unregister on decommission) is owned by the
+// unit test TestHandleDecommissionSteward_RegistryConnectionDropped in the api package.
+// It is deliberately not re-exercised here: the decommission path never calls the
+// connection's transport sender, so a registry entry adds no full-stack coverage and
+// would require standing up a bespoke transport sender purely to satisfy the struct field.
+func TestStewardDecommissionCycle_FullControllerStack(t *testing.T) {
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+
+	// Real durable storage (flat-file steward + audit stores, in-memory SQLite for RBAC/tenant).
+	storageManager := pkgtesting.SetupTestStorage(t)
+
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(ctx))
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = rbacManager.Close(closeCtx)
+	})
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+
+	controllerService := service.NewControllerService(logger)
+	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
+
+	server, err := controllerapi.New(
+		cfg, logger, controllerService, configService, nil, rbacService,
+		nil, tenantManager, rbacManager,
+		nil, nil, nil, "", nil, auditMgr, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Close(closeCtx)
+	})
+
+	// Wire the durable fleet store.
+	stewardStore := storageManager.GetStewardStore()
+	require.NotNil(t, stewardStore, "OSS storage manager must provide a steward store")
+	server.SetStewardStore(stewardStore)
+
+	const stewardID = "s-decomm-integration"
+	const tenantID = "integration-tenant"
+
+	// Seed the durable and in-memory representations of a registered steward.
+	require.NoError(t, stewardStore.RegisterSteward(ctx, &business.StewardRecord{
+		ID:       stewardID,
+		TenantID: tenantID,
+		Status:   business.StewardStatusActive,
+	}))
+	require.NoError(t, controllerService.RegisterSteward(stewardID, tenantID, "10.0.0.5:7443", "active"))
+
+	// Drive the DELETE through the production router with an admin mTLS principal.
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/"+stewardID, nil)
+	req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{newAdminPeerCert(t)}}
+	rec := httptest.NewRecorder()
+	server.GetRouter().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "admin decommission must succeed: %s", rec.Body.String())
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data["id"])
+	assert.Equal(t, "deregistered", resp.Data["status"])
+
+	// (1) Durable tombstone — record retained, status flipped to deregistered.
+	got, err := stewardStore.GetSteward(ctx, stewardID)
+	require.NoError(t, err)
+	assert.Equal(t, business.StewardStatusDeregistered, got.Status, "durable record must be tombstoned")
+
+	// (2) In-memory status update — record retained for audit, status deregistered.
+	info, ok := controllerService.GetStewardInfo(stewardID)
+	require.True(t, ok, "in-memory record must still exist after decommission (retained for audit)")
+	assert.Equal(t, string(business.StewardStatusDeregistered), info.Status, "in-memory status must be deregistered")
+
+	// (3) Audit — a high-severity steward.decommissioned event is durably written.
+	require.NoError(t, auditMgr.Flush(ctx))
+	entries, err := auditMgr.QueryEntries(ctx, &business.AuditFilter{Actions: []string{"steward.decommissioned"}})
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "a steward.decommissioned audit entry must be written")
+	e := entries[0]
+	assert.Equal(t, business.AuditSeverityHigh, e.Severity)
+	assert.Equal(t, "steward", e.ResourceType)
+	assert.Equal(t, stewardID, e.ResourceID)
+	assert.Equal(t, business.AuditResultSuccess, e.Result)
 }


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/v1/stewards/{id}` (TierMTLSOnly / mTLS-only) that tombstones the fleet record with `status: deregistered` in durable storage
- Drops the steward's active QUIC/gRPC session via `registry.Unregister` immediately after the tombstone write
- Filters deregistered stewards from `GET /api/v1/stewards` by default; `?include_deregistered=true` restores them
- Adds `cfg steward decommission <id>` CLI command with matching flag set (url, api-key, tls-ca-cert, tls-insecure)
- Emits `steward.decommissioned` audit event at `AuditSeverityHigh` via `audit.NewEventBuilder`

## Test plan

- [x] `TestHandleDecommissionSteward_HappyPath` — 200, tombstone verified in real flat-file store
- [x] `TestHandleDecommissionSteward_APIKeyRejected` — 403 MTLS_REQUIRED via full router
- [x] `TestHandleDecommissionSteward_InvalidID` — 400 INVALID_STEWARD_ID
- [x] `TestHandleDecommissionSteward_NilStore` — 503 SERVICE_UNAVAILABLE
- [x] `TestHandleDecommissionSteward_NotFound` — 404 STEWARD_NOT_FOUND
- [x] `TestHandleDecommissionSteward_CrossTenant` — 404 (not 403) for out-of-scope steward
- [x] `TestHandleDecommissionSteward_AuditEmitted` — audit entry with correct action/severity/resource_type
- [x] `TestHandleDecommissionSteward_RegistryConnectionDropped` — registry.Count() decrements after decommission
- [x] `TestHandleDecommissionSteward_ExcludedFromList` — deregistered steward absent from default list response
- [x] `TestTier3Enforcement_RouteSetMatchesCanonicalSet` — DELETE /api/v1/stewards/{id} verified as Tier-3 gate (updated tier3RouteTable)
- [x] CLI decommission command tests in `cmd/cfg/cmd/steward_test.go`
- [x] `make test-agent-complete` — all gates pass, 5-platform cross-compile clean

Fixes #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)