### PR TITLE
cli: confirm-gate + keyed --json for run-script, run-command, upgrade (Issue #2443)

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -109,6 +109,11 @@ var (
 	stewardExecJSONOutput bool
 )
 
+var (
+	stewardRunScriptJSONOutput  bool
+	stewardRunCommandJSONOutput bool
+)
+
 // runWaitPollInterval is the delay between status polls in the --wait loop.
 // Overridable in tests to avoid real sleeps.
 var runWaitPollInterval = 5 * time.Second
@@ -467,6 +472,7 @@ func init() {
 	stewardRunScriptCmd.Flags().BoolVar(&stewardRunWait, "wait", false, "Block until all jobs reach terminal state")
 	stewardRunScriptCmd.Flags().BoolVar(&stewardRunSkipOffline, "skip-offline", false, "Skip offline stewards instead of queuing for them")
 	stewardRunScriptCmd.Flags().DurationVar(&stewardRunWaitTimeout, "wait-timeout", 5*time.Minute, "Maximum time to wait when --wait is set")
+	stewardRunScriptCmd.Flags().BoolVar(&stewardRunScriptJSONOutput, "json", false, "Emit keyed-by-steward JSON dispatch results (requires --target)")
 
 	// run-command flags
 	stewardRunCommandCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
@@ -479,6 +485,7 @@ func init() {
 	stewardRunCommandCmd.Flags().BoolVar(&stewardRunWait, "wait", false, "Block until all jobs reach terminal state")
 	stewardRunCommandCmd.Flags().BoolVar(&stewardRunSkipOffline, "skip-offline", false, "Skip offline stewards instead of queuing for them")
 	stewardRunCommandCmd.Flags().DurationVar(&stewardRunWaitTimeout, "wait-timeout", 5*time.Minute, "Maximum time to wait when --wait is set")
+	stewardRunCommandCmd.Flags().BoolVar(&stewardRunCommandJSONOutput, "json", false, "Emit keyed-by-steward JSON dispatch results (requires --target)")
 
 	// exec flags (single-steward ad-hoc run)
 	stewardExecCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
@@ -572,6 +579,7 @@ func init() {
 	stewardUpgradeCmd.Flags().StringVar(&stewardUpgradeArch, "arch", "", "Target architecture (e.g. amd64, arm64; auto-detected if omitted)")
 	stewardUpgradeCmd.Flags().BoolVar(&stewardUpgradeWait, "wait", false, "Block until all stewards reach a terminal state")
 	stewardUpgradeCmd.Flags().DurationVar(&stewardUpgradeWaitTimeout, "wait-timeout", 2*time.Minute, "Maximum time to wait when --wait is set")
+	stewardUpgradeCmd.Flags().BoolVar(&stewardUpgradeJSONOutput, "json", false, "Emit keyed-by-steward JSON dispatch results")
 
 	stewardUpgradeStatusCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
 	stewardUpgradeStatusCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
@@ -1081,6 +1089,22 @@ func runRunScript(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	var matches []StewardInfo
+	if stewardRunTarget != "" {
+		matches, err = resolveOrFailFast(context.Background(), client, stewardRunTarget)
+		if err != nil {
+			return err
+		}
+		if err := confirmMultiHost(matches, stewardYes); err != nil {
+			return err
+		}
+	}
+
 	reqBody := map[string]interface{}{
 		"target":         stewardRunTarget,
 		"script_id":      stewardRunScript,
@@ -1092,11 +1116,6 @@ func runRunScript(_ *cobra.Command, _ []string) error {
 	bodyJSON, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to encode request: %w", err)
-	}
-
-	client, err := getStewardClient()
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
 	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/runs/script", bytes.NewReader(bodyJSON))
@@ -1120,6 +1139,10 @@ func runRunScript(_ *cobra.Command, _ []string) error {
 	}
 
 	runID := apiResp.Data.RunID
+
+	if stewardRunScriptJSONOutput && len(matches) > 0 {
+		return emitKeyedDispatchOutput(matches, map[string]interface{}{"run_id": runID})
+	}
 
 	if stewardRunWait {
 		fmt.Printf("Run ID: %s\n", runID)
@@ -1150,6 +1173,22 @@ func runRunCommand(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	var matches []StewardInfo
+	if stewardRunTarget != "" {
+		matches, err = resolveOrFailFast(context.Background(), client, stewardRunTarget)
+		if err != nil {
+			return err
+		}
+		if err := confirmMultiHost(matches, stewardYes); err != nil {
+			return err
+		}
+	}
+
 	reqBody := map[string]interface{}{
 		"target":       stewardRunTarget,
 		"content":      base64.StdEncoding.EncodeToString(content),
@@ -1162,11 +1201,6 @@ func runRunCommand(_ *cobra.Command, args []string) error {
 	bodyJSON, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to encode request: %w", err)
-	}
-
-	client, err := getStewardClient()
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
 	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/runs/command", bytes.NewReader(bodyJSON))
@@ -1190,6 +1224,10 @@ func runRunCommand(_ *cobra.Command, args []string) error {
 	}
 
 	runID := apiResp.Data.RunID
+
+	if stewardRunCommandJSONOutput && len(matches) > 0 {
+		return emitKeyedDispatchOutput(matches, map[string]interface{}{"run_id": runID})
+	}
 
 	if stewardRunWait {
 		fmt.Printf("Run ID: %s\n", runID)

--- a/cmd/cfg/cmd/steward_run_test.go
+++ b/cmd/cfg/cmd/steward_run_test.go
@@ -92,6 +92,10 @@ func saveStewardRunGlobals(t *testing.T) {
 	origExecShell := stewardExecShell
 	origExecTimeout := stewardExecTimeout
 	origExecJSON := stewardExecJSONOutput
+	// confirm gate and JSON output vars
+	origYes := stewardYes
+	origScriptJSON := stewardRunScriptJSONOutput
+	origCommandJSON := stewardRunCommandJSONOutput
 	t.Cleanup(func() {
 		stewardURL = origURL
 		stewardTLSInsecure = origInsecure
@@ -113,6 +117,9 @@ func saveStewardRunGlobals(t *testing.T) {
 		stewardExecShell = origExecShell
 		stewardExecTimeout = origExecTimeout
 		stewardExecJSONOutput = origExecJSON
+		stewardYes = origYes
+		stewardRunScriptJSONOutput = origScriptJSON
+		stewardRunCommandJSONOutput = origCommandJSON
 	})
 }
 
@@ -124,10 +131,16 @@ func TestStewardRunScript_AsyncReturnsRunID(t *testing.T) {
 	var requestPath, requestMethod string
 	var requestBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestPath = r.URL.Path
-		requestMethod = r.Method
-		requestBody, _ = io.ReadAll(r.Body)
-		writeRunAPIResponse(w, map[string]string{"run_id": "run-abc123"})
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			// Single match — confirm gate is a no-op.
+			writeRunAPIResponse(w, []map[string]interface{}{{"id": "s1", "status": "online"}})
+		default:
+			requestPath = r.URL.Path
+			requestMethod = r.Method
+			requestBody, _ = io.ReadAll(r.Body)
+			writeRunAPIResponse(w, map[string]string{"run_id": "run-abc123"})
+		}
 	}))
 	defer server.Close()
 
@@ -243,9 +256,15 @@ func TestStewardRunCommand_SignsAndBase64Encodes(t *testing.T) {
 	var capturedBody []byte
 	var capturedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedPath = r.URL.Path
-		capturedBody, _ = io.ReadAll(r.Body)
-		writeRunAPIResponse(w, map[string]string{"run_id": "cmd-run-id"})
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			// Single match — confirm gate is a no-op.
+			writeRunAPIResponse(w, []map[string]interface{}{{"id": "s1", "status": "online"}})
+		default:
+			capturedPath = r.URL.Path
+			capturedBody, _ = io.ReadAll(r.Body)
+			writeRunAPIResponse(w, map[string]string{"run_id": "cmd-run-id"})
+		}
 	}))
 	defer server.Close()
 
@@ -672,13 +691,13 @@ func TestStewardRunCommandsRegistered(t *testing.T) {
 }
 
 func TestStewardRunScript_FlagsRegistered(t *testing.T) {
-	for _, flag := range []string{"target", "script", "version", "param", "wait", "skip-offline", "wait-timeout"} {
+	for _, flag := range []string{"target", "script", "version", "param", "wait", "skip-offline", "wait-timeout", "json"} {
 		assert.NotNil(t, stewardRunScriptCmd.Flags().Lookup(flag), "run-script must have --%s flag", flag)
 	}
 }
 
 func TestStewardRunCommand_FlagsRegistered(t *testing.T) {
-	for _, flag := range []string{"target", "shell", "param", "wait", "skip-offline", "wait-timeout"} {
+	for _, flag := range []string{"target", "shell", "param", "wait", "skip-offline", "wait-timeout", "json"} {
 		assert.NotNil(t, stewardRunCommandCmd.Flags().Lookup(flag), "run-command must have --%s flag", flag)
 	}
 }
@@ -812,4 +831,235 @@ func TestStewardExecFlagsRegistered(t *testing.T) {
 	for _, flag := range []string{"command", "shell", "timeout", "json"} {
 		assert.NotNil(t, stewardExecCmd.Flags().Lookup(flag), "exec must have --%s flag", flag)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] confirm-gate wiring — run-script
+// ---------------------------------------------------------------------------
+
+// newRunScriptResolveServer creates a minimal test server that handles
+// POST /api/v1/fleet/resolve → resolveMatches and POST /api/v1/runs/script →
+// {"run_id": runID}. Requests to other paths return 404.
+func newRunScriptResolveServer(t *testing.T, runID string, resolveMatches []map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeRunAPIResponse(w, resolveMatches)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/runs/script":
+			writeRunAPIResponse(w, map[string]string{"run_id": runID})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestRunScript_ConfirmGate_SingleMatchNoPrompt verifies that a selector
+// resolving to exactly one steward proceeds without requiring --yes.
+func TestRunScript_ConfirmGate_SingleMatchNoPrompt(t *testing.T) {
+	srv := newRunScriptResolveServer(t, "run-single",
+		[]map[string]interface{}{{"id": "s1", "status": "online"}},
+	)
+	defer srv.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunTarget = "id:s1"
+	stewardYes = false // single match → no prompt required
+
+	_ = captureStdout(t, func() {
+		err := runRunScript(stewardRunScriptCmd, []string{})
+		require.NoError(t, err)
+	})
+}
+
+// TestRunScript_ConfirmGate_MultiMatchNonTTYRequiresYes verifies that a selector
+// resolving to more than one steward is blocked when --yes is not set and stdin
+// is not an interactive TTY (which is always true in test environments).
+func TestRunScript_ConfirmGate_MultiMatchNonTTYRequiresYes(t *testing.T) {
+	srv := newRunScriptResolveServer(t, "run-multi",
+		[]map[string]interface{}{
+			{"id": "s1", "status": "online"},
+			{"id": "s2", "status": "online"},
+		},
+	)
+	defer srv.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunTarget = "os:linux"
+	stewardYes = false
+
+	err := runRunScript(stewardRunScriptCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "yes")
+}
+
+// TestRunScript_JSONOutput_KeyedBySteward verifies that --json produces a
+// keyed-by-steward array (story 4 schema) with the run_id in each payload.
+func TestRunScript_JSONOutput_KeyedBySteward(t *testing.T) {
+	srv := newRunScriptResolveServer(t, "run-json-id",
+		[]map[string]interface{}{
+			{"id": "s1", "dna": map[string]interface{}{"hostname": "host-one"}},
+			{"id": "s2", "dna": map[string]interface{}{"hostname": "host-two"}},
+		},
+	)
+	defer srv.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunTarget = "os:linux"
+	stewardYes = true
+	stewardRunScriptJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runRunScript(stewardRunScriptCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be valid JSON")
+	require.Len(t, entries, 2, "must have one entry per resolved steward")
+
+	keys := make(map[string]bool)
+	for _, e := range entries {
+		key, ok := e["key"].(string)
+		require.True(t, ok, "each entry must have a string 'key' field")
+		keys[key] = true
+		assert.True(t, e["success"].(bool), "each entry must be success=true")
+		payload, ok := e["payload"].(map[string]interface{})
+		require.True(t, ok, "each entry must have a payload object")
+		assert.Equal(t, "run-json-id", payload["run_id"], "payload must contain run_id")
+	}
+	assert.True(t, keys["host-one#s1"], "output must contain key 'host-one#s1'")
+	assert.True(t, keys["host-two#s2"], "output must contain key 'host-two#s2'")
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] confirm-gate wiring — run-command
+// ---------------------------------------------------------------------------
+
+// newRunCommandResolveServer creates a minimal test server for run-command confirm-gate tests.
+func newRunCommandResolveServer(t *testing.T, runID string, resolveMatches []map[string]interface{}, capturedBody *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeRunAPIResponse(w, resolveMatches)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/runs/command":
+			if capturedBody != nil {
+				*capturedBody, _ = io.ReadAll(r.Body)
+			}
+			writeRunAPIResponse(w, map[string]string{"run_id": runID})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestRunCommand_ConfirmGate_SingleMatchNoPrompt verifies that a single-match
+// target proceeds without --yes.
+func TestRunCommand_ConfirmGate_SingleMatchNoPrompt(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	srv := newRunCommandResolveServer(t, "cmd-single",
+		[]map[string]interface{}{{"id": "s1", "status": "online"}},
+		nil,
+	)
+	defer srv.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardRunShell = "bash"
+	stewardRunTarget = "id:s1"
+	stewardYes = false
+
+	_ = captureStdout(t, func() {
+		err := runRunCommand(stewardRunCommandCmd, []string{"echo hello"})
+		require.NoError(t, err)
+	})
+}
+
+// TestRunCommand_ConfirmGate_MultiMatchNonTTYRequiresYes verifies that a multi-
+// match target is blocked without --yes in a non-interactive context.
+func TestRunCommand_ConfirmGate_MultiMatchNonTTYRequiresYes(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	srv := newRunCommandResolveServer(t, "cmd-multi",
+		[]map[string]interface{}{
+			{"id": "s1", "status": "online"},
+			{"id": "s2", "status": "online"},
+		},
+		nil,
+	)
+	defer srv.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardRunShell = "bash"
+	stewardRunTarget = "os:linux"
+	stewardYes = false
+
+	err := runRunCommand(stewardRunCommandCmd, []string{"echo hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "yes")
+}
+
+// TestRunCommand_JSONOutput_KeyedBySteward verifies that --json output from
+// run-command is a keyed-by-steward array with the run_id in each payload.
+func TestRunCommand_JSONOutput_KeyedBySteward(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	srv := newRunCommandResolveServer(t, "cmd-json-id",
+		[]map[string]interface{}{
+			{"id": "s1", "dna": map[string]interface{}{"hostname": "host-one"}},
+			{"id": "s2", "dna": map[string]interface{}{"hostname": "host-two"}},
+		},
+		nil,
+	)
+	defer srv.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardRunShell = "bash"
+	stewardRunTarget = "os:linux"
+	stewardYes = true
+	stewardRunCommandJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runRunCommand(stewardRunCommandCmd, []string{"echo hello"})
+		require.NoError(t, err)
+	})
+
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be valid JSON")
+	require.Len(t, entries, 2, "must have one entry per resolved steward")
+
+	keys := make(map[string]bool)
+	for _, e := range entries {
+		key, ok := e["key"].(string)
+		require.True(t, ok, "each entry must have a string 'key' field")
+		keys[key] = true
+		assert.True(t, e["success"].(bool), "each entry must be success=true")
+		payload, ok := e["payload"].(map[string]interface{})
+		require.True(t, ok, "each entry must have a payload object")
+		assert.Equal(t, "cmd-json-id", payload["run_id"], "payload must contain run_id")
+	}
+	assert.True(t, keys["host-one#s1"], "output must contain key 'host-one#s1'")
+	assert.True(t, keys["host-two#s2"], "output must contain key 'host-two#s2'")
 }

--- a/cmd/cfg/cmd/steward_selector.go
+++ b/cmd/cfg/cmd/steward_selector.go
@@ -198,6 +198,28 @@ type KeyedOutputEntry struct {
 	Error   string          `json:"error,omitempty"`
 }
 
+// emitKeyedDispatchOutput writes a keyed-by-steward JSON array to stdout
+// where every matched steward receives the same payload. Used by run-script,
+// run-command, and upgrade --json, where the server fans out to all matches
+// under a single run/upgrade ID rather than issuing per-steward REST calls.
+func emitKeyedDispatchOutput(matches []StewardInfo, payload map[string]interface{}) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payload: %w", err)
+	}
+	perStewardResult := make(map[string]fanOutResult, len(matches))
+	for _, m := range matches {
+		perStewardResult[stewardKey(m)] = fanOutResult{
+			Success: true,
+			Payload: payloadJSON,
+		}
+	}
+	entries := keyedOutput(matches, perStewardResult)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(entries)
+}
+
 // keyedOutput builds the keyed-by-steward output slice consumed by --json
 // and the human host-prefix output. Entries are in the same order as matches
 // for deterministic output. Each entry carries an explicit success/failure

--- a/cmd/cfg/cmd/steward_upgrade.go
+++ b/cmd/cfg/cmd/steward_upgrade.go
@@ -24,6 +24,7 @@ var (
 	stewardUpgradeWaitTimeout time.Duration
 	stewardUpgradeID          string
 	stewardUpgradeToVersion   string
+	stewardUpgradeJSONOutput  bool
 )
 
 // stewardUpgradeCmd dispatches a steward binary upgrade to matching stewards.
@@ -100,6 +101,14 @@ func runStewardUpgrade(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
+	if err != nil {
+		return err
+	}
+	if err := confirmMultiHost(matches, stewardYes); err != nil {
+		return err
+	}
+
 	req := &APIDispatchUpgradeRequest{
 		Selector: selector,
 		Version:  stewardUpgradeVersion,
@@ -110,6 +119,13 @@ func runStewardUpgrade(cmd *cobra.Command, args []string) error {
 	result, err := client.DispatchUpgrade(context.Background(), req)
 	if err != nil {
 		return err
+	}
+
+	if stewardUpgradeJSONOutput {
+		return emitKeyedDispatchOutput(matches, map[string]interface{}{
+			"upgrade_id":    result.UpgradeID,
+			"steward_count": result.StewardCount,
+		})
 	}
 
 	fmt.Printf("Upgrade id: %s\n", result.UpgradeID)

--- a/cmd/cfg/cmd/steward_upgrade_test.go
+++ b/cmd/cfg/cmd/steward_upgrade_test.go
@@ -35,6 +35,8 @@ func saveStewardUpgradeGlobals(t *testing.T) {
 	origNoBundle := noBundle
 	origUserConfigDir := userConfigDirFn
 	origSystemBundle := systemBundlePathFn
+	origYes := stewardYes
+	origJSONOutput := stewardUpgradeJSONOutput
 	t.Cleanup(func() {
 		stewardURL = origURL
 		stewardAPIKey = origAPIKey
@@ -52,6 +54,8 @@ func saveStewardUpgradeGlobals(t *testing.T) {
 		noBundle = origNoBundle
 		userConfigDirFn = origUserConfigDir
 		systemBundlePathFn = origSystemBundle
+		stewardYes = origYes
+		stewardUpgradeJSONOutput = origJSONOutput
 	})
 }
 
@@ -74,6 +78,15 @@ func writeUpgradeDispatchResponse(w http.ResponseWriter, upgradeID string, stewa
 		UpgradeID:    upgradeID,
 		StewardCount: stewardCount,
 		Status:       "accepted",
+	})
+}
+
+// writeUpgradeResolveResponse writes a canned fleet/resolve 200 response
+// containing a list of StewardInfo entries.
+func writeUpgradeResolveResponse(w http.ResponseWriter, stewards []StewardInfo) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"data": stewards,
 	})
 }
 
@@ -123,6 +136,8 @@ func TestRunStewardUpgrade_Wait(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+				writeUpgradeResolveResponse(w, []StewardInfo{{ID: "steward-abc"}})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/stewards/upgrade":
 				writeUpgradeDispatchResponse(w, "upgrade-wait-id", 2)
 			case r.Method == http.MethodGet:
@@ -164,6 +179,8 @@ func TestRunStewardUpgrade_Wait(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+				writeUpgradeResolveResponse(w, []StewardInfo{{ID: "steward-abc"}})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/stewards/upgrade":
 				writeUpgradeDispatchResponse(w, "upgrade-auth-id", 1)
 			case r.Method == http.MethodGet:
@@ -201,6 +218,8 @@ func TestRunStewardUpgrade_Wait(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+				writeUpgradeResolveResponse(w, []StewardInfo{{ID: "steward-abc"}})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/stewards/upgrade":
 				writeUpgradeDispatchResponse(w, "upgrade-forbidden-id", 1)
 			case r.Method == http.MethodGet:
@@ -241,10 +260,15 @@ func TestRunStewardUpgrade_AsyncSuccess(t *testing.T) {
 	var requestBody []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestPath = r.URL.Path
-		requestMethod = r.Method
-		requestBody, _ = io.ReadAll(r.Body)
-		writeUpgradeDispatchResponse(w, "upgrade-async-id", 3)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeUpgradeResolveResponse(w, []StewardInfo{{ID: "steward-abc"}})
+		default:
+			requestPath = r.URL.Path
+			requestMethod = r.Method
+			requestBody, _ = io.ReadAll(r.Body)
+			writeUpgradeDispatchResponse(w, "upgrade-async-id", 3)
+		}
 	}))
 	defer server.Close()
 
@@ -274,8 +298,13 @@ func TestRunStewardUpgrade_PlatformArchIncludedInBody(t *testing.T) {
 	var requestBody []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestBody, _ = io.ReadAll(r.Body)
-		writeUpgradeDispatchResponse(w, "upgrade-plat-id", 1)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeUpgradeResolveResponse(w, []StewardInfo{{ID: "s1"}})
+		default:
+			requestBody, _ = io.ReadAll(r.Body)
+			writeUpgradeDispatchResponse(w, "upgrade-plat-id", 1)
+		}
 	}))
 	defer server.Close()
 
@@ -297,10 +326,16 @@ func TestRunStewardUpgrade_PlatformArchIncludedInBody(t *testing.T) {
 }
 
 func TestRunStewardUpgrade_NonAcceptedStatusReturnsError(t *testing.T) {
+	// Resolve succeeds (1 match), but DispatchUpgrade returns 400.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid selector"})
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeUpgradeResolveResponse(w, []StewardInfo{{ID: "s1"}})
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid selector"})
+		}
 	}))
 	defer server.Close()
 
@@ -316,8 +351,10 @@ func TestRunStewardUpgrade_NonAcceptedStatusReturnsError(t *testing.T) {
 
 func TestRunStewardUpgrade_WaitExitsNonZeroOnFailedSteward(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeUpgradeResolveResponse(w, []StewardInfo{{ID: "steward-abc"}})
+		case r.Method == http.MethodPost:
 			writeUpgradeDispatchResponse(w, "upgrade-fail-id", 2)
 		default:
 			stewards := []APIUpgradeStewardStatus{
@@ -349,8 +386,10 @@ func TestRunStewardUpgrade_WaitExitsNonZeroOnFailedSteward(t *testing.T) {
 
 func TestRunStewardUpgrade_WaitTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeUpgradeResolveResponse(w, []StewardInfo{{ID: "steward-abc"}})
+		case r.Method == http.MethodPost:
 			writeUpgradeDispatchResponse(w, "upgrade-timeout-id", 1)
 		default:
 			// Always return dispatched (non-terminal)
@@ -619,7 +658,7 @@ func TestStewardUpgradeCommandsRegistered(t *testing.T) {
 }
 
 func TestStewardUpgradeFlagsRegistered(t *testing.T) {
-	for _, flag := range []string{"url", "api-key", "tls-ca-cert", "version", "platform", "arch", "wait", "wait-timeout"} {
+	for _, flag := range []string{"url", "api-key", "tls-ca-cert", "version", "platform", "arch", "wait", "wait-timeout", "json"} {
 		assert.NotNil(t, stewardUpgradeCmd.Flags().Lookup(flag), "upgrade must have --%s flag", flag)
 	}
 	// --tls-insecure must NOT be registered on the upgrade command
@@ -638,4 +677,108 @@ func TestStewardUpgradeRollbackFlagsRegistered(t *testing.T) {
 		assert.NotNil(t, stewardUpgradeRollbackCmd.Flags().Lookup(flag), "upgrade rollback must have --%s flag", flag)
 	}
 	assert.Nil(t, stewardUpgradeRollbackCmd.Flags().Lookup("tls-insecure"), "upgrade rollback must NOT have --tls-insecure flag")
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] confirm-gate wiring — upgrade
+// ---------------------------------------------------------------------------
+
+// newUpgradeResolveDispatchServer builds a minimal test server that stubs
+// both POST /api/v1/fleet/resolve and POST /api/v1/stewards/upgrade.
+func newUpgradeResolveDispatchServer(t *testing.T, resolveMatches []StewardInfo, upgradeID string, stewardCount int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve":
+			writeUpgradeResolveResponse(w, resolveMatches)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/stewards/upgrade":
+			writeUpgradeDispatchResponse(w, upgradeID, stewardCount)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestRunStewardUpgrade_ConfirmGate_SingleMatchNoPrompt verifies that a
+// selector resolving to one steward proceeds without --yes.
+func TestRunStewardUpgrade_ConfirmGate_SingleMatchNoPrompt(t *testing.T) {
+	srv := newUpgradeResolveDispatchServer(t,
+		[]StewardInfo{{ID: "steward-abc"}},
+		"upgrade-single-id", 1,
+	)
+	defer srv.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+	stewardYes = false // single match → no prompt required
+
+	_ = captureStdout(t, func() {
+		err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+		require.NoError(t, err)
+	})
+}
+
+// TestRunStewardUpgrade_ConfirmGate_MultiMatchNonTTYRequiresYes verifies that
+// a multi-match selector is blocked without --yes in a non-interactive context.
+func TestRunStewardUpgrade_ConfirmGate_MultiMatchNonTTYRequiresYes(t *testing.T) {
+	srv := newUpgradeResolveDispatchServer(t,
+		[]StewardInfo{{ID: "s1"}, {ID: "s2"}},
+		"upgrade-multi-id", 2,
+	)
+	defer srv.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+	stewardYes = false
+
+	err := runStewardUpgrade(stewardUpgradeCmd, []string{"group:production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "yes")
+}
+
+// TestRunStewardUpgrade_JSONOutput_KeyedBySteward verifies that --json emits a
+// keyed-by-steward array with upgrade_id and steward_count in each payload.
+func TestRunStewardUpgrade_JSONOutput_KeyedBySteward(t *testing.T) {
+	srv := newUpgradeResolveDispatchServer(t,
+		[]StewardInfo{
+			{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-one"}},
+			{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-two"}},
+		},
+		"upgrade-json-id", 2,
+	)
+	defer srv.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = srv.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+	stewardYes = true
+	stewardUpgradeJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgrade(stewardUpgradeCmd, []string{"group:production"})
+		require.NoError(t, err)
+	})
+
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be valid JSON")
+	require.Len(t, entries, 2, "must have one entry per resolved steward")
+
+	keys := make(map[string]bool)
+	for _, e := range entries {
+		key, ok := e["key"].(string)
+		require.True(t, ok, "each entry must have a string 'key' field")
+		keys[key] = true
+		assert.True(t, e["success"].(bool), "each entry must be success=true")
+		payload, ok := e["payload"].(map[string]interface{})
+		require.True(t, ok, "each entry must have a payload object")
+		assert.Equal(t, "upgrade-json-id", payload["upgrade_id"], "payload must contain upgrade_id")
+		assert.InDelta(t, float64(2), payload["steward_count"], 0, "payload must contain steward_count")
+	}
+	assert.True(t, keys["host-one#s1"], "output must contain key 'host-one#s1'")
+	assert.True(t, keys["host-two#s2"], "output must contain key 'host-two#s2'")
 }


### PR DESCRIPTION
## Summary

- `run-script` and `run-command` now call `resolveOrFailFast` + `confirmMultiHost` before dispatch when `--target` is set; non-TTY callers targeting N>1 stewards must pass `--yes/-y` or get a fail-closed error
- `upgrade` gains the same confirm gate (selector is always required, so gate is unconditional)
- `--json` flag added to all three verbs: emits a keyed-by-steward JSON array via new `emitKeyedDispatchOutput` helper (shared in `steward_selector.go`), where every matched steward receives the same shared `run_id` or `upgrade_id` payload
- All pre-existing dispatch tests updated to stub the `/api/v1/fleet/resolve` endpoint that these verbs now call before dispatch

## Specialist Review Results

| Lens | Verdict |
|------|---------|
| Security | PASS — no findings; TLS secure-by-default, no hardcoded secrets, fail-closed multi-host gate |
| Test Quality | PASS — real httptest.Server throughout, no mocks, all error paths covered |
| Code Review | PASS — 0 fix rounds required |

## Test plan

- [ ] `go test ./cmd/cfg/cmd/... -run "TestRunScript_ConfirmGate|TestRunCommand_ConfirmGate|TestRunStewardUpgrade_ConfirmGate"` — confirm-gate wiring
- [ ] `go test ./cmd/cfg/cmd/... -run "TestRunScript_JSONOutput|TestRunCommand_JSONOutput|TestRunStewardUpgrade_JSONOutput"` — keyed JSON output
- [ ] `make test-complete` passes

Fixes #2443

🤖 Generated with [Claude Code](https://claude.com/claude-code)