### PR TITLE
selector: bare-token exact case-insensitive hostname match (Issue #2440)

### DIFF
--- a/features/controller/fleet/memory.go
+++ b/features/controller/fleet/memory.go
@@ -78,7 +78,7 @@ func matchesFilter(s StewardData, f Filter) bool {
 		return false
 	}
 	if f.Name != "" {
-		matched, err := path.Match(f.Name, attrs["hostname"])
+		matched, err := path.Match(strings.ToLower(f.Name), strings.ToLower(attrs["hostname"]))
 		if err != nil || !matched {
 			return false
 		}

--- a/pkg/fleet/selector/selector.go
+++ b/pkg/fleet/selector/selector.go
@@ -96,7 +96,9 @@ type term struct {
 
 // tokenize splits the expression into key:value pairs. The first colon in each
 // token is the key separator; unquoted values extend to the next space;
-// double-quoted values may contain spaces.
+// double-quoted values may contain spaces. A token with no colon before its
+// next space (or end of string) is a bare token and maps to an implicit
+// name:<value> term, enabling bare hostname targeting without a key prefix.
 func tokenize(expr string) ([]term, error) {
 	var terms []term
 	i := 0
@@ -109,14 +111,24 @@ func tokenize(expr string) ([]term, error) {
 			break
 		}
 
-		// Find the colon separating key from value.
 		rest := expr[i:]
 		colonRel := strings.IndexByte(rest, ':')
-		if colonRel < 0 {
-			return nil, fmt.Errorf("invalid selector term %q: expected key:value format", rest)
-		}
-		colonIdx := i + colonRel
+		spaceRel := strings.IndexByte(rest, ' ')
 
+		// Bare token: no colon found, or colon appears after the next space.
+		// The whole token becomes an implicit name: value.
+		if colonRel < 0 || (spaceRel >= 0 && spaceRel < colonRel) {
+			end := len(expr)
+			if spaceRel >= 0 {
+				end = i + spaceRel
+			}
+			terms = append(terms, term{key: "name", value: expr[i:end]})
+			i = end
+			continue
+		}
+
+		// key:value term — colon appears before the next space.
+		colonIdx := i + colonRel
 		key := expr[i:colonIdx]
 		if key == "" {
 			return nil, fmt.Errorf("empty key in selector near position %d", i)

--- a/pkg/fleet/selector/selector_test.go
+++ b/pkg/fleet/selector/selector_test.go
@@ -135,10 +135,31 @@ func TestParse_UnknownKey_IsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "typo")
 }
 
-func TestParse_MissingColon_IsError(t *testing.T) {
-	_, _, err := Parse("namevalue")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "key:value")
+func TestParse_BareToken_ParsesAsNameExact(t *testing.T) {
+	// A token without key: syntax maps to an implicit name: term (bare hostname match).
+	f, _, err := Parse("namevalue")
+	require.NoError(t, err)
+	assert.Equal(t, "namevalue", f.Name)
+}
+
+func TestParse_BareToken_Glob_ParsesAsNameGlob(t *testing.T) {
+	f, _, err := Parse("web*")
+	require.NoError(t, err)
+	assert.Equal(t, "web*", f.Name)
+}
+
+func TestParse_BareToken_Combined_BeforeKeyedTerm(t *testing.T) {
+	f, _, err := Parse("web os:linux")
+	require.NoError(t, err)
+	assert.Equal(t, "web", f.Name)
+	assert.Equal(t, "linux", f.OS)
+}
+
+func TestParse_BareToken_Combined_AfterKeyedTerm(t *testing.T) {
+	f, _, err := Parse("os:linux web")
+	require.NoError(t, err)
+	assert.Equal(t, "linux", f.OS)
+	assert.Equal(t, "web", f.Name)
 }
 
 func TestParse_EmptyDNASubkey_IsError(t *testing.T) {
@@ -426,6 +447,81 @@ func TestResolve_ID_Combined_AND_Matches(t *testing.T) {
 	assert.Equal(t, []string{"s-linux-arm64"}, ids)
 }
 
+// ── Bare-token and case-insensitive hostname tests (Issue #2440) ──────────────
+
+// TestResolve_BareToken_CaseInsensitiveExact is the REQUIRED TEST from Issue #2440:
+// a bare token matches hostnames case-insensitively and exactly (no implicit wildcards).
+func TestResolve_BareToken_CaseInsensitiveExact(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-web-upper", "online", map[string]string{"hostname": "WEB"}),
+		makeSteward("s-web-lower", "online", map[string]string{"hostname": "web"}),
+		makeSteward("s-web-01", "online", map[string]string{"hostname": "web-01"}),
+		makeSteward("s-other", "online", map[string]string{"hostname": "db-01"}),
+	}
+	// "web" must match WEB and web (exact, case-insensitive) but not web-01.
+	ids := resolveIDsFrom(t, stewards, "web")
+	assert.ElementsMatch(t, []string{"s-web-upper", "s-web-lower"}, ids)
+}
+
+// TestResolve_BareToken_AND_Composition verifies bare token composes via AND with other terms.
+func TestResolve_BareToken_AND_Composition(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-linux-web", "online", map[string]string{"hostname": "web", "os": "linux"}),
+		makeSteward("s-win-web", "online", map[string]string{"hostname": "web", "os": "windows"}),
+		makeSteward("s-linux-db", "online", map[string]string{"hostname": "db", "os": "linux"}),
+	}
+	// "web os:linux" must narrow to exactly the linux web host.
+	ids := resolveIDsFrom(t, stewards, "web os:linux")
+	assert.Equal(t, []string{"s-linux-web"}, ids)
+}
+
+// TestResolve_BareToken_GlobCaseInsensitive verifies a bare glob token remains a glob
+// and is also case-insensitive.
+func TestResolve_BareToken_GlobCaseInsensitive(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-web01", "online", map[string]string{"hostname": "WEB-01"}),
+		makeSteward("s-web02", "online", map[string]string{"hostname": "WEB-02"}),
+		makeSteward("s-db01", "online", map[string]string{"hostname": "DB-01"}),
+	}
+	// bare "web*" globs and is case-insensitive — matches WEB-01 and WEB-02.
+	ids := resolveIDsFrom(t, stewards, "web*")
+	assert.ElementsMatch(t, []string{"s-web01", "s-web02"}, ids)
+}
+
+// TestResolve_Name_CaseInsensitive verifies name: key matching is case-insensitive.
+func TestResolve_Name_CaseInsensitive(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-web", "online", map[string]string{"hostname": "web"}),
+		makeSteward("s-db", "online", map[string]string{"hostname": "db"}),
+	}
+	// name:WEB must match hostname "web" case-insensitively.
+	ids := resolveIDsFrom(t, stewards, "name:WEB")
+	assert.Equal(t, []string{"s-web"}, ids)
+}
+
+// TestResolve_Name_GlobCaseInsensitive verifies glob patterns via name: are case-insensitive.
+func TestResolve_Name_GlobCaseInsensitive(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-web01", "online", map[string]string{"hostname": "web-01"}),
+		makeSteward("s-web02", "online", map[string]string{"hostname": "web-02"}),
+		makeSteward("s-db01", "online", map[string]string{"hostname": "db-01"}),
+	}
+	// name:WEB* glob is case-insensitive — matches web-01 and web-02.
+	ids := resolveIDsFrom(t, stewards, "name:WEB*")
+	assert.ElementsMatch(t, []string{"s-web01", "s-web02"}, ids)
+}
+
+// TestResolve_ID_CaseSensitive_Unchanged verifies id: matching stays case-sensitive.
+// Device IDs are not hostnames and must not be lowercased.
+func TestResolve_ID_CaseSensitive_Unchanged(t *testing.T) {
+	stewards := []fleet.StewardData{
+		makeSteward("s-linux-arm64", "online", map[string]string{"hostname": "host1"}),
+	}
+	// id:S-LINUX-ARM64 (uppercase) must NOT match steward with ID "s-linux-arm64".
+	ids := resolveIDsFrom(t, stewards, "id:S-LINUX-ARM64")
+	assert.Empty(t, ids, "id: matching must remain case-sensitive")
+}
+
 // resolveIDsFrom is like resolveIDs but uses a caller-supplied steward list.
 func resolveIDsFrom(t *testing.T, stewards []fleet.StewardData, expr string) []string {
 	t.Helper()
@@ -476,6 +572,16 @@ func TestParse_TableCoverage(t *testing.T) {
 		want    fleet.Filter
 		wantErr string
 	}{
+		{
+			name: "bare token (no colon) is implicit name",
+			expr: "web",
+			want: fleet.Filter{Name: "web"},
+		},
+		{
+			name: "bare glob token is implicit name glob",
+			expr: "web*",
+			want: fleet.Filter{Name: "web*"},
+		},
 		{
 			name: "id comma-OR",
 			expr: "id:a,b",


### PR DESCRIPTION
## Summary

- Bare tokens (no `key:` prefix) in selector expressions now resolve as implicit `name:<value>` terms, enabling `web` instead of `name:web` for hostname targeting.
- `f.Name` matching in `matchesFilter` is now case-insensitive: both the pattern and `attrs["hostname"]` are lowercased before `path.Match`, so `web` matches `WEB`, `Web`, or `web` exactly, and `web*` matches `WEB-01`.
- `id:` matching is unaffected and remains case-sensitive — device IDs are not hostnames.

Fixes #2440

## Changed files

| File | Change |
|------|--------|
| `pkg/fleet/selector/selector.go` | `tokenize`: bare token (no colon before next space) → implicit `name:` term |
| `features/controller/fleet/memory.go` | `matchesFilter` `f.Name` branch: `strings.ToLower` both sides before `path.Match` |
| `pkg/fleet/selector/selector_test.go` | Replace `TestParse_MissingColon_IsError`; add bare-token parse + resolution tests; update `TestParse_TableCoverage` |

## Behavior changes

A grep of all test fixtures confirms no existing caller uses mixed-case hostnames with `Filter.Name` — this is a deliberate epic-directed behavior change (A1).

- `web` → exact match against `WEB`, `web`; does not match `web-01`
- `web*` → glob match against `WEB-01`, `Web-02`; does not match `db-01`
- `web os:linux` → AND-composes correctly (narrows to linux web hosts only)
- `id:S-1` → does NOT match steward with ID `s-1` (case-sensitive unchanged)

## Specialist review

All 4 review lenses (code review, test quality, security, acceptance) passed in round 1 with zero findings and zero fix rounds.

## Test plan

- [x] `TestResolve_BareToken_CaseInsensitiveExact` — `web` matches `WEB` and `web` but not `web-01`
- [x] `TestResolve_BareToken_AND_Composition` — `web os:linux` narrows correctly
- [x] `TestResolve_BareToken_GlobCaseInsensitive` — `web*` matches `WEB-01`, `WEB-02`
- [x] `TestResolve_Name_CaseInsensitive` — `name:WEB` matches hostname `web`
- [x] `TestResolve_Name_GlobCaseInsensitive` — `name:WEB*` matches `web-01`, `web-02`
- [x] `TestResolve_ID_CaseSensitive_Unchanged` — `id:S-LINUX-ARM64` does not match `s-linux-arm64`
- [x] All 67 selector tests pass; fleet package tests pass