### PR TITLE
storage: durable DNA history query path surviving controller restart (Issue #2525)

### DIFF
--- a/features/controller/fleet/storage/fleet_query.go
+++ b/features/controller/fleet/storage/fleet_query.go
@@ -259,6 +259,22 @@ func (m *Manager) GetLatestByDeviceID(ctx context.Context, deviceID string) (*DN
 	}
 }
 
+// GetHistoryByDeviceID returns all DNA records for a device in version-descending
+// order, read directly from the SQL store. Unlike GetHistory (which consults the
+// in-memory index), this path returns correct results after a controller restart
+// when the in-memory index starts empty.
+//
+// options may be nil; Limit, Offset, and TimeRange are applied when set.
+// The second return value is the total count of matching records before pagination.
+func (m *Manager) GetHistoryByDeviceID(ctx context.Context, deviceID string, options *QueryOptions) ([]*DNARecord, int64, error) {
+	switch backend := m.storage.(type) {
+	case *SQLiteBackend:
+		return backend.GetHistoryByDeviceID(ctx, deviceID, options)
+	default:
+		return nil, 0, fmt.Errorf("GetHistoryByDeviceID requires SQLite backend, got %T", m.storage)
+	}
+}
+
 // listAllDeviceIDs queries the distinct device IDs stored in dna_history.
 func (b *SQLiteBackend) listAllDeviceIDs(ctx context.Context) ([]string, error) {
 	b.mutex.RLock()
@@ -280,6 +296,92 @@ func (b *SQLiteBackend) listAllDeviceIDs(ctx context.Context) ([]string, error) 
 	}
 
 	return ids, rows.Err()
+}
+
+// GetHistoryByDeviceID queries dna_history for all records belonging to a device,
+// applying optional time-range and pagination from options. Results are ordered
+// by version descending (newest first) to match MemoryIndexer.QueryRecords ordering.
+func (b *SQLiteBackend) GetHistoryByDeviceID(ctx context.Context, deviceID string, options *QueryOptions) ([]*DNARecord, int64, error) {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	conditions := []string{"device_id = ?"}
+	args := []interface{}{deviceID}
+
+	if options != nil && options.TimeRange != nil {
+		conditions = append(conditions, "timestamp >= ?", "timestamp <= ?")
+		args = append(args, options.TimeRange.Start, options.TimeRange.End)
+	}
+
+	where := " WHERE " + strings.Join(conditions, " AND ")
+
+	// Count query for TotalCount (pagination-independent).
+	countArgs := make([]interface{}, len(args))
+	copy(countArgs, args)
+	var totalCount int64
+	if err := b.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dna_history"+where, countArgs...).Scan(&totalCount); err != nil {
+		return nil, 0, fmt.Errorf("failed to count history for device %s: %w", deviceID, err)
+	}
+
+	// where is built exclusively from static literal strings; all caller-supplied
+	// values are bound through ? placeholders in args.
+	query := "SELECT device_id, tenant_id, os, architecture, hostname, status," +
+		" version, timestamp, dna_json, content_hash," +
+		" original_size, compressed_size, compression_ratio, shard_id" +
+		" FROM dna_history" + where + " ORDER BY version DESC" // #nosec G202 -- where uses only static string literals; user values bound via ? placeholders
+
+	// LIMIT and OFFSET are formatted as integers (%d) — type-safe, no string injection risk.
+	if options != nil && options.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", options.Limit)
+	}
+	if options != nil && options.Offset > 0 {
+		query += fmt.Sprintf(" OFFSET %d", options.Offset)
+	}
+
+	rows, err := b.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query history for device %s: %w", deviceID, err)
+	}
+	defer rows.Close() //nolint:errcheck // rows.Close() error is non-actionable after row iteration completes
+
+	var records []*DNARecord
+	for rows.Next() {
+		var rec DNARecord
+		var storedAt time.Time
+		var dnaJSON string
+		if err := rows.Scan(
+			&rec.DeviceID,
+			&rec.TenantID,
+			new(string), // os — available in DNA.Attributes
+			new(string), // architecture
+			new(string), // hostname
+			&rec.Status,
+			&rec.Version,
+			&storedAt,
+			&dnaJSON,
+			&rec.ContentHash,
+			&rec.OriginalSize,
+			&rec.CompressedSize,
+			&rec.CompressionRatio,
+			&rec.ShardID,
+		); err != nil {
+			return nil, 0, fmt.Errorf("failed to scan history record for device %s: %w", deviceID, err)
+		}
+		rec.StoredAt = storedAt
+
+		var dna commonpb.DNA
+		if err := json.Unmarshal([]byte(dnaJSON), &dna); err != nil {
+			return nil, 0, fmt.Errorf("failed to unmarshal DNA JSON for device %s: %w", deviceID, err)
+		}
+		rec.DNA = &dna
+
+		records = append(records, &rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("history query row iteration error for device %s: %w", deviceID, err)
+	}
+
+	return records, totalCount, nil
 }
 
 // GetLatestByDeviceID retrieves the most recent DNA record for a device using

--- a/features/controller/fleet/storage/fleet_query_test.go
+++ b/features/controller/fleet/storage/fleet_query_test.go
@@ -4,6 +4,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -295,6 +296,10 @@ func TestQueryFleet_NonSQLiteBackendReturnsError(t *testing.T) {
 	err = mgr.Ping(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Ping requires SQLite or database backend")
+
+	_, _, err = mgr.GetHistoryByDeviceID(context.Background(), "dev-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GetHistoryByDeviceID requires SQLite backend")
 }
 
 // noopBackend is a minimal Backend implementation used to exercise error paths.
@@ -348,4 +353,43 @@ func TestStore_WithNilOptions(t *testing.T) {
 	ids, err := mgr.ListAllDeviceIDs(ctx)
 	require.NoError(t, err)
 	assert.Contains(t, ids, "dev-y")
+}
+
+func TestGetHistoryByDeviceID(t *testing.T) {
+	mgr := newTestFleetStorage(t)
+	ctx := context.Background()
+
+	const deviceID = "hist-device"
+
+	// Store 3 versions.
+	for i := 1; i <= 3; i++ {
+		dna := makeTestDNA(deviceID, map[string]string{"os": "linux", "v": fmt.Sprintf("%d", i)})
+		require.NoError(t, mgr.Store(ctx, deviceID, dna, nil))
+	}
+
+	t.Run("returns all records in version-descending order", func(t *testing.T) {
+		records, total, err := mgr.GetHistoryByDeviceID(ctx, deviceID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+		assert.Len(t, records, 3)
+		// Verify newest-first ordering.
+		for i := 0; i+1 < len(records); i++ {
+			assert.Greater(t, records[i].Version, records[i+1].Version,
+				"records should be version-descending")
+		}
+	})
+
+	t.Run("respects Limit and Offset", func(t *testing.T) {
+		records, total, err := mgr.GetHistoryByDeviceID(ctx, deviceID, &QueryOptions{Limit: 2, Offset: 1})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total, "TotalCount must reflect all matching rows, not just the page")
+		assert.Len(t, records, 2)
+	})
+
+	t.Run("unknown device returns empty with zero total", func(t *testing.T) {
+		records, total, err := mgr.GetHistoryByDeviceID(ctx, "no-such-device", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), total)
+		assert.Empty(t, records)
+	})
 }

--- a/features/controller/fleet/storage/restart_test.go
+++ b/features/controller/fleet/storage/restart_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestControllerRestart_DurableQueryPath verifies that a freshly-constructed Manager
+// correctly serves GetHistory/GetCurrent for DNA records written by a previous process,
+// and that Store assigns the next version without colliding or resetting to 1.
+//
+// Simulates a controller restart by closing a Manager and constructing a second one
+// against the same DataDir, which is the exact sequence that happens on every restart.
+func TestControllerRestart_DurableQueryPath(t *testing.T) {
+	logger := logging.NewLogger("error")
+	dataDir := t.TempDir()
+
+	config := DefaultConfig()
+	config.DataDir = dataDir
+
+	const deviceID = "restart-test-device"
+	ctx := context.Background()
+
+	// Phase 1: write 3 versions and close (simulating a pre-restart controller).
+	manager1, err := NewManager(config, logger)
+	if err != nil {
+		t.Fatalf("failed to create first manager: %v", err)
+	}
+
+	for i := 1; i <= 3; i++ {
+		dna := createTestDNA(deviceID, map[string]string{
+			"os":      "linux",
+			"version": fmt.Sprintf("v%d", i),
+		})
+		if err := manager1.Store(ctx, deviceID, dna, nil); err != nil {
+			t.Fatalf("Store v%d failed before restart: %v", i, err)
+		}
+	}
+
+	if err := manager1.Close(); err != nil {
+		t.Fatalf("failed to close first manager: %v", err)
+	}
+
+	// Phase 2: new Manager on the same DataDir — simulates a controller restart.
+	// The in-memory indexer starts empty; only the durable SQLite store carries
+	// the pre-restart records.
+	manager2, err := NewManager(config, logger)
+	if err != nil {
+		t.Fatalf("failed to create second manager: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := manager2.Close(); err != nil {
+			t.Errorf("second manager Close() failed: %v", err)
+		}
+	})
+
+	t.Run("GetHistory returns pre-restart records", func(t *testing.T) {
+		history, err := manager2.GetHistory(ctx, deviceID, &QueryOptions{
+			IncludeData: true,
+			Limit:       10,
+		})
+		if err != nil {
+			t.Fatalf("GetHistory failed after restart: %v", err)
+		}
+		if got := len(history.Records); got != 3 {
+			t.Fatalf("expected 3 records after restart, got %d", got)
+		}
+		if history.TotalCount != 3 {
+			t.Errorf("expected TotalCount=3 after restart, got %d", history.TotalCount)
+		}
+		// Records must be version-descending (newest first).
+		for i := 0; i+1 < len(history.Records); i++ {
+			if history.Records[i].Version < history.Records[i+1].Version {
+				t.Errorf("records not version-descending after restart: [%d].Version=%d < [%d].Version=%d",
+					i, history.Records[i].Version, i+1, history.Records[i+1].Version)
+			}
+		}
+	})
+
+	t.Run("GetHistoryByDeviceID returns pre-restart records via Manager wrapper", func(t *testing.T) {
+		// Exercises the Manager.GetHistoryByDeviceID wrapper (fleet_query.go),
+		// which routes directly to SQLiteBackend and bypasses the in-memory index.
+		// This is the path that returns correct results after a restart when the
+		// index starts empty, and is distinct from GetHistory's index-backed path.
+		records, total, err := manager2.GetHistoryByDeviceID(ctx, deviceID, &QueryOptions{
+			IncludeData: true,
+			Limit:       10,
+		})
+		if err != nil {
+			t.Fatalf("GetHistoryByDeviceID failed after restart: %v", err)
+		}
+		if got := len(records); got != 3 {
+			t.Fatalf("expected 3 records from GetHistoryByDeviceID, got %d", got)
+		}
+		if total != 3 {
+			t.Errorf("expected total count=3 from GetHistoryByDeviceID, got %d", total)
+		}
+		// Records must be version-descending (newest first).
+		for i := 0; i+1 < len(records); i++ {
+			if records[i].Version < records[i+1].Version {
+				t.Errorf("GetHistoryByDeviceID records not version-descending: [%d].Version=%d < [%d].Version=%d",
+					i, records[i].Version, i+1, records[i+1].Version)
+			}
+		}
+		if records[0].Version != 3 {
+			t.Errorf("expected newest record version=3, got %d", records[0].Version)
+		}
+	})
+
+	t.Run("GetCurrent returns latest pre-restart record", func(t *testing.T) {
+		current, err := manager2.GetCurrent(ctx, deviceID)
+		if err != nil {
+			t.Fatalf("GetCurrent failed after restart: %v", err)
+		}
+		if current.Version != 3 {
+			t.Errorf("expected current version=3 after restart, got %d", current.Version)
+		}
+		if current.DNA == nil {
+			t.Fatal("expected non-nil DNA on current record")
+		}
+		if got := current.DNA.Attributes["version"]; got != "v3" {
+			t.Errorf("expected version attribute=v3, got %q", got)
+		}
+	})
+
+	t.Run("Store after restart increments version without collision or reset", func(t *testing.T) {
+		dna := createTestDNA(deviceID, map[string]string{
+			"os":      "linux",
+			"version": "v4",
+		})
+		if err := manager2.Store(ctx, deviceID, dna, nil); err != nil {
+			t.Fatalf("Store after restart failed: %v", err)
+		}
+
+		current, err := manager2.GetCurrent(ctx, deviceID)
+		if err != nil {
+			t.Fatalf("GetCurrent after post-restart Store failed: %v", err)
+		}
+		// Must be 4, not 1 (reset) or collide with an existing version.
+		if current.Version != 4 {
+			t.Errorf("expected version=4 after post-restart Store, got %d (reset or collision)",
+				current.Version)
+		}
+		if got := current.DNA.Attributes["version"]; got != "v4" {
+			t.Errorf("expected version attribute=v4 on post-restart record, got %q", got)
+		}
+	})
+}

--- a/features/controller/fleet/storage/storage.go
+++ b/features/controller/fleet/storage/storage.go
@@ -248,8 +248,17 @@ func (m *Manager) Store(ctx context.Context, deviceID string, dna *commonpb.DNA,
 	// Determine shard for storage
 	shardID := m.getShardID(deviceID, time.Now())
 
-	// Get next version number for this device
-	version, err := m.indexer.GetNextVersion(ctx, deviceID)
+	// Get the next version from the durable backend when possible. The in-memory
+	// indexer resets to version 1 on every controller restart, which causes
+	// (device_id, version) collisions with rows written by the previous process.
+	// SQLiteBackend.GetNextVersion reads MAX(version)+1 from dna_history, so it
+	// always picks up where the last process left off.
+	var version int64
+	if sqliteBackend, ok := m.storage.(*SQLiteBackend); ok {
+		version, err = sqliteBackend.GetNextVersion(ctx, deviceID)
+	} else {
+		version, err = m.indexer.GetNextVersion(ctx, deviceID)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get next version: %w", err)
 	}
@@ -319,45 +328,68 @@ func (m *Manager) GetHistory(ctx context.Context, deviceID string, options *Quer
 		options = &QueryOptions{IncludeData: true}
 	}
 
-	// Query index for matching records
-	recordRefs, totalCount, err := m.indexer.QueryRecords(ctx, deviceID, options)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query DNA records: %w", err)
-	}
-
 	var records []*DNARecord
+	var totalCount int64
 	var bytesProcessed int64
 	var compressionSavings int64
+	var recordsScanned int64
 
-	// Retrieve and decompress records
-	for _, ref := range recordRefs {
-		record, err := m.storage.GetRecord(ctx, ref.ContentHash, ref.ShardID)
+	switch backend := m.storage.(type) {
+	case *SQLiteBackend:
+		// Read directly from the durable store — the in-memory indexer starts empty
+		// after every controller restart, so using it here would make GetHistory return
+		// zero records for any device that was not seen in the current process lifetime.
+		durableRecords, count, err := backend.GetHistoryByDeviceID(ctx, deviceID, options)
 		if err != nil {
-			m.logger.Error("Failed to retrieve DNA record", "error", err, "content_hash", ref.ContentHash)
-			continue
+			return nil, fmt.Errorf("failed to query DNA records: %w", err)
 		}
-
-		// Override the device ID with the one from the reference (for deduplication support)
-		record.DeviceID = ref.DeviceID
-		record.Version = ref.Version
-		record.StoredAt = ref.StoredAt
-
-		// Decompress data if requested
-		if options.IncludeData {
-			if err := m.decompressRecord(record); err != nil {
-				m.logger.Error("Failed to decompress DNA record", "error", err, "content_hash", ref.ContentHash)
+		totalCount = count
+		recordsScanned = int64(len(durableRecords))
+		for _, record := range durableRecords {
+			if options.IncludeData {
+				if err := m.decompressRecord(record); err != nil {
+					m.logger.Error("Failed to decompress DNA record", "error", err, "content_hash", record.ContentHash)
+					continue
+				}
+			}
+			if len(options.Attributes) > 0 && record.DNA != nil {
+				record.DNA = m.filterAttributes(record.DNA, options.Attributes)
+			}
+			records = append(records, record)
+			bytesProcessed += record.OriginalSize
+			compressionSavings += (record.OriginalSize - record.CompressedSize)
+		}
+	default:
+		// Fall back to in-memory indexer for non-durable backends (file, memory).
+		recordRefs, count, err := m.indexer.QueryRecords(ctx, deviceID, options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query DNA records: %w", err)
+		}
+		totalCount = count
+		recordsScanned = int64(len(recordRefs))
+		for _, ref := range recordRefs {
+			record, err := m.storage.GetRecord(ctx, ref.ContentHash, ref.ShardID)
+			if err != nil {
+				m.logger.Error("Failed to retrieve DNA record", "error", err, "content_hash", ref.ContentHash)
 				continue
 			}
+			// Override the device ID with the one from the reference (for deduplication support)
+			record.DeviceID = ref.DeviceID
+			record.Version = ref.Version
+			record.StoredAt = ref.StoredAt
+			if options.IncludeData {
+				if err := m.decompressRecord(record); err != nil {
+					m.logger.Error("Failed to decompress DNA record", "error", err, "content_hash", ref.ContentHash)
+					continue
+				}
+			}
+			if len(options.Attributes) > 0 && record.DNA != nil {
+				record.DNA = m.filterAttributes(record.DNA, options.Attributes)
+			}
+			records = append(records, record)
+			bytesProcessed += record.OriginalSize
+			compressionSavings += (record.OriginalSize - record.CompressedSize)
 		}
-
-		// Filter attributes if requested
-		if len(options.Attributes) > 0 && record.DNA != nil {
-			record.DNA = m.filterAttributes(record.DNA, options.Attributes)
-		}
-
-		records = append(records, record)
-		bytesProcessed += record.OriginalSize
-		compressionSavings += (record.OriginalSize - record.CompressedSize)
 	}
 
 	executionTime := time.Since(startTime)
@@ -369,7 +401,7 @@ func (m *Manager) GetHistory(ctx context.Context, deviceID string, options *Quer
 		Metadata: &QueryMetadata{
 			ExecutionTime:      executionTime,
 			CacheHit:           false, // TODO: Implement caching
-			RecordsScanned:     int64(len(recordRefs)),
+			RecordsScanned:     recordsScanned,
 			BytesProcessed:     bytesProcessed,
 			CompressionSavings: compressionSavings,
 		},


### PR DESCRIPTION
## Summary

- **GetHistory** for `*SQLiteBackend` now queries `dna_history` directly via a new `SQLiteBackend.GetHistoryByDeviceID` method, bypassing the `MemoryIndexer` that starts empty after a controller restart
- **Store** for `*SQLiteBackend` now calls the durable `SQLiteBackend.GetNextVersion` (previously dead code) instead of `MemoryIndexer.GetNextVersion`, so version numbering continues from the last persisted version after restart rather than resetting to 1
- **New test** `TestControllerRestart_DurableQueryPath` simulates a controller restart by closing a `Manager` and constructing a second one on the same `DataDir`, asserting `GetHistory`/`GetCurrent` return pre-restart records and that the next `Store` assigns version 4, not 1

## What is NOT changed

- `MemoryIndexer` is not deleted — `QueryByAttribute`, `GetAttributeValues`, and `GetTimeRangeStats` still use it (no durable equivalent exists yet)
- Non-SQLite backends (file, memory) keep the existing in-memory indexer path
- The `ON CONFLICT(device_id, version) DO UPDATE` upsert in `StoreRecord` is preserved — this fix removes the wrong-version-number race source without weakening the collision guard
- `GetCurrent`/`GetLatest` call `GetHistory` internally; they require no separate change

## Known gap not fixed here

`DatabaseBackend` (cluster/PostgreSQL mode) shares the same `MemoryIndexer` wiring and therefore the same restart gap. It is out of scope for this story (the default deployment uses `SQLiteBackend`). A follow-up story should apply the same type-switch pattern to `DatabaseBackend`.

## Review results

- **QA (code review):** PASS (round 2, after minor fix in round 1)
- **QA (test runner):** PASS
- **Security:** PASS
- **Acceptance:** verified post-PR by cron acceptance-reviewer

Fixes #2525

Co-Authored-By: Claude <noreply@anthropic.com>