### PR TITLE
steward: wire module Monitor engine into controller-mode stewards (Issue #2435)

### DIFF
--- a/cmd/steward/dna_adapter_test.go
+++ b/cmd/steward/dna_adapter_test.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Issue #2435: dnaCollectorAdapter post-construction wiring and end-to-end test.
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
+	"github.com/cfgis/cfgms/features/steward/execution"
+	"github.com/cfgis/cfgms/features/steward/factory"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ─── real module DNA source fixture ──────────────────────────────────────────
+
+// newModuleDNAExecutor builds a real *execution.Executor — the same CFGMS
+// component that satisfies moduleDNASource in production — wired to a
+// Monitor-capable test module. It applies a config, starts monitors, and drives
+// a synthetic ChangeEvent through the module's Changes() channel so that
+// CollectModuleDNAAttributes returns the flattened, namespaced module attribute
+// set keyed under resourceID (e.g. "<resourceID>.state"). No mocks: the returned
+// executor is the production producer, exercised end to end.
+func newModuleDNAExecutor(t *testing.T, logger logging.Logger, resourceID string, details map[string]interface{}) *execution.Executor {
+	t.Helper()
+
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	const moduleName = "e2emon"
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logger)
+	mod := newE2EMonitorModule()
+	f.RegisterModule(moduleName, mod)
+
+	e, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logger,
+		Factory:       f,
+		ErrorHandling: errCfg,
+	})
+	require.NoError(t, err)
+	// Short debounce so the change is coalesced and applied promptly.
+	e.SetMonitorDebounceWindow(20 * time.Millisecond)
+
+	configYAML := []byte(fmt.Sprintf(`
+steward:
+  id: dna-test-steward
+resources:
+  - name: %s
+    module: %s
+    config:
+      state: present
+`, resourceID, moduleName))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	_, applyErr := e.ApplyConfiguration(ctx, configYAML, "v1")
+	require.NoError(t, applyErr)
+
+	resources := []stewardconfig.ResourceConfig{
+		{Name: resourceID, Module: moduleName, Config: map[string]interface{}{"state": "present"}},
+	}
+	require.NoError(t, e.StartMonitors(ctx, resources))
+	t.Cleanup(e.StopMonitors)
+
+	mod.SendChange(modules.ChangeEvent{
+		ResourceID: resourceID,
+		ChangeType: modules.ChangeTypeModified,
+		Details:    execution.NewConfigState(details),
+	})
+
+	require.Eventually(t, func() bool {
+		return len(e.CollectModuleDNAAttributes(ctx)) > 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"real module DNA source must publish attributes before use")
+
+	return e
+}
+
+// ─── Issue #2435 AC7: adapter with setModuleDNASource post-construction ───────
+
+// TestDNACollectorAdapter_SetModuleDNASource_PurityTest verifies that
+// setModuleDNASource is thread-safe and that the swapped-in source is the one
+// actually read by the adapter on the next CollectAttributes call — proving the
+// modules field is live (read under the RWMutex) and not captured at construction.
+// Every assertion goes through adapter.CollectAttributes, not the source directly.
+func TestDNACollectorAdapter_SetModuleDNASource_PurityTest(t *testing.T) {
+	logger := logging.NewLogger("debug")
+	adapter := newDNACollectorAdapter(logger, nil)
+	ctx := context.Background()
+
+	// Real executor #1 produces "res-a.state=running".
+	src := newModuleDNAExecutor(t, logger, "res-a", map[string]interface{}{"state": "running"})
+	adapter.setModuleDNASource(src)
+
+	// Concurrently call CollectAttributes to exercise the RWMutex around modules.
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = adapter.CollectAttributes(ctx)
+		}()
+	}
+	wg.Wait()
+
+	// Through the adapter, the wired source's module attribute must be present.
+	attrs1, err := adapter.CollectAttributes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "running", attrs1["res-a.state"],
+		"adapter.CollectAttributes must surface the wired source's module attribute")
+
+	// Swap to a second real executor producing a disjoint key.
+	src2 := newModuleDNAExecutor(t, logger, "res-b", map[string]interface{}{"state": "healthy"})
+	adapter.setModuleDNASource(src2)
+
+	// The adapter must now read from src2 — proving setModuleDNASource stored src2
+	// under the RWMutex and CollectAttributes reads the live field.
+	attrs2, err := adapter.CollectAttributes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "healthy", attrs2["res-b.state"],
+		"setModuleDNASource must swap the live source read by adapter.CollectAttributes")
+	_, hadOld := attrs2["res-a.state"]
+	assert.False(t, hadOld, "after the swap the adapter must not read the previous source")
+}
+
+// ─── AC7 parity test: pre-wired vs post-wired adapter return identical result ─
+
+// TestDNACollectorAdapter_PreWiredVsPostWired is the REQUIRED TEST for Issue #2435
+// AC7: an adapter with moduleDNASource set post-construction produces the same
+// module attribute map as one wired at construction time.
+func TestDNACollectorAdapter_PreWiredVsPostWired(t *testing.T) {
+	logger := logging.NewLogger("debug")
+	ctx := context.Background()
+
+	// One real executor shared by both adapters, producing a namespaced module set.
+	src := newModuleDNAExecutor(t, logger, "res-x", map[string]interface{}{
+		"state":   "running",
+		"version": "3.2.1",
+	})
+
+	// Pre-wired adapter (construction-time wiring, as standalone mode does).
+	preWired := newDNACollectorAdapter(logger, src)
+
+	// Post-wired adapter (construction with nil, then setter, as controller mode does).
+	postWired := newDNACollectorAdapter(logger, nil)
+	postWired.setModuleDNASource(src)
+
+	// Invoke each adapter's CollectAttributes — the actual production path.
+	preAttrs, err := preWired.CollectAttributes(ctx)
+	require.NoError(t, err)
+	postAttrs, err := postWired.CollectAttributes(ctx)
+	require.NoError(t, err)
+
+	// The module-namespaced subset must be identical regardless of when the source
+	// was wired. Compare against the executor's own output to avoid asserting on
+	// host-dependent hardware facts.
+	wantModule := src.CollectModuleDNAAttributes(ctx)
+	require.NotEmpty(t, wantModule, "executor must produce module attributes")
+	for k, v := range wantModule {
+		assert.Equal(t, v, preAttrs[k],
+			"pre-wired adapter must surface module attribute %s via CollectAttributes", k)
+		assert.Equal(t, v, postAttrs[k],
+			"post-wired adapter must surface module attribute %s via CollectAttributes", k)
+	}
+}
+
+// ─── Issue #2435 AC8: real end-to-end controller-mode monitor → DNA ───────────
+
+// e2eMonitorModule is a real modules.Module + modules.Monitor for the end-to-end test.
+type e2eMonitorModule struct {
+	mu          sync.Mutex
+	changesCh   chan modules.ChangeEvent
+	setCalled   bool
+	closeCalled bool
+}
+
+func newE2EMonitorModule() *e2eMonitorModule {
+	return &e2eMonitorModule{changesCh: make(chan modules.ChangeEvent, 16)}
+}
+
+func (m *e2eMonitorModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	// Return matching state so reconcile does not call Set during initial convergence.
+	return execution.NewConfigState(map[string]interface{}{"state": "present"}), nil
+}
+
+func (m *e2eMonitorModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	m.mu.Lock()
+	m.setCalled = true
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *e2eMonitorModule) Monitor(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+func (m *e2eMonitorModule) Changes() <-chan modules.ChangeEvent { return m.changesCh }
+
+func (m *e2eMonitorModule) Close() error {
+	m.mu.Lock()
+	m.closeCalled = true
+	close(m.changesCh)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *e2eMonitorModule) SendChange(evt modules.ChangeEvent) { m.changesCh <- evt }
+
+// TestDNACollectorAdapter_EndToEnd_ControllerMode is the REQUIRED TEST for
+// Issue #2435 AC8: a Monitor-capable test module registered into the executor's
+// factory, a config applied via ApplyConfiguration (simulating syncConfigNow),
+// a synthetic ChangeEvent sent through the module's Changes() channel, and the
+// wired dnaCollectorAdapter.CollectModuleDNAAttributes returns the flattened
+// module attribute — proving the controller-mode producer is live end-to-end.
+func TestDNACollectorAdapter_EndToEnd_ControllerMode(t *testing.T) {
+	logger := logging.NewLogger("debug")
+
+	// Build factory with the Monitor-capable module.
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logger)
+	mod := newE2EMonitorModule()
+	f.RegisterModule("e2emon", mod)
+
+	// Create the executor (mimics InitializeConfigExecutor in controller mode).
+	e, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logger,
+		Factory:       f,
+		ErrorHandling: errCfg,
+	})
+	require.NoError(t, err)
+	// Short debounce so the test doesn't wait 1500ms.
+	e.SetMonitorDebounceWindow(20 * time.Millisecond)
+
+	// Build the DNA adapter with nil moduleDNASource (as main.go does pre-wiring).
+	adapter := newDNACollectorAdapter(logger, nil)
+
+	// Wire the executor as the module DNA source (as main.go does post-InitializeConfigExecutor).
+	adapter.setModuleDNASource(e)
+
+	// Apply a config that includes the monitored resource (mimics syncConfigNow →
+	// ApplyConfiguration → StartMonitors).
+	configYAML := []byte(`
+steward:
+  id: e2e-test-steward
+resources:
+  - name: test-resource
+    module: e2emon
+    config:
+      state: present
+`)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, applyErr := e.ApplyConfiguration(ctx, configYAML, "v1")
+	require.NoError(t, applyErr)
+
+	// Start monitors (mimics the StartMonitors call in syncConfigNow after ApplyConfiguration).
+	resources := []stewardconfig.ResourceConfig{
+		{
+			Name:   "test-resource",
+			Module: "e2emon",
+			Config: map[string]interface{}{"state": "present"},
+		},
+	}
+	require.NoError(t, e.StartMonitors(ctx, resources))
+	defer e.StopMonitors()
+
+	// Send a synthetic ChangeEvent through the module's Changes() channel.
+	mod.SendChange(modules.ChangeEvent{
+		ResourceID: "test-resource",
+		ChangeType: modules.ChangeTypeModified,
+		Details: execution.NewConfigState(map[string]interface{}{
+			"state":   "running",
+			"version": "2.1.0",
+		}),
+	})
+
+	// The wired adapter must return the flattened module attribute after the event
+	// is processed — proving the controller-mode producer is live end-to-end.
+	require.Eventually(t, func() bool {
+		attrs := e.CollectModuleDNAAttributes(ctx)
+		return attrs["test-resource.state"] == "running"
+	}, 2*time.Second, 10*time.Millisecond,
+		"controller-mode monitor producer must populate DNA attributes end-to-end")
+
+	attrs := e.CollectModuleDNAAttributes(ctx)
+	assert.Equal(t, "running", attrs["test-resource.state"])
+	assert.Equal(t, "2.1.0", attrs["test-resource.version"])
+
+	// Verify the adapter.CollectModuleDNAAttributes (the wired source path) also
+	// returns the same data — proving the wired chain works correctly.
+	moduleAttrs := adapter.modules.CollectModuleDNAAttributes(ctx)
+	assert.Equal(t, "running", moduleAttrs["test-resource.state"],
+		"adapter.modules.CollectModuleDNAAttributes must return the executor's module DNA")
+}

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1269,6 +1269,10 @@ func connectWithApprovedRegistration(
 	// offline queue encryption (Issue #920).
 	certMgr, secretStore := buildCertManagerAndSecretStore(reg.ClientCert, reg.ClientKey, logger)
 
+	// Build the composite DNA collector early so we can wire the executor into it
+	// after InitializeConfigExecutor creates it (Issue #2435).
+	dnaAdapter := newDNACollectorAdapter(logger, nil)
+
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
 		ControllerURL:               reg.TransportAddress,
 		RegistrationToken:           token,
@@ -1284,7 +1288,7 @@ func connectWithApprovedRegistration(
 		UpgradeAllowDowngrade:       upgradeAllowDowngrade,
 		UpgradePublisherTrustStore:  buildTestPublisherTrustStore(logger),
 		DNARefreshInterval:          dnaRefreshInterval,
-		DNACollector:                newDNACollectorAdapter(logger, nil), // no monitor engine in this mode (#2423)
+		DNACollector:                dnaAdapter,
 		Logger:                      logger,
 		IdentityPersistFunc: func(pems []string, at *time.Time) error {
 			cur, loadErr := loadIdentity(certStoreDir)
@@ -1322,6 +1326,13 @@ func connectWithApprovedRegistration(
 	}
 
 	logger.Info("Configuration executor initialized", "tenant_id", reg.TenantID)
+
+	// Wire the executor as the module DNA source now that it exists (Issue #2435).
+	// The DNA adapter was constructed with nil; setting the executor here means
+	// the first DNA refresh tick after config sync will include module attributes.
+	if executor := transportClient.GetConfigExecutor(); executor != nil {
+		dnaAdapter.setModuleDNASource(executor)
+	}
 
 	return transportClient, nil
 }
@@ -1406,6 +1417,10 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 		dnaRefreshIntervalReconnect = stewardconfig.GetDNARefreshInterval(cfg)
 	}
 
+	// Build the composite DNA collector early so we can wire the executor into it
+	// after InitializeConfigExecutor creates it (Issue #2435).
+	dnaAdapterReconnect := newDNACollectorAdapter(logger, nil)
+
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
 		ControllerURL:               id.TransportAddress,
 		RegistrationToken:           token,
@@ -1421,7 +1436,7 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 		UpgradeAllowDowngrade:       upgradeAllowDowngradeReconnect,
 		UpgradePublisherTrustStore:  buildTestPublisherTrustStore(logger),
 		DNARefreshInterval:          dnaRefreshIntervalReconnect,
-		DNACollector:                newDNACollectorAdapter(logger, nil), // no monitor engine in this mode (#2423)
+		DNACollector:                dnaAdapterReconnect,
 		Logger:                      logger,
 		IdentityPersistFunc: func(pems []string, at *time.Time) error {
 			cur, loadErr := loadIdentity(certStoreDir)
@@ -1460,6 +1475,11 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 	}
 
 	logger.Info("Configuration executor initialized after reconnect", "tenant_id", logging.SanitizeLogValue(id.TenantID))
+
+	// Wire the executor as the module DNA source now that it exists (Issue #2435).
+	if executor := transportClient.GetConfigExecutor(); executor != nil {
+		dnaAdapterReconnect.setModuleDNASource(executor)
+	}
 
 	return transportClient, nil
 }
@@ -1803,22 +1823,30 @@ type moduleDNASource interface {
 // dnaCollectorAdapter adapts dna.Collector to the client.DNACollector interface
 // by extracting the Attributes map from the proto DNA result (Issue #1915),
 // merged with a flattened, namespaced snapshot of monitored module resource
-// state when a moduleDNASource is wired (#2423). Both attribute sets ride the
-// same PublishDNAUpdate delta-compression path — a change in only a module
-// attribute still triggers a publish.
+// state when a moduleDNASource is wired (#2423 / #2435). Both attribute sets
+// ride the same PublishDNAUpdate delta-compression path — a change in only a
+// module attribute still triggers a publish.
 type dnaCollectorAdapter struct {
 	collector *dna.Collector
+	mu        sync.RWMutex
 	modules   moduleDNASource
 }
 
-// newDNACollectorAdapter builds the composite DNA collector. modules may be
-// nil: the monitor fan-in (and therefore CollectModuleDNAAttributes) lives on
-// the standalone steward engine (features/steward.Steward.startMonitors),
-// which the controller-mode transport paths do not construct today — they pass
-// nil and publish hardware facts only, exactly as before #2423. Wire the
-// steward engine (or a narrow method-value) here when a mode has one.
+// newDNACollectorAdapter builds the composite DNA collector. modules may be nil;
+// call setModuleDNASource after InitializeConfigExecutor to wire the real producer
+// (Issue #2435).
 func newDNACollectorAdapter(logger logging.Logger, modules moduleDNASource) *dnaCollectorAdapter {
 	return &dnaCollectorAdapter{collector: dna.NewCollector(logger), modules: modules}
+}
+
+// setModuleDNASource wires the module DNA producer after construction. Thread-safe:
+// the DNA refresh loop may be reading modules concurrently. Called once, right after
+// InitializeConfigExecutor succeeds, at both registration and reconnect call sites
+// (Issue #2435).
+func (a *dnaCollectorAdapter) setModuleDNASource(src moduleDNASource) {
+	a.mu.Lock()
+	a.modules = src
+	a.mu.Unlock()
 }
 
 func (a *dnaCollectorAdapter) CollectAttributes(ctx context.Context) (map[string]string, error) {
@@ -1826,7 +1854,10 @@ func (a *dnaCollectorAdapter) CollectAttributes(ctx context.Context) (map[string
 	if err != nil {
 		return nil, err
 	}
-	if result == nil && a.modules == nil {
+	a.mu.RLock()
+	moduleSrc := a.modules
+	a.mu.RUnlock()
+	if result == nil && moduleSrc == nil {
 		return nil, nil
 	}
 	// Union of hardware facts and module attributes. The two key spaces cannot
@@ -1838,8 +1869,8 @@ func (a *dnaCollectorAdapter) CollectAttributes(ctx context.Context) (map[string
 			attrs[k] = v
 		}
 	}
-	if a.modules != nil {
-		for k, v := range a.modules.CollectModuleDNAAttributes(ctx) {
+	if moduleSrc != nil {
+		for k, v := range moduleSrc.CollectModuleDNAAttributes(ctx) {
 			attrs[k] = v
 		}
 	}

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -585,6 +585,7 @@ The steward binary is the same in every deployment. The table below shows which 
 | Convergence loop (apply/monitor) | Yes | Yes |
 | Scheduled re-check (`converge_interval`) | Yes | Yes (default 30m until cfg received) |
 | Event hooks | Yes | Yes |
+| Module Monitor engine (fan-in, debounce, targeted reconcile) | Yes | Yes — started by `syncConfigNow` after each cfg fetch; stopped by `Disconnect` |
 | DNA collection | Yes | Yes |
 | Health monitoring | Yes | Yes |
 | Performance monitoring | Yes | Yes |

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -1018,6 +1018,13 @@ func (c *TransportClient) syncConfigNow(ctx context.Context, commandID string, m
 		return fmt.Errorf("config application failed: %w", err)
 	}
 
+	// Start module monitors for the new config's resources (Issue #2435).
+	// Full stop+restart — previous engine (from any prior config push) is closed first.
+	// TriggerConvergence re-applies the SAME config and must NOT restart monitors.
+	if startErr := executor.StartMonitors(ctx, goConfig.Resources); startErr != nil {
+		c.logger.Warn("Failed to start module monitors after config sync", "error", startErr)
+	}
+
 	// Publish configuration status report.
 	report.StewardID = sid
 	if err := c.publishConfigStatus(report); err != nil {
@@ -1562,6 +1569,12 @@ func (c *TransportClient) Disconnect(ctx context.Context) error {
 		}
 	}
 
+	// Stop module monitors before closing connections so no further ExecuteResource
+	// calls fire against a disconnected transport (Issue #2435).
+	if c.configExecutor != nil {
+		c.configExecutor.StopMonitors()
+	}
+
 	// Drain and stop the event emitter before closing the gRPC connection so
 	// buffered convergence events are flushed to the controller first.
 	if c.eventEmitter != nil {
@@ -1614,6 +1627,16 @@ func (c *TransportClient) SetStewardID(id string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.stewardID = id
+}
+
+// GetConfigExecutor returns the configuration executor. Returns nil when not yet
+// initialized (before InitializeConfigExecutor is called). The executor implements
+// moduleDNASource after StartMonitors is called — wire it into the DNA collector
+// adapter immediately after InitializeConfigExecutor succeeds (Issue #2435).
+func (c *TransportClient) GetConfigExecutor() *execution.Executor {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.configExecutor
 }
 
 // SetTenantID sets the tenant ID (used after HTTP registration).

--- a/features/steward/client/monitor_test.go
+++ b/features/steward/client/monitor_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Issue #2435: TransportClient wires and stops module Monitor engine.
+package client
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
+	"github.com/cfgis/cfgms/features/steward/execution"
+	"github.com/cfgis/cfgms/features/steward/factory"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ─── real Monitor-capable module for client tests ────────────────────────────
+
+type clientMonitorTestModule struct {
+	mu            sync.Mutex
+	monitorCalled bool
+	closeCalled   int
+	changesCh     chan modules.ChangeEvent
+	closed        bool
+}
+
+func newClientMonitorTestModule() *clientMonitorTestModule {
+	return &clientMonitorTestModule{changesCh: make(chan modules.ChangeEvent, 16)}
+}
+
+func (m *clientMonitorTestModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	return execution.NewConfigState(map[string]interface{}{"state": "present"}), nil
+}
+
+func (m *clientMonitorTestModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+func (m *clientMonitorTestModule) Monitor(_ context.Context, _ string, _ modules.ConfigState) error {
+	m.mu.Lock()
+	m.monitorCalled = true
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *clientMonitorTestModule) Changes() <-chan modules.ChangeEvent { return m.changesCh }
+
+func (m *clientMonitorTestModule) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closeCalled++
+	if !m.closed {
+		m.closed = true
+		close(m.changesCh)
+	}
+	return nil
+}
+
+func (m *clientMonitorTestModule) IsMonitorCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.monitorCalled
+}
+
+func (m *clientMonitorTestModule) CloseCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closeCalled
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// newExecutorWithModule creates an Executor with the given module pre-registered.
+func newExecutorWithModule(t *testing.T, name string, mod modules.Module) *execution.Executor {
+	t.Helper()
+	logger := logging.NewLogger("debug")
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logger)
+	f.RegisterModule(name, mod)
+	e, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logger,
+		Factory:       f,
+		ErrorHandling: errCfg,
+	})
+	require.NoError(t, err)
+	return e
+}
+
+// ─── Issue #2435 AC5: Disconnect stops monitor engine ─────────────────────────
+
+// TestTransportClient_Disconnect_StopsMonitors is the REQUIRED TEST for Issue #2435
+// AC5: no monitor goroutine survives disconnect. The test exercises the Executor's
+// monitor engine directly (StartMonitors + StopMonitors path wired by Disconnect),
+// since TransportClient.Disconnect calls configExecutor.StopMonitors().
+//
+// We test the executor-level guarantee here (the path that Disconnect exercises)
+// rather than the full TransportClient (which requires a live controller connection).
+func TestTransportClient_Disconnect_StopsMonitors(t *testing.T) {
+	mod := newClientMonitorTestModule()
+	e := newExecutorWithModule(t, "testmon", mod)
+	e.SetMonitorDebounceWindow(20 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resources := []stewardconfig.ResourceConfig{
+		{
+			Name:   "res1",
+			Module: "testmon",
+			Config: map[string]interface{}{"state": "present"},
+		},
+	}
+	require.NoError(t, e.StartMonitors(ctx, resources))
+	assert.True(t, mod.IsMonitorCalled(), "Monitor() must be called after StartMonitors")
+	assert.Equal(t, 0, mod.CloseCallCount(), "monitor must not be closed yet")
+
+	// Simulate what TransportClient.Disconnect calls.
+	e.StopMonitors()
+
+	// After StopMonitors (which Disconnect invokes), Close must have been called
+	// and the engine must have stopped — monitorWg.Wait() inside StopMonitors
+	// guarantees no goroutine outlives the call.
+	assert.Equal(t, 1, mod.CloseCallCount(), "Close must be called exactly once on Disconnect path")
+
+	// CollectModuleDNAAttributes must return empty map after stop.
+	assert.Empty(t, e.CollectModuleDNAAttributes(context.Background()),
+		"no module DNA attributes must survive after StopMonitors")
+}
+
+// TestTransportClient_GetConfigExecutor_ReturnsExecutorAfterInitialize verifies
+// that GetConfigExecutor returns the executor set by InitializeConfigExecutor.
+// This is the accessor used by main.go to wire the DNA adapter (Issue #2435).
+func TestTransportClient_GetConfigExecutor_ReturnsExecutorAfterInitialize(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	c := &TransportClient{
+		stewardID:       "test-steward",
+		tenantID:        "test-tenant",
+		heartbeatStop:   make(chan struct{}),
+		convergenceStop: make(chan struct{}),
+		dnaRefreshStop:  make(chan struct{}),
+		offlineQueue:    q,
+		logger:          logging.NewLogger("debug"),
+	}
+
+	// Before initialization, GetConfigExecutor returns nil.
+	assert.Nil(t, c.GetConfigExecutor(), "GetConfigExecutor must return nil before InitializeConfigExecutor")
+
+	// Wire the executor directly (simulating what InitializeConfigExecutor does).
+	e, err := execution.NewExecutor(&execution.ExecutorConfig{Logger: c.logger})
+	require.NoError(t, err)
+	c.mu.Lock()
+	c.configExecutor = e
+	c.mu.Unlock()
+
+	assert.Equal(t, e, c.GetConfigExecutor(), "GetConfigExecutor must return the wired executor")
+}

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -102,6 +102,9 @@ type Executor struct {
 	// and verifyChanges. Derived from ModuleCallTimeoutSec at construction; defaults
 	// to 120 s when the config field is zero or negative (ADR-012 §7).
 	moduleCallTimeout time.Duration
+
+	// Monitor engine fields (Issue #2435). Protected by monitorMu except where noted.
+	monitorFields
 }
 
 // NewExecutor creates an Executor. When cfg.Factory is nil, an empty registry and

--- a/features/steward/execution/monitor.go
+++ b/features/steward/execution/monitor.go
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package execution
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// monitorQueueCapacity is the maximum number of ChangeEvents the fan-in channel
+// can buffer. When full, events are shed to the next scheduled convergence pass.
+const monitorQueueCapacity = 64
+
+// monitorEntry pairs a module's Monitor with its resource configuration.
+// Used to fan-in ChangeEvents and dispatch targeted reconciles.
+type monitorEntry struct {
+	resourceID string
+	resource   config.ResourceConfig
+	monitor    modules.Monitor
+}
+
+// bundleNameFromModuleRef extracts the module bundle name from a module reference.
+// "hyperv.vm" → "hyperv"; "file" → "file".
+func bundleNameFromModuleRef(moduleRef string) string {
+	if idx := strings.IndexByte(moduleRef, '.'); idx >= 0 {
+		return moduleRef[:idx]
+	}
+	return moduleRef
+}
+
+// monitorFields holds the monitor-engine state added to Executor (Issue #2435).
+// Separated into a struct purely for readability; Executor embeds these fields inline.
+type monitorFields struct {
+	// monitorMu guards monitorEntries and monitorStop so StartMonitors and
+	// StopMonitors can coordinate without holding the executor's main RWMutex.
+	monitorMu      sync.Mutex
+	monitorEntries []monitorEntry
+	monitorStop    chan struct{} // closed by StopMonitors; recreated by StartMonitors
+	monitorWg      sync.WaitGroup
+
+	// monitorStateMu guards monitorState.
+	monitorStateMu sync.Mutex
+	monitorState   map[string]map[string]interface{}
+
+	// monitorDebounceWindow is the per-resource debounce interval (default 1500ms).
+	// Overridden by SetMonitorDebounceWindow for tests.
+	monitorDebounceWindow time.Duration
+
+	// monitorFanInCap overrides the fan-in channel capacity when non-zero.
+	// Tests set a small value to guarantee queue overflow without relying on timing.
+	monitorFanInCap int
+
+	// monitorReconcileObserver is called after a targeted reconcile applies changes.
+	// Standalone mode wires in DNA refresh + counter increment; controller mode leaves nil.
+	monitorReconcileObserver func(ctx context.Context, resourceID string)
+}
+
+// SetMonitorReconcileObserver registers a callback invoked by the monitor engine
+// after a targeted reconcile applies changes (ChangesApplied is true). Standalone
+// mode wires this to detectUnmanagedDNADrift + counter increment; controller mode
+// leaves it nil. Pass nil to clear the observer.
+func (e *Executor) SetMonitorReconcileObserver(fn func(ctx context.Context, resourceID string)) {
+	e.monitorMu.Lock()
+	e.monitorReconcileObserver = fn
+	e.monitorMu.Unlock()
+}
+
+// SetMonitorDebounceWindow overrides the debounce window for tests.
+// Call before StartMonitors; has no effect on a running engine.
+func (e *Executor) SetMonitorDebounceWindow(d time.Duration) {
+	e.monitorMu.Lock()
+	e.monitorDebounceWindow = d
+	e.monitorMu.Unlock()
+}
+
+// SetMonitorFanInCap overrides the fan-in channel capacity for tests.
+// Call before StartMonitors; has no effect on a running engine.
+func (e *Executor) SetMonitorFanInCap(cap int) {
+	e.monitorMu.Lock()
+	e.monitorFanInCap = cap
+	e.monitorMu.Unlock()
+}
+
+// StartMonitors iterates the provided resources, loads each module from the
+// factory, type-asserts modules.Monitor, and calls Monitor(ctx, resourceID,
+// desired) for each module that implements the interface. A fan-in goroutine
+// forwards all ChangeEvents to a single dispatch loop that calls
+// runTargetedReconcile on the affected resource.
+//
+// Any previously-running monitor engine is stopped (all goroutines and module
+// instances closed) before the new one starts — a full stop+restart, no
+// incremental diffing. This is safe because factory.ModuleFactory caches
+// instances: calling Monitor() on an already-monitoring instance without an
+// intervening Close() is undefined/leaky.
+//
+// Modules that do not implement Monitor are silently skipped — they fall back
+// to the scheduled convergence interval.
+func (e *Executor) StartMonitors(ctx context.Context, resources []config.ResourceConfig) error {
+	// Stop any previously-running engine first. Full stop+restart — no diff.
+	e.stopMonitorEngine()
+
+	var entries []monitorEntry
+
+	for _, resource := range resources {
+		bundle := bundleNameFromModuleRef(resource.Module)
+
+		mod, err := e.factory.LoadModule(bundle)
+		if err != nil || mod == nil {
+			continue
+		}
+
+		mon, ok := mod.(modules.Monitor)
+		if !ok {
+			continue
+		}
+
+		resourceID := e.GetResourceID(resource)
+		desired := NewConfigState(resource.Config)
+
+		if err := mon.Monitor(ctx, resourceID, desired); err != nil {
+			e.logger.Warn("Failed to start module monitor",
+				"resource", resource.Name,
+				"resource_id", logging.SanitizeLogValue(resourceID),
+				"error", err)
+			continue
+		}
+
+		entries = append(entries, monitorEntry{
+			resourceID: resourceID,
+			resource:   resource,
+			monitor:    mon,
+		})
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	e.monitorMu.Lock()
+	e.monitorEntries = entries
+	stopCh := make(chan struct{})
+	e.monitorStop = stopCh
+	debounce := e.monitorDebounceWindow
+	fanInCap := e.monitorFanInCap
+	e.monitorMu.Unlock()
+
+	if debounce <= 0 {
+		debounce = 1500 * time.Millisecond
+	}
+
+	// Fan-in: one forwarding goroutine per monitor; all send to fanIn.
+	// fanIn is bounded; excess events are shed to the next scheduled convergence
+	// pass (non-blocking drop with Warn log).
+	cap := monitorQueueCapacity
+	if fanInCap > 0 {
+		cap = fanInCap
+	}
+	fanIn := make(chan modules.ChangeEvent, cap)
+
+	for _, entry := range entries {
+		ch := entry.monitor.Changes()
+		e.monitorWg.Add(1)
+		go func(ch <-chan modules.ChangeEvent) {
+			defer e.monitorWg.Done()
+			// seen tracks every resourceID this goroutine cached state for,
+			// so all of them are evicted when monitoring stops.
+			seen := make(map[string]struct{})
+			defer func() { e.evictMonitorState(seen) }()
+			for {
+				select {
+				case evt, ok := <-ch:
+					if !ok {
+						return
+					}
+					// Cache the latest observed state BEFORE the non-blocking
+					// send, so even a shed event still refreshes the module
+					// DNA snapshot (Issue #2423).
+					if e.cacheMonitorState(evt) {
+						seen[evt.ResourceID] = struct{}{}
+					}
+					// Non-blocking send: if the queue is full, shed this event.
+					select {
+					case fanIn <- evt:
+					default:
+						e.logger.Warn("Monitor event queue full, event shed to scheduled poll",
+							"resource_id", logging.SanitizeLogValue(evt.ResourceID))
+					}
+				case <-ctx.Done():
+					return
+				case <-stopCh:
+					return
+				}
+			}
+		}(ch)
+	}
+
+	e.monitorWg.Add(1)
+	go func() {
+		defer e.monitorWg.Done()
+		e.monitorEventLoop(ctx, fanIn, stopCh, debounce)
+	}()
+
+	return nil
+}
+
+// StopMonitors stops the running monitor engine: closes all goroutines, waits
+// for them to exit, closes all monitor instances, and clears state. Idempotent
+// — safe to call when no engine is running.
+func (e *Executor) StopMonitors() {
+	e.stopMonitorEngine()
+}
+
+// stopMonitorEngine is the internal implementation shared by StartMonitors
+// (before re-starting) and StopMonitors (public teardown).
+func (e *Executor) stopMonitorEngine() {
+	e.monitorMu.Lock()
+	stopCh := e.monitorStop
+	entries := e.monitorEntries
+	e.monitorStop = nil
+	e.monitorEntries = nil
+	e.monitorMu.Unlock()
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+
+	// Wait for all fan-in and event-loop goroutines to exit before closing
+	// monitor instances — no further ChangeEvents will be produced after Close().
+	e.monitorWg.Wait()
+
+	// Close all monitor instances (releases OS-level watchers).
+	for _, entry := range entries {
+		if err := entry.monitor.Close(); err != nil {
+			e.logger.Warn("Failed to close monitor",
+				"resource_id", logging.SanitizeLogValue(entry.resourceID),
+				"error", err)
+		}
+	}
+
+	// Clear cached state so CollectModuleDNAAttributes returns empty after stop.
+	e.monitorStateMu.Lock()
+	e.monitorState = nil
+	e.monitorStateMu.Unlock()
+}
+
+// monitorEventLoop reads ChangeEvents from the fan-in channel and dispatches
+// debounced targeted reconciles. Multiple events for the same resourceID within
+// the debounce window are coalesced into a single runTargetedReconcile call.
+// Exits when ctx is cancelled or stopCh is closed.
+func (e *Executor) monitorEventLoop(ctx context.Context, events <-chan modules.ChangeEvent, stopCh <-chan struct{}, debounce time.Duration) {
+	// fireCh receives debounced resourceIDs after their timer window elapses.
+	fireCh := make(chan string, 16)
+	pending := make(map[string]*time.Timer)
+	// afterFuncWg tracks in-flight AfterFunc goroutines so monitorEventLoop
+	// does not return until every timer callback has exited (goroutine-leak guard).
+	var afterFuncWg sync.WaitGroup
+
+	defer func() {
+		// Stop pending timers; if t.Stop() returns true the goroutine never ran,
+		// so call Done() ourselves to balance the Add(1).
+		for _, t := range pending {
+			if t.Stop() {
+				afterFuncWg.Done()
+			}
+		}
+		afterFuncWg.Wait()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-stopCh:
+			return
+		case evt, ok := <-events:
+			if !ok {
+				return
+			}
+			e.logger.Info("Monitor change event received",
+				"resource_id", logging.SanitizeLogValue(evt.ResourceID),
+				"change_type", fmt.Sprintf("%d", evt.ChangeType))
+			resourceID := evt.ResourceID
+			if _, exists := pending[resourceID]; !exists {
+				afterFuncWg.Add(1)
+				pending[resourceID] = time.AfterFunc(debounce, func() {
+					defer afterFuncWg.Done()
+					select {
+					case fireCh <- resourceID:
+					case <-ctx.Done():
+					case <-stopCh:
+					}
+				})
+			}
+			// Duplicate events within the window are coalesced — the existing
+			// timer fires once after the debounce window elapses.
+		case resourceID := <-fireCh:
+			delete(pending, resourceID)
+			e.runTargetedReconcile(ctx, stopCh, resourceID)
+		}
+	}
+}
+
+// cacheMonitorState stores the latest ChangeEvent Details snapshot for a
+// resourceID (Issue #2423). Returns true when a snapshot was cached.
+// Nil Details or an empty ResourceID cache nothing.
+func (e *Executor) cacheMonitorState(evt modules.ChangeEvent) bool {
+	if evt.ResourceID == "" || evt.Details == nil {
+		return false
+	}
+	snap := evt.Details.AsMap()
+	if snap == nil {
+		return false
+	}
+	// Shallow-copy so a module mutating the map it returned cannot race the flattener.
+	copied := make(map[string]interface{}, len(snap))
+	for k, v := range snap {
+		copied[k] = v
+	}
+	e.monitorStateMu.Lock()
+	if e.monitorState == nil {
+		e.monitorState = make(map[string]map[string]interface{})
+	}
+	e.monitorState[evt.ResourceID] = copied
+	e.monitorStateMu.Unlock()
+	return true
+}
+
+// evictMonitorState removes the given resourceIDs from the module-DNA cache.
+// Called when a fan-in goroutine exits so a resource that leaves monitoring
+// disappears from CollectModuleDNAAttributes — the missing key becomes the
+// "this is gone" signal on the next PublishDNAUpdate delta.
+func (e *Executor) evictMonitorState(resourceIDs map[string]struct{}) {
+	if len(resourceIDs) == 0 {
+		return
+	}
+	e.monitorStateMu.Lock()
+	for id := range resourceIDs {
+		delete(e.monitorState, id)
+	}
+	e.monitorStateMu.Unlock()
+}
+
+// CollectModuleDNAAttributes returns a flattened, namespaced snapshot of every
+// actively-monitored module resource's latest observed state (Issue #2423).
+//
+// Key convention:
+//   - every key is "<resourceID>.<field>" with the resourceID verbatim
+//   - nested map keys join with "." → "cluster:cfg-lab.resource_owner.web-01"
+//   - slice values join with ","   → "CFG-70-02,CFG-AB-02"
+//   - any other value stringifies via fmt.Sprintf("%v", v)
+func (e *Executor) CollectModuleDNAAttributes(_ context.Context) map[string]string {
+	out := make(map[string]string)
+	e.monitorStateMu.Lock()
+	defer e.monitorStateMu.Unlock()
+	for resourceID, snap := range e.monitorState {
+		for field, v := range snap {
+			flattenDNAValue(resourceID+"."+field, v, out)
+		}
+	}
+	return out
+}
+
+// RunTargetedReconcile is the exported entry point for targeted reconcile
+// dispatch, called by tests that need to exercise the reconcile path directly
+// without going through the async event loop (e.g. to test the "unmanaged
+// resource" early-exit without starting monitors). A never-closed stop channel
+// is used so the function never exits early via the shutdown path.
+func (e *Executor) RunTargetedReconcile(ctx context.Context, resourceID string) {
+	neverStop := make(chan struct{})
+	e.runTargetedReconcile(ctx, neverStop, resourceID)
+}
+
+// runTargetedReconcile finds the monitorEntry whose resourceID matches and calls
+// ExecuteResource for it. The ChangeEvent that triggered this call is a hint only
+// — current state is read via module.Get() and desired state comes from the
+// retained monitorEntry's ResourceConfig, never from the event.
+//
+// If resourceID is not in the retained entries (unmanaged resource), the call is
+// a no-op. Both ctx.Done() and stopCh are checked before the reconcile so a
+// shutdown mid-dispatch exits cleanly without calling Set after Close().
+//
+// An optional monitorReconcileObserver is called when ChangesApplied is true;
+// standalone mode registers DNA refresh logic there (Issue #2435).
+func (e *Executor) runTargetedReconcile(ctx context.Context, stopCh <-chan struct{}, resourceID string) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-stopCh:
+		return
+	default:
+	}
+
+	// Resolve resourceID → resource from the retained monitorEntry slice.
+	e.monitorMu.Lock()
+	entries := e.monitorEntries
+	observer := e.monitorReconcileObserver
+	e.monitorMu.Unlock()
+
+	for _, entry := range entries {
+		if entry.resourceID == resourceID {
+			e.logger.Info("Running targeted reconcile for monitored resource",
+				"resource", entry.resource.Name,
+				"resource_id", logging.SanitizeLogValue(resourceID))
+			result := e.ExecuteResource(ctx, entry.resource)
+			if result.ChangesApplied && observer != nil {
+				observer(ctx, resourceID)
+			}
+			return
+		}
+	}
+
+	e.logger.Info("Monitor event for unmanaged resource (not in cfg, skipping)",
+		"resource_id", logging.SanitizeLogValue(resourceID))
+}
+
+// flattenDNAValue flattens one value into out under key, per the convention
+// documented on CollectModuleDNAAttributes. Handles the ConfigState.AsMap
+// shapes that occur in practice and falls back to fmt.Sprintf("%v") for
+// anything else — never panics on an unexpected type.
+func flattenDNAValue(key string, v interface{}, out map[string]string) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, sub := range val {
+			flattenDNAValue(key+"."+k, sub, out)
+		}
+	case map[string]string:
+		for k, sub := range val {
+			out[key+"."+k] = sub
+		}
+	case []string:
+		out[key] = strings.Join(val, ",")
+	case []interface{}:
+		parts := make([]string, 0, len(val))
+		for _, elem := range val {
+			parts = append(parts, fmt.Sprintf("%v", elem))
+		}
+		out[key] = strings.Join(parts, ",")
+	case string:
+		out[key] = val
+	default:
+		out[key] = fmt.Sprintf("%v", val)
+	}
+}

--- a/features/steward/execution/monitor_test.go
+++ b/features/steward/execution/monitor_test.go
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package execution_test
+
+// Issue #2435: module Monitor engine on Executor — controller-mode stewards.
+//
+// These tests cover the monitor machinery moved from features/steward.Steward to
+// execution.Executor (Issue #2435). They use real modules.Module + modules.Monitor
+// implementations (no mocks) and follow the same rigor as the Steward-level tests
+// from Issue #2423.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/execution"
+	"github.com/cfgis/cfgms/features/steward/factory"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ─── test module fixtures ────────────────────────────────────────────────────
+
+// monitorTestModule is a real modules.Module + modules.Monitor whose Changes
+// channel the test controls. Tracks Get/Set call counts and Monitor() calls.
+type monitorTestModule struct {
+	mu sync.Mutex
+
+	getCalls   int
+	setCalls   int
+	setConfigs []map[string]interface{}
+
+	monitorCalled     bool
+	monitorResourceID string
+
+	closeCalled int
+	changesCh   chan modules.ChangeEvent
+	closed      bool
+}
+
+func newMonitorTestModule() *monitorTestModule {
+	return &monitorTestModule{changesCh: make(chan modules.ChangeEvent, 16)}
+}
+
+func (m *monitorTestModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	m.mu.Lock()
+	m.getCalls++
+	m.mu.Unlock()
+	// Return drifted state so a targeted reconcile detects drift and calls Set.
+	return execution.NewConfigState(map[string]interface{}{"state": "drifted"}), nil
+}
+
+func (m *monitorTestModule) Set(_ context.Context, _ string, cfg modules.ConfigState) error {
+	m.mu.Lock()
+	m.setCalls++
+	m.setConfigs = append(m.setConfigs, cfg.AsMap())
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *monitorTestModule) Monitor(_ context.Context, resourceID string, _ modules.ConfigState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.monitorCalled = true
+	m.monitorResourceID = resourceID
+	return nil
+}
+
+func (m *monitorTestModule) Changes() <-chan modules.ChangeEvent { return m.changesCh }
+
+func (m *monitorTestModule) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closeCalled++
+	if !m.closed {
+		m.closed = true
+		close(m.changesCh)
+	}
+	return nil
+}
+
+func (m *monitorTestModule) SendChange(evt modules.ChangeEvent) { m.changesCh <- evt }
+
+func (m *monitorTestModule) GetCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getCalls
+}
+
+func (m *monitorTestModule) SetCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.setCalls
+}
+
+func (m *monitorTestModule) CloseCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closeCalled
+}
+
+func (m *monitorTestModule) MonitorCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.monitorCalled {
+		return 1
+	}
+	return 0
+}
+
+func (m *monitorTestModule) ResetTracking() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls = 0
+	m.setCalls = 0
+	m.setConfigs = nil
+}
+
+// noopModule implements modules.Module but NOT modules.Monitor. Get returns
+// a state matching the desired cfg so no drift is detected.
+type noopModule struct {
+	mu       sync.Mutex
+	getCalls int
+}
+
+func (m *noopModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	m.mu.Lock()
+	m.getCalls++
+	m.mu.Unlock()
+	return execution.NewConfigState(map[string]interface{}{"state": "present"}), nil
+}
+
+func (m *noopModule) Set(_ context.Context, _ string, _ modules.ConfigState) error { return nil }
+
+func (m *noopModule) GetCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getCalls
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+// newMonitorExecutor creates a minimal Executor with an empty module factory.
+func newMonitorExecutor(t *testing.T) *execution.Executor {
+	t.Helper()
+	logger := logging.NewLogger("debug")
+	f := factory.New(nil, stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}, logger)
+	e, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:  logger,
+		Factory: f,
+	})
+	require.NoError(t, err)
+	return e
+}
+
+// singleResourceCfg builds a minimal resource slice for the given module name.
+func singleResourceCfg(name, moduleName string) []stewardconfig.ResourceConfig {
+	return []stewardconfig.ResourceConfig{
+		{
+			Name:   name,
+			Module: moduleName,
+			Config: map[string]interface{}{"state": "present"},
+		},
+	}
+}
+
+// ─── Issue #2435 AC1: StartMonitors / StopMonitors / CollectModuleDNAAttributes ─
+
+// TestExecutor_StartMonitors_CallsMonitorOnEligibleModule verifies that
+// StartMonitors calls Monitor() on modules that implement the interface.
+func TestExecutor_StartMonitors_CallsMonitorOnEligibleModule(t *testing.T) {
+	e := newMonitorExecutor(t)
+	mod := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := e.StartMonitors(ctx, singleResourceCfg("res1", "testmon"))
+	require.NoError(t, err)
+	defer e.StopMonitors()
+
+	assert.Equal(t, 1, mod.MonitorCallCount(), "Monitor() must be called on eligible module")
+	assert.Equal(t, "res1", mod.monitorResourceID)
+}
+
+// TestExecutor_StartMonitors_SkipsNonMonitorModules verifies that modules that
+// don't implement Monitor are silently skipped.
+func TestExecutor_StartMonitors_SkipsNonMonitorModules(t *testing.T) {
+	e := newMonitorExecutor(t)
+	noop := &noopModule{}
+	execution.ExecutorFactory(e).RegisterModule("noop", noop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := e.StartMonitors(ctx, singleResourceCfg("res1", "noop"))
+	require.NoError(t, err)
+	// No goroutines started — StopMonitors is a no-op but safe to call.
+	e.StopMonitors()
+}
+
+// TestExecutor_StartMonitors_CachesChangeEventDetails verifies that a ChangeEvent
+// sent through the module's Changes() channel is cached and returned by
+// CollectModuleDNAAttributes with the expected flattened structure.
+func TestExecutor_StartMonitors_CachesChangeEventDetails(t *testing.T) {
+	e := newMonitorExecutor(t)
+	mod := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, e.StartMonitors(ctx, singleResourceCfg("res1", "testmon")))
+	defer e.StopMonitors()
+
+	mod.SendChange(modules.ChangeEvent{
+		ResourceID: "res1",
+		ChangeType: modules.ChangeTypeModified,
+		Details: execution.NewConfigState(map[string]interface{}{
+			"nodes":  []string{"n1", "n2"},
+			"owner":  "n1",
+			"nested": map[string]interface{}{"leaf": "v"},
+		}),
+	})
+
+	require.Eventually(t, func() bool {
+		attrs := e.CollectModuleDNAAttributes(context.Background())
+		return attrs["res1.owner"] == "n1"
+	}, 2*time.Second, 10*time.Millisecond, "ChangeEvent must be cached and flattened")
+
+	attrs := e.CollectModuleDNAAttributes(context.Background())
+	assert.Equal(t, "n1,n2", attrs["res1.nodes"], "slice values join with ','")
+	assert.Equal(t, "n1", attrs["res1.owner"])
+	assert.Equal(t, "v", attrs["res1.nested.leaf"], "nested map keys join with '.'")
+}
+
+// TestExecutor_StartMonitors_SecondCallStopsPreviousMonitors is the REQUIRED TEST
+// for Issue #2435 AC3: a second StartMonitors call closes every previously-started
+// monitor before starting new ones — no duplicate Monitor() call on a cached module
+// instance, no leaked goroutine.
+func TestExecutor_StartMonitors_SecondCallStopsPreviousMonitors(t *testing.T) {
+	e := newMonitorExecutor(t)
+
+	// Two separate module instances to track which one is active after the restart.
+	mod1 := newMonitorTestModule()
+	mod2 := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// First StartMonitors call — mod1 is used.
+	require.NoError(t, e.StartMonitors(ctx, singleResourceCfg("res1", "testmon")))
+	assert.Equal(t, 1, mod1.MonitorCallCount(), "Monitor() called once for first start")
+	assert.Equal(t, 0, mod1.CloseCallCount(), "mod1 must not be closed yet")
+
+	// Replace the module in the factory to simulate a new module instance being
+	// returned for a second config push. In production the factory caches by name
+	// (LoadModule returns the same instance), so Close() must be called before
+	// Monitor() is called again on the same instance. Here we swap mod2 in to make
+	// it observable that the OLD instance got Close()d and the NEW one got Monitor().
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod2)
+
+	// Second StartMonitors call — must close mod1 before starting mod2.
+	require.NoError(t, e.StartMonitors(ctx, singleResourceCfg("res1", "testmon")))
+
+	// mod1 must have been closed (its goroutines stopped, Close() called).
+	assert.Equal(t, 1, mod1.CloseCallCount(), "first monitor instance must be closed before restart")
+
+	// mod2 must have Monitor() called exactly once.
+	assert.Equal(t, 1, mod2.MonitorCallCount(), "Monitor() must be called on new module instance")
+
+	// Stop the second engine cleanly.
+	e.StopMonitors()
+	assert.Equal(t, 1, mod2.CloseCallCount(), "second monitor instance must be closed by StopMonitors")
+
+	// Verify no goroutine leak: monitorWg.Wait() inside StopMonitors would deadlock
+	// if any goroutine were still running — the test itself proves no leak.
+}
+
+// TestExecutor_StartMonitors_ReconcileDispatch is the REQUIRED TEST for Issue #2435
+// AC4: a ChangeEvent triggers ExecuteResource/Set on the Executor-hosted engine,
+// proving the rewritten runTargetedReconcile uses the retained monitorEntry slice.
+func TestExecutor_StartMonitors_ReconcileDispatch(t *testing.T) {
+	e := newMonitorExecutor(t)
+	// Set a very short debounce so the test doesn't wait 1500ms.
+	e.SetMonitorDebounceWindow(20 * time.Millisecond)
+
+	mod := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, e.StartMonitors(ctx, singleResourceCfg("res1", "testmon")))
+	defer e.StopMonitors()
+
+	// Record Get count after StartMonitors (no drift check yet).
+	baseGet := mod.GetCallCount()
+
+	// Send a ChangeEvent — the debounce loop must call ExecuteResource → Get → drift
+	// detected → Set (since Get returns "drifted" vs desired "present").
+	mod.SendChange(modules.ChangeEvent{
+		ResourceID: "res1",
+		ChangeType: modules.ChangeTypeModified,
+	})
+
+	// Wait for Set to be called — proves the full reconcile dispatch ran.
+	require.Eventually(t, func() bool {
+		return mod.SetCallCount() > 0
+	}, 2*time.Second, 5*time.Millisecond,
+		"targeted reconcile must call Set() after ChangeEvent through the Executor-hosted engine")
+
+	assert.Greater(t, mod.GetCallCount(), baseGet,
+		"Get must have been called to read actual current state during reconcile")
+	assert.Equal(t, "present", mod.setConfigs[0]["state"],
+		"Set must use cfg desired state ('present'), not event details")
+}
+
+// TestExecutor_StartMonitors_ReconcileObserverCalled verifies that a registered
+// reconcile observer is invoked when ChangesApplied is true.
+func TestExecutor_StartMonitors_ReconcileObserverCalled(t *testing.T) {
+	e := newMonitorExecutor(t)
+	e.SetMonitorDebounceWindow(20 * time.Millisecond)
+
+	mod := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod)
+
+	var observedResourceID string
+	var observerMu sync.Mutex
+	e.SetMonitorReconcileObserver(func(_ context.Context, resourceID string) {
+		observerMu.Lock()
+		observedResourceID = resourceID
+		observerMu.Unlock()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, e.StartMonitors(ctx, singleResourceCfg("res1", "testmon")))
+	defer e.StopMonitors()
+
+	mod.SendChange(modules.ChangeEvent{
+		ResourceID: "res1",
+		ChangeType: modules.ChangeTypeModified,
+	})
+
+	require.Eventually(t, func() bool {
+		observerMu.Lock()
+		defer observerMu.Unlock()
+		return observedResourceID == "res1"
+	}, 2*time.Second, 5*time.Millisecond,
+		"reconcile observer must be called with the correct resourceID when changes are applied")
+}
+
+// TestExecutor_StopMonitors_ClearsState verifies that CollectModuleDNAAttributes
+// returns an empty map after StopMonitors (cached state is cleared).
+func TestExecutor_StopMonitors_ClearsState(t *testing.T) {
+	e := newMonitorExecutor(t)
+	mod := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, e.StartMonitors(ctx, singleResourceCfg("res1", "testmon")))
+
+	mod.SendChange(modules.ChangeEvent{
+		ResourceID: "res1",
+		ChangeType: modules.ChangeTypeModified,
+		Details:    execution.NewConfigState(map[string]interface{}{"x": "1"}),
+	})
+
+	require.Eventually(t, func() bool {
+		return len(e.CollectModuleDNAAttributes(context.Background())) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	e.StopMonitors()
+
+	assert.Empty(t, e.CollectModuleDNAAttributes(context.Background()),
+		"CollectModuleDNAAttributes must return empty map after StopMonitors")
+}
+
+// TestExecutor_RunTargetedReconcile_UnmanagedResource verifies the unmanaged-resource
+// early-exit: a resourceID not in monitorEntries performs no Get/Set.
+func TestExecutor_RunTargetedReconcile_UnmanagedResource(t *testing.T) {
+	e := newMonitorExecutor(t)
+	mod := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod)
+
+	// Call RunTargetedReconcile WITHOUT calling StartMonitors first — monitorEntries is nil.
+	e.RunTargetedReconcile(context.Background(), "not-in-cfg")
+
+	assert.Equal(t, 0, mod.GetCallCount(), "Get must not be called for unmanaged resource")
+	assert.Equal(t, 0, mod.SetCallCount(), "Set must not be called for unmanaged resource")
+}
+
+// TestExecutor_CollectModuleDNAAttributes_EvictsOnChannelClose verifies that
+// when the module's Changes() channel is closed (module Stop signal), the
+// cached state for that resourceID is evicted.
+func TestExecutor_CollectModuleDNAAttributes_EvictsOnChannelClose(t *testing.T) {
+	e := newMonitorExecutor(t)
+	mod := newMonitorTestModule()
+	execution.ExecutorFactory(e).RegisterModule("testmon", mod)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, e.StartMonitors(ctx, singleResourceCfg("res1", "testmon")))
+	defer e.StopMonitors()
+
+	mod.SendChange(modules.ChangeEvent{
+		ResourceID: "res1",
+		ChangeType: modules.ChangeTypeModified,
+		Details:    execution.NewConfigState(map[string]interface{}{"owner": "n1"}),
+	})
+
+	require.Eventually(t, func() bool {
+		return len(e.CollectModuleDNAAttributes(context.Background())) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Close the channel — simulates the module stopping.
+	// mod.Close() already closes the channel; we invoke it directly here.
+	require.NoError(t, mod.Close())
+
+	require.Eventually(t, func() bool {
+		return len(e.CollectModuleDNAAttributes(context.Background())) == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"eviction must happen when the monitor channel closes")
+}

--- a/features/steward/export_test.go
+++ b/features/steward/export_test.go
@@ -3,6 +3,7 @@
 package steward
 
 import (
+	"context"
 	"time"
 
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
@@ -43,21 +44,26 @@ var SetDriftDetector = func(s *Steward, d drift.Detector) {
 	s.driftDetector = d
 }
 
-// RunTargetedReconcile exposes the unexported runTargetedReconcile for black-box tests.
-var RunTargetedReconcile = (*Steward).runTargetedReconcile
+// RunTargetedReconcile exposes the executor's targeted reconcile for black-box tests
+// that need to exercise the reconcile path directly (e.g. unmanaged-resource early-exit).
+var RunTargetedReconcile = func(s *Steward, ctx context.Context, resourceID string) {
+	s.executor.RunTargetedReconcile(ctx, resourceID)
+}
 
 // SetDebounceWindowForTest overrides the per-resource monitor debounce window on a
 // specific Steward instance. Tests set a short window (e.g. 20ms) so they don't
 // wait the production 1500ms before a coalesced reconcile fires.
+// Delegates to the executor's monitor engine (Issue #2435).
 var SetDebounceWindowForTest = func(s *Steward, d time.Duration) {
-	s.debounceWindow = d
+	s.executor.SetMonitorDebounceWindow(d)
 }
 
 // SetMonitorFanInCapForTest overrides the fan-in channel capacity for a specific
 // Steward instance. Tests set a small value (e.g. 2) to guarantee queue overflow
 // without relying on scheduler timing when testing shed-to-poll behavior.
+// Delegates to the executor's monitor engine (Issue #2435).
 var SetMonitorFanInCapForTest = func(s *Steward, cap int) {
-	s.monitorFanInCap = cap
+	s.executor.SetMonitorFanInCap(cap)
 }
 
 // RegisterTestModule injects a module instance into the steward's factory cache.

--- a/features/steward/steward.go
+++ b/features/steward/steward.go
@@ -28,13 +28,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
-	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/features/modules/script"
 	"github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/discovery"
@@ -51,27 +49,6 @@ import (
 // (derived from MAC + hostname) changes between convergence cycles, indicating a
 // VM/container migration or hardware change that requires manual reconciliation.
 var ErrDNAIDMismatch = errors.New("DNA-ID mismatch: manual reconciliation required")
-
-// monitorQueueCapacity is the maximum number of ChangeEvents the fan-in channel
-// can buffer. When full, events are shed to the next scheduled convergence pass.
-const monitorQueueCapacity = 64
-
-// monitorEntry pairs a module's Monitor with its resource configuration.
-// Used to fan-in ChangeEvents and dispatch targeted reconciles.
-type monitorEntry struct {
-	resourceID string
-	resource   config.ResourceConfig
-	monitor    modules.Monitor
-}
-
-// bundleNameFromModuleRef extracts the module bundle name from a module reference.
-// "hyperv.vm" → "hyperv"; "file" → "file".
-func bundleNameFromModuleRef(moduleRef string) string {
-	if idx := strings.IndexByte(moduleRef, '.'); idx >= 0 {
-		return moduleRef[:idx]
-	}
-	return moduleRef
-}
 
 // Steward manages configuration for a single endpoint in standalone mode.
 //
@@ -107,43 +84,14 @@ type Steward struct {
 	// Secret store for steward-side secret management
 	secretStore secretsif.SecretStore
 
-	// monitors holds active monitor entries started on cfg load.
-	// Each entry has had Monitor(ctx, resourceID, desired) called on it.
-	monitors []monitorEntry
-
-	// debounceWindow is the per-resource debounce interval for monitor events.
-	// Events for the same resourceID within this window are coalesced into one
-	// targeted reconcile. Defaults to 1500ms; override via export_test.go in tests.
-	debounceWindow time.Duration
-
-	// monitorFanInCap overrides the fan-in channel capacity when non-zero.
-	// Tests set a small value (e.g. 2) to guarantee queue overflow without
-	// relying on scheduler timing. Production code always uses monitorQueueCapacity.
-	monitorFanInCap int
-
-	// monitorState caches the latest ChangeEvent.Details.AsMap() per
-	// resourceID for every actively-monitored resource (#2423). It feeds
-	// CollectModuleDNAAttributes — the module half of the DNA attribute set —
-	// and holds only the latest snapshot per resource (last-write-wins, no
-	// history). Entries are evicted when the resource's monitor forwarding
-	// goroutine exits (module Close / steward shutdown), so a resource that
-	// leaves monitoring disappears from the next CollectAttributes map and
-	// PublishDNAUpdate's delta compression signals the removal.
-	monitorStateMu sync.Mutex
-	monitorState   map[string]map[string]interface{}
-
 	// monitorDNARefreshes counts DNA snapshot refreshes triggered by a
-	// monitor-driven targeted reconcile that applied changes. In controller mode
-	// the same post-reconcile path updates the heartbeat currentDNAHash; this
-	// counter makes the early (pre-scheduled-tick) refresh observable in
-	// standalone tests. Read via export_test.go.
+	// monitor-driven targeted reconcile that applied changes (standalone only).
+	// Read via export_test.go.
 	monitorDNARefreshes atomic.Int64
 
 	// wg tracks the convergence loop goroutine and the health monitor goroutine
 	// for clean shutdown.
 	wg sync.WaitGroup
-	// monitorWg tracks fan-in and event-loop goroutines started by startMonitors.
-	monitorWg sync.WaitGroup
 
 	// Shutdown coordination
 	shutdown chan struct{}
@@ -270,7 +218,6 @@ func NewStandalone(configPath string, logger logging.Logger) (*Steward, error) {
 		executor:         executor,
 		dnaCollector:     dnaCollector,
 		driftDetector:    driftDetector,
-		debounceWindow:   1500 * time.Millisecond,
 		shutdown:         make(chan struct{}),
 	}, nil
 }
@@ -511,326 +458,29 @@ func (s *Steward) convergenceLoop(ctx context.Context, interval time.Duration) {
 	}
 }
 
-// startMonitors iterates the cfg resources, loads each module from the factory,
-// type-asserts modules.Monitor, and calls Monitor(ctx, resourceID, desired) for
-// each module that implements the interface. A fan-in goroutine forwards all
-// ChangeEvents to a single dispatch loop that calls runTargetedReconcile.
-//
-// Modules that do not implement Monitor are silently skipped — they fall back
-// to the scheduled convergence interval. This is always the case today; the
-// first Monitor implementation (Hyper-V) lands in S2.
+// startMonitors delegates to the executor's monitor engine, registering a
+// standalone-mode reconcile observer that refreshes DNA snapshots and increments
+// monitorDNARefreshes when a targeted reconcile applies changes.
 func (s *Steward) startMonitors(ctx context.Context) {
-	var entries []monitorEntry
-
-	for _, resource := range s.standaloneConfig.Resources {
-		bundle := bundleNameFromModuleRef(resource.Module)
-
-		mod, err := s.moduleFactory.LoadModule(bundle)
-		if err != nil || mod == nil {
-			continue
-		}
-
-		mon, ok := mod.(modules.Monitor)
-		if !ok {
-			continue
-		}
-
-		resourceID := s.executor.GetResourceID(resource)
-		desired := execution.NewConfigState(resource.Config)
-
-		if err := mon.Monitor(ctx, resourceID, desired); err != nil {
-			s.logger.Warn("Failed to start module monitor",
-				"resource", resource.Name,
+	// Register the standalone-specific post-reconcile observer before starting
+	// the engine so the first reconcile already has it wired.
+	s.executor.SetMonitorReconcileObserver(func(rCtx context.Context, resourceID string) {
+		s.monitorDNARefreshes.Add(1)
+		if _, err := s.detectUnmanagedDNADrift(rCtx); err != nil {
+			s.logger.Warn("DNA refresh after targeted reconcile returned error",
 				"resource_id", logging.SanitizeLogValue(resourceID),
 				"error", err)
-			continue
 		}
-
-		entries = append(entries, monitorEntry{
-			resourceID: resourceID,
-			resource:   resource,
-			monitor:    mon,
-		})
-	}
-
-	if len(entries) == 0 {
-		return
-	}
-
-	s.monitors = entries
-
-	// Fan-in: one forwarding goroutine per monitor channel; all send to fanIn.
-	// fanIn is bounded at monitorQueueCapacity; excess events are shed to the
-	// next scheduled convergence pass (non-blocking drop with Warn log).
-	fanInCap := monitorQueueCapacity
-	if s.monitorFanInCap > 0 {
-		fanInCap = s.monitorFanInCap
-	}
-	fanIn := make(chan modules.ChangeEvent, fanInCap)
-	for _, entry := range entries {
-		ch := entry.monitor.Changes()
-		s.monitorWg.Add(1)
-		go func(ch <-chan modules.ChangeEvent) {
-			defer s.monitorWg.Done()
-			// seen tracks every resourceID this goroutine cached module-DNA
-			// state for (#2423), so all of them are evicted when monitoring
-			// stops — the channel closing (module Close), ctx cancel, or
-			// steward shutdown. Eviction keys on what was actually cached,
-			// not the entry's own resourceID, because a module may emit
-			// events for more than one resourceID on a single channel.
-			seen := make(map[string]struct{})
-			defer func() { s.evictMonitorState(seen) }()
-			for {
-				select {
-				case evt, ok := <-ch:
-					if !ok {
-						return
-					}
-					// Cache the latest observed state BEFORE the non-blocking
-					// send, so even a shed event still refreshes the module
-					// DNA snapshot (#2423).
-					if s.cacheMonitorState(evt) {
-						seen[evt.ResourceID] = struct{}{}
-					}
-					// Non-blocking send: if the queue is full, shed this event to
-					// the next scheduled convergence pass and log at Warn.
-					select {
-					case fanIn <- evt:
-					default:
-						s.logger.Warn("Monitor event queue full, event shed to scheduled poll",
-							"resource_id", logging.SanitizeLogValue(evt.ResourceID))
-					}
-				case <-ctx.Done():
-					return
-				case <-s.shutdown:
-					return
-				}
-			}
-		}(ch)
-	}
-
-	s.monitorWg.Add(1)
-	go func() {
-		defer s.monitorWg.Done()
-		s.monitorEventLoop(ctx, fanIn)
-	}()
-}
-
-// monitorEventLoop reads ChangeEvents from the fan-in channel and dispatches
-// debounced targeted reconciles. Multiple events for the same resourceID within
-// the debounce window are coalesced into a single runTargetedReconcile call.
-// Exits when the context is cancelled or the shutdown channel is closed.
-func (s *Steward) monitorEventLoop(ctx context.Context, events <-chan modules.ChangeEvent) {
-	// fireCh receives debounced resourceIDs after their timer window elapses.
-	// Buffered to avoid blocking the timer goroutines under load.
-	fireCh := make(chan string, 16)
-	// debounce maps resourceID → pending AfterFunc timer.
-	debounce := make(map[string]*time.Timer)
-	// afterFuncWg tracks in-flight AfterFunc goroutines so monitorEventLoop
-	// does not return (and monitorWg.Done() is not called) until every timer
-	// callback has exited. Without this, a timer that fires concurrently with
-	// Stop() outlives monitorWg.Wait() and is caught by goleak as a leak.
-	var afterFuncWg sync.WaitGroup
-
-	defer func() {
-		// Stop pending timers. t.Stop() returns true only if the timer has not
-		// yet fired — in that case the goroutine will never run, so we call
-		// Done() ourselves to balance the Add(1) from below. If t.Stop()
-		// returns false the goroutine is already running; it will call Done().
-		for _, t := range debounce {
-			if t.Stop() {
-				afterFuncWg.Done()
-			}
-		}
-		// Wait for any in-flight AfterFunc goroutines to exit. They observe
-		// s.shutdown (already closed) via their select and return promptly.
-		afterFuncWg.Wait()
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.shutdown:
-			return
-		case evt, ok := <-events:
-			if !ok {
-				return
-			}
-			s.logger.Info("Monitor change event received",
-				"resource_id", logging.SanitizeLogValue(evt.ResourceID),
-				"change_type", evt.ChangeType)
-			resourceID := evt.ResourceID
-			if _, exists := debounce[resourceID]; !exists {
-				// First event for this resourceID in the window — start the timer.
-				afterFuncWg.Add(1)
-				debounce[resourceID] = time.AfterFunc(s.debounceWindow, func() {
-					defer afterFuncWg.Done()
-					select {
-					case fireCh <- resourceID:
-					case <-ctx.Done():
-					case <-s.shutdown:
-					}
-				})
-			}
-			// Duplicate events within the window are coalesced — the existing
-			// timer will fire once after the debounce window elapses.
-		case resourceID := <-fireCh:
-			delete(debounce, resourceID)
-			s.runTargetedReconcile(ctx, resourceID)
-		}
+	})
+	if err := s.executor.StartMonitors(ctx, s.standaloneConfig.Resources); err != nil {
+		s.logger.Warn("Failed to start module monitors", "error", err)
 	}
 }
 
-// cacheMonitorState stores the latest ChangeEvent Details snapshot for a
-// resourceID (#2423). Returns true when a snapshot was cached (the caller
-// tracks the ID for eviction). Nil Details or an empty ResourceID cache
-// nothing. The snapshot is shallow-copied so a module mutating the map it
-// returned from AsMap cannot race the flattener.
-func (s *Steward) cacheMonitorState(evt modules.ChangeEvent) bool {
-	if evt.ResourceID == "" || evt.Details == nil {
-		return false
-	}
-	snap := evt.Details.AsMap()
-	if snap == nil {
-		return false
-	}
-	copied := make(map[string]interface{}, len(snap))
-	for k, v := range snap {
-		copied[k] = v
-	}
-	s.monitorStateMu.Lock()
-	if s.monitorState == nil {
-		s.monitorState = make(map[string]map[string]interface{})
-	}
-	s.monitorState[evt.ResourceID] = copied
-	s.monitorStateMu.Unlock()
-	return true
-}
-
-// evictMonitorState removes the given resourceIDs from the module-DNA cache
-// (#2423). Called when a monitor forwarding goroutine exits, so a resource
-// that leaves monitoring actually disappears from the map returned by
-// CollectModuleDNAAttributes — PublishDNAUpdate's delta compression turns the
-// missing key into the "this is gone" signal on the next publish.
-func (s *Steward) evictMonitorState(resourceIDs map[string]struct{}) {
-	if len(resourceIDs) == 0 {
-		return
-	}
-	s.monitorStateMu.Lock()
-	for id := range resourceIDs {
-		delete(s.monitorState, id)
-	}
-	s.monitorStateMu.Unlock()
-}
-
-// CollectModuleDNAAttributes returns a flattened, namespaced snapshot of every
-// actively-monitored module resource's latest observed state (#2423), built
-// purely from the generic ConfigState.AsMap() — no module-specific types.
-//
-// Key convention (documented in docs/architecture/steward-operating-model.md):
-//   - every key is "<resourceID>.<field>" with the resourceID VERBATIM — e.g.
-//     "cluster:cfg-lab.member_nodes"; the colon stays, and no module-name
-//     prefix is added (the resourceID is the module's own ChangeEvent scheme)
-//   - nested map keys join with "."  → "cluster:cfg-lab.resource_owner.web-01"
-//   - slice values join with ","     → "CFG-70-02,CFG-AB-02"
-//   - any other value stringifies via fmt.Sprintf("%v", v)
-//
-// The result rides the existing DNA refresh/publish pipeline exactly as
-// hardware facts do (merged by the composite collector in cmd/steward);
-// last-write-wins per resource, eventually consistent by design.
-func (s *Steward) CollectModuleDNAAttributes(_ context.Context) map[string]string {
-	out := make(map[string]string)
-	s.monitorStateMu.Lock()
-	defer s.monitorStateMu.Unlock()
-	for resourceID, snap := range s.monitorState {
-		for field, v := range snap {
-			flattenDNAValue(resourceID+"."+field, v, out)
-		}
-	}
-	return out
-}
-
-// flattenDNAValue flattens one value into out under key, per the convention
-// documented on CollectModuleDNAAttributes. It handles the ConfigState.AsMap
-// shapes that occur in practice (string, bool, ints, []string, []interface{},
-// map[string]string, nested map[string]interface{}) and falls back to
-// fmt.Sprintf("%v") for anything else — never panics on an unexpected type.
-func flattenDNAValue(key string, v interface{}, out map[string]string) {
-	switch val := v.(type) {
-	case map[string]interface{}:
-		for k, sub := range val {
-			flattenDNAValue(key+"."+k, sub, out)
-		}
-	case map[string]string:
-		for k, sub := range val {
-			out[key+"."+k] = sub
-		}
-	case []string:
-		out[key] = strings.Join(val, ",")
-	case []interface{}:
-		parts := make([]string, 0, len(val))
-		for _, e := range val {
-			parts = append(parts, fmt.Sprintf("%v", e))
-		}
-		out[key] = strings.Join(parts, ",")
-	case string:
-		out[key] = val
-	default:
-		out[key] = fmt.Sprintf("%v", val)
-	}
-}
-
-// runTargetedReconcile finds the ResourceConfig whose module-internal ID matches
-// resourceID and calls ExecuteResource for it. The ChangeEvent that triggered
-// this call is treated as a hint only — current state is read via module.Get()
-// and desired state comes from the cfg ResourceConfig, never from the event.
-//
-// If resourceID is not present in cfg (unmanaged resource), the call is a no-op.
-// Both ctx.Done() and s.shutdown are checked before the reconcile so a shutdown
-// mid-dispatch exits cleanly without calling Set after Close().
-//
-// When the reconcile changes state (ChangesApplied), a fresh DNA snapshot is
-// collected so the next heartbeat reflects the corrected state before the
-// scheduled convergence tick fires.
-func (s *Steward) runTargetedReconcile(ctx context.Context, resourceID string) {
-	select {
-	case <-ctx.Done():
-		return
-	case <-s.shutdown:
-		return
-	default:
-	}
-
-	for _, resource := range s.standaloneConfig.Resources {
-		if s.executor.GetResourceID(resource) == resourceID {
-			s.logger.Info("Running targeted reconcile for monitored resource",
-				"resource", resource.Name,
-				"resource_id", logging.SanitizeLogValue(resourceID))
-			result := s.executor.ExecuteResource(ctx, resource)
-			if result.ChangesApplied {
-				s.logger.Info("Targeted reconcile changed state, refreshing DNA snapshot",
-					"resource", resource.Name,
-					"resource_id", logging.SanitizeLogValue(resourceID))
-				// Record the early DNA refresh BEFORE collecting it. In controller
-				// mode the same post-reconcile path updates the heartbeat
-				// currentDNAHash before the next scheduled convergence tick; this
-				// counter makes that observable in tests. It is incremented ahead of
-				// the (potentially slow) collection so the "a monitor-driven refresh
-				// was triggered" signal is observable even while collection runs.
-				s.monitorDNARefreshes.Add(1)
-				if _, err := s.detectUnmanagedDNADrift(ctx); err != nil {
-					s.logger.Warn("DNA refresh after targeted reconcile returned error",
-						"resource", resource.Name,
-						"error", err)
-				}
-			}
-			return
-		}
-	}
-
-	s.logger.Info("Monitor event for unmanaged resource (not in cfg, skipping)",
-		"resource_id", logging.SanitizeLogValue(resourceID))
+// CollectModuleDNAAttributes delegates to the executor's monitor engine.
+// See execution.Executor.CollectModuleDNAAttributes for the key convention.
+func (s *Steward) CollectModuleDNAAttributes(ctx context.Context) map[string]string {
+	return s.executor.CollectModuleDNAAttributes(ctx)
 }
 
 // Stop gracefully shuts down the steward and cleans up resources.
@@ -866,10 +516,10 @@ func (s *Steward) Stop(ctx context.Context) error {
 	// Wait for the convergence loop goroutine to exit.
 	s.wg.Wait()
 
-	// Wait for all monitor goroutines (fan-in + event loop) to exit.
-	// This guarantees no further ExecuteResource calls after Close() is called
-	// on the monitors below.
-	s.monitorWg.Wait()
+	// Stop the monitor engine: waits for all fan-in + event-loop goroutines to
+	// exit, then closes all monitor instances. Must happen before UnloadAllModules
+	// so no further ChangeEvents are produced after module Close().
+	s.executor.StopMonitors()
 
 	// Close drift detector
 	if s.driftDetector != nil {
@@ -882,17 +532,6 @@ func (s *Steward) Stop(ctx context.Context) error {
 	if s.secretStore != nil {
 		if err := s.secretStore.Close(); err != nil {
 			s.logger.Warn("Failed to close secret store", "error", err)
-		}
-	}
-
-	// Close all active monitors before unloading modules.
-	// Closing the monitor releases any OS-level watchers and signals to the
-	// module that no further ChangeEvents will be produced.
-	for _, entry := range s.monitors {
-		if err := entry.monitor.Close(); err != nil {
-			s.logger.Warn("Failed to close monitor",
-				"resource_id", logging.SanitizeLogValue(entry.resourceID),
-				"error", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Moves the monitor fan-in/debounce/targeted-reconcile engine from `features/steward.Steward` (standalone-only) into `features/steward/execution.Executor` (shared by all modes), so controller-connected stewards run the same `Monitor` interface machinery as standalone.
- `syncConfigNow` calls `executor.StartMonitors` after `ApplyConfiguration`; `Disconnect` calls `executor.StopMonitors`; `GetConfigExecutor` exposes the executor for post-construction DNA adapter wiring in `cmd/steward/main.go`.
- `dnaCollectorAdapter` gains `setModuleDNASource` for thread-safe post-construction wiring; both registration and reconnect call sites wire the real executor after `InitializeConfigExecutor` succeeds.

## Test plan

- [x] `execution/monitor_test.go` — AC1–AC4: StartMonitors calls Monitor(), skips non-monitor modules, caches ChangeEvent details, second call stops previous engine, reconcile dispatch, reconcile observer, StopMonitors clears state, RunTargetedReconcile unmanaged resource, CollectModuleDNAAttributes evicts on channel close
- [x] `client/monitor_test.go` — AC5: Disconnect stops monitors (StopMonitors path), GetConfigExecutor returns executor after initialize
- [x] `cmd/steward/dna_adapter_test.go` — AC7: setModuleDNASource thread-safety and pre/post-wired parity; AC8: real end-to-end controller-mode monitor → DNA attributes
- [x] `docs/architecture/steward-operating-model.md` updated — AC6: confirms controller-mode stewards run the same monitor engine
- [x] `make check-architecture` passes (no central provider violations)
- [x] `story-review` workflow passed (2 rounds, 1 fix round, 0 remaining findings)

Fixes #2435

🤖 Generated with [Claude Code](https://claude.com/claude-code)