### PR TITLE
hyperv: CNO-owner gate for first-ever ha_role VM creation (Issue #2421)

### DIFF
--- a/docs/architecture/decisions/009-hyperv-vm-provisioning-from-install-media.md
+++ b/docs/architecture/decisions/009-hyperv-vm-provisioning-from-install-media.md
@@ -140,3 +140,72 @@ This capability provisions from **install media or a vendor cloud image** (§6a)
 - **Golden-image cloning first.** Deferred to Phase 3 (#1792) — requires an image store + build pipeline; ISO install is the simpler first capability.
 - **Controller blob store for ISOs.** Deferred — host-path + the `file` module is sufficient now.
 - **Per-VM short-lived enrollment tokens for v1.** Deferred — reuse the existing steward-deploy enrollment now; harden later (§8).
+
+---
+
+## Amendment 1: Cluster-scope existence gating for `ha_role` VMs
+
+**Status:** Accepted (founder-ratified 2026-07-08). **Related:** epic #2418; stories #2420, #2421, #2447.
+
+This ADR's existence gate (§2) was written for a single host: "the VM does not
+exist (by name) **on the host**." A VM declared with `ha_role` breaks that
+framing — the identical resource cascades to **every** member steward of the
+cluster, so per-host existence alone would let N stewards each conclude
+"absent here → create," producing duplicate VMs and duplicate provisioning
+runs. This amendment re-scopes the existence question to the cluster for
+`ha_role` VMs. Non-HA VMs are unaffected.
+
+### A1.1 Cluster-wide existence gate (#2420)
+
+For an `ha_role` VM, "exists" means **exists anywhere in the cluster**: locally
+present, OR registered as a clustered VM role owned by any node (the `Get`
+membership probe reports this even when the VM is locally absent). A steward
+where the VM is locally absent but the role is registered cluster-wide takes
+**no create action** — no `New-VM`, no provisioning — and converges as an
+audited no-op.
+
+**Promote-before-cascade rule (founder ruling 2026-07-08).** Cluster-wide
+existence is evaluated as *local presence OR registered cluster role*. An
+existing-but-unregistered VM on **another** host is therefore invisible to the
+gate. Promoting a standalone VM to `ha_role` must consequently happen **on the
+owning host first** (via that host steward's config), and only after role
+registration does the definition move to the cluster config. Cascading an
+`ha_role` declaration for an unregistered VM that lives on a different host is
+undefined and risks a duplicate create.
+
+### A1.2 CNO-owner creation gate (#2421)
+
+When the role exists **nowhere** in the cluster (locally absent AND no
+registered role), exactly one node must perform the first-ever
+create/provision: the steward currently owning the cluster's CNO group. Every
+other member records an audit skip and returns cleanly — coordination, not
+authorization, the same non-owner shape as the cluster module's role-membership
+reconcile. Non-owners converge automatically once the owner creates (their next
+probe sees the registered role; A1.1 applies). The gate sits before the
+source/plain dispatch, so expensive `source` provisioning is owner-gated too. A
+transient owner-less CNO (mid-failover) means no node creates that cycle;
+an ownership-read failure fails the converge rather than silently skipping.
+
+### A1.3 Preserved §2 invariants
+
+The amendment widens *where* existence is evaluated; it changes nothing about
+*what* triggers action. Provisioning remains **existence-gated, never
+health-gated**; `on_existing: never` remains the default; nothing is destroyed
+automatically, ever.
+
+### A1.4 Cluster-visible provisioning record — Option A (ratified)
+
+A1.1/A1.2 close the duplicate-create window for *registered* roles, but a
+provisioning run in flight on the owner has no registered role yet — a CNO
+failover mid-provision could let the new owner start a second run. **Option A**
+is ratified: the per-VM provisioning record (§3) for `ha_role` VMs is stored
+**cluster-visible on the CSV**, so every member steward sees an in-progress
+record regardless of which node wrote it. A steward observing an in-progress
+record it cannot attribute to itself **surfaces-and-waits** — it never
+provisions over another node's run. Implementation is story #2447 (this
+amendment documents the decision).
+
+**Caveat:** *cluster-visible* means visible to **cluster member nodes**, NOT
+controller-visible. The controller-side completion reconciler wiring (§8's
+`ready` transition) is a separate, pre-existing gap and is unchanged by this
+amendment and its epic.

--- a/docs/architecture/decisions/017-dna-composition-and-sync.md
+++ b/docs/architecture/decisions/017-dna-composition-and-sync.md
@@ -184,6 +184,15 @@ Read everything — even managed objects — from osquery.
 - `features/steward/dna/drift` — drift subsystem gated by the managed/observe-only class
 - `docs/product/roadmap.md` — Captured Backlog (OSquery, controller baseline DNA) + [Digital Twin & DEX — Tiered Rollout](../../product/roadmap.md#digital-twin--digital-employee-experience-dex--tiered-rollout) (the Tier-1 commitments this amendment lands)
 
+**Flat-DNA-surface consumers to re-home on the fragment model.** Two shipped
+consumers read/write today's flat attribute map directly and must be migrated
+onto fragments when the DNA-composition epic is decomposed (epic #2418, ADR
+Alignment item 1): the steward-side ChangeEvent→DNA attribute bridge
+(#2423/#2435 — module Monitor engine events surfaced as DNA attributes) and the
+controller-side cluster-registry parser (#2424 — cluster membership parsed from
+steward DNA attributes). Both are attribute-key contracts on the flat surface;
+re-homing them is in scope for that epic, not this ADR.
+
 ---
 
 ## Amendment 1 (2026-07-07) — Twin/DEX data-model commitments

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -635,8 +635,8 @@ existence gate closes the duplicate-VM window this creates:
   `vm-set-skip-hosted-elsewhere` audit event and converges as a no-op.
 - The gate keys on the role's **existence**, not its owner — a non-hosting
   steward never needs to know who hosts the VM, only that someone does.
-  (Owner-side creation of a cluster-wide-missing role is a separate concern,
-  #2421.)
+  (Owner-side creation of a cluster-wide-missing role is the CNO-owner
+  creation gate below, #2421.)
 - A transient membership-probe failure degrades to "no role observed" for that
   cycle (unchanged from #2372): the gate simply cannot fire, and the pre-#2420
   create logic — whose clustered-role registration is still CNO-gated and
@@ -644,6 +644,28 @@ existence gate closes the duplicate-VM window this creates:
   converge; no new error-path behavior is introduced.
 - Non-HA VMs (`ha_role` absent) are untouched: a locally-absent standalone VM
   is created exactly as before.
+
+#### CNO-owner creation gate (#2421)
+
+The existence gate answers "someone already hosts this role — don't create".
+Its complement is the first-ever create: the role exists **nowhere** in the
+cluster (locally absent **and** no clustered role registered), yet the identical
+declaration just cascaded to every member steward at once. First-ever creation
+of an `ha_role` VM is therefore **CNO-owner-gated**, exactly like
+`hyperv.cluster`'s existing role-membership reconcile:
+
+- Only the steward currently owning the cluster's CNO group proceeds to
+  create/provision. The gate sits **before** the source/plain dispatch, so a
+  source-provisioned VM's expensive provisioning is owner-gated too.
+- Every other member records a `vm-set-skip-not-cno-owner` audit event (with
+  the observed CNO owner) and returns `nil` — coordination, not authorization,
+  the same non-owner shape as the role-membership reconcile. Non-owners
+  converge automatically once the owner creates: their next `Get` sees the
+  registered role and the existence gate above takes over.
+- A transient "CNO has no current owner" cycle (mid-failover) means **no**
+  node creates that cycle — creation is delayed one cycle, never duplicated.
+- An ownership-read failure is **fail-safe**: it fails the `Set` (surfaced as
+  a converge error) rather than being silently swallowed into a skip.
 
 **Drift detection requires the module-level `cluster_name` scope cap.** `Get`
 reports a VM's current cluster-role membership by probing the scope-capped

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -954,6 +954,40 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		return nil
 	}
 
+	// CNO-owner creation gate (#2421): the role does not exist ANYWHERE in the
+	// cluster yet (locally absent AND no clustered role registered — the #2420
+	// probe reports cluster-wide membership on the absent path), so exactly one
+	// node must perform the first-ever create. Reuse the cluster module's
+	// coordination primitive: only the CNO-owner steward proceeds to
+	// create/provision (the gate sits BEFORE the source/plain dispatch, so
+	// expensive provisioning is owner-gated too); every other member records an
+	// audit skip and returns nil — coordination, not authorization, mirroring
+	// reconcileRoleMembership's non-owner shape. Non-owners converge once the
+	// owner creates: their next getVM sees the registered role and the #2420
+	// gate above takes over. A transient "CNO has no current owner" cycle
+	// returns (false, nil, nil) — no node creates that cycle, which is safe
+	// (creation is delayed one cycle, never duplicated). A helper error is
+	// fail-safe: it fails the Set rather than being swallowed into a skip.
+	if !vmExists && cfg.HARole != nil && current.HARole == nil {
+		ownsCNO, _, ownErr := m.clusterOwnershipHelper(ctx, cfg.HARole.ClusterName)
+		if ownErr != nil {
+			return fmt.Errorf("hyperv: set VM %q: CNO ownership for first-ever ha_role create: %w", vmName, ownErr)
+		}
+		if !ownsCNO {
+			cnoOwner := m.readCNOOwner(ctx, cfg.HARole.ClusterName)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"vm-set-skip-not-cno-owner", "vm:"+vmName, nil,
+				map[string]interface{}{
+					"owns_cno":     false,
+					"cno_owner":    cnoOwner,
+					"skipped":      true,
+					"cluster_name": cfg.HARole.ClusterName,
+					"locally":      "absent",
+				}, nil)
+			return nil
+		}
+	}
+
 	// Existence-gating safety invariant (ADR-009 §2): source provisioning is
 	// existence-gated, never health-gated. When a source block is declared, the
 	// create/destroy decision is made HERE — before any plain-lifecycle apply —

--- a/features/modules/hyperv/vm_harole_convergence_test.go
+++ b/features/modules/hyperv/vm_harole_convergence_test.go
@@ -252,6 +252,208 @@ func TestSetVM_StandaloneVM_UnaffectedByGate(t *testing.T) {
 		"a standalone (non-HA) VM must still be created when locally absent")
 }
 
+// ─── Issue #2421: CNO-owner creates cluster-wide-missing HA role VMs ───────────
+//
+// When ha_role is declared and the role does not exist ANYWHERE in the cluster
+// yet (locally absent AND current.HARole == nil per the #2420 probe), only the
+// steward currently owning the CNO group proceeds to create/provision; every
+// other member records an audit skip and returns nil. Non-owners converge once
+// the owner creates it (their next getVM sees the registered role, #2420 gate).
+
+// TestSetVM_ClusterWideAbsentRole_NonOwnerSurfacesAndWaits (REQUIRED, #2421):
+// role absent cluster-wide and this node does NOT own the CNO → zero
+// New-VM/provisioning transport calls, setVM returns nil, and the skip is
+// audited — for BOTH the plain-lifecycle path and the source path.
+func TestSetVM_ClusterWideAbsentRole_NonOwnerSurfacesAndWaits(t *testing.T) {
+	const vmName = "ha-first-vm"
+	const cluster = "lab-hv"
+
+	// Five transport calls total: getVM + membership probe (role absent
+	// everywhere), then the ownership helper's CNO-owner read + role-owner map
+	// + the audit cnoOwner re-read. Anything beyond that (New-VM, provisioning)
+	// violates the gate.
+	newTransport := func() *testWinRMTransport {
+		return &testWinRMTransport{perCallOutputs: []string{
+			`{"found":false}`,   // getVM: locally absent
+			`{"owners":{}}`,     // getVM probe: role absent cluster-wide
+			`{"owner":"NODE2"}`, // ownership helper: another node owns the CNO
+			`{"owners":{}}`,     // ownership helper: role owners
+			`{"owner":"NODE2"}`, // audit cnoOwner re-read
+		}}
+	}
+
+	t.Run("plain_lifecycle_path", func(t *testing.T) {
+		transport := newTransport()
+		m := vmModuleWithTransport(transport, "t-2421")
+		m.clusterName = cluster
+		m.nodeHostname = "NODE1"
+		mgr, store := newFakeAuditManager(t)
+		m.auditMgr = mgr
+		m.stewardID = "steward-2421"
+
+		require.NoError(t, m.Set(context.Background(), "vm:"+vmName, &VMConfig{
+			Name:       vmName,
+			MemoryMB:   4096,
+			CPUCount:   2,
+			VHDPath:    `C:\VMs\ha-first-vm.vhdx`,
+			SwitchName: "Default Switch",
+			Generation: 2,
+			State:      "running",
+			HARole:     &HARoleConfig{ClusterName: cluster},
+		}))
+
+		assert.Equal(t, 0, countCmd(transport, psCreateVM),
+			"a non-CNO-owner must never issue New-VM for a first-ever ha_role create")
+		transport.mu.Lock()
+		callCount := len(transport.calls)
+		transport.mu.Unlock()
+		assert.Equal(t, 5, callCount,
+			"gate must stop after getVM+probe+ownership reads — no mutation calls")
+
+		require.NoError(t, m.auditMgr.Flush(context.Background()))
+		skips := auditEntriesByActionCT(store.captured(), "vm-set-skip-not-cno-owner")
+		require.Len(t, skips, 1, "the non-owner skip must be audited")
+	})
+
+	t.Run("source_path", func(t *testing.T) {
+		transport := newTransport()
+		m := vmModuleWithTransport(transport, "t-2421")
+		m.clusterName = cluster
+		m.nodeHostname = "NODE1"
+
+		require.NoError(t, m.Set(context.Background(), "vm:"+vmName, &VMConfig{
+			Name:       vmName,
+			MemoryMB:   4096,
+			CPUCount:   2,
+			VHDPath:    `C:\VMs\ha-first-vm.vhdx`,
+			SwitchName: "Default Switch",
+			Generation: 2,
+			State:      "running",
+			HARole:     &HARoleConfig{ClusterName: cluster},
+			Source: &SourceConfig{
+				Image:      `C:\images\debian.raw`,
+				OSFamily:   "linux",
+				Completion: CompletionConfig{Mode: "steward-registration", Timeout: "10m"},
+			},
+		}))
+
+		assert.Equal(t, 0, countCmd(transport, psCreateVM),
+			"the owner gate must fire before applySourceGated ever provisions")
+		transport.mu.Lock()
+		callCount := len(transport.calls)
+		transport.mu.Unlock()
+		assert.Equal(t, 5, callCount,
+			"gate must stop after getVM+probe+ownership reads — no provisioning calls")
+	})
+}
+
+// TestSetVM_ClusterWideAbsentRole_OwnerCreates (REQUIRED, #2421): same
+// preconditions, but this node DOES own the CNO → the existing create path
+// (createVM + registerClusteredRole) proceeds exactly as before this story.
+func TestSetVM_ClusterWideAbsentRole_OwnerCreates(t *testing.T) {
+	const vmName = "ha-first-vm"
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"found":false}`,   // getVM: locally absent
+		`{"owners":{}}`,     // getVM probe: role absent cluster-wide
+		`{"owner":"NODE1"}`, // ownership helper (#2421 gate): this node owns the CNO
+		`{"owners":{}}`,     // ownership helper: role owners
+		``,                  // New-VM
+		``,                  // Cfgms-SetVMHome: config-home move (#2411)
+		`{"owner":"NODE1"}`, // registerClusteredRole ownership helper: CNO owner
+		`{"owners":{}}`,     // registerClusteredRole ownership helper: role owners
+		`{"owner":"NODE1"}`, // registerClusteredRole audit cnoOwner re-read
+		``,                  // Add-ClusterVirtualMachineRole
+	}}
+	m := vmModuleWithTransport(transport, "t-2421")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	require.NoError(t, m.Set(context.Background(), "vm:"+vmName, &VMConfig{
+		Name:       vmName,
+		MemoryMB:   4096,
+		CPUCount:   2,
+		VHDPath:    `C:\VMs\ha-first-vm.vhdx`,
+		SwitchName: "Default Switch",
+		Generation: 2,
+		State:      "stopped",
+		HARole:     &HARoleConfig{ClusterName: cluster},
+	}))
+
+	assert.Equal(t, 1, countCmd(transport, psCreateVM),
+		"the CNO owner must perform the first-ever create")
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"the created VM must still be registered as a clustered role")
+}
+
+// TestSetVM_ClusterOwnershipHelperError_PropagatesAsSetError (REQUIRED, #2421):
+// a transport error from clusterOwnershipHelper is returned as a setVM error —
+// never silently swallowed into a skip (fail-safe).
+func TestSetVM_ClusterOwnershipHelperError_PropagatesAsSetError(t *testing.T) {
+	const vmName = "ha-first-vm"
+	const cluster = "lab-hv"
+
+	// readCNOOwner reports a valid owner, then the role-owner read fails —
+	// clusterOwnershipHelper returns that error.
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,   // getVM: locally absent
+			`{"owners":{}}`,     // getVM probe: role absent cluster-wide
+			`{"owner":"NODE2"}`, // ownership helper: CNO owner read
+			``,                  // ownership helper: role owners — errors below
+		},
+		perCallErrors: []error{nil, nil, nil, errors.New("cluster service down")},
+	}
+	m := vmModuleWithTransport(transport, "t-2421")
+	m.clusterName = cluster
+	m.nodeHostname = "NODE1"
+
+	err := m.Set(context.Background(), "vm:"+vmName, &VMConfig{
+		Name:       vmName,
+		MemoryMB:   4096,
+		CPUCount:   2,
+		VHDPath:    `C:\VMs\ha-first-vm.vhdx`,
+		SwitchName: "Default Switch",
+		Generation: 2,
+		State:      "running",
+		HARole:     &HARoleConfig{ClusterName: cluster},
+	})
+	require.Error(t, err,
+		"an ownership-helper failure must fail the Set, not silently skip")
+	assert.Contains(t, err.Error(), "cluster service down")
+	assert.Equal(t, 0, countCmd(transport, psCreateVM),
+		"no create may proceed when ownership could not be determined")
+}
+
+// TestSetVM_ClusterWideAbsentRole_ScopeCapErrorPropagates (#2421): an
+// out-of-scope ha_role.cluster_name fails the Set with ErrClusterNotDeclared
+// (S5 scope cap) — never a silent skip, never a create.
+func TestSetVM_ClusterWideAbsentRole_ScopeCapErrorPropagates(t *testing.T) {
+	const vmName = "ha-rogue-vm"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"found":false}`, // getVM: locally absent
+		`{"owners":{}}`,   // getVM probe (module scope): role absent cluster-wide
+	}}
+	m := vmModuleWithTransport(transport, "t-2421")
+	m.clusterName = "lab-hv"
+	m.nodeHostname = "NODE1"
+
+	err := m.Set(context.Background(), "vm:"+vmName, &VMConfig{
+		Name:       vmName,
+		MemoryMB:   4096,
+		CPUCount:   2,
+		VHDPath:    `C:\VMs\ha-rogue-vm.vhdx`,
+		SwitchName: "Default Switch",
+		Generation: 2,
+		State:      "running",
+		HARole:     &HARoleConfig{ClusterName: "rogue-cluster"},
+	})
+	require.ErrorIs(t, err, ErrClusterNotDeclared)
+	assert.Equal(t, 0, countCmd(transport, psCreateVM))
+}
+
 // ─── AC1 (REQUIRED TEST): promote / demote an existing VM, idempotent ─────────
 
 // TestSetVM_HARole_PromoteExistingVM: adding ha_role to an already-created VM

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -1419,6 +1419,8 @@ func TestSetVM_HARole_RegistersClusteredRole(t *testing.T) {
 		transport := &testWinRMTransport{perCallOutputs: []string{
 			`{"found":false}`,   // getVM: VM absent
 			`{"owners":{}}`,     // getVM probe (#2420): role absent cluster-wide
+			`{"owner":"NODE1"}`, // #2421 owner gate: CNO owner read (this node owns)
+			`{"owners":{}}`,     // #2421 owner gate: resource owners
 			``,                  // New-VM: create succeeds
 			``,                  // Cfgms-SetVMHome: config-home move (#2411)
 			`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)
@@ -1527,6 +1529,8 @@ func TestSetVM_HARole_MapShapeRegistersClusteredRole(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{
 		`{"found":false}`,   // getVM: VM absent
 		`{"owners":{}}`,     // getVM probe (#2420): role absent cluster-wide
+		`{"owner":"NODE1"}`, // #2421 owner gate: CNO owner read (this node owns)
+		`{"owners":{}}`,     // #2421 owner gate: resource owners
 		``,                  // New-VM: create succeeds
 		``,                  // Cfgms-SetVMHome: config-home move (#2411)
 		`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)


### PR DESCRIPTION
## Summary

When a `hyperv.vm` resource declares `ha_role` and the role does not exist anywhere in the cluster yet (locally absent AND `current.HARole == nil` per #2420's absent-path probe), only the steward owning the cluster's CNO group proceeds to create/provision. Every other member records a `vm-set-skip-not-cno-owner` audit event and returns nil — coordination, not authorization, mirroring `reconcileRoleMembership`'s non-owner shape. Non-owners converge automatically once the owner creates (their next `getVM` sees the registered role; the #2420 gate takes over).

## Changes

- `features/modules/hyperv/vm.go` — second branch of the `setVM` gate (after the #2420 block, before the source/plain dispatch): `!vmExists && cfg.HARole != nil && current.HARole == nil` → `clusterOwnershipHelper`; helper error propagates as the Set error (fail-safe, never swallowed into a skip); non-owner records audit skip + returns nil; owner falls through unchanged. Source provisioning is owner-gated too (gate sits before `applySourceGated`).
- `features/modules/hyperv/vm_harole_convergence_test.go` — REQUIRED tests: `TestSetVM_ClusterWideAbsentRole_NonOwnerSurfacesAndWaits` (plain + source subtests, zero New-VM/provisioning calls, audit skip asserted), `TestSetVM_ClusterWideAbsentRole_OwnerCreates` (create path proceeds exactly as before), `TestSetVM_ClusterOwnershipHelperError_PropagatesAsSetError`, plus `TestSetVM_ClusterWideAbsentRole_ScopeCapErrorPropagates` (S5).
- `features/modules/hyperv/vm_test.go` — two existing owner-path fixtures gained the two ownership reads that now precede New-VM (assertions unchanged).
- `features/modules/hyperv/README.md` — CNO-owner creation gate section extending the #2420 addendum.
- `docs/architecture/decisions/009-hyperv-vm-provisioning-from-install-media.md` — Amendment 1 (founder-ratified 2026-07-08): A1.1 cluster-wide existence gate + promote-before-cascade rule, A1.2 CNO-owner creation gate, A1.3 preserved §2 invariants, A1.4 Option A (CSV provisioning record, implemented by #2447) with the cluster-visible ≠ controller-visible caveat.
- `docs/architecture/decisions/017-dna-composition-and-sync.md` — flat-DNA-surface consumer note (#2423/#2435 ChangeEvent→DNA bridge, #2424 cluster-registry parser) for re-homing at DNA-composition decomposition.

## Review results (story-review workflow, 4 lenses)

- **Acceptance checker: PASS** (round 1)
- **QA code review: PASS** (round 1)
- **Security review: PASS** (round 1)
- **Tests (`make test-quality`): FAIL — pre-existing host issue, not this story.** Sole finding: `scripts/tier1-smoke-test_test.sh` aborts under `set -e` on this Windows/Git-Bash host (MSYS path-mangling of `openssl -subj /CN=...` + no `/proc` process substitution). Reproduced on a **clean `origin/develop` worktree** (zero story changes): exits 1 at the identical spot. This story never touches that file. `make test` passes on this branch (full run, exit 0); Linux CI is the authoritative gate for the suite.

## Live validation

The 3-node cfg-lab cascade validation (only CNO owner creates; other two stewards record non-owner skips with zero PS mutations) is story #2426 (`fleet-e2e`), which depends on this PR.

Fixes #2421

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SUVZR6kTwcXDNwjgq8ygn
