### PR TITLE
ci: harden Windows safe.directory step against non-writable runner HOME (Issue #2531)

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -94,6 +94,8 @@ jobs:
 
     - name: Mark workspace safe for git (needed on self-hosted after service-account changes; idempotent on hosted)
       shell: bash
+      env:
+        GIT_CONFIG_GLOBAL: ${{ runner.temp }}/.gitconfig
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Set up Go


### PR DESCRIPTION
## Summary

- Adds `GIT_CONFIG_GLOBAL: ${{ runner.temp }}/.gitconfig` to the "Mark workspace safe for git" step in the `native-builds` job
- Redirects git config writes to a guaranteed-writable, job-scoped path (`$RUNNER_TEMP`) instead of the runner account's ambient `$HOME/.gitconfig`
- No other jobs or workflow files are touched; the change is a no-op on hosted Linux/macOS runners

## Root Cause

On self-hosted Windows runners whose service account has no writable profile directory, git-bash resolves `$HOME` to `C:\Program Files\Git` (its fallback). `git config --global` then fails with `could not lock config file .../.gitconfig: Permission denied` (exit 255), killing the entire Native Build (Windows) job and blocking the Build Gate.

## Fix

Set `GIT_CONFIG_GLOBAL` to `$RUNNER_TEMP/.gitconfig` for that one step. `$RUNNER_TEMP` is always writable and cleaned between jobs. No downstream step in the `native-builds` job invokes git after checkout, so step-level env is sufficient.

## Specialist Review Results

All three lenses passed in round 1 with zero fix rounds:
- **Code review**: PASS
- **Test quality**: PASS
- **Security**: PASS

## Test Plan

- [ ] Native Build (Windows) passes on the self-hosted Windows runner in this PR's CI run
- [ ] Native Build (Linux) and Native Build (macOS) continue to pass (no-op on hosted runners)
- [ ] Build Gate passes

Fixes #2531

🤖 Generated with [Claude Code](https://claude.com/claude-code)