### PR TITLE
hyperv: role-owner gate on existing HA-role VM lifecycle convergence (Issue #2422)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -165,6 +165,55 @@ failover.
 > the location drift and performs a live storage migration, then completes the
 > registration on a subsequent converge.
 
+#### Owner-gated lifecycle convergence (#2422)
+
+For an `ha_role` VM, the module gates **all** lifecycle convergence — power
+state, CPU/memory resize, NIC reconcile, and the #2411 storage-move — on cluster
+**role ownership**: it runs only on the node that `Get-ClusterGroup` currently
+reports as the role's owner. On every convergence tick the module reads the
+per-role owner map and, if the map affirmatively names a **different** node as
+the VM's owner, takes **no** lifecycle action and goes quiet (the skip is audited
+as `vm-lifecycle-skip-not-owner`).
+
+This matters most **immediately after a failover**. When the cluster moves a role
+from node A to node B, node A's local `Get-VM` view may transiently still show
+the VM. Without the owner gate, node A's next convergence cycle could issue
+power/resize/NIC calls against a VM the cluster has already reassigned. The gate
+makes the previous owner go quiet and lets the **new** owner converge — even in
+the window where local `Get-VM` visibility lags cluster-role ownership.
+
+A **missing** owner-map entry (the role is not registered anywhere yet) does
+**not** skip: local possession decides. This is the first-time promote of an
+existing standalone VM to `ha_role` — the node that holds the VM locally proceeds
+so the promote path can register the role. Standalone (non-HA) VMs are wholly
+unaffected: the owner check is never invoked and no cluster query is issued.
+
+A transient owner-probe failure is **fail-safe-quiet** — the module skips that
+cycle (logs a warning, no error) and retries on the next tick, rather than either
+blocking a legitimate owner or letting a non-owner act. This deliberately differs
+from the first-creation CNO gate (#2421), which fails loud: that call happens
+once, at create time; the owner gate runs on every tick of every existing HA VM,
+where a hard error would spam the steward's error state on a known-transient
+condition.
+
+#### Promote procedure (founder ruling 2026-07-08)
+
+Promoting an **existing standalone** VM to `ha_role` is done on the host that
+owns the VM **first**: add the `ha_role` block to the VM's definition in **that
+host's steward config**. Only after the role is registered does the definition
+move from the steward config into the **cluster config** (the cascade). Moving an
+unpromoted-but-existing VM's definition straight into the cluster config is
+**unsupported** — the cluster-wide existence gate (#2420) cannot see a VM that is
+not yet a registered role on any node, so no node would ever create or adopt it.
+
+#### One-reporter rule (#2418)
+
+The node currently hosting an `ha_role` is the **sole reporter** of the VM's
+observed state. A non-hosting member's `Get("vm:<name>")` returns `state: absent`
+with `HARole` populated and no other VM object fields, and its `Set` path is a
+no-op (audited as `vm-set-skip-hosted-elsewhere`, #2420). One logical VM, one
+reporter — a precursor to ADR-017's shared typed entity identity (A1.2).
+
 ### Declarative storage location (#2411)
 
 The directory containing the declared `vhd_path` is the VM's **home** — its

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -1327,13 +1327,33 @@ func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string
 	// letting the next tick retry. A future reviewer must not "fix" this to match
 	// #2421/S2. Standalone VMs (desired.HARole == nil) skip this block entirely —
 	// zero added transport calls, zero behavior change.
+	//
+	// An UNRESOLVED owner (the map has an entry for the VM but the owner string is
+	// empty — Get-ClusterGroup reports "" for a role with no current OwnerNode, the
+	// in-flight-failover window this story targets) is treated the same as a
+	// different owner: the node goes quiet. This is the safe bias — while ownership
+	// is unsettled, EVERY member reads "" and waits, so no two nodes ever act at
+	// once; it self-heals the moment the cluster settles an owner. Proceeding on
+	// local possession here would instead risk two nodes converging the same role
+	// during the settle window.
 	if desired.HARole != nil {
-		owners, roErr := m.readResourceOwners(ctx, desired.HARole.ClusterName)
+		clusterName := desired.HARole.ClusterName
+		// Scope cap (S5): never issue a transport call for a cluster this steward is
+		// not permitted to read — the same invariant every other cluster-touching
+		// function enforces before the transport (clusterOwnershipHelper,
+		// reconcileRoleMembership, getCluster). A mismatched ha_role.cluster_name is
+		// a persistent misconfiguration, not a transient probe failure, so it fails
+		// LOUD (exactly as the downstream promote path's reconcileRoleMembership
+		// would) rather than taking the fail-safe-quiet path below.
+		if m.clusterName != "" && clusterName != m.clusterName {
+			return fmt.Errorf("hyperv: apply VM state %q: %w", vmName, ErrClusterNotDeclared)
+		}
+		owners, roErr := m.readResourceOwners(ctx, clusterName)
 		if roErr != nil {
 			if logger, ok := m.GetLogger(); ok {
 				logger.Warn("hyperv: ha_role owner probe failed; skipping lifecycle convergence this cycle",
 					"vm_name", logging.SanitizeLogValue(vmName),
-					"cluster", logging.SanitizeLogValue(desired.HARole.ClusterName),
+					"cluster", logging.SanitizeLogValue(clusterName),
 					"error", roErr.Error())
 			}
 			return nil
@@ -1343,7 +1363,7 @@ func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string
 				"vm-lifecycle-skip-not-owner", cfgResourceID, nil,
 				map[string]interface{}{
 					"skipped":      true,
-					"cluster_name": desired.HARole.ClusterName,
+					"cluster_name": clusterName,
 					"owner":        owner,
 				}, nil)
 			return nil

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -1299,6 +1299,57 @@ func (m *hypervModule) connectAdditionalNics(ctx context.Context, cfgResourceID,
 func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string, desired, current *VMConfig, state string) error {
 	cfgResourceID := "vm:" + vmName
 
+	// Role-owner gate (#2422): lifecycle convergence (storage move, NIC reconcile,
+	// promote/demote, resize, power) for an ha_role VM runs ONLY on the node that
+	// currently owns the role. A non-owner — most importantly the PREVIOUS owner
+	// right after a failover, whose local Get-VM view may transiently still show
+	// the VM — takes no lifecycle action and goes quiet; the new owner converges
+	// instead. This makes success criterion #3 ("after failover the new owner
+	// converges and the previous owner goes quiet") hold even in the edge case
+	// where local Get-VM visibility lags cluster-role ownership, not just when they
+	// already agree.
+	//
+	// Skip only on an AFFIRMATIVE different-owner report: the owner map contains an
+	// entry for this VM AND that entry is a node other than us. A MISSING entry
+	// (role not yet registered — the first-time promote of an existing standalone
+	// VM to ha_role) does NOT skip: local possession decides, and this node holds
+	// the VM locally (applyVMState is the existing-VM path), so it proceeds and the
+	// promote/demote switch below registers the role (founder ruling 2026-07-08:
+	// promotion happens on the host that owns the VM first; only then does the
+	// definition move from the steward config to the cluster config).
+	//
+	// A probe error here is fail-safe-QUIET, deliberately UNLIKE #2421's
+	// clusterOwnershipHelper (which propagates): that call happens once, at
+	// first-creation time, where fail-safe-loud is correct. This call happens on
+	// every convergence tick of every already-existing HA VM, so a transient
+	// cluster-service hiccup must not surface as a steward error state or spam the
+	// error log — treat it as "cannot determine ownership this cycle" and skip,
+	// letting the next tick retry. A future reviewer must not "fix" this to match
+	// #2421/S2. Standalone VMs (desired.HARole == nil) skip this block entirely —
+	// zero added transport calls, zero behavior change.
+	if desired.HARole != nil {
+		owners, roErr := m.readResourceOwners(ctx, desired.HARole.ClusterName)
+		if roErr != nil {
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: ha_role owner probe failed; skipping lifecycle convergence this cycle",
+					"vm_name", logging.SanitizeLogValue(vmName),
+					"cluster", logging.SanitizeLogValue(desired.HARole.ClusterName),
+					"error", roErr.Error())
+			}
+			return nil
+		}
+		if owner, isMember := owners[vmName]; isMember && !strings.EqualFold(owner, m.nodeHostname) {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"vm-lifecycle-skip-not-owner", cfgResourceID, nil,
+				map[string]interface{}{
+					"skipped":      true,
+					"cluster_name": desired.HARole.ClusterName,
+					"owner":        owner,
+				}, nil)
+			return nil
+		}
+	}
+
 	// Storage-location convergence (#2411) runs FIRST: an ha_role registration
 	// on a mislocated VM fails (Add-ClusterVirtualMachineRole refuses a VM whose
 	// configuration files are off cluster storage), and power/resize actions are

--- a/features/modules/hyperv/vm_harole_convergence_test.go
+++ b/features/modules/hyperv/vm_harole_convergence_test.go
@@ -465,6 +465,7 @@ func TestSetVM_HARole_PromoteExistingVM(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{
 		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
 		`{"owners":{}}`,                        // getVM probe: not a member
+		`{"owners":{}}`,                        // #2422 lifecycle owner gate: role not yet registered → proceed (first-time promote)
 		`{"owner":"NODE1"}`,                    // ownership helper: CNO owner
 		`{"owners":{}}`,                        // ownership helper: role owners
 		`{"owner":"NODE1"}`,                    // audit cnoOwner re-read
@@ -531,6 +532,7 @@ func TestSetVM_HARole_PromoteIdempotent(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{
 		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
 		`{"owners":{"ha-steady-vm":"NODE1"}}`,  // getVM probe: already a member
+		`{"owners":{"ha-steady-vm":"NODE1"}}`,  // #2422 lifecycle owner gate: this node owns the role → proceed
 	}}
 	m := vmModuleWithTransport(transport, "t-ha")
 	m.clusterName = cluster
@@ -550,8 +552,8 @@ func TestSetVM_HARole_PromoteIdempotent(t *testing.T) {
 	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource))
 	transport.mu.Lock()
 	defer transport.mu.Unlock()
-	assert.Len(t, transport.calls, 2,
-		"steady state must be exactly getVM + probe — no membership machinery")
+	assert.Len(t, transport.calls, 3,
+		"steady state must be exactly getVM + probe + #2422 owner gate — no membership machinery")
 }
 
 // TestSetVM_HARole_DemoteIdempotent: a VM that is already standalone with no

--- a/features/modules/hyperv/vm_harole_convergence_test.go
+++ b/features/modules/hyperv/vm_harole_convergence_test.go
@@ -592,6 +592,7 @@ func TestSetVM_HARole_NonOwnerNoop(t *testing.T) {
 	transport := &testWinRMTransport{perCallOutputs: []string{
 		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
 		`{"owners":{}}`,                        // getVM probe: not a member
+		`{"owners":{}}`,                        // #2422 lifecycle owner gate: role not registered → proceed (first-time promote)
 		`{"owner":"NODE2"}`,                    // ownership helper: another node owns CNO
 		`{"owners":{}}`,                        // ownership helper: role owners
 		`{"owner":"NODE2"}`,                    // audit cnoOwner re-read

--- a/features/modules/hyperv/vm_lifecycle_owner_gate_test.go
+++ b/features/modules/hyperv/vm_lifecycle_owner_gate_test.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Issue #2422: role-owner gate on existing HA-role VM lifecycle convergence ──
+//
+// applyVMState (power/resize/NIC/storage-move) for an ha_role VM runs only on the
+// node readResourceOwners reports as the role's current owner. A non-owner — most
+// importantly the PREVIOUS owner right after a failover, whose local Get-VM view
+// may transiently still show the VM — takes no lifecycle action and goes quiet;
+// the new owner converges instead. A MISSING owner entry (role not yet registered:
+// the first-time promote of an existing standalone VM) does NOT skip — local
+// possession decides. Standalone VMs never consult the cluster at all.
+
+// TestApplyVMState_NonOwner_GoesQuiet (REQUIRED, #2422): a post-failover state —
+// the VM is present locally but readResourceOwners reports a DIFFERENT node as the
+// role owner — issues zero write PS calls of any kind and returns nil. The only
+// transport call is the ownership probe itself; the skip is audited.
+func TestApplyVMState_NonOwner_GoesQuiet(t *testing.T) {
+	const vmName = "ha-failover-vm"
+	const cluster = "lab-hv"
+
+	// One transport call only: the ownership probe. Anything beyond it (storage
+	// move, NIC reconcile, promote/demote, stop/resize/start) violates the gate.
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"owners":{"ha-failover-vm":"NODE2"}}`, // role owned by the OTHER node
+	}}
+	m := vmModuleWithTransport(transport, "t-2422")
+	m.nodeHostname = "NODE1"
+	mgr, store := newFakeAuditManager(t)
+	m.auditMgr = mgr
+	m.stewardID = "steward-2422"
+
+	// desired diverges from current in every actionable way (power, CPU, memory)
+	// so an UNGATED convergence would issue multiple writes — the zero-call
+	// assertion below is only meaningful because the drift is real.
+	desired := &VMConfig{
+		Name:     vmName,
+		CPUCount: 4,
+		MemoryMB: 8192,
+		HARole:   &HARoleConfig{ClusterName: cluster},
+	}
+	current := &VMConfig{Name: vmName, CPUCount: 2, MemoryMB: 4096, State: "stopped"}
+
+	require.NoError(t, m.applyVMState(context.Background(), vmName, vmName, desired, current, "running"))
+
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 1, callCount,
+		"a non-owner must issue exactly one call (the ownership probe) and no lifecycle writes")
+	assert.Equal(t, 0, countCmd(transport, psStartVM), "no power change on a non-owner")
+	assert.Equal(t, 0, countCmd(transport, psStopVM), "no power change on a non-owner")
+	assert.Equal(t, 0, countCmd(transport, psSetVMProcessor), "no resize on a non-owner")
+	assert.Equal(t, 0, countCmd(transport, psSetVMMemory), "no resize on a non-owner")
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole), "no membership mutation on a non-owner")
+
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	skips := auditEntriesByActionCT(store.captured(), "vm-lifecycle-skip-not-owner")
+	require.Len(t, skips, 1, "the non-owner lifecycle skip must be audited")
+}
+
+// TestApplyVMState_Owner_ConvergesNormally (REQUIRED, #2422): when this node is
+// the owner (or the role is not yet registered anywhere), the gate does not skip
+// and existing convergence runs unchanged. Two sub-cases:
+//   - first-time promote: desired.HARole != nil, current.HARole == nil, owner map
+//     has NO entry for the VM (role not yet registered) → the promote path
+//     (registerClusteredRole) is reached.
+//   - steady owner: this node IS the reported owner → a pending resize is applied.
+func TestApplyVMState_Owner_ConvergesNormally(t *testing.T) {
+	const cluster = "lab-hv"
+
+	t.Run("first_time_promote_missing_owner_entry", func(t *testing.T) {
+		const vmName = "ha-promote-existing-vm"
+		// call0: gate probe — role absent cluster-wide (no entry ⇒ do NOT skip).
+		// calls 1-4: registerClusteredRole on the CNO owner (this node).
+		transport := &testWinRMTransport{perCallOutputs: []string{
+			`{"owners":{}}`,     // gate: role not yet registered → local possession decides
+			`{"owner":"NODE1"}`, // reconcileRoleMembership: CNO owner
+			`{"owners":{}}`,     // reconcileRoleMembership: role owners
+			`{"owner":"NODE1"}`, // reconcileRoleMembership: audit cnoOwner re-read
+			``,                  // Add-ClusterVirtualMachineRole
+		}}
+		m := vmModuleWithTransport(transport, "t-2422")
+		m.nodeHostname = "NODE1"
+
+		desired := &VMConfig{
+			Name:     vmName,
+			CPUCount: 2,
+			MemoryMB: 4096,
+			HARole:   &HARoleConfig{ClusterName: cluster},
+		}
+		current := &VMConfig{Name: vmName, CPUCount: 2, MemoryMB: 4096, State: "stopped"} // HARole nil
+
+		require.NoError(t, m.applyVMState(context.Background(), vmName, vmName, desired, current, "stopped"))
+
+		assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+			"a missing owner entry must NOT skip — the first-time promote path must register the role")
+	})
+
+	t.Run("steady_owner_applies_resize", func(t *testing.T) {
+		const vmName = "ha-owned-vm"
+		// call0: gate probe — this node owns the role → do NOT skip; convergence runs.
+		transport := &testWinRMTransport{perCallOutputs: []string{
+			`{"owners":{"ha-owned-vm":"NODE1"}}`, // gate: this node IS the owner
+		}}
+		m := vmModuleWithTransport(transport, "t-2422")
+		m.nodeHostname = "NODE1"
+
+		desired := &VMConfig{
+			Name:     vmName,
+			CPUCount: 4, // resize vs current
+			MemoryMB: 4096,
+			HARole:   &HARoleConfig{ClusterName: cluster},
+		}
+		// current already a member (HARole non-nil) so the promote/demote switch is a no-op.
+		current := &VMConfig{
+			Name:     vmName,
+			CPUCount: 2,
+			MemoryMB: 4096,
+			State:    "running",
+			HARole:   &HARoleConfig{ClusterName: cluster},
+		}
+
+		require.NoError(t, m.applyVMState(context.Background(), vmName, vmName, desired, current, "running"))
+
+		assert.Equal(t, 1, countCmd(transport, psSetVMProcessor),
+			"the reported owner must converge normally — the CPU resize must be applied")
+		assert.Equal(t, 1, countCmd(transport, psStartVM),
+			"the owner's resize ends with a start back to the desired running state")
+		assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+			"an already-registered member is not re-promoted")
+	})
+}
+
+// TestApplyVMState_StandaloneVM_NoOwnerQuery (REQUIRED, #2422): a standalone VM
+// (desired.HARole == nil) never invokes the owner check — readResourceOwners is
+// not called at all — and existing convergence (here, a resize) still runs.
+func TestApplyVMState_StandaloneVM_NoOwnerQuery(t *testing.T) {
+	const vmName = "standalone-vm"
+
+	transport := &testWinRMTransport{} // no cluster outputs needed — none must be requested
+	m := vmModuleWithTransport(transport, "t-2422")
+	m.nodeHostname = "NODE1"
+	m.clusterName = "lab-hv" // even on a cluster-scoped module, a non-HA VM must not query
+
+	desired := &VMConfig{Name: vmName, CPUCount: 4, MemoryMB: 4096} // HARole nil
+	current := &VMConfig{Name: vmName, CPUCount: 2, MemoryMB: 4096, State: "running"}
+
+	require.NoError(t, m.applyVMState(context.Background(), vmName, vmName, desired, current, "running"))
+
+	assert.Equal(t, 0, countCmd(transport, psGetClusterResourceOwner),
+		"a standalone VM must never issue a cluster ownership query")
+	assert.Equal(t, 1, countCmd(transport, psSetVMProcessor),
+		"standalone convergence is unchanged — the CPU resize must still be applied")
+}
+
+// TestApplyVMState_OwnerQueryError_SkipsQuietly (#2422 implementation note): a
+// transient readResourceOwners failure is fail-safe-QUIET — it neither blocks a
+// legitimate owner nor lets a non-owner act. The cycle skips (return nil, warn),
+// issuing no lifecycle writes; the next tick retries once the probe recovers.
+// This deliberately differs from #2421's fail-safe-LOUD (which propagates) because
+// this call runs on every tick of every existing HA VM, where a hard error would
+// spam the steward error state on a known-transient condition.
+func TestApplyVMState_OwnerQueryError_SkipsQuietly(t *testing.T) {
+	const vmName = "ha-probe-flaky-vm"
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{``},
+		perCallErrors:  []error{errors.New("cluster service down")},
+	}
+	m := vmModuleWithTransport(transport, "t-2422")
+	m.nodeHostname = "NODE1"
+
+	desired := &VMConfig{
+		Name:     vmName,
+		CPUCount: 4,
+		MemoryMB: 8192,
+		HARole:   &HARoleConfig{ClusterName: cluster},
+	}
+	current := &VMConfig{Name: vmName, CPUCount: 2, MemoryMB: 4096, State: "stopped"}
+
+	require.NoError(t, m.applyVMState(context.Background(), vmName, vmName, desired, current, "running"),
+		"a transient ownership-probe error must not surface as a steward error")
+
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 1, callCount,
+		"a probe error must skip the cycle after exactly one call — no lifecycle writes")
+	assert.Equal(t, 0, countCmd(transport, psStartVM))
+	assert.Equal(t, 0, countCmd(transport, psSetVMProcessor))
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole))
+}

--- a/features/modules/hyperv/vm_lifecycle_owner_gate_test.go
+++ b/features/modules/hyperv/vm_lifecycle_owner_gate_test.go
@@ -203,3 +203,73 @@ func TestApplyVMState_OwnerQueryError_SkipsQuietly(t *testing.T) {
 	assert.Equal(t, 0, countCmd(transport, psSetVMProcessor))
 	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole))
 }
+
+// TestApplyVMState_UnresolvedOwner_GoesQuiet (#2422): the owner map has an entry
+// for the VM but the owner string is empty — Get-ClusterGroup reports "" for a
+// role with no current OwnerNode, the in-flight-failover settle window. Every
+// member reads "" and goes quiet, so no two nodes ever converge the same role
+// while ownership is unsettled; it self-heals once the cluster settles an owner.
+// This is the safe bias (fail-safe-quiet), locked in against a future "empty ⇒
+// proceed on local possession" change that would risk double-action.
+func TestApplyVMState_UnresolvedOwner_GoesQuiet(t *testing.T) {
+	const vmName = "ha-unsettled-vm"
+	const cluster = "lab-hv"
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"owners":{"ha-unsettled-vm":""}}`, // registered role, no current owner (settling)
+	}}
+	m := vmModuleWithTransport(transport, "t-2422")
+	m.nodeHostname = "NODE1"
+
+	desired := &VMConfig{
+		Name:     vmName,
+		CPUCount: 4,
+		MemoryMB: 8192,
+		HARole:   &HARoleConfig{ClusterName: cluster},
+	}
+	current := &VMConfig{Name: vmName, CPUCount: 2, MemoryMB: 4096, State: "stopped"}
+
+	require.NoError(t, m.applyVMState(context.Background(), vmName, vmName, desired, current, "running"))
+
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 1, callCount,
+		"an unresolved (empty) owner must skip after exactly one call — no lifecycle writes")
+	assert.Equal(t, 0, countCmd(transport, psStartVM))
+	assert.Equal(t, 0, countCmd(transport, psSetVMProcessor))
+}
+
+// TestApplyVMState_OutOfScopeCluster_ErrorsWithoutTransport (#2422): an ha_role
+// naming a cluster outside the module's cluster_name scope cap (S5) fails LOUD
+// with ErrClusterNotDeclared and issues ZERO transport calls — the same
+// "no transport for an out-of-scope cluster" invariant clusterOwnershipHelper /
+// reconcileRoleMembership / getCluster enforce. A scope mismatch is a persistent
+// misconfiguration, not a transient probe failure, so it errors rather than
+// taking the fail-safe-quiet path.
+func TestApplyVMState_OutOfScopeCluster_ErrorsWithoutTransport(t *testing.T) {
+	const vmName = "ha-rogue-lifecycle-vm"
+
+	transport := &testWinRMTransport{} // any transport call is a violation
+	m := vmModuleWithTransport(transport, "t-2422")
+	m.nodeHostname = "NODE1"
+	m.clusterName = "lab-hv" // scope cap
+
+	desired := &VMConfig{
+		Name:     vmName,
+		CPUCount: 4,
+		MemoryMB: 8192,
+		HARole:   &HARoleConfig{ClusterName: "rogue-cluster"}, // out of scope
+	}
+	current := &VMConfig{Name: vmName, CPUCount: 2, MemoryMB: 4096, State: "stopped"}
+
+	err := m.applyVMState(context.Background(), vmName, vmName, desired, current, "running")
+	require.ErrorIs(t, err, ErrClusterNotDeclared,
+		"an out-of-scope ha_role.cluster_name must fail loud with the scope-cap sentinel")
+
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 0, callCount,
+		"the scope cap must reject before any transport call — no out-of-scope cluster query")
+}


### PR DESCRIPTION
## Summary

Gates all lifecycle convergence (storage move, NIC reconcile, promote/demote, resize, power) for an `ha_role` VM on cluster **role ownership**, at the top of `applyVMState`. A node that `readResourceOwners` affirmatively reports as a **different** owner than itself takes no lifecycle action and goes quiet (audited `vm-lifecycle-skip-not-owner`); the current owner converges instead. This makes the previous owner go silent immediately after a failover even when local `Get-VM` visibility transiently lags cluster-role ownership.

Fixes #2422 (epic #2418).

## Behavior

- **Different owner** → skip, `return nil`, zero write PS calls.
- **Missing owner entry** (role not yet registered — first-time promote of an existing standalone VM) → does NOT skip; local possession decides, so the promote path registers the role (founder ruling 2026-07-08).
- **Unresolved/empty owner** (mid-failover settle window) → fail-safe-quiet: every member reads `""` and waits, so no two nodes converge the same role at once; self-heals once ownership settles.
- **Standalone VM** (`desired.HARole == nil`) → block skipped entirely; zero added transport calls, zero behavior change.
- **Probe error** → fail-safe-quiet (skip cycle, warn, retry next tick) — deliberately unlike `#2421`'s fail-safe-loud create-time gate, because this runs on every convergence tick of every existing HA VM.
- **S5 scope cap** enforced before the transport call: an out-of-scope `ha_role.cluster_name` fails loud with `ErrClusterNotDeclared` and issues zero transport calls, matching `clusterOwnershipHelper` / `reconcileRoleMembership` / `getCluster`.

## Tests

New `vm_lifecycle_owner_gate_test.go`: non-owner-goes-quiet, owner-converges-normally (incl. first-time-promote), standalone-no-owner-query, probe-error-skips-quietly, unresolved-owner-goes-quiet, out-of-scope-cluster-errors-without-transport. Two existing exact-call-count HA-role tests updated for the one added ownership probe on the existing-VM path.

## Docs

`features/modules/hyperv/README.md`: owner-gated lifecycle + why (post-failover quiet-down), the promote procedure (founder ruling 2026-07-08), and the one-reporter rule (#2418).

## Review

Pre-PR adversarial review team (acceptance + QA + security) all PASS; 2 QA-blocking findings (missing S5 scope-cap check; a stale test sequence) were fixed and re-verified before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)