### PR TITLE
steward: compute heartbeat DNA hash from current state, not publish cache (Issue #2521)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1466,6 +1466,14 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 		"steward_id", logging.SanitizeLogValue(id.StewardID),
 		"transport_address", logging.SanitizeLogValue(id.TransportAddress))
 
+	// Populate currentDNAHash from a fresh collect so the first heartbeat after
+	// reconnect is never empty. The collector is available now; the module DNA
+	// source is wired in later (after InitializeConfigExecutor), but partial
+	// hardware-fact DNA is still a truthful, non-empty hash. (Issue #2521)
+	if err := transportClient.RefreshCurrentDNA(ctx); err != nil {
+		logger.Warn("Initial DNA refresh failed; first heartbeat DNA hash will be empty", "error", err)
+	}
+
 	if err := transportClient.SendHeartbeat(ctx, "healthy", nil); err != nil {
 		logger.Warn("Failed to send initial heartbeat after reconnect", "error", err)
 	}

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -158,9 +158,10 @@ type TransportClient struct {
 	secretStore secretsif.SecretStore
 
 	// DNA state for hash-based sync (Issue #418).
-	// dnaMu guards currentDNAHash and lastPublishedDNA.
+	// dnaMu guards currentDNAHash, currentDNAAttrs, and lastPublishedDNA.
 	dnaMu            sync.RWMutex
-	currentDNAHash   string            // SHA-256 hash of most-recently observed DNA
+	currentDNAHash   string            // SHA-256 hash of most-recently collected DNA (Issue #2521)
+	currentDNAAttrs  map[string]string // full enriched snapshot of most-recently collected DNA (Issue #2521)
 	lastPublishedDNA map[string]string // full DNA from the last PublishDNAUpdate call
 
 	// DNA refresh loop control (Issue #1915).
@@ -1169,11 +1170,14 @@ func (c *TransportClient) PublishDNAUpdate(ctx context.Context, dnaAttrs map[str
 	dnaAttrs = enriched
 
 	// Always update local DNA state first so the hash is available for heartbeats
-	// even when the control plane is temporarily unavailable.
+	// even when the control plane is temporarily unavailable. currentDNAAttrs and
+	// currentDNAHash track the freshest collected state; lastPublishedDNA tracks
+	// what has been sent to the controller for delta-compression. (Issue #2521)
 	c.dnaMu.Lock()
 	delta := computeDelta(c.lastPublishedDNA, dnaAttrs)
 	newHash := dna.ComputeHash(dnaAttrs)
 	c.lastPublishedDNA = copyStringMap(dnaAttrs)
+	c.currentDNAAttrs = copyStringMap(dnaAttrs)
 	c.currentDNAHash = newHash
 	c.dnaMu.Unlock()
 
@@ -1475,6 +1479,50 @@ func (c *TransportClient) triggerVersionConvergence(ctx context.Context, desired
 	}
 }
 
+// setCurrentDNAFromAttrs enriches raw collected attributes with the running
+// steward version, then atomically updates currentDNAAttrs and currentDNAHash
+// under dnaMu. It does not touch lastPublishedDNA, so heartbeat hash and
+// publish-delta state are tracked independently. (Issue #2521)
+func (c *TransportClient) setCurrentDNAFromAttrs(attrs map[string]string) {
+	enriched := make(map[string]string, len(attrs)+1)
+	for k, v := range attrs {
+		enriched[k] = v
+	}
+	enriched["steward.version"] = version.Short()
+	hash := dna.ComputeHash(enriched)
+	c.dnaMu.Lock()
+	c.currentDNAAttrs = enriched
+	c.currentDNAHash = hash
+	c.dnaMu.Unlock()
+}
+
+// RefreshCurrentDNA collects the current DNA attributes from the configured
+// DNACollector and updates currentDNAHash so the next heartbeat carries a
+// truthful, non-empty hash. It does not publish a delta to the controller.
+//
+// This is called by the reconnect path (tryReconnectWithStoredIdentity) before
+// the first SendHeartbeat so the steward never reports an empty hash immediately
+// after a reconnect. (Issue #2521)
+func (c *TransportClient) RefreshCurrentDNA(ctx context.Context) error {
+	c.mu.RLock()
+	collector := c.dnaCollector
+	c.mu.RUnlock()
+
+	if collector == nil {
+		return nil
+	}
+
+	attrs, err := collector.CollectAttributes(ctx)
+	if err != nil {
+		return fmt.Errorf("DNA collection failed: %w", err)
+	}
+	if len(attrs) == 0 {
+		return nil
+	}
+	c.setCurrentDNAFromAttrs(attrs)
+	return nil
+}
+
 // StartDNARefreshLoop starts a background goroutine that re-collects system DNA
 // attributes on the configured interval and publishes delta updates to the
 // controller when at least one attribute value has changed.
@@ -1521,6 +1569,9 @@ func (c *TransportClient) StartDNARefreshLoop(ctx context.Context) {
 				if len(attrs) == 0 {
 					continue
 				}
+				// Always refresh the current snapshot so heartbeats carry a
+				// truthful hash even when no delta is published. (Issue #2521)
+				c.setCurrentDNAFromAttrs(attrs)
 				if err := c.PublishDNAUpdate(ctx, attrs, "", ""); err != nil {
 					c.logger.Warn("DNA refresh publish failed", "error", err)
 				}

--- a/features/steward/client/client_transport_dna_test.go
+++ b/features/steward/client/client_transport_dna_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	dna "github.com/cfgis/cfgms/features/steward/dna"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	dataplaneInterfaces "github.com/cfgis/cfgms/pkg/dataplane/interfaces"
 	dpTypes "github.com/cfgis/cfgms/pkg/dataplane/types"
@@ -533,6 +534,145 @@ func TestDNARefreshLoop_CollectorErrorSkipsTick(t *testing.T) {
 
 	assert.Equal(t, 1, q.Len(),
 		"loop must continue after a collection error and publish when a change is detected")
+}
+
+// ---------------------------------------------------------------------------
+// RefreshCurrentDNA — Issue #2521
+// ---------------------------------------------------------------------------
+
+// TestRefreshCurrentDNA_PopulatesHashAfterReconnect asserts the required AC:
+// a freshly-created TransportClient (zero currentDNAHash, nil lastPublishedDNA)
+// reports a correct, non-empty DNAHash on its first heartbeat once
+// RefreshCurrentDNA is called — matching what dna.ComputeHash would produce
+// over the same freshly-collected attribute set.
+func TestRefreshCurrentDNA_PopulatesHashAfterReconnect(t *testing.T) {
+	c := newMinimalClient(t)
+
+	rawAttrs := map[string]string{"hostname": "machine-1", "os": "linux", "arch": "amd64"}
+	stub := &stubDNACollector{attrs: rawAttrs}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	// Pre-condition: no hash before the collect.
+	c.dnaMu.RLock()
+	assert.Empty(t, c.currentDNAHash, "currentDNAHash must be empty on a fresh client")
+	c.dnaMu.RUnlock()
+
+	require.NoError(t, c.RefreshCurrentDNA(context.Background()))
+
+	// Compute the expected hash the same way RefreshCurrentDNA should — enrich
+	// with steward.version then feed to dna.ComputeHash.
+	enriched := make(map[string]string, len(rawAttrs)+1)
+	for k, v := range rawAttrs {
+		enriched[k] = v
+	}
+	enriched["steward.version"] = version.Short()
+	wantHash := dna.ComputeHash(enriched)
+
+	c.dnaMu.RLock()
+	gotHash := c.currentDNAHash
+	c.dnaMu.RUnlock()
+
+	require.NotEmpty(t, gotHash, "currentDNAHash must be non-empty after RefreshCurrentDNA")
+	assert.Equal(t, wantHash, gotHash,
+		"currentDNAHash must equal dna.ComputeHash of the collected+enriched attributes")
+}
+
+// TestCurrentDNAHash_StableWhenUnchangedChangesOnDrift asserts the required AC:
+// the reported hash is stable across heartbeats when machine state is unchanged,
+// and changes when a collected attribute changes — consistent with
+// dna.ComputeHash determinism.
+func TestCurrentDNAHash_StableWhenUnchangedChangesOnDrift(t *testing.T) {
+	c := newMinimalClient(t)
+
+	attrs := map[string]string{"hostname": "box-1", "os": "linux"}
+	stub := &stubDNACollector{attrs: attrs}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	// Collect N times with unchanged state — hash must be identical each time.
+	const rounds = 3
+	var hashes [rounds]string
+	for i := 0; i < rounds; i++ {
+		require.NoError(t, c.RefreshCurrentDNA(context.Background()))
+		c.dnaMu.RLock()
+		hashes[i] = c.currentDNAHash
+		c.dnaMu.RUnlock()
+	}
+	require.NotEmpty(t, hashes[0], "hash must be non-empty after first collect")
+	for i := 1; i < rounds; i++ {
+		assert.Equal(t, hashes[0], hashes[i],
+			"hash must be stable across repeated collects when attributes are unchanged")
+	}
+
+	// Mutate an attribute — hash must change on the next collect.
+	stub.setAttrs(map[string]string{"hostname": "box-2", "os": "linux"})
+	require.NoError(t, c.RefreshCurrentDNA(context.Background()))
+
+	c.dnaMu.RLock()
+	changedHash := c.currentDNAHash
+	c.dnaMu.RUnlock()
+
+	assert.NotEqual(t, hashes[0], changedHash,
+		"hash must change when a collected attribute value changes")
+}
+
+// TestRefreshCurrentDNA_CollectorErrorPropagates asserts that when the collector
+// returns an error, RefreshCurrentDNA wraps it as "DNA collection failed: %w" and
+// leaves currentDNAHash untouched (no partial state is written on the error path).
+func TestRefreshCurrentDNA_CollectorErrorPropagates(t *testing.T) {
+	c := newMinimalClient(t)
+
+	collectErr := errors.New("transient")
+	stub := &stubDNACollector{err: collectErr}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	err := c.RefreshCurrentDNA(context.Background())
+
+	require.Error(t, err, "RefreshCurrentDNA must return the collection error")
+	assert.ErrorIs(t, err, collectErr, "returned error must wrap the underlying collector error")
+	assert.Contains(t, err.Error(), "DNA collection failed",
+		"returned error must carry the DNA collection failure context")
+
+	c.dnaMu.RLock()
+	gotHash := c.currentDNAHash
+	c.dnaMu.RUnlock()
+	assert.Empty(t, gotHash, "currentDNAHash must not be mutated when collection fails")
+}
+
+// TestRefreshCurrentDNA_EmptyAttrsLeavesHashUnchanged asserts that when the
+// collector returns an empty attribute map, RefreshCurrentDNA returns nil without
+// mutating currentDNAHash — so a transient empty collect cannot clobber a known
+// good hash.
+func TestRefreshCurrentDNA_EmptyAttrsLeavesHashUnchanged(t *testing.T) {
+	c := newMinimalClient(t)
+
+	stub := &stubDNACollector{attrs: map[string]string{"hostname": "box-1", "os": "linux"}}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	// Establish a known-good hash from a non-empty collect.
+	require.NoError(t, c.RefreshCurrentDNA(context.Background()))
+	c.dnaMu.RLock()
+	seededHash := c.currentDNAHash
+	c.dnaMu.RUnlock()
+	require.NotEmpty(t, seededHash, "hash must be seeded by the initial non-empty collect")
+
+	// Now return an empty map — RefreshCurrentDNA must no-op the hash.
+	stub.setAttrs(map[string]string{})
+	require.NoError(t, c.RefreshCurrentDNA(context.Background()),
+		"an empty collect must not be treated as an error")
+
+	c.dnaMu.RLock()
+	afterHash := c.currentDNAHash
+	c.dnaMu.RUnlock()
+	assert.Equal(t, seededHash, afterHash,
+		"currentDNAHash must be unchanged when the collector returns an empty map")
 }
 
 // TestStartDNARefreshLoop_NilCollectorWarns verifies that StartDNARefreshLoop


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `currentDNAHash` was only updated inside `PublishDNAUpdate`. A reconnecting steward had an empty DNA hash on all heartbeats until the refresh loop ticked or a config apply triggered a publish, defeating controller-side reconciliation.
- **Decoupled hash from publish**: Added `setCurrentDNAFromAttrs` (internal) and `RefreshCurrentDNA` (exported) to update `currentDNAHash` from a fresh collect without publishing a delta. The reconnect path (`tryReconnectWithStoredIdentity`) now calls `RefreshCurrentDNA` before the first `SendHeartbeat`.
- **Snapshot foundation for #2522**: Added `currentDNAAttrs map[string]string` field (guarded by `dnaMu`) that both `setCurrentDNAFromAttrs` and `PublishDNAUpdate` keep current — the full-sync handler in Issue #2522 can read from it without a re-collect.
- **Refresh loop**: `StartDNARefreshLoop` now calls `setCurrentDNAFromAttrs` on every successful collect tick before `PublishDNAUpdate`, so the hash stays current even on no-delta ticks.
- **Delta compression unchanged**: `PublishDNAUpdate` still computes and sends only changed attributes.

## Test plan

- [x] `TestRefreshCurrentDNA_PopulatesHashAfterReconnect` — reconnect with zero `lastPublishedDNA` and zero `currentDNAHash`; after `RefreshCurrentDNA`, hash equals `dna.ComputeHash(collected+enriched)` and is non-empty
- [x] `TestCurrentDNAHash_StableWhenUnchangedChangesOnDrift` — three collects with same attrs → identical hash; mutated attr → new hash
- [x] All existing DNA refresh loop tests pass (no regression to delta-publish path)
- [x] `go test ./features/steward/client/... ./cmd/steward/...` — all pass
- [x] Adversarial review workflow: **passed** (2 review rounds, 1 fix round, 0 remaining findings)

## Specialist review results

| Reviewer | Result |
|----------|--------|
| Code Review | PASS (round 2 after fix) |
| Test Quality | PASS |
| Security | PASS |

Fixes #2521

🤖 Generated with [Claude Code](https://claude.ai/claude-code)