### PR TITLE
launcher: detect and self-repair a deleted Windows service registration (Issue #2465)

### DIFF
--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -71,7 +71,24 @@ type Supervisor struct {
 	// <Root>/versions/ after each successful (committed) startup.
 	// Zero value means no pruning occurs.
 	RetentionPolicy RetentionPolicy
+
+	// ServiceRepairInterval is the cadence of the dedicated SCM
+	// service-registration self-repair ticker (#2465), independent of the
+	// supervised child's exit/restart cadence. Zero uses
+	// defaultServiceRepairInterval. Tests set a short interval to drive the
+	// check quickly.
+	ServiceRepairInterval time.Duration
 }
+
+// defaultServiceRepairInterval is the production cadence of the SCM
+// service-registration self-repair check (#2465). It is set at or tighter than
+// the fastest install-time SCM recovery-action delay (10s — see
+// cmd/steward/service/manager_windows.go's SetRecoveryActions) so a repair can
+// plausibly land before or alongside the SCM's own first restart attempt. It is
+// deliberately NOT gated on supervise-loop iterations: execOnce blocks for the
+// full child lifetime (days/weeks for a stable steward), so a per-iteration
+// cadence would leave a deleted registration undetected for that entire span.
+const defaultServiceRepairInterval = 10 * time.Second
 
 type clock interface {
 	Now() time.Time
@@ -82,6 +99,30 @@ type realClock struct{}
 
 func (realClock) Now() time.Time                  { return time.Now() }
 func (realClock) Since(t time.Time) time.Duration { return time.Since(t) }
+
+// runServiceRegistrationRepair runs check on its own ticker until ctx is
+// cancelled. Supervise launches it in a goroutine so the SCM
+// service-registration self-repair (#2465) runs independent of the supervised
+// child's exit/restart cadence. check is maybeRepairServiceRegistration in
+// production (a no-op on non-Windows); tests inject a check bound to a unique
+// throwaway service so they never touch the host's real registration. Uses a
+// real time.Ticker, not s.clock, because the repair cadence is wall-clock
+// (SCM recovery timing), not the injectable child-lifecycle clock.
+func (s *Supervisor) runServiceRegistrationRepair(ctx context.Context, interval time.Duration, check func(io.Writer)) {
+	if check == nil || interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			check(s.Stderr)
+		}
+	}
+}
 
 // Supervise runs the supervision loop until ctx is cancelled, the child
 // exits normally without triggering rollback, or all rollback attempts are
@@ -105,6 +146,21 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 	if s.MaxRollbackCycles < 0 {
 		s.MaxRollbackCycles = 0
 	}
+
+	// Start the SCM service-registration self-repair ticker (#2465) BEFORE the
+	// supervise loop. It runs in its own goroutine on its own ticker, fully
+	// decoupled from execOnce's blocking child lifecycle, so a registration
+	// deleted out from under a long-running healthy steward is detected and
+	// re-created within one interval rather than not until the next child exit.
+	// repairCtx is cancelled when Supervise returns (any path), stopping the
+	// goroutine. maybeRepairServiceRegistration is a no-op on non-Windows builds.
+	repairInterval := s.ServiceRepairInterval
+	if repairInterval <= 0 {
+		repairInterval = defaultServiceRepairInterval
+	}
+	repairCtx, cancelRepair := context.WithCancel(ctx)
+	defer cancelRepair()
+	go s.runServiceRegistrationRepair(repairCtx, repairInterval, maybeRepairServiceRegistration)
 
 	rollbacksRemaining := s.MaxRollbackCycles
 	for {

--- a/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -306,26 +307,55 @@ func TestSupervise_RepairsMissingServiceRegistration(t *testing.T) {
 	require.False(t, ok, "precondition: registration deleted")
 
 	// Run the repair ticker on a short interval, targeting the test service.
-	var buf bytes.Buffer
-	sup := &Supervisor{Stderr: &buf}
+	// buf is mutex-guarded because the ticker goroutine writes to it concurrently
+	// with the assertion read below; repaired signals once the per-tick action has
+	// both re-created the registration AND written its event, establishing a
+	// happens-before edge so the read after <-repaired sees the completed write.
+	buf := &syncBuffer{}
+	sup := &Supervisor{Stderr: buf}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	repaired := make(chan struct{}, 1)
 	go sup.runServiceRegistrationRepair(ctx, 100*time.Millisecond, func(w io.Writer) {
 		repairServiceIfMissing(w, name, testRepairExePath, nil)
+		if ok, err := serviceRegistrationOK(name); err == nil && ok {
+			select {
+			case repaired <- struct{}{}:
+			default:
+			}
+		}
 	})
 
-	// Within a few intervals the registration must be back.
-	deadline := time.Now().Add(3 * time.Second)
-	recreated := false
-	for time.Now().Before(deadline) {
-		if ok, err := serviceRegistrationOK(name); err == nil && ok {
-			recreated = true
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
+	select {
+	case <-repaired:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the supervise repair ticker did not re-create the deleted registration within 3s")
 	}
 	cancel()
-	require.True(t, recreated, "the supervise repair ticker must re-create the deleted registration within one interval")
+
+	ok, err = serviceRegistrationOK(name)
+	require.NoError(t, err)
+	require.True(t, ok, "registration must exist after the repair ticker ran")
 	assert.Contains(t, buf.String(), "event=service_registration_repaired",
 		"the repair must emit a greppable structured event")
+}
+
+// syncBuffer is a minimal mutex-guarded io.Writer for tests that read a buffer
+// written by a background goroutine — avoids the data race a bare bytes.Buffer
+// would incur under `go test -race`.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
@@ -6,6 +6,9 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,8 +17,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
 )
 
 // TestWindowsServiceHandler_TerminalFailure_ReportsServiceSpecificExitCode
@@ -34,8 +39,9 @@ import (
 //     exhausts rollback budget and the launcher process exits.
 //
 // Expected Win32_Service state after terminal failure:
-//   ExitCode:        ERROR_SERVICE_SPECIFIC_ERROR (1066)
-//   ServiceExitCode: the launcher's own exit code (1 for supervise error)
+//
+//	ExitCode:        ERROR_SERVICE_SPECIFIC_ERROR (1066)
+//	ServiceExitCode: the launcher's own exit code (1 for supervise error)
 func TestWindowsServiceHandler_TerminalFailure_ReportsServiceSpecificExitCode(t *testing.T) {
 	// Empty root with no current version: Supervise returns an error immediately.
 	root := t.TempDir()
@@ -51,11 +57,11 @@ func TestWindowsServiceHandler_TerminalFailure_ReportsServiceSpecificExitCode(t 
 	svcSpecific, exitCode := h.Execute(nil, r, status)
 
 	if !svcSpecific {
-		t.Errorf("Execute returned svcSpecificEC=false on terminal failure; want true so SCM "+
+		t.Errorf("Execute returned svcSpecificEC=false on terminal failure; want true so SCM " +
 			"records ERROR_SERVICE_SPECIFIC_ERROR and applies recovery actions (AC5)")
 	}
 	if exitCode == 0 {
-		t.Errorf("Execute returned exitCode=0 on terminal failure; want non-zero so "+
+		t.Errorf("Execute returned exitCode=0 on terminal failure; want non-zero so " +
 			"Win32_Service.ExitCode is non-zero and SCM recovery fires (AC5)")
 	}
 }
@@ -122,7 +128,7 @@ sendStop:
 	select {
 	case res := <-resultCh:
 		if res.svcSpecific {
-			t.Errorf("Execute returned svcSpecificEC=true on admin Stop; "+
+			t.Errorf("Execute returned svcSpecificEC=true on admin Stop; " +
 				"must be false (clean stop, no SCM recovery) (AC5)")
 		}
 	case <-time.After(15 * time.Second):
@@ -269,4 +275,57 @@ func runOuterLauncher() {
 	// while the supervised steward is still running. The Job Object's
 	// kill-on-close limit is the only thing that can cull the child.
 	os.Exit(2)
+}
+
+// TestSupervise_RepairsMissingServiceRegistration (REQUIRED, #2465): the
+// dedicated repair ticker the supervise loop launches (runServiceRegistrationRepair)
+// re-creates a service registration that is deleted mid-flight, within one check
+// interval, and logs a greppable self-repair event.
+//
+// It drives runServiceRegistrationRepair directly with the real per-tick action
+// (repairServiceIfMissing) bound to a UNIQUE throwaway service — not via a full
+// Supervise() run, which would need a live steward child, and not against the
+// real CFGMSSteward name, which would delete the host's running steward. This is
+// the exact goroutine + per-tick function Supervise wires in production.
+func TestSupervise_RepairsMissingServiceRegistration(t *testing.T) {
+	scm := requireSCM(t)
+	name := uniqueTestServiceName(t)
+
+	// Create the service, then delete it out from under us — the incident's
+	// "AV remediation deleted the registration" failure mode.
+	s, err := scm.CreateService(name, testRepairExePath, mgr.Config{StartType: mgr.StartAutomatic})
+	require.NoError(t, err)
+	s.Close()
+	existing, err := scm.OpenService(name)
+	require.NoError(t, err)
+	require.NoError(t, existing.Delete())
+	existing.Close()
+
+	ok, err := serviceRegistrationOK(name)
+	require.NoError(t, err)
+	require.False(t, ok, "precondition: registration deleted")
+
+	// Run the repair ticker on a short interval, targeting the test service.
+	var buf bytes.Buffer
+	sup := &Supervisor{Stderr: &buf}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.runServiceRegistrationRepair(ctx, 100*time.Millisecond, func(w io.Writer) {
+		repairServiceIfMissing(w, name, testRepairExePath, nil)
+	})
+
+	// Within a few intervals the registration must be back.
+	deadline := time.Now().Add(3 * time.Second)
+	recreated := false
+	for time.Now().Before(deadline) {
+		if ok, err := serviceRegistrationOK(name); err == nil && ok {
+			recreated = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	cancel()
+	require.True(t, recreated, "the supervise repair ticker must re-create the deleted registration within one interval")
+	assert.Contains(t, buf.String(), "event=service_registration_repaired",
+		"the repair must emit a greppable structured event")
 }

--- a/cmd/cfgms-steward-launcher/service_check_other.go
+++ b/cmd/cfgms-steward-launcher/service_check_other.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package main
+
+import "io"
+
+// maybeRepairServiceRegistration is a no-op on non-Windows platforms. The SCM
+// service-registration self-repair (#2465) targets the Windows Service Control
+// Manager, which has no equivalent on Linux/macOS (systemd/launchd units are
+// managed differently and were not the incident's failure mode). The supervise
+// loop calls this unconditionally; keeping the platform split here mirrors the
+// attachChildToJobObject pattern (lifecycle_posix.go / lifecycle_windows.go),
+// so lifecycle.go needs no runtime.GOOS check at the call site.
+func maybeRepairServiceRegistration(w io.Writer) { _ = w }

--- a/cmd/cfgms-steward-launcher/service_check_windows.go
+++ b/cmd/cfgms-steward-launcher/service_check_windows.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
@@ -127,7 +128,21 @@ func repairServiceRegistration(name, exePath string, args []string) error {
 // re-creates the service from the currently-running process's own arguments
 // (os.Args[1:]) so a repaired service starts with the same
 // --root/--child-args/--regtoken the operator originally configured.
+//
+// It acts ONLY when this process is actually running AS the CFGMSSteward SCM
+// service. An interactive `launcher run` or a unit-test binary is not the
+// service and must never CreateService against the real service name — so the
+// IsWindowsService gate no-ops there. This is both semantically correct
+// (self-repairing your own SCM registration only makes sense when you ARE that
+// service) and the test-isolation guard that keeps every Supervise()-driven
+// unit test on an elevated CI host from touching the real registration.
+// IsWindowsService stays true for the running process even after the
+// registration is deleted (the process was SCM-started; deleting the entry does
+// not re-parent it), so the repair scenario itself is unaffected.
 func maybeRepairServiceRegistration(w io.Writer) {
+	if isSvc, err := svc.IsWindowsService(); err != nil || !isSvc {
+		return
+	}
 	repairServiceIfMissing(w, launcherServiceName, launcherServiceExePath, os.Args[1:])
 }
 
@@ -140,10 +155,15 @@ func maybeRepairServiceRegistration(w io.Writer) {
 func repairServiceIfMissing(w io.Writer, name, exePath string, args []string) {
 	ok, err := serviceRegistrationOK(name)
 	if err != nil {
-		// Cannot determine ownership of the registration this tick (usually a
-		// non-elevated/standalone run where mgr.Connect is denied — the service
-		// normally runs as LocalSystem where it succeeds). Skip quietly and
-		// retry next tick rather than spam a benign, known-transient condition.
+		// The production caller (maybeRepairServiceRegistration) only reaches
+		// here when running AS the elevated SCM service, so a check error is a
+		// genuine SCM fault — not the benign non-elevated case, which the
+		// IsWindowsService gate already filtered out. Surface it (the self-repair
+		// path's own health is otherwise invisible), then skip and retry next
+		// tick. If it recurs every tick that is itself the signal of a persistent
+		// SCM problem worth seeing in C:\ProgramData\cfgms\logs.
+		_, _ = fmt.Fprintf(w, "launcher: WARN could not check service registration "+
+			"[event=service_registration_check_failed service=%s error=%v]\n", name, err)
 		return
 	}
 	if ok {

--- a/cmd/cfgms-steward-launcher/service_check_windows.go
+++ b/cmd/cfgms-steward-launcher/service_check_windows.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// Self-repair of a deleted SCM service registration (#2465).
+//
+// Observed live 2026-07-08 (epic #565 runner scale-out): an AV product
+// quarantined the launcher binary and, as "remediation", DELETED the
+// CFGMSSteward service registration out from under the still-running launcher.
+// The SCM's install-time restart recovery actions cannot help — they only fire
+// when a service entry still exists to restart. With the registration gone the
+// steward is silently and permanently dead until the next manual reinstall.
+//
+// This is the missing detect-and-recreate loop: the supervise loop runs a
+// dedicated ticker (see runServiceRegistrationRepair in lifecycle.go) that, on
+// every tick, verifies CFGMSSteward still exists in the SCM and re-creates it
+// with the same binary path, start type, and recovery actions as the original
+// Install path if it does not.
+
+const (
+	// launcherServiceName MUST stay in sync with windowsServiceName in
+	// cmd/steward/service/manager_windows.go — the SCM registration the install
+	// path creates and this self-repair path re-creates are the same service.
+	launcherServiceName = "CFGMSSteward"
+	// launcherServiceExePath MUST stay in sync with windowsLauncherPath in
+	// cmd/steward/service/manager_windows.go. The steward's push-upgrade handler
+	// execs the launcher at this exact compile-time path, so a repaired service
+	// must point HERE — never at os.Args[0], which may be a temp/staged path when
+	// the running process was launched from somewhere other than the install dir.
+	launcherServiceExePath = `C:\Program Files\CFGMS\cfgms-steward-launcher.exe`
+	// launcherServiceDisplayName / launcherServiceDescription MUST stay in sync
+	// with windowsDisplayName / windowsDescription in manager_windows.go.
+	launcherServiceDisplayName = "CFGMS Steward"
+	launcherServiceDescription = "CFGMS endpoint configuration management agent"
+)
+
+// serviceRegistrationOK reports whether the named service still exists in the
+// SCM. It returns (false, nil) — a definite "missing", the repair trigger —
+// only when the SCM answers ERROR_SERVICE_DOES_NOT_EXIST. Any other error
+// (cannot connect to the SCM in a non-elevated context, a transient RPC fault)
+// is returned as (false, err) so the caller SKIPS this tick rather than
+// attempting a recreate it could not complete — recreating on an access error
+// would just fail. This is a more precise sentinel match than Uninstall's
+// catch-all in manager_windows.go:303, deliberately, because here a false
+// "missing" verdict would issue a needless CreateService.
+func serviceRegistrationOK(name string) (bool, error) {
+	scm, err := mgr.Connect()
+	if err != nil {
+		return false, fmt.Errorf("connect SCM: %w", err)
+	}
+	defer scm.Disconnect()
+
+	svc, err := scm.OpenService(name)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+			return false, nil
+		}
+		return false, fmt.Errorf("open service %q: %w", name, err)
+	}
+	svc.Close()
+	return true, nil
+}
+
+// repairServiceRegistration re-creates a deleted service registration with the
+// SAME mgr.Config shape and SetRecoveryActions call the install path uses
+// (cmd/steward/service/manager_windows.go:224-261). The literal is duplicated
+// here rather than shared via an exported helper: factoring it out would make
+// this launcher command import cmd/steward/service (a new cmd→cmd dependency —
+// today only cmd/steward/main.go imports that package), which is more invasive
+// than the ~10-line duplication for a story this size. The const comments above
+// call out the fields that MUST stay in sync.
+//
+// name is a parameter (not the launcherServiceName const) so tests can exercise
+// this against a unique throwaway service without ever touching the host's real
+// CFGMSSteward registration.
+func repairServiceRegistration(name, exePath string, args []string) error {
+	scm, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect SCM: %w", err)
+	}
+	defer scm.Disconnect()
+
+	newSvc, err := scm.CreateService(
+		name,
+		exePath,
+		mgr.Config{
+			StartType:   mgr.StartAutomatic,
+			DisplayName: launcherServiceDisplayName,
+			Description: launcherServiceDescription,
+		},
+		args...,
+	)
+	if err != nil {
+		return fmt.Errorf("create service %q: %w", name, err)
+	}
+	defer newSvc.Close()
+
+	// Same recovery policy as install: 3 escalating restart delays, 1-day reset.
+	recoveryActions := []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 30 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+	}
+	if err := newSvc.SetRecoveryActions(recoveryActions, 86400); err != nil {
+		return fmt.Errorf("set recovery actions for %q: %w", name, err)
+	}
+	return nil
+}
+
+// maybeRepairServiceRegistration is the per-tick action of the supervise loop's
+// repair ticker (runServiceRegistrationRepair). It targets the production
+// CFGMSSteward registration and the launcher's own known install path, and
+// re-creates the service from the currently-running process's own arguments
+// (os.Args[1:]) so a repaired service starts with the same
+// --root/--child-args/--regtoken the operator originally configured.
+func maybeRepairServiceRegistration(w io.Writer) {
+	repairServiceIfMissing(w, launcherServiceName, launcherServiceExePath, os.Args[1:])
+}
+
+// repairServiceIfMissing is the parameterized core of the per-tick check so it
+// can be driven against a unique test service. A repair FAILURE is logged
+// loudly-but-non-fatally and the loop continues: the running steward child is
+// unaffected by a missing SCM entry until the next reboot, so preserving the
+// current (bad but not worse) state beats crashing the supervisor. A repair
+// SUCCESS logs a greppable event so it surfaces in C:\ProgramData\cfgms\logs.
+func repairServiceIfMissing(w io.Writer, name, exePath string, args []string) {
+	ok, err := serviceRegistrationOK(name)
+	if err != nil {
+		// Cannot determine ownership of the registration this tick (usually a
+		// non-elevated/standalone run where mgr.Connect is denied — the service
+		// normally runs as LocalSystem where it succeeds). Skip quietly and
+		// retry next tick rather than spam a benign, known-transient condition.
+		return
+	}
+	if ok {
+		return
+	}
+	if repairErr := repairServiceRegistration(name, exePath, args); repairErr != nil {
+		_, _ = fmt.Fprintf(w, "launcher: WARN service registration repair FAILED "+
+			"[event=service_registration_repair_failed service=%s error=%v]\n", name, repairErr)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "launcher: WARN service registration was deleted — re-created SCM entry "+
+		"[event=service_registration_repaired service=%s path=%s]\n", name, exePath)
+}

--- a/cmd/cfgms-steward-launcher/service_check_windows_test.go
+++ b/cmd/cfgms-steward-launcher/service_check_windows_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// These tests exercise the real Windows Service Control Manager (CLAUDE.md
+// forbids mocks). Creating/deleting a service requires Administrator, so they
+// skip when the process is not elevated — the same mgr.Connect()-succeeds gate
+// cmd/steward/service's windowsManager.IsElevated uses. They ALWAYS operate on
+// a unique throwaway service name, never the real CFGMSSteward registration, so
+// a run on the live lab host cannot disturb the running steward.
+
+// requireSCM skips the test when the SCM is not writable (non-elevated), and
+// otherwise returns a connected manager closed at test end.
+func requireSCM(t *testing.T) *mgr.Mgr {
+	t.Helper()
+	scm, err := mgr.Connect()
+	if err != nil {
+		t.Skipf("skipping — requires Administrator (SCM connect failed: %v)", err)
+	}
+	t.Cleanup(func() { _ = scm.Disconnect() })
+	return scm
+}
+
+// uniqueTestServiceName returns a throwaway service name distinct from the real
+// CFGMSSteward registration and scoped to this test so parallel packages can't
+// collide. It also registers cleanup that force-deletes the service if a test
+// leaves it behind.
+func uniqueTestServiceName(t *testing.T) string {
+	t.Helper()
+	name := fmt.Sprintf("CFGMSSelfRepairTest_%d_%s", os.Getpid(), t.Name())
+	// Sanitize: service names may not contain '/' (t.Name() uses it for subtests).
+	safe := make([]rune, 0, len(name))
+	for _, r := range name {
+		if r == '/' || r == ' ' {
+			r = '_'
+		}
+		safe = append(safe, r)
+	}
+	name = string(safe)
+	t.Cleanup(func() { deleteServiceIfPresent(name) })
+	return name
+}
+
+// deleteServiceIfPresent removes a service if it exists, ignoring all errors —
+// used only for test cleanup.
+func deleteServiceIfPresent(name string) {
+	scm, err := mgr.Connect()
+	if err != nil {
+		return
+	}
+	defer scm.Disconnect()
+	s, err := scm.OpenService(name)
+	if err != nil {
+		return
+	}
+	defer s.Close()
+	_ = s.Delete()
+}
+
+const testRepairExePath = `C:\Program Files\CFGMS\cfgms-steward-launcher.exe`
+
+// TestServiceRegistrationOK_DetectsMissingService (REQUIRED, #2465): the check
+// reports true while the service exists and (false, nil) — the definite
+// "missing" verdict — after it is deleted.
+func TestServiceRegistrationOK_DetectsMissingService(t *testing.T) {
+	scm := requireSCM(t)
+	name := uniqueTestServiceName(t)
+
+	// Absent to start with → (false, nil).
+	ok, err := serviceRegistrationOK(name)
+	require.NoError(t, err)
+	assert.False(t, ok, "a never-created service must read as missing")
+
+	// Create it → present → (true, nil).
+	s, err := scm.CreateService(name, testRepairExePath, mgr.Config{StartType: mgr.StartAutomatic})
+	require.NoError(t, err)
+	s.Close()
+
+	ok, err = serviceRegistrationOK(name)
+	require.NoError(t, err)
+	assert.True(t, ok, "an existing service must read as present")
+
+	// Delete it → missing again → (false, nil).
+	existing, err := scm.OpenService(name)
+	require.NoError(t, err)
+	require.NoError(t, existing.Delete())
+	existing.Close()
+
+	ok, err = serviceRegistrationOK(name)
+	require.NoError(t, err)
+	assert.False(t, ok, "a deleted service must read as missing (the repair trigger)")
+}
+
+// TestRepairServiceRegistration_RecreatesService (REQUIRED, #2465): recreate a
+// missing registration with the same start type, binary path, args, and
+// recovery actions as the install path.
+func TestRepairServiceRegistration_RecreatesService(t *testing.T) {
+	requireSCM(t)
+	name := uniqueTestServiceName(t)
+
+	// Precondition: absent.
+	ok, err := serviceRegistrationOK(name)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	args := []string{"run", "--root", `C:\Program Files\CFGMS`, "--child-args", "--regtoken abc"}
+	require.NoError(t, repairServiceRegistration(name, testRepairExePath, args))
+
+	// Now present with the expected config.
+	scm, err := mgr.Connect()
+	require.NoError(t, err)
+	defer scm.Disconnect()
+	s, err := scm.OpenService(name)
+	require.NoError(t, err, "repaired service must exist")
+	defer s.Close()
+
+	cfg, err := s.Config()
+	require.NoError(t, err)
+	assert.Equal(t, mgr.StartAutomatic, cfg.StartType, "start type must match install")
+	assert.Equal(t, launcherServiceDisplayName, cfg.DisplayName)
+	assert.Equal(t, launcherServiceDescription, cfg.Description)
+	assert.Contains(t, cfg.BinaryPathName, testRepairExePath,
+		"repaired service must point at the launcher install path")
+	assert.Contains(t, cfg.BinaryPathName, "--regtoken abc",
+		"repaired service must carry the original launcher args")
+
+	recovery, err := s.RecoveryActions()
+	require.NoError(t, err)
+	require.Len(t, recovery, 3, "install-parity recovery actions (3 escalating restarts)")
+	assert.Equal(t, mgr.ServiceRestart, recovery[0].Type)
+}

--- a/cmd/cfgms-steward-launcher/service_check_windows_test.go
+++ b/cmd/cfgms-steward-launcher/service_check_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -140,5 +141,31 @@ func TestRepairServiceRegistration_RecreatesService(t *testing.T) {
 	recovery, err := s.RecoveryActions()
 	require.NoError(t, err)
 	require.Len(t, recovery, 3, "install-parity recovery actions (3 escalating restarts)")
+	// Full parity with cmd/steward/service/manager_windows.go:254-256 — same
+	// action type and the same escalating 10s/30s/60s delays.
 	assert.Equal(t, mgr.ServiceRestart, recovery[0].Type)
+	assert.Equal(t, mgr.ServiceRestart, recovery[1].Type)
+	assert.Equal(t, mgr.ServiceRestart, recovery[2].Type)
+	assert.Equal(t, 10*time.Second, recovery[0].Delay)
+	assert.Equal(t, 30*time.Second, recovery[1].Delay)
+	assert.Equal(t, 60*time.Second, recovery[2].Delay)
+}
+
+// TestRepairServiceRegistration_ErrorsOnConflict (#2465): repairServiceRegistration
+// surfaces a CreateService failure as an error (rather than swallowing it) — the
+// error that drives the event=service_registration_repair_failed WARN log in the
+// per-tick repairServiceIfMissing path. Induced with a real name collision, since
+// the no-mock rule rules out faulting the SCM directly.
+func TestRepairServiceRegistration_ErrorsOnConflict(t *testing.T) {
+	scm := requireSCM(t)
+	name := uniqueTestServiceName(t)
+
+	// Pre-create the service so a second create collides.
+	s, err := scm.CreateService(name, testRepairExePath, mgr.Config{StartType: mgr.StartAutomatic})
+	require.NoError(t, err)
+	s.Close()
+
+	err = repairServiceRegistration(name, testRepairExePath, nil)
+	require.Error(t, err, "recreating an already-existing service must return an error, not silently succeed")
+	assert.Contains(t, err.Error(), "create service", "the error must identify the failed CreateService step")
 }

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -44,6 +44,30 @@ modules when the controller is unreachable — it never falls back to `bypass`.
 An unloadable or tampered cert store triggers re-registration or stop, not a
 degraded-but-trusted continue.
 
+#### Windows service-registration self-repair (#2465)
+
+On Windows the launcher supervises the steward as a Service Control Manager
+(SCM) service (`CFGMSSteward`). The SCM's install-time recovery actions restart
+a *crashed* service, but they cannot help if the service **registration itself**
+is deleted out from under the running launcher — the failure mode observed live
+when an anti-virus product quarantined the launcher binary and removed its SCM
+entry as "remediation", leaving the steward silently and permanently dead until
+a manual reinstall.
+
+To close that gap the launcher runs a dedicated self-repair ticker inside its
+supervise loop, on its own cadence (≤ the fastest SCM recovery delay, 10 s) and
+**independent of the supervised child's lifecycle** — a stable steward may run
+for weeks between child restarts, so the check must not be gated on that. Each
+tick verifies the `CFGMSSteward` registration still exists and, if it has been
+deleted, re-creates it with the same binary path, automatic start type, and
+recovery actions as the original install, reusing the currently-running
+process's own arguments. The repair is logged loudly at warning level with a
+greppable `event=service_registration_repaired` field (visible in
+`C:\ProgramData\cfgms\logs`); a repair that itself fails is logged and the
+supervise loop continues rather than crashing (the steward child is unaffected
+by a missing SCM entry until the next reboot). This behavior is Windows-only —
+the launcher's supervise loop no-ops the check on Linux/macOS.
+
 ### Normal Operation
 
 The steward runs three concurrent activities:


### PR DESCRIPTION
## Summary

The Windows launcher supervises the steward as an SCM service (`CFGMSSteward`). SCM install-time recovery actions restart a *crashed* service, but do nothing if the service **registration itself** is deleted out from under the running launcher — the failure mode observed live 2026-07-08 (epic #565 runner scale-out) when an AV product quarantined the launcher and removed its SCM entry as "remediation", leaving the steward silently and permanently dead until a manual reinstall.

This adds the missing detect-and-recreate loop.

Fixes #2465.

## Design

- **`service_check_windows.go`** (new, `//go:build windows`):
  - `serviceRegistrationOK(name)` — precise `ERROR_SERVICE_DOES_NOT_EXIST` sentinel (a false "missing" would issue a needless `CreateService`); any other error (non-elevated, transient RPC) skips the tick.
  - `repairServiceRegistration(name, exePath, args)` — recreates with the **same** `mgr.Config` + `SetRecoveryActions` shape as the install path (`cmd/steward/service/manager_windows.go:224-261`).
  - `maybeRepairServiceRegistration` — gated on `svc.IsWindowsService()` so it acts **only** when the process is actually the SCM service (never in tests or interactive `run`); repairs from the known install-path const (never `os.Args[0]`) using the running process's own `os.Args[1:]`.
- **`service_check_other.go`** (new, `//go:build !windows`): no-op, mirroring the `attachChildToJobObject` platform split so `lifecycle.go` needs no `GOOS` check.
- **`lifecycle.go`**: `Supervise` starts `runServiceRegistrationRepair` in its own goroutine on a dedicated `time.Ticker` (default 10s, `ServiceRepairInterval`-injectable) **before** the supervise loop — decoupled from `execOnce`'s per-child blocking cadence, which can span weeks for a stable steward.

**Package-boundary choice (per story):** the ~10-line `CreateService`/recovery literal is duplicated with "MUST stay in sync" const comments rather than factored into an exported `cmd/steward/service` helper, to avoid a new cmd→cmd import (only `cmd/steward/main.go` imports that package today). `launcherServiceName` / `launcherServiceExePath` / display / description are the synced constants.

## Behavior

- Repair logged loudly at Warn with a greppable `event=service_registration_repaired` field (visible in `C:\ProgramData\cfgms\logs`); a repair failure logs `event=service_registration_repair_failed` and the supervise loop continues (the steward child is unaffected by a missing SCM entry until reboot). A check error while elevated logs `event=service_registration_check_failed`.

## Tests

Real SCM, no mocks, admin-gated (skip via `mgr.Connect` when non-elevated), always a **unique throwaway service name** — never the live `CFGMSSteward`:
`TestServiceRegistrationOK_DetectsMissingService`, `TestRepairServiceRegistration_RecreatesService` (asserts full 10s/30s/60s recovery parity), `TestRepairServiceRegistration_ErrorsOnConflict`, `TestSupervise_RepairsMissingServiceRegistration` (drives the real repair ticker, mutex-guarded buffer + done-channel — clean under `-race`). These run for real on the elevated Windows CI runner; they skip on non-elevated dev hosts.

## Docs

`docs/architecture/steward-operating-model.md` documents the Windows-only self-repair behavior.

## Review

Pre-PR adversarial review team (acceptance + QA + security) all **PASS**. Two QA-blocking findings — a test data race and a test-isolation hazard (the ticker firing against the real service in unit tests on an elevated CI host) — were fixed and re-verified before this PR; the `IsWindowsService` gate is the structural fix for the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)