### PR TITLE
api: lazy-register workflow/reports/rollback routes at Set* time (Issue #2373)

### DIFF
--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -61,6 +61,7 @@ type Server struct {
 	logger                         logging.Logger
 	httpServer                     *http.Server
 	router                         *mux.Router
+	apiRouter                      *mux.Router // /api/v1 subrouter; used by Set* methods for lazy route registration
 	controllerService              *service.ControllerService
 	configService                  *service.ConfigurationServiceV2
 	certProvisioningService        *service.CertificateProvisioningService
@@ -411,6 +412,7 @@ func (s *Server) setupRouter() {
 	api.Use(s.authenticationMiddleware) // extract principal (API key or mTLS)
 	api.Use(s.requireTier(TierAny))     // Issue #1419: explicit Tier-1 default for the api subrouter
 	api.Use(s.validationMiddleware)
+	s.apiRouter = api // saved so Set* methods can lazy-register routes after construction
 
 	// --- Tier 0 (TierPublic) — no authentication required ---
 	//   GET  /api/v1/health
@@ -702,51 +704,6 @@ func (s *Server) setupRouter() {
 	// Raft status endpoint: requires HA read-status permission via API authentication
 	api.Handle("/raft/status", s.requirePermission("ha", "read-status")(http.HandlerFunc(s.handleRaftStatus))).Methods("GET")
 
-	// Rollback management endpoints (Story #416)
-	if s.rollbackManager != nil {
-		// Read the principal from the request context (set by authenticationMiddleware)
-		// so both mTLS admin principals and scoped API-key principals are evaluated.
-		rollbackPrincipalExtractor := func(r *http.Request) *Principal {
-			p, _ := r.Context().Value(principalContextKey).(*Principal)
-			return p
-		}
-		// Resolve the steward's registered tenant from the controller registry.
-		// This is the authoritative cross-tenant check — it cannot be bypassed by
-		// the caller supplying a fabricated steward_tenant_path in the request body.
-		stewardTenantLookup := func(stewardID string) string {
-			if s.controllerService != nil {
-				if info, ok := s.controllerService.GetStewardInfo(stewardID); ok {
-					return info.TenantID
-				}
-			}
-			return ""
-		}
-		rollbackHandler := NewRollbackHandler(s.rollbackManager, rollbackPrincipalExtractor, stewardTenantLookup, s.auditManager)
-		rollbackRouter := api.PathPrefix("/rollback").Subrouter()
-		// Require config/rollback permission for all rollback endpoints — same gate pattern
-		// as every other mutating endpoint in this server.
-		rollbackRouter.Use(s.requirePermission("config", "rollback"))
-		rollbackHandler.RegisterRoutes(rollbackRouter)
-		s.logger.Info("Rollback API routes registered")
-	}
-
-	// Reports engine endpoints (Story #416)
-	if s.reportsHandler != nil {
-		reportsRouter := api.PathPrefix("/reports").Subrouter()
-		s.reportsHandler.RegisterRoutes(reportsRouter)
-		s.logger.Info("Reports API routes registered")
-	}
-
-	// Workflow engine endpoints (Issue #414)
-	if s.workflowHandler != nil {
-		workflowRouter := api.PathPrefix("/workflows").Subrouter()
-		s.workflowHandler.RegisterWorkflowRoutes(workflowRouter)
-
-		triggerRouter := api.PathPrefix("/triggers").Subrouter()
-		s.workflowHandler.RegisterTriggerRoutes(triggerRouter)
-		s.logger.Info("Workflow and trigger API routes registered")
-	}
-
 	// TODO(#997): Wire terminal WebSocket handler when HTTP route is added (gated on epic #750).
 	// When the terminal route is registered, parse CFGMS_TERMINAL_ALLOWED_ORIGINS and pass the
 	// resulting slice to terminal.NewWebSocketHandler as the third argument. Parsing pattern
@@ -905,22 +862,58 @@ func (s *Server) Stop() error {
 	return s.Close(ctx)
 }
 
-// SetRollbackManager sets the rollback manager for rollback API routes (Story #416)
+// SetRollbackManager sets the rollback manager and registers rollback API routes (Story #416).
+// Call this after New() returns but before Start() is called.
 func (s *Server) SetRollbackManager(m rollback.RollbackManager) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.rollbackManager = m
+	if m == nil {
+		return
+	}
+	// Read the principal from the request context (set by authenticationMiddleware)
+	// so both mTLS admin principals and scoped API-key principals are evaluated.
+	rollbackPrincipalExtractor := func(r *http.Request) *Principal {
+		p, _ := r.Context().Value(principalContextKey).(*Principal)
+		return p
+	}
+	// Resolve the steward's registered tenant from the controller registry.
+	// This is the authoritative cross-tenant check — it cannot be bypassed by
+	// the caller supplying a fabricated steward_tenant_path in the request body.
+	stewardTenantLookup := func(stewardID string) string {
+		if s.controllerService != nil {
+			if info, ok := s.controllerService.GetStewardInfo(stewardID); ok {
+				return info.TenantID
+			}
+		}
+		return ""
+	}
+	rollbackHandler := NewRollbackHandler(m, rollbackPrincipalExtractor, stewardTenantLookup, s.auditManager)
+	rollbackRouter := s.apiRouter.PathPrefix("/rollback").Subrouter()
+	// Require config/rollback permission for all rollback endpoints — same gate pattern
+	// as every other mutating endpoint in this server.
+	rollbackRouter.Use(s.requirePermission("config", "rollback"))
+	rollbackHandler.RegisterRoutes(rollbackRouter)
+	s.logger.Info("Rollback API routes registered")
 }
 
-// SetReportsHandler sets the reports handler for reports API routes (Story #416)
+// SetReportsHandler sets the reports handler and registers reports API routes (Story #416).
+// Call this after New() returns but before Start() is called.
 func (s *Server) SetReportsHandler(h *reportapi.Handler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.reportsHandler = h
+	if h == nil {
+		return
+	}
+	reportsRouter := s.apiRouter.PathPrefix("/reports").Subrouter()
+	h.RegisterRoutes(reportsRouter)
+	s.logger.Info("Reports API routes registered")
 }
 
-// SetWorkflowHandler sets the workflow handler for workflow and trigger API routes (Issue #414).
-// Propagates the server's fleet query so that script dispatch targeting is wired at setup time (Issue #609).
+// SetWorkflowHandler sets the workflow handler and registers workflow and trigger API routes
+// (Issue #414). Propagates the server's fleet query so that script dispatch targeting is wired
+// at setup time (Issue #609). Call this after New() returns but before Start() is called.
 func (s *Server) SetWorkflowHandler(h *WorkflowHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -928,6 +921,14 @@ func (s *Server) SetWorkflowHandler(h *WorkflowHandler) {
 	if h != nil && s.fleetQuery != nil {
 		h.SetFleetQuery(s.fleetQuery)
 	}
+	if h == nil {
+		return
+	}
+	workflowRouter := s.apiRouter.PathPrefix("/workflows").Subrouter()
+	h.RegisterWorkflowRoutes(workflowRouter)
+	triggerRouter := s.apiRouter.PathPrefix("/triggers").Subrouter()
+	h.RegisterTriggerRoutes(triggerRouter)
+	s.logger.Info("Workflow and trigger API routes registered")
 }
 
 // GetRouter returns the HTTP router for testing purposes.

--- a/features/controller/api/server_lazy_routes_test.go
+++ b/features/controller/api/server_lazy_routes_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	reportapi "github.com/cfgis/cfgms/features/reports/api"
+	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/features/workflow/trigger"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestServer_SetWorkflowHandler_RegistersRoutes_PostConstruction verifies that
+// workflow and trigger routes are present when SetWorkflowHandler is called after
+// New() — the production wiring order.  An unauthenticated request must return 401
+// (auth middleware fired) not 404 (route absent).
+func TestServer_SetWorkflowHandler_RegistersRoutes_PostConstruction(t *testing.T) {
+	server := setupTestServer(t)
+
+	// No workflow handler has been set; route must be absent (404).
+	req := httptest.NewRequest("POST", "/api/v1/workflows", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"workflow route must be 404 before SetWorkflowHandler")
+
+	// Wire a handler exactly as production does: after New() returns.
+	// Include a real trigger manager so trigger routes are also registered.
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logging.NewNoopLogger(), nil, nil, nil)
+	triggerMgr := trigger.NewControllerTriggerManager(nil, nil)
+	handler := NewWorkflowHandler(engine, nil, triggerMgr, logging.NewNoopLogger())
+	server.SetWorkflowHandler(handler)
+
+	// Unauthenticated POST /api/v1/workflows must now return 401 (route present,
+	// auth middleware rejected the caller) rather than 404.
+	req = httptest.NewRequest("POST", "/api/v1/workflows", nil)
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"POST /api/v1/workflows must return 401 after SetWorkflowHandler (auth enforced, not 404)")
+
+	// Trigger routes must also be live after SetWorkflowHandler.
+	req = httptest.NewRequest("GET", "/api/v1/triggers", nil)
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"GET /api/v1/triggers must return 401 after SetWorkflowHandler (auth enforced, not 404)")
+}
+
+// TestServer_SetReportsHandler_RegistersRoutes_PostConstruction verifies that reports
+// routes are live when SetReportsHandler is called after New() — the production wiring
+// order.  An unauthenticated request must return 401, not 404.
+func TestServer_SetReportsHandler_RegistersRoutes_PostConstruction(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Route must be absent before SetReportsHandler.
+	req := httptest.NewRequest("GET", "/api/v1/reports/dashboard/overview", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"reports route must be 404 before SetReportsHandler")
+
+	// Wire the handler post-construction, exactly as production does.
+	h := reportapi.New(nil, nil, logging.NewNoopLogger())
+	server.SetReportsHandler(h)
+
+	// Unauthenticated request must now return 401, not 404.
+	req = httptest.NewRequest("GET", "/api/v1/reports/dashboard/overview", nil)
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"GET /api/v1/reports/dashboard/overview must return 401 after SetReportsHandler (auth enforced, not 404)")
+}
+
+// TestServer_SetRollbackManager_RegistersRoutes_PostConstruction verifies that rollback
+// routes are live when SetRollbackManager is called after New() — the production wiring
+// order.  An unauthenticated request must return 401, not 404.
+func TestServer_SetRollbackManager_RegistersRoutes_PostConstruction(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Route must be absent before SetRollbackManager.
+	req := httptest.NewRequest("GET", "/api/v1/rollback/points", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"rollback route must be 404 before SetRollbackManager")
+
+	// Wire the manager post-construction, exactly as production does.
+	server.SetRollbackManager(&testRollbackManager{})
+
+	// Unauthenticated request must now return 401, not 404.
+	req = httptest.NewRequest("GET", "/api/v1/rollback/points", nil)
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"GET /api/v1/rollback/points must return 401 after SetRollbackManager (auth enforced, not 404)")
+}
+
+// TestServer_SetRollbackManager_EnforcesPermissionGate verifies that the config/rollback
+// permission gate is applied to rollback routes when they are lazily registered.
+// A caller with a valid API key but without config:rollback permission must receive 403.
+func TestServer_SetRollbackManager_EnforcesPermissionGate(t *testing.T) {
+	server := setupTestServer(t)
+	server.SetRollbackManager(&testRollbackManager{})
+
+	// Key without config:rollback permission.
+	noPermKey := NewTestKey(t, server, []string{"steward:read"})
+	req := httptest.NewRequest("GET", "/api/v1/rollback/points", nil)
+	req.Header.Set("X-API-Key", noPermKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"rollback route must return 403 for caller without config:rollback permission")
+
+	// Key with config:rollback permission must pass the gate (handler response, not 403 or 404).
+	permKey := NewTestKey(t, server, []string{"config:rollback"})
+	req = httptest.NewRequest("GET", "/api/v1/rollback/points", nil)
+	req.Header.Set("X-API-Key", permKey)
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"rollback route must not return 403 for caller with config:rollback permission")
+	assert.NotEqual(t, http.StatusNotFound, rec.Code,
+		"rollback route must not return 404 for caller with config:rollback permission")
+}
+
+// TestServer_SetWorkflowHandler_NilHandler_NoopSafe re-verifies (regression guard) that
+// passing nil to SetWorkflowHandler does not panic and leaves workflowHandler nil.
+func TestServer_SetWorkflowHandler_NilAfterSet_NoopSafe(t *testing.T) {
+	server := setupTestServer(t)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logging.NewNoopLogger(), nil, nil, nil)
+	handler := NewWorkflowHandler(engine, nil, nil, logging.NewNoopLogger())
+	server.SetWorkflowHandler(handler)
+
+	// Calling again with nil must not panic.
+	assert.NotPanics(t, func() {
+		server.SetWorkflowHandler(nil)
+	}, "SetWorkflowHandler(nil) must not panic even after a prior non-nil set")
+}

--- a/features/controller/clusterregistry/registry_test.go
+++ b/features/controller/clusterregistry/registry_test.go
@@ -25,7 +25,7 @@ func TestClusterRegistry_ParsesDNAAttributes_MultiSteward(t *testing.T) {
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
-				"hostname": "CFG-70-02",
+				"hostname":                           "CFG-70-02",
 			},
 		},
 		{
@@ -35,7 +35,7 @@ func TestClusterRegistry_ParsesDNAAttributes_MultiSteward(t *testing.T) {
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
-				"hostname": "CFG-AB-02",
+				"hostname":                           "CFG-AB-02",
 			},
 		},
 	}
@@ -103,9 +103,9 @@ func TestClusterRegistry_MalformedKeySkipped(t *testing.T) {
 			TenantID: "default",
 			DNAAttributes: map[string]string{
 				// Malformed: no dot separator → should be silently skipped.
-				"cluster:badkey":                     "val",
+				"cluster:badkey": "val",
 				// Malformed: empty cluster name → should be silently skipped.
-				"cluster:.member_nodes":              "x",
+				"cluster:.member_nodes": "x",
 				// Valid key alongside the bad ones.
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
@@ -129,10 +129,10 @@ func TestClusterRegistry_MultipleClusters(t *testing.T) {
 			ID:       "steward-a",
 			TenantID: "default",
 			DNAAttributes: map[string]string{
-				"cluster:cfg-lab.member_nodes":         "CFG-70-02",
-				"cluster:cfg-lab.resource_owner.csv":   "CFG-70-02",
-				"cluster:cfg-prod.member_nodes":        "CFG-70-02",
-				"cluster:cfg-prod.resource_owner.cno":  "CFG-70-02",
+				"cluster:cfg-lab.member_nodes":        "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.csv":  "CFG-70-02",
+				"cluster:cfg-prod.member_nodes":       "CFG-70-02",
+				"cluster:cfg-prod.resource_owner.cno": "CFG-70-02",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- `setupRouter()` ran nil-checks at construction time; `Set*` methods set struct fields but never registered routes — so `POST /api/v1/workflows`, `GET /api/v1/reports/*`, and `GET /api/v1/rollback/*` permanently returned 404.
- Fix: persist the `/api/v1` subrouter on a new `apiRouter` field; delete the three nil-gated blocks from `setupRouter()`; have `SetRollbackManager`, `SetReportsHandler`, and `SetWorkflowHandler` register their routes lazily via `s.apiRouter` at call time.
- All middleware, permission gates, and security posture preserved verbatim — only the timing of registration changes.

Fixes #2373

## Specialist Review Results

**Code Review**: PASS  
**Test Quality**: PASS (1 fix round — gofmt alignment in `clusterregistry/registry_test.go`)  
**Security**: PASS  

## Test plan

- [ ] `TestServer_SetWorkflowHandler_RegistersRoutes_PostConstruction` — workflow/trigger routes absent before Set*, 401 (not 404) after
- [ ] `TestServer_SetReportsHandler_RegistersRoutes_PostConstruction` — reports routes absent before Set*, 401 (not 404) after
- [ ] `TestServer_SetRollbackManager_RegistersRoutes_PostConstruction` — rollback routes absent before Set*, 401 (not 404) after
- [ ] `TestServer_SetRollbackManager_EnforcesPermissionGate` — 403 without `config:rollback`, handler response with it
- [ ] `TestServer_SetWorkflowHandler_NilAfterSet_NoopSafe` — no panic on nil after prior non-nil set
- [ ] `make test-complete` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)