### PR TITLE
controller: cluster registry parsed from steward DNA attributes + read API (Issue #2424)

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -1759,6 +1759,90 @@ Get execution history for a trigger.
 }
 ```
 
+### Cluster Management
+
+Read-only view of the Hyper-V cluster topology derived on demand from steward DNA
+attributes. **This API is eventually consistent**: it reflects whatever `cluster:<name>.*`
+DNA attributes were last published by each steward's `DNARefreshLoop` ticker (default
+30 minutes, configurable via `DNARefreshInterval`). A cluster topology change — a new
+member node, a role ownership transfer — can take up to one refresh interval to appear
+in these endpoints. This is acceptable because no safety-critical behavior (no-duplicate-VM
+enforcement, owner-gated lifecycle actions) depends on this registry; those operations gate
+off live PowerShell queries on every convergence tick, not off this read API.
+
+#### GET /api/v1/clusters
+
+List all clusters visible to the authenticated caller. Clusters are derived by parsing
+`cluster:<name>.*` keys from each steward's `DNA.Attributes`. Only clusters whose member
+stewards belong to the caller's tenant (or a descendant tenant) are returned.
+
+**Required permission:** `cluster:list`
+
+**Tenant scoping:** Caller's tenant from the authenticated context limits which stewards'
+DNA is scanned. An admin mTLS principal (empty tenant) has no scope restriction and sees
+all clusters.
+
+**Response:**
+
+```json
+{
+  "data": [
+    {
+      "name": "cfg-lab",
+      "members": ["steward-a", "steward-b"],
+      "role_owners": {
+        "csv": "CFG-70-02",
+        "cno": "CFG-AB-02"
+      }
+    }
+  ],
+  "timestamp": "2026-07-08T12:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Cluster name from the `cluster:<name>.*` DNA key prefix |
+| `members` | []string | Sorted steward IDs whose DNA carries `cluster:<name>.*` keys |
+| `role_owners` | object | Map of role name → owner node, parsed from `cluster:<name>.resource_owner.<role>` keys |
+
+#### GET /api/v1/clusters/{name}
+
+Get the registry entry for a single named cluster.
+
+Returns 404 when the cluster does not exist or all its member stewards are outside
+the caller's tenant scope. 404 (not 403) is used to avoid disclosing cluster existence
+across tenant boundaries.
+
+**Required permission:** `cluster:read`
+
+**Parameters:**
+
+- `name` (path): Cluster name (e.g., `cfg-lab`)
+
+**Response (200):**
+
+```json
+{
+  "data": {
+    "name": "cfg-lab",
+    "members": ["steward-a", "steward-b"],
+    "role_owners": {
+      "csv": "CFG-70-02",
+      "cno": "CFG-AB-02"
+    }
+  },
+  "timestamp": "2026-07-08T12:00:00Z"
+}
+```
+
+**Error responses:**
+
+| Status | Code | Condition |
+|--------|------|-----------|
+| 400 | `MISSING_CLUSTER_NAME` | `name` path variable is empty |
+| 404 | `CLUSTER_NOT_FOUND` | Cluster does not exist or is outside the caller's tenant |
+
 ### Internal Endpoints (not for external use)
 
 #### POST /raft/message

--- a/features/controller/api/handlers_clusters.go
+++ b/features/controller/api/handlers_clusters.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/controller/clusterregistry"
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ClusterInfo is the per-cluster shape returned by the cluster read endpoints.
+type ClusterInfo struct {
+	Name       string            `json:"name"`
+	Members    []string          `json:"members"`
+	RoleOwners map[string]string `json:"role_owners,omitempty"`
+}
+
+// stewardsToFleetData converts the controller service's StewardInfo slice to the
+// fleet.StewardData slice required by clusterregistry.BuildRegistry. It mirrors
+// controllerServiceAdapter.GetAllStewards (server.go:375-397) but returns only
+// the stewards whose TenantID is in scope for callerTenant.
+//
+// Access rules:
+//   - callerTenant == "" → admin mTLS principal; all tenants are in scope.
+//   - callerTenant == steward.TenantID → exact match; in scope.
+//   - strings.HasPrefix(steward.TenantID, callerTenant+"/") → caller is a hierarchical
+//     ancestor of the steward's tenant; in scope.
+func (s *Server) stewardsInTenantScope(callerTenant string) []fleet.StewardData {
+	infos := s.controllerService.GetAllStewards()
+	result := make([]fleet.StewardData, 0, len(infos))
+	for _, info := range infos {
+		if callerTenant != "" {
+			sameTenant := info.TenantID == callerTenant
+			ancestorTenant := strings.HasPrefix(info.TenantID, callerTenant+"/")
+			if !sameTenant && !ancestorTenant {
+				continue
+			}
+		}
+		var attrs map[string]string
+		if info.DNA != nil {
+			attrs = info.DNA.Attributes
+		}
+		result = append(result, fleet.StewardData{
+			ID:            info.ID,
+			TenantID:      info.TenantID,
+			Status:        info.Status,
+			LastHeartbeat: info.LastHeartbeat,
+			DNAAttributes: attrs,
+		})
+	}
+	return result
+}
+
+// handleListClusters handles GET /api/v1/clusters.
+//
+// Returns all clusters visible to the authenticated caller, derived on demand
+// from cluster:<name>.* DNA attributes in each steward's already-durable
+// DNA.Attributes. The result is eventually consistent — it reflects whatever
+// DNA was last published by the steward's DNARefreshLoop (default 30 min).
+//
+// Tenant scoping mirrors handleListStewards: the caller's tenant from the
+// authenticated context limits which stewards' DNA is scanned. An admin mTLS
+// principal (empty TenantID) has no scope restriction.
+func (s *Server) handleListClusters(w http.ResponseWriter, r *http.Request) {
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
+	reg := clusterregistry.BuildRegistry(s.stewardsInTenantScope(callerTenant))
+
+	clusters := make([]ClusterInfo, 0, len(reg.Clusters()))
+	for name, entry := range reg.Clusters() {
+		members := make([]string, len(entry.Members))
+		copy(members, entry.Members)
+		clusters = append(clusters, ClusterInfo{
+			Name:       name,
+			Members:    members,
+			RoleOwners: entry.RoleOwners,
+		})
+	}
+	sort.Slice(clusters, func(i, j int) bool { return clusters[i].Name < clusters[j].Name })
+
+	s.logger.Info("Listed clusters", "count", len(clusters))
+	s.writeSuccessResponse(w, clusters)
+}
+
+// handleGetCluster handles GET /api/v1/clusters/{name}.
+//
+// Returns the cluster entry for the named cluster, or 404 when the cluster is
+// not found or all its member stewards are outside the caller's tenant scope.
+// 404 (not 403) is used for cross-tenant misses to avoid disclosing cluster
+// existence across tenant boundaries — mirrors handleGetStewardDNA's pattern.
+func (s *Server) handleGetCluster(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	clusterName := vars["name"]
+	clusterNameForLog := logging.SanitizeLogValue(clusterName)
+
+	if clusterName == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Cluster name is required", "MISSING_CLUSTER_NAME")
+		return
+	}
+
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
+	reg := clusterregistry.BuildRegistry(s.stewardsInTenantScope(callerTenant))
+
+	entry := reg.Cluster(clusterName)
+	if entry == nil {
+		// 404 not 403: avoids disclosing whether the cluster exists in another tenant.
+		s.writeErrorResponse(w, http.StatusNotFound, "Cluster not found", "CLUSTER_NOT_FOUND")
+		return
+	}
+
+	members := make([]string, len(entry.Members))
+	copy(members, entry.Members)
+
+	s.logger.Info("Fetched cluster",
+		"cluster_name", clusterNameForLog,
+		"member_count", len(members))
+	s.writeSuccessResponse(w, ClusterInfo{
+		Name:       entry.Name,
+		Members:    members,
+		RoleOwners: entry.RoleOwners,
+	})
+}

--- a/features/controller/api/handlers_clusters_test.go
+++ b/features/controller/api/handlers_clusters_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+)
+
+// seedClusterSteward registers a steward and sets its DNA to carry the given
+// cluster DNA attributes. Used by cluster handler tests.
+func seedClusterSteward(t *testing.T, server *Server, id, tenantID string, dnaAttrs map[string]string) {
+	t.Helper()
+	require.NoError(t, server.controllerService.RegisterSteward(id, tenantID, "addr", "active"))
+	ok := server.controllerService.SetStewardDNA(id, &commonpb.DNA{Id: id, Attributes: dnaAttrs})
+	require.True(t, ok, "SetStewardDNA must return true for a registered steward")
+}
+
+// withClusterTenant returns a copy of req with callerTenant injected via ctxkeys.TenantID,
+// mirroring what authenticationMiddleware does for API-key callers.
+func withClusterTenant(req *http.Request, callerTenant string) *http.Request {
+	ctx := context.WithValue(req.Context(), ctxkeys.TenantID, callerTenant)
+	return req.WithContext(ctx)
+}
+
+// TestHandleListClusters_HappyPath verifies the list endpoint returns all clusters
+// when called by a root admin (no tenant restriction).
+func TestHandleListClusters_HappyPath(t *testing.T) {
+	server := setupTestServer(t)
+
+	seedClusterSteward(t, server, "steward-a", "default", map[string]string{
+		"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
+		"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+	})
+	seedClusterSteward(t, server, "steward-b", "default", map[string]string{
+		"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
+		"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	// No tenant in context → root admin scope (sees everything).
+	rec := httptest.NewRecorder()
+	server.handleListClusters(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []ClusterInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "cfg-lab", resp.Data[0].Name)
+	assert.Len(t, resp.Data[0].Members, 2)
+	assert.Contains(t, resp.Data[0].Members, "steward-a")
+	assert.Contains(t, resp.Data[0].Members, "steward-b")
+	assert.Equal(t, map[string]string{"csv": "CFG-70-02"}, resp.Data[0].RoleOwners)
+}
+
+// TestHandleListClusters_TenantIsolation is the required AC test. A scoped caller
+// must only see clusters whose member stewards belong to the caller's tenant.
+func TestHandleListClusters_TenantIsolation(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Steward in tenant-a has cluster cfg-lab.
+	seedClusterSteward(t, server, "steward-a", "tenant-a", map[string]string{
+		"cluster:cfg-lab.member_nodes":       "node-a",
+		"cluster:cfg-lab.resource_owner.csv": "node-a",
+	})
+	// Steward in tenant-b has cluster cfg-prod.
+	seedClusterSteward(t, server, "steward-b", "tenant-b", map[string]string{
+		"cluster:cfg-prod.member_nodes":       "node-b",
+		"cluster:cfg-prod.resource_owner.cno": "node-b",
+	})
+
+	// Caller scoped to tenant-a: must only see cfg-lab, not cfg-prod.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	req = withClusterTenant(req, "tenant-a")
+	rec := httptest.NewRecorder()
+	server.handleListClusters(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []ClusterInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Data, 1, "tenant-a caller must only see tenant-a clusters")
+	assert.Equal(t, "cfg-lab", resp.Data[0].Name)
+}
+
+// TestHandleListClusters_AncestorTenantSeesDescendants verifies hierarchical ancestor
+// access: a caller at root/msp-a can see clusters from root/msp-a/client-1.
+func TestHandleListClusters_AncestorTenantSeesDescendants(t *testing.T) {
+	server := setupTestServer(t)
+
+	seedClusterSteward(t, server, "steward-child", "root/msp-a/client-1", map[string]string{
+		"cluster:cfg-lab.member_nodes": "node-child",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	req = withClusterTenant(req, "root/msp-a")
+	rec := httptest.NewRecorder()
+	server.handleListClusters(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []ClusterInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "cfg-lab", resp.Data[0].Name)
+}
+
+// TestHandleListClusters_EmptyResult verifies 200 with empty slice when no clusters exist.
+func TestHandleListClusters_EmptyResult(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	rec := httptest.NewRecorder()
+	server.handleListClusters(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []ClusterInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Data)
+}
+
+// TestHandleGetCluster_HappyPath verifies the detail endpoint returns the correct cluster.
+func TestHandleGetCluster_HappyPath(t *testing.T) {
+	server := setupTestServer(t)
+
+	seedClusterSteward(t, server, "steward-a", "default", map[string]string{
+		"cluster:cfg-lab.member_nodes":       "CFG-70-02",
+		"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+		"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters/cfg-lab", nil)
+	req = withVars(req, map[string]string{"name": "cfg-lab"})
+	rec := httptest.NewRecorder()
+	server.handleGetCluster(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data ClusterInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "cfg-lab", resp.Data.Name)
+	assert.Equal(t, []string{"steward-a"}, resp.Data.Members)
+	assert.Equal(t, map[string]string{"csv": "CFG-70-02", "cno": "CFG-AB-02"}, resp.Data.RoleOwners)
+}
+
+// TestHandleGetCluster_NotFound is the required AC test.
+// 404 for unknown cluster name; 404 (not 403) for a cluster outside the caller's tenant.
+func TestHandleGetCluster_NotFound(t *testing.T) {
+	server := setupTestServer(t)
+
+	// A cluster that exists but belongs to tenant-b.
+	seedClusterSteward(t, server, "steward-b", "tenant-b", map[string]string{
+		"cluster:cfg-prod.member_nodes": "node-b",
+	})
+
+	t.Run("unknown cluster name returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters/no-such-cluster", nil)
+		req = withVars(req, map[string]string{"name": "no-such-cluster"})
+		rec := httptest.NewRecorder()
+		server.handleGetCluster(rec, req)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("cluster outside caller tenant returns 404 not 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters/cfg-prod", nil)
+		req = withVars(req, map[string]string{"name": "cfg-prod"})
+		req = withClusterTenant(req, "tenant-a")
+		rec := httptest.NewRecorder()
+		server.handleGetCluster(rec, req)
+		// 404 not 403 — avoids disclosing cluster existence across tenant boundaries.
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
+// TestHandleGetCluster_MissingName verifies 400 when the {name} path variable is empty.
+func TestHandleGetCluster_MissingName(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters/", nil)
+	req = withVars(req, map[string]string{"name": ""})
+	rec := httptest.NewRecorder()
+	server.handleGetCluster(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleClusters_RoutedViaAPIKey exercises the full router path with API keys
+// to verify the route registration and permission gates are wired correctly.
+func TestHandleClusters_RoutedViaAPIKey(t *testing.T) {
+	server := setupTestServer(t)
+
+	listKey := NewTestKey(t, server, []string{"cluster:list"})
+	readKey := NewTestKey(t, server, []string{"cluster:read"})
+
+	t.Run("GET /api/v1/clusters with cluster:list key returns 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+		req.Header.Set("X-API-Key", listKey)
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("GET /api/v1/clusters/{name} with cluster:read key returns 404 for unknown", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters/no-such-cluster", nil)
+		req.Header.Set("X-API-Key", readKey)
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+		// 404: cluster does not exist, but the route resolved and permission passed.
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("GET /api/v1/clusters without credentials returns 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -92,6 +92,9 @@ var knownPermissions = map[string]bool{
 	"registration:manage-refresh-policy": true,
 	// Batch job management (Issue #2296)
 	"jobs:write": true,
+	// Cluster registry (Issue #2424)
+	"cluster:list": true,
+	"cluster:read": true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -455,6 +455,13 @@ func (s *Server) setupRouter() {
 	// Default for all routes on the api subrouter. Tier-3 (TierMTLSOnly) endpoints are
 	// additionally wrapped with requireTier(TierMTLSOnly); see Issue #1419 story S3.
 
+	// Cluster registry endpoints (Issue #2424): read-only view of cluster topology
+	// derived on demand from steward DNA attributes. Eventually consistent (up to one
+	// DNARefreshInterval, default 30 min) — see docs/api/rest-api.md for details.
+	clusters := api.PathPrefix("/clusters").Subrouter()
+	clusters.Handle("", s.requirePermission("cluster", "list")(http.HandlerFunc(s.handleListClusters))).Methods("GET")
+	clusters.Handle("/{name}", s.requirePermission("cluster", "read")(http.HandlerFunc(s.handleGetCluster))).Methods("GET")
+
 	// Steward management endpoints (require API key authentication)
 	stewards := api.PathPrefix("/stewards").Subrouter()
 	stewards.Handle("", s.requirePermission("steward", "list")(http.HandlerFunc(s.handleListStewards))).Methods("GET")

--- a/features/controller/clusterregistry/registry.go
+++ b/features/controller/clusterregistry/registry.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package clusterregistry builds a read-model cluster registry from steward DNA
+// attributes. It has no internal state of its own — BuildRegistry is a pure
+// parse function over already-durable data; callers provide the steward slice
+// (usually from fleet.StewardProvider.GetAllStewards) and receive an immutable
+// Registry snapshot. The registry is eventually consistent: it reflects whatever
+// DNA attributes were last published by the steward's DNARefreshLoop ticker
+// (default 30 min); topology changes can take up to one interval to appear.
+package clusterregistry
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+)
+
+const (
+	clusterKeyPrefix    = "cluster:"
+	resourceOwnerPrefix = "resource_owner."
+)
+
+// ClusterEntry holds the parsed view for one cluster.
+type ClusterEntry struct {
+	// Name is the cluster name extracted from the cluster:<Name>.* DNA key prefix.
+	Name string
+	// Members is the sorted list of steward IDs whose DNA carries cluster:<Name>.* keys.
+	Members []string
+	// RoleOwners maps role name → owner value parsed from cluster:<Name>.resource_owner.<role> keys.
+	RoleOwners map[string]string
+}
+
+// Registry is the cluster view derived from steward DNA attributes.
+// It is immutable after construction by BuildRegistry.
+type Registry struct {
+	clusters    map[string]*ClusterEntry
+	memberIndex map[string][]string // stewardID → sorted slice of cluster names
+}
+
+// Clusters returns all cluster entries keyed by cluster name.
+// The returned map must not be mutated by the caller.
+func (r *Registry) Clusters() map[string]*ClusterEntry {
+	return r.clusters
+}
+
+// Cluster returns the entry for one cluster by name, or nil if not found.
+func (r *Registry) Cluster(name string) *ClusterEntry {
+	return r.clusters[name]
+}
+
+// MemberClusters returns the sorted cluster names that stewardID belongs to.
+// Returns nil (not an empty slice) when stewardID has no cluster membership.
+func (r *Registry) MemberClusters(stewardID string) []string {
+	return r.memberIndex[stewardID]
+}
+
+// BuildRegistry parses cluster:<name>.* DNA attributes from the given stewards
+// into an immutable Registry.
+//
+// Tenant scoping must be applied by the caller before passing the steward slice
+// (pass only stewards whose TenantID is in the caller's scope).
+//
+// Defensive parsing: unrecognised or malformed cluster:* keys are silently
+// skipped and never affect other stewards' valid keys.
+func BuildRegistry(stewards []fleet.StewardData) *Registry {
+	reg := &Registry{
+		clusters:    make(map[string]*ClusterEntry),
+		memberIndex: make(map[string][]string),
+	}
+
+	// seen tracks which stewards have already been recorded as members of each
+	// cluster so that multiple cluster:<name>.* keys for the same steward do
+	// not produce duplicate member entries.
+	seen := make(map[string]map[string]bool) // clusterName → set of steward IDs
+
+	for _, steward := range stewards {
+		for key, value := range steward.DNAAttributes {
+			if !strings.HasPrefix(key, clusterKeyPrefix) {
+				continue
+			}
+			rest := key[len(clusterKeyPrefix):]
+			dotIdx := strings.Index(rest, ".")
+			if dotIdx <= 0 {
+				// Malformed: no dot separator or empty cluster name — skip silently.
+				continue
+			}
+			clusterName := rest[:dotIdx]
+			field := rest[dotIdx+1:]
+			if field == "" {
+				continue
+			}
+
+			// Get or create the cluster entry.
+			entry, exists := reg.clusters[clusterName]
+			if !exists {
+				entry = &ClusterEntry{
+					Name:       clusterName,
+					RoleOwners: make(map[string]string),
+				}
+				reg.clusters[clusterName] = entry
+				seen[clusterName] = make(map[string]bool)
+			}
+
+			// Record this steward as a member exactly once per cluster.
+			if !seen[clusterName][steward.ID] {
+				seen[clusterName][steward.ID] = true
+				entry.Members = append(entry.Members, steward.ID)
+				reg.memberIndex[steward.ID] = append(reg.memberIndex[steward.ID], clusterName)
+			}
+
+			// Parse role ownership from resource_owner.<role> fields.
+			if strings.HasPrefix(field, resourceOwnerPrefix) {
+				role := field[len(resourceOwnerPrefix):]
+				if role != "" {
+					entry.RoleOwners[role] = value
+				}
+			}
+		}
+	}
+
+	// Sort for deterministic output.
+	for _, entry := range reg.clusters {
+		sort.Strings(entry.Members)
+	}
+	for id := range reg.memberIndex {
+		sort.Strings(reg.memberIndex[id])
+	}
+
+	return reg
+}

--- a/features/controller/clusterregistry/registry_test.go
+++ b/features/controller/clusterregistry/registry_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package clusterregistry_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/clusterregistry"
+	"github.com/cfgis/cfgms/features/controller/fleet"
+)
+
+// TestClusterRegistry_ParsesDNAAttributes_MultiSteward is the required AC test.
+// It asserts both the forward view (cluster → members → role owners) and the
+// reverse MemberClusters(stewardID) lookup against the same fixture data.
+func TestClusterRegistry_ParsesDNAAttributes_MultiSteward(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{
+			ID:       "steward-a",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
+				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
+				"hostname": "CFG-70-02",
+			},
+		},
+		{
+			ID:       "steward-b",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
+				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
+				"hostname": "CFG-AB-02",
+			},
+		},
+	}
+
+	reg := clusterregistry.BuildRegistry(stewards)
+	require.NotNil(t, reg)
+
+	// Forward view: cluster → members → role owners.
+	clusters := reg.Clusters()
+	assert.Len(t, clusters, 1)
+
+	entry, ok := clusters["cfg-lab"]
+	require.True(t, ok, "expected cluster 'cfg-lab' in registry")
+	assert.Equal(t, "cfg-lab", entry.Name)
+
+	members := make([]string, len(entry.Members))
+	copy(members, entry.Members)
+	sort.Strings(members)
+	assert.Equal(t, []string{"steward-a", "steward-b"}, members)
+
+	assert.Equal(t, map[string]string{
+		"csv": "CFG-70-02",
+		"cno": "CFG-AB-02",
+	}, entry.RoleOwners)
+
+	// Reverse lookup: stewardID → cluster names.
+	clustersA := reg.MemberClusters("steward-a")
+	assert.Equal(t, []string{"cfg-lab"}, clustersA)
+
+	clustersB := reg.MemberClusters("steward-b")
+	assert.Equal(t, []string{"cfg-lab"}, clustersB)
+
+	// Unknown steward returns empty/nil.
+	clustersC := reg.MemberClusters("unknown-steward")
+	assert.Empty(t, clustersC)
+}
+
+func TestClusterRegistry_EmptyInput(t *testing.T) {
+	reg := clusterregistry.BuildRegistry(nil)
+	require.NotNil(t, reg)
+	assert.Empty(t, reg.Clusters())
+	assert.Empty(t, reg.MemberClusters("any"))
+}
+
+func TestClusterRegistry_NoClusterKeys(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{
+			ID:       "steward-a",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				"hostname": "myhost",
+				"os":       "linux",
+			},
+		},
+	}
+	reg := clusterregistry.BuildRegistry(stewards)
+	assert.Empty(t, reg.Clusters())
+	assert.Empty(t, reg.MemberClusters("steward-a"))
+}
+
+func TestClusterRegistry_MalformedKeySkipped(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{
+			ID:       "steward-a",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				// Malformed: no dot separator → should be silently skipped.
+				"cluster:badkey":                     "val",
+				// Malformed: empty cluster name → should be silently skipped.
+				"cluster:.member_nodes":              "x",
+				// Valid key alongside the bad ones.
+				"cluster:cfg-lab.member_nodes":       "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+			},
+		},
+	}
+	reg := clusterregistry.BuildRegistry(stewards)
+	clusters := reg.Clusters()
+	// Only the valid cluster should appear; malformed keys are silently dropped.
+	assert.Len(t, clusters, 1)
+	_, ok := clusters["cfg-lab"]
+	assert.True(t, ok)
+	// Bad keys must not have leaked into the registry.
+	_, badPresent := clusters["badkey"]
+	assert.False(t, badPresent)
+}
+
+func TestClusterRegistry_MultipleClusters(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{
+			ID:       "steward-a",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				"cluster:cfg-lab.member_nodes":         "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.csv":   "CFG-70-02",
+				"cluster:cfg-prod.member_nodes":        "CFG-70-02",
+				"cluster:cfg-prod.resource_owner.cno":  "CFG-70-02",
+			},
+		},
+	}
+	reg := clusterregistry.BuildRegistry(stewards)
+
+	assert.Len(t, reg.Clusters(), 2)
+
+	labEntry := reg.Cluster("cfg-lab")
+	require.NotNil(t, labEntry)
+	assert.Equal(t, []string{"steward-a"}, labEntry.Members)
+
+	prodEntry := reg.Cluster("cfg-prod")
+	require.NotNil(t, prodEntry)
+	assert.Equal(t, []string{"steward-a"}, prodEntry.Members)
+
+	// Reverse lookup: steward-a belongs to both clusters.
+	memberClusters := reg.MemberClusters("steward-a")
+	sort.Strings(memberClusters)
+	assert.Equal(t, []string{"cfg-lab", "cfg-prod"}, memberClusters)
+}
+
+func TestClusterRegistry_StewardDeduplication(t *testing.T) {
+	// A steward with multiple cluster:name.* keys for the same cluster should
+	// appear exactly once as a member, even though multiple keys trigger it.
+	stewards := []fleet.StewardData{
+		{
+			ID:       "steward-a",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				"cluster:cfg-lab.member_nodes":       "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.cno": "CFG-70-02",
+				"cluster:cfg-lab.found":              "true",
+			},
+		},
+	}
+	reg := clusterregistry.BuildRegistry(stewards)
+	entry := reg.Cluster("cfg-lab")
+	require.NotNil(t, entry)
+	assert.Len(t, entry.Members, 1, "steward should appear exactly once as a member")
+	assert.Equal(t, []string{"steward-a"}, entry.Members)
+}
+
+func TestClusterRegistry_Cluster_NotFound(t *testing.T) {
+	reg := clusterregistry.BuildRegistry(nil)
+	assert.Nil(t, reg.Cluster("does-not-exist"))
+}
+
+func TestClusterRegistry_RoleOwnerNotOverwrittenByNonOwnerField(t *testing.T) {
+	// Non resource_owner fields (e.g., member_nodes, found) must not pollute RoleOwners.
+	stewards := []fleet.StewardData{
+		{
+			ID:       "steward-a",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				"cluster:cfg-lab.member_nodes":       "CFG-70-02",
+				"cluster:cfg-lab.found":              "true",
+				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
+			},
+		},
+	}
+	reg := clusterregistry.BuildRegistry(stewards)
+	entry := reg.Cluster("cfg-lab")
+	require.NotNil(t, entry)
+	// Only csv role should be present; member_nodes and found must not appear.
+	assert.Equal(t, map[string]string{"csv": "CFG-70-02"}, entry.RoleOwners)
+}


### PR DESCRIPTION
## Summary

- New `features/controller/clusterregistry` package: pure `BuildRegistry([]fleet.StewardData) *Registry` parse function derives cluster topology from `cluster:<name>.*` DNA attributes on demand — no new storage, no background goroutine
- New `GET /api/v1/clusters` and `GET /api/v1/clusters/{name}` REST endpoints with tenant isolation mirroring the existing steward read-API patterns
- Forward view (cluster → member steward IDs → role owners) plus reverse `MemberClusters(stewardID)` lookup for Issue #2425 cascade story
- Docs: "### Cluster Management" section added to `docs/api/rest-api.md` with eventual-consistency staleness bound (≤1 DNARefreshInterval, default 30 min)

## Specialist Review Results

| Lens | Verdict |
|------|---------|
| Security Review | **PASS** — tenant isolation correct (exact + ancestor prefix with `/` boundary), cross-tenant 404-not-403, `SanitizeLogValue` applied, permission gates wired, no SQL/secrets/provider violations |
| QA Code Review | **PASS** — all new code covered by functional tests using real CFGMS components; error paths, tenant isolation, and hierarchical ancestor access each have dedicated tests; no mocks, no t.Skip |
| Acceptance Check | **PASS** — all AC code references verified against working tree; required tests `TestClusterRegistry_ParsesDNAAttributes_MultiSteward`, `TestHandleListClusters_TenantIsolation`, `TestHandleGetCluster_NotFound` present and passing |

## AC Coverage

- [x] ≥2 stewards with `cluster:cfg-lab.*` DNA → `GET /api/v1/clusters` reports one cluster with both stewards as members and correct role owners
- [x] `GET /api/v1/clusters` returns only clusters in caller's tenant scope
- [x] `TestClusterRegistry_ParsesDNAAttributes_MultiSteward` — forward + reverse lookup
- [x] `TestHandleListClusters_TenantIsolation`
- [x] `TestHandleGetCluster_NotFound` — 404 for unknown and cross-tenant (not 403)
- [x] `docs/api/rest-api.md` updated with eventual-consistency note
- [x] All changed-package tests pass (`clusterregistry`, `controller/api`, `controller/service`, `controller/fleet`)

Fixes #2424