### PR TITLE
storage: durable SQLite-backed UpgradeStore replaces in-memory provider (Issue #2464)

### DIFF
--- a/features/controller/server/providers_test.go
+++ b/features/controller/server/providers_test.go
@@ -12,6 +12,7 @@ import (
 
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	memoryprovider "github.com/cfgis/cfgms/pkg/storage/providers/memory"
 )
 
 // newFlatFileStewardStore returns a real flat-file StewardStore rooted at a
@@ -23,4 +24,13 @@ func newFlatFileStewardStore(t *testing.T) business.StewardStore {
 	st, err := flatfile.NewFlatFileStewardStore(t.TempDir())
 	require.NoError(t, err, "creating flat-file steward store")
 	return st
+}
+
+// requireInMemoryUpgradeStore asserts that store is the in-memory fallback
+// UpgradeStore. The concrete memoryprovider import is confined to this
+// allowlisted */providers_test.go path (see scripts/check-providers.sh) so that
+// business-logic tests depend on pkg/storage/interfaces only.
+func requireInMemoryUpgradeStore(t *testing.T, store business.UpgradeStore, msgAndArgs ...interface{}) {
+	t.Helper()
+	require.IsType(t, (*memoryprovider.UpgradeStore)(nil), store, msgAndArgs...)
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -74,8 +74,8 @@ import (
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/blobstore/filesystem" // register filesystem blob provider (Issue #1702)
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/blobstore/s3"         // register S3 blob provider for cluster mode (Issue #2118)
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"             // register flatfile provider for OSS composite manager
-	memoryprovider "github.com/cfgis/cfgms/pkg/storage/providers/memory"  // in-memory upgrade store (Issue #1948) and batch job store (Issue #2296)
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"               // register sqlite provider for OSS composite manager
+	memoryprovider "github.com/cfgis/cfgms/pkg/storage/providers/memory"  // in-memory fallback stores (Issue #1948, #2296)
+	sqliteprovider "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"  // register sqlite provider; provides SQLiteUpgradeStore (Issue #2464)
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
 	"gopkg.in/yaml.v3"
@@ -1007,12 +1007,9 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		httpServer.SetAuditStore(as)
 	}
 
-	// Issue #1948: Wire in-memory upgrade store so the dispatch/status endpoints
-	// are operational. A durable SQLite-backed store is a follow-up; for the
-	// OSS composite deployment the in-memory store is sufficient because upgrade
-	// records are short-lived (< 60s) and not required to survive a controller restart.
-	httpServer.SetUpgradeStore(memoryprovider.NewUpgradeStore())
-	logger.Info("In-memory upgrade store wired to HTTP API server (Issue #1948)")
+	// Issue #2464: Wire durable SQLite-backed upgrade store; falls back to in-memory
+	// when SQLite is not configured so controller startup is never blocked on storage.
+	httpServer.SetUpgradeStore(initializeUpgradeStore(context.Background(), cfg, logger))
 
 	// Issue #2296: Wire batch job store and rolling-batch executor so that
 	// POST /api/v1/jobs and GET /api/v1/jobs/{id} are operational.
@@ -2259,6 +2256,40 @@ func initializeRunManager(
 
 	logger.Info("Run manager initialized", "sqlite_path", cfg.Storage.SQLitePath)
 	return controllerrun.NewManager(store, executionQueue)
+}
+
+// initializeUpgradeStore opens a SQLite-backed UpgradeStore at cfg.Storage.SQLitePath,
+// initializes its schema, and returns it as the interface. Falls back to an in-memory
+// store (logging a warning, no startup failure) when SQLitePath is empty or either
+// open/Initialize fails — mirroring the degrade-gracefully pattern of initializeRunManager.
+func initializeUpgradeStore(
+	ctx context.Context,
+	cfg *config.Config,
+	logger logging.Logger,
+) business.UpgradeStore {
+	if cfg.Storage == nil || cfg.Storage.SQLitePath == "" {
+		logger.Warn("Upgrade store: SQLite path not configured, using in-memory store (records will not survive restart)")
+		return memoryprovider.NewUpgradeStore()
+	}
+
+	dsn := cfg.Storage.SQLitePath
+	if !strings.HasPrefix(dsn, "file:") {
+		dsn = "file:" + dsn
+	}
+
+	store, err := sqliteprovider.NewUpgradeStoreSQLFromDSN(dsn)
+	if err != nil {
+		logger.Warn("Upgrade store: failed to open SQLite, falling back to in-memory store", "error", err)
+		return memoryprovider.NewUpgradeStore()
+	}
+	if err := store.Initialize(ctx); err != nil {
+		logger.Warn("Upgrade store: failed to initialize schema, falling back to in-memory store", "error", err)
+		_ = store.Close()
+		return memoryprovider.NewUpgradeStore()
+	}
+
+	logger.Info("Upgrade store initialized with SQLite backend (Issue #2464)", "sqlite_path", cfg.Storage.SQLitePath)
+	return store
 }
 
 // seedFleetCascadeTestData seeds the tenant hierarchy and MSP-level parent policy

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -121,6 +121,7 @@ type Server struct {
 	executionQueue          *scriptmodule.ExecutionQueue             // Issue #1672: persistent queue for script executions
 	jobDispatcher           *dispatcher.Dispatcher                   // Issue #1672: job dispatcher for script executions
 	runManager              *controllerrun.Manager                   // Issue #1673: run/job tracking (must be closed on Stop to release SQLite handle)
+	upgradeStore            business.UpgradeStore                    // Issue #2464: durable upgrade store (must be closed on Stop to release SQLite handle)
 	ipTrustExpiryJob        *controllerRegistration.IPTrustExpiryJob // Issue #1697: 30-day dark-window expiry
 	pendingExpiryJob        *controllerRegistration.PendingExpiryJob // Issue #1697: 5-day pending-registration expiry
 	stewardEventManager     *logging.LoggingManager                  // Issue #2139: dedicated sink for ingested steward events
@@ -1009,7 +1010,9 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 
 	// Issue #2464: Wire durable SQLite-backed upgrade store; falls back to in-memory
 	// when SQLite is not configured so controller startup is never blocked on storage.
-	httpServer.SetUpgradeStore(initializeUpgradeStore(context.Background(), cfg, logger))
+	// The store is held in srv.upgradeStore so Stop() can close the SQLite handle.
+	upgradeStore := initializeUpgradeStore(context.Background(), cfg, logger)
+	httpServer.SetUpgradeStore(upgradeStore)
 
 	// Issue #2296: Wire batch job store and rolling-batch executor so that
 	// POST /api/v1/jobs and GET /api/v1/jobs/{id} are operational.
@@ -1099,6 +1102,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		healthCollector:         healthCollector,
 		alertManager:            healthAlertManager,
 		storageManager:          storageManager,
+		upgradeStore:            upgradeStore,     // Issue #2464: closed in Stop() to release SQLite handle on Windows
 		executionQueue:          executionQueue,   // Issue #1672
 		jobDispatcher:           jobDispatcher,    // Issue #1672
 		ipTrustExpiryJob:        ipTrustExpiryJob, // Issue #1697
@@ -1819,6 +1823,14 @@ func (s *Server) Stop() error {
 	if s.runManager != nil {
 		if err := s.runManager.Close(); err != nil {
 			s.logger.Warn("Failed to close run manager", "error", err)
+		}
+	}
+
+	// Close upgrade store — releases the SQLite connection so temp-directory cleanup
+	// succeeds on Windows (Issue #2464).
+	if s.upgradeStore != nil {
+		if err := s.upgradeStore.Close(); err != nil {
+			s.logger.Warn("Failed to close upgrade store", "error", err)
 		}
 	}
 

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	memoryprovider "github.com/cfgis/cfgms/pkg/storage/providers/memory"
 )
 
 // testNonClusterProvider implements interfaces.StorageProvider with ClusterCapable() == false.
@@ -854,7 +853,7 @@ func TestInitializeUpgradeStore_NoSQLitePath_FallsBackToInMemory(t *testing.T) {
 
 			store := initializeUpgradeStore(ctx, tc.cfg, rec)
 			require.NotNil(t, store, "must return a non-nil store even without SQLite configured")
-			require.IsType(t, (*memoryprovider.UpgradeStore)(nil), store,
+			requireInMemoryUpgradeStore(t, store,
 				"unconfigured SQLite path must degrade to the in-memory store")
 			t.Cleanup(func() { _ = store.Close() })
 
@@ -883,7 +882,7 @@ func TestInitializeUpgradeStore_OpenFailure_FallsBackToInMemory(t *testing.T) {
 
 	store := initializeUpgradeStore(ctx, cfg, rec)
 	require.NotNil(t, store)
-	require.IsType(t, (*memoryprovider.UpgradeStore)(nil), store,
+	requireInMemoryUpgradeStore(t, store,
 		"an unopenable SQLite DSN must degrade to the in-memory store")
 	t.Cleanup(func() { _ = store.Close() })
 
@@ -911,7 +910,7 @@ func TestInitializeUpgradeStore_InitializeFailure_FallsBackToInMemory(t *testing
 
 	store := initializeUpgradeStore(ctx, cfg, rec)
 	require.NotNil(t, store)
-	require.IsType(t, (*memoryprovider.UpgradeStore)(nil), store,
+	requireInMemoryUpgradeStore(t, store,
 		"a schema-init failure must degrade to the in-memory store")
 	t.Cleanup(func() { _ = store.Close() })
 

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -4,9 +4,12 @@ package server
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +21,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	memoryprovider "github.com/cfgis/cfgms/pkg/storage/providers/memory"
 )
 
 // testNonClusterProvider implements interfaces.StorageProvider with ClusterCapable() == false.
@@ -772,4 +776,178 @@ func TestSeedTestTokens_LogsUsefulNonSensitiveInfo(t *testing.T) {
 		"seeding path must emit at least one observable log line")
 	assert.True(t, rec.containsAny("test-tenant"),
 		"seeding log must include the tenant ID for observability")
+}
+
+// TestUpgradeStore_SurvivesControllerRestart_WhenSQLiteConfigured verifies that
+// upgrade records written through initializeUpgradeStore survive a simulated controller
+// restart (close + reopen against the same SQLitePath). This is the integration-level
+// regression test for Issue #2464.
+func TestUpgradeStore_SurvivesControllerRestart_WhenSQLiteConfigured(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "upgrade_restart.db")
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{
+			SQLitePath: dbPath,
+		},
+	}
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+
+	// First "controller instance": open the store, create a record, then close.
+	store1 := initializeUpgradeStore(ctx, cfg, logger)
+	require.NotNil(t, store1, "initializeUpgradeStore must return a non-nil store")
+
+	rec := &business.UpgradeRecord{
+		ID:        "upg-restart-001",
+		StewardID: "steward-abc",
+		TenantID:  "tenant-restart",
+		Version:   "v2.0.0",
+		Platform:  "linux",
+		Arch:      "amd64",
+		SHA256:    "deadbeefdeadbeefdeadbeefdeadbeef",
+		Status:    business.UpgradeStatusDispatched,
+		InitiatedBy: business.InitiatedByIdentity{
+			Subject:    "operator@example.com",
+			TenantID:   "tenant-restart",
+			AuthMethod: "mtls",
+		},
+		Publisher:       "cfgms",
+		SignatureDigest: "sha256:cafebabe",
+		BundleSignature: []byte{0xca, 0xfe, 0xba, 0xbe, 0x01, 0x02, 0x03, 0x04},
+		CreatedAt:       time.Now().UTC(),
+		DispatchedAt:    time.Now().UTC(),
+	}
+	require.NoError(t, store1.CreateUpgrade(ctx, rec))
+	require.NoError(t, store1.Close(), "store1 close (simulated shutdown) must not error")
+
+	// Second "controller instance": reopen the same path and verify durability.
+	store2 := initializeUpgradeStore(ctx, cfg, logger)
+	require.NotNil(t, store2)
+	defer func() { _ = store2.Close() }()
+
+	got, err := store2.GetUpgrade(ctx, "upg-restart-001")
+	require.NoError(t, err, "upgrade record must be readable after simulated controller restart")
+	assert.Equal(t, "upg-restart-001", got.ID)
+	assert.Equal(t, business.UpgradeStatusDispatched, got.Status)
+	assert.Equal(t, "steward-abc", got.StewardID)
+	assert.Equal(t, rec.BundleSignature, got.BundleSignature)
+}
+
+// TestInitializeUpgradeStore_NoSQLitePath_FallsBackToInMemory covers the
+// degrade-gracefully branch at server.go:2270: when the SQLite path is not
+// configured (nil Storage or empty SQLitePath), initializeUpgradeStore must
+// return a functional non-nil in-memory store and log a durability warning
+// rather than failing controller startup.
+func TestInitializeUpgradeStore_NoSQLitePath_FallsBackToInMemory(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "nil Storage", cfg: &config.Config{}},
+		{name: "empty SQLitePath", cfg: &config.Config{Storage: &config.StorageConfig{SQLitePath: ""}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingLogger{}
+
+			store := initializeUpgradeStore(ctx, tc.cfg, rec)
+			require.NotNil(t, store, "must return a non-nil store even without SQLite configured")
+			require.IsType(t, (*memoryprovider.UpgradeStore)(nil), store,
+				"unconfigured SQLite path must degrade to the in-memory store")
+			t.Cleanup(func() { _ = store.Close() })
+
+			assert.True(t, rec.containsAny("records will not survive restart"),
+				"silent degradation to non-durable storage must emit an observable warning")
+
+			// The fallback store must actually be usable, not just non-nil.
+			assertUpgradeStoreFunctional(t, ctx, store)
+		})
+	}
+}
+
+// TestInitializeUpgradeStore_OpenFailure_FallsBackToInMemory covers the branch
+// at server.go:2282: when the SQLite database cannot be opened (here the DSN
+// points at a directory rather than a writable file), initializeUpgradeStore
+// must fall back to a functional in-memory store and warn instead of crashing.
+func TestInitializeUpgradeStore_OpenFailure_FallsBackToInMemory(t *testing.T) {
+	ctx := context.Background()
+	rec := &recordingLogger{}
+
+	// A directory can never be opened as a SQLite database file, so the open
+	// (busy_timeout PRAGMA) fails deterministically across platforms.
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{SQLitePath: t.TempDir()},
+	}
+
+	store := initializeUpgradeStore(ctx, cfg, rec)
+	require.NotNil(t, store)
+	require.IsType(t, (*memoryprovider.UpgradeStore)(nil), store,
+		"an unopenable SQLite DSN must degrade to the in-memory store")
+	t.Cleanup(func() { _ = store.Close() })
+
+	assert.True(t, rec.containsAny("failed to open SQLite"),
+		"open failure must emit an observable warning")
+	assertUpgradeStoreFunctional(t, ctx, store)
+}
+
+// TestInitializeUpgradeStore_InitializeFailure_FallsBackToInMemory covers the
+// branch at server.go:2286: the DSN opens but schema Initialize fails because
+// the file already holds non-SQLite content. initializeUpgradeStore must close
+// the half-open handle, fall back to a functional in-memory store, and warn.
+func TestInitializeUpgradeStore_InitializeFailure_FallsBackToInMemory(t *testing.T) {
+	ctx := context.Background()
+	rec := &recordingLogger{}
+
+	dbPath := filepath.Join(t.TempDir(), "corrupt.db")
+	// Pre-place garbage so sql.Open succeeds (header is only read on first DDL)
+	// but the CREATE TABLE inside Initialize fails with "file is not a database".
+	require.NoError(t, os.WriteFile(dbPath, []byte("not a sqlite database, just raw bytes"), 0o600))
+
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{SQLitePath: dbPath},
+	}
+
+	store := initializeUpgradeStore(ctx, cfg, rec)
+	require.NotNil(t, store)
+	require.IsType(t, (*memoryprovider.UpgradeStore)(nil), store,
+		"a schema-init failure must degrade to the in-memory store")
+	t.Cleanup(func() { _ = store.Close() })
+
+	assert.True(t, rec.containsAny("failed to initialize schema"),
+		"initialize failure must emit an observable warning")
+	assertUpgradeStoreFunctional(t, ctx, store)
+}
+
+// assertUpgradeStoreFunctional performs a round-trip write/read to prove the
+// fallback store is genuinely usable, not merely non-nil.
+func assertUpgradeStoreFunctional(t *testing.T, ctx context.Context, store business.UpgradeStore) {
+	t.Helper()
+	rec := &business.UpgradeRecord{
+		ID:        "upg-fallback-001",
+		StewardID: "steward-fallback",
+		TenantID:  "tenant-fallback",
+		Version:   "v1.0.0",
+		Platform:  "linux",
+		Arch:      "amd64",
+		SHA256:    "feedfacefeedfacefeedfacefeedface",
+		Status:    business.UpgradeStatusDispatched,
+		InitiatedBy: business.InitiatedByIdentity{
+			Subject:    "operator@example.com",
+			TenantID:   "tenant-fallback",
+			AuthMethod: "mtls",
+		},
+		Publisher:       "cfgms",
+		SignatureDigest: "sha256:feedface",
+		BundleSignature: []byte{0xfe, 0xed, 0xfa, 0xce},
+		CreatedAt:       time.Now().UTC(),
+		DispatchedAt:    time.Now().UTC(),
+	}
+	require.NoError(t, store.CreateUpgrade(ctx, rec), "fallback store must accept writes")
+
+	got, err := store.GetUpgrade(ctx, "upg-fallback-001")
+	require.NoError(t, err, "fallback store must serve reads")
+	assert.Equal(t, "upg-fallback-001", got.ID)
+	assert.Equal(t, business.UpgradeStatusDispatched, got.Status)
 }

--- a/pkg/storage/providers/sqlite/upgrade_store.go
+++ b/pkg/storage/providers/sqlite/upgrade_store.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements UpgradeStore using SQLite for durable upgrade-state persistence.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// SQLiteUpgradeStore implements business.UpgradeStore using a SQLite database.
+// Records survive controller restarts and are queryable across sessions, closing
+// the CLAUDE.md "No memory-only storage" violation that the prior in-memory wiring introduced.
+type SQLiteUpgradeStore struct {
+	db *sql.DB
+}
+
+// NewUpgradeStoreSQLFromDSN opens a SQLite database at dsn and returns a
+// SQLiteUpgradeStore backed by it. The caller must call Initialize before any
+// other method, and Close when done to release the underlying connection.
+// Mirrors features/controller/run/run.go:NewRunStoreSQLFromDSN — open + busy_timeout only;
+// schema creation belongs in Initialize.
+func NewUpgradeStoreSQLFromDSN(dsn string) (*SQLiteUpgradeStore, error) {
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("upgrade store: open sqlite %s: %w", dsn, err)
+	}
+	// busy_timeout prevents SQLITE_BUSY errors when the main connection is writing.
+	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("upgrade store: set busy_timeout: %w", err)
+	}
+	return &SQLiteUpgradeStore{db: db}, nil
+}
+
+// Initialize creates the upgrade_records table if it does not already exist.
+// Safe to call multiple times (idempotent). Unlike push_store.go whose schema is
+// applied in the composite plugin's openAndInit, this store is wired standalone so
+// its own Initialize method owns the DDL.
+func (s *SQLiteUpgradeStore) Initialize(_ context.Context) error {
+	_, err := s.db.Exec(`
+CREATE TABLE IF NOT EXISTS upgrade_records (
+    id                       TEXT NOT NULL PRIMARY KEY,
+    steward_id               TEXT NOT NULL,
+    tenant_id                TEXT NOT NULL,
+    version                  TEXT NOT NULL,
+    platform                 TEXT NOT NULL,
+    arch                     TEXT NOT NULL,
+    sha256                   TEXT NOT NULL,
+    status                   TEXT NOT NULL,
+    initiated_by_subject     TEXT NOT NULL,
+    initiated_by_tenant      TEXT NOT NULL,
+    initiated_by_auth_method TEXT NOT NULL,
+    publisher                TEXT NOT NULL,
+    signature_digest         TEXT NOT NULL,
+    bundle_signature         BLOB NOT NULL,
+    created_at               TEXT NOT NULL,
+    operation_nonce          BLOB,
+    dispatched_at            TEXT NOT NULL,
+    completed_at             TEXT,
+    error_message            TEXT NOT NULL DEFAULT ''
+)`)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to create upgrade_records table: %w", err)
+	}
+	return nil
+}
+
+// Close releases the database connection.
+func (s *SQLiteUpgradeStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// HealthCheck pings the database to verify it is reachable and operational.
+func (s *SQLiteUpgradeStore) HealthCheck(ctx context.Context) error {
+	if err := s.db.PingContext(ctx); err != nil {
+		return fmt.Errorf("sqlite: upgrade store health check failed: %w", err)
+	}
+	return nil
+}
+
+// CreateUpgrade inserts a new upgrade record.
+// Returns an error if record.BundleSignature is nil or empty — enforcing the same
+// audit-completeness invariant as the memory provider (memory/upgrade_store.go:31-34).
+func (s *SQLiteUpgradeStore) CreateUpgrade(ctx context.Context, record *business.UpgradeRecord) error {
+	if len(record.BundleSignature) == 0 {
+		return fmt.Errorf("sqlite: bundle signature is required")
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO upgrade_records (
+			id, steward_id, tenant_id, version, platform, arch, sha256, status,
+			initiated_by_subject, initiated_by_tenant, initiated_by_auth_method,
+			publisher, signature_digest, bundle_signature,
+			created_at, operation_nonce, dispatched_at, completed_at, error_message
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.ID,
+		record.StewardID,
+		record.TenantID,
+		record.Version,
+		record.Platform,
+		record.Arch,
+		record.SHA256,
+		string(record.Status),
+		record.InitiatedBy.Subject,
+		record.InitiatedBy.TenantID,
+		record.InitiatedBy.AuthMethod,
+		record.Publisher,
+		record.SignatureDigest,
+		record.BundleSignature,
+		formatTime(record.CreatedAt),
+		record.OperationNonce,
+		formatTime(record.DispatchedAt),
+		nullTime(record.CompletedAt),
+		record.ErrorMessage,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("sqlite: upgrade record %s already exists", record.ID)
+		}
+		return fmt.Errorf("sqlite: failed to create upgrade record %s: %w", record.ID, err)
+	}
+	return nil
+}
+
+// UpdateUpgradeStatus updates the status and error message of the given upgrade record.
+// Sets completed_at to the current UTC time when status is a terminal state
+// (Committed, RolledBack, Failed), preserving any existing completed_at otherwise.
+// Returns ErrUpgradeNotFound if no record exists for the ID.
+func (s *SQLiteUpgradeStore) UpdateUpgradeStatus(ctx context.Context, id string, status business.UpgradeStatus, errorMsg string) error {
+	isTerminal := status == business.UpgradeStatusCommitted ||
+		status == business.UpgradeStatusRolledBack ||
+		status == business.UpgradeStatusFailed
+	var completedAt sql.NullString
+	if isTerminal {
+		now := nowUTC()
+		completedAt = nullTime(&now)
+	}
+	// COALESCE keeps the existing completed_at when completedAt is NULL (non-terminal status).
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE upgrade_records
+		SET status = ?, error_message = ?, completed_at = COALESCE(?, completed_at)
+		WHERE id = ?`,
+		string(status), errorMsg, completedAt, id,
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to update upgrade status for %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrUpgradeNotFound
+	}
+	return nil
+}
+
+// GetUpgrade retrieves the upgrade record for the given ID.
+// Returns ErrUpgradeNotFound if no record exists.
+func (s *SQLiteUpgradeStore) GetUpgrade(ctx context.Context, id string) (*business.UpgradeRecord, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, steward_id, tenant_id, version, platform, arch, sha256, status,
+		       initiated_by_subject, initiated_by_tenant, initiated_by_auth_method,
+		       publisher, signature_digest, bundle_signature,
+		       created_at, operation_nonce, dispatched_at, completed_at, error_message
+		FROM upgrade_records WHERE id = ?`, id)
+	return scanUpgradeRow(row)
+}
+
+// ListUpgradesBySteward returns all upgrade records for the given stewardID,
+// ordered by created_at descending (most recent first).
+// Returns an empty slice (not an error) when no records exist.
+func (s *SQLiteUpgradeStore) ListUpgradesBySteward(ctx context.Context, stewardID string) ([]*business.UpgradeRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, steward_id, tenant_id, version, platform, arch, sha256, status,
+		       initiated_by_subject, initiated_by_tenant, initiated_by_auth_method,
+		       publisher, signature_digest, bundle_signature,
+		       created_at, operation_nonce, dispatched_at, completed_at, error_message
+		FROM upgrade_records
+		WHERE steward_id = ?
+		ORDER BY created_at DESC, rowid DESC`, stewardID)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to list upgrade records by steward: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanUpgradeRows(rows)
+}
+
+// ListUpgradesByTenant returns all upgrade records for the given tenantID,
+// ordered by created_at descending (most recent first).
+// Returns an empty slice (not an error) when no records exist.
+func (s *SQLiteUpgradeStore) ListUpgradesByTenant(ctx context.Context, tenantID string) ([]*business.UpgradeRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, steward_id, tenant_id, version, platform, arch, sha256, status,
+		       initiated_by_subject, initiated_by_tenant, initiated_by_auth_method,
+		       publisher, signature_digest, bundle_signature,
+		       created_at, operation_nonce, dispatched_at, completed_at, error_message
+		FROM upgrade_records
+		WHERE tenant_id = ?
+		ORDER BY created_at DESC, rowid DESC`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to list upgrade records by tenant: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanUpgradeRows(rows)
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func scanUpgradeRow(row *sql.Row) (*business.UpgradeRecord, error) {
+	r := &business.UpgradeRecord{}
+	var statusStr, createdStr, dispatchedStr string
+	var completedStr sql.NullString
+	err := row.Scan(
+		&r.ID, &r.StewardID, &r.TenantID, &r.Version, &r.Platform, &r.Arch, &r.SHA256,
+		&statusStr,
+		&r.InitiatedBy.Subject, &r.InitiatedBy.TenantID, &r.InitiatedBy.AuthMethod,
+		&r.Publisher, &r.SignatureDigest, &r.BundleSignature,
+		&createdStr, &r.OperationNonce, &dispatchedStr, &completedStr, &r.ErrorMessage,
+	)
+	if err == sql.ErrNoRows {
+		return nil, business.ErrUpgradeNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to scan upgrade record: %w", err)
+	}
+	return populateUpgrade(r, statusStr, createdStr, dispatchedStr, completedStr), nil
+}
+
+func scanUpgradeRows(rows *sql.Rows) ([]*business.UpgradeRecord, error) {
+	var records []*business.UpgradeRecord
+	for rows.Next() {
+		r := &business.UpgradeRecord{}
+		var statusStr, createdStr, dispatchedStr string
+		var completedStr sql.NullString
+		if err := rows.Scan(
+			&r.ID, &r.StewardID, &r.TenantID, &r.Version, &r.Platform, &r.Arch, &r.SHA256,
+			&statusStr,
+			&r.InitiatedBy.Subject, &r.InitiatedBy.TenantID, &r.InitiatedBy.AuthMethod,
+			&r.Publisher, &r.SignatureDigest, &r.BundleSignature,
+			&createdStr, &r.OperationNonce, &dispatchedStr, &completedStr, &r.ErrorMessage,
+		); err != nil {
+			return nil, fmt.Errorf("sqlite: failed to scan upgrade record row: %w", err)
+		}
+		records = append(records, populateUpgrade(r, statusStr, createdStr, dispatchedStr, completedStr))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if records == nil {
+		return []*business.UpgradeRecord{}, nil
+	}
+	return records, nil
+}
+
+func populateUpgrade(r *business.UpgradeRecord, statusStr, createdStr, dispatchedStr string, completedStr sql.NullString) *business.UpgradeRecord {
+	r.Status = business.UpgradeStatus(statusStr)
+	r.CreatedAt = parseTime(createdStr)
+	r.DispatchedAt = parseTime(dispatchedStr)
+	r.CompletedAt = parseNullTime(completedStr)
+	return r
+}
+
+// Compile-time assertion that SQLiteUpgradeStore satisfies business.UpgradeStore.
+var _ business.UpgradeStore = (*SQLiteUpgradeStore)(nil)

--- a/pkg/storage/providers/sqlite/upgrade_store_test.go
+++ b/pkg/storage/providers/sqlite/upgrade_store_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestUpgradeStore creates a file-backed SQLiteUpgradeStore for tests using a
+// t.TempDir() path so the DB is cleaned up automatically.
+func newTestUpgradeStore(t *testing.T) *SQLiteUpgradeStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "upgrade_test.db")
+	store, err := NewUpgradeStoreSQLFromDSN("file:" + dbPath)
+	require.NoError(t, err)
+	require.NoError(t, store.Initialize(context.Background()))
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// testUpgradeRecord returns an UpgradeRecord with all mandatory fields populated.
+func testUpgradeRecord(id string) *business.UpgradeRecord {
+	return &business.UpgradeRecord{
+		ID:        id,
+		StewardID: "steward-" + id,
+		TenantID:  "tenant-1",
+		Version:   "v1.2.3",
+		Platform:  "linux",
+		Arch:      "amd64",
+		SHA256:    "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+		Status:    business.UpgradeStatusDispatched,
+		InitiatedBy: business.InitiatedByIdentity{
+			Subject:    "admin@example.com",
+			TenantID:   "tenant-1",
+			AuthMethod: "api_key",
+		},
+		Publisher:       "cfgms",
+		SignatureDigest: "sha256:deadbeef",
+		BundleSignature: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		CreatedAt:       time.Now().UTC().Truncate(time.Second),
+		OperationNonce:  []byte{0xde, 0xad, 0xbe, 0xef},
+		DispatchedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+func TestUpgradeStore_CreateAndGet(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	ctx := context.Background()
+
+	rec := testUpgradeRecord("upg-001")
+	require.NoError(t, store.CreateUpgrade(ctx, rec))
+
+	got, err := store.GetUpgrade(ctx, "upg-001")
+	require.NoError(t, err)
+
+	assert.Equal(t, rec.ID, got.ID)
+	assert.Equal(t, rec.StewardID, got.StewardID)
+	assert.Equal(t, rec.TenantID, got.TenantID)
+	assert.Equal(t, rec.Version, got.Version)
+	assert.Equal(t, rec.Platform, got.Platform)
+	assert.Equal(t, rec.Arch, got.Arch)
+	assert.Equal(t, rec.SHA256, got.SHA256)
+	assert.Equal(t, rec.Status, got.Status)
+	assert.Equal(t, rec.InitiatedBy.Subject, got.InitiatedBy.Subject)
+	assert.Equal(t, rec.InitiatedBy.TenantID, got.InitiatedBy.TenantID)
+	assert.Equal(t, rec.InitiatedBy.AuthMethod, got.InitiatedBy.AuthMethod)
+	assert.Equal(t, rec.Publisher, got.Publisher)
+	assert.Equal(t, rec.SignatureDigest, got.SignatureDigest)
+	assert.Equal(t, rec.BundleSignature, got.BundleSignature)
+	assert.Equal(t, rec.OperationNonce, got.OperationNonce)
+	assert.Equal(t, rec.ErrorMessage, got.ErrorMessage)
+	assert.Nil(t, got.CompletedAt)
+	assert.False(t, got.CreatedAt.IsZero(), "CreatedAt should be set")
+	assert.False(t, got.DispatchedAt.IsZero(), "DispatchedAt should be set")
+}
+
+func TestUpgradeStore_GetUpgrade_NotFound(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	_, err := store.GetUpgrade(context.Background(), "does-not-exist")
+	assert.ErrorIs(t, err, business.ErrUpgradeNotFound)
+}
+
+func TestUpgradeStore_UpdateStatus(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	ctx := context.Background()
+
+	rec := testUpgradeRecord("upg-upd")
+	require.NoError(t, store.CreateUpgrade(ctx, rec))
+
+	require.NoError(t, store.UpdateUpgradeStatus(ctx, "upg-upd", business.UpgradeStatusDownloaded, ""))
+
+	got, err := store.GetUpgrade(ctx, "upg-upd")
+	require.NoError(t, err)
+	assert.Equal(t, business.UpgradeStatusDownloaded, got.Status)
+	assert.Nil(t, got.CompletedAt, "completed_at should remain nil for non-terminal status")
+}
+
+func TestUpgradeStore_UpdateStatus_TerminalSetsCompletedAt(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	ctx := context.Background()
+
+	rec := testUpgradeRecord("upg-terminal")
+	require.NoError(t, store.CreateUpgrade(ctx, rec))
+
+	require.NoError(t, store.UpdateUpgradeStatus(ctx, "upg-terminal", business.UpgradeStatusFailed, "binary checksum mismatch"))
+
+	got, err := store.GetUpgrade(ctx, "upg-terminal")
+	require.NoError(t, err)
+	assert.Equal(t, business.UpgradeStatusFailed, got.Status)
+	assert.Equal(t, "binary checksum mismatch", got.ErrorMessage)
+	require.NotNil(t, got.CompletedAt, "completed_at must be set for terminal status")
+	assert.False(t, got.CompletedAt.IsZero())
+}
+
+func TestUpgradeStore_UpdateStatus_NotFound(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	err := store.UpdateUpgradeStatus(context.Background(), "ghost", business.UpgradeStatusFailed, "")
+	assert.ErrorIs(t, err, business.ErrUpgradeNotFound)
+}
+
+func TestUpgradeStore_CreateUpgrade_MissingSignature(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	ctx := context.Background()
+
+	rec := testUpgradeRecord("upg-nosig")
+	rec.BundleSignature = nil
+	err := store.CreateUpgrade(ctx, rec)
+	assert.Error(t, err, "CreateUpgrade must reject nil BundleSignature")
+
+	rec.BundleSignature = []byte{}
+	err = store.CreateUpgrade(ctx, rec)
+	assert.Error(t, err, "CreateUpgrade must reject empty BundleSignature")
+}
+
+func TestUpgradeStore_ListBySteward(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	ctx := context.Background()
+
+	r1 := testUpgradeRecord("upg-a")
+	r1.StewardID = "steward-target"
+	r1.CreatedAt = time.Now().UTC().Add(-2 * time.Second).Truncate(time.Second)
+	require.NoError(t, store.CreateUpgrade(ctx, r1))
+
+	r2 := testUpgradeRecord("upg-b")
+	r2.StewardID = "steward-target"
+	r2.CreatedAt = time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, store.CreateUpgrade(ctx, r2))
+
+	other := testUpgradeRecord("upg-other")
+	other.StewardID = "steward-other"
+	require.NoError(t, store.CreateUpgrade(ctx, other))
+
+	results, err := store.ListUpgradesBySteward(ctx, "steward-target")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	// Most recent first.
+	assert.Equal(t, "upg-b", results[0].ID)
+	assert.Equal(t, "upg-a", results[1].ID)
+}
+
+func TestUpgradeStore_ListBySteward_Empty(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	results, err := store.ListUpgradesBySteward(context.Background(), "no-such-steward")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestUpgradeStore_ListByTenant(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	ctx := context.Background()
+
+	r1 := testUpgradeRecord("upg-ta")
+	r1.TenantID = "tenant-target"
+	r1.CreatedAt = time.Now().UTC().Add(-2 * time.Second).Truncate(time.Second)
+	require.NoError(t, store.CreateUpgrade(ctx, r1))
+
+	r2 := testUpgradeRecord("upg-tb")
+	r2.TenantID = "tenant-target"
+	r2.CreatedAt = time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, store.CreateUpgrade(ctx, r2))
+
+	other := testUpgradeRecord("upg-other-tenant")
+	other.TenantID = "tenant-other"
+	require.NoError(t, store.CreateUpgrade(ctx, other))
+
+	results, err := store.ListUpgradesByTenant(ctx, "tenant-target")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	// Most recent first.
+	assert.Equal(t, "upg-tb", results[0].ID)
+	assert.Equal(t, "upg-ta", results[1].ID)
+}
+
+func TestUpgradeStore_ListByTenant_Empty(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	results, err := store.ListUpgradesByTenant(context.Background(), "no-such-tenant")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestUpgradeStore_Initialize_Idempotent(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	// Initialize was already called in newTestUpgradeStore; calling again must not error.
+	assert.NoError(t, store.Initialize(context.Background()))
+	assert.NoError(t, store.Initialize(context.Background()))
+}
+
+func TestUpgradeStore_HealthCheck(t *testing.T) {
+	store := newTestUpgradeStore(t)
+	assert.NoError(t, store.HealthCheck(context.Background()))
+}
+
+// TestUpgradeStore_DurabilityAcrossRestart is the regression test for Issue #2464.
+// It closes a store, reopens a new store against the same DSN (simulating a controller
+// restart), and verifies that records created before the close are still readable.
+func TestUpgradeStore_DurabilityAcrossRestart(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "upgrade_persist.db")
+	dsn := "file:" + dbPath
+	ctx := context.Background()
+
+	// First "controller instance": create a record and close.
+	store1, err := NewUpgradeStoreSQLFromDSN(dsn)
+	require.NoError(t, err)
+	require.NoError(t, store1.Initialize(ctx))
+
+	rec := testUpgradeRecord("upg-persist")
+	require.NoError(t, store1.CreateUpgrade(ctx, rec))
+	require.NoError(t, store1.UpdateUpgradeStatus(ctx, "upg-persist", business.UpgradeStatusDownloaded, ""))
+	require.NoError(t, store1.Close())
+
+	// Second "controller instance": reopen and verify the record survived.
+	store2, err := NewUpgradeStoreSQLFromDSN(dsn)
+	require.NoError(t, err)
+	require.NoError(t, store2.Initialize(ctx))
+	defer func() { _ = store2.Close() }()
+
+	got, err := store2.GetUpgrade(ctx, "upg-persist")
+	require.NoError(t, err, "upgrade record must survive a controller restart (SQLite durability)")
+	assert.Equal(t, "upg-persist", got.ID)
+	assert.Equal(t, business.UpgradeStatusDownloaded, got.Status)
+	assert.Equal(t, rec.BundleSignature, got.BundleSignature)
+	assert.Equal(t, rec.Publisher, got.Publisher)
+
+	// ListBySteward must also return the record.
+	list, err := store2.ListUpgradesBySteward(ctx, rec.StewardID)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "upg-persist", list[0].ID)
+}


### PR DESCRIPTION
## Summary

- Closes CLAUDE.md's "No memory-only storage" violation: the controller was wiring `memoryprovider.NewUpgradeStore()` unconditionally, silently dropping every upgrade audit record on controller restart. Discovered live during epic #565 runner scale-out on 2026-07-08.
- New `SQLiteUpgradeStore` in `pkg/storage/providers/sqlite/` implements `business.UpgradeStore` fully (CRUD + durability) — `upgrade_records` table, nullable `completed_at` set on terminal statuses, mandatory `BundleSignature` enforcement matching the memory provider.
- `features/controller/server/server.go` now wires the SQLite-backed store via `cfg.Storage.SQLitePath` (already configured for every OSS deployment), falling back to the in-memory provider with a logged warning — no hard startup failure.
- No interface changes, no handler changes, no new config keys, no API surface change.

## Review Results

- **Code Review**: PASS (2 rounds — 1 minor finding resolved in fix loop)
- **Test Quality**: PASS
- **Security**: PASS

Workflow verdict: `passed: true` — no remaining findings.

## Test plan

- [x] `pkg/storage/providers/sqlite/upgrade_store_test.go` — 13 tests: create/get, update-status (non-terminal/terminal), list-by-steward, list-by-tenant, empty-signature rejection, `ErrUpgradeNotFound`, idempotent `Initialize`, `HealthCheck`, and `TestUpgradeStore_DurabilityAcrossRestart` (close + reopen same DSN)
- [x] `features/controller/server/server_test.go` — `TestUpgradeStore_SurvivesControllerRestart_WhenSQLiteConfigured` calls `initializeUpgradeStore` twice against the same `SQLitePath` and asserts the record survives
- [x] `pkg/storage/providers/memory/upgrade_store.go` unchanged — `features/workflow/nodes/providers_test.go` still passes using the in-memory store
- [x] `make test-agent-complete` passes (all pre-commit, fast comprehensive, production-critical, cross-platform compilation checks)

Fixes #2464

🤖 Generated with [Claude Code](https://claude.com/claude-code)