### PR TITLE
steward: Windows launcher-managed install — bundle launcher in MSI (Issue #2379)

### DIFF
--- a/build/windows/build-msi.ps1
+++ b/build/windows/build-msi.ps1
@@ -187,6 +187,43 @@ try {
     Remove-Item Env:CGO_ENABLED -ErrorAction SilentlyContinue
 }
 
+# ── Step 1c: Build the steward launcher binary ──────────────────────────────
+# The launcher is bundled in the MSI payload next to cfgms-steward.exe;
+# windowsManager.Install() registers it as the service binary and requires it
+# in the bundle (launcher-managed install — what makes the steward
+# push-upgradeable). Never fetched post-install.
+
+Write-Host ""
+Write-Host "Building cfgms-steward-launcher binary for windows/$Arch..." -ForegroundColor Yellow
+
+$LauncherPath = Join-Path $RepoRoot "bin" "cfgms-steward-launcher-windows-$Arch.exe"
+
+$env:GOOS        = "windows"
+$env:GOARCH      = $Arch
+$env:CGO_ENABLED = "0"
+
+Push-Location $RepoRoot
+try {
+    $LauncherArgs = @(
+        "build",
+        "-trimpath",
+        "-ldflags", "-s -w -X github.com/cfgis/cfgms/pkg/version.Version=$Version",
+        "-o", $LauncherPath,
+        "./cmd/cfgms-steward-launcher"
+    )
+    & go @LauncherArgs
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "go build failed for cfgms-steward-launcher (exit $LASTEXITCODE)"
+    }
+} finally {
+    Pop-Location
+    Remove-Item Env:GOOS        -ErrorAction SilentlyContinue
+    Remove-Item Env:GOARCH      -ErrorAction SilentlyContinue
+    Remove-Item Env:CGO_ENABLED -ErrorAction SilentlyContinue
+}
+
+Write-Host "  Launcher: $LauncherPath" -ForegroundColor Green
+
 # ── Step 2: Ensure WiX 4 toolset is installed ────────────────────────────────
 
 Write-Host ""
@@ -232,6 +269,7 @@ $WixArgs = @(
     $WxsFile,
     "-d", "ProductVersion=$MsiVersion",
     "-d", "BinaryPath=$BinaryPath",
+    "-d", "LauncherPath=$LauncherPath",
     "-d", "ModulesDir=$ModulesDir",
     "-out", $OutputMsi
 )

--- a/build/windows/cfgms-steward.wxs
+++ b/build/windows/cfgms-steward.wxs
@@ -68,6 +68,19 @@
                 Name="cfgms-steward.exe"
                 KeyPath="yes" />
         </Component>
+        <!--
+          Launcher binary — must be in the MSI payload next to cfgms-steward.exe
+          BEFORE the RunInstall* custom actions run: cfgms-steward.exe install
+          (windowsManager.Install) fails closed when the launcher is absent, and
+          registers the service to exec the launcher (launcher-managed install,
+          push-upgradeable). Bundled only; never fetched post-install.
+        -->
+        <Component Id="StewardLauncherBinary" Guid="*">
+          <File Id="StewardLauncherExe"
+                Source="$(var.LauncherPath)"
+                Name="cfgms-steward-launcher.exe"
+                KeyPath="yes" />
+        </Component>
         <Directory Id="MODULESDIR" Name="modules">
           <Component Id="ModuleFile" Guid="*">
             <File Id="ModuleFileExe" Source="$(var.ModulesDir)\cfgms-module-file.exe" Name="cfgms-module-file.exe" KeyPath="yes" />
@@ -93,6 +106,7 @@
 
     <Feature Id="ProductFeature" Title="CFGMS Steward" Level="1">
       <ComponentRef Id="StewardBinary" />
+      <ComponentRef Id="StewardLauncherBinary" />
       <ComponentRef Id="ModuleFile" />
       <ComponentRef Id="ModuleService" />
       <ComponentRef Id="ModulePackage" />

--- a/cmd/steward/service/manager_windows.go
+++ b/cmd/steward/service/manager_windows.go
@@ -8,20 +8,39 @@ package service
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
 	"golang.org/x/sys/windows/registry"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/cfgis/cfgms/pkg/version"
 )
 
 const (
-	windowsInstallDir  = `C:\Program Files\CFGMS`
+	// windowsInstallDir is the install root. It equals the launcher's own
+	// defaultRoot() on Windows (cmd/cfgms-steward-launcher/main.go), so the
+	// launcher's versioned layout (versions/, state.json) nests under it.
+	windowsInstallDir = `C:\Program Files\CFGMS`
+	// windowsInstallPath is the legacy bare-steward binary path. The MSI
+	// payload still places cfgms-steward.exe here (it hosts the install/
+	// uninstall custom actions); the service itself execs the launcher.
 	windowsInstallPath = `C:\Program Files\CFGMS\cfgms-steward.exe`
-	windowsServiceName = "CFGMSSteward"
-	windowsDisplayName = "CFGMS Steward"
-	windowsDescription = "CFGMS endpoint configuration management agent"
+	// windowsLauncherPath is where the launcher binary is installed. The
+	// steward's push-upgrade handler execs "cfgms-steward-launcher.exe swap"
+	// at this exact compile-time path (features/steward/client
+	// launcherPath()), so a launcher-managed install is what makes a Windows
+	// steward upgradeable via the control plane. It must not change.
+	windowsLauncherPath = `C:\Program Files\CFGMS\cfgms-steward-launcher.exe`
+	// windowsLauncherBinaryName is the launcher binary as shipped in the
+	// install bundle (MSI payload), expected alongside the cfgms-steward
+	// binary being installed.
+	windowsLauncherBinaryName = "cfgms-steward-launcher.exe"
+	windowsServiceName        = "CFGMSSteward"
+	windowsDisplayName        = "CFGMS Steward"
+	windowsDescription        = "CFGMS endpoint configuration management agent"
 )
 
 // platformCACertPath returns the path where the CA cert is written, respecting
@@ -98,16 +117,19 @@ func (m *windowsManager) IsElevated() bool {
 	return true
 }
 
-// Install copies the binary to C:\Program Files\CFGMS\, creates a Windows
-// service configured to start automatically with failure-restart recovery,
-// and starts it. If the service already exists it is stopped, the binary
-// replaced, and the service restarted.
+// Install installs the launcher to C:\Program Files\CFGMS\, stages the
+// steward binary under the launcher's versioned layout, and creates a Windows
+// service that runs the launcher (which supervises the steward) — mirroring
+// the Linux launcher-managed model. This is what makes a Windows steward
+// upgradeable via the control plane: the push-upgrade handler execs
+// "cfgms-steward-launcher.exe swap" at windowsLauncherPath. If the service
+// already exists it is stopped and re-registered.
 //
 // Uses the native Windows Service API via golang.org/x/sys/windows/svc/mgr.
 // Does NOT shell out to sc.exe.
 //
-// When controllerURL is non-empty, --controller-url is passed to CreateService
-// args so the steward connects to the specified controller on start.
+// When controllerURL is non-empty, --controller-url is forwarded to the
+// supervised steward via the launcher's --child-args.
 // If caCertPEM is non-empty, the CA cert is written to the platform-standard
 // path before the service is started. When expectedFingerprint is also non-empty,
 // fingerprint verification runs first — a mismatch returns an error without any
@@ -123,6 +145,23 @@ func (m *windowsManager) Install(token, controllerURL, caCertPEM, expectedFinger
 			return err
 		}
 	}
+
+	// A launcher-managed install (steward supervised by
+	// cfgms-steward-launcher.exe, staged under versions\) is what makes the
+	// steward upgradeable via the control plane: the push-upgrade handler
+	// execs "cfgms-steward-launcher.exe swap" and requires the launcher at
+	// windowsLauncherPath. A bare direct-service steward cannot be
+	// push-upgraded. The launcher binary ships alongside the steward binary
+	// in the install bundle (MSI payload). Checked before the elevation gate
+	// (read-only stat) so the caller gets the actionable bundle error even
+	// without Administrator rights.
+	launcherSrc := filepath.Join(filepath.Dir(m.binaryPath), windowsLauncherBinaryName)
+	if _, err := os.Stat(launcherSrc); err != nil {
+		return fmt.Errorf("launcher binary %q not found next to the steward binary: %w\n"+
+			"  a launcher-managed install requires %s in the install bundle",
+			launcherSrc, err, windowsLauncherBinaryName)
+	}
+
 	if !m.IsElevated() {
 		return fmt.Errorf("install requires Administrator privileges: right-click the binary and select 'Run as administrator'")
 	}
@@ -153,9 +192,25 @@ func (m *windowsManager) Install(token, controllerURL, caCertPEM, expectedFinger
 		return fmt.Errorf("failed to create install directory %s: %w", windowsInstallDir, err)
 	}
 
-	fmt.Printf("Installing to %s...\n", windowsInstallPath)
-	if err := copyBinary(m.binaryPath, windowsInstallPath); err != nil {
-		return fmt.Errorf("failed to copy binary: %w", err)
+	ver := version.Short()
+
+	// The MSI payload already places the launcher at windowsLauncherPath;
+	// copyBinary is a same-path-safe atomic copy (temp file + rename), so this
+	// also covers manual installs from an extracted bundle elsewhere on disk.
+	fmt.Printf("Installing launcher to %s...\n", windowsLauncherPath)
+	if err := copyBinary(launcherSrc, windowsLauncherPath); err != nil {
+		return fmt.Errorf("failed to install launcher: %w", err)
+	}
+
+	// Bootstrap the launcher layout: stage the steward binary as the current
+	// version under versions\<ver>\ and record it in state.json. This reuses
+	// the launcher's own "swap" surface (fixed binary path + discrete argv,
+	// never a composed shell string), so the on-disk layout is identical to
+	// what a subsequent push-upgrade produces. windowsInstallDir equals the
+	// launcher's defaultRoot() on Windows.
+	fmt.Printf("Staging steward %s under %s...\n", ver, windowsInstallDir)
+	if out, err := exec.Command(windowsLauncherPath, "swap", "--root", windowsInstallDir, ver, m.binaryPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stage steward binary via launcher: %w\n%s", err, out)
 	}
 
 	// Write CA cert before registering the service so the service finds it on first start.
@@ -166,23 +221,19 @@ func (m *windowsManager) Install(token, controllerURL, caCertPEM, expectedFinger
 		}
 	}
 
-	// Build service start arguments; --controller-url is optional (ADR-013 §3).
-	svcArgs := []string{"--regtoken", token}
-	if controllerURL != "" {
-		svcArgs = append(svcArgs, "--controller-url", controllerURL)
-	}
-
 	fmt.Println("Registering Windows service...")
 	newSvc, err := scm.CreateService(
 		windowsServiceName,
-		windowsInstallPath,
+		windowsLauncherPath,
 		mgr.Config{
 			StartType:   mgr.StartAutomatic,
 			DisplayName: windowsDisplayName,
 			Description: windowsDescription,
 		},
-		// Arguments appended to the binary path; received as os.Args on service start.
-		svcArgs...,
+		// Arguments appended to the binary path; received as os.Args on
+		// service start. The launcher supervises the steward and forwards
+		// --child-args to it.
+		buildLauncherServiceArgs(windowsInstallDir, token, controllerURL)...,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create Windows service: %w", err)
@@ -221,8 +272,23 @@ func (m *windowsManager) Install(token, controllerURL, caCertPEM, expectedFinger
 	return nil
 }
 
+// buildLauncherServiceArgs returns the service start arguments that make the
+// SCM run the launcher's supervision loop: `run --root <root> --child-args
+// "<steward args>"`. Args inside child-args are space-separated (the launcher
+// splits on whitespace via strings.Fields); the registration token is
+// validated to be free of spaces/quotes, so no per-arg quoting is needed.
+// Mirrors generateSystemdUnit's childArgs on Linux.
+func buildLauncherServiceArgs(root, token, controllerURL string) []string {
+	childArgs := fmt.Sprintf(`--regtoken %s`, token)
+	if controllerURL != "" {
+		childArgs += fmt.Sprintf(` --controller-url %s`, controllerURL)
+	}
+	return []string{"run", "--root", root, "--child-args", childArgs}
+}
+
 // Uninstall stops and removes the Windows service. If purge is true the
-// installed binary at windowsInstallPath is also deleted.
+// installed launcher binary, its versioned staging layout, and the legacy
+// bare-steward binary at windowsInstallPath are also deleted.
 func (m *windowsManager) Uninstall(purge bool) error {
 	if !m.IsElevated() {
 		return fmt.Errorf("uninstall requires Administrator privileges: right-click the binary and select 'Run as administrator'")
@@ -253,6 +319,33 @@ func (m *windowsManager) Uninstall(purge bool) error {
 	}
 
 	if purge {
+		// Launcher binary + versioned layout (versions\, state.json and the
+		// legacy pointer files) for launcher-managed installs. Remove the
+		// specific known paths only — windowsInstallDir also holds MSI-owned
+		// files (cfgms-steward.exe, modules\), so never RemoveAll the root.
+		if _, err := os.Stat(windowsLauncherPath); err == nil {
+			fmt.Printf("Removing %s...\n", windowsLauncherPath)
+			if err := os.Remove(windowsLauncherPath); err != nil {
+				return fmt.Errorf("failed to remove launcher: %w", err)
+			}
+		}
+		versionsDir := filepath.Join(windowsInstallDir, "versions")
+		if _, err := os.Stat(versionsDir); err == nil {
+			fmt.Printf("Removing %s...\n", versionsDir)
+			if err := os.RemoveAll(versionsDir); err != nil {
+				return fmt.Errorf("failed to remove launcher versions dir: %w", err)
+			}
+		}
+		for _, stateFile := range []string{"state.json", "current.txt", "previous.txt"} {
+			p := filepath.Join(windowsInstallDir, stateFile)
+			if _, err := os.Stat(p); err == nil {
+				fmt.Printf("Removing %s...\n", p)
+				if err := os.Remove(p); err != nil {
+					return fmt.Errorf("failed to remove launcher state file: %w", err)
+				}
+			}
+		}
+		// Legacy bare-steward binary (pre-launcher direct-service installs).
 		if _, err := os.Stat(windowsInstallPath); err == nil {
 			fmt.Printf("Removing %s...\n", windowsInstallPath)
 			if err := os.Remove(windowsInstallPath); err != nil {
@@ -269,7 +362,9 @@ func (m *windowsManager) Uninstall(purge bool) error {
 func (m *windowsManager) Status() (*ServiceStatus, error) {
 	status := &ServiceStatus{
 		ServiceName: windowsServiceName,
-		InstallPath: windowsInstallPath,
+		// Launcher-managed: the service's exec target is the launcher
+		// (mirrors linuxManager.Status reporting linuxLauncherPath).
+		InstallPath: windowsLauncherPath,
 	}
 
 	scm, err := mgr.Connect()

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -8,6 +8,7 @@ package service
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,9 @@ func TestWindowsManagerInstallPath(t *testing.T) {
 	m := New("cfgms-steward.exe")
 	status, err := m.Status()
 	require.NoError(t, err)
-	assert.Equal(t, windowsInstallPath, status.InstallPath)
+	// Launcher-managed install: the service's exec target is the launcher,
+	// so that is the install path Status reports (mirrors linuxLauncherPath).
+	assert.Equal(t, windowsLauncherPath, status.InstallPath)
 }
 
 func TestWindowsManagerStatusNotInstalled(t *testing.T) {
@@ -30,11 +33,15 @@ func TestWindowsManagerStatusNotInstalled(t *testing.T) {
 	status, err := m.Status()
 	require.NoError(t, err)
 	assert.Equal(t, windowsServiceName, status.ServiceName)
-	assert.Equal(t, windowsInstallPath, status.InstallPath)
+	assert.Equal(t, windowsLauncherPath, status.InstallPath)
 }
 
 func TestWindowsManagerInstallRequiresElevation(t *testing.T) {
-	m := New("cfgms-steward.exe")
+	// Stage a launcher stub next to the steward path so the pre-elevation
+	// bundle check passes and Install reaches the elevation gate.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, windowsLauncherBinaryName), []byte("stub"), 0o600))
+	m := New(filepath.Join(dir, "cfgms-steward.exe"))
 	if m.IsElevated() {
 		t.Skip("skipping elevation check — running as Administrator")
 	}
@@ -122,6 +129,74 @@ func TestSetServiceEnvironmentRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint32(registry.MULTI_SZ), valType, "Environment must be REG_MULTI_SZ — the only type the SCM accepts")
 	assert.Equal(t, []string{"CFGMS_LOG_DIR=" + logDir}, vals)
+}
+
+// TestWindowsLauncherPathParity is the REQUIRED path-parity TEST for #2379:
+// windowsLauncherPath must equal the literal path returned by
+// features/steward/client's launcherPath() on windows
+// (client_transport_upgrade.go) — the compile-time contract push-upgrade
+// execs. Drift between install-time and the upgrade runtime path silently
+// breaks push-upgrade, so the literal is pinned here.
+func TestWindowsLauncherPathParity(t *testing.T) {
+	assert.Equal(t, `C:\Program Files\CFGMS\cfgms-steward-launcher.exe`, windowsLauncherPath,
+		"windowsLauncherPath must match client_transport_upgrade.go launcherPath() exactly")
+	assert.Equal(t, "cfgms-steward-launcher.exe", windowsLauncherBinaryName)
+}
+
+// TestWindowsInstallLauncherMissing is the REQUIRED fail-closed TEST for
+// #2379: Install must return a clear, actionable error — before any service
+// registration — when the launcher binary is not bundled next to the steward
+// binary. The check runs before the elevation gate (like fingerprint
+// verification), so this asserts an early return without touching privileged
+// state.
+func TestWindowsInstallLauncherMissing(t *testing.T) {
+	dir := t.TempDir() // empty: no launcher next to the (hypothetical) steward binary
+	m := New(filepath.Join(dir, "cfgms-steward.exe"))
+	err := m.Install("tok_test123", "", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), windowsLauncherBinaryName,
+		"error must name the missing launcher binary")
+	assert.Contains(t, err.Error(), "not found next to the steward binary",
+		"error must explain the bundle expectation")
+	assert.NotContains(t, err.Error(), "Administrator",
+		"launcher presence is checked before the elevation gate")
+}
+
+// TestBuildLauncherServiceArgs is the REQUIRED launcher-target TEST for
+// #2379: the Windows service must be registered to invoke the launcher
+// (`run --root ... --child-args "..."`), never the bare steward binary —
+// mirrors TestGenerateSystemdUnit's assertions for Linux.
+func TestBuildLauncherServiceArgs(t *testing.T) {
+	token := "tok_svc_args_abc123"
+
+	args := buildLauncherServiceArgs(windowsInstallDir, token, "")
+	assert.Equal(t, []string{"run", "--root", windowsInstallDir, "--child-args", "--regtoken " + token}, args)
+
+	withURL := buildLauncherServiceArgs(windowsInstallDir, token, "https://ctrl.example.com:8443")
+	assert.Equal(t, []string{"run", "--root", windowsInstallDir, "--child-args",
+		"--regtoken " + token + " --controller-url https://ctrl.example.com:8443"}, withURL)
+
+	// The service args must never point execution at the bare steward binary.
+	joined := strings.Join(withURL, " ")
+	assert.NotContains(t, joined, windowsInstallPath+" --regtoken",
+		"service must exec the launcher, not the bare steward binary")
+
+	// Token appears exactly once (no duplication across args).
+	assert.Equal(t, 1, strings.Count(joined, token), "token should appear exactly once")
+}
+
+// TestWindowsLauncherUnderProgramFilesACL is the REQUIRED LPE-hardening TEST
+// for #2379: the launcher — a binary a SYSTEM service execs — must be
+// installed under the install dir whose default Program Files ACL restricts
+// writes to Administrators/SYSTEM. No install-dir ACL is loosened by this
+// package (copyBinary sets no Windows ACLs; the directory inherits Program
+// Files protection), so the load-bearing guarantee is that the path never
+// moves out from under it.
+func TestWindowsLauncherUnderProgramFilesACL(t *testing.T) {
+	assert.True(t, strings.HasPrefix(windowsLauncherPath, windowsInstallDir+`\`),
+		"launcher must live inside the install dir")
+	assert.True(t, strings.HasPrefix(windowsInstallDir, `C:\Program Files\`),
+		"install dir must be under Program Files (Administrator-only-writable default ACL)")
 }
 
 // TestPlatformLogDir verifies the ProgramData-with-fallback resolution mirrors


### PR DESCRIPTION
## Summary

Mirrors the Linux launcher-managed model on Windows so an MSI-installed steward is push-upgradeable via the control plane. `windowsManager.Install()` now installs `cfgms-steward-launcher.exe` to the exact compile-time path push-upgrade execs (`C:\Program Files\CFGMS\cfgms-steward-launcher.exe`, matching `client_transport_upgrade.go`'s `launcherPath()`), stages the steward via the launcher's own `swap` surface, and registers the SCM service to run the launcher — never the bare steward binary. The launcher is bundled in the MSI payload (decision 1: bundled only, no post-install fetch path exists).

## Changes

- `cmd/steward/service/manager_windows.go` — launcher constants (path parity with push-upgrade), fail-closed launcher-presence check before any privileged operation, launcher install via `copyBinary`, staging via `exec.Command(windowsLauncherPath, "swap", "--root", windowsInstallDir, ver, m.binaryPath)` (fixed binary + discrete argv, no shell composition), service registration via `buildLauncherServiceArgs()` (`run --root ... --child-args "..."`, mirroring `generateSystemdUnit`), purge-time removal of launcher + `versions\` + state files by specific path (never the MSI-owned install dir), `Status()` reports the launcher path (Linux parity). The legacy steward self-copy to `windowsInstallPath` is removed — from the MSI custom action it was a self-overwrite of a running exe; under the launcher model the steward runs from the versioned layout.
- `build/windows/build-msi.ps1` — Step 1c builds `cfgms-steward-launcher.exe` per-arch; new `-d LauncherPath=...` wix define.
- `build/windows/cfgms-steward.wxs` — `StewardLauncherBinary` component bundles the launcher into `CFGMSDIR` before the `RunInstall*` custom actions run; `ComponentRef` added.
- `cmd/steward/service/manager_windows_test.go` — REQUIRED tests: path parity (`TestWindowsLauncherPathParity`), fail-closed launcher-missing (`TestWindowsInstallLauncherMissing`), launcher-targeted service args incl. negative bare-binary assertion (`TestBuildLauncherServiceArgs`), Program Files ACL placement (`TestWindowsLauncherUnderProgramFilesACL`); existing path/status tests updated to the launcher path.

## Live verification (this Windows host, real binaries)

- Built steward + launcher; drove the real CLI: `status` reports `Install path: C:\Program Files\CFGMS\cfgms-steward-launcher.exe`.
- Drove the exact staging argv `Install()` composes against a scratch root: `swap` staged `versions\v0.5.0-test\cfgms-steward.exe` + `state.json`; `launcher status` shows `Current: v0.5.0-test`.
- Drove `launcher run --root ... --child-args "--regtoken ..."` (the registered service command): launcher exec'd the staged steward, forwarded child args, and correctly handled the child exit with no-rollback-available (unconfigured dev binary — expected).
- Non-admin `install` correctly stops at the elevation gate (`cmd/steward/main.go:710` CLI gate precedes `Install()`); the launcher-missing fail-closed path fires for elevated callers (the MSI SYSTEM custom action) before any service mutation, and is unit-tested.
- MSI build itself not run on this host (no dotnet/WiX toolchain); the `build-msi.ps1` change parses clean and mirrors the shipped darwin `build-pkg.sh` launcher step.

## Review (story-review adversarial gate, 4 lenses, round 1 clean)

- **Acceptance checker**: PASS — all named symbols/tests delivered, no stubs.
- **QA test runner**: PASS — `make test` green except the two documented pre-existing Windows-host failures (`cmd/cfg/cmd` Unix-perm tests, `cmd/cfgms-steward-launcher` timing tests, from the #2221 merge — unrelated packages, no new failing test names); `go vet` and `gofmt` clean on changed files.
- **QA code reviewer**: PASS — no mocks, no skips, functional tests for new production code.
- **Security engineer**: PASS — staging exec uses fixed compile-time absolute path + discrete argv (no shell composition, no PATH lookup); no ACL loosening (Program Files default ACL inherited); no post-install fetch path; no secrets. Host lacks gosec/Trivy/Nancy binaries — the security-deployment-gate CI check enforces the full scan matrix on this PR.

Fixes #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SUVZR6kTwcXDNwjgq8ygn