### PR TITLE
tooling: route macOS stories to Linux dispatch (no macOS dev host)

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -74,21 +74,25 @@ def detect_required_env(env_section, labels):
     """Resolve a story's required execution environment from its `## Environment`
     section text and its GitHub labels. Label wins (explicit founder/Planning
     signal); body marker is the fallback that also works for label-less project
-    drafts. Defaults to "linux"."""
+    drafts. Defaults to "linux".
+
+    macOS is deliberately NOT a routing env: there is no macOS dev host, so
+    darwin-targeting stories (macOS launcher/.pkg, `manager_darwin.go`, etc.) are
+    written and cross-compiled on Linux and validated by CI's macOS runners.
+    `needs-macos` / a macos-mentioning `## Environment` therefore fall through to
+    the Linux default rather than parking forever for a host that will never
+    self-dispatch them. Windows routing stays (a real Windows host self-dispatches
+    those via §7)."""
     label_names = {
         ((l.get("name") if isinstance(l, dict) else l) or "").lower()
         for l in (labels or [])
     }
     if "needs-windows" in label_names:
         return "windows"
-    if "needs-macos" in label_names:
-        return "macos"
     if env_section:
         t = env_section.strip().lower()
         if "windows" in t:
             return "windows"
-        if "macos" in t or "darwin" in t:
-            return "macos"
     return DEFAULT_ENV
 
 
@@ -2087,9 +2091,9 @@ def main():
     out["host_caps"] = sorted(caps)
     # Ready stories whose required env this host cannot serve — surfaced so the
     # dashboard can show the cross-host backlog (e.g. the Windows queue) and so a
-    # self-dispatch host can pick up exactly its slice. Intentionally windows-only
-    # for now (macos routing is reserved — see the needs-macos label); add a
-    # parallel macos_queue here if/when a macOS host comes online.
+    # self-dispatch host can pick up exactly its slice. Windows-only by design:
+    # macOS is not a routing env (no macOS dev host — darwin stories dev on Linux
+    # + validate in CI, see detect_required_env), so there is no macos_queue.
     out["windows_queue"] = [
         {"number": s["number"], "item_id": s.get("item_id", ""), "title": s["title"]}
         for s in ready_parsed

--- a/.claude/scripts/tests/env_routing.test.sh
+++ b/.claude/scripts/tests/env_routing.test.sh
@@ -46,8 +46,9 @@ def check(desc, got, want):
 # ── detect_required_env: body section ──
 check("env body 'windows'", m.detect_required_env("windows", []), "windows")
 check("env body 'Windows 11 host'", m.detect_required_env("Windows 11 host", []), "windows")
-check("env body 'macos'", m.detect_required_env("macos", []), "macos")
-check("env body 'darwin' alias", m.detect_required_env("build on a darwin runner", []), "macos")
+# macOS is not a routing env — no macOS dev host; dev on Linux, validate in CI.
+check("env body 'macos' -> linux", m.detect_required_env("macos", []), "linux")
+check("env body 'darwin' alias -> linux", m.detect_required_env("build on a darwin runner", []), "linux")
 check("env body 'linux'", m.detect_required_env("linux", []), "linux")
 check("env body None -> linux", m.detect_required_env(None, []), "linux")
 check("env body empty -> linux", m.detect_required_env("", []), "linux")
@@ -55,7 +56,7 @@ check("env body empty -> linux", m.detect_required_env("", []), "linux")
 # ── detect_required_env: labels (dict and str forms), label wins ──
 check("label needs-windows (dict)", m.detect_required_env(None, [{"name": "needs-windows"}]), "windows")
 check("label needs-windows (str)", m.detect_required_env(None, ["needs-windows"]), "windows")
-check("label needs-macos", m.detect_required_env(None, [{"name": "needs-macos"}]), "macos")
+check("label needs-macos -> linux", m.detect_required_env(None, [{"name": "needs-macos"}]), "linux")
 check("label overrides linux body", m.detect_required_env("linux", [{"name": "needs-windows"}]), "windows")
 check("unrelated label -> linux", m.detect_required_env(None, [{"name": "story"}]), "linux")
 


### PR DESCRIPTION
## Problem

There is no macOS dev environment. But the PO preflight routed darwin-targeting stories (macOS launcher/.pkg install, `manager_darwin.go`, etc.) to a `macos` execution env that **no host serves** — the `macos_queue` was explicitly "reserved… if/when a macOS host comes online." Result: those stories parked forever (e.g. #2380 held every cron cycle with no path to dispatch).

## Fix

macOS stories are written and cross-compiled **on Linux** and validated by **CI's macOS runners** — they never need a macOS host. So `detect_required_env` no longer returns `"macos"`: a `needs-macos` label or a macos/darwin `## Environment` marker now falls through to the Linux default and dispatches normally.

**Windows routing is unchanged** — a real Windows host (CFG-70-02) self-dispatches those via §7. Dropped the stale reserved-`macos_queue` comment.

## Tests
- `env_routing.test.sh` updated: macos body / darwin alias / `needs-macos` label now assert `"linux"` — **23/23 pass**
- `py_compile` clean

## Effect
#2380 (and any future darwin story) becomes Linux-dispatchable on the next cron cycle instead of parking in a never-served queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzgEq4v2eUsKcFw92SkbmL