### PR TITLE
selector: tenant-path scoping with subtree authz boundary (Issue #2439)

### DIFF
--- a/features/controller/api/handlers_fleet.go
+++ b/features/controller/api/handlers_fleet.go
@@ -5,6 +5,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
@@ -36,7 +37,7 @@ func (s *Server) handleResolveSelector(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filter, err := selector.Parse(req.Selector)
+	filter, parsedTenantPath, err := selector.Parse(req.Selector)
 	if err != nil {
 		s.logger.Info("Invalid selector expression",
 			"selector", logging.SanitizeLogValue(req.Selector), "error", err)
@@ -44,10 +45,22 @@ func (s *Server) handleResolveSelector(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce tenant scope from the authenticated context — the selector expression
-	// must never be able to broaden or override the caller's tenant boundary.
-	if tid, ok := r.Context().Value(ctxkeys.TenantID).(string); ok && tid != "" {
-		filter.TenantID = tid
+	// Enforce tenant subtree scope. An explicit tenant prefix in the selector
+	// must be at or below the caller's own node; absent prefix defaults to the
+	// caller's entire subtree. Admin callers (empty tid) are unrestricted.
+	tid, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if parsedTenantPath != "" {
+		if tid != "" && parsedTenantPath != tid && !strings.HasPrefix(parsedTenantPath, tid+"/") {
+			s.logger.Info("Selector tenant outside caller subtree",
+				"parsed_tenant", logging.SanitizeLogValue(parsedTenantPath),
+				"caller_tenant", logging.SanitizeLogValue(tid))
+			s.writeErrorResponse(w, http.StatusForbidden,
+				"Target tenant is outside the caller's authorized subtree", "CROSS_TENANT")
+			return
+		}
+		filter.TenantSubtree = parsedTenantPath
+	} else if tid != "" {
+		filter.TenantSubtree = tid
 	}
 
 	results, err := s.fleetQuery.Search(r.Context(), filter)

--- a/features/controller/api/handlers_fleet_test.go
+++ b/features/controller/api/handlers_fleet_test.go
@@ -296,6 +296,167 @@ func TestHandleResolveSelector_IDSelector_UnknownKeyStillRejected(t *testing.T) 
 	assert.Contains(t, resp.Error.Message, "id", "error message must list id in the valid key set")
 }
 
+// ── handleResolveSelector: subtree boundary enforcement ──────────────────────
+
+// postResolveSelectorWithPrincipal sends a resolve request with both a principal
+// and a tenant ID in context, simulating an authenticated operator session.
+func postResolveSelectorWithPrincipal(server *Server, body, tenantID string, isAdmin bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/resolve",
+		bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := req.Context()
+	if tenantID != "" {
+		ctx = context.WithValue(ctx, ctxkeys.TenantID, tenantID)
+	}
+	if isAdmin {
+		ctx = context.WithValue(ctx, principalContextKey, &Principal{IsAdmin: true, TenantID: ""})
+	} else {
+		ctx = context.WithValue(ctx, principalContextKey, &Principal{IsAdmin: false, TenantID: tenantID})
+	}
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	server.handleResolveSelector(rec, req)
+	return rec
+}
+
+// multiTenantFleet returns a fleet with stewards in several tenant positions for
+// subtree boundary tests.
+func multiTenantFleet() []fleet.StewardData {
+	return []fleet.StewardData{
+		{ID: "s-msp-a-client-1", TenantID: "msp-a/client-1", Status: "online",
+			LastHeartbeat: time.Now(), DNAAttributes: map[string]string{"hostname": "host-1"}},
+		{ID: "s-msp-a-client-1-web", TenantID: "msp-a/client-1/servers/web", Status: "online",
+			LastHeartbeat: time.Now(), DNAAttributes: map[string]string{"hostname": "web-1"}},
+		{ID: "s-msp-a-client-2", TenantID: "msp-a/client-2", Status: "online",
+			LastHeartbeat: time.Now(), DNAAttributes: map[string]string{"hostname": "host-2"}},
+		{ID: "s-msp-b-client-1", TenantID: "msp-b/client-1", Status: "online",
+			LastHeartbeat: time.Now(), DNAAttributes: map[string]string{"hostname": "host-3"}},
+	}
+}
+
+// resolveIDs unmarshals the response steward list and returns their IDs.
+func resolveIDs(t *testing.T, rec *httptest.ResponseRecorder) []string {
+	t.Helper()
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	list, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	ids := make([]string, len(list))
+	for i, item := range list {
+		ids[i] = item.(map[string]interface{})["id"].(string)
+	}
+	return ids
+}
+
+// TestHandleResolveSelector_SubtreeBoundary_DefaultSubtree verifies that an
+// operator with no explicit tenant prefix in the selector sees their entire
+// subtree (exact tenant + descendants), not just the exact tenant.
+func TestHandleResolveSelector_SubtreeBoundary_DefaultSubtree(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: multiTenantFleet()})
+
+	// Operator at msp-a/client-1 with "all" selector — should see client-1 AND client-1/servers/web.
+	rec := postResolveSelectorWithTenant(server, `{"selector":"all"}`, "msp-a/client-1")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	ids := resolveIDs(t, rec)
+	assert.Contains(t, ids, "s-msp-a-client-1", "exact tenant must be included")
+	assert.Contains(t, ids, "s-msp-a-client-1-web", "descendant tenant must be included")
+	assert.NotContains(t, ids, "s-msp-a-client-2", "sibling tenant must be excluded")
+	assert.NotContains(t, ids, "s-msp-b-client-1", "different MSP must be excluded")
+}
+
+// TestHandleResolveSelector_SubtreeBoundary_ExplicitDescendantAllowed verifies
+// that an operator may explicitly target a descendant tenant in their selector.
+func TestHandleResolveSelector_SubtreeBoundary_ExplicitDescendantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: multiTenantFleet()})
+
+	// Operator at msp-a targets descendant msp-a/client-1/servers/web explicitly.
+	rec := postResolveSelectorWithTenant(server, `{"selector":"msp-a/client-1/servers/web/all"}`, "msp-a")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	ids := resolveIDs(t, rec)
+	assert.Contains(t, ids, "s-msp-a-client-1-web")
+	assert.NotContains(t, ids, "s-msp-a-client-1")
+	assert.NotContains(t, ids, "s-msp-a-client-2")
+}
+
+// TestHandleResolveSelector_SubtreeBoundary_SiblingRejected verifies that an
+// operator cannot target a sibling tenant — the request returns 403.
+func TestHandleResolveSelector_SubtreeBoundary_SiblingRejected(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: multiTenantFleet()})
+
+	// Operator at msp-a/client-1 attempts to target msp-a/client-2 — must be 403.
+	rec := postResolveSelectorWithTenant(server, `{"selector":"msp-a/client-2/all"}`, "msp-a/client-1")
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "CROSS_TENANT", resp.Error.Code)
+}
+
+// TestHandleResolveSelector_SubtreeBoundary_UnrelatedTenantRejected verifies
+// that targeting a completely unrelated tenant returns 403.
+func TestHandleResolveSelector_SubtreeBoundary_UnrelatedTenantRejected(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: multiTenantFleet()})
+
+	// Operator at msp-a/client-1 attempts to target msp-b/client-1 — must be 403.
+	rec := postResolveSelectorWithTenant(server, `{"selector":"msp-b/client-1/all"}`, "msp-a/client-1")
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "CROSS_TENANT", resp.Error.Code)
+}
+
+// TestHandleResolveSelector_SubtreeBoundary_ParentTargetsDescendant verifies
+// that a parent operator can explicitly target a child or grandchild tenant.
+func TestHandleResolveSelector_SubtreeBoundary_ParentTargetsDescendant(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: multiTenantFleet()})
+
+	// Operator at msp-a (parent) targets msp-a/client-1 (child).
+	rec := postResolveSelectorWithTenant(server, `{"selector":"msp-a/client-1/all"}`, "msp-a")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	ids := resolveIDs(t, rec)
+	assert.Contains(t, ids, "s-msp-a-client-1")
+	assert.Contains(t, ids, "s-msp-a-client-1-web")
+	assert.NotContains(t, ids, "s-msp-a-client-2")
+}
+
+// TestHandleResolveSelector_SubtreeBoundary_AdminUnrestricted verifies that an
+// admin caller (empty tenant, IsAdmin=true) is not limited by subtree boundaries.
+func TestHandleResolveSelector_SubtreeBoundary_AdminUnrestricted(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: multiTenantFleet()})
+
+	// Admin with "all" — must see everything.
+	rec := postResolveSelectorWithPrincipal(server, `{"selector":"all"}`, "", true)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	ids := resolveIDs(t, rec)
+	assert.Len(t, ids, len(multiTenantFleet()), "admin must see all stewards")
+}
+
+// TestHandleResolveSelector_SubtreeBoundary_ExplicitOwnTenantAllowed verifies
+// that a caller may explicitly name their own tenant as the selector prefix.
+func TestHandleResolveSelector_SubtreeBoundary_ExplicitOwnTenantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: multiTenantFleet()})
+
+	// Operator at msp-a/client-1 explicitly targets msp-a/client-1 (themselves).
+	rec := postResolveSelectorWithTenant(server, `{"selector":"msp-a/client-1/all"}`, "msp-a/client-1")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	ids := resolveIDs(t, rec)
+	assert.Contains(t, ids, "s-msp-a-client-1")
+	assert.Contains(t, ids, "s-msp-a-client-1-web")
+}
+
 // TestHandleResolveSelector_TenantIsolation verifies that a caller authenticated
 // as tenant-a cannot see tenant-b stewards even when the selector would otherwise
 // match them (e.g. "all"). The authenticated tenant is always AND-ed onto the filter.

--- a/features/controller/api/handlers_jobs.go
+++ b/features/controller/api/handlers_jobs.go
@@ -45,7 +45,7 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reject non-admin callers with no tenant — mirrors authRunAccess (Issue #1990).
-	_, tenantID, ok := s.authRunAccess(w, r)
+	principal, tenantID, ok := s.authRunAccess(w, r)
 	if !ok {
 		return
 	}
@@ -71,7 +71,7 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	// reach the log calls below (logging.SanitizeLogValue is not modeled by CodeQL).
 	safeSelector := strings.ReplaceAll(strings.ReplaceAll(req.Selector, "\n", ""), "\r", "")
 
-	filter, err := selector.Parse(req.Selector)
+	filter, parsedTenantPath, err := selector.Parse(req.Selector)
 	if err != nil {
 		s.logger.Info("Invalid selector expression",
 			"selector", safeSelector, "error", err)
@@ -79,7 +79,21 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filter.TenantID = tenantID
+	// Scope to the caller's subtree. An explicit selector prefix must be within
+	// the caller's subtree; absent prefix defaults to tenantID and all descendants.
+	// Admin callers (empty tenantID) are unrestricted.
+	if parsedTenantPath != "" {
+		if !principal.IsAdmin && tenantID != "" &&
+			parsedTenantPath != tenantID &&
+			!strings.HasPrefix(parsedTenantPath, tenantID+"/") {
+			s.writeErrorResponse(w, http.StatusForbidden,
+				"Target tenant is outside the caller's authorized subtree", "CROSS_TENANT")
+			return
+		}
+		filter.TenantSubtree = parsedTenantPath
+	} else if !principal.IsAdmin {
+		filter.TenantSubtree = tenantID
+	}
 
 	results, err := s.fleetQuery.Search(r.Context(), filter)
 	if err != nil {

--- a/features/controller/api/handlers_jobs_test.go
+++ b/features/controller/api/handlers_jobs_test.go
@@ -254,6 +254,56 @@ func TestHandleCreateJob_TenantScoped(t *testing.T) {
 	assert.Equal(t, "tenant-x", job.TenantID)
 }
 
+// ── handleCreateJob: explicit tenant-path-prefix selectors ───────────────────
+
+// TestHandleCreateJob_ExplicitTenantPrefix_CrossTenantRejected verifies that a
+// non-admin caller whose selector carries an explicit tenant-path prefix outside
+// their authorized subtree is rejected with 403 CROSS_TENANT before any fleet
+// query runs (handlers_jobs.go:85-92). The existing bare-selector tests never
+// exercise this branch because they carry no leading tenant prefix.
+func TestHandleCreateJob_ExplicitTenantPrefix_CrossTenantRejected(t *testing.T) {
+	server := setupTestServer(t)
+	server.batchJobStore = newTestBatchJobStoreForAPI()
+
+	// Caller is scoped to tenant-a but the selector prefix targets tenant-b.
+	rec := postCreateJobWithTenant(server, `{"selector":"tenant-b/all","batch_size":3}`, "tenant-a")
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "CROSS_TENANT", resp.Error.Code)
+}
+
+// TestHandleCreateJob_ExplicitTenantPrefix_ScopesToSubtree verifies that a valid
+// in-subtree tenant-path prefix drives filter.TenantSubtree = parsedTenantPath
+// (handlers_jobs.go:93): the resolved target set is scoped to the prefixed
+// sub-tenant, excluding sibling sub-tenants under the same caller tenant.
+func TestHandleCreateJob_ExplicitTenantPrefix_ScopesToSubtree(t *testing.T) {
+	server := setupTestServer(t)
+	store := newTestBatchJobStoreForAPI()
+	server.batchJobStore = store
+
+	// Two stewards under sibling sub-tenants of tenant-a.
+	inScope := registerActiveSteward(t, server.controllerService, "job-prefix-c1", "tenant-a/client-1")
+	registerActiveSteward(t, server.controllerService, "job-prefix-c2", "tenant-a/client-2")
+
+	// Caller tenant-a targets only the client-1 subtree via an explicit prefix.
+	rec := postCreateJobWithTenant(server, `{"selector":"tenant-a/client-1/all","batch_size":2}`, "tenant-a")
+	require.Equal(t, http.StatusAccepted, rec.Code, "body: %s", rec.Body.String())
+
+	var apiResp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &apiResp))
+	dataMap, ok := apiResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	jobID, ok := dataMap["job_id"].(string)
+	require.True(t, ok)
+
+	job, err := store.GetBatchJob(context.Background(), jobID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{inScope}, job.Targets,
+		"explicit prefix must scope targets to tenant-a/client-1, excluding sibling client-2")
+}
+
 // ── handleGetJob: auth guard ──────────────────────────────────────────────────
 
 // TestHandleGetJob_NoPrincipal_Returns401 verifies that GET without a principal is rejected.

--- a/features/controller/api/handlers_push.go
+++ b/features/controller/api/handlers_push.go
@@ -92,16 +92,26 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 	// Strip newlines so CodeQL's go/log-injection taint cannot reach log calls.
 	safeSelector := strings.ReplaceAll(strings.ReplaceAll(req.Selector, "\n", ""), "\r", "")
 
-	filter, err := selector.Parse(req.Selector)
+	filter, parsedTenantPath, err := selector.Parse(req.Selector)
 	if err != nil {
 		s.logger.Info("Invalid selector expression", "selector", safeSelector, "error", logging.SanitizeLogValue(err.Error()))
 		s.respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// Enforce tenant boundary unconditionally: always scope to cfg.TenantID,
-	// overriding anything the selector implied. Without this an admin's "all"
-	// yields an empty Filter{} and Search would fan out across every tenant.
-	filter.TenantID = cfg.TenantID
+	// Scope to cfg.TenantID subtree. An explicit selector prefix must be within
+	// that subtree; absent prefix defaults to cfg.TenantID and all descendants.
+	if parsedTenantPath != "" {
+		if parsedTenantPath != cfg.TenantID && !strings.HasPrefix(parsedTenantPath, cfg.TenantID+"/") {
+			s.logger.Info("Selector tenant outside config tenant subtree",
+				"parsed_tenant", logging.SanitizeLogValue(parsedTenantPath),
+				"config_tenant", logging.SanitizeLogValue(cfg.TenantID))
+			s.respondError(w, http.StatusForbidden, "selector tenant outside config tenant subtree")
+			return
+		}
+		filter.TenantSubtree = parsedTenantPath
+	} else {
+		filter.TenantSubtree = cfg.TenantID
+	}
 
 	results, err := s.fleetQuery.Search(r.Context(), filter)
 	if err != nil {

--- a/features/controller/api/handlers_push_test.go
+++ b/features/controller/api/handlers_push_test.go
@@ -844,6 +844,79 @@ func TestHandleConfigPush_FanoutTenantIsolation(t *testing.T) {
 		"steward from a different tenant must never receive SendCommand")
 }
 
+// TestHandleConfigPush_ExplicitTenantPrefix_OutsideSubtreeRejected verifies that
+// a selector carrying an explicit tenant-path prefix outside the config's tenant
+// subtree is rejected with 403 (handlers_push.go:103-110). An admin caller passes
+// the earlier caller-vs-cfg.TenantID auth check, so execution reaches the selector
+// prefix check — which the existing TestHandleConfigPush_TenantCallerCrosstenantRejected
+// never does (it is rejected at the earlier auth gate).
+func TestHandleConfigPush_ExplicitTenantPrefix_OutsideSubtreeRejected(t *testing.T) {
+	cp := &syncedControlPlane{}
+	server, pushStore := makePushServerWithStore(t, cp)
+	server.pushLeaderStatus = nil // leader
+
+	body := configPushRequest{
+		Selector: "tenant-other/all",
+		StewardConfiguration: push.StewardConfiguration{
+			ConfigID: "cfg-001",
+			Version:  "1.0.0",
+			TenantID: "tenant-abc",
+		},
+	}
+	// Admin caller passes the caller-vs-cfg auth check, reaching the prefix branch.
+	req := withAdminPrincipal(newPushRequest(t, body))
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["error"], "outside config tenant subtree")
+
+	// The 403 prefix rejection must short-circuit before persistence and fan-out.
+	pending, err := pushStore.GetPendingPushes(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, pending, "403 prefix rejection must not create a push record")
+	assert.Empty(t, cp.ReceivedIDs(), "403 prefix rejection must not trigger fan-out")
+}
+
+// TestHandleConfigPush_ExplicitTenantPrefix_ScopesToSubtree verifies that a valid
+// in-subtree tenant-path prefix drives filter.TenantSubtree = parsedTenantPath
+// (handlers_push.go:111): fan-out is scoped to the prefixed sub-tenant, reaching
+// only its steward and excluding a sibling sub-tenant under the same config tenant.
+func TestHandleConfigPush_ExplicitTenantPrefix_ScopesToSubtree(t *testing.T) {
+	cp := &syncedControlPlane{}
+	server, _ := makePushServerWithStore(t, cp)
+	server.pushLeaderStatus = nil // leader
+
+	// Two active stewards under sibling sub-tenants of tenant-abc.
+	inScope := registerActiveSteward(t, server.controllerService, "push-prefix-c1", "tenant-abc/client-1")
+	registerActiveSteward(t, server.controllerService, "push-prefix-c2", "tenant-abc/client-2")
+
+	body := configPushRequest{
+		Selector: "tenant-abc/client-1/all",
+		StewardConfiguration: push.StewardConfiguration{
+			ConfigID: "cfg-001",
+			Version:  "1.0.0",
+			TenantID: "tenant-abc",
+		},
+	}
+
+	// Exactly one in-subtree steward should receive a SendCommand.
+	cp.wg.Add(1)
+
+	req := withAdminPrincipal(newPushRequest(t, body))
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code, "body: %s", rec.Body.String())
+
+	cp.wg.Wait()
+	assert.ElementsMatch(t, []string{inScope}, cp.ReceivedIDs(),
+		"explicit prefix must scope fan-out to tenant-abc/client-1, excluding sibling client-2")
+}
+
 // --- GET /api/v1/config/push/{id} tests ---
 
 // newGetPushRequest builds a GET /api/v1/config/push/{id} request with the

--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -487,11 +487,14 @@ func (s *Server) handleDeleteRun(w http.ResponseWriter, r *http.Request) {
 
 // parseRunTarget converts an optional fleet selector string to a fleet.Filter.
 // An empty target matches all stewards (within the caller's tenant, enforced by synthesis).
+// The tenant path extracted by selector.Parse is discarded here; exec tenant enforcement
+// uses enforceExecTenantScope (device-ID prefix check) rather than Filter.TenantSubtree.
 func parseRunTarget(target string) (fleet.Filter, error) {
 	if target == "" || target == "all" {
 		return fleet.Filter{}, nil
 	}
-	return selector.Parse(target)
+	f, _, err := selector.Parse(target)
+	return f, err
 }
 
 // enforceExecTenantScope checks whether the principal's tenantID is a path-prefix

--- a/features/controller/api/handlers_upgrade.go
+++ b/features/controller/api/handlers_upgrade.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
-	"github.com/cfgis/cfgms/features/controller/fleet"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
@@ -123,15 +122,30 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse selector and apply tenant scope.
-	filter, err := selector.Parse(req.Selector)
+	// Parse selector and apply tenant subtree scope.
+	filter, parsedTenantPath, err := selector.Parse(req.Selector)
 	if err != nil {
 		s.writeErrorResponse(w, http.StatusBadRequest,
 			"Invalid selector: "+err.Error(),
 			"INVALID_SELECTOR")
 		return
 	}
-	filter.TenantID = callerTenantID
+
+	// Scope to the caller's subtree. An explicit selector prefix must be within
+	// the caller's subtree; absent prefix defaults to callerTenantID and all
+	// descendants. Admin callers (empty callerTenantID) are unrestricted.
+	if parsedTenantPath != "" {
+		if !principal.IsAdmin && callerTenantID != "" &&
+			parsedTenantPath != callerTenantID &&
+			!strings.HasPrefix(parsedTenantPath, callerTenantID+"/") {
+			s.writeErrorResponse(w, http.StatusForbidden,
+				"Target tenant is outside the caller's authorized subtree", "CROSS_TENANT")
+			return
+		}
+		filter.TenantSubtree = parsedTenantPath
+	} else if !principal.IsAdmin {
+		filter.TenantSubtree = callerTenantID
+	}
 
 	// Resolve matching stewards.
 	stewards, err := s.fleetQuery.Search(r.Context(), filter)
@@ -141,22 +155,9 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce tenant isolation for scoped (non-admin) callers: drop stewards from other
-	// tenants, return 403 if none remain. Admin mTLS principals (empty tenant) have global
-	// scope and act on every matched steward (Issue #1999).
-	var tenantStewards []fleet.StewardResult
-	if principal.IsAdmin {
-		tenantStewards = stewards
-	} else {
-		for _, st := range stewards {
-			if st.TenantID == callerTenantID {
-				tenantStewards = append(tenantStewards, st)
-			}
-		}
-	}
-	if len(tenantStewards) == 0 {
+	if len(stewards) == 0 {
 		s.writeErrorResponse(w, http.StatusForbidden,
-			"No stewards in caller tenant match the given selector",
+			"No stewards match the given selector within the caller's tenant scope",
 			"CROSS_TENANT")
 		return
 	}
@@ -217,7 +218,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 	var created []createdRecord
 
-	for _, st := range tenantStewards {
+	for _, st := range stewards {
 		// Check for non-terminal upgrade records for this steward.
 		existing, listErr := s.upgradeStore.ListUpgradesBySteward(r.Context(), st.ID)
 		if listErr != nil {

--- a/features/controller/api/handlers_upgrade_test.go
+++ b/features/controller/api/handlers_upgrade_test.go
@@ -267,6 +267,59 @@ func TestDispatch_RejectsCrossTenantSelector(t *testing.T) {
 	assert.Contains(t, body, "CROSS_TENANT")
 }
 
+// TestDispatch_ExplicitTenantPrefix_OutsideSubtreeRejected verifies that a
+// non-admin caller whose selector carries an explicit tenant-path prefix outside
+// their authorized subtree is rejected with 403 CROSS_TENANT by the early-return
+// branch (handlers_upgrade.go:137-144), before the fleet query or approval gate.
+// The existing TestDispatch_RejectsCrossTenantSelector uses a prefix-less selector
+// and hits the len(stewards)==0 path instead, leaving this branch uncovered.
+func TestDispatch_ExplicitTenantPrefix_OutsideSubtreeRejected(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	// Caller tenant-a, but the selector prefix targets tenant-b (outside subtree).
+	rec := doDispatchUpgrade(server, "tenant-a", "tenant-b/id:steward-1", "v0.5.12", "linux", "amd64")
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CROSS_TENANT")
+}
+
+// TestDispatch_ExplicitTenantPrefix_ScopesToSubtree verifies that a valid
+// in-subtree tenant-path prefix drives filter.TenantSubtree = parsedTenantPath
+// (handlers_upgrade.go:145): dispatch resolves only stewards at or below the
+// prefixed sub-tenant, excluding sibling sub-tenants under the caller's tenant.
+func TestDispatch_ExplicitTenantPrefix_ScopesToSubtree(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-c1", TenantID: "tenant-a/client-1", Status: "online"},
+		{ID: "steward-c2", TenantID: "tenant-a/client-2", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	// Caller tenant-a targets only the client-1 subtree via an explicit prefix.
+	rec := doDispatchUpgrade(server, "tenant-a", "tenant-a/client-1/all", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	count, _ := data["steward_count"].(float64)
+	assert.Equal(t, float64(1), count,
+		"explicit prefix must scope to tenant-a/client-1, excluding sibling client-2")
+
+	// The in-subtree steward must have a record; the sibling must have none.
+	c1records, err := upgradeStore.ListUpgradesBySteward(context.Background(), "steward-c1")
+	require.NoError(t, err)
+	assert.Len(t, c1records, 1, "in-subtree steward must receive an upgrade record")
+	c2records, err := upgradeStore.ListUpgradesBySteward(context.Background(), "steward-c2")
+	require.NoError(t, err)
+	assert.Empty(t, c2records, "sibling-subtree steward must not receive an upgrade record")
+}
+
 // TestDispatch_RejectsUnapprovedBlob verifies that a blob in published state
 // (approved_by label absent) returns 403.
 func TestDispatch_RejectsUnapprovedBlob(t *testing.T) {

--- a/features/controller/batchjob/executor_test.go
+++ b/features/controller/batchjob/executor_test.go
@@ -148,7 +148,7 @@ type fleetQueryAdapter struct {
 }
 
 func (a *fleetQueryAdapter) Search(ctx context.Context, selector, tenantID string) ([]batchjob.StewardMeta, error) {
-	filter, err := fleetSelector.Parse(selector)
+	filter, _, err := fleetSelector.Parse(selector)
 	if err != nil {
 		return nil, err
 	}

--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -26,6 +26,7 @@ type StewardProvider interface {
 // Multiple non-empty fields are AND-combined.
 type Filter struct {
 	TenantID      string            // Scope to this tenant (exact match)
+	TenantSubtree string            // Match stewards at or below this tenant path (exact OR prefix+"/"); additive with TenantID
 	OS            string            // Match DNA["os"] (exact)
 	Platform      string            // Match DNA["platform"] (exact)
 	Architecture  string            // Match DNA["arch"] (exact)

--- a/features/controller/fleet/memory.go
+++ b/features/controller/fleet/memory.go
@@ -62,6 +62,9 @@ func matchesFilter(s StewardData, f Filter) bool {
 	if f.TenantID != "" && s.TenantID != f.TenantID {
 		return false
 	}
+	if f.TenantSubtree != "" && s.TenantID != f.TenantSubtree && !strings.HasPrefix(s.TenantID, f.TenantSubtree+"/") {
+		return false
+	}
 	if f.OS != "" && attrs["os"] != f.OS {
 		return false
 	}

--- a/features/controller/fleet/memory_test.go
+++ b/features/controller/fleet/memory_test.go
@@ -407,3 +407,120 @@ func TestMemoryQuery_FilterByIDs_AND_WithOS(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
+
+// resultIDs extracts IDs from a StewardResult slice for assertion convenience.
+func resultIDs(results []StewardResult) []string {
+	ids := make([]string, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids
+}
+
+// ── TenantSubtree filter tests ────────────────────────────────────────────────
+
+func TestMemoryQuery_TenantSubtree_ExactMatch(t *testing.T) {
+	q := newQuery(
+		testSteward("s1", "msp-a/client-1", "online", nil),
+		testSteward("s2", "msp-a/client-2", "online", nil),
+	)
+	results, err := q.Search(context.Background(), Filter{TenantSubtree: "msp-a/client-1"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "s1", results[0].ID)
+}
+
+func TestMemoryQuery_TenantSubtree_DescendantIncluded(t *testing.T) {
+	q := newQuery(
+		testSteward("s1", "msp-a/client-1", "online", nil),
+		testSteward("s2", "msp-a/client-1/servers/web", "online", nil),
+		testSteward("s3", "msp-a/client-2", "online", nil),
+	)
+	results, err := q.Search(context.Background(), Filter{TenantSubtree: "msp-a/client-1"})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.ElementsMatch(t, []string{"s1", "s2"}, resultIDs(results))
+}
+
+func TestMemoryQuery_TenantSubtree_SiblingExcluded(t *testing.T) {
+	q := newQuery(
+		testSteward("s1", "msp-a/client-1", "online", nil),
+		testSteward("s2", "msp-a/client-2", "online", nil),
+		testSteward("s3", "msp-b/client-1", "online", nil),
+	)
+	results, err := q.Search(context.Background(), Filter{TenantSubtree: "msp-a/client-1"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "s1", results[0].ID)
+}
+
+func TestMemoryQuery_TenantSubtree_NoPrefixFalsePositive(t *testing.T) {
+	// "msp-a/client-10" must NOT match subtree "msp-a/client-1" — requires "/" suffix.
+	q := newQuery(
+		testSteward("s1", "msp-a/client-1", "online", nil),
+		testSteward("s2", "msp-a/client-10", "online", nil),
+	)
+	results, err := q.Search(context.Background(), Filter{TenantSubtree: "msp-a/client-1"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "s1", results[0].ID)
+}
+
+func TestMemoryQuery_TenantSubtree_EmptyIsUnrestricted(t *testing.T) {
+	q := newQuery(
+		testSteward("s1", "msp-a/client-1", "online", nil),
+		testSteward("s2", "msp-b/client-1", "online", nil),
+	)
+	results, err := q.Search(context.Background(), Filter{TenantSubtree: ""})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+}
+
+// TestMemoryQuery_TenantSubtree_BoundaryRequiredTest covers the required subtree
+// boundary scenarios from issue #2439: descendant target allowed, sibling rejected,
+// parent targeting descendant allowed, admin (empty TenantSubtree) unrestricted.
+func TestMemoryQuery_TenantSubtree_BoundaryRequiredTest(t *testing.T) {
+	stewards := []StewardData{
+		testSteward("s-msp-a-client-1", "msp-a/client-1", "online", nil),
+		testSteward("s-msp-a-client-1-web", "msp-a/client-1/servers/web", "online", nil),
+		testSteward("s-msp-a-client-2", "msp-a/client-2", "online", nil),
+	}
+
+	t.Run("descendant_target_allowed", func(t *testing.T) {
+		q := NewMemoryQuery(&staticProvider{stewards: stewards})
+		// operator at msp-a/client-1 targets msp-a/client-1/servers/web (descendant).
+		results, err := q.Search(context.Background(), Filter{TenantSubtree: "msp-a/client-1"})
+		require.NoError(t, err)
+		ids := resultIDs(results)
+		assert.Contains(t, ids, "s-msp-a-client-1-web", "descendant tenant must be included")
+		assert.Contains(t, ids, "s-msp-a-client-1", "exact tenant must be included")
+		assert.NotContains(t, ids, "s-msp-a-client-2", "sibling tenant must be excluded")
+	})
+
+	t.Run("sibling_tenant_rejected", func(t *testing.T) {
+		q := NewMemoryQuery(&staticProvider{stewards: stewards})
+		// operator at msp-a/client-1 cannot see msp-a/client-2.
+		results, err := q.Search(context.Background(), Filter{TenantSubtree: "msp-a/client-1"})
+		require.NoError(t, err)
+		assert.NotContains(t, resultIDs(results), "s-msp-a-client-2")
+	})
+
+	t.Run("parent_can_target_descendant", func(t *testing.T) {
+		q := NewMemoryQuery(&staticProvider{stewards: stewards})
+		// operator at msp-a (parent) targets msp-a/client-1/servers/web (grandchild).
+		results, err := q.Search(context.Background(), Filter{TenantSubtree: "msp-a"})
+		require.NoError(t, err)
+		ids := resultIDs(results)
+		assert.Contains(t, ids, "s-msp-a-client-1", "child tenant must be included")
+		assert.Contains(t, ids, "s-msp-a-client-1-web", "grandchild tenant must be included")
+		assert.Contains(t, ids, "s-msp-a-client-2", "second child tenant must be included")
+	})
+
+	t.Run("admin_unrestricted", func(t *testing.T) {
+		q := NewMemoryQuery(&staticProvider{stewards: stewards})
+		// admin (empty TenantSubtree) sees all stewards.
+		results, err := q.Search(context.Background(), Filter{TenantSubtree: ""})
+		require.NoError(t, err)
+		assert.Len(t, results, len(stewards))
+	})
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -2307,7 +2307,7 @@ type serverBatchjobFleetQuery struct {
 }
 
 func (a *serverBatchjobFleetQuery) Search(ctx context.Context, selectorStr, tenantID string) ([]batchjob.StewardMeta, error) {
-	filter, err := fleetSelector.Parse(selectorStr)
+	filter, _, err := fleetSelector.Parse(selectorStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid selector %q: %w", selectorStr, err)
 	}

--- a/pkg/fleet/selector/selector.go
+++ b/pkg/fleet/selector/selector.go
@@ -10,6 +10,15 @@ import (
 )
 
 // Parse converts a filter expression string into a fleet.Filter.
+// The second return value is the normalized tenant path if the expression
+// carried a leading <tenant-path><sep> prefix; it is empty when no prefix
+// was present. The caller is responsible for enforcing the authz boundary
+// between the parsed tenant path and the authenticated principal's scope.
+//
+// Tenant prefix: an optional leading "<path><sep>" where sep is '/' or '\'
+// (both accepted and normalized to '/'). The path may have multiple segments
+// separated by '/' or '\'. Example: "msp-a/client-1/name:web*" parses to
+// tenant path "msp-a/client-1" and selector "name:web*".
 //
 // The expression is a space-separated list of key:value terms. Values may be
 // double-quoted to include spaces. Supported keys:
@@ -25,27 +34,59 @@ import (
 // The special keyword "all" matches all stewards. An empty expression is
 // rejected — fail-closed so a fat-fingered command cannot fan out fleet-wide.
 // Unknown keys are parse errors.
-func Parse(expr string) (fleet.Filter, error) {
+func Parse(expr string) (fleet.Filter, string, error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
-		return fleet.Filter{}, fmt.Errorf("empty selector: use 'all' to match all stewards")
-	}
-	if expr == "all" {
-		return fleet.Filter{}, nil
+		return fleet.Filter{}, "", fmt.Errorf("empty selector: use 'all' to match all stewards")
 	}
 
-	terms, err := tokenize(expr)
+	tenantPath, rest := extractTenantPrefix(expr)
+	rest = strings.TrimSpace(rest)
+
+	if rest == "" {
+		return fleet.Filter{}, tenantPath, fmt.Errorf("empty selector: use 'all' to match all stewards")
+	}
+	if rest == "all" {
+		return fleet.Filter{}, tenantPath, nil
+	}
+
+	terms, err := tokenize(rest)
 	if err != nil {
-		return fleet.Filter{}, err
+		return fleet.Filter{}, tenantPath, err
 	}
 
 	var f fleet.Filter
 	for _, t := range terms {
 		if err := applyTerm(&f, t); err != nil {
-			return fleet.Filter{}, err
+			return fleet.Filter{}, tenantPath, err
 		}
 	}
-	return f, nil
+	return f, tenantPath, nil
+}
+
+// extractTenantPrefix detects and strips a leading <tenant-path><sep> prefix
+// from expr, where sep is '/' or '\'. Returns the normalized tenant path (with
+// '/' separators) and the remaining selector expression. The tenant path is the
+// rightmost prefix such that everything to the left of the final separator
+// contains no ':' and no whitespace (valid path segments only). If no such
+// prefix exists, returns ("", expr).
+func extractTenantPrefix(expr string) (tenantPath, rest string) {
+	splitAt := -1
+	for i := 0; i < len(expr); i++ {
+		ch := expr[i]
+		if ch == '/' || ch == '\\' {
+			left := expr[:i]
+			if left != "" && !strings.ContainsAny(left, ": \t") {
+				splitAt = i
+			}
+		}
+	}
+	if splitAt < 0 {
+		return "", expr
+	}
+	raw := expr[:splitAt]
+	normalized := strings.ReplaceAll(raw, "\\", "/")
+	return normalized, expr[splitAt+1:]
 }
 
 type term struct {

--- a/pkg/fleet/selector/selector_test.go
+++ b/pkg/fleet/selector/selector_test.go
@@ -15,109 +15,110 @@ import (
 // ── Parser tests ─────────────────────────────────────────────────────────────
 
 func TestParse_Empty_IsRejected(t *testing.T) {
-	_, err := Parse("")
+	_, _, err := Parse("")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty selector")
 }
 
 func TestParse_Whitespace_IsRejected(t *testing.T) {
-	_, err := Parse("   ")
+	_, _, err := Parse("   ")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty selector")
 }
 
 func TestParse_All_ReturnsEmptyFilter(t *testing.T) {
-	f, err := Parse("all")
+	f, tp, err := Parse("all")
 	require.NoError(t, err)
 	assert.Equal(t, fleet.Filter{}, f)
+	assert.Empty(t, tp)
 }
 
 func TestParse_Name(t *testing.T) {
-	f, err := Parse("name:my-server")
+	f, _, err := Parse("name:my-server")
 	require.NoError(t, err)
 	assert.Equal(t, "my-server", f.Name)
 }
 
 func TestParse_Name_TrailingGlob(t *testing.T) {
-	f, err := Parse("name:es-hv0*")
+	f, _, err := Parse("name:es-hv0*")
 	require.NoError(t, err)
 	assert.Equal(t, "es-hv0*", f.Name)
 }
 
 func TestParse_Name_LeadingGlob(t *testing.T) {
-	f, err := Parse("name:*web")
+	f, _, err := Parse("name:*web")
 	require.NoError(t, err)
 	assert.Equal(t, "*web", f.Name)
 }
 
 func TestParse_Name_MidStringGlob(t *testing.T) {
-	f, err := Parse("name:web*1")
+	f, _, err := Parse("name:web*1")
 	require.NoError(t, err)
 	assert.Equal(t, "web*1", f.Name)
 }
 
 func TestParse_OS(t *testing.T) {
-	f, err := Parse("os:linux")
+	f, _, err := Parse("os:linux")
 	require.NoError(t, err)
 	assert.Equal(t, "linux", f.OS)
 }
 
 func TestParse_OS_Quoted(t *testing.T) {
-	f, err := Parse(`os:"windows server"`)
+	f, _, err := Parse(`os:"windows server"`)
 	require.NoError(t, err)
 	assert.Equal(t, "windows server", f.OS)
 }
 
 func TestParse_Platform(t *testing.T) {
-	f, err := Parse("platform:debian")
+	f, _, err := Parse("platform:debian")
 	require.NoError(t, err)
 	assert.Equal(t, "debian", f.Platform)
 }
 
 func TestParse_Platform_Quoted(t *testing.T) {
-	f, err := Parse(`platform:"ubuntu 22.04"`)
+	f, _, err := Parse(`platform:"ubuntu 22.04"`)
 	require.NoError(t, err)
 	assert.Equal(t, "ubuntu 22.04", f.Platform)
 }
 
 func TestParse_Arch(t *testing.T) {
-	f, err := Parse("arch:arm64")
+	f, _, err := Parse("arch:arm64")
 	require.NoError(t, err)
 	assert.Equal(t, "arm64", f.Architecture)
 }
 
 func TestParse_Tag_Single(t *testing.T) {
-	f, err := Parse("tag:prod")
+	f, _, err := Parse("tag:prod")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"prod"}, f.Tags)
 }
 
 func TestParse_Tag_Repeatable(t *testing.T) {
-	f, err := Parse("tag:prod tag:web tag:db")
+	f, _, err := Parse("tag:prod tag:web tag:db")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"prod", "web", "db"}, f.Tags)
 }
 
 func TestParse_DNAKey(t *testing.T) {
-	f, err := Parse("dna.arch:arm64")
+	f, _, err := Parse("dna.arch:arm64")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"arch": "arm64"}, f.DNAAttributes)
 }
 
 func TestParse_DNAKey_Repeatable(t *testing.T) {
-	f, err := Parse("dna.zone:us-east dna.tier:premium")
+	f, _, err := Parse("dna.zone:us-east dna.tier:premium")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"zone": "us-east", "tier": "premium"}, f.DNAAttributes)
 }
 
 func TestParse_DNAKey_Quoted(t *testing.T) {
-	f, err := Parse(`dna.label:"web server"`)
+	f, _, err := Parse(`dna.label:"web server"`)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"label": "web server"}, f.DNAAttributes)
 }
 
 func TestParse_Combined(t *testing.T) {
-	f, err := Parse(`name:es-hv0* os:"windows server" tag:prod dna.arch:arm64`)
+	f, _, err := Parse(`name:es-hv0* os:"windows server" tag:prod dna.arch:arm64`)
 	require.NoError(t, err)
 	assert.Equal(t, "es-hv0*", f.Name)
 	assert.Equal(t, "windows server", f.OS)
@@ -128,39 +129,118 @@ func TestParse_Combined(t *testing.T) {
 }
 
 func TestParse_UnknownKey_IsError(t *testing.T) {
-	_, err := Parse("typo:value")
+	_, _, err := Parse("typo:value")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown selector key")
 	assert.Contains(t, err.Error(), "typo")
 }
 
 func TestParse_MissingColon_IsError(t *testing.T) {
-	_, err := Parse("namevalue")
+	_, _, err := Parse("namevalue")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "key:value")
 }
 
 func TestParse_EmptyDNASubkey_IsError(t *testing.T) {
-	_, err := Parse("dna.:value")
+	_, _, err := Parse("dna.:value")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty DNA attribute key")
 }
 
 func TestParse_EmptyValue_IsError(t *testing.T) {
-	_, err := Parse("os: name:foo")
+	_, _, err := Parse("os: name:foo")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty value")
 }
 
 func TestParse_UnclosedQuote_IsError(t *testing.T) {
-	_, err := Parse(`os:"windows server`)
+	_, _, err := Parse(`os:"windows server`)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unterminated quoted value")
 }
 
 func TestParse_KeyWithSpace_IsError(t *testing.T) {
-	_, err := Parse("bad key:value")
+	_, _, err := Parse("bad key:value")
 	require.Error(t, err)
+}
+
+// ── Tenant prefix tests ───────────────────────────────────────────────────────
+
+func TestParse_TenantPrefix_ForwardSlash(t *testing.T) {
+	f, tp, err := Parse("msp-a/client-1/name:web*")
+	require.NoError(t, err)
+	assert.Equal(t, "msp-a/client-1", tp)
+	assert.Equal(t, "web*", f.Name)
+}
+
+func TestParse_TenantPrefix_Backslash(t *testing.T) {
+	f, tp, err := Parse(`msp-a\client-1\name:web*`)
+	require.NoError(t, err)
+	assert.Equal(t, "msp-a/client-1", tp, "backslash must be normalized to forward slash")
+	assert.Equal(t, "web*", f.Name)
+}
+
+func TestParse_TenantPrefix_NormalizedIdentically(t *testing.T) {
+	_, tp1, err1 := Parse("msp-a/client-1/name:web*")
+	_, tp2, err2 := Parse(`msp-a\client-1\name:web*`)
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	assert.Equal(t, tp1, tp2, "forward slash and backslash must produce the same tenant path")
+}
+
+func TestParse_TenantPrefix_MultiSegment(t *testing.T) {
+	f, tp, err := Parse("msp-a/client-1/servers/web/os:linux")
+	require.NoError(t, err)
+	assert.Equal(t, "msp-a/client-1/servers/web", tp)
+	assert.Equal(t, "linux", f.OS)
+}
+
+func TestParse_TenantPrefix_WithAll(t *testing.T) {
+	f, tp, err := Parse("msp-a/client-1/all")
+	require.NoError(t, err)
+	assert.Equal(t, "msp-a/client-1", tp)
+	assert.Equal(t, fleet.Filter{}, f)
+}
+
+func TestParse_TenantPrefix_SingleSegment(t *testing.T) {
+	f, tp, err := Parse("msp-a/name:web*")
+	require.NoError(t, err)
+	assert.Equal(t, "msp-a", tp)
+	assert.Equal(t, "web*", f.Name)
+}
+
+func TestParse_TenantPrefix_MixedSeparators(t *testing.T) {
+	f, tp, err := Parse(`msp-a/client-1\name:web*`)
+	require.NoError(t, err)
+	assert.Equal(t, "msp-a/client-1", tp)
+	assert.Equal(t, "web*", f.Name)
+}
+
+func TestParse_NoTenantPrefix_PlainSelector(t *testing.T) {
+	f, tp, err := Parse("name:web*")
+	require.NoError(t, err)
+	assert.Empty(t, tp)
+	assert.Equal(t, "web*", f.Name)
+}
+
+func TestParse_NoTenantPrefix_All(t *testing.T) {
+	_, tp, err := Parse("all")
+	require.NoError(t, err)
+	assert.Empty(t, tp)
+}
+
+func TestParse_TenantPrefix_EmptySelectorAfterPrefix_IsRejected(t *testing.T) {
+	_, _, err := Parse("msp-a/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty selector")
+}
+
+func TestParse_TenantPrefix_MultipleTermsAfterPrefix(t *testing.T) {
+	f, tp, err := Parse("msp-a/client-1/os:linux name:web*")
+	require.NoError(t, err)
+	assert.Equal(t, "msp-a/client-1", tp)
+	assert.Equal(t, "linux", f.OS)
+	assert.Equal(t, "web*", f.Name)
 }
 
 // ── Resolution tests ──────────────────────────────────────────────────────────
@@ -222,7 +302,7 @@ var seedData = []fleet.StewardData{
 
 func resolveIDs(t *testing.T, expr string) []string {
 	t.Helper()
-	filter, err := Parse(expr)
+	filter, _, err := Parse(expr)
 	require.NoError(t, err)
 
 	q := fleet.NewMemoryQuery(&staticProvider{stewards: seedData})
@@ -302,19 +382,19 @@ func TestResolve_Combined_ExactSteward(t *testing.T) {
 // ── id: selector tests ────────────────────────────────────────────────────────
 
 func TestParse_ID_Single(t *testing.T) {
-	f, err := Parse("id:s-linux-arm64")
+	f, _, err := Parse("id:s-linux-arm64")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"s-linux-arm64"}, f.IDs)
 }
 
 func TestParse_ID_MultiValue(t *testing.T) {
-	f, err := Parse("id:s-linux-arm64,s-windows")
+	f, _, err := Parse("id:s-linux-arm64,s-windows")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"s-linux-arm64", "s-windows"}, f.IDs)
 }
 
 func TestParse_UnknownKey_ErrorIncludesID(t *testing.T) {
-	_, err := Parse("typo:value")
+	_, _, err := Parse("typo:value")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "id")
 }
@@ -349,7 +429,7 @@ func TestResolve_ID_Combined_AND_Matches(t *testing.T) {
 // resolveIDsFrom is like resolveIDs but uses a caller-supplied steward list.
 func resolveIDsFrom(t *testing.T, stewards []fleet.StewardData, expr string) []string {
 	t.Helper()
-	filter, err := Parse(expr)
+	filter, _, err := Parse(expr)
 	require.NoError(t, err)
 	q := fleet.NewMemoryQuery(&staticProvider{stewards: stewards})
 	results, err := q.Search(context.Background(), filter)
@@ -445,7 +525,7 @@ func TestParse_TableCoverage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Parse(tc.expr)
+			got, _, err := Parse(tc.expr)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)


### PR DESCRIPTION
## Summary

- Adds tenant-path prefix parsing to `selector.Parse` (e.g. `msp-a/client-1/name:web*` → tenant path `msp-a/client-1` + selector `name:web*`), returning `(fleet.Filter, string, error)`
- Introduces `Filter.TenantSubtree` in `features/controller/fleet` for exact-or-descendant tenant matching in the memory store (`s.TenantID == f.TenantSubtree || strings.HasPrefix(s.TenantID, f.TenantSubtree+"/")`)
- Enforces subtree boundaries in `handleResolveSelector`, `handleConfigPush`, `handleDispatchUpgrade`, and `handleCreateJob`: explicit prefixes outside the caller's subtree return 403 `CROSS_TENANT`; absent prefixes default to the caller's full subtree; admin callers (empty tenant ID) are unrestricted

## Test plan

- [ ] `pkg/fleet/selector`: `TestParse_TenantPrefix_*` and `TestParse_NoTenantPrefix_*` cover all extractTenantPrefix branches including multi-segment paths, backslash normalization, mixed separators, `all` sentinel, and empty-selector-after-prefix rejection
- [ ] `features/controller/fleet`: `TestMemoryQuery_TenantSubtree_*` cover exact match, descendant inclusion, sibling exclusion, false-positive prefix guard (`client-10` ≠ `client-1` subtree), empty=unrestricted, and the full boundary matrix (descendant allowed / sibling rejected / parent→child / admin unrestricted)
- [ ] `features/controller/api` — fleet: `TestHandleResolveSelector_SubtreeBoundary_*` (7 cases: default subtree, explicit descendant allowed, sibling rejected, unrelated tenant rejected, parent targets descendant, admin unrestricted, explicit own-tenant allowed)
- [ ] `features/controller/api` — push: `TestHandleConfigPush_ExplicitTenantPrefix_OutsideSubtreeRejected` and `_ScopesToSubtree`
- [ ] `features/controller/api` — upgrade: `TestDispatch_ExplicitTenantPrefix_OutsideSubtreeRejected` and `_ScopesToSubtree`
- [ ] `features/controller/api` — jobs: `TestHandleCreateJob_ExplicitTenantPrefix_CrossTenantRejected` and `_ScopesToSubtree`
- [ ] All 16 changed files compile; `make check-architecture` and `make lint-log-injection` pass; all affected package tests pass

## Specialist review results

- **Security**: PASS — all user-supplied values wrapped with `logging.SanitizeLogValue()`, no new external dependencies, no information disclosure in error messages
- **Acceptance checker**: PASS — all ACs from Issue #2439 verified against working tree

Fixes #2439

🤖 Generated with [Claude Code](https://claude.com/claude-code)