### PR TITLE
hyperv: declarative VM storage location via live Move-VMStorage (Issue #2411)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -154,18 +154,54 @@ failover.
 > `ErrInvalidHARoleSeedDir`. Set `seed_dir` to a per-node path such as
 > `C:\ProgramData\cfgms\seed`.
 
-> **VM configuration files must also be on cluster storage.** `New-VM` places
-> the VM's configuration files at the host default (the local system drive)
-> unless told otherwise, and `Add-ClusterVirtualMachineRole` refuses a VM whose
-> configuration lives on non-clustered storage — the promote then fails each
-> converge with *"The clustered role was not successfully created"* (the module
-> retries convergently; the error is in the steward log with the cluster report
-> path). The module does not yet expose a VM configuration-path setting, so for
-> a VM that will carry `ha_role`, either provision it with everything on the
-> CSV or move it once with
-> `Move-VMStorage <vm> -DestinationStoragePath C:\ClusterStorage\<csv>\<vm>` —
-> the next converge completes the registration (verified live on cfg-lab,
-> #2372).
+> **VM configuration files must also be on cluster storage** —
+> `Add-ClusterVirtualMachineRole` refuses a VM whose configuration lives on
+> non-clustered storage. Since #2411 this is satisfied **by config alone**: the
+> directory of the declared `vhd_path` is the VM's storage home (see
+> *Declarative storage location* below), so a VM declared with a CSV `vhd_path`
+> plus `ha_role` is created with its configuration files on the CSV and reaches
+> clustered-role membership with **zero operator steps**. A pre-existing VM
+> whose configuration sits elsewhere converges the same way: the module detects
+> the location drift and performs a live storage migration, then completes the
+> registration on a subsequent converge.
+
+### Declarative storage location (#2411)
+
+The directory containing the declared `vhd_path` is the VM's **home** — its
+configuration files, checkpoints, smart-paging files, and virtual disks all
+belong there. There is no separate config key:
+
+- **Create:** `New-VM` receives `-Path <dir(vhd_path)>` and the create path
+  homes the configuration files at exactly `dir(vhd_path)` — a fresh VM starts
+  with zero location drift.
+- **Converge:** changing `vhd_path`'s directory on an existing VM (or a VM
+  whose configuration files sit outside the home) starts a **live,
+  non-destructive `Move-VMStorage`** migration: configuration + checkpoints +
+  smart paging + all attached disks, each landing at `home\<its current file
+  name>` — for the primary disk that is exactly the declared `vhd_path` in the
+  normal case where the file name matches. The move works on running and
+  stopped VMs; the VM is **never stopped, deleted, or recreated** by this path.
+- **Async:** the migration can run for minutes-to-hours, so it is dispatched as
+  a detached process and tracked through a durable move record (the #2371
+  record machinery). Converge cycles observing an in-flight move are cheap
+  no-ops (never a duplicate dispatch); completion is judged by re-observing the
+  VM's location; a move in flight survives a steward restart.
+- **Safety:** a free-space preflight on the destination volume (CSV mounts
+  resolved) fails the move loudly *before* dispatch when the disks won't fit.
+  A failed or interrupted migration leaves the VM running at its original
+  location (Hyper-V semantics), surfaces the error on the record, and the next
+  converge retries — bounded to one attempt per converge cycle.
+- **Observed state:** `Get`/DNA report the VM's configuration-file location as
+  `configuration_location` (observed-only; the desired location is always
+  derived from `vhd_path`).
+
+Limitations: location convergence is **directory-level** — `Move-VMStorage`
+refuses a destination whose file name differs from the source, so renaming a
+VHD file via `vhd_path` does not converge (recreate or rename out-of-band
+instead; a checkpointed VM's current `.avhdx` likewise keeps its name and
+moves directory-wise). Cross-host migration (`Move-VM` between cluster nodes)
+and per-disk differential placement (multiple VHDs on different volumes) are
+out of scope; secondary disks follow the primary into the home directory.
 
 ### Create an external virtual switch
 

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -80,6 +80,12 @@ type hypervModule struct {
 	// WithProvisionStore.
 	provisionStore ProvisionStore
 
+	// fallbackMoveStore backs the storage-location move records (#2411) when
+	// provisionStore does not implement MoveStore (both in-repo stores do; this
+	// exists so a custom ProvisionStore cannot panic the move path). Lazily
+	// created by moveStore().
+	fallbackMoveStore *memProvisionStore
+
 	// profileStore loads unattended-install profiles referenced as
 	// profile://<name> in a VM source (ADR-009 §7). It is wired from the
 	// controller's stored-config backend in Configure() when a "config_store"

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -73,7 +73,16 @@ behavioral_envelope:
     Remove-ClusterAccess (grant/revoke a node computer account's cluster-management
     access) — a PRIVILEGED, controller-orchestrated action tied to node lifecycle,
     NOT reachable from routine cluster cfg convergence (a lateral-movement
-    primitive). All arguments travel via
+    primitive). The VM STORAGE-LOCATION cmdlets (#2411) are: Move-VMStorage
+    (live, non-destructive storage migration homing a VM's configuration files
+    and disks at the directory of its declared vhd_path — a synchronous
+    config-only move at create, and a converge-time full migration dispatched
+    as a DETACHED powershell.exe -File process because the migration outlives
+    the executor's per-module-call deadline; directory-level, file names never
+    change; tracked on a durable move record, never a stop/delete/recreate)
+    and Get-Volume (read-only free-space preflight on the destination volume
+    before any migration is dispatched).
+    All arguments travel via
     ArgumentList (never string-composed). Cluster FORMATION cmdlets
     (New-Cluster, Add-ClusterNode, Remove-ClusterNode, quorum) are NOT declared
     and out of scope. This envelope change requires ADR-006 module re-signing

--- a/features/modules/hyperv/provision.go
+++ b/features/modules/hyperv/provision.go
@@ -64,16 +64,21 @@ type ProvisionStore interface {
 	ListProvisions(ctx context.Context) ([]*ProvisionRecord, error)
 }
 
-// memProvisionStore is a thread-safe in-memory ProvisionStore for tests.
+// memProvisionStore is a thread-safe in-memory ProvisionStore (and MoveStore —
+// see vm_storage.go) for tests.
 type memProvisionStore struct {
 	mu      sync.RWMutex
 	records map[string]*ProvisionRecord
+	moves   map[string]*MoveRecord
 }
 
 // NewMemProvisionStore returns a new in-memory ProvisionStore suitable for
 // tests and as a no-op placeholder when the hyperv feature is not configured.
 func NewMemProvisionStore() *memProvisionStore {
-	return &memProvisionStore{records: make(map[string]*ProvisionRecord)}
+	return &memProvisionStore{
+		records: make(map[string]*ProvisionRecord),
+		moves:   make(map[string]*MoveRecord),
+	}
 }
 
 func (s *memProvisionStore) GetProvision(_ context.Context, vmName string) (*ProvisionRecord, error) {

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -39,13 +39,16 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 	case psGetVM:
 		return t.run(ctx, "Cfgms-GetVM -Name "+quoteArg(psArgs, "Name"))
 	case psCreateVM:
+		// -Path is optional (#2411): the VM home (dir(vhd_path)); omitted when
+		// no vhd_path directory is derivable so New-VM keeps the host default.
 		return t.run(ctx,
 			"Cfgms-CreateVM -Name "+quoteArg(psArgs, "Name")+
 				" -MemoryMB "+intArg(psArgs, "MemoryMB")+
 				" -CPU "+intArg(psArgs, "CPU")+
 				" -VHDPath "+quoteArg(psArgs, "VHDPath")+
 				" -SwitchName "+quoteArg(psArgs, "SwitchName")+
-				" -Generation "+intArg(psArgs, "Generation"))
+				" -Generation "+intArg(psArgs, "Generation")+
+				optArg(psArgs, "Path", "Path"))
 	case psRemoveVM:
 		return t.run(ctx, "Cfgms-RemoveVM -Name "+quoteArg(psArgs, "Name"))
 	case psStartVM:
@@ -143,13 +146,41 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 				" -CPU "+intArg(psArgs, "CPU")+
 				" -VHDPath "+quoteArg(psArgs, "VHDPath")+
 				" -SwitchName "+quoteArg(psArgs, "SwitchName")+
-				" -Generation "+intArg(psArgs, "Generation"))
+				" -Generation "+intArg(psArgs, "Generation")+
+				optArg(psArgs, "Path", "Path"))
 	case psSetHddFirstBoot:
 		// runFresh: Set-VMFirmware -FirstBootDevice referencing a disk deadlocks
 		// in the persistent host (same as Cfgms-SetDVDFirstBoot).
 		return t.runFresh(ctx,
 			"Cfgms-SetHddFirstBoot -Name "+quoteArg(psArgs, "Name")+
 				" -VHDPath "+quoteArg(psArgs, "VHDPath"))
+
+	// ── VM storage location (#2411) ──────────────────────────────────
+	case psSetVMHome:
+		// runFresh: Move-VMStorage engages the storage-migration service —
+		// async storage ops deadlock in the persistent -Command - host.
+		return t.runFresh(ctx,
+			"Cfgms-SetVMHome -Name "+quoteArg(psArgs, "Name")+
+				" -VMHome "+quoteArg(psArgs, "Home"))
+	case psVMStorageMovePreflight:
+		// runFresh: Get-Volume is a Storage-module cmdlet (same family as the
+		// seed-disk ops that deadlock in the persistent host).
+		return t.runFresh(ctx,
+			"Cfgms-VMStorageMovePreflight -Name "+quoteArg(psArgs, "Name")+
+				" -DestDir "+quoteArg(psArgs, "DestDir"))
+	case psMoveVMStorage:
+		// runDetached: the live migration can run for minutes-to-hours; the
+		// module call must return as soon as the migration process starts
+		// (executor per-call deadline, ADR-012 §7). The MoveRecord is the
+		// source of truth for "started"; failure surfaces via the error
+		// marker probed by Cfgms-GetVMMoveError.
+		return t.runDetached(
+			"Cfgms-MoveVMStorage -Name " + quoteArg(psArgs, "Name") +
+				" -VMHome " + quoteArg(psArgs, "Home"))
+	case psGetVMMoveError:
+		return t.run(ctx, "Cfgms-GetVMMoveError -Name "+quoteArg(psArgs, "Name"))
+	case psClearVMMoveError:
+		return t.run(ctx, "Cfgms-ClearVMMoveError -Name "+quoteArg(psArgs, "Name"))
 
 	// ── VM network reconcile (declarative multi-NIC, #2021) ──────────
 	case psConnectVMNic:

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -59,7 +59,8 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 			" -CPU " + intArg(psArgs, "CPU") +
 			" -VHDPath " + quoteArg(psArgs, "VHDPath") +
 			" -SwitchName " + quoteArg(psArgs, "SwitchName") +
-			" -Generation " + intArg(psArgs, "Generation"))
+			" -Generation " + intArg(psArgs, "Generation") +
+			optArg(psArgs, "Path", "Path"))
 	case psNewSeedVHD:
 		return emit("Cfgms-NewSeedVHD -Path " + quoteArg(psArgs, "Path") +
 			" -SizeBytes " + intArg(psArgs, "SizeBytes"))
@@ -90,7 +91,21 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 			" -CPU " + intArg(psArgs, "CPU") +
 			" -VHDPath " + quoteArg(psArgs, "VHDPath") +
 			" -SwitchName " + quoteArg(psArgs, "SwitchName") +
-			" -Generation " + intArg(psArgs, "Generation"))
+			" -Generation " + intArg(psArgs, "Generation") +
+			optArg(psArgs, "Path", "Path"))
+	case psSetVMHome:
+		return emit("Cfgms-SetVMHome -Name " + quoteArg(psArgs, "Name") +
+			" -VMHome " + quoteArg(psArgs, "Home"))
+	case psVMStorageMovePreflight:
+		return emit("Cfgms-VMStorageMovePreflight -Name " + quoteArg(psArgs, "Name") +
+			" -DestDir " + quoteArg(psArgs, "DestDir"))
+	case psMoveVMStorage:
+		return emit("Cfgms-MoveVMStorage -Name " + quoteArg(psArgs, "Name") +
+			" -VMHome " + quoteArg(psArgs, "Home"))
+	case psGetVMMoveError:
+		return emit("Cfgms-GetVMMoveError -Name " + quoteArg(psArgs, "Name"))
+	case psClearVMMoveError:
+		return emit("Cfgms-ClearVMMoveError -Name " + quoteArg(psArgs, "Name"))
 	case psSetHddFirstBoot:
 		return emit("Cfgms-SetHddFirstBoot -Name " + quoteArg(psArgs, "Name") +
 			" -VHDPath " + quoteArg(psArgs, "VHDPath"))
@@ -295,6 +310,55 @@ func TestPSDispatch_VMVerbs(t *testing.T) {
 			psCommand: psSetVMMemory,
 			psArgs:    map[string]string{"Name": "cfgms-t__web-01", "MemoryMB": "8192"},
 			want:      "Cfgms-SetVMMemory -Name 'cfgms-t__web-01' -MemoryMB 8192",
+		},
+		{
+			// #2411: -Path (the VM home, dir(vhd_path)) rides New-VM as an
+			// optional arg so config files start co-located with the disk.
+			name:      "New-VM with home Path",
+			psCommand: psCreateVM,
+			psArgs: map[string]string{
+				"Name":       "cfgms-t__web-01",
+				"MemoryMB":   "4096",
+				"CPU":        "4",
+				"VHDPath":    "C:\\VMs\\web-01\\web-01.vhdx",
+				"SwitchName": "External",
+				"Generation": "2",
+				"Path":       "C:\\VMs\\web-01",
+			},
+			want: "Cfgms-CreateVM -Name 'cfgms-t__web-01' -MemoryMB 4096 -CPU 4 -VHDPath 'C:\\VMs\\web-01\\web-01.vhdx' -SwitchName 'External' -Generation 2 -Path 'C:\\VMs\\web-01'",
+		},
+		{
+			// #2411: the create-time config-only home move. NOTE the parameter is
+			// -VMHome (the Go psArgs key is "Home"): $Home is a read-only PowerShell
+			// automatic variable and cannot be a function parameter name.
+			name:      "SetVMHome",
+			psCommand: psSetVMHome,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01", "Home": "C:\\VMs\\web-01"},
+			want:      "Cfgms-SetVMHome -Name 'cfgms-t__web-01' -VMHome 'C:\\VMs\\web-01'",
+		},
+		{
+			name:      "VMStorageMovePreflight",
+			psCommand: psVMStorageMovePreflight,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01", "DestDir": "C:\\ClusterStorage\\CSV01\\web-01"},
+			want:      "Cfgms-VMStorageMovePreflight -Name 'cfgms-t__web-01' -DestDir 'C:\\ClusterStorage\\CSV01\\web-01'",
+		},
+		{
+			name:      "MoveVMStorage",
+			psCommand: psMoveVMStorage,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01", "Home": "C:\\ClusterStorage\\CSV01\\web-01"},
+			want:      "Cfgms-MoveVMStorage -Name 'cfgms-t__web-01' -VMHome 'C:\\ClusterStorage\\CSV01\\web-01'",
+		},
+		{
+			name:      "GetVMMoveError",
+			psCommand: psGetVMMoveError,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01"},
+			want:      "Cfgms-GetVMMoveError -Name 'cfgms-t__web-01'",
+		},
+		{
+			name:      "ClearVMMoveError",
+			psCommand: psClearVMMoveError,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01"},
+			want:      "Cfgms-ClearVMMoveError -Name 'cfgms-t__web-01'",
 		},
 		{
 			name:      "Connect-VMNic",
@@ -532,6 +596,14 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		// Failover cluster write verbs (cluster.go, #2202 S2)
 		{"psAddClusterVMRole", psAddClusterVMRole, map[string]string{"ClusterName": "lab-hv", "VMName": "web-01"}},
 		{"psRemoveClusterResource", psRemoveClusterResource, map[string]string{"Name": "web-01"}},
+		// VM storage location verbs (vm_storage.go, #2411)
+		{"psCreateVM/homePath", psCreateVM, map[string]string{"Name": "cfgms-t__web-01", "MemoryMB": "1024", "CPU": "1", "VHDPath": "C:\\VMs\\w\\test.vhdx", "SwitchName": "sw", "Generation": "2", "Path": "C:\\VMs\\w"}},
+		{"psCreateVMFromDisk/homePath", psCreateVMFromDisk, map[string]string{"Name": "cfgms-t__web-01", "MemoryMB": "2048", "CPU": "2", "VHDPath": "C:\\VMs\\w\\web-01.vhdx", "SwitchName": "External", "Generation": "2", "Path": "C:\\VMs\\w"}},
+		{"psSetVMHome", psSetVMHome, map[string]string{"Name": "cfgms-t__web-01", "Home": "C:\\VMs\\w"}},
+		{"psVMStorageMovePreflight", psVMStorageMovePreflight, map[string]string{"Name": "cfgms-t__web-01", "DestDir": "C:\\ClusterStorage\\CSV01\\w"}},
+		{"psMoveVMStorage", psMoveVMStorage, map[string]string{"Name": "cfgms-t__web-01", "Home": "C:\\ClusterStorage\\CSV01\\w"}},
+		{"psGetVMMoveError", psGetVMMoveError, map[string]string{"Name": "cfgms-t__web-01"}},
+		{"psClearVMMoveError", psClearVMMoveError, map[string]string{"Name": "cfgms-t__web-01"}},
 	}
 
 	for _, tc := range commands {

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -68,6 +68,10 @@ function Cfgms-GetVM {
         ProcessorCount     = [int]$vm.ProcessorCount
         Generation         = [int]$vm.Generation
         Path               = if ($disk) { $disk.Path } else { '' }
+        # The VM's configuration-file directory (#2411). Observed state for the
+        # declarative storage-location convergence: the desired location is
+        # always dir(vhd_path), so config files anywhere else are drift.
+        ConfigurationLocation = [string]$vm.ConfigurationLocation
         SwitchName         = if ($switchNames.Count -gt 0) { $switchNames[0] } else { '' }
         SwitchNames        = $switchNames
         State              = $vm.State.ToString()
@@ -89,6 +93,11 @@ function Cfgms-CreateVM {
         # so it is mandatory here; a missing value is a dispatcher bug, not a
         # silent default.
         [Parameter(Mandatory)][int]$Generation,
+        # Optional VM home directory (#2411) — dir(vhd_path). When set, New-VM
+        # receives it as -Path so the configuration files start co-located with
+        # the disk (New-VM appends a VM-name subfolder; the Go create path
+        # follows with Cfgms-SetVMHome to land at exactly the home).
+        [string]$Path = '',
         # Optional — defaults to a 64 GB dynamic VHD. The schema currently
         # doesn't expose vhd_size_gb so the Go dispatcher never passes one;
         # 64 GB matches the Hyper-V Manager default and is fine for any test
@@ -99,7 +108,9 @@ function Cfgms-CreateVM {
     # New-VM does NOT accept -ProcessorCount (real PS pitfall — surfaced by
     # PR #1912 live B1 bucket). Create with default 1 vCPU, then resize via
     # Set-VMProcessor only when the operator asked for something different.
-    New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes ($VHDSizeGB * 1GB) -SwitchName $SwitchName -Generation $Generation | Out-Null
+    $vmArgs = @{}
+    if ($Path) { $vmArgs['Path'] = $Path }
+    New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes ($VHDSizeGB * 1GB) -SwitchName $SwitchName -Generation $Generation @vmArgs | Out-Null
     if ($CPU -ne 1) {
         Set-VMProcessor -VMName $Name -Count $CPU
     }
@@ -116,9 +127,13 @@ function Cfgms-CreateVMFromDisk {
         [Parameter(Mandatory)][int]$CPU,
         [Parameter(Mandatory)][string]$VHDPath,
         [Parameter(Mandatory)][string]$SwitchName,
-        [Parameter(Mandatory)][int]$Generation
+        [Parameter(Mandatory)][int]$Generation,
+        # Optional VM home directory (#2411) — see Cfgms-CreateVM.
+        [string]$Path = ''
     )
-    New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -VHDPath $VHDPath -SwitchName $SwitchName -Generation $Generation | Out-Null
+    $vmArgs = @{}
+    if ($Path) { $vmArgs['Path'] = $Path }
+    New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -VHDPath $VHDPath -SwitchName $SwitchName -Generation $Generation @vmArgs | Out-Null
     if ($CPU -ne 1) {
         Set-VMProcessor -VMName $Name -Count $CPU
     }
@@ -481,6 +496,126 @@ function Cfgms-BootKeypress {
         if ($kb) { $kb.TypeKey(0x20) | Out-Null }
         Start-Sleep -Milliseconds 400
     }
+}
+
+# ── VM storage location (#2411) ────────────────────────────────────────
+# Declarative VM home: the directory of the declared vhd_path holds the VM's
+# configuration files AND its disks. Cfgms-SetVMHome is the synchronous
+# config-only move used at create; Cfgms-MoveVMStorage is the full live
+# migration, run INSIDE a detached process (dispatched via the Go transport's
+# runDetached — the executor's per-module-call deadline forbids holding a
+# module call open for a multi-minute migration). Failure is surfaced through
+# a per-VM error marker under ProgramData that the converge loop probes;
+# completion is judged by re-observing the location, never by job objects.
+
+# Cfgms-VMMoveErrFile composes the per-VM move error-marker path. $Name is
+# validated upstream against ^[a-zA-Z0-9_\-]{1,64}$ so it is filename-safe.
+function Cfgms-VMMoveErrFile {
+    param([Parameter(Mandatory)][string]$Name)
+    return (Join-Path $env:ProgramData ('cfgms\hyperv\move-' + $Name + '.err'))
+}
+
+# Cfgms-SetVMHome homes the VM's configuration files (config + checkpoints +
+# smart paging; disks are NOT touched) at exactly $VMHome. New-VM -Path appends
+# a VM-name subfolder (verified live on cfg-lab 2026-07-07), so the create path
+# always follows New-VM with this move; on a fresh VM it is a KB-scale rename
+# that completes well within the module-call deadline. Dispatched via runFresh
+# (storage-migration service; the persistent -Command - host deadlocks on
+# async storage operations).
+function Cfgms-SetVMHome {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$VMHome)
+    Move-VMStorage -VMName $Name -VirtualMachinePath $VMHome -SnapshotFilePath $VMHome -SmartPagingFilePath $VMHome
+}
+
+# Cfgms-VMStorageMovePreflight reports the bytes required to move the VM's
+# disks into $DestDir vs the destination volume's free bytes, as JSON. Only
+# disks whose directory differs from $DestDir are counted — disks already at
+# the destination do not move (the #2372 shape: disks manually moved to CSV,
+# config still local, must not demand disk-sized free space for a KB-scale
+# config move). free_bytes is -1 when the volume cannot be resolved; the Go
+# caller proceeds and lets the move itself surface a real failure. Get-Volume
+# -FilePath resolves CSV mounts (C:\ClusterStorage\...) directly (verified
+# live); the walk-up finds the deepest existing ancestor since the destination
+# directory may not exist yet.
+function Cfgms-VMStorageMovePreflight {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$DestDir)
+    $required = [long]0
+    foreach ($d in @(Get-VMHardDiskDrive -VMName $Name)) {
+        if ((Split-Path -Path $d.Path -Parent).TrimEnd('\') -ine $DestDir.TrimEnd('\')) {
+            $required += (Get-Item -LiteralPath $d.Path).Length
+        }
+    }
+    $probe = $DestDir
+    while ($probe -and -not (Test-Path -LiteralPath $probe)) { $probe = Split-Path -Path $probe -Parent }
+    $free = [long]-1
+    if ($probe) {
+        $vol = Get-Volume -FilePath $probe -ErrorAction SilentlyContinue
+        if ($vol) { $free = [long]$vol.SizeRemaining }
+    }
+    ConvertTo-Json @{ required_bytes = $required; free_bytes = $free } -Compress
+}
+
+# Cfgms-MoveVMStorage performs the full live storage migration: configuration,
+# checkpoints, smart paging, and every attached disk whose directory is not
+# already $VMHome — each disk lands at $VMHome\<its current leaf> (DIRECTORY-
+# level convergence: Hyper-V refuses a -Vhds destination whose file name
+# differs from the source — "the source and destination file names must
+# match", surfaced live by a checkpointed VM whose current disk is an .avhdx —
+# so file names are never changed here). -DestinationStoragePath is
+# deliberately NOT used: it drops disks into a "Virtual Hard Disks" subfolder,
+# which would never converge the declared vhd_path (verified live on cfg-lab
+# 2026-07-07). This function runs INSIDE the detached process (runDetached);
+# on failure it writes the error marker the converge loop probes via
+# Cfgms-GetVMMoveError.
+function Cfgms-MoveVMStorage {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$VMHome
+    )
+    $errFile = Cfgms-VMMoveErrFile -Name $Name
+    New-Item -ItemType Directory -Force -Path (Split-Path -Path $errFile -Parent) | Out-Null
+    try {
+        $vhds = @()
+        foreach ($d in @(Get-VMHardDiskDrive -VMName $Name)) {
+            # The [string] casts are REQUIRED: PSObject-wrapped property values
+            # inside the -Vhds hashtables fail Move-VMStorage's validation with
+            # a misleading "Hash tables in the Vhds parameter must contain
+            # 'DestinationFilePath' key" error even though the key is present
+            # (root-caused live on cfg-lab 2026-07-07).
+            $src = [string]$d.Path
+            $dest = [string](Join-Path $VMHome ([string](Split-Path -Path $src -Leaf)))
+            if ($src -ine $dest) {
+                $vhds += @{ SourceFilePath = $src; DestinationFilePath = $dest }
+            }
+        }
+        if ($vhds.Count -gt 0) {
+            Move-VMStorage -VMName $Name -VirtualMachinePath $VMHome -SnapshotFilePath $VMHome -SmartPagingFilePath $VMHome -Vhds $vhds
+        } else {
+            Move-VMStorage -VMName $Name -VirtualMachinePath $VMHome -SnapshotFilePath $VMHome -SmartPagingFilePath $VMHome
+        }
+    } catch {
+        Set-Content -LiteralPath $errFile -Value $_.Exception.Message
+        throw
+    }
+}
+
+# Cfgms-GetVMMoveError reads the per-VM move error marker as JSON ({"error":""}
+# when no failure is recorded).
+function Cfgms-GetVMMoveError {
+    param([Parameter(Mandatory)][string]$Name)
+    $errFile = Cfgms-VMMoveErrFile -Name $Name
+    $text = ''
+    if (Test-Path -LiteralPath $errFile) {
+        $text = [string](Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue)
+    }
+    ConvertTo-Json @{ error = $text.Trim() } -Compress
+}
+
+# Cfgms-ClearVMMoveError removes a stale error marker before a (re)dispatch so
+# a prior failure is never misattributed to the new attempt. Idempotent.
+function Cfgms-ClearVMMoveError {
+    param([Parameter(Mandatory)][string]$Name)
+    Remove-Item -LiteralPath (Cfgms-VMMoveErrFile -Name $Name) -Force -ErrorAction SilentlyContinue
 }
 
 # ── VSwitch read + lifecycle ──────────────────────────────────────────

--- a/features/modules/hyperv/pstransport_windows.go
+++ b/features/modules/hyperv/pstransport_windows.go
@@ -261,6 +261,56 @@ func (t *psHostTransport) runFresh(ctx context.Context, expression string) (stri
 	return string(out), nil
 }
 
+// runDetached launches a single Cfgms-* expression in a DETACHED fresh
+// powershell.exe -File process and returns as soon as the process has
+// started — it never waits for completion. This is REQUIRED for the live
+// storage migration (Cfgms-MoveVMStorage): the move can run for minutes to
+// hours, far past the executor's per-module-call deadline (ADR-012 §7), so
+// the module call must not hold it open. The MoveRecord written by the Go
+// caller is the source of truth for "started"; the detached function writes
+// a per-VM error marker on failure, and completion is judged by the converge
+// loop re-observing the VM's location.
+//
+// The temp script is preamble + expression, exactly like runFresh, with a
+// trailing self-delete (Go cannot remove the file while the child holds it
+// open; PowerShell parses the whole script before executing, so the script
+// deleting itself on its last line is safe). A background goroutine reaps
+// the process handle and removes the script if the self-delete never ran
+// (e.g. a parse-stage failure). No ctx: cancelling the dispatching call must
+// not kill an already-started migration — Windows children outlive their
+// parent, which is also what lets the move survive a steward restart.
+func (t *psHostTransport) runDetached(expression string) (string, error) {
+	f, err := os.CreateTemp("", "cfgms-moveop-*.ps1")
+	if err != nil {
+		return "", fmt.Errorf("hyperv-ps-host: create temp move script: %w", err)
+	}
+	tmpPath := f.Name()
+	body := psHostPreamble + "\n" + expression + "\n" +
+		"Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue\n"
+	if _, werr := io.WriteString(f, body); werr != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("hyperv-ps-host: write temp move script: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("hyperv-ps-host: close temp move script: %w", cerr)
+	}
+
+	cmd := exec.Command("powershell.exe",
+		"-NoProfile", "-NonInteractive", "-File", tmpPath,
+	) //#nosec G204 -- fixed flags; the temp script path is generated, not user-supplied
+	if serr := cmd.Start(); serr != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("hyperv-ps-host: start detached move process: %w", serr)
+	}
+	go func() {
+		_ = cmd.Wait()
+		_ = os.Remove(tmpPath) // no-op when the script already self-deleted
+	}()
+	return "", nil
+}
+
 func (t *psHostTransport) run(_ context.Context, expression string) (string, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/features/modules/hyperv/schema.yaml
+++ b/features/modules/hyperv/schema.yaml
@@ -18,7 +18,16 @@ resources:
         minimum: 1
       vhd_path:
         type: string
-        description: Absolute Windows path to the VHD/VHDX file (e.g. C:\\VMs\\disk.vhdx)
+        description: >
+          Absolute Windows path to the VHD/VHDX file (e.g.
+          C:\\VMs\\disk.vhdx). The containing directory is the VM's storage
+          HOME (#2411): configuration files, checkpoints, smart-paging files,
+          and all attached disks belong there. Creation places everything at
+          the home; changing the directory on an existing VM converges via a
+          live, non-destructive Move-VMStorage migration (async, tracked on a
+          durable move record; the VM is never stopped or recreated).
+          Directory-level only — changing just the file name does not converge
+          (Move-VMStorage ignores renames).
       switch_name:
         description: >
           The VM's FULL desired network, declared on the VM. Accepts either a

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -155,6 +155,14 @@ type VMConfig struct {
 	// (non-HA) resource with unchanged behavior.
 	HARole *HARoleConfig `yaml:"ha_role,omitempty"`
 
+	// ConfigLocation is the OBSERVED configuration-file location (Hyper-V
+	// ConfigurationLocation), populated by getVM and exposed on the Get/DNA
+	// surface. It is never declared in config — the desired location is always
+	// derived as dir(vhd_path) (the VM's home, #2411) — so it is deliberately
+	// absent from GetManagedFields to keep the executor's comparison free of
+	// false drift.
+	ConfigLocation string `yaml:"configuration_location,omitempty"`
+
 	// seedDir is the module-level provisioning seed directory (m.seedDir),
 	// injected by setVM before Validate so the HA-role CSV seed-dir rule can be
 	// checked. It is NOT a per-VM YAML field (seed_dir is module-level config) —
@@ -473,6 +481,9 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 		"generation":   c.Generation,
 		"state":        c.State,
 		"source":       nil,
+		// Observed-only (#2411): reported for the Get/DNA surface, absent from
+		// GetManagedFields so it never participates in drift comparison.
+		"configuration_location": c.ConfigLocation,
 	}
 	if c.Source != nil {
 		m["source"] = map[string]interface{}{
@@ -551,7 +562,7 @@ func (c *VMConfig) GetManagedFields() []string {
 // VMConfig.VHDPath stores the disk path; conflating it with the config
 // directory caused #1887 B1 verification to flag 2-changed drift on
 // every successful create.
-const psGetVM = `$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue; if (-not $vm) { Write-Output '{"found":false}'; return }; $adapters = @(Get-VMNetworkAdapter -VMName $Name -ErrorAction SilentlyContinue); $switchNames = @($adapters | ForEach-Object { $_.SwitchName } | Where-Object { $_ }); $disk = Get-VMHardDiskDrive -VMName $Name -ErrorAction SilentlyContinue | Select-Object -First 1; $mem = Get-VMMemory -VMName $Name -ErrorAction SilentlyContinue; $startupBytes = if ($mem) { [long]$mem.Startup } else { 0 }; $result = @{ found=$true; Name=$vm.Name; MemoryStartupBytes=$startupBytes; ProcessorCount=[int]$vm.ProcessorCount; Generation=[int]$vm.Generation; Path=if ($disk) { $disk.Path } else { "" }; SwitchName=if ($switchNames.Count -gt 0) { $switchNames[0] } else { "" }; SwitchNames=$switchNames; State=$vm.State.ToString() }; ConvertTo-Json $result -Compress -Depth 4`
+const psGetVM = `$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue; if (-not $vm) { Write-Output '{"found":false}'; return }; $adapters = @(Get-VMNetworkAdapter -VMName $Name -ErrorAction SilentlyContinue); $switchNames = @($adapters | ForEach-Object { $_.SwitchName } | Where-Object { $_ }); $disk = Get-VMHardDiskDrive -VMName $Name -ErrorAction SilentlyContinue | Select-Object -First 1; $mem = Get-VMMemory -VMName $Name -ErrorAction SilentlyContinue; $startupBytes = if ($mem) { [long]$mem.Startup } else { 0 }; $result = @{ found=$true; Name=$vm.Name; MemoryStartupBytes=$startupBytes; ProcessorCount=[int]$vm.ProcessorCount; Generation=[int]$vm.Generation; Path=if ($disk) { $disk.Path } else { "" }; ConfigurationLocation=[string]$vm.ConfigurationLocation; SwitchName=if ($switchNames.Count -gt 0) { $switchNames[0] } else { "" }; SwitchNames=$switchNames; State=$vm.State.ToString() }; ConvertTo-Json $result -Compress -Depth 4`
 
 // psCreateVM is the script block passed to ExecutePS for VM creation.
 // All user-supplied values are transmitted via ArgumentList — none are
@@ -573,7 +584,12 @@ const psGetVM = `$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue; if (-no
 //     ADR-009 §5 supports Gen1 and Gen2 VMs (the seed VHDX boots on both,
 //     no floppy needed). setVM passes cfg.Generation (defaulting to 2 when
 //     0). The value travels via ArgumentList as a bare integer literal.
-const psCreateVM = `New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes 64GB -SwitchName $SwitchName -Generation $Generation | Out-Null; if ($CPU -ne 1) { Set-VMProcessor -VMName $Name -Count $CPU }`
+//   - -Path is passed via a splat guard: when $Path is non-empty the VM's
+//     configuration files start under dir(vhd_path) rather than the host
+//     default on the system drive (#2411). New-VM appends a VM-name
+//     subfolder to -Path, so createVM follows with a config-only
+//     Move-VMStorage (psSetVMHome) to land at exactly the declared home.
+const psCreateVM = `$vmArgs = @{}; if ($Path) { $vmArgs['Path'] = $Path }; New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes 64GB -SwitchName $SwitchName -Generation $Generation @vmArgs | Out-Null; if ($CPU -ne 1) { Set-VMProcessor -VMName $Name -Count $CPU }`
 
 // psRemoveVM deletes a VM. Hyper-V refuses to remove a VM that is not Off
 // ("the operation cannot be performed while the object is in its current
@@ -674,6 +690,11 @@ func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, err
 	}
 	if v, ok := parsed["Path"].(string); ok {
 		cfg.VHDPath = v
+	}
+	// ConfigurationLocation is the VM's configuration-file directory (#2411).
+	// Observed-only: the desired location is derived as dir(vhd_path).
+	if v, ok := parsed["ConfigurationLocation"].(string); ok {
+		cfg.ConfigLocation = v
 	}
 	// Adapter-reported switch names are the exact names admins specified; the
 	// drift comparison is name vs name with no translation.
@@ -781,6 +802,11 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 			if err := m.provisionStore.DeleteProvision(ctx, vmName); err != nil && !errors.Is(err, ErrProvisionNotFound) {
 				return err
 			}
+		}
+		// Delete any storage-move record (#2411) so a later same-named VM
+		// starts clean rather than inheriting an in-flight/failed move.
+		if err := m.moveStore().DeleteMove(ctx, vmName); err != nil && !errors.Is(err, ErrMoveNotFound) {
+			return err
 		}
 		return nil
 	}
@@ -1110,6 +1136,13 @@ func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cf
 		generation = 2
 	}
 
+	// home is the VM's storage home — the directory of the declared vhd_path
+	// (#2411). New-VM receives it as -Path so the configuration files start
+	// co-located with the disk; because New-VM appends a VM-name subfolder to
+	// -Path, a config-only Move-VMStorage follows the create to land the
+	// configuration at exactly the home (zero location drift on a fresh VM).
+	home := vmHomeDir(cfg.VHDPath)
+
 	psArgs := map[string]string{
 		"Name":       hostName,
 		"MemoryMB":   fmt.Sprintf("%d", cfg.MemoryMB),
@@ -1117,6 +1150,7 @@ func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cf
 		"VHDPath":    cfg.VHDPath,
 		"SwitchName": cfg.SwitchName,
 		"Generation": fmt.Sprintf("%d", generation),
+		"Path":       home,
 	}
 
 	cfgResourceID := "vm:" + vmName
@@ -1148,6 +1182,11 @@ func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cf
 		if psErr != nil {
 			return fmt.Errorf("hyperv: create VM %q from cloud image: %w", vmName, psErr)
 		}
+		if home != "" {
+			if err := m.execSetVMHome(ctx, cfgResourceID, hostName, home); err != nil {
+				return err
+			}
+		}
 		return m.connectAdditionalNics(ctx, cfgResourceID, vmName, hostName, cfg)
 	}
 
@@ -1155,6 +1194,12 @@ func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cf
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", cfgResourceID, nil, after, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: create VM %q: %w", vmName, psErr)
+	}
+
+	if home != "" {
+		if err := m.execSetVMHome(ctx, cfgResourceID, hostName, home); err != nil {
+			return err
+		}
 	}
 
 	return m.connectAdditionalNics(ctx, cfgResourceID, vmName, hostName, cfg)
@@ -1178,6 +1223,20 @@ func (m *hypervModule) connectAdditionalNics(ctx context.Context, cfgResourceID,
 // CPU/memory resize when the desired values differ from current.
 func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string, desired, current *VMConfig, state string) error {
 	cfgResourceID := "vm:" + vmName
+
+	// Storage-location convergence (#2411) runs FIRST: an ha_role registration
+	// on a mislocated VM fails (Add-ClusterVirtualMachineRole refuses a VM whose
+	// configuration files are off cluster storage), and power/resize actions are
+	// deferred while a live move is in flight. proceed=false means a move was
+	// started or is in flight — the rest of this cycle is a cheap no-op and the
+	// lifecycle resumes once the location converges.
+	proceed, err := m.convergeStorageLocation(ctx, vmName, hostName, desired, current)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
+	}
 
 	// Reconcile the VM's network adapters to the desired switch set before any
 	// power-state change. Add-VMNetworkAdapter / Remove-VMNetworkAdapter both

--- a/features/modules/hyperv/vm_storage.go
+++ b/features/modules/hyperv/vm_storage.go
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+)
+
+// ── Declarative VM storage location (#2411) ───────────────────────────────────
+//
+// The directory containing the declared vhd_path is the VM's home: the VM's
+// configuration files AND its virtual disk both belong there. Creation places
+// everything at the home (New-VM -Path + a config-only Move-VMStorage, because
+// New-VM unconditionally appends a VM-name subfolder to -Path — verified live
+// on cfg-lab 2026-07-07). Location drift on an existing VM converges via a
+// live, non-destructive Move-VMStorage.
+//
+// The converge move is ASYNC: the executor's per-module-call deadline
+// (ADR-012 §7) would kill a multi-minute storage migration mid-flight, so the
+// module dispatches the migration as a detached PowerShell process and tracks
+// it through a durable MoveRecord (#2371 record machinery). Converge cycles
+// that observe an in-flight record are cheap no-ops; completion is judged by
+// re-observing the location, never by parsing migration-job objects.
+//
+// Location convergence is DIRECTORY-level: Move-VMStorage silently ignores a
+// -Vhds destination whose only difference is the file name (verified live), so
+// renaming a VHD via vhd_path is not supported — only its directory converges.
+
+// ── Provisioning PS verb constants ────────────────────────────────────────────
+//
+// Like the ADR-009 §5 provisioning verbs in vm_provision.go, these are
+// platform-neutral dispatch keys: the Windows ps-host transport
+// (pstransport_dispatch_windows.go) pattern-matches them to their Cfgms-*
+// preamble functions; the recording transport in tests records them verbatim.
+// All user-controlled values travel via PS function parameters — never
+// interpolated into script text.
+const (
+	// psSetVMHome homes a VM's configuration files (config + checkpoints +
+	// smart paging, NOT disks) at exactly $Home via a synchronous config-only
+	// Move-VMStorage. Used at create time, where the config files are KB-scale
+	// and the move completes well within the module-call deadline.
+	psSetVMHome = `Cfgms-SetVMHome`
+
+	// psVMStorageMovePreflight reports the bytes required to move the VM's
+	// disks into $DestDir vs the free bytes on the destination volume, as JSON
+	// {"required_bytes":N,"free_bytes":M}. free_bytes is -1 when the
+	// destination volume cannot be resolved.
+	psVMStorageMovePreflight = `Cfgms-VMStorageMovePreflight`
+
+	// psMoveVMStorage dispatches the full live storage migration (config +
+	// checkpoints + smart paging + all attached disks, each landing at
+	// $Home\<its current leaf> — directory-level; Hyper-V refuses file-name
+	// changes in a move) as a DETACHED process. The module call returns as
+	// soon as the migration process has started; the MoveRecord is the source
+	// of truth for "started".
+	psMoveVMStorage = `Cfgms-MoveVMStorage`
+
+	// psGetVMMoveError reads the error marker the detached migration writes on
+	// failure, as JSON {"error":"..."} ("" when no failure is recorded).
+	psGetVMMoveError = `Cfgms-GetVMMoveError`
+
+	// psClearVMMoveError removes a stale error marker before a (re)dispatch so
+	// a prior failure is never misattributed to the new attempt.
+	psClearVMMoveError = `Cfgms-ClearVMMoveError`
+)
+
+// moveStallTimeout bounds how long an in-flight move record is trusted without
+// observable completion or a surfaced error. A move interrupted by a host
+// reboot leaves the VM at its original location (Hyper-V semantics) with no
+// error marker; once StartedAt is older than this bound the record is failed
+// loudly and the next converge may retry. Sized for multi-hundred-GB disks on
+// spinning storage; lab-scale moves complete in minutes.
+const moveStallTimeout = 4 * time.Hour
+
+// MoveState is the lifecycle position of an async VM storage migration.
+type MoveState string
+
+const (
+	// MoveStateMoving marks a dispatched, in-flight storage migration.
+	MoveStateMoving MoveState = "moving"
+	// MoveStateFailed marks a migration that failed (preflight, dispatch, or
+	// surfaced error) — the next converge cycle may retry, bounded to one
+	// attempt per cycle.
+	MoveStateFailed MoveState = "failed"
+)
+
+// ErrMoveNotFound is returned when no move record exists for a VM.
+var ErrMoveNotFound = errors.New("hyperv: move record not found")
+
+// MoveRecord tracks an in-flight (or failed) storage-location migration for a
+// VM. It is JSON-serialisable and persisted through the durable record store
+// (#2371) so a move in flight across a steward restart is re-observed, never
+// re-dispatched blindly.
+type MoveRecord struct {
+	VMName    string    `json:"vm_name"`
+	State     MoveState `json:"state"`
+	DestDir   string    `json:"dest_dir"`
+	StartedAt time.Time `json:"started_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	LastError string    `json:"last_error,omitempty"`
+}
+
+// MoveStore is the persistence surface for VM storage-move records. Both
+// in-repo ProvisionStore implementations (in-memory and flatfile-durable)
+// implement it; move records live in a keyspace separate from provision
+// records so the two lifecycles never collide.
+type MoveStore interface {
+	GetMove(ctx context.Context, vmName string) (*MoveRecord, error)
+	SetMove(ctx context.Context, record *MoveRecord) error
+	DeleteMove(ctx context.Context, vmName string) error
+}
+
+// moveStore returns the MoveStore backing this module: the provision store
+// when it implements MoveStore (both in-repo stores do — the factory-wired
+// flatfile store makes records durable), else a module-local in-memory
+// fallback so a custom ProvisionStore cannot panic the move path.
+func (m *hypervModule) moveStore() MoveStore {
+	if m.provisionStore == nil {
+		m.provisionStore = NewMemProvisionStore()
+	}
+	if ms, ok := m.provisionStore.(MoveStore); ok {
+		return ms
+	}
+	if m.fallbackMoveStore == nil {
+		m.fallbackMoveStore = NewMemProvisionStore()
+	}
+	return m.fallbackMoveStore
+}
+
+// vmHomeDir returns the directory containing a declared vhd_path — the VM's
+// home. Computed with Windows path semantics (split on \ or /) rather than
+// filepath.Dir, which mangles always-Windows Hyper-V paths on a non-Windows
+// steward or CI host (same rationale as seedVHDPath, Issue #2044). Returns ""
+// when the path has no directory component.
+func vmHomeDir(vhdPath string) string {
+	i := strings.LastIndexAny(vhdPath, `\/`)
+	if i < 0 {
+		return ""
+	}
+	return strings.TrimRight(vhdPath[:i], `\/`)
+}
+
+// sameWindowsPath reports whether two Windows paths refer to the same
+// location: case-insensitive, separator-insensitive (\ vs /), trailing
+// separators ignored. Empty paths never match anything.
+func sameWindowsPath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	norm := func(p string) string {
+		p = strings.ReplaceAll(p, "/", `\`)
+		return strings.TrimRight(p, `\`)
+	}
+	return strings.EqualFold(norm(a), norm(b))
+}
+
+// storageLocationDrift reports whether the observed VM state has its storage
+// outside the declared home directory: the configuration-file location (when
+// the host reports one) or the primary disk's directory differing from home is
+// drift. home == "" (no vhd_path declared) never drifts.
+func storageLocationDrift(current *VMConfig, home string) bool {
+	if home == "" {
+		return false
+	}
+	if current.ConfigLocation != "" && !sameWindowsPath(current.ConfigLocation, home) {
+		return true
+	}
+	if current.VHDPath != "" && !sameWindowsPath(vmHomeDir(current.VHDPath), home) {
+		return true
+	}
+	return false
+}
+
+// convergeStorageLocation drives the declarative storage-location convergence
+// for an existing VM. Returns proceed=true when the rest of the apply cycle
+// (network, ha_role, power state) should continue — i.e. the location is
+// converged. When a move is started or in flight it returns proceed=false so
+// the cycle defers everything else (an ha_role registration on a mislocated VM
+// fails; power transitions resume once the location converges).
+//
+// The decision tree, per converge cycle:
+//
+//	no drift            → clear any lingering record; proceed.
+//	drift + no record   → preflight, dispatch detached move, record moving.
+//	drift + moving      → completed-at-old-dest → clear record, start new move;
+//	                      error marker surfaced → record failed, loud error;
+//	                      stalled past moveStallTimeout → record failed, loud;
+//	                      otherwise → cheap no-op (never a duplicate dispatch).
+//	drift + failed      → retry: one new attempt this cycle.
+func (m *hypervModule) convergeStorageLocation(ctx context.Context, vmName, hostName string, desired, current *VMConfig) (bool, error) {
+	home := vmHomeDir(desired.VHDPath)
+	if home == "" {
+		return true, nil
+	}
+
+	store := m.moveStore()
+	record, err := store.GetMove(ctx, vmName)
+	if err != nil && !errors.Is(err, ErrMoveNotFound) {
+		return false, fmt.Errorf("hyperv: read move record for VM %q: %w", vmName, err)
+	}
+	if errors.Is(err, ErrMoveNotFound) {
+		record = nil
+	}
+
+	if !storageLocationDrift(current, home) {
+		// Converged. A lingering record (the move that produced this state, or
+		// one obsoleted by a config change) is complete — clear it.
+		if record != nil {
+			if dErr := store.DeleteMove(ctx, vmName); dErr != nil && !errors.Is(dErr, ErrMoveNotFound) {
+				return false, fmt.Errorf("hyperv: clear completed move record for VM %q: %w", vmName, dErr)
+			}
+			if logger, ok := m.GetLogger(); ok {
+				logger.Info("hyperv: storage move complete; VM at declared home",
+					"vm_name", logging.SanitizeLogValue(vmName),
+					"home", logging.SanitizeLogValue(home))
+			}
+		}
+		return true, nil
+	}
+
+	if record != nil && record.State == MoveStateMoving {
+		// The declared home may have changed while a previous move was in
+		// flight: a VM observed at the RECORDED destination means that move
+		// completed — clear it and start the move to the new home below.
+		if !storageLocationDrift(current, record.DestDir) {
+			if dErr := store.DeleteMove(ctx, vmName); dErr != nil && !errors.Is(dErr, ErrMoveNotFound) {
+				return false, fmt.Errorf("hyperv: clear superseded move record for VM %q: %w", vmName, dErr)
+			}
+			record = nil
+		} else {
+			// In flight. Surface a failure the detached migration recorded;
+			// otherwise this cycle is a cheap no-op — never a second dispatch.
+			moveErr, pErr := m.probeMoveError(ctx, hostName)
+			if pErr != nil {
+				return false, pErr
+			}
+			if moveErr != "" {
+				return false, m.failMove(ctx, vmName, record, fmt.Errorf("hyperv: storage move for VM %q failed: %s", vmName, moveErr))
+			}
+			if time.Since(record.StartedAt) > moveStallTimeout {
+				return false, m.failMove(ctx, vmName, record, fmt.Errorf(
+					"hyperv: storage move for VM %q did not complete within %s (interrupted move leaves the VM at its original location); will retry", vmName, moveStallTimeout))
+			}
+			if logger, ok := m.GetLogger(); ok {
+				logger.Info("hyperv: storage move in flight; waiting (no duplicate dispatch)",
+					"vm_name", logging.SanitizeLogValue(vmName),
+					"dest", logging.SanitizeLogValue(record.DestDir))
+			}
+			return false, nil
+		}
+	}
+
+	// Drift with no in-flight record (fresh, failed-retry, or superseded):
+	// one attempt this cycle. Preflight the destination's free space BEFORE
+	// dispatching — a move that cannot fit must fail loudly without starting.
+	required, free, pfErr := m.moveSpacePreflight(ctx, hostName, home)
+	if pfErr != nil {
+		return false, m.failMove(ctx, vmName, ensureMoveRecord(record, vmName, home), pfErr)
+	}
+	if free >= 0 && free < required {
+		return false, m.failMove(ctx, vmName, ensureMoveRecord(record, vmName, home), fmt.Errorf(
+			"hyperv: insufficient space on destination volume for VM %q storage move: need %d bytes, %d free at %q", vmName, required, free, home))
+	}
+
+	// Clear any stale error marker so a prior failure is never misattributed
+	// to this attempt, then dispatch the detached live migration.
+	if _, psErr := m.transport.ExecutePS(ctx, psClearVMMoveError, map[string]string{"Name": hostName}); psErr != nil {
+		return false, m.failMove(ctx, vmName, ensureMoveRecord(record, vmName, home), fmt.Errorf("hyperv: clear move error marker for VM %q: %w", vmName, psErr))
+	}
+	before := map[string]interface{}{"configuration_location": current.ConfigLocation}
+	after := map[string]interface{}{"configuration_location": home}
+	_, psErr := m.transport.ExecutePS(ctx, psMoveVMStorage, map[string]string{
+		"Name": hostName,
+		"Home": home,
+	})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Move-VMStorage", "vm:"+vmName, before, after, psErr)
+	if psErr != nil {
+		return false, m.failMove(ctx, vmName, ensureMoveRecord(record, vmName, home), fmt.Errorf("hyperv: dispatch storage move for VM %q: %w", vmName, psErr))
+	}
+
+	now := time.Now().UTC()
+	newRecord := &MoveRecord{
+		VMName:    vmName,
+		State:     MoveStateMoving,
+		DestDir:   home,
+		StartedAt: now,
+		UpdatedAt: now,
+	}
+	if sErr := store.SetMove(ctx, newRecord); sErr != nil {
+		return false, fmt.Errorf("hyperv: persist move record for VM %q: %w", vmName, sErr)
+	}
+	if logger, ok := m.GetLogger(); ok {
+		logger.Info("hyperv: live storage move dispatched",
+			"vm_name", logging.SanitizeLogValue(vmName),
+			"home", logging.SanitizeLogValue(home))
+	}
+	return false, nil
+}
+
+// ensureMoveRecord returns the existing record, or a fresh one for vmName →
+// destDir when none exists yet, so failures before the first dispatch still
+// land on a record.
+func ensureMoveRecord(record *MoveRecord, vmName, destDir string) *MoveRecord {
+	if record != nil {
+		return record
+	}
+	now := time.Now().UTC()
+	return &MoveRecord{
+		VMName:    vmName,
+		State:     MoveStateFailed,
+		DestDir:   destDir,
+		StartedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// failMove records the failure on the move record (state=failed, LastError
+// set), persists it, emits a structured log event, and returns the cause so
+// the caller surfaces it loudly.
+func (m *hypervModule) failMove(ctx context.Context, vmName string, record *MoveRecord, cause error) error {
+	record.State = MoveStateFailed
+	record.UpdatedAt = time.Now().UTC()
+	if cause != nil {
+		record.LastError = cause.Error()
+	}
+	// Persist best-effort; the original cause is the error we surface.
+	_ = m.moveStore().SetMove(ctx, record)
+	if logger, ok := m.GetLogger(); ok {
+		logger.Warn("hyperv: storage move failed",
+			"vm_name", logging.SanitizeLogValue(vmName),
+			"dest", logging.SanitizeLogValue(record.DestDir))
+	}
+	return cause
+}
+
+// moveSpacePreflight asks the host how many bytes the VM's disks require at
+// destDir vs the destination volume's free bytes. free == -1 means the volume
+// could not be resolved; the caller proceeds (the move itself surfaces a real
+// failure) rather than blocking on a probe gap.
+func (m *hypervModule) moveSpacePreflight(ctx context.Context, hostName, destDir string) (required, free int64, err error) {
+	output, psErr := m.transport.ExecutePS(ctx, psVMStorageMovePreflight, map[string]string{
+		"Name":    hostName,
+		"DestDir": destDir,
+	})
+	if psErr != nil {
+		return 0, 0, fmt.Errorf("hyperv: storage move preflight for VM %q: %w", hostName, psErr)
+	}
+	var parsed struct {
+		RequiredBytes int64 `json:"required_bytes"`
+		FreeBytes     int64 `json:"free_bytes"`
+	}
+	if jErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jErr != nil {
+		return 0, 0, fmt.Errorf("hyperv: parse storage move preflight for VM %q: %w", hostName, jErr)
+	}
+	return parsed.RequiredBytes, parsed.FreeBytes, nil
+}
+
+// probeMoveError reads the error marker the detached migration process writes
+// on failure. An empty string means no failure has been recorded.
+func (m *hypervModule) probeMoveError(ctx context.Context, hostName string) (string, error) {
+	output, psErr := m.transport.ExecutePS(ctx, psGetVMMoveError, map[string]string{"Name": hostName})
+	if psErr != nil {
+		return "", fmt.Errorf("hyperv: probe move error for VM %q: %w", hostName, psErr)
+	}
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if jErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jErr != nil {
+		return "", fmt.Errorf("hyperv: parse move error probe for VM %q: %w", hostName, jErr)
+	}
+	return strings.TrimSpace(parsed.Error), nil
+}
+
+// execSetVMHome homes a freshly created VM's configuration files at exactly
+// home via a synchronous config-only Move-VMStorage (New-VM -Path appends a
+// VM-name subfolder, so the create path always follows with this move; the
+// files are KB-scale and complete well within the module-call deadline).
+func (m *hypervModule) execSetVMHome(ctx context.Context, cfgResourceID, hostName, home string) error {
+	_, psErr := m.transport.ExecutePS(ctx, psSetVMHome, map[string]string{
+		"Name": hostName,
+		"Home": home,
+	})
+	after := map[string]interface{}{"configuration_location": home}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Move-VMStorage", cfgResourceID, nil, after, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: home configuration files for VM %q at %q: %w", hostName, home, psErr)
+	}
+	return nil
+}
+
+// ── MoveStore implementations ─────────────────────────────────────────────────
+
+// GetMove implements MoveStore for the in-memory store.
+func (s *memProvisionStore) GetMove(_ context.Context, vmName string) (*MoveRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.moves[vmName]
+	if !ok {
+		return nil, ErrMoveNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+
+// SetMove implements MoveStore for the in-memory store.
+func (s *memProvisionStore) SetMove(_ context.Context, record *MoveRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *record
+	s.moves[record.VMName] = &cp
+	return nil
+}
+
+// DeleteMove implements MoveStore for the in-memory store.
+func (s *memProvisionStore) DeleteMove(_ context.Context, vmName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.moves[vmName]; !ok {
+		return ErrMoveNotFound
+	}
+	delete(s.moves, vmName)
+	return nil
+}
+
+// moveNamespace is the stored-config namespace for hyperv move records —
+// separate from provisionNamespace so the two record lifecycles never collide.
+// Dash separator (not slash) for keysafe path-safety compliance.
+const moveNamespace = "hyperv-moves"
+
+func (s *ConfigBackedProvisionStore) moveKey(vmName string) *cfgconfig.ConfigKey {
+	return &cfgconfig.ConfigKey{
+		TenantID:  s.tenantID,
+		Namespace: moveNamespace,
+		Name:      vmName,
+	}
+}
+
+// GetMove implements MoveStore for the durable config-backed store.
+func (s *ConfigBackedProvisionStore) GetMove(ctx context.Context, vmName string) (*MoveRecord, error) {
+	entry, err := s.store.GetConfig(ctx, s.moveKey(vmName))
+	if err != nil {
+		if errors.Is(err, cfgconfig.ErrConfigNotFound) {
+			return nil, ErrMoveNotFound
+		}
+		return nil, fmt.Errorf("hyperv: get move record %q: %w", vmName, err)
+	}
+	var record MoveRecord
+	if err := json.Unmarshal(entry.Data, &record); err != nil {
+		return nil, fmt.Errorf("hyperv: decode move record %q: %w", vmName, err)
+	}
+	return &record, nil
+}
+
+// SetMove implements MoveStore for the durable config-backed store.
+func (s *ConfigBackedProvisionStore) SetMove(ctx context.Context, record *MoveRecord) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("hyperv: encode move record %q: %w", record.VMName, err)
+	}
+	return s.store.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key:    s.moveKey(record.VMName),
+		Data:   data,
+		Format: cfgconfig.ConfigFormatJSON,
+	})
+}
+
+// DeleteMove implements MoveStore for the durable config-backed store.
+func (s *ConfigBackedProvisionStore) DeleteMove(ctx context.Context, vmName string) error {
+	err := s.store.DeleteConfig(ctx, s.moveKey(vmName))
+	if err != nil {
+		if errors.Is(err, cfgconfig.ErrConfigNotFound) {
+			return ErrMoveNotFound
+		}
+		return fmt.Errorf("hyperv: delete move record %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// Verify both in-repo stores satisfy the MoveStore contract.
+var (
+	_ MoveStore = (*memProvisionStore)(nil)
+	_ MoveStore = (*ConfigBackedProvisionStore)(nil)
+)

--- a/features/modules/hyperv/vm_storage_location_test.go
+++ b/features/modules/hyperv/vm_storage_location_test.go
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── #2411 declarative VM storage location ────────────────────────────────────
+//
+// The directory containing the declared vhd_path is the VM's home: creation
+// places configuration files and VHD there; location drift on an existing VM
+// converges via a live, non-destructive Move-VMStorage driven through an async
+// MoveRecord in the durable store (the executor per-call deadline forbids a
+// synchronous multi-minute migration).
+
+// homeVMJSON builds getVM-shaped host JSON with an explicit disk path and
+// configuration location, for storage-location drift scenarios.
+func homeVMJSON(name, state, diskPath, configLocation string) string {
+	hvState := "Off"
+	if state == "running" {
+		hvState = "Running"
+	}
+	return `{"found":true,"Name":"` + name + `","MemoryStartupBytes":1073741824,"ProcessorCount":2,"Generation":2,` +
+		`"Path":"` + jsonEscapeBackslashes(diskPath) + `","ConfigurationLocation":"` + jsonEscapeBackslashes(configLocation) + `",` +
+		`"SwitchName":"","SwitchNames":[],"State":"` + hvState + `"}`
+}
+
+func jsonEscapeBackslashes(s string) string {
+	out := make([]byte, 0, len(s)*2)
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			out = append(out, '\\', '\\')
+			continue
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+// callsByScript returns the indexes of recorded transport calls whose
+// scriptBlock equals the given psXxx const.
+func callsByScript(calls []winRMCall, script string) []int {
+	var out []int
+	for i, c := range calls {
+		if c.scriptBlock == script {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// ─── vmHomeDir / path comparison ──────────────────────────────────────────────
+
+func TestVMHomeDir(t *testing.T) {
+	cases := map[string]string{
+		`C:\VMs\a.vhdx`:                         `C:\VMs`,
+		`C:\ClusterStorage\CSV01\vm1\vm1.vhdx`:  `C:\ClusterStorage\CSV01\vm1`,
+		`C:/ClusterStorage/CSV01/vm1/disk.vhdx`: `C:/ClusterStorage/CSV01/vm1`,
+		`no-separator.vhdx`:                     ``,
+		``:                                      ``,
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, vmHomeDir(in), "vmHomeDir(%q)", in)
+	}
+}
+
+func TestSameWindowsPath(t *testing.T) {
+	assert.True(t, sameWindowsPath(`C:\VMs\vm1`, `c:\vms\vm1`), "case-insensitive")
+	assert.True(t, sameWindowsPath(`C:\VMs\vm1\`, `C:\VMs\vm1`), "trailing separator")
+	assert.True(t, sameWindowsPath(`C:/VMs/vm1`, `C:\VMs\vm1`), "mixed separators")
+	assert.False(t, sameWindowsPath(`C:\VMs\vm1`, `C:\VMs\vm2`))
+	assert.False(t, sameWindowsPath(``, `C:\VMs`), "empty never matches")
+}
+
+// ─── MoveStore CRUD ───────────────────────────────────────────────────────────
+
+// TestMoveStore_CRUD exercises Get/Set/Delete/ErrMoveNotFound on the in-memory
+// store, and confirms move records are independent of provision records.
+func TestMoveStore_CRUD(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemProvisionStore()
+
+	_, err := store.GetMove(ctx, "vm1")
+	require.ErrorIs(t, err, ErrMoveNotFound)
+
+	rec := &MoveRecord{
+		VMName:    "vm1",
+		State:     MoveStateMoving,
+		DestDir:   `C:\ClusterStorage\CSV01\vm1`,
+		StartedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, store.SetMove(ctx, rec))
+
+	got, err := store.GetMove(ctx, "vm1")
+	require.NoError(t, err)
+	assert.Equal(t, MoveStateMoving, got.State)
+	assert.Equal(t, rec.DestDir, got.DestDir)
+
+	// A move record must NOT satisfy a provision-record read for the same VM.
+	_, err = store.GetProvision(ctx, "vm1")
+	assert.ErrorIs(t, err, ErrProvisionNotFound,
+		"move records must live in a separate keyspace from provision records")
+
+	require.NoError(t, store.DeleteMove(ctx, "vm1"))
+	_, err = store.GetMove(ctx, "vm1")
+	require.ErrorIs(t, err, ErrMoveNotFound)
+
+	// Deleting an absent record is reported, matching DeleteProvision.
+	err = store.DeleteMove(ctx, "vm1")
+	require.ErrorIs(t, err, ErrMoveNotFound)
+}
+
+// TestMoveStore_Durable_SurvivesReopen verifies the flatfile-backed store
+// persists move records across a close/reopen — a move in flight across a
+// steward restart must be re-observed, not re-dispatched blindly (#2371).
+func TestMoveStore_Durable_SurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	store1, err := NewFlatFileProvisionStore(root)
+	require.NoError(t, err)
+	ms1, ok := store1.(MoveStore)
+	require.True(t, ok, "durable provision store must implement MoveStore")
+
+	rec := &MoveRecord{
+		VMName:    "vm-restart",
+		State:     MoveStateMoving,
+		DestDir:   `C:\ClusterStorage\CSV01\vm-restart`,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+		UpdatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, ms1.SetMove(ctx, rec))
+
+	store2, err := NewFlatFileProvisionStore(root)
+	require.NoError(t, err)
+	ms2 := store2.(MoveStore)
+	got, err := ms2.GetMove(ctx, "vm-restart")
+	require.NoError(t, err, "move record must survive a store reopen")
+	assert.Equal(t, MoveStateMoving, got.State)
+	assert.Equal(t, rec.DestDir, got.DestDir)
+}
+
+// ─── Create path: -Path + explicit home move ──────────────────────────────────
+
+// TestCreateVM_PlacesConfigAtVHDHome is the [REQUIRED TEST] for the create
+// path: a fresh VM is created with New-VM -Path <dir(vhd_path)> and its
+// configuration files are then homed at exactly dir(vhd_path) (New-VM appends
+// a VM-name subfolder to -Path, so an explicit config-only Move-VMStorage to
+// the declared home follows — verified live on cfg-lab 2026-07-07).
+func TestCreateVM_PlacesConfigAtVHDHome(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`, // getVM: absent → create path
+			"",                // New-VM
+			"",                // Cfgms-SetVMHome
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	const home = `C:\ClusterStorage\CSV01\newvm`
+	require.NoError(t, m.Set(context.Background(), "vm:newvm", mapConfigState{
+		"name":      "newvm",
+		"state":     "stopped",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\newvm.vhdx`,
+	}))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	createIdxs := callsByScript(calls, psCreateVM)
+	require.Len(t, createIdxs, 1, "exactly one New-VM call")
+	// psArgs keys sorted: CPU, Generation, MemoryMB, Name, Path, SwitchName, VHDPath
+	createArgs := calls[createIdxs[0]].args
+	assert.Contains(t, createArgs, home, "New-VM must receive -Path dir(vhd_path)")
+
+	homeIdxs := callsByScript(calls, psSetVMHome)
+	require.Len(t, homeIdxs, 1, "exactly one config-home move after create")
+	assert.Greater(t, homeIdxs[0], createIdxs[0], "home move must follow New-VM")
+	assert.Contains(t, calls[homeIdxs[0]].args, home,
+		"config home move must target dir(vhd_path)")
+}
+
+// TestGetVM_ReportsConfigurationLocation: the observed state and the Get/DNA
+// surface expose the VM's configuration-file location.
+func TestGetVM_ReportsConfigurationLocation(t *testing.T) {
+	const cfgLoc = `C:\VMs\vm7`
+	transport := &testWinRMTransport{
+		output: homeVMJSON("vm7", "running", `C:\VMs\vm7\vm7.vhdx`, cfgLoc),
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	state, err := m.Get(context.Background(), "vm:vm7")
+	require.NoError(t, err)
+	got := state.AsMap()
+	assert.Equal(t, cfgLoc, got["configuration_location"],
+		"Get must expose the observed ConfigurationLocation")
+}
+
+// ─── Converge path: async live move ───────────────────────────────────────────
+
+// TestLocationDrift_DispatchesExactlyOneMove is the [REQUIRED TEST] for the
+// converge path: location drift on an existing VM runs the free-space
+// preflight, dispatches Move-VMStorage exactly once, records an in-flight
+// MoveRecord — and never stops, deletes, or recreates the VM.
+func TestLocationDrift_DispatchesExactlyOneMove(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv1`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv1", "running", `C:\VMs\mv1.vhdx`, `C:\VMs\mv1`), // getVM: local home
+			`{"required_bytes":1073741824,"free_bytes":269386489856}`,     // preflight: plenty free
+			"", // clear stale error marker
+			"", // detached Move-VMStorage dispatch
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	require.NoError(t, m.Set(context.Background(), "vm:mv1", mapConfigState{
+		"name":      "mv1",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv1.vhdx`,
+	}))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	moveIdxs := callsByScript(calls, psMoveVMStorage)
+	require.Len(t, moveIdxs, 1, "exactly one Move-VMStorage dispatch")
+	moveArgs := calls[moveIdxs[0]].args
+	assert.Contains(t, moveArgs, home,
+		"move must target the declared home (disks follow at home\\<current leaf>)")
+
+	preIdxs := callsByScript(calls, psVMStorageMovePreflight)
+	require.Len(t, preIdxs, 1, "free-space preflight must run before dispatch")
+	assert.Less(t, preIdxs[0], moveIdxs[0])
+
+	clearIdxs := callsByScript(calls, psClearVMMoveError)
+	require.Len(t, clearIdxs, 1, "stale error marker must be cleared before dispatch")
+	assert.Less(t, clearIdxs[0], moveIdxs[0])
+
+	for _, c := range calls {
+		assert.NotContains(t, c.scriptBlock, "Remove-VM", "the VM must never be deleted by the move path")
+		assert.NotContains(t, c.scriptBlock, "Stop-VM", "the VM must never be stopped by the move path")
+	}
+
+	rec, err := m.moveStore().GetMove(context.Background(), "mv1")
+	require.NoError(t, err, "an in-flight MoveRecord must exist after dispatch")
+	assert.Equal(t, MoveStateMoving, rec.State)
+	assert.Equal(t, home, rec.DestDir)
+}
+
+// TestLocationDrift_InFlightMoveIsNoOp is the [REQUIRED TEST] idempotency
+// half: a converge that observes an in-flight record does NOT dispatch a
+// second move — the cycle is a cheap no-op (getVM + error probe only).
+func TestLocationDrift_InFlightMoveIsNoOp(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv2`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv2", "running", `C:\VMs\mv2.vhdx`, `C:\VMs\mv2`), // still at old location
+			`{"error":""}`, // no failure surfaced by the detached move
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+	require.NoError(t, m.moveStore().SetMove(context.Background(), &MoveRecord{
+		VMName:    "mv2",
+		State:     MoveStateMoving,
+		DestDir:   home,
+		StartedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}))
+
+	require.NoError(t, m.Set(context.Background(), "vm:mv2", mapConfigState{
+		"name":      "mv2",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv2.vhdx`,
+	}))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsByScript(calls, psMoveVMStorage), "no duplicate Move-VMStorage dispatch")
+	assert.Empty(t, callsByScript(calls, psVMStorageMovePreflight), "no re-preflight while in flight")
+	require.Len(t, calls, 2, "in-flight cycle must be cheap: getVM + error probe only")
+
+	rec, err := m.moveStore().GetMove(context.Background(), "mv2")
+	require.NoError(t, err)
+	assert.Equal(t, MoveStateMoving, rec.State, "record stays in flight")
+}
+
+// TestLocationDrift_CompletionClearsRecord: when the observed location matches
+// the declared home, the in-flight record completes (is removed) and the
+// normal lifecycle proceeds.
+func TestLocationDrift_CompletionClearsRecord(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv3`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv3", "running", home+`\mv3.vhdx`, home), // converged
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+	require.NoError(t, m.moveStore().SetMove(context.Background(), &MoveRecord{
+		VMName:    "mv3",
+		State:     MoveStateMoving,
+		DestDir:   home,
+		StartedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}))
+
+	require.NoError(t, m.Set(context.Background(), "vm:mv3", mapConfigState{
+		"name":      "mv3",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv3.vhdx`,
+	}))
+
+	_, err := m.moveStore().GetMove(context.Background(), "mv3")
+	assert.ErrorIs(t, err, ErrMoveNotFound, "completed move record must be cleared")
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+	assert.Empty(t, callsByScript(calls, psMoveVMStorage), "no move dispatch when converged")
+}
+
+// TestMovePreflight_InsufficientSpace is the [REQUIRED TEST] safety half:
+// insufficient destination space fails the move BEFORE dispatch, loudly, on
+// the record.
+func TestMovePreflight_InsufficientSpace(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv4`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv4", "running", `C:\VMs\mv4.vhdx`, `C:\VMs\mv4`),
+			`{"required_bytes":1073741824,"free_bytes":1024}`, // destination nearly full
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	err := m.Set(context.Background(), "vm:mv4", mapConfigState{
+		"name":      "mv4",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv4.vhdx`,
+	})
+	require.Error(t, err, "preflight failure must surface loudly")
+	assert.Contains(t, err.Error(), "insufficient")
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+	assert.Empty(t, callsByScript(calls, psMoveVMStorage),
+		"Move-VMStorage must NOT be dispatched when the preflight fails")
+
+	rec, recErr := m.moveStore().GetMove(context.Background(), "mv4")
+	require.NoError(t, recErr, "the failure must be recorded")
+	assert.Equal(t, MoveStateFailed, rec.State)
+	assert.Contains(t, rec.LastError, "insufficient")
+}
+
+// TestMoveFailure_SurfacesOnRecord is the [REQUIRED TEST] failure half: a
+// dispatched-move failure (surfaced by the detached process's error marker)
+// flips the record to failed with the error, and Set returns the error.
+func TestMoveFailure_SurfacesOnRecord(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv5`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv5", "running", `C:\VMs\mv5.vhdx`, `C:\VMs\mv5`), // still at source
+			`{"error":"Move-VMStorage : migration failed"}`,               // error marker
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+	require.NoError(t, m.moveStore().SetMove(context.Background(), &MoveRecord{
+		VMName:    "mv5",
+		State:     MoveStateMoving,
+		DestDir:   home,
+		StartedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}))
+
+	err := m.Set(context.Background(), "vm:mv5", mapConfigState{
+		"name":      "mv5",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv5.vhdx`,
+	})
+	require.Error(t, err, "a failed move must surface loudly")
+	assert.Contains(t, err.Error(), "migration failed")
+
+	rec, recErr := m.moveStore().GetMove(context.Background(), "mv5")
+	require.NoError(t, recErr)
+	assert.Equal(t, MoveStateFailed, rec.State)
+	assert.Contains(t, rec.LastError, "migration failed")
+}
+
+// TestMoveFailure_NextConvergeRetriesOnce: a failed record retries — exactly
+// one new dispatch on the next converge cycle (bounded retry).
+func TestMoveFailure_NextConvergeRetriesOnce(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv6`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv6", "running", `C:\VMs\mv6.vhdx`, `C:\VMs\mv6`),
+			`{"required_bytes":1073741824,"free_bytes":269386489856}`,
+			"", // clear error marker
+			"", // Move-VMStorage retry dispatch
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+	require.NoError(t, m.moveStore().SetMove(context.Background(), &MoveRecord{
+		VMName:    "mv6",
+		State:     MoveStateFailed,
+		DestDir:   home,
+		StartedAt: time.Now().UTC().Add(-time.Hour),
+		UpdatedAt: time.Now().UTC().Add(-time.Hour),
+		LastError: "previous attempt failed",
+	}))
+
+	require.NoError(t, m.Set(context.Background(), "vm:mv6", mapConfigState{
+		"name":      "mv6",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv6.vhdx`,
+	}))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+	require.Len(t, callsByScript(calls, psMoveVMStorage), 1,
+		"exactly one retry dispatch per converge cycle")
+
+	rec, err := m.moveStore().GetMove(context.Background(), "mv6")
+	require.NoError(t, err)
+	assert.Equal(t, MoveStateMoving, rec.State, "retry returns the record to in-flight")
+	assert.Empty(t, rec.LastError, "retry clears the previous error")
+}
+
+// TestMoveStalled_FailsRecord: an in-flight record older than the stall bound
+// with no observable completion and no error marker is failed loudly (covers a
+// move interrupted by a host reboot, where the detached process left no error).
+func TestMoveStalled_FailsRecord(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv7`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv7", "running", `C:\VMs\mv7.vhdx`, `C:\VMs\mv7`),
+			`{"error":""}`, // no error marker — the move just never completed
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+	require.NoError(t, m.moveStore().SetMove(context.Background(), &MoveRecord{
+		VMName:    "mv7",
+		State:     MoveStateMoving,
+		DestDir:   home,
+		StartedAt: time.Now().UTC().Add(-moveStallTimeout - time.Minute),
+		UpdatedAt: time.Now().UTC().Add(-moveStallTimeout - time.Minute),
+	}))
+
+	err := m.Set(context.Background(), "vm:mv7", mapConfigState{
+		"name":      "mv7",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv7.vhdx`,
+	})
+	require.Error(t, err, "a stalled move must surface loudly")
+
+	rec, recErr := m.moveStore().GetMove(context.Background(), "mv7")
+	require.NoError(t, recErr)
+	assert.Equal(t, MoveStateFailed, rec.State)
+}
+
+// TestSetVM_Absent_DeletesMoveRecord: deleting a VM clears any move record so
+// a later same-named VM starts clean (mirrors the provision-record cleanup).
+func TestSetVM_Absent_DeletesMoveRecord(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv8", "running", `C:\VMs\mv8.vhdx`, `C:\VMs\mv8`), // before-snapshot
+			"", // Remove-VM
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+	require.NoError(t, m.moveStore().SetMove(context.Background(), &MoveRecord{
+		VMName:    "mv8",
+		State:     MoveStateMoving,
+		DestDir:   `C:\ClusterStorage\CSV01\mv8`,
+		StartedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}))
+
+	require.NoError(t, m.Set(context.Background(), "vm:mv8", mapConfigState{
+		"name":  "mv8",
+		"state": "absent",
+	}))
+
+	_, err := m.moveStore().GetMove(context.Background(), "mv8")
+	assert.ErrorIs(t, err, ErrMoveNotFound, "VM deletion must clear the move record")
+}
+
+// TestNoLocationDrift_NoMoveMachinery: a VM whose config and disk already sit
+// at the declared home runs the plain lifecycle with zero storage-location
+// calls (no probe, no preflight, no dispatch).
+func TestNoLocationDrift_NoMoveMachinery(t *testing.T) {
+	const home = `C:\ClusterStorage\CSV01\mv9`
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			homeVMJSON("mv9", "running", home+`\mv9.vhdx`, home),
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	require.NoError(t, m.Set(context.Background(), "vm:mv9", mapConfigState{
+		"name":      "mv9",
+		"state":     "running",
+		"memory_mb": 1024,
+		"cpu_count": 2,
+		"vhd_path":  home + `\mv9.vhdx`,
+	}))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+	require.Len(t, calls, 1, "converged VM: getVM only — no storage-location machinery")
+}

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -509,17 +509,20 @@ func TestSetVM_MultiSwitchCreate(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	// getVM (not-found) + New-VM + one Add-VMNetworkAdapter for the 2nd switch.
-	require.Len(t, calls, 3)
+	// getVM (not-found) + New-VM + config-home move (#2411) + one
+	// Add-VMNetworkAdapter for the 2nd switch.
+	require.Len(t, calls, 4)
 	assert.Contains(t, calls[1].scriptBlock, "New-VM", "second call must be New-VM")
-	assert.Contains(t, calls[2].scriptBlock, "Add-VMNetworkAdapter",
-		"third call must connect the additional adapter")
+	assert.Equal(t, psSetVMHome, calls[2].scriptBlock,
+		"third call homes the configuration files at dir(vhd_path)")
+	assert.Contains(t, calls[3].scriptBlock, "Add-VMNetworkAdapter",
+		"fourth call must connect the additional adapter")
 	// The additional switch name travels as an argument, never in the script.
-	require.NotEmpty(t, calls[2].args)
+	require.NotEmpty(t, calls[3].args)
 	// The switch name is the EXACT name (no namespacing) and travels via args,
 	// never interpolated into the script body.
-	assert.Contains(t, calls[2].args, "Mgmt", "additional switch must travel via args, exact name")
-	assert.NotContains(t, calls[2].scriptBlock, "Mgmt",
+	assert.Contains(t, calls[3].args, "Mgmt", "additional switch must travel via args, exact name")
+	assert.NotContains(t, calls[3].scriptBlock, "Mgmt",
 		"switch name must not be interpolated into the script body")
 }
 
@@ -946,8 +949,8 @@ func TestGet_VM_ReturnsConfig(t *testing.T) {
 // TestSet_VMCreate verifies that Set creates a VM and passes all fields via ArgumentList.
 // setVM calls getVM first to check existence: the mock returns `{"found":false}`
 // for call[0] so getVM reports state:"absent" (per the F14 contract), then Set
-// falls through to New-VM as call[1]. Two transport calls expected total:
-// getVM (call[0]) + New-VM (call[1]).
+// falls through to New-VM as call[1] and the config-home move (#2411) as
+// call[2].
 func TestSet_VMCreate(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`},
@@ -970,8 +973,12 @@ func TestSet_VMCreate(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	// Two calls: getVM existence check (returns not-found) + New-VM creation
-	require.Len(t, calls, 2)
+	// Three calls: getVM existence check (returns not-found) + New-VM creation
+	// + the config-home move that lands the VM's configuration files at
+	// dir(vhd_path) (#2411).
+	require.Len(t, calls, 3)
+	assert.Equal(t, psSetVMHome, calls[2].scriptBlock,
+		"create must home the configuration files at dir(vhd_path)")
 	call := calls[1] // New-VM is the second call
 
 	// Script must reference $Name parameter, not the literal name
@@ -1412,6 +1419,7 @@ func TestSetVM_HARole_RegistersClusteredRole(t *testing.T) {
 		transport := &testWinRMTransport{perCallOutputs: []string{
 			`{"found":false}`,   // getVM: VM absent
 			``,                  // New-VM: create succeeds
+			``,                  // Cfgms-SetVMHome: config-home move (#2411)
 			`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)
 			`{"owners":{}}`,     // ownership helper: resource owners (role absent)
 			`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read
@@ -1444,6 +1452,7 @@ func TestSetVM_HARole_RegistersClusteredRole(t *testing.T) {
 		transport := &testWinRMTransport{perCallOutputs: []string{
 			`{"found":false}`,              // getVM: VM absent on this node
 			``,                             // New-VM
+			``,                             // Cfgms-SetVMHome: config-home move (#2411)
 			`{"owner":"NODE1"}`,            // CNO owner read
 			`{"owners":{"ha-vm":"NODE1"}}`, // resource owners: role ALREADY present
 			`{"owner":"NODE1"}`,            // cnoOwner re-read
@@ -1516,6 +1525,7 @@ func TestSetVM_HARole_MapShapeRegistersClusteredRole(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{
 		`{"found":false}`,   // getVM: VM absent
 		``,                  // New-VM: create succeeds
+		``,                  // Cfgms-SetVMHome: config-home move (#2411)
 		`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)
 		`{"owners":{}}`,     // ownership helper: resource owners (role absent)
 		`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read


### PR DESCRIPTION
## Summary

The directory of the declared `vhd_path` is now the VM's storage **home**: creating a `hyperv.vm` places its configuration files and VHD there, and changing the declared home on an existing VM converges via a **live, non-destructive `Move-VMStorage`** — no operator steps. As a direct consequence, a VM declared with a CSV home plus `ha_role:` becomes a clustered HA role end-to-end from config alone, replacing the #2372 operator `Move-VMStorage` README note.

## Changes

- **Create path**: `psCreateVM`/`Cfgms-CreateVM` (and the cloud-init `Cfgms-CreateVMFromDisk`) pass `-Path dir(vhd_path)`, followed by a synchronous config-only home move (`Cfgms-SetVMHome`) — `New-VM -Path` appends a VM-name subfolder (verified live), so the follow-up move lands the config at exactly the home. Fresh VMs start with zero location drift.
- **Observed state**: `getVM`/Get/DNA expose the VM's `ConfigurationLocation` as `configuration_location` (observed-only; never drift-compared — the desired location is always derived from `vhd_path`).
- **Converge path**: location drift starts an **async** live migration — a detached `powershell -File` process (`runDetached`) tracked on a durable `MoveRecord` (#2371 store machinery, new `hyperv-moves` namespace), because the executor per-module-call deadline (ADR-012 §7) forbids holding a Set open for a multi-minute migration. In-flight cycles are cheap no-ops (no duplicate dispatch); completion is judged by re-observing the location; failures surface on the record via a per-VM error marker; retries are bounded to one per converge cycle with a 4h stall bound for interrupted moves.
- **Safety**: free-space preflight (`Get-Volume -FilePath`, CSV-mount aware) fails the move loudly *before* dispatch; the VM is never stopped, deleted, or recreated by this path; `source.on_existing` semantics untouched.
- **Directory-level semantics** (live-root-caused): `-Vhds` hashtable values must be `[string]`-cast (PSObject-wrapped values fail validation with a misleading missing-key error) and Hyper-V refuses file renames in a move — each disk lands at `home\<current leaf>`.
- `module.yaml` behavioral envelope declares `Move-VMStorage` + `Get-Volume` (ADR-006 re-sign applies); README + schema document the single-home semantics.

## Live validation (cfg-lab, steward v0.9.13 built from this branch)

- Fresh VM created with config + VHD at exactly the declared home (zero drift).
- Declared home flipped local → `C:\ClusterStorage\CSV01\...`: config + disk live-migrated with the VM **running**.
- `ha_role:` added: clustered role registered, **Online**, owner CFG-70-02 — zero operator steps. Demote and `state: absent` cleanup also converged.
- The two pre-existing CI-runner VMs (one with a checkpoint `.avhdx`, one with a stale attached seed disk) converged their config files to their declared homes while running — after surfacing two real `-Vhds` bugs through the record machinery exactly as designed (both fixed in this PR).

## Review

- Acceptance check: PASS (all ACs verified against code + required tests)
- QA test run: PASS (hyperv suite, downstream packages, vet, gofmt, linux cross-compile)
- QA code review: PASS (2 warnings; the dispatch-table test-coverage gap is fixed in the second commit, the lazy-init note mirrors a pre-existing accepted pattern)
- Security review: PASS (0 blocking; injection-safety, banned-pattern, tempfile, and envelope checks clean; gosec/gitleaks/golangci-lint deferred to CI — binaries absent on the Windows self-dispatch host)
- Known cosmetic: while a move is in flight the executor logs `verification failed` each cycle until the location converges (observed state truthfully lags the migration).

Fixes #2411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SUVZR6kTwcXDNwjgq8ygn