### PR TITLE
test: eliminate features/controller/api unit-test timeouts via fast raft timings (Issue #2452)

### DIFF
--- a/features/controller/api/server_tls_ha_test.go
+++ b/features/controller/api/server_tls_ha_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/ha"
@@ -28,19 +29,34 @@ import (
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )
 
-// newClusterModeHAManager creates a commercial ha.Manager in ClusterMode with the given CA cert path.
+// newClusterModeHAManager creates an ha.Manager in ClusterMode with the given CA cert path.
+// It uses FastElectionConfig so raft elections converge in milliseconds (not seconds),
+// preventing election storms under CI CPU contention.
+//
+// Cleanup ordering (LIFO): manager.Stop → sm.Close → goleak.VerifyNone.
+// goleak.IgnoreCurrent snapshots goroutines before the manager is constructed so only
+// goroutines introduced by this helper are checked for leaks.
 func newClusterModeHAManager(t *testing.T, caCertPath string) *ha.Manager {
 	t.Helper()
+
+	// Snapshot pre-existing goroutines; goleak.VerifyNone (registered below, runs last)
+	// will only flag goroutines that are NEW relative to this snapshot.
+	existingGoroutines := goleak.IgnoreCurrent()
+	t.Cleanup(func() { goleak.VerifyNone(t, existingGoroutines) })
+
 	sm, err := storage.CreateTestStorageManager()
 	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, sm.Close()) })
 
 	cfg := ha.DefaultConfig()
 	cfg.Mode = ha.ClusterMode
 	cfg.CACertPath = caCertPath
 	cfg.Node.ID = fmt.Sprintf("test-node-%d", time.Now().UnixNano())
+	cfg.Cluster = ha.FastElectionConfig()
 
 	manager, err := ha.NewManager(cfg, logging.GetLogger(), sm)
 	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Stop(context.Background())) })
 	return manager
 }
 

--- a/features/controller/clusterregistry/registry_test.go
+++ b/features/controller/clusterregistry/registry_test.go
@@ -25,7 +25,7 @@ func TestClusterRegistry_ParsesDNAAttributes_MultiSteward(t *testing.T) {
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
-				"hostname": "CFG-70-02",
+				"hostname":                           "CFG-70-02",
 			},
 		},
 		{
@@ -35,7 +35,7 @@ func TestClusterRegistry_ParsesDNAAttributes_MultiSteward(t *testing.T) {
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
-				"hostname": "CFG-AB-02",
+				"hostname":                           "CFG-AB-02",
 			},
 		},
 	}
@@ -103,9 +103,9 @@ func TestClusterRegistry_MalformedKeySkipped(t *testing.T) {
 			TenantID: "default",
 			DNAAttributes: map[string]string{
 				// Malformed: no dot separator → should be silently skipped.
-				"cluster:badkey":                     "val",
+				"cluster:badkey": "val",
 				// Malformed: empty cluster name → should be silently skipped.
-				"cluster:.member_nodes":              "x",
+				"cluster:.member_nodes": "x",
 				// Valid key alongside the bad ones.
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
@@ -129,10 +129,10 @@ func TestClusterRegistry_MultipleClusters(t *testing.T) {
 			ID:       "steward-a",
 			TenantID: "default",
 			DNAAttributes: map[string]string{
-				"cluster:cfg-lab.member_nodes":         "CFG-70-02",
-				"cluster:cfg-lab.resource_owner.csv":   "CFG-70-02",
-				"cluster:cfg-prod.member_nodes":        "CFG-70-02",
-				"cluster:cfg-prod.resource_owner.cno":  "CFG-70-02",
+				"cluster:cfg-lab.member_nodes":        "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.csv":  "CFG-70-02",
+				"cluster:cfg-prod.member_nodes":       "CFG-70-02",
+				"cluster:cfg-prod.resource_owner.cno": "CFG-70-02",
 			},
 		},
 	}

--- a/pkg/ha/config.go
+++ b/pkg/ha/config.go
@@ -294,6 +294,23 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// FastElectionConfig returns a ClusterConfig with test-scale election timings.
+// Use in place of DefaultConfig().Cluster in tests to prevent election storms
+// under CPU contention: elections converge in milliseconds, not seconds.
+// ElectionTick = ElectionTimeout / HeartbeatInterval = 200ms / 40ms = 5,
+// satisfying the ≥5 invariant enforced by NewRaftConsensus.
+func FastElectionConfig() ClusterConfig {
+	return ClusterConfig{
+		ExpectedSize:      3,
+		MinQuorum:         2,
+		ElectionTimeout:   200 * time.Millisecond,
+		HeartbeatInterval: 40 * time.Millisecond,
+		Discovery: &DiscoveryConfig{
+			Config: make(map[string]interface{}),
+		},
+	}
+}
+
 // GetModeString returns the deployment mode as a string
 func (c *Config) GetModeString() string {
 	return c.Mode.String()

--- a/pkg/ha/config_test.go
+++ b/pkg/ha/config_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package ha
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFastElectionConfig_ElectionTickInvariant asserts that the values returned by
+// FastElectionConfig satisfy the ElectionTick ≥ 5 invariant enforced by
+// NewRaftConsensus (raft_consensus.go:111). A ratio below 5 causes NewRaftConsensus
+// to return an error, which would silently break every test that calls
+// newClusterModeHAManager.
+func TestFastElectionConfig_ElectionTickInvariant(t *testing.T) {
+	cfg := FastElectionConfig()
+	electionTick := int(cfg.ElectionTimeout / cfg.HeartbeatInterval)
+	assert.GreaterOrEqual(t, electionTick, 5,
+		"ElectionTimeout (%v) / HeartbeatInterval (%v) = ElectionTick %d must be ≥5",
+		cfg.ElectionTimeout, cfg.HeartbeatInterval, electionTick)
+}

--- a/pkg/ha/manager.go
+++ b/pkg/ha/manager.go
@@ -225,6 +225,14 @@ func (m *Manager) Stop(ctx context.Context) error {
 	defer m.mu.Unlock()
 
 	if !m.isStarted {
+		// runRaft goroutine starts in NewRaftConsensus (called from initializeComponents,
+		// before Start) and must be stopped even when Stop is called on a never-started
+		// manager — otherwise it leaks. RaftConsensus.Stop is idempotent via sync.Once.
+		if m.raftConsensus != nil {
+			if err := m.raftConsensus.Stop(); err != nil {
+				return fmt.Errorf("raft consensus stop: %w", err)
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- **Root cause**: `newClusterModeHAManager` inherited the production `ElectionTimeout: 10s` from `DefaultConfig()`. Under CPU contention on the 4-vCPU self-hosted runner with `-race`, goroutines missed scheduling windows, raft re-ran elections repeatedly through the SQLite-backed FSM — a non-linear storm that caused `panic: test timed out after 5m0s`.
- **Fix**: Added `ha.FastElectionConfig()` (`ElectionTimeout: 200ms`, `HeartbeatInterval: 40ms`, `ElectionTick: 5`). Wired into `newClusterModeHAManager` so all 5 call sites get fast timings with zero assertion changes.
- **Goroutine cleanup**: Fixed `manager.Stop()` to stop raft consensus even for never-started managers (the `runRaft` goroutine starts in `NewRaftConsensus` before `Start` is called); added `t.Cleanup` for both `manager.Stop()` and `sm.Close()`; added per-test `goleak.IgnoreCurrent/VerifyNone` to verify zero raft goroutine leaks.
- **Test count**: 648 before and after (verified via `go test -list '.*'`).

## Specialist Review Results

- **Code Review**: PASS (3 rounds, 2 fix rounds to resolve minor issues)
- **Test Quality**: PASS
- **Security**: PASS

## Measured Results

```
GOMAXPROCS=2 go test -short -race -timeout=5m ./features/controller/api/
ok  github.com/cfgis/cfgms/features/controller/api  114.363s  (~1m56s wall-clock)
```

Previously timed out at 5m on CI. Now comfortably under budget with margin.

## Files Changed

| File | Change |
|------|--------|
| `pkg/ha/config.go` | Add `FastElectionConfig()` with 200ms/40ms timings |
| `pkg/ha/config_test.go` | New: `TestFastElectionConfig_ElectionTickInvariant` |
| `pkg/ha/manager.go` | Fix `Stop()` to clean up raft goroutine on never-started managers |
| `features/controller/api/server_tls_ha_test.go` | Wire `FastElectionConfig()`, add `t.Cleanup`, add goleak |
| `features/controller/clusterregistry/registry_test.go` | Reviewer-requested test hygiene fixes |

Fixes #2452