### PR TITLE
cli: exec — kill id: prepend, route through shared selector surface (Issue #2442)

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -100,8 +100,8 @@ var (
 	stewardRunResultDevice string
 )
 
-// Package-level vars for steward exec (single-steward ad-hoc run). Declared
-// separately from run-command vars so the two commands cannot share state.
+// Package-level vars for steward exec. Declared separately from run-command
+// vars so the two commands cannot share state.
 var (
 	stewardExecCommand    string
 	stewardExecShell      string
@@ -149,30 +149,34 @@ Examples:
 }
 
 var stewardExecCmd = &cobra.Command{
-	Use:   "exec <steward-id>",
-	Short: "Execute an ad-hoc command on a single steward",
-	Long: `Sign and submit an inline command to a single named steward and display the result.
+	Use:   "exec <selector>",
+	Short: "Execute an ad-hoc command on matching stewards",
+	Long: `Sign and submit an inline command to matching stewards and display the result.
 
-The argument is the steward ID to target. The command is submitted as a signed
-inline script and the controller dispatches it exclusively to that steward.
-The CLI blocks until the job reaches a terminal state or the timeout elapses.
+The argument is a selector identifying which stewards to target — a bare
+hostname, id:, glob, or attribute filter. The command is submitted as a signed
+inline script and dispatched to every steward the selector matches.
+The CLI blocks until all jobs reach a terminal state or the timeout elapses.
 
 Requires an admin bundle with a private key (--bundle or CFGMS_ADMIN_BUNDLE).
 
 The --shell flag is required. Allowed values: bash, sh, pwsh (cmd on Windows as fallback).
 
-Output is capped at 64 KB in the CLI display. If the output exceeds the cap a
-truncation warning is printed to stderr.
+Output is capped at 64 KB per steward in the CLI display. If the output for a
+steward exceeds the cap a truncation warning is printed to stderr.
 
 Examples:
-  # Run a command on a specific steward with 30-second timeout
-  cfg steward exec steward-abc123 --command "hostname" --shell bash --timeout 30s
+  # Run a command on a steward by bare hostname
+  cfg steward exec host-abc123 --command "hostname" --shell bash
 
-  # Run a script file on a steward
-  cfg steward exec steward-abc123 --command ./scripts/check.sh --shell bash
+  # Run a command on a steward by explicit id: selector
+  cfg steward exec id:steward-abc123 --command "uptime" --shell bash --timeout 30s
 
-  # Output as JSON
-  cfg steward exec steward-abc123 --command "uptime" --shell bash --json`,
+  # Run against all Linux stewards (requires --yes or interactive confirmation)
+  cfg steward exec os:linux --command "uname -r" --shell bash --yes
+
+  # Output as JSON keyed by steward
+  cfg steward exec host-abc123 --command "uptime" --shell bash --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRunCommandSingle,
 }
@@ -1119,7 +1123,7 @@ func runRunScript(_ *cobra.Command, _ []string) error {
 
 	if stewardRunWait {
 		fmt.Printf("Run ID: %s\n", runID)
-		return waitForRun(context.Background(), client, runID, stewardRunWaitTimeout)
+		return waitForRun(context.Background(), client, runID, stewardRunWaitTimeout, os.Stdout)
 	}
 
 	fmt.Println(runID)
@@ -1189,7 +1193,7 @@ func runRunCommand(_ *cobra.Command, args []string) error {
 
 	if stewardRunWait {
 		fmt.Printf("Run ID: %s\n", runID)
-		return waitForRun(context.Background(), client, runID, stewardRunWaitTimeout)
+		return waitForRun(context.Background(), client, runID, stewardRunWaitTimeout, os.Stdout)
 	}
 
 	fmt.Println(runID)
@@ -1197,7 +1201,7 @@ func runRunCommand(_ *cobra.Command, args []string) error {
 }
 
 // ---------------------------------------------------------------------------
-// exec (single-steward ad-hoc run)
+// exec (selector-based ad-hoc run)
 // ---------------------------------------------------------------------------
 
 // execCLIOutputCap is the maximum bytes of job output the CLI displays.
@@ -1205,7 +1209,7 @@ func runRunCommand(_ *cobra.Command, args []string) error {
 const execCLIOutputCap = 64 * 1024
 
 func runRunCommandSingle(_ *cobra.Command, args []string) error {
-	stewardID := args[0]
+	selector := args[0]
 
 	if stewardExecCommand == "" {
 		return fmt.Errorf("--command is required")
@@ -1229,8 +1233,24 @@ func runRunCommandSingle(_ *cobra.Command, args []string) error {
 		timeout = 30 * time.Second
 	}
 
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	// Resolve selector to determine match count for the confirm gate.
+	// exec is a mutating verb (A4): confirmMultiHost blocks when N > 1 and
+	// --yes is absent.
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
+	if err != nil {
+		return err
+	}
+	if err := confirmMultiHost(matches, stewardYes); err != nil {
+		return err
+	}
+
 	reqBody := map[string]interface{}{
-		"target":    "id:" + stewardID,
+		"target":    selector,
 		"content":   base64.StdEncoding.EncodeToString(content),
 		"shell":     stewardExecShell,
 		"signature": sig,
@@ -1239,11 +1259,6 @@ func runRunCommandSingle(_ *cobra.Command, args []string) error {
 	bodyJSON, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to encode request: %w", err)
-	}
-
-	client, err := getStewardClient()
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
 	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/runs/command", bytes.NewReader(bodyJSON))
@@ -1267,18 +1282,28 @@ func runRunCommandSingle(_ *cobra.Command, args []string) error {
 	}
 
 	runID := apiResp.Data.RunID
-	fmt.Printf("Run ID: %s\n", runID)
+	// In --json mode, route progress text to stderr so stdout carries only
+	// the keyed JSON payload.
+	progressW := io.Writer(os.Stdout)
+	if stewardExecJSONOutput {
+		progressW = os.Stderr
+	}
+	if _, err := fmt.Fprintf(progressW, "Run ID: %s\n", runID); err != nil {
+		return fmt.Errorf("failed to write progress: %w", err)
+	}
 
-	if err := waitForRun(context.Background(), client, runID, timeout); err != nil {
+	if err := waitForRun(context.Background(), client, runID, timeout, progressW); err != nil {
 		return err
 	}
 
-	return fetchAndDisplayExecOutput(client, runID, stewardID)
+	return fetchAndDisplayExecOutput(client, runID, matches)
 }
 
-// fetchAndDisplayExecOutput retrieves job records for runID and prints the output
-// for the job targeting stewardID. Applies the 64 KB CLI display cap.
-func fetchAndDisplayExecOutput(client *APIClient, runID, stewardID string) error {
+// fetchAndDisplayExecOutput retrieves job records for runID and prints output
+// for every steward in matches. Each steward gets a host-prefixed block in
+// human mode; --json produces a keyed-by-steward array (story 4 schema).
+// Applies the 64 KB CLI display cap per steward in human mode.
+func fetchAndDisplayExecOutput(client *APIClient, runID string, matches []StewardInfo) error {
 	resp, err := client.Get(context.Background(), "/api/v1/runs/"+runID+"/jobs")
 	if err != nil {
 		return fmt.Errorf("failed to fetch job output: %w", err)
@@ -1297,29 +1322,62 @@ func fetchAndDisplayExecOutput(client *APIClient, runID, stewardID string) error
 		return fmt.Errorf("failed to parse job results: %w", err)
 	}
 
-	if stewardExecJSONOutput {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(apiResp.Data)
+	// Index returned jobs by device ID for O(1) lookup when building per-steward output.
+	jobByDevice := make(map[string]runJobRecord, len(apiResp.Data))
+	for _, job := range apiResp.Data {
+		jobByDevice[job.DeviceID] = job
 	}
 
-	for _, job := range apiResp.Data {
-		if job.DeviceID != stewardID {
+	if stewardExecJSONOutput {
+		// Build keyed-by-steward output using story 4's keyedOutput helper.
+		perStewardResult := make(map[string]fanOutResult, len(matches))
+		for _, m := range matches {
+			key := stewardKey(m)
+			job, ok := jobByDevice[m.ID]
+			if !ok {
+				perStewardResult[key] = fanOutResult{
+					Err: fmt.Errorf("no job record returned for steward %s", m.ID),
+				}
+				continue
+			}
+			payload, merr := json.Marshal(map[string]interface{}{
+				"exit_code": job.ExitCode,
+				"output":    job.Output,
+				"status":    job.Status,
+			})
+			if merr != nil {
+				return fmt.Errorf("failed to marshal job output: %w", merr)
+			}
+			perStewardResult[key] = fanOutResult{
+				Success: job.Status == "completed",
+				Payload: payload,
+			}
+		}
+		entries := keyedOutput(matches, perStewardResult)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+
+	// Human output: one host-prefixed block per matched steward, in match order.
+	for _, m := range matches {
+		key := stewardKey(m)
+		job, ok := jobByDevice[m.ID]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "warning: no job record returned for %s\n", key)
 			continue
 		}
 		output := job.Output
 		if len(output) > execCLIOutputCap {
-			fmt.Fprintf(os.Stderr, "warning: output truncated at 64 KB\n")
+			fmt.Fprintf(os.Stderr, "warning: output for %s truncated at 64 KB\n", key)
 			output = output[:execCLIOutputCap]
 		}
+		fmt.Printf("=== %s ===\n", key)
 		fmt.Printf("Exit code: %d\n", job.ExitCode)
 		if output != "" {
 			fmt.Print(output)
 		}
-		return nil
 	}
-
-	fmt.Println("No output returned for steward", stewardID)
 	return nil
 }
 
@@ -1578,8 +1636,10 @@ func fetchRunRecord(ctx context.Context, client *APIClient, runID string) (*runR
 }
 
 // waitForRun polls GET /api/v1/runs/{runID} every runWaitPollInterval until the
-// run reaches a terminal state or the timeout elapses.
-func waitForRun(ctx context.Context, client *APIClient, runID string, timeout time.Duration) error {
+// run reaches a terminal state or the timeout elapses. Progress text is written
+// to progressW so callers can route it to stdout or stderr without mutating
+// global state.
+func waitForRun(ctx context.Context, client *APIClient, runID string, timeout time.Duration, progressW io.Writer) error {
 	deadline := time.Now().Add(timeout)
 
 	for {
@@ -1589,8 +1649,12 @@ func waitForRun(ctx context.Context, client *APIClient, runID string, timeout ti
 		}
 
 		if isRunTerminal(run.Status) {
-			fmt.Printf("Status: %s\n", run.Status)
-			fmt.Printf("Jobs: %d total, %d completed, %d failed\n", run.JobCount, run.CompletedJobs, run.FailedJobs)
+			if _, err := fmt.Fprintf(progressW, "Status: %s\n", run.Status); err != nil {
+				return fmt.Errorf("failed to write progress: %w", err)
+			}
+			if _, err := fmt.Fprintf(progressW, "Jobs: %d total, %d completed, %d failed\n", run.JobCount, run.CompletedJobs, run.FailedJobs); err != nil {
+				return fmt.Errorf("failed to write progress: %w", err)
+			}
 			return nil
 		}
 
@@ -1599,7 +1663,9 @@ func waitForRun(ctx context.Context, client *APIClient, runID string, timeout ti
 				timeout, runID, run.Status, run.CompletedJobs, run.JobCount)
 		}
 
-		fmt.Printf("Waiting... status: %s (%d/%d completed)\n", run.Status, run.CompletedJobs, run.JobCount)
+		if _, err := fmt.Fprintf(progressW, "Waiting... status: %s (%d/%d completed)\n", run.Status, run.CompletedJobs, run.JobCount); err != nil {
+			return fmt.Errorf("failed to write progress: %w", err)
+		}
 
 		select {
 		case <-time.After(runWaitPollInterval):

--- a/cmd/cfg/cmd/steward_exec_test.go
+++ b/cmd/cfg/cmd/steward_exec_test.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// saveExecGlobals saves all run globals (via saveStewardRunGlobals) plus
+// stewardYes, which is needed for multi-host confirm tests.
+func saveExecGlobals(t *testing.T) {
+	t.Helper()
+	saveStewardRunGlobals(t)
+	origYes := stewardYes
+	t.Cleanup(func() {
+		stewardYes = origYes
+	})
+}
+
+// newExecTestServer builds a minimal fake controller that handles the full exec
+// flow:
+//
+//   - POST /api/v1/fleet/resolve  → resolveMatches wrapped in {"data": [...]}
+//   - POST /api/v1/runs/command   → {"data": {"run_id": runID}}
+//   - GET  /api/v1/runs/<runID>   → completed run status
+//   - GET  /api/v1/runs/<runID>/jobs → jobRecords wrapped in {"data": [...]}
+//
+// If capturedTarget is non-nil, the "target" field from the command POST body
+// is written there so the caller can assert it.
+func newExecTestServer(
+	t *testing.T,
+	runID string,
+	resolveMatches []StewardInfo,
+	jobRecords []map[string]interface{},
+	capturedTarget *string,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": resolveMatches,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/runs/command":
+			if capturedTarget != nil {
+				b, _ := io.ReadAll(r.Body)
+				var body map[string]interface{}
+				_ = json.Unmarshal(b, &body)
+				if target, ok := body["target"].(string); ok {
+					*capturedTarget = target
+				}
+			}
+			writeRunAPIResponse(w, map[string]string{"run_id": runID})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/"+runID:
+			writeRunAPIResponse(w, map[string]interface{}{
+				"run_id":         runID,
+				"status":         "completed",
+				"job_count":      len(jobRecords),
+				"completed_jobs": len(jobRecords),
+				"failed_jobs":    0,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/"+runID+"/jobs":
+			writeRunAPIResponse(w, jobRecords)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] regression: id: prepend bug (#2257)
+// ---------------------------------------------------------------------------
+
+// TestExec_NoPrepend_BareSelector_SendsRawTarget is a regression test for
+// issue #2257: a bare hostname passed as the selector must not have "id:"
+// prepended before dispatch. The target field in the POST body must be the
+// raw selector string.
+func TestExec_NoPrepend_BareSelector_SendsRawTarget(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	var capturedTarget string
+	srv := newExecTestServer(t, "bare-run-id",
+		[]StewardInfo{{ID: "host-abc", DNA: &StewardInfoDNA{Hostname: "host-abc"}}},
+		[]map[string]interface{}{
+			{"job_id": "j1", "device_id": "host-abc", "status": "completed", "output": "ok\n", "exit_code": 0},
+		},
+		&capturedTarget,
+	)
+	defer srv.Close()
+
+	saveExecGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardExecCommand = "hostname"
+	stewardExecShell = "bash"
+	stewardExecTimeout = 30 * time.Second
+	runWaitPollInterval = time.Millisecond
+
+	_ = captureStdout(t, func() {
+		err := runRunCommandSingle(stewardExecCmd, []string{"host-abc"})
+		require.NoError(t, err)
+	})
+
+	// "host-abc" must reach the server verbatim — not as "id:host-abc".
+	assert.Equal(t, "host-abc", capturedTarget, "bare selector must not be prepended with id:")
+}
+
+// TestExec_NoPrepend_IDPrefixedArg_NoDoubleID is a regression test for #2257:
+// when the caller already passes "id:steward-X", the CLI must not prepend
+// another "id:" — the target must remain exactly "id:steward-X".
+func TestExec_NoPrepend_IDPrefixedArg_NoDoubleID(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	var capturedTarget string
+	srv := newExecTestServer(t, "id-run-id",
+		[]StewardInfo{{ID: "steward-xyz", DNA: &StewardInfoDNA{Hostname: "steward-xyz"}}},
+		[]map[string]interface{}{
+			{"job_id": "j1", "device_id": "steward-xyz", "status": "completed", "output": "ok\n", "exit_code": 0},
+		},
+		&capturedTarget,
+	)
+	defer srv.Close()
+
+	saveExecGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardExecCommand = "hostname"
+	stewardExecShell = "bash"
+	stewardExecTimeout = 30 * time.Second
+	runWaitPollInterval = time.Millisecond
+
+	_ = captureStdout(t, func() {
+		err := runRunCommandSingle(stewardExecCmd, []string{"id:steward-xyz"})
+		require.NoError(t, err)
+	})
+
+	// "id:steward-xyz" must stay "id:steward-xyz", never "id:id:steward-xyz".
+	assert.Equal(t, "id:steward-xyz", capturedTarget,
+		"id:-prefixed selector must not gain a second id: prefix")
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] multi-match dispatch
+// ---------------------------------------------------------------------------
+
+// TestExec_MultiMatch_HumanOutput_HostPrefixed verifies that a selector
+// matching 2 stewards produces one host-prefixed output block per steward
+// in human (non-JSON) mode.
+func TestExec_MultiMatch_HumanOutput_HostPrefixed(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	matches := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-one"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-two"}},
+	}
+	jobs := []map[string]interface{}{
+		{"job_id": "j1", "device_id": "s1", "status": "completed", "output": "output from s1\n", "exit_code": 0},
+		{"job_id": "j2", "device_id": "s2", "status": "completed", "output": "output from s2\n", "exit_code": 0},
+	}
+	srv := newExecTestServer(t, "multi-run-id", matches, jobs, nil)
+	defer srv.Close()
+
+	saveExecGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardExecCommand = "hostname"
+	stewardExecShell = "bash"
+	stewardExecTimeout = 30 * time.Second
+	runWaitPollInterval = time.Millisecond
+	stewardYes = true // suppress multi-host confirm prompt
+
+	output := captureStdout(t, func() {
+		err := runRunCommandSingle(stewardExecCmd, []string{"glob:host-*"})
+		require.NoError(t, err)
+	})
+
+	// Both stewards must appear with host-prefixed keys in the output.
+	assert.Contains(t, output, "host-one#s1")
+	assert.Contains(t, output, "host-two#s2")
+	assert.Contains(t, output, "output from s1")
+	assert.Contains(t, output, "output from s2")
+}
+
+// TestExec_MultiMatch_JSONOutput_KeyedBySteward verifies that --json output
+// from a multi-match exec is a keyed-by-steward array (story 4 schema)
+// rather than a raw []runJobRecord dump.
+func TestExec_MultiMatch_JSONOutput_KeyedBySteward(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	matches := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-one"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-two"}},
+	}
+	jobs := []map[string]interface{}{
+		{"job_id": "j1", "device_id": "s1", "status": "completed", "output": "s1-result\n", "exit_code": 0},
+		{"job_id": "j2", "device_id": "s2", "status": "completed", "output": "s2-result\n", "exit_code": 0},
+	}
+	srv := newExecTestServer(t, "json-run-id", matches, jobs, nil)
+	defer srv.Close()
+
+	saveExecGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardExecCommand = "hostname"
+	stewardExecShell = "bash"
+	stewardExecTimeout = 30 * time.Second
+	runWaitPollInterval = time.Millisecond
+	stewardExecJSONOutput = true
+	stewardYes = true
+
+	output := captureStdout(t, func() {
+		err := runRunCommandSingle(stewardExecCmd, []string{"glob:host-*"})
+		require.NoError(t, err)
+	})
+
+	// Output must be a JSON array with keyed entries.
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be valid JSON")
+	require.Len(t, entries, 2, "must have one entry per matched steward")
+
+	keys := make(map[string]bool)
+	for _, e := range entries {
+		key, ok := e["key"].(string)
+		require.True(t, ok, "each entry must have a string 'key' field")
+		keys[key] = true
+		_, hasSuccess := e["success"]
+		assert.True(t, hasSuccess, "each entry must have a 'success' field")
+		// Must not be a raw job record (no job_id at the top level).
+		assert.Nil(t, e["job_id"], "keyed output must not expose raw job_id fields")
+	}
+	assert.True(t, keys["host-one#s1"], "output must contain key 'host-one#s1'")
+	assert.True(t, keys["host-two#s2"], "output must contain key 'host-two#s2'")
+}
+
+// ---------------------------------------------------------------------------
+// Missing job-record branch coverage
+// ---------------------------------------------------------------------------
+
+// TestExec_MissingJobRecord_HumanMode verifies that when the API returns fewer
+// job records than resolved stewards, the human-mode output path prints a
+// warning to stderr and continues without panicking.
+func TestExec_MissingJobRecord_HumanMode(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	// Two stewards resolved, but only one job record returned.
+	matches := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-one"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-two"}},
+	}
+	jobs := []map[string]interface{}{
+		{"job_id": "j1", "device_id": "s1", "status": "completed", "output": "output from s1\n", "exit_code": 0},
+		// s2 intentionally omitted
+	}
+	srv := newExecTestServer(t, "missing-job-run-id", matches, jobs, nil)
+	defer srv.Close()
+
+	saveExecGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardExecCommand = "hostname"
+	stewardExecShell = "bash"
+	stewardExecTimeout = 30 * time.Second
+	runWaitPollInterval = time.Millisecond
+	stewardYes = true
+
+	output := captureStdout(t, func() {
+		err := runRunCommandSingle(stewardExecCmd, []string{"glob:host-*"})
+		require.NoError(t, err)
+	})
+
+	// s1 output must be present; s2 must not appear (no job record, only a stderr warning).
+	assert.Contains(t, output, "host-one#s1")
+	assert.Contains(t, output, "output from s1")
+	assert.NotContains(t, output, "host-two#s2")
+}
+
+// TestExec_MissingJobRecord_JSONMode verifies that when the API returns fewer
+// job records than resolved stewards, the --json output marks the missing
+// steward with success=false and an error string.
+func TestExec_MissingJobRecord_JSONMode(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	matches := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-one"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-two"}},
+	}
+	jobs := []map[string]interface{}{
+		{"job_id": "j1", "device_id": "s1", "status": "completed", "output": "s1-result\n", "exit_code": 0},
+		// s2 intentionally omitted
+	}
+	srv := newExecTestServer(t, "missing-json-run-id", matches, jobs, nil)
+	defer srv.Close()
+
+	saveExecGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardExecCommand = "hostname"
+	stewardExecShell = "bash"
+	stewardExecTimeout = 30 * time.Second
+	runWaitPollInterval = time.Millisecond
+	stewardExecJSONOutput = true
+	stewardYes = true
+
+	output := captureStdout(t, func() {
+		err := runRunCommandSingle(stewardExecCmd, []string{"glob:host-*"})
+		require.NoError(t, err)
+	})
+
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be valid JSON")
+	require.Len(t, entries, 2)
+
+	entryByKey := make(map[string]map[string]interface{})
+	for _, e := range entries {
+		if k, ok := e["key"].(string); ok {
+			entryByKey[k] = e
+		}
+	}
+
+	s1 := entryByKey["host-one#s1"]
+	require.NotNil(t, s1, "s1 entry must be present")
+	assert.Equal(t, true, s1["success"], "s1 with a job record must be success=true")
+
+	s2 := entryByKey["host-two#s2"]
+	require.NotNil(t, s2, "s2 entry must be present even with no job record")
+	assert.Equal(t, false, s2["success"], "s2 missing a job record must be success=false")
+	assert.NotEmpty(t, s2["error"], "s2 must carry an error message")
+}

--- a/cmd/cfg/cmd/steward_run_test.go
+++ b/cmd/cfg/cmd/steward_run_test.go
@@ -692,7 +692,7 @@ func TestStewardRunResult_FlagsRegistered(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestRunCommandSingle_SubmitsCommandAndDisplaysOutput verifies that:
-//   - POST /api/v1/runs/command is called with target: id:<id>
+//   - POST /api/v1/runs/command is called with the raw selector (no id: prepend)
 //   - The job output is printed after the run reaches terminal state.
 func TestRunCommandSingle_SubmitsCommandAndDisplaysOutput(t *testing.T) {
 	dir := t.TempDir()
@@ -701,6 +701,10 @@ func TestRunCommandSingle_SubmitsCommandAndDisplaysOutput(t *testing.T) {
 	var capturedBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeRunAPIResponse(w, []map[string]interface{}{
+				{"id": "target-steward-id", "status": "online"},
+			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/runs/command":
 			capturedBody, _ = io.ReadAll(r.Body)
 			writeRunAPIResponse(w, map[string]string{"run_id": "exec-run-id"})
@@ -743,10 +747,10 @@ func TestRunCommandSingle_SubmitsCommandAndDisplaysOutput(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// Verify request body has target: id:<steward-id>
+	// target must be the raw selector — no id: prepend (regression: issue #2257).
 	var body map[string]interface{}
 	require.NoError(t, json.Unmarshal(capturedBody, &body))
-	assert.Equal(t, "id:target-steward-id", body["target"], "target must be id:<steward-id>")
+	assert.Equal(t, "target-steward-id", body["target"], "target must be the raw selector, not id:<steward-id>")
 
 	// Verify output is displayed
 	assert.Contains(t, output, "exec-run-id")
@@ -761,10 +765,14 @@ func TestRunCommandSingle_TimeoutError(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeRunAPIResponse(w, []map[string]interface{}{
+				{"id": "some-steward-id", "status": "online"},
+			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/runs/command":
 			writeRunAPIResponse(w, map[string]string{"run_id": "timeout-exec-run"})
 		default:
-			// Always return running
+			// Always return running status for the wait-poll loop.
 			writeRunAPIResponse(w, map[string]interface{}{
 				"run_id":         "timeout-exec-run",
 				"status":         "running",


### PR DESCRIPTION
## Summary

- Removes the `id:` prepend bug (#2257): `cfg steward exec <selector>` now passes the raw selector string to the server instead of unconditionally prefixing `id:`, fixing bare hostnames, preventing double `id:id:` on already-prefixed args, and enabling all selector forms (glob, attribute, `all`, etc.)
- Wires exec through story 4's shared selector surface (`resolveOrFailFast` → `confirmMultiHost` → dispatch → `keyedOutput`): exec resolves once for the confirm gate, sends a single request, and reshapes the response into keyed-by-steward output
- Human mode prints one host-prefixed block per steward (`=== hostname#id ===`); `--json` produces story 4's keyed array schema instead of a raw `[]runJobRecord` dump
- Refactors `waitForRun` to accept an `io.Writer` parameter (eliminates global `os.Stdout` mutation); updates `stewardExecCmd` Use/Short/Long to accurately describe selector-based multi-host dispatch

Fixes #2442

## Specialist Review Results

| Reviewer | Result | Findings |
|----------|--------|----------|
| Code reviewer | PASS | 0 blocking |
| Security engineer | PASS | 1 low warning (pre-existing ANSI display, not blocking) |
| QA code reviewer | PASS | 2 warnings (both addressed in fix cycle) |
| QA test runner (round 1) | FAIL | 4 blocking: errcheck on `fmt.Fprintf(progressW, ...)` |
| Fix cycle | — | Replaced `_, _ =` with proper `if _, err := ...; err != nil { return ... }` |
| QA test runner (round 2) | PASS | 0 remaining findings |

**Overall workflow verdict: passed: true** (2 review rounds, 1 fix round, 0 remaining findings)

## Test plan

- [x] `TestExec_NoPrepend_BareSelector_SendsRawTarget` — bare hostname passes through without id: prepend
- [x] `TestExec_NoPrepend_IDPrefixedArg_NoDoubleID` — `id:steward-X` stays `id:steward-X`, never `id:id:steward-X`
- [x] `TestExec_MultiMatch_HumanOutput_HostPrefixed` — 2-steward match produces host-prefixed output blocks
- [x] `TestExec_MultiMatch_JSONOutput_KeyedBySteward` — `--json` produces keyed-by-steward array
- [x] `TestExec_MissingJobRecord_HumanMode` — missing job record handled gracefully
- [x] `TestExec_MissingJobRecord_JSONMode` — missing job record surfaced as success=false in JSON
- [x] `TestRunCommandSingle_SubmitsCommandAndDisplaysOutput` — updated: resolve endpoint added, target assertion fixed
- [x] `TestRunCommandSingle_TimeoutError` — updated: resolve endpoint added
- [x] `make test-quality` passes (confirmed by QA test runner round 2)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)