### PR TITLE
steward: register github_runner module as steward factory builtin (Issue #2427)

### DIFF
--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -99,7 +99,8 @@ CFGMS-authored but used on only a subset of the fleet; built as standalone bundl
 
 - `acme` - ACME/Let's Encrypt certificate management
 - `activedirectory` - Local Active Directory integration (steward)
-- `hyperv` - In-host Hyper-V management via a persistent PowerShell host subprocess (steward kind; runs on the Hyper-V host itself)
+- `github_runner` - GitHub Actions self-hosted runner agent lifecycle (install + service management; the module is token-free, never mints/consumes registration tokens). Like `hyperv`, it is currently statically registered in the steward factory as an interim measure pending the future stdlib/extended split-loading story, rather than pulled on-demand per ADR-006.
+- `hyperv` - In-host Hyper-V management via a persistent PowerShell host subprocess (steward kind; runs on the Hyper-V host itself). Statically registered in the steward factory as an interim measure (same as `github_runner` above).
 
 **Outpost modules:**
 

--- a/docs/development/ci-runner-github-app-setup.md
+++ b/docs/development/ci-runner-github-app-setup.md
@@ -141,12 +141,13 @@ is viable.
 **Deviations from the target workflow path (pre-existing gaps, filed for follow-up):**
 the `cirunner-provision.yaml` workflow could not run this sequence yet. The deployed
 lab controller predates the workflow-submission endpoint (`cfg workflow run` → 404),
-and two source-level gaps block it on any current build: the workflow engine
+and one source-level gap blocks it on any current build: the workflow engine
 registers the `github` APIProvider with a nil secrets store
 (`features/workflow/providers.go` — never re-injected with the controller's secret
-store), and the `github_runner` module is not registered in the steward module
-factory (`features/steward/factory/factory.go`), so the runner cfg cannot converge
-on a steward. The registration token for this run was minted directly against the
+store). The `github_runner` module is now registered in the steward factory
+(`features/steward/factory/factory.go` — Issue #2427); the operator-assisted
+registration used in this lab run was a point-in-time deviation, not a standing
+limitation. The registration token for this run was minted directly against the
 GitHub API (same endpoint the App-based provider calls) and delivered over an
 operator SSH session — never composed into a CFGMS command string. Sequence and
 timings otherwise mirror the workflow's steps 1–4.
@@ -192,7 +193,8 @@ auto-start) — runner `online` at the first API poll after the script exits.
 
 **Deviations for this run:** same workflow-path gaps as the Linux run above (token
 minted directly against the GitHub API; agent staged operator-side because the
-`github_runner` module is still not in the steward factory). Two additional lab
+`github_runner` module was not yet in the steward factory at the time of this lab
+run — that gap was closed by Issue #2427). Two additional lab
 findings recorded for follow-up: (1) the deployed v0.9.9 hyperv module rendered the
 pre-#2355 `--ca-cert` install flag, which no current steward accepts — resolved by
 push-upgrading the HV-host steward to v0.9.10 and staging a matching guest

--- a/features/steward/factory/factory.go
+++ b/features/steward/factory/factory.go
@@ -43,6 +43,7 @@ import (
 	acme_module "github.com/cfgis/cfgms/features/modules/acme"
 	"github.com/cfgis/cfgms/features/modules/file"
 	"github.com/cfgis/cfgms/features/modules/firewall"
+	github_runner_module "github.com/cfgis/cfgms/features/modules/github_runner"
 	"github.com/cfgis/cfgms/features/modules/hyperv"
 	package_module "github.com/cfgis/cfgms/features/modules/package"
 	"github.com/cfgis/cfgms/features/modules/patch"
@@ -174,13 +175,14 @@ func (f *ModuleFactory) LoadModule(moduleName string) (modules.Module, error) {
 // Note: "hyperv" is intentionally absent — it is handled separately by newHypervModule
 // (which wires the durable provision store) and early-returned in loadBuiltinModule.
 var builtinModuleConstructors = map[string]func() modules.Module{
-	"acme":      func() modules.Module { return acme_module.New() },
-	"directory": func() modules.Module { return file.New() }, // merged into file module (type: directory)
-	"file":      func() modules.Module { return file.New() },
-	"firewall":  func() modules.Module { return firewall.New() },
-	"package":   func() modules.Module { return package_module.New() },
-	"patch":     func() modules.Module { return patch.New() },
-	"script":    func() modules.Module { return script.New() },
+	"acme":          func() modules.Module { return acme_module.New() },
+	"directory":     func() modules.Module { return file.New() }, // merged into file module (type: directory)
+	"file":          func() modules.Module { return file.New() },
+	"firewall":      func() modules.Module { return firewall.New() },
+	"github_runner": func() modules.Module { return github_runner_module.New() },
+	"package":       func() modules.Module { return package_module.New() },
+	"patch":         func() modules.Module { return patch.New() },
+	"script":        func() modules.Module { return script.New() },
 }
 
 // loadBuiltinModule creates a new instance of a built-in module.

--- a/features/steward/factory/factory_test.go
+++ b/features/steward/factory/factory_test.go
@@ -226,10 +226,26 @@ func TestGetModuleInfo(t *testing.T) {
 
 func TestAllBuiltinModulesLoad(t *testing.T) {
 	factory := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail}, logging.NewNoopLogger())
-	for _, name := range []string{"acme", "directory", "file", "firewall", "hyperv", "package", "patch", "script"} {
+	for _, name := range []string{"acme", "directory", "file", "firewall", "github_runner", "hyperv", "package", "patch", "script"} {
 		mod, err := factory.LoadModule(name)
 		assert.NoError(t, err, "built-in module %q must load without error", name)
 		assert.NotNil(t, mod, "built-in module %q must not be nil", name)
+	}
+}
+
+// TestGithubRunner_IsInBuiltinModuleConstructors asserts that "github_runner" is
+// present in builtinModuleConstructors (contrast with hyperv, which is absent
+// from the map and handled separately by newHypervModule). The loaded instance
+// must satisfy modules.Module.
+func TestGithubRunner_IsInBuiltinModuleConstructors(t *testing.T) {
+	ctor, ok := builtinModuleConstructors["github_runner"]
+	assert.True(t, ok, `"github_runner" must be in builtinModuleConstructors`)
+
+	if ok {
+		instance := ctor()
+		assert.NotNil(t, instance, "github_runner constructor must return a non-nil instance")
+		_, isModule := interface{}(instance).(modules.Module)
+		assert.True(t, isModule, "github_runner instance must satisfy modules.Module")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `"github_runner"` to `builtinModuleConstructors` in `features/steward/factory/factory.go` — a one-line map entry plus one import, following the plain-constructor pattern already used by `acme`, `file`, `firewall`, `package`, `patch`, and `script`.
- Adds `"github_runner"` to `TestAllBuiltinModulesLoad` and a new `TestGithubRunner_IsInBuiltinModuleConstructors` test that asserts map presence and `modules.Module` satisfaction.
- Updates `docs/architecture/modules/README.md` to list `github_runner` in the extended steward modules section with an interim-static-registration note.
- Updates both Deviations paragraphs in `docs/development/ci-runner-github-app-setup.md` to reflect the registration gap is now closed.

Fixes #2427

## Why

The `github_runner` module (closed #2188) existed but was unreachable from a live steward — `LoadModule("github_runner")` returned "not a built-in module". This blocked the two lab CI runners provisioned by epic #565 (#2335, #2336) from converging their cfg resources.

This is an intentional interim fix mirroring the existing `hyperv` special-case rationale: `github_runner` is nominally `extended` per ADR-016 but is statically registered now for the same "make it load" reason. The stdlib/extended split-loading path is deferred.

## Specialist Review Results

**Code Review:** PASS  
**Test Quality:** PASS (1 fix round — linter cleaned up a redundant compile-time assertion in the new test)  
**Security:** PASS  

## Test plan

- [ ] `TestAllBuiltinModulesLoad` includes `"github_runner"` and passes
- [ ] `TestGithubRunner_IsInBuiltinModuleConstructors` asserts map presence and interface satisfaction
- [ ] All existing factory tests continue to pass
- [ ] `make test-complete` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)