### PR TITLE
dispatcher: per-device lock TTL fallback and explicit cancel release (Issue #2468)

### DIFF
--- a/features/controller/clusterregistry/registry_test.go
+++ b/features/controller/clusterregistry/registry_test.go
@@ -25,7 +25,7 @@ func TestClusterRegistry_ParsesDNAAttributes_MultiSteward(t *testing.T) {
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
-				"hostname": "CFG-70-02",
+				"hostname":                           "CFG-70-02",
 			},
 		},
 		{
@@ -35,7 +35,7 @@ func TestClusterRegistry_ParsesDNAAttributes_MultiSteward(t *testing.T) {
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02,CFG-AB-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.cno": "CFG-AB-02",
-				"hostname": "CFG-AB-02",
+				"hostname":                           "CFG-AB-02",
 			},
 		},
 	}
@@ -103,9 +103,9 @@ func TestClusterRegistry_MalformedKeySkipped(t *testing.T) {
 			TenantID: "default",
 			DNAAttributes: map[string]string{
 				// Malformed: no dot separator → should be silently skipped.
-				"cluster:badkey":                     "val",
+				"cluster:badkey": "val",
 				// Malformed: empty cluster name → should be silently skipped.
-				"cluster:.member_nodes":              "x",
+				"cluster:.member_nodes": "x",
 				// Valid key alongside the bad ones.
 				"cluster:cfg-lab.member_nodes":       "CFG-70-02",
 				"cluster:cfg-lab.resource_owner.csv": "CFG-70-02",
@@ -129,10 +129,10 @@ func TestClusterRegistry_MultipleClusters(t *testing.T) {
 			ID:       "steward-a",
 			TenantID: "default",
 			DNAAttributes: map[string]string{
-				"cluster:cfg-lab.member_nodes":         "CFG-70-02",
-				"cluster:cfg-lab.resource_owner.csv":   "CFG-70-02",
-				"cluster:cfg-prod.member_nodes":        "CFG-70-02",
-				"cluster:cfg-prod.resource_owner.cno":  "CFG-70-02",
+				"cluster:cfg-lab.member_nodes":        "CFG-70-02",
+				"cluster:cfg-lab.resource_owner.csv":  "CFG-70-02",
+				"cluster:cfg-prod.member_nodes":       "CFG-70-02",
+				"cluster:cfg-prod.resource_owner.cno": "CFG-70-02",
 			},
 		},
 	}

--- a/features/controller/dispatcher/dispatcher.go
+++ b/features/controller/dispatcher/dispatcher.go
@@ -31,7 +31,23 @@ const (
 	// maxScriptContentBytes is the decoded size cap for script_content params.
 	// gRPC default max recv is 4 MB; 1 MB decoded ≈ 1.33 MB base64 leaves margin.
 	maxScriptContentBytes = 1 << 20 // 1 MiB
+
+	// defaultLockGraceMultiplier is multiplied by an execution's own Timeout to
+	// compute the per-device lock TTL used by the sweep. A value of 2 gives 100%
+	// headroom above the declared script timeout before a lock is considered wedged.
+	defaultLockGraceMultiplier = 2.0
 )
+
+// lockMetaEntry holds per-device lock metadata used by the TTL sweep and the
+// cancel-release path. executionID is stored alongside acquiredAt so that
+// ReleaseDeviceForCancelledExecution can verify that a late cancel does not
+// accidentally release a lock now held by a newer execution for the same device.
+type lockMetaEntry struct {
+	acquiredAt  time.Time
+	executionID string
+	// lockTTL is exec.Timeout * lockGraceMultiplier. Zero means use d.defaultLockTTL.
+	lockTTL time.Duration
+}
 
 // Dispatcher drains the ExecutionQueue and sends CommandExecuteScript to stewards.
 //
@@ -40,6 +56,11 @@ const (
 // (so nothing is dequeued when the device is already busy) and released only
 // inside handleCompletionEvent or on send failure, ensuring exactly one
 // execution is in-flight per device at any given time.
+//
+// Three release paths ensure the lock is never held permanently:
+//  1. handleCompletionEvent (normal completion)
+//  2. TTL sweep in pollLoop (no completion event within lockTTL)
+//  3. ReleaseDeviceForCancelledExecution (explicit cancellation via CancelRun)
 type Dispatcher struct {
 	queue        *script.ExecutionQueue
 	controlPlane controlplaneInterfaces.ControlPlaneProvider
@@ -57,6 +78,19 @@ type Dispatcher struct {
 	// grantManager, when set, creates and consumes per-execution relay grants
 	// (Issue #1675). Set once via SetGrantManager before Start; nil = no grants.
 	grantManager GrantManager
+
+	// lockMetaMu guards lockMetaMap for atomic check-and-delete in the cancel and
+	// TTL-sweep paths. Separate from mu so neither sweep nor cancel blocks Stop.
+	lockMetaMu  sync.Mutex
+	lockMetaMap map[string]lockMetaEntry
+
+	// defaultLockTTL is used when a lock's execution has zero Timeout.
+	// Set to 10 × pollInterval in New — conservative, covering multi-minute scripts.
+	defaultLockTTL time.Duration
+
+	// lockGraceMultiplier is applied to exec.Timeout to compute the per-execution
+	// lock TTL. Configurable via Config.LockGraceMultiplier; defaults to 2.
+	lockGraceMultiplier float64
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -101,7 +135,12 @@ type Config struct {
 	// PollInterval is how often the background loop polls all devices.
 	// Defaults to 30 s when zero.
 	PollInterval time.Duration
-	Logger       logging.Logger
+	// LockGraceMultiplier is applied to each execution's Timeout to compute the
+	// per-device lock TTL for the sweep. Defaults to 2 (100% grace headroom above
+	// the declared script timeout). When the execution has no declared Timeout,
+	// 10 × PollInterval is used instead. Configurable mainly for tests.
+	LockGraceMultiplier float64
+	Logger              logging.Logger
 }
 
 // New creates a new Dispatcher. Call Start to begin operation.
@@ -121,16 +160,24 @@ func New(cfg *Config) (*Dispatcher, error) {
 		interval = defaultPollInterval
 	}
 
+	graceMultiplier := cfg.LockGraceMultiplier
+	if graceMultiplier == 0 {
+		graceMultiplier = defaultLockGraceMultiplier
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Dispatcher{
-		queue:        cfg.Queue,
-		controlPlane: cfg.ControlPlane,
-		signer:       cfg.Signer,
-		pollInterval: interval,
-		logger:       cfg.Logger,
-		ctx:          ctx,
-		cancel:       cancel,
+		queue:               cfg.Queue,
+		controlPlane:        cfg.ControlPlane,
+		signer:              cfg.Signer,
+		pollInterval:        interval,
+		logger:              cfg.Logger,
+		lockMetaMap:         make(map[string]lockMetaEntry),
+		defaultLockTTL:      10 * interval,
+		lockGraceMultiplier: graceMultiplier,
+		ctx:                 ctx,
+		cancel:              cancel,
 	}, nil
 }
 
@@ -219,26 +266,133 @@ func (d *Dispatcher) lockForDevice(deviceID string) chan struct{} {
 
 // tryAcquireDevice attempts a non-blocking send on the device's channel.
 // Returns true if the lock was acquired, false if another dispatch is in-flight.
+// On acquisition, a lockMetaEntry is recorded with the current time so the TTL
+// sweep can detect wedged locks. The executionID is filled in later via
+// setLockExecution once the dequeued execution is known.
 func (d *Dispatcher) tryAcquireDevice(deviceID string) bool {
 	ch := d.lockForDevice(deviceID)
 	select {
 	case ch <- struct{}{}:
+		d.lockMetaMu.Lock()
+		d.lockMetaMap[deviceID] = lockMetaEntry{acquiredAt: time.Now()}
+		d.lockMetaMu.Unlock()
 		return true
 	default:
 		return false
 	}
 }
 
-// releaseDevice drains the device's channel, freeing the slot for the next dispatch.
+// setLockExecution updates the lock metadata for deviceID with the in-flight
+// executionID and its computed TTL. Called immediately after DequeueForDevice
+// returns the execution so the cancel and TTL-sweep paths can match by ID.
+func (d *Dispatcher) setLockExecution(deviceID, executionID string, timeout time.Duration) {
+	d.lockMetaMu.Lock()
+	defer d.lockMetaMu.Unlock()
+	entry, ok := d.lockMetaMap[deviceID]
+	if !ok {
+		return
+	}
+	entry.executionID = executionID
+	if timeout > 0 {
+		entry.lockTTL = time.Duration(float64(timeout) * d.lockGraceMultiplier)
+	}
+	d.lockMetaMap[deviceID] = entry
+}
+
+// releaseDevice drains the device's channel and clears its lock metadata,
+// freeing the slot for the next dispatch.
 func (d *Dispatcher) releaseDevice(deviceID string) {
 	ch := d.lockForDevice(deviceID)
 	select {
 	case <-ch:
 	default:
 	}
+	d.lockMetaMu.Lock()
+	delete(d.lockMetaMap, deviceID)
+	d.lockMetaMu.Unlock()
 }
 
-// pollLoop fires dispatchAll on each poll interval tick.
+// releaseDeviceIfExecution releases the device lock only when the currently-held
+// executionID matches. This prevents a stale cancel or late sweep entry from
+// accidentally releasing a lock now held by a newer execution for the same device.
+// Returns true if the lock was released.
+//
+// The metadata is deleted under lockMetaMu before the channel is drained. Between
+// deletion and drain, tryAcquireDevice cannot succeed (channel still full), so no
+// new dispatch can start in that window.
+func (d *Dispatcher) releaseDeviceIfExecution(deviceID, executionID string) bool {
+	d.lockMetaMu.Lock()
+	entry, ok := d.lockMetaMap[deviceID]
+	if !ok || entry.executionID != executionID {
+		d.lockMetaMu.Unlock()
+		return false
+	}
+	delete(d.lockMetaMap, deviceID)
+	d.lockMetaMu.Unlock()
+
+	ch := d.lockForDevice(deviceID)
+	select {
+	case <-ch:
+	default:
+	}
+	return true
+}
+
+// ReleaseDeviceForCancelledExecution releases the per-device dispatch lock for
+// deviceID when the currently-held execution matches executionID. It is called
+// by run.Manager.CancelRun so the device is unblocked immediately on cancellation
+// rather than waiting for the TTL sweep.
+//
+// Returns true if the lock was released; false if the lock is held by a different
+// (newer) execution or is not currently held.
+func (d *Dispatcher) ReleaseDeviceForCancelledExecution(deviceID, executionID string) bool {
+	released := d.releaseDeviceIfExecution(deviceID, executionID)
+	if released {
+		d.logger.Info("Device lock released for cancelled execution",
+			"device_id", logging.SanitizeLogValue(deviceID),
+			"execution_id", logging.SanitizeLogValue(executionID))
+	}
+	return released
+}
+
+// sweepExpiredLocks checks all held device locks and releases any whose TTL has
+// elapsed without a completion event. The TTL is derived from the execution's own
+// Timeout (× lockGraceMultiplier); zero-Timeout executions use defaultLockTTL.
+// A Warn-level event with "event"="device_lock_ttl_released" is emitted for each
+// release so wedge incidents are distinguishable in logs from normal completions.
+func (d *Dispatcher) sweepExpiredLocks() {
+	now := time.Now()
+
+	d.lockMetaMu.Lock()
+	type expiredEntry struct {
+		deviceID    string
+		executionID string
+	}
+	var expired []expiredEntry
+	for deviceID, meta := range d.lockMetaMap {
+		ttl := meta.lockTTL
+		if ttl == 0 {
+			ttl = d.defaultLockTTL
+		}
+		if now.Sub(meta.acquiredAt) > ttl {
+			expired = append(expired, expiredEntry{deviceID, meta.executionID})
+		}
+	}
+	d.lockMetaMu.Unlock()
+
+	for _, e := range expired {
+		if d.releaseDeviceIfExecution(e.deviceID, e.executionID) {
+			d.logger.Warn("Device lock TTL exceeded; releasing wedged lock",
+				"event", "device_lock_ttl_released",
+				"device_id", logging.SanitizeLogValue(e.deviceID),
+				"execution_id", logging.SanitizeLogValue(e.executionID))
+		}
+	}
+}
+
+// pollLoop fires sweepExpiredLocks then dispatchAll on each poll interval tick.
+// sweepExpiredLocks runs first so that any freed device slots are immediately
+// available for the following dispatchAll.
 // The initial dispatch on startup is handled synchronously by Start.
 func (d *Dispatcher) pollLoop() {
 	defer d.wg.Done()
@@ -251,6 +405,7 @@ func (d *Dispatcher) pollLoop() {
 		case <-d.ctx.Done():
 			return
 		case <-ticker.C:
+			d.sweepExpiredLocks()
 			d.dispatchAll(d.ctx)
 		}
 	}
@@ -309,6 +464,9 @@ func (d *Dispatcher) dispatchForDevice(ctx context.Context, deviceID string) {
 	// the queue's background maintenance (RequeueStale) will move them back to queued
 	// after dispatchTimeout so they can be picked up in a future cycle.
 	exec := executions[0]
+
+	// Record executionID and lock TTL now that we know the execution.
+	d.setLockExecution(deviceID, exec.ExecutionID, exec.Timeout)
 
 	prepared, err := d.queue.PrepareExecutionForDevice(ctx, deviceID, "", exec)
 	if err != nil {

--- a/features/controller/dispatcher/dispatcher_test.go
+++ b/features/controller/dispatcher/dispatcher_test.go
@@ -1274,6 +1274,112 @@ func TestDispatcher_OutputExceedsControllerCeiling(t *testing.T) {
 		"output exceeding the 4 MB ceiling must be dropped — job record must have empty output")
 }
 
+// TestDispatcher_TTLReleasesWedgedDeviceLock verifies AC1 (Story #2468):
+// a device lock held beyond the per-execution lock TTL (Timeout * graceMultiplier)
+// is automatically released by the periodic sweep, and a second execution for the
+// same device can then be dispatched.
+//
+// The dispatcher is configured with a short PollInterval so the sweep fires quickly.
+// The queued execution uses a short Timeout so the lock TTL expires within the test
+// window — no fake clock injection is needed.
+func TestDispatcher_TTLReleasesWedgedDeviceLock(t *testing.T) {
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+
+	// shortTimeout drives a short lock TTL: lockTTL = shortTimeout * graceMultiplier.
+	// With the default multiplier of 2, lockTTL = 200 ms. The sweep fires every
+	// pollInterval (50 ms), so the lock is released within ~250 ms of being acquired.
+	const shortTimeout = 100 * time.Millisecond
+	const pollInterval = 50 * time.Millisecond
+
+	d, err := New(&Config{
+		Queue:        q,
+		ControlPlane: cp,
+		PollInterval: pollInterval,
+		Logger:       logging.NewLogger("debug"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	// Queue exec-wedged and dispatch it. No completion event will ever arrive,
+	// simulating a steward that silently disconnects mid-execution.
+	require.NoError(t, q.QueueExecution("device-wedge", &script.QueuedExecution{
+		ExecutionID: "exec-wedged",
+		ScriptID:    "script-wedge",
+		ScriptRef:   "script-wedge",
+		Shell:       script.ShellBash,
+		Timeout:     shortTimeout,
+	}))
+	d.OnHeartbeat("device-wedge")
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "exec-wedged must be dispatched")
+
+	// Queue exec-after WHILE the device lock is held by exec-wedged.
+	require.NoError(t, q.QueueExecution("device-wedge", &script.QueuedExecution{
+		ExecutionID: "exec-after-ttl",
+		ScriptID:    "script-after",
+		ScriptRef:   "script-after",
+		Shell:       script.ShellBash,
+		Timeout:     5 * time.Minute,
+	}))
+
+	// The TTL sweep fires on each poll tick. Once the lock TTL elapses, the sweep
+	// releases the lock and the following dispatchAll sends a second command.
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 2
+	}, 3*time.Second, 20*time.Millisecond,
+		"TTL sweep must release the wedged lock so a second command can be sent")
+}
+
+// TestDispatcher_ReleaseForCancelledExecution verifies that
+// ReleaseDeviceForCancelledExecution releases the lock when executionID matches
+// and returns false when it does not (race-safety against stale cancels).
+func TestDispatcher_ReleaseForCancelledExecution(t *testing.T) {
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	// Dispatch exec-A, acquiring the device lock for "device-x".
+	require.NoError(t, q.QueueExecution("device-x", queuedExec("exec-A", "script-abc")))
+	d.OnHeartbeat("device-x")
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "exec-A must be dispatched")
+
+	// A cancel for a DIFFERENT executionID must not release the lock.
+	released := d.ReleaseDeviceForCancelledExecution("device-x", "exec-B-stale")
+	assert.False(t, released, "stale cancel must not release the lock held by exec-A")
+
+	// Verify the lock is still held — exec-A has not completed.
+	require.Never(t, func() bool {
+		if !d.tryAcquireDevice("device-x") {
+			return false
+		}
+		d.releaseDevice("device-x")
+		return true
+	}, 50*time.Millisecond, 5*time.Millisecond,
+		"lock must still be held after stale cancel")
+
+	// Cancel for the CORRECT executionID releases the lock immediately.
+	released = d.ReleaseDeviceForCancelledExecution("device-x", "exec-A")
+	assert.True(t, released, "cancel with matching executionID must release the lock")
+
+	// Lock is now free — a new dispatch can proceed.
+	require.Eventually(t, func() bool {
+		if !d.tryAcquireDevice("device-x") {
+			return false
+		}
+		d.releaseDevice("device-x")
+		return true
+	}, 500*time.Millisecond, 10*time.Millisecond,
+		"lock must be free after correct-ID cancel")
+}
+
 // mustOpenMemDB opens an in-memory SQLite database closed via t.Cleanup.
 func mustOpenMemDB(t *testing.T) *sql.DB {
 	t.Helper()

--- a/features/controller/run/cancel_dispatcher_test.go
+++ b/features/controller/run/cancel_dispatcher_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Package run_test provides external integration tests for run.Manager that
+// require importing features/controller/dispatcher. External package placement
+// avoids the import cycle dispatcher→run→dispatcher.
+package run_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/dispatcher"
+	"github.com/cfgis/cfgms/features/controller/run"
+	script "github.com/cfgis/cfgms/features/modules/script"
+	cpinterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+	_ "modernc.org/sqlite"
+)
+
+// ----------------------------------------------------------------------------
+// Minimal test infrastructure (real components, not mocks).
+// ----------------------------------------------------------------------------
+
+// cancelTestCP is a minimal in-process ControlPlaneProvider for the integration
+// tests in this file. It records sent commands and captures the event handler
+// registered by the dispatcher, satisfying the full ControlPlaneProvider contract.
+var _ cpinterfaces.ControlPlaneProvider = (*cancelTestCP)(nil)
+
+type cancelTestCP struct {
+	mu           sync.Mutex
+	sent         []*controlplaneTypes.SignedCommand
+	eventHandler cpinterfaces.EventHandler
+}
+
+func (p *cancelTestCP) Name() string      { return "cancel-test" }
+func (p *cancelTestCP) IsConnected() bool { return true }
+func (p *cancelTestCP) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (p *cancelTestCP) Start(_ context.Context) error     { return nil }
+func (p *cancelTestCP) Stop(_ context.Context) error      { return nil }
+func (p *cancelTestCP) Reconnect(_ context.Context) error { return nil }
+func (p *cancelTestCP) FanOutCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand, ids []string) (*controlplaneTypes.FanOutResult, error) {
+	return &controlplaneTypes.FanOutResult{Succeeded: ids, Failed: map[string]error{}}, nil
+}
+func (p *cancelTestCP) SubscribeCommands(_ context.Context, _ string, _ cpinterfaces.CommandHandler) error {
+	return nil
+}
+func (p *cancelTestCP) PublishEvent(_ context.Context, _ *controlplaneTypes.Event) error {
+	return nil
+}
+func (p *cancelTestCP) SendHeartbeat(_ context.Context, _ *controlplaneTypes.Heartbeat) error {
+	return nil
+}
+func (p *cancelTestCP) SubscribeHeartbeats(_ context.Context, _ cpinterfaces.HeartbeatHandler) error {
+	return nil
+}
+func (p *cancelTestCP) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
+	return &controlplaneTypes.ControlPlaneStats{}, nil
+}
+func (p *cancelTestCP) SendCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sent = append(p.sent, cmd)
+	return nil
+}
+func (p *cancelTestCP) SubscribeEvents(_ context.Context, _ *controlplaneTypes.EventFilter, handler cpinterfaces.EventHandler) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.eventHandler = handler
+	return nil
+}
+func (p *cancelTestCP) sentCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.sent)
+}
+
+// newCancelTestQueue builds a real ExecutionQueue with a one-hour dispatch
+// timeout and queue TTL — long enough that no background maintenance fires
+// during the test.
+func newCancelTestQueue(t *testing.T) *script.ExecutionQueue {
+	t.Helper()
+	monitor := script.NewExecutionMonitor()
+	keyManager := script.NewEphemeralKeyManager()
+	t.Cleanup(keyManager.Stop)
+	q := script.NewExecutionQueue(monitor, keyManager, time.Hour, "https://localhost:8080", nil, nil, time.Hour)
+	t.Cleanup(q.Stop)
+	return q
+}
+
+// newCancelTestRunStore opens an in-memory SQLite store, initialises the schema,
+// and registers cleanup.
+func newCancelTestRunStore(t *testing.T) *run.RunStoreSQL {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err, "open in-memory sqlite")
+	t.Cleanup(func() { _ = db.Close() })
+	store := run.NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()), "Init must succeed")
+	return store
+}
+
+// ----------------------------------------------------------------------------
+// TestCancelRun_ReleasesDispatcherDeviceLock (Story #2468 AC2)
+// ----------------------------------------------------------------------------
+
+// TestCancelRun_ReleasesDispatcherDeviceLock verifies that CancelRun releases the
+// per-device dispatcher lock immediately — not waiting for the TTL sweep — so a
+// subsequently queued execution for the same device dispatches without delay.
+// It also verifies that the cancel-release is executionID-scoped: a stale cancel
+// with a non-matching ID does not free a lock held by a different execution.
+func TestCancelRun_ReleasesDispatcherDeviceLock(t *testing.T) {
+	store := newCancelTestRunStore(t)
+
+	const (
+		runID  = "run-cancel-dispatch-lock"
+		jobID  = "job-cancel-dispatch"
+		execID = "exec-cancel-dispatch"
+		device = "device-cancel-dispatch"
+	)
+
+	// Persist the run and job records.
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID:     runID,
+		TenantID:  "tenant-cancel",
+		Status:    run.RunStatusRunning,
+		JobCount:  1,
+		CreatedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID:       jobID,
+		RunID:       runID,
+		DeviceID:    device,
+		ExecutionID: execID,
+		Status:      run.JobStatusRunning,
+		CreatedAt:   time.Now().UTC(),
+	}))
+
+	// Wire up real dispatcher and manager with a long poll interval so the TTL
+	// sweep does not fire during the test — only the explicit cancel path matters.
+	cp := &cancelTestCP{}
+	q := newCancelTestQueue(t)
+	d, err := dispatcher.New(&dispatcher.Config{
+		Queue:        q,
+		ControlPlane: cp,
+		PollInterval: 24 * time.Hour,
+		Logger:       logging.NewLogger("debug"),
+	})
+	require.NoError(t, err)
+
+	mgr := run.NewManager(store, q)
+	mgr.SetDeviceLockReleaser(d)
+	d.SetRunCompletionSink(mgr)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	// Queue the execution and dispatch it so the device lock is held.
+	require.NoError(t, q.QueueExecution(device, &script.QueuedExecution{
+		ExecutionID: execID,
+		ScriptID:    "script-cancel-a",
+		ScriptRef:   "script-cancel-a",
+		Shell:       script.ShellBash,
+		Timeout:     5 * time.Minute,
+		Metadata: map[string]interface{}{
+			"workflow_run_id": runID,
+			"job_id":          jobID,
+		},
+	}))
+	d.OnHeartbeat(device)
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "execution must be dispatched before cancel")
+
+	// The device lock is now held. A second execution cannot dispatch.
+	require.NoError(t, q.QueueExecution(device, &script.QueuedExecution{
+		ExecutionID: "exec-after-cancel",
+		ScriptID:    "script-cancel-b",
+		ScriptRef:   "script-cancel-b",
+		Shell:       script.ShellBash,
+		Timeout:     5 * time.Minute,
+	}))
+
+	// Cancel the run. This must immediately release the dispatcher lock for the
+	// cancelled execution — not after a TTL sweep (poll interval is 24h).
+	require.NoError(t, mgr.CancelRun(context.Background(), runID))
+
+	// The run and job must reflect the cancelled state.
+	cancelledRun, err := store.GetRun(runID)
+	require.NoError(t, err)
+	assert.Equal(t, run.RunStatusCancelled, cancelledRun.Status, "run must be cancelled")
+
+	jobs, err := store.ListRunJobs(runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, run.JobStatusCancelled, jobs[0].Status, "job must be cancelled")
+
+	// The device lock must now be free — exec-after-cancel can dispatch without
+	// waiting for the 24-hour poll interval.
+	require.Eventually(t, func() bool {
+		d.OnHeartbeat(device)
+		return cp.sentCount() >= 2
+	}, 2*time.Second, 20*time.Millisecond,
+		"CancelRun must release the device lock immediately so the next execution dispatches")
+}
+
+// TestCancelRun_StaleExecutionIDDoesNotReleaseLock verifies that cancelling a run
+// whose job holds a stale (no longer current) executionID does not release a lock
+// held by a newer execution for the same device. This exercises the ID-match guard
+// in ReleaseDeviceForCancelledExecution.
+func TestCancelRun_StaleExecutionIDDoesNotReleaseLock(t *testing.T) {
+	store := newCancelTestRunStore(t)
+
+	const (
+		runIDStale  = "run-stale-cancel"
+		jobIDStale  = "job-stale-cancel"
+		execIDStale = "exec-stale"
+		execIDNew   = "exec-new"
+		device      = "device-stale-cancel"
+	)
+
+	// A run with a stale executionID (the job was re-dispatched with a new ID).
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID:     runIDStale,
+		TenantID:  "tenant-stale",
+		Status:    run.RunStatusRunning,
+		JobCount:  1,
+		CreatedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID:       jobIDStale,
+		RunID:       runIDStale,
+		DeviceID:    device,
+		ExecutionID: execIDStale, // stale — the device is actually running execIDNew
+		Status:      run.JobStatusRunning,
+		CreatedAt:   time.Now().UTC(),
+	}))
+
+	cp := &cancelTestCP{}
+	q := newCancelTestQueue(t)
+	d, err := dispatcher.New(&dispatcher.Config{
+		Queue:        q,
+		ControlPlane: cp,
+		PollInterval: 24 * time.Hour,
+		Logger:       logging.NewLogger("debug"),
+	})
+	require.NoError(t, err)
+
+	mgr := run.NewManager(store, q)
+	mgr.SetDeviceLockReleaser(d)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	// Acquire the lock with execIDNew (simulates a newer dispatch for the device).
+	require.NoError(t, q.QueueExecution(device, &script.QueuedExecution{
+		ExecutionID: execIDNew,
+		ScriptID:    "script-new",
+		ScriptRef:   "script-new",
+		Shell:       script.ShellBash,
+		Timeout:     5 * time.Minute,
+	}))
+	d.OnHeartbeat(device)
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "execIDNew must be dispatched")
+
+	sentBefore := cp.sentCount()
+
+	// Cancelling the stale run (whose job refers to execIDStale) must NOT release
+	// the lock that is currently held by execIDNew.
+	require.NoError(t, mgr.CancelRun(context.Background(), runIDStale))
+
+	// The lock must still be held — no additional dispatch should happen.
+	require.Never(t, func() bool {
+		return cp.sentCount() > sentBefore
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		fmt.Sprintf("lock held by %s must not be released by stale cancel of %s", execIDNew, execIDStale))
+}

--- a/features/controller/run/run.go
+++ b/features/controller/run/run.go
@@ -535,17 +535,36 @@ func nullableStr(s string) sql.NullString {
 	return sql.NullString{String: s, Valid: s != ""}
 }
 
+// DeviceLockReleaser releases a per-device dispatcher lock for a cancelled
+// execution. It is implemented by *dispatcher.Dispatcher. The Manager depends on
+// this narrow interface rather than importing the dispatcher package directly.
+type DeviceLockReleaser interface {
+	// ReleaseDeviceForCancelledExecution releases the device lock only if the
+	// currently-held execution matches executionID, preventing a late cancel from
+	// freeing a lock now held by a newer execution for the same device.
+	// Returns true if the lock was released.
+	ReleaseDeviceForCancelledExecution(deviceID, executionID string) bool
+}
+
 // Manager coordinates the lifecycle of run records: retrieval and cancellation.
 // Run creation is performed by the synthesis functions in synthesis.go.
 type Manager struct {
 	store          RunStore
 	executionQueue *scriptmodule.ExecutionQueue
+	lockReleaser   DeviceLockReleaser
 }
 
 // NewManager creates a Manager backed by store and executionQueue.
 // executionQueue may be nil; CancelRun will then skip queue-level cancellation.
 func NewManager(store RunStore, executionQueue *scriptmodule.ExecutionQueue) *Manager {
 	return &Manager{store: store, executionQueue: executionQueue}
+}
+
+// SetDeviceLockReleaser wires the dispatcher's cancel-release path so CancelRun
+// immediately frees the per-device dispatcher lock for cancelled jobs. Must be
+// called before any CancelRun call. Nil removes the wiring.
+func (m *Manager) SetDeviceLockReleaser(r DeviceLockReleaser) {
+	m.lockReleaser = r
 }
 
 // GetRun returns the run record for runID.
@@ -589,6 +608,9 @@ func (m *Manager) CancelRun(_ context.Context, runID string) error {
 		}
 		if m.executionQueue != nil && job.ExecutionID != "" {
 			_ = m.executionQueue.CancelExecution(job.DeviceID, job.ExecutionID)
+		}
+		if m.lockReleaser != nil && job.ExecutionID != "" {
+			m.lockReleaser.ReleaseDeviceForCancelledExecution(job.DeviceID, job.ExecutionID)
 		}
 		if updateErr := m.store.UpdateJobStatus(job.JobID, JobStatusCancelled, ""); updateErr != nil {
 			return fmt.Errorf("cancel run: update job %s: %w", job.JobID, updateErr)


### PR DESCRIPTION
## Summary

Resolves a class of permanent dispatch stalls where the per-device `deviceLocks` channel in `Dispatcher` was held indefinitely after (a) a steward disconnected silently without sending `EventScriptCompleted`, or (b) a run was cancelled but no release path existed for the dispatcher lock.

Three release paths now ensure the lock is always freed:
- **Normal completion** — `handleCompletionEvent` (unchanged, existing path)  
- **TTL sweep** — `sweepExpiredLocks` in `pollLoop` releases locks held > `exec.Timeout × 2`; logs Warn `"event"="device_lock_ttl_released"` to distinguish wedge recoveries from normal completions
- **Explicit cancel** — `ReleaseDeviceForCancelledExecution` (new) called from `run.Manager.CancelRun`, keyed on `executionID` so a late cancel never accidentally frees a lock held by a newer execution for the same device

Key design decisions:
- `lockMetaEntry` (`acquiredAt`, `executionID`, `lockTTL`) tracked in a mutex-guarded map alongside the existing capacity-1 channel, per-the issue's instruction not to restructure `deviceLocks` semantics
- `releaseDeviceIfExecution` atomically check-and-deletes under `lockMetaMu` before draining the channel, preventing the window where a concurrent `tryAcquireDevice` could observe "no metadata" while the channel still holds the old token
- `DeviceLockReleaser` narrow interface defined in the `run` package (not `dispatcher`) to avoid the `dispatcher→run→dispatcher` import cycle

## Specialist Review Results

| Reviewer | Verdict | Notes |
|----------|---------|-------|
| Security | **PASS** | Log sanitization correct; cancel-release is executionID-scoped; no TLS/crypto changes; gosec/gitleaks clean |
| Test Quality | **PASS** | All new functions have functional test coverage; real components, no mocks, no t.Skip; uses require.Eventually/Never |
| Acceptance | **PASS** | All 6 AC items verified against working tree; warning only on test filename placement (cancel_dispatcher_test.go vs run_test.go — unavoidable due to import cycle, same Go package run_test, test discovered normally) |

## Test Plan

- [ ] `TestDispatcher_TTLReleasesWedgedDeviceLock` — TTL sweep releases wedged lock, second command dispatches
- [ ] `TestDispatcher_ReleaseForCancelledExecution` — stale executionID returns false; matching ID releases immediately
- [ ] `TestCancelRun_ReleasesDispatcherDeviceLock` — CancelRun releases lock without waiting for TTL (PollInterval=24h)
- [ ] `TestCancelRun_StaleExecutionIDDoesNotReleaseLock` — ID-match guard prevents stale cancel from freeing active lock
- [ ] All existing dispatcher and run tests continue to pass
- [ ] `go test -race` clean on both packages
- [ ] `make test-agent-complete` passes (exit code 0)

Fixes #2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)