### PR TITLE
ci: route pull_request Windows builds to windows-latest; merge_group stays self-hosted (Issue #2503)

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -63,17 +63,20 @@ jobs:
 
   # Native build tests on each platform
   #
-  # Windows routing (#2337, epic #565): internal events (merge_group, non-fork
-  # pull_request) build natively on the CFGMS-managed self-hosted Windows
-  # runner; fork PRs and workflow_dispatch (no fork property) use GitHub-hosted
-  # windows-latest. Linux and macOS stay hosted unconditionally. The whole
-  # include list is selected via fromJSON because individual matrix entries
-  # cannot carry conditions.
+  # Windows routing (#2337, #2503, epic #565): only merge_group (merge-gating)
+  # builds run natively on the CFGMS-managed self-hosted Windows runner. ALL
+  # pull_request events (fork or not) and workflow_dispatch use GitHub-hosted
+  # windows-latest — PR Windows builds are advisory (the merge queue re-runs
+  # everything self-hosted at merge time), so routing them to hosted removes
+  # roughly half the self-hosted Windows load without touching the merge-critical
+  # path. Linux and macOS stay hosted unconditionally. The whole include list is
+  # selected via fromJSON because individual matrix entries cannot carry
+  # conditions.
   #
-  # SECURITY: the fork expression is convenience routing, NOT the security
-  # boundary — fork PRs run the fork's workflow copy. The enforcing control is
-  # the repository Actions setting "Require approval for ALL external
-  # contributors"; do not weaken it while self-hosted runners are attached.
+  # SECURITY: routing pull_request to hosted is convenience/load management, NOT
+  # the security boundary — fork PRs run the fork's workflow copy regardless. The
+  # enforcing control is the repository Actions setting "Require approval for ALL
+  # external contributors"; do not weaken it while self-hosted runners are attached.
   native-builds:
     name: Native Build (${{ matrix.platform }})
     permissions:
@@ -81,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.event_name == 'workflow_dispatch') && '[{"os":"ubuntu-latest","platform":"Linux"},{"os":"macos-latest","platform":"macOS"},{"os":"windows-latest","platform":"Windows"}]' || '[{"os":"ubuntu-latest","platform":"Linux"},{"os":"macos-latest","platform":"macOS"},{"os":["self-hosted","Windows","cfgms"],"platform":"Windows"}]') }}
+        include: ${{ fromJSON((github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && '[{"os":"ubuntu-latest","platform":"Linux"},{"os":"macos-latest","platform":"macOS"},{"os":"windows-latest","platform":"Windows"}]' || '[{"os":"ubuntu-latest","platform":"Linux"},{"os":"macos-latest","platform":"macOS"},{"os":["self-hosted","Windows","cfgms"],"platform":"Windows"}]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

Route **all `pull_request`** Windows native builds to GitHub-hosted `windows-latest`, leaving only **`merge_group`** (merge-gating) builds on the self-hosted Windows runner. One-line change to the `native-builds` matrix expression (`cross-platform-build.yml`) — drops the `&& github.event.pull_request.head.repo.fork == true` sub-condition so the hosted branch fires for any `pull_request` or `workflow_dispatch`.

Fixes #2503 (epic #565).

## Why

PR Windows builds are **advisory** — the merge queue re-runs everything on the self-hosted runner at merge time, so routing PR builds to hosted costs nothing on the merge-critical path while removing ~half the self-hosted Windows demand. Of the last 30 `cross-platform-build` runs, **16 were `pull_request`** — all move off the self-hosted pool.

Timely: the pool is currently down to one healthy self-hosted Windows runner (`CFGMS-CI-WIN-01`; the two mis-provisioned canary runners were deregistered), and its queue is saturated with advisory PR builds. This cuts that demand in half.

## Routing after this change

| Event | Windows runner |
|---|---|
| `pull_request` (fork or not) | `windows-latest` (hosted) |
| `workflow_dispatch` | `windows-latest` (hosted) |
| `merge_group` | `["self-hosted","Windows","cfgms"]` |

## Security

Unchanged boundary. Routing is load management, not the security control — fork PRs run the fork's own workflow copy regardless, and the enforcing control remains the repo Actions setting *"Require approval for ALL external contributors."* Comment updated to match.

## Note on ordering vs #2485

#2503's `## Dependencies` lists #2485 (both touch `cross-platform-build.yml`'s `native-builds` job). They edit **different regions** (matrix expression here vs. the resource-sampler steps in #2485), so there is no textual conflict and #2485 rebases cleanly. Landing #2503 first is deliberate: #2485's own Windows re-run is currently stuck in the saturated self-hosted queue that this PR drains, so #2503-first unblocks #2485 rather than the reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)