### PR TITLE
selector: converge ParseTargetSelector and selector.Parse (Issue #2438)

### DIFF
--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -20,6 +20,7 @@ import (
 	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -274,11 +275,22 @@ func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
 	// Tenant RBAC check for id: targets — enforce admin.tenant_path is a prefix of
 	// steward.tenant_path. Applied only when the principal has a non-empty TenantID
 	// (API key users). Admin mTLS principals (TenantID="") have global access.
-	if filter.DeviceID != "" && principal.TenantID != "" {
-		if forbidden := s.enforceExecTenantScope(r.Context(), filter.DeviceID, principal.TenantID); forbidden {
-			s.writeErrorResponse(w, http.StatusForbidden,
-				"access denied: steward is not in your tenant scope", "FORBIDDEN")
-			return
+	// selector.Parse populates filter.IDs (comma-OR list); filter.DeviceID is the
+	// legacy query-param path only.
+	if principal.TenantID != "" {
+		for _, targetID := range filter.IDs {
+			if forbidden := s.enforceExecTenantScope(r.Context(), targetID, principal.TenantID); forbidden {
+				s.writeErrorResponse(w, http.StatusForbidden,
+					"access denied: steward is not in your tenant scope", "FORBIDDEN")
+				return
+			}
+		}
+		if filter.DeviceID != "" {
+			if forbidden := s.enforceExecTenantScope(r.Context(), filter.DeviceID, principal.TenantID); forbidden {
+				s.writeErrorResponse(w, http.StatusForbidden,
+					"access denied: steward is not in your tenant scope", "FORBIDDEN")
+				return
+			}
 		}
 	}
 
@@ -305,7 +317,13 @@ func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
 
 	// Audit dispatch for single-steward exec (id: target). command_hash and
 	// output_hash are computed here; exit_code and output are not yet available.
-	if filter.DeviceID != "" {
+	// selector.Parse places the id: value in filter.IDs; emit when exactly one ID
+	// is targeted (multi-ID comma-OR runs are not audited here, only per-job).
+	auditDeviceID := filter.DeviceID
+	if auditDeviceID == "" && len(filter.IDs) == 1 {
+		auditDeviceID = filter.IDs[0]
+	}
+	if auditDeviceID != "" {
 		commandHash := sha256.Sum256(inlineContent)
 		sigID := ""
 		if req.Signature != nil {
@@ -313,7 +331,7 @@ func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
 			h := sha256.Sum256(sigBytes)
 			sigID = hex.EncodeToString(h[:])
 		}
-		s.emitExecCommandAudit(r.Context(), tenantID, principal.ID, filter.DeviceID,
+		s.emitExecCommandAudit(r.Context(), tenantID, principal.ID, auditDeviceID,
 			hex.EncodeToString(commandHash[:]), sigID, runID)
 	}
 
@@ -473,7 +491,7 @@ func parseRunTarget(target string) (fleet.Filter, error) {
 	if target == "" || target == "all" {
 		return fleet.Filter{}, nil
 	}
-	return fleet.ParseTargetSelector(target)
+	return selector.Parse(target)
 }
 
 // enforceExecTenantScope checks whether the principal's tenantID is a path-prefix

--- a/features/controller/api/handlers_upgrade.go
+++ b/features/controller/api/handlers_upgrade.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -123,7 +124,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse selector and apply tenant scope.
-	filter, err := fleet.ParseTargetSelector(req.Selector)
+	filter, err := selector.Parse(req.Selector)
 	if err != nil {
 		s.writeErrorResponse(w, http.StatusBadRequest,
 			"Invalid selector: "+err.Error(),

--- a/features/controller/batchjob/executor_test.go
+++ b/features/controller/batchjob/executor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	cpinterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	fleetSelector "github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -147,7 +148,7 @@ type fleetQueryAdapter struct {
 }
 
 func (a *fleetQueryAdapter) Search(ctx context.Context, selector, tenantID string) ([]batchjob.StewardMeta, error) {
-	filter, err := fleet.ParseTargetSelector(selector)
+	filter, err := fleetSelector.Parse(selector)
 	if err != nil {
 		return nil, err
 	}

--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -4,8 +4,6 @@ package fleet
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 )
 
@@ -34,58 +32,10 @@ type Filter struct {
 	Tags          []string          // All tags must be present (DNA["tags"] is comma-separated)
 	DNAAttributes map[string]string // All key-value pairs must match exactly
 	Status        string            // "online", "offline", or "any"/empty (any status)
-	Hostname      string            // Substring match on DNA["hostname"] (kept for backward compat)
+	Hostname      string            // Substring/prefix-glob match on DNA["hostname"]; query-param path only — do not set from a selector-string parser
 	Name          string            // Glob match on DNA["hostname"] via path.Match (use name: selector key)
 	DeviceID      string            // Match by exact device ID (id: selector)
 	IDs           []string          // Match stewards whose ID is any of these (OR within the set; id: selector)
-}
-
-// ParseTargetSelector parses a space-separated key:value selector string into a Filter.
-// Supported keys: name, os, platform, arch, tag, dna.<k>.
-// Glob matching (path.Match) applies to name: and tag: values; all other keys are exact match.
-// An empty selector is an error. Use the literal "all" to match all stewards.
-func ParseTargetSelector(s string) (Filter, error) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return Filter{}, fmt.Errorf("target selector must not be empty; use \"all\" to match all stewards")
-	}
-	if s == "all" {
-		return Filter{}, nil
-	}
-
-	var f Filter
-	for _, token := range strings.Fields(s) {
-		idx := strings.Index(token, ":")
-		if idx < 0 {
-			return Filter{}, fmt.Errorf("invalid selector token %q: expected key:value format", token)
-		}
-		key := token[:idx]
-		value := token[idx+1:]
-
-		switch {
-		case key == "name":
-			f.Name = value
-		case key == "os":
-			f.OS = value
-		case key == "platform":
-			f.Platform = value
-		case key == "arch":
-			f.Architecture = value
-		case key == "tag":
-			f.Tags = append(f.Tags, value)
-		case key == "id":
-			f.DeviceID = value
-		case strings.HasPrefix(key, "dna."):
-			dnaKey := strings.TrimPrefix(key, "dna.")
-			if f.DNAAttributes == nil {
-				f.DNAAttributes = make(map[string]string)
-			}
-			f.DNAAttributes[dnaKey] = value
-		default:
-			return Filter{}, fmt.Errorf("unrecognised selector key %q", key)
-		}
-	}
-	return f, nil
 }
 
 // StewardResult is a device record returned by a fleet query.

--- a/features/controller/fleet/fleet_test.go
+++ b/features/controller/fleet/fleet_test.go
@@ -55,66 +55,6 @@ func TestFleetQuery_InterfaceContract(t *testing.T) {
 	})
 }
 
-// TestParseTargetSelector covers selector parsing per the acceptance criteria.
-func TestParseTargetSelector(t *testing.T) {
-	t.Run("multi-key selector", func(t *testing.T) {
-		f, err := ParseTargetSelector("os:linux name:web-* tag:production")
-		require.NoError(t, err)
-		assert.Equal(t, "linux", f.OS)
-		assert.Equal(t, "web-*", f.Name)
-		assert.Equal(t, []string{"production"}, f.Tags)
-	})
-
-	t.Run("dna key selector", func(t *testing.T) {
-		f, err := ParseTargetSelector("dna.custom_key:val")
-		require.NoError(t, err)
-		assert.Equal(t, map[string]string{"custom_key": "val"}, f.DNAAttributes)
-	})
-
-	t.Run("unknown key returns error naming the key", func(t *testing.T) {
-		_, err := ParseTargetSelector("unknown:x")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unknown")
-	})
-
-	t.Run("empty selector returns error", func(t *testing.T) {
-		_, err := ParseTargetSelector("")
-		require.Error(t, err)
-	})
-
-	t.Run("all returns empty filter", func(t *testing.T) {
-		f, err := ParseTargetSelector("all")
-		require.NoError(t, err)
-		assert.Equal(t, Filter{}, f)
-	})
-
-	t.Run("multiple tag keys accumulate", func(t *testing.T) {
-		f, err := ParseTargetSelector("tag:production tag:web")
-		require.NoError(t, err)
-		assert.Equal(t, []string{"production", "web"}, f.Tags)
-	})
-
-	t.Run("all supported keys parse without error", func(t *testing.T) {
-		f, err := ParseTargetSelector("os:linux platform:ubuntu arch:amd64 name:web-*")
-		require.NoError(t, err)
-		assert.Equal(t, "linux", f.OS)
-		assert.Equal(t, "ubuntu", f.Platform)
-		assert.Equal(t, "amd64", f.Architecture)
-		assert.Equal(t, "web-*", f.Name)
-	})
-
-	t.Run("token without colon returns error", func(t *testing.T) {
-		_, err := ParseTargetSelector("badtoken")
-		require.Error(t, err)
-	})
-
-	t.Run("id selector sets DeviceID", func(t *testing.T) {
-		f, err := ParseTargetSelector("id:steward-abc123")
-		require.NoError(t, err)
-		assert.Equal(t, "steward-abc123", f.DeviceID)
-	})
-}
-
 // TestFleetQuery_DeviceIDFilter verifies that Filter.DeviceID matches only the exact device.
 func TestFleetQuery_DeviceIDFilter(t *testing.T) {
 	q := newQuery(

--- a/pkg/fleet/selector/selector.go
+++ b/pkg/fleet/selector/selector.go
@@ -123,7 +123,7 @@ func applyTerm(f *fleet.Filter, t term) error {
 	case t.key == "id":
 		f.IDs = append(f.IDs, strings.Split(t.value, ",")...)
 	case t.key == "name":
-		f.Hostname = t.value
+		f.Name = t.value
 	case t.key == "os":
 		f.OS = t.value
 	case t.key == "platform":

--- a/pkg/fleet/selector/selector_test.go
+++ b/pkg/fleet/selector/selector_test.go
@@ -35,13 +35,25 @@ func TestParse_All_ReturnsEmptyFilter(t *testing.T) {
 func TestParse_Name(t *testing.T) {
 	f, err := Parse("name:my-server")
 	require.NoError(t, err)
-	assert.Equal(t, "my-server", f.Hostname)
+	assert.Equal(t, "my-server", f.Name)
 }
 
 func TestParse_Name_TrailingGlob(t *testing.T) {
 	f, err := Parse("name:es-hv0*")
 	require.NoError(t, err)
-	assert.Equal(t, "es-hv0*", f.Hostname)
+	assert.Equal(t, "es-hv0*", f.Name)
+}
+
+func TestParse_Name_LeadingGlob(t *testing.T) {
+	f, err := Parse("name:*web")
+	require.NoError(t, err)
+	assert.Equal(t, "*web", f.Name)
+}
+
+func TestParse_Name_MidStringGlob(t *testing.T) {
+	f, err := Parse("name:web*1")
+	require.NoError(t, err)
+	assert.Equal(t, "web*1", f.Name)
 }
 
 func TestParse_OS(t *testing.T) {
@@ -107,7 +119,7 @@ func TestParse_DNAKey_Quoted(t *testing.T) {
 func TestParse_Combined(t *testing.T) {
 	f, err := Parse(`name:es-hv0* os:"windows server" tag:prod dna.arch:arm64`)
 	require.NoError(t, err)
-	assert.Equal(t, "es-hv0*", f.Hostname)
+	assert.Equal(t, "es-hv0*", f.Name)
 	assert.Equal(t, "windows server", f.OS)
 	assert.Equal(t, []string{"prod"}, f.Tags)
 	assert.Equal(t, map[string]string{"arch": "arm64"}, f.DNAAttributes)
@@ -239,9 +251,16 @@ func TestResolve_NameGlob_NoMatch(t *testing.T) {
 	assert.Empty(t, ids)
 }
 
-func TestResolve_NameExact_SubstringMatch(t *testing.T) {
-	ids := resolveIDs(t, "name:win-srv")
+func TestResolve_Name_ExactMatch(t *testing.T) {
+	// path.Match requires the full hostname; "win-srv" does not match "win-srv-01".
+	ids := resolveIDs(t, "name:win-srv-01")
 	assert.Equal(t, []string{"s-windows"}, ids)
+}
+
+func TestResolve_Name_ExactNoMatch(t *testing.T) {
+	// Without a glob, path.Match is an exact match — a partial name returns nothing.
+	ids := resolveIDs(t, "name:win-srv")
+	assert.Empty(t, ids)
 }
 
 func TestResolve_OS_Linux(t *testing.T) {
@@ -325,4 +344,115 @@ func TestResolve_ID_Combined_AND_Matches(t *testing.T) {
 	// id:s-linux-arm64 AND os:linux — s-linux-arm64 is linux, so exactly one match.
 	ids := resolveIDs(t, "id:s-linux-arm64 os:linux")
 	assert.Equal(t, []string{"s-linux-arm64"}, ids)
+}
+
+// resolveIDsFrom is like resolveIDs but uses a caller-supplied steward list.
+func resolveIDsFrom(t *testing.T, stewards []fleet.StewardData, expr string) []string {
+	t.Helper()
+	filter, err := Parse(expr)
+	require.NoError(t, err)
+	q := fleet.NewMemoryQuery(&staticProvider{stewards: stewards})
+	results, err := q.Search(context.Background(), filter)
+	require.NoError(t, err)
+	ids := make([]string, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids
+}
+
+// TestResolve_Name_LeadingGlob verifies that name:*web matches hostnames ending in
+// "web" via path.Match. Previously broken: Filter.Hostname used prefix-glob only
+// (strings.HasSuffix(v,"*")), so "*web" fell through to a literal substring search
+// that never matched anything useful.
+func TestResolve_Name_LeadingGlob(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-appweb", "online", map[string]string{"hostname": "app-web"}),
+		makeSteward("s-db", "online", map[string]string{"hostname": "db-01"}),
+	}
+	ids := resolveIDsFrom(t, stewards, "name:*web")
+	assert.Equal(t, []string{"s-appweb"}, ids)
+}
+
+// TestResolve_Name_MidStringGlob verifies that name:web*1 matches hostnames like
+// "web-01" via path.Match. Previously broken: Filter.Hostname's HasSuffix("*") check
+// failed for mid-string globs, so "web*1" fell through to a literal substring search.
+func TestResolve_Name_MidStringGlob(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-web01", "online", map[string]string{"hostname": "web-01"}),
+		makeSteward("s-web02", "online", map[string]string{"hostname": "web-02"}),
+		makeSteward("s-db01", "online", map[string]string{"hostname": "db-01"}),
+	}
+	ids := resolveIDsFrom(t, stewards, "name:web*1")
+	assert.Equal(t, []string{"s-web01"}, ids)
+}
+
+// TestParse_TableCoverage is the required table test covering every selector shape
+// both legacy parsers (selector.Parse and fleet.ParseTargetSelector) handled.
+func TestParse_TableCoverage(t *testing.T) {
+	cases := []struct {
+		name    string
+		expr    string
+		want    fleet.Filter
+		wantErr string
+	}{
+		{
+			name: "id comma-OR",
+			expr: "id:a,b",
+			want: fleet.Filter{IDs: []string{"a", "b"}},
+		},
+		{
+			name: "quoted tag with space",
+			expr: `tag:"prod east"`,
+			want: fleet.Filter{Tags: []string{"prod east"}},
+		},
+		{
+			name: "name trailing glob",
+			expr: "name:web*",
+			want: fleet.Filter{Name: "web*"},
+		},
+		{
+			name: "name leading glob (previously broken via Filter.Hostname)",
+			expr: "name:*web",
+			want: fleet.Filter{Name: "*web"},
+		},
+		{
+			name: "name mid-string glob (previously broken via Filter.Hostname)",
+			expr: "name:web*1",
+			want: fleet.Filter{Name: "web*1"},
+		},
+		{
+			name: "dna attribute",
+			expr: "dna.role:db",
+			want: fleet.Filter{DNAAttributes: map[string]string{"role": "db"}},
+		},
+		{
+			name: "all returns empty filter",
+			expr: "all",
+			want: fleet.Filter{},
+		},
+		{
+			name:    "empty string rejected",
+			expr:    "",
+			wantErr: "empty selector",
+		},
+		{
+			name:    "unknown key rejected",
+			expr:    "unknown:val",
+			wantErr: "unknown selector key",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Parse(tc.expr)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- **Deletes** `features/controller/fleet.ParseTargetSelector` — `selector.Parse` in `pkg/fleet/selector` is now the single selector-parsing implementation
- **Fixes bug**: `selector.Parse`'s `name:` key was writing to `Filter.Hostname` (limited prefix-glob) instead of `Filter.Name` (full `path.Match`), silently zero-matching leading globs (`name:*web`) and mid-string globs (`name:web*1`)
- **Migrates** all 5 REST handlers (`handlers_runs.go`, `handlers_upgrade.go`) and the batchjob executor test adapter to `selector.Parse`

## Security note

`handlers_runs.go` had a tenant RBAC check gated on `filter.DeviceID != ""`. Since `selector.Parse` populates `filter.IDs` (not `filter.DeviceID`), this check was silently skipped for all `id:` selectors — allowing cross-tenant exec. This was caught by the pre-existing test `TestRunCommandSingle_RejectsCrossTenantSteward` and fixed by updating the check to iterate `filter.IDs`. The single-steward audit path was updated similarly.

## Behavior changes for callers

- `name:web-server` now requires an **exact** hostname match (was substring). Operators needing prefix/suffix matching must use `name:web-server*` or `name:*server`.
- `name:*web` (leading glob) and `name:web*1` (mid-string glob) now match correctly; previously they zero-matched.

## Test plan

- [x] `TestParse_TableCoverage` — required table test covering all selector shapes both legacy parsers handled, including `name:*web` and `name:web*1`
- [x] `TestResolve_Name_LeadingGlob` / `TestResolve_Name_MidStringGlob` — explicit regression tests for the previously broken glob shapes
- [x] `TestResolve_Name_ExactMatch` / `TestResolve_Name_ExactNoMatch` — document the path.Match exact-match semantics replacing old substring behavior
- [x] `TestRunCommandSingle_RejectsCrossTenantSteward` — security regression test passes (pre-existing, would have caught this without the IDs fix)
- [x] `grep -r ParseTargetSelector` returns zero matches outside test comments
- [x] `make test-agent-complete` passes (verified by story-review workflow: passed=true, 2 rounds, 1 fix round)

## Reviewer highlights

- `Filter.Hostname` is **retained** — `buildFleetFilter` in `handlers_stewards.go` still sets it from the `hostname=` query param. It is annotated as query-param-path only and must not be set from a selector-string parser.
- This story spans 3 packages (`pkg/fleet/selector`, `features/controller/fleet`, `features/controller/api`), which exceeds the usual ≤2-package guidance. This is founder-locked per epic addendum A6 and was flagged for explicit Tech Lead sign-off.

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS (after 1 fix round) |
| Security | PASS |

Fixes #2438

🤖 Generated with [Claude Code](https://claude.com/claude-code)