### PR TITLE
steward: wire macOS launcher-managed install (Issue #2380)

### DIFF
--- a/build/darwin/build-pkg.sh
+++ b/build/darwin/build-pkg.sh
@@ -107,6 +107,27 @@ else
     fi
 fi
 
+# ── Step 1b: Build the launcher binary ───────────────────────────────────────
+# The launcher must be bundled in the .pkg payload — Install() hard-fails when
+# it is absent, so we always build it inline (not from a pre-existing artifact).
+
+echo ""
+echo "Building cfgms-steward-launcher binary for darwin/$ARCH..."
+
+LAUNCHER_BUILD_DIR="$REPO_ROOT/bin/darwin-$ARCH"
+LAUNCHER_BUILD_PATH="$LAUNCHER_BUILD_DIR/cfgms-steward-launcher"
+mkdir -p "$LAUNCHER_BUILD_DIR"
+
+LAUNCHER_LD_FLAGS="-s -w -X github.com/cfgis/cfgms/pkg/version.Version=$VERSION"
+
+GOOS=darwin GOARCH="$ARCH" CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags "$LAUNCHER_LD_FLAGS" \
+    -o "$LAUNCHER_BUILD_PATH" \
+    "$REPO_ROOT/cmd/cfgms-steward-launcher"
+
+echo "  Launcher: $LAUNCHER_BUILD_PATH"
+
 # ── Step 2: Assemble the package payload ──────────────────────────────────────
 # pkgbuild expects a directory tree that mirrors the target filesystem.
 
@@ -121,9 +142,20 @@ SCRIPTS_DIR="$WORK_DIR/scripts"
 mkdir -p "$PAYLOAD_DIR/usr/local/bin"
 mkdir -p "$SCRIPTS_DIR"
 
-# Install the binary into the payload tree.
+# Install the steward binary into the payload tree.
 cp "$BINARY_PATH" "$PAYLOAD_DIR/usr/local/bin/cfgms-steward"
 chmod 755 "$PAYLOAD_DIR/usr/local/bin/cfgms-steward"
+
+# Install the launcher binary into the payload tree. This is required — Install()
+# hard-fails when the launcher is absent, so we fail loudly here rather than
+# producing a broken .pkg.
+if [[ ! -f "$LAUNCHER_BUILD_PATH" ]]; then
+    echo "ERROR: launcher binary not found after build: $LAUNCHER_BUILD_PATH" >&2
+    exit 1
+fi
+cp "$LAUNCHER_BUILD_PATH" "$PAYLOAD_DIR/usr/local/bin/cfgms-launcher"
+chmod 755 "$PAYLOAD_DIR/usr/local/bin/cfgms-launcher"
+echo "  Launcher payload: $PAYLOAD_DIR/usr/local/bin/cfgms-launcher"
 
 # Install stdlib module binaries into the payload tree.
 STDLIB_MODULES=(cfgms-module-file cfgms-module-service cfgms-module-package cfgms-module-script cfgms-module-firewall cfgms-module-patch)

--- a/cmd/steward/service/manager_darwin.go
+++ b/cmd/steward/service/manager_darwin.go
@@ -11,9 +11,24 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/cfgis/cfgms/pkg/version"
 )
 
 const (
+	// darwinLauncherPath is where the launcher binary is installed. The steward's
+	// push-upgrade handler execs "cfgms-launcher swap" at this exact path
+	// (features/steward/client launcherPath()), so a launcher-managed install is
+	// what makes a macOS steward upgradeable via the control plane. It must not change.
+	darwinLauncherPath = "/usr/local/bin/cfgms-launcher"
+	// darwinLauncherRoot is the launcher install root holding versions/ and
+	// state.json. Matches the launcher's defaultRoot() on macOS (non-Windows default).
+	darwinLauncherRoot = "/opt/cfgms"
+	// darwinLauncherBinaryName is the launcher binary as shipped in the install
+	// bundle, expected alongside the cfgms-steward binary being installed.
+	darwinLauncherBinaryName = "cfgms-steward-launcher"
+	// darwinInstallPath is the legacy bare-steward binary path. Retained only so
+	// Uninstall(purge) also cleans up pre-launcher (direct-service) installs.
 	darwinInstallPath = "/usr/local/bin/cfgms-steward"
 	darwinPlistPath   = "/Library/LaunchDaemons/com.cfgms.steward.plist"
 	darwinServiceName = "com.cfgms.steward"
@@ -41,9 +56,10 @@ func (m *darwinManager) IsElevated() bool {
 	return os.Getuid() == 0
 }
 
-// Install copies the binary to /usr/local/bin, writes the launchd plist, and
-// loads it via launchctl. If already installed, the existing daemon is unloaded
-// first, the binary replaced, then reloaded.
+// Install copies the launcher and steward to their installed locations, stages
+// the steward under the launcher's versioned layout, writes the launchd plist,
+// and loads it via launchctl. If already installed, the existing daemon is
+// unloaded first, the binaries are replaced, then the daemon is reloaded.
 //
 // When controllerURL is non-empty, it is embedded in ProgramArguments as
 // --controller-url. If caCertPEM is non-empty, the CA cert is written to the
@@ -61,6 +77,20 @@ func (m *darwinManager) Install(token, controllerURL, caCertPEM, expectedFingerp
 			return err
 		}
 	}
+
+	// A launcher-managed install (steward supervised by cfgms-launcher, staged
+	// under /opt/cfgms/versions/) is what makes the steward upgradeable via the
+	// control plane: the push-upgrade handler execs "cfgms-launcher swap" and
+	// requires the launcher at darwinLauncherPath. A bare direct-service steward
+	// cannot be push-upgraded. The launcher binary ships alongside the steward
+	// binary in the install bundle.
+	launcherSrc := filepath.Join(filepath.Dir(m.binaryPath), darwinLauncherBinaryName)
+	if _, err := os.Stat(launcherSrc); err != nil {
+		return fmt.Errorf("launcher binary %q not found next to the steward binary: %w\n"+
+			"  a launcher-managed install requires %s in the install bundle",
+			launcherSrc, err, darwinLauncherBinaryName)
+	}
+
 	if !m.IsElevated() {
 		return fmt.Errorf("install requires root privileges: re-run with sudo")
 	}
@@ -71,9 +101,20 @@ func (m *darwinManager) Install(token, controllerURL, caCertPEM, expectedFingerp
 		_ = exec.Command("launchctl", "unload", darwinPlistPath).Run()
 	}
 
-	fmt.Printf("Installing to %s...\n", darwinInstallPath)
-	if err := copyBinary(m.binaryPath, darwinInstallPath); err != nil {
-		return fmt.Errorf("failed to copy binary: %w", err)
+	ver := version.Short()
+
+	fmt.Printf("Installing launcher to %s...\n", darwinLauncherPath)
+	if err := copyBinary(launcherSrc, darwinLauncherPath); err != nil {
+		return fmt.Errorf("failed to install launcher: %w", err)
+	}
+
+	// Bootstrap the launcher layout: stage the steward binary as the current
+	// version under /opt/cfgms/versions/<ver>/ and record it in state.json. This
+	// reuses the launcher's own "swap" surface, so the on-disk layout is identical
+	// to what a subsequent push-upgrade produces.
+	fmt.Printf("Staging steward %s under %s...\n", ver, darwinLauncherRoot)
+	if out, err := exec.Command(darwinLauncherPath, "swap", "--root", darwinLauncherRoot, ver, m.binaryPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stage steward binary via launcher: %w\n%s", err, out)
 	}
 
 	// Write CA cert before loading the daemon so the service finds it on first start.
@@ -103,7 +144,8 @@ func (m *darwinManager) Install(token, controllerURL, caCertPEM, expectedFingerp
 }
 
 // Uninstall unloads and removes the launchd daemon. If purge is true the
-// installed binary is also removed.
+// installed launcher binary and its versioned staging layout are also removed,
+// along with the legacy bare-steward binary for pre-launcher installs.
 func (m *darwinManager) Uninstall(purge bool) error {
 	if !m.IsElevated() {
 		return fmt.Errorf("uninstall requires root privileges: re-run with sudo")
@@ -122,6 +164,20 @@ func (m *darwinManager) Uninstall(purge bool) error {
 	}
 
 	if purge {
+		// Launcher binary + layout (versions/, state.json) for launcher-managed installs.
+		if _, err := os.Stat(darwinLauncherPath); err == nil {
+			fmt.Printf("Removing %s...\n", darwinLauncherPath)
+			if err := os.Remove(darwinLauncherPath); err != nil {
+				return fmt.Errorf("failed to remove launcher: %w", err)
+			}
+		}
+		if _, err := os.Stat(darwinLauncherRoot); err == nil {
+			fmt.Printf("Removing %s...\n", darwinLauncherRoot)
+			if err := os.RemoveAll(darwinLauncherRoot); err != nil {
+				return fmt.Errorf("failed to remove launcher root: %w", err)
+			}
+		}
+		// Legacy bare-steward binary (pre-launcher direct-service installs).
 		if _, err := os.Stat(darwinInstallPath); err == nil {
 			fmt.Printf("Removing %s...\n", darwinInstallPath)
 			if err := os.Remove(darwinInstallPath); err != nil {
@@ -139,7 +195,7 @@ func (m *darwinManager) Uninstall(purge bool) error {
 func (m *darwinManager) Status() (*ServiceStatus, error) {
 	status := &ServiceStatus{
 		ServiceName: darwinServiceName,
-		InstallPath: darwinInstallPath,
+		InstallPath: darwinLauncherPath,
 	}
 
 	// Installed if the plist exists.
@@ -157,18 +213,21 @@ func (m *darwinManager) Status() (*ServiceStatus, error) {
 }
 
 // generateLaunchdPlist returns a macOS launchd plist for the steward daemon.
-// When controllerURL is non-empty, --controller-url is added to ProgramArguments.
+// When controllerURL is non-empty, --controller-url is appended to childArgs.
+// The launcher supervises the steward and forwards --child-args to it.
 // KeepAlive ensures the daemon restarts on exit; RunAtLoad starts it immediately.
 //
 // Security note: the token appears in the plist (readable by root only for
 // LaunchDaemons). The token is a one-time registration credential — after
 // first registration the steward authenticates via mTLS certificates.
 func generateLaunchdPlist(token, controllerURL string) string {
-	urlArgs := ""
+	// The launcher supervises the steward and forwards --child-args to it. Args
+	// are space-separated (the launcher splits on whitespace); the registration
+	// token is validated to be free of spaces/quotes, so no per-arg quoting is
+	// needed inside the child-args string.
+	childArgs := fmt.Sprintf(`--regtoken %s`, token)
 	if controllerURL != "" {
-		urlArgs = fmt.Sprintf(`
-    <string>--controller-url</string>
-    <string>%s</string>`, controllerURL)
+		childArgs += fmt.Sprintf(` --controller-url %s`, controllerURL)
 	}
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -180,8 +239,11 @@ func generateLaunchdPlist(token, controllerURL string) string {
   <key>ProgramArguments</key>
   <array>
     <string>%s</string>
-    <string>--regtoken</string>
-    <string>%s</string>%s
+    <string>run</string>
+    <string>--root</string>
+    <string>%s</string>
+    <string>--child-args</string>
+    <string>%s</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -198,5 +260,5 @@ func generateLaunchdPlist(token, controllerURL string) string {
   <string>/var/log/cfgms-steward.log</string>
 </dict>
 </plist>
-`, darwinServiceName, darwinInstallPath, token, urlArgs)
+`, darwinServiceName, darwinLauncherPath, darwinLauncherRoot, childArgs)
 }

--- a/cmd/steward/service/manager_darwin_test.go
+++ b/cmd/steward/service/manager_darwin_test.go
@@ -19,7 +19,7 @@ func TestDarwinManagerInstallPath(t *testing.T) {
 	m := New("/usr/local/bin/cfgms-steward")
 	status, err := m.Status()
 	require.NoError(t, err)
-	assert.Equal(t, darwinInstallPath, status.InstallPath)
+	assert.Equal(t, darwinLauncherPath, status.InstallPath)
 }
 
 func TestDarwinManagerIsElevated(t *testing.T) {
@@ -32,7 +32,15 @@ func TestDarwinManagerInstallRequiresElevation(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("skipping elevation check — running as root")
 	}
-	m := New("/usr/local/bin/cfgms-steward")
+	dir := t.TempDir()
+	// Create both the steward binary and launcher so the check advances past the
+	// launcher-present gate and reaches the elevation check.
+	binaryPath := filepath.Join(dir, "cfgms-steward")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("binary"), 0755))
+	launcherPath := filepath.Join(dir, darwinLauncherBinaryName)
+	require.NoError(t, os.WriteFile(launcherPath, []byte("launcher"), 0755))
+
+	m := New(binaryPath)
 	err := m.Install("tok_test123", "", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "root")
@@ -74,6 +82,23 @@ func TestDarwinInstallCACertWritten(t *testing.T) {
 	assert.Equal(t, os.FileMode(0444), info.Mode().Perm(), "CA cert must be written with mode 0444 per ADR-013 §3")
 }
 
+// TestDarwinInstallMissingLauncher is the REQUIRED TEST for fail-closed behaviour:
+// Install() must return a clear, actionable error and perform no daemon registration
+// when the launcher binary is absent next to binaryPath.
+func TestDarwinInstallMissingLauncher(t *testing.T) {
+	dir := t.TempDir()
+	// Write only the steward binary — deliberately omit the launcher binary.
+	binaryPath := filepath.Join(dir, "cfgms-steward")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("binary"), 0755))
+
+	m := New(binaryPath)
+	err := m.Install("tok_test123", "", "", "")
+	require.Error(t, err)
+	// Error must name the missing binary and the bundle requirement.
+	assert.Contains(t, err.Error(), "launcher binary")
+	assert.Contains(t, err.Error(), darwinLauncherBinaryName)
+}
+
 func TestDarwinManagerUninstallRequiresElevation(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("skipping elevation check — running as root")
@@ -89,7 +114,7 @@ func TestDarwinManagerStatusNotInstalled(t *testing.T) {
 	status, err := m.Status()
 	require.NoError(t, err)
 	assert.Equal(t, darwinServiceName, status.ServiceName)
-	assert.Equal(t, darwinInstallPath, status.InstallPath)
+	assert.Equal(t, darwinLauncherPath, status.InstallPath)
 	if _, statErr := os.Stat(darwinPlistPath); os.IsNotExist(statErr) {
 		assert.False(t, status.Installed)
 		assert.False(t, status.Running)
@@ -102,7 +127,15 @@ func TestGenerateLaunchdPlist(t *testing.T) {
 
 	assert.Contains(t, plist, "<?xml")
 	assert.Contains(t, plist, darwinServiceName)
-	assert.Contains(t, plist, darwinInstallPath)
+	// Launcher-managed: ProgramArguments runs the launcher, which supervises the
+	// steward and forwards the token via --child-args. This is what makes the
+	// steward push-upgradeable.
+	assert.Contains(t, plist, darwinLauncherPath)
+	assert.Contains(t, plist, "run")
+	assert.Contains(t, plist, "--root")
+	assert.Contains(t, plist, darwinLauncherRoot)
+	assert.Contains(t, plist, "--child-args")
+	assert.NotContains(t, plist, darwinInstallPath+" --regtoken", "ProgramArguments must run the launcher, not the bare steward")
 	assert.Contains(t, plist, "--regtoken")
 	assert.Contains(t, plist, token)
 	assert.Contains(t, plist, "<key>KeepAlive</key>")
@@ -151,4 +184,31 @@ func TestGenerateLaunchdPlistSetsLogDir(t *testing.T) {
 	assert.Contains(t, plist, "<key>CFGMS_LOG_DIR</key>")
 	assert.Contains(t, plist, "<string>/usr/local/var/log/cfgms</string>",
 		"launchd plist must set the platform-conventional log directory")
+}
+
+// TestDarwinLauncherPathParity is the REQUIRED TEST for path parity: darwinLauncherPath
+// must equal the literal non-Windows-default path in client_transport_upgrade.go's
+// launcherPath(), guarding against silent drift between install-time and push-upgrade
+// runtime.
+func TestDarwinLauncherPathParity(t *testing.T) {
+	assert.Equal(t, "/usr/local/bin/cfgms-launcher", darwinLauncherPath,
+		"darwinLauncherPath must match the non-Windows default used by push-upgrade (client_transport_upgrade.go launcherPath())")
+}
+
+// TestDarwinLauncherBinaryPermissions is the REQUIRED TEST for LPE hardening:
+// the launcher binary is installed via copyBinary which sets root-owned 0750
+// (owner rwx, group rx, no world access) — a standard user cannot replace the
+// binary a root daemon execs.
+func TestDarwinLauncherBinaryPermissions(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "cfgms-steward-launcher-src")
+	require.NoError(t, os.WriteFile(src, []byte("launcher content"), 0600))
+
+	dst := filepath.Join(t.TempDir(), "cfgms-launcher")
+	require.NoError(t, copyBinary(src, dst))
+
+	info, err := os.Stat(dst)
+	require.NoError(t, err)
+	// 0750: owner rwx (service binary), group rx (service group), no world access
+	assert.Equal(t, os.FileMode(0750), info.Mode().Perm(),
+		"launcher binary must be installed with 0750 to prevent standard-user replacement")
 }


### PR DESCRIPTION
## Summary

- Wire `darwinManager.Install()` to the same launcher-managed model already shipped on Linux: install the bundled `cfgms-steward-launcher` to `/usr/local/bin/cfgms-launcher`, stage the steward via `launcher swap --root /opt/cfgms`, and configure launchd to exec the launcher (not the bare steward), making the daemon push-upgradeable via the control plane
- `generateLaunchdPlist()` ProgramArguments now invoke `[darwinLauncherPath, "run", "--root", darwinLauncherRoot, "--child-args", "..."]` instead of the bare steward binary
- `Uninstall(purge=true)` removes the launcher binary and versioned staging layout under `/opt/cfgms`; `build/darwin/build-pkg.sh` builds the launcher inline and hard-fails if absent, ensuring no broken `.pkg` is produced

Fixes #2380

## Specialist Review Results

- **Acceptance Checker**: PASS — all AC references verified against working tree (path parity, fail-closed, LPE hardening, plist ProgramArguments, build-pkg.sh payload)
- **Code Reviewer**: PASS — no blocking issues; two low-severity warnings (missing `--root`/`darwinLauncherRoot` plist assertions, addressed in fix; purge paths follow same untestable-without-root pattern as the Linux reference)
- **Security Engineer**: PASS — no blocking issues; automated scans (gitleaks, gosec, check-architecture) clean; three low-severity informational notes about `controllerURL` whitespace (accepted pattern identical to Linux reference), a comment accuracy nit, and the pre-existing 0644 plist mode

## Test plan

- [ ] `GOOS=darwin go test -c ./cmd/steward/service/` compiles cleanly
- [ ] `make test-agent-complete` passes (linux unit/integration/cross-platform compile)
- [ ] CI: unit-tests, integration-tests, Build Gate, security-deployment-gate
- [ ] New required tests present: `TestDarwinInstallMissingLauncher`, `TestDarwinLauncherPathParity`, `TestDarwinLauncherBinaryPermissions`
- [ ] `TestGenerateLaunchdPlist` asserts `NotContains(darwinInstallPath+" --regtoken")` and `Contains(darwinLauncherPath, "--root", darwinLauncherRoot, "--child-args")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)