### PR TITLE
ci: fix cross-platform-build.yml YAML parse error blocking Build Gate repo-wide (Issue #2428)

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -109,20 +109,20 @@ jobs:
         $sampleFile = "$env:TEMP\resource-samples-win.txt"
         $scriptFile = "$env:TEMP\resource-sampler.ps1"
         @'
-param([string]$OutputFile)
-while ($true) {
-    try {
-        $cpuVal = (Get-Counter '\Processor(_Total)\% Processor Time' -ErrorAction Stop).CounterSamples[0].CookedValue
-        $memAvailMB = (Get-Counter '\Memory\Available MBytes' -ErrorAction Stop).CounterSamples[0].CookedValue
-        $memTotalMB = [Math]::Round((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1MB)
-        $cpuPct = [Math]::Round($cpuVal)
-        $memUsedMB = $memTotalMB - [Math]::Round($memAvailMB)
-        $ts = Get-Date -Format 'HH:mm:ss'
-        Add-Content $OutputFile "$ts cpu_pct=$cpuPct mem_used_mb=$memUsedMB/$memTotalMB"
-    } catch {}
-    Start-Sleep -Seconds 5
-}
-'@ | Set-Content $scriptFile -Encoding UTF8
+        param([string]$OutputFile)
+        while ($true) {
+            try {
+                $cpuVal = (Get-Counter '\Processor(_Total)\% Processor Time' -ErrorAction Stop).CounterSamples[0].CookedValue
+                $memAvailMB = (Get-Counter '\Memory\Available MBytes' -ErrorAction Stop).CounterSamples[0].CookedValue
+                $memTotalMB = [Math]::Round((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1MB)
+                $cpuPct = [Math]::Round($cpuVal)
+                $memUsedMB = $memTotalMB - [Math]::Round($memAvailMB)
+                $ts = Get-Date -Format 'HH:mm:ss'
+                Add-Content $OutputFile "$ts cpu_pct=$cpuPct mem_used_mb=$memUsedMB/$memTotalMB"
+            } catch {}
+            Start-Sleep -Seconds 5
+        }
+        '@ | Set-Content $scriptFile -Encoding UTF8
         $proc = Start-Process pwsh -ArgumentList @('-NoProfile', '-NonInteractive', '-File', $scriptFile, '-OutputFile', $sampleFile) -PassThru -WindowStyle Hidden
         $proc.Id | Set-Content "$env:TEMP\sampler-pid.txt" -Encoding UTF8
 


### PR DESCRIPTION
## P0 — merge queue unblocked

The Windows resource-sampler step added in #2430 (from #2428) embedded a PowerShell here-string (`@'...'@`) whose content was dedented to column 0. That terminated the YAML block scalar early, making the whole workflow file unparseable (`could not find expected ':'` at line 112).

**Impact:** GitHub could not schedule `cross-platform-build.yml` on ANY event, so the required **Build Gate** status check failed across every branch (push / pull_request / merge_group) since ~16:21 UTC — **blocking the merge queue for every open PR** (#2448, #2449, #2455, and the whole develop queue).

**Fix:** indent the here-string body to the block-scalar level (8 spaces). YAML strips the common indentation, so PowerShell still receives the here-string with the closing `'@` at column 0 — valid for both parsers. No behavioral change to the sampler.

**Validation:** `python3 yaml.safe_load` now parses the file (was erroring); the authoritative check is this PR's own Build Gate run using the fixed file.

Fixes the regression from #2428 / #2430.