### PR TITLE
cli: move + decommission selector-based multi-host with confirm gate (Issue #2444)

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -46,6 +46,11 @@ var (
 
 var stewardMoveToTenant string
 
+var (
+	stewardMoveJSONOutput         bool
+	stewardDecommissionJSONOutput bool
+)
+
 // stewardYes is the persistent --yes/-y flag shared across the steward command
 // tree. It suppresses the multi-host confirmation prompt for mutating verbs but
 // never suppresses the 0-match fail-fast error (see confirmMultiHost).
@@ -222,13 +227,17 @@ Examples:
 	RunE: runRunCancel,
 }
 
-// stewardMoveCmd moves a steward to a different tenant via the controller REST API.
+// stewardMoveCmd moves one or more stewards to a different tenant via the controller REST API.
 var stewardMoveCmd = &cobra.Command{
-	Use:   "move <steward-id>",
-	Short: "Move a steward to a different tenant",
-	Long: `Move a steward to a different tenant.
+	Use:   "move <selector>",
+	Short: "Move matching stewards to a different tenant",
+	Long: `Move one or more stewards to a different tenant.
 
-Post-move, the steward is subject to the DESTINATION tenant's refresh policy and
+The selector is resolved against the fleet before any mutation occurs. A selector
+that matches more than one steward triggers the --yes confirmation gate; a
+single-match selector proceeds without prompting.
+
+Post-move, each steward is subject to the DESTINATION tenant's refresh policy and
 module/publisher trust configuration. Trust is never resolved from the old
 (source-tenant, device-key) pair — identity continuity is preserved while the
 trust context changes immediately to the destination tenant.
@@ -236,56 +245,114 @@ trust context changes immediately to the destination tenant.
 Requires an admin bundle with mTLS access (Tier-3 endpoint).
 
 Examples:
-  # Move steward to a different tenant
-  cfg steward move <steward-id> --to-tenant dest-tenant
+  # Move a single steward by ID
+  cfg steward move steward-abc123 --to-tenant dest-tenant
 
-  # Move steward using explicit controller URL
-  cfg steward move <steward-id> --to-tenant dest-tenant --url=https://controller.example.com`,
+  # Move all stewards in a group
+  cfg steward move group:prod --to-tenant dest-tenant --yes
+
+  # Move and emit keyed JSON results
+  cfg steward move os:linux --to-tenant dest-tenant --yes --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runStewardMove,
 }
 
-// stewardDecommissionCmd permanently decommissions a steward from the fleet.
+// stewardDecommissionCmd permanently decommissions one or more stewards from the fleet.
 var stewardDecommissionCmd = &cobra.Command{
-	Use:   "decommission <id>",
-	Short: "Decommission a steward from the fleet",
-	Long: `Mark a steward record as deregistered after its host or VM has been torn down.
+	Use:   "decommission <selector>",
+	Short: "Decommission matching stewards from the fleet",
+	Long: `Mark one or more stewards as deregistered after their hosts or VMs have been torn down.
 
-Requires an admin mTLS certificate. The record is retained in durable storage
-for audit but no longer appears in cfg steward list. Any active connection is dropped.
+The selector is resolved against the fleet before any mutation occurs. A selector
+that matches more than one steward triggers the --yes confirmation gate; a
+single-match selector proceeds without prompting.
+
+Requires an admin mTLS certificate. Records are retained in durable storage
+for audit but no longer appear in cfg steward list. Any active connections are dropped.
 
 Examples:
-  cfg steward decommission steward-abc123`,
+  cfg steward decommission steward-abc123
+  cfg steward decommission group:decommissioned --yes
+  cfg steward decommission os:linux --yes --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runStewardDecommission,
 }
 
 func runStewardDecommission(_ *cobra.Command, args []string) error {
-	stewardID := args[0]
+	selector := args[0]
+
 	client, err := getStewardClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
-	resp, err := client.doRequest(context.Background(), http.MethodDelete,
-		"/api/v1/stewards/"+stewardID, nil)
+
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
 	if err != nil {
-		return fmt.Errorf("failed to decommission steward: %w", err)
+		return err
 	}
-	defer func() { _ = resp.Body.Close() }()
-	switch resp.StatusCode {
-	case http.StatusOK:
-		fmt.Printf("Steward %s decommissioned.\n", stewardID)
-		return nil
-	case http.StatusNotFound:
-		return fmt.Errorf("steward %s not found", stewardID)
-	case http.StatusForbidden:
-		return fmt.Errorf("decommission requires an admin mTLS certificate")
-	case http.StatusServiceUnavailable:
-		return fmt.Errorf("fleet store unavailable; retry later")
-	default:
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+
+	if err := confirmMultiHost(matches, stewardYes); err != nil {
+		return err
 	}
+
+	results, overallErr := fanOutConcurrent(context.Background(), matches,
+		func(ctx context.Context, s StewardInfo) (json.RawMessage, error) {
+			resp, err := client.doRequest(ctx, http.MethodDelete, "/api/v1/stewards/"+s.ID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decommission steward: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			switch resp.StatusCode {
+			case http.StatusOK:
+				return json.RawMessage(`{"status":"decommissioned"}`), nil
+			case http.StatusNotFound:
+				return nil, fmt.Errorf("steward %s not found", s.ID)
+			case http.StatusForbidden:
+				return nil, fmt.Errorf("decommission requires an admin mTLS certificate")
+			case http.StatusServiceUnavailable:
+				return nil, fmt.Errorf("fleet store unavailable; retry later")
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+			}
+		})
+
+	if stewardDecommissionJSONOutput {
+		entries := keyedOutput(matches, results)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			return err
+		}
+		return overallErr
+	}
+
+	for _, m := range matches {
+		key := stewardKey(m)
+		r := results[key]
+		if r.Err != nil {
+			// Multi-host: print per-steward errors to stderr so partial failures
+			// are visible while the generic overallErr signals the non-zero exit.
+			// Single-host: skip printing here; the specific error is returned below.
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr, "error: %s: %v\n", key, r.Err)
+			}
+			continue
+		}
+		fmt.Printf("Steward %s decommissioned.\n", m.ID)
+	}
+
+	// For single-host failure, surface the specific per-steward error from RunE
+	// (cobra prints it) — preserves the pre-selector single-ID error semantics.
+	if overallErr != nil && len(matches) == 1 {
+		for _, r := range results {
+			if r.Err != nil {
+				return r.Err
+			}
+		}
+	}
+	return overallErr
 }
 
 // stewardLogsCmd pulls recent log entries from a steward via the controller REST API.
@@ -305,67 +372,128 @@ Examples:
 }
 
 func runStewardMove(_ *cobra.Command, args []string) error {
-	stewardID := args[0]
+	selector := args[0]
 
 	client, err := getStewardClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	reqBody, err := json.Marshal(map[string]string{"new_tenant_id": stewardMoveToTenant})
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
 	if err != nil {
-		return fmt.Errorf("failed to encode request: %w", err)
+		return err
 	}
 
-	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/stewards/"+stewardID+"/move", bytes.NewReader(reqBody))
-	if err != nil {
-		return fmt.Errorf("failed to move steward: %w", err)
+	if err := confirmMultiHost(matches, stewardYes); err != nil {
+		return err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+
+	results, overallErr := fanOutConcurrent(context.Background(), matches,
+		func(ctx context.Context, s StewardInfo) (json.RawMessage, error) {
+			reqBody, err := json.Marshal(map[string]string{"new_tenant_id": stewardMoveToTenant})
+			if err != nil {
+				return nil, fmt.Errorf("failed to encode request: %w", err)
+			}
+
+			resp, err := client.doRequest(ctx, http.MethodPost, "/api/v1/stewards/"+s.ID+"/move", bytes.NewReader(reqBody))
+			if err != nil {
+				return nil, fmt.Errorf("failed to move steward: %w", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+				}
+			}()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response: %w", err)
+			}
+
+			switch resp.StatusCode {
+			case http.StatusForbidden:
+				return nil, fmt.Errorf("move denied: insufficient scope to move steward %s to tenant %s", s.ID, stewardMoveToTenant)
+			case http.StatusNotFound:
+				return nil, fmt.Errorf("steward %s not found", s.ID)
+			case http.StatusOK:
+				// handled below
+			default:
+				return nil, fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+			}
+
+			var apiResp struct {
+				Data struct {
+					StewardID      string `json:"steward_id"`
+					TenantID       string `json:"tenant_id"`
+					PreviousTenant string `json:"previous_tenant"`
+					Status         string `json:"status"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(body, &apiResp); err != nil {
+				return nil, fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			payload, err := json.Marshal(apiResp.Data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal result: %w", err)
+			}
+			return payload, nil
+		})
+
+	if stewardMoveJSONOutput {
+		entries := keyedOutput(matches, results)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			return err
 		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
+		return overallErr
 	}
 
-	if resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("move denied: insufficient scope to move steward %s to tenant %s", stewardID, stewardMoveToTenant)
-	}
+	for _, m := range matches {
+		key := stewardKey(m)
+		r := results[key]
+		if r.Err != nil {
+			// Multi-host: print per-steward errors to stderr so partial failures
+			// are visible while the generic overallErr signals the non-zero exit.
+			// Single-host: skip printing here; the specific error is returned below.
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr, "error: %s: %v\n", key, r.Err)
+			}
+			continue
+		}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("steward %s not found", stewardID)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
-	}
-
-	var apiResp struct {
-		Data struct {
+		var d struct {
 			StewardID      string `json:"steward_id"`
 			TenantID       string `json:"tenant_id"`
 			PreviousTenant string `json:"previous_tenant"`
 			Status         string `json:"status"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
+		}
+		if err := json.Unmarshal(r.Payload, &d); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: failed to parse result: %v\n", key, err)
+			continue
+		}
+
+		switch d.Status {
+		case "no_change":
+			fmt.Printf("Steward %s is already in tenant %s (no change)\n", m.ID, d.TenantID)
+		case "moved":
+			fmt.Printf("Steward %s moved to tenant %s (was: %s)\n", m.ID, d.TenantID, d.PreviousTenant)
+		default:
+			fmt.Printf("Steward %s: status=%s tenant=%s\n", m.ID, d.Status, d.TenantID)
+		}
 	}
 
-	d := apiResp.Data
-	switch d.Status {
-	case "no_change":
-		fmt.Printf("Steward %s is already in tenant %s (no change)\n", stewardID, d.TenantID)
-	case "moved":
-		fmt.Printf("Steward %s moved to tenant %s (was: %s)\n", stewardID, d.TenantID, d.PreviousTenant)
-	default:
-		fmt.Printf("Steward %s: status=%s tenant=%s\n", stewardID, d.Status, d.TenantID)
+	// For single-host failure, surface the specific per-steward error from RunE
+	// (cobra prints it) — preserves the pre-selector single-ID error semantics.
+	if overallErr != nil && len(matches) == 1 {
+		for _, r := range results {
+			if r.Err != nil {
+				return r.Err
+			}
+		}
 	}
-	return nil
+	return overallErr
 }
 
 func runStewardLogs(_ *cobra.Command, args []string) error {
@@ -534,21 +662,23 @@ func init() {
 	stewardLogsCmd.Flags().StringVar(&stewardLogsModule, "module", "", "Filter by module name")
 	stewardLogsCmd.Flags().BoolVar(&stewardLogsJSON, "json", false, "Emit raw JSON output instead of human-readable text")
 
-	// move flags (Issue #2342)
+	// move flags (Issue #2342, #2444)
 	stewardMoveCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
 	stewardMoveCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
 	stewardMoveCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
 	stewardMoveCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
 	stewardMoveCmd.Flags().StringVar(&stewardMoveToTenant, "to-tenant", "", "Destination tenant ID (required)")
+	stewardMoveCmd.Flags().BoolVar(&stewardMoveJSONOutput, "json", false, "Emit keyed-by-steward JSON results")
 	if err := stewardMoveCmd.MarkFlagRequired("to-tenant"); err != nil {
 		panic(err)
 	}
 
-	// decommission flags (Issue #2408)
+	// decommission flags (Issue #2408, #2444)
 	stewardDecommissionCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
 	stewardDecommissionCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
 	stewardDecommissionCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
 	stewardDecommissionCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+	stewardDecommissionCmd.Flags().BoolVar(&stewardDecommissionJSONOutput, "json", false, "Emit keyed-by-steward JSON results")
 
 	// --yes/-y is a persistent flag on the steward command tree so it is
 	// accepted (and inert where irrelevant) by every subcommand. Mutating

--- a/cmd/cfg/cmd/steward_decommission_test.go
+++ b/cmd/cfg/cmd/steward_decommission_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newDecommissionMultiServer creates a test server that handles:
+//   - POST /api/v1/fleet/resolve → returns stewards
+//   - DELETE /api/v1/stewards/{id} → calls perSteward(id) for status + body
+func newDecommissionMultiServer(t *testing.T, stewards []StewardInfo, perSteward func(id string) (int, interface{})) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve" {
+			if err := json.NewEncoder(w).Encode(struct {
+				Data []StewardInfo `json:"data"`
+			}{Data: stewards}); err != nil {
+				t.Errorf("encode resolve: %v", err)
+			}
+			return
+		}
+		// DELETE /api/v1/stewards/{id}
+		if r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/stewards/") {
+			parts := strings.Split(r.URL.Path, "/")
+			id := parts[len(parts)-1]
+			status, body := perSteward(id)
+			w.WriteHeader(status)
+			if err := json.NewEncoder(w).Encode(body); err != nil {
+				t.Errorf("encode decommission response: %v", err)
+			}
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+}
+
+// setStewardDecommissionFlags sets global steward flags for decommission tests.
+func setStewardDecommissionFlags(t *testing.T, serverURL string, yes, jsonOut bool) {
+	t.Helper()
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	origYes := stewardYes
+	origJSON := stewardDecommissionJSONOutput
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+		stewardYes = origYes
+		stewardDecommissionJSONOutput = origJSON
+	})
+	stewardURL = serverURL
+	stewardTLSInsecure = true
+	stewardYes = yes
+	stewardDecommissionJSONOutput = jsonOut
+}
+
+// ---- multi-match all-success ------------------------------------------------
+
+func TestStewardDecommissionSelector_MultiMatch_AllSuccess(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newDecommissionMultiServer(t, stewards, func(_ string) (int, interface{}) {
+		return http.StatusOK, map[string]interface{}{"data": map[string]string{"status": "deregistered"}}
+	})
+	t.Cleanup(srv.Close)
+	setStewardDecommissionFlags(t, srv.URL, true, false)
+
+	output := captureStdout(t, func() {
+		err := runStewardDecommission(stewardDecommissionCmd, []string{"group:old"})
+		require.NoError(t, err)
+	})
+
+	// Both stewards appear as decommissioned.
+	assert.Contains(t, output, "s1")
+	assert.Contains(t, output, "s2")
+	assert.Contains(t, output, "decommissioned")
+}
+
+func TestStewardDecommissionSelector_MultiMatch_AllSuccess_JSONOutput(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newDecommissionMultiServer(t, stewards, func(_ string) (int, interface{}) {
+		return http.StatusOK, map[string]interface{}{"data": map[string]string{"status": "deregistered"}}
+	})
+	t.Cleanup(srv.Close)
+	setStewardDecommissionFlags(t, srv.URL, true, true)
+
+	output := captureStdout(t, func() {
+		err := runStewardDecommission(stewardDecommissionCmd, []string{"group:old"})
+		require.NoError(t, err)
+	})
+
+	// Output must be a valid JSON array with one entry per steward.
+	var entries []KeyedOutputEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array")
+	require.Len(t, entries, 2)
+
+	keys := make(map[string]bool)
+	for _, e := range entries {
+		keys[e.Key] = true
+		assert.True(t, e.Success, "entry %s should be successful", e.Key)
+		assert.Empty(t, e.Error)
+	}
+	assert.True(t, keys["host-a#s1"], "host-a#s1 must appear in output")
+	assert.True(t, keys["host-b#s2"], "host-b#s2 must appear in output")
+}
+
+// ---- multi-match partial failure --------------------------------------------
+
+func TestStewardDecommissionSelector_MultiMatch_PartialFailure_HumanOutput(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newDecommissionMultiServer(t, stewards, func(id string) (int, interface{}) {
+		if id == "s2" {
+			return http.StatusNotFound, map[string]interface{}{"error": "steward not found"}
+		}
+		return http.StatusOK, map[string]interface{}{"data": map[string]string{"status": "deregistered"}}
+	})
+	t.Cleanup(srv.Close)
+	setStewardDecommissionFlags(t, srv.URL, true, false)
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runStewardDecommission(stewardDecommissionCmd, []string{"group:old"})
+	})
+
+	// Command must exit non-zero when any host fails.
+	require.Error(t, runErr, "partial failure must make RunE return non-nil error")
+
+	// Successful steward still appears in human output.
+	assert.Contains(t, output, "s1")
+	assert.Contains(t, output, "decommissioned")
+}
+
+func TestStewardDecommissionSelector_MultiMatch_PartialFailure_JSONOutput(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newDecommissionMultiServer(t, stewards, func(id string) (int, interface{}) {
+		if id == "s2" {
+			return http.StatusForbidden, map[string]interface{}{"error": "insufficient permissions"}
+		}
+		return http.StatusOK, map[string]interface{}{"data": map[string]string{"status": "deregistered"}}
+	})
+	t.Cleanup(srv.Close)
+	setStewardDecommissionFlags(t, srv.URL, true, true)
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runStewardDecommission(stewardDecommissionCmd, []string{"group:old"})
+	})
+
+	// Non-zero exit even with --json.
+	require.Error(t, runErr, "partial failure must make RunE return non-nil error")
+
+	// Output is still valid JSON with both entries.
+	var entries []KeyedOutputEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array even on partial failure")
+	require.Len(t, entries, 2)
+
+	byKey := make(map[string]KeyedOutputEntry, len(entries))
+	for _, e := range entries {
+		byKey[e.Key] = e
+	}
+
+	s1 := byKey["host-a#s1"]
+	assert.True(t, s1.Success)
+	assert.Empty(t, s1.Error)
+
+	s2 := byKey["host-b#s2"]
+	assert.False(t, s2.Success)
+	assert.NotEmpty(t, s2.Error)
+}
+
+// ---- selector resolves to single match (no confirm gate) --------------------
+
+func TestStewardDecommissionSelector_SingleMatch_NoConfirmNeeded(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+	}
+
+	srv := newDecommissionMultiServer(t, stewards, func(_ string) (int, interface{}) {
+		return http.StatusOK, map[string]interface{}{"data": map[string]string{"status": "deregistered"}}
+	})
+	t.Cleanup(srv.Close)
+	setStewardDecommissionFlags(t, srv.URL, false, false) // yes=false
+
+	output := captureStdout(t, func() {
+		err := runStewardDecommission(stewardDecommissionCmd, []string{"s1"})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "s1")
+	assert.Contains(t, output, "decommissioned")
+}
+
+// ---- --json flag registered -------------------------------------------------
+
+func TestStewardDecommissionCmd_JSONFlagRegistered(t *testing.T) {
+	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("json"), "--json flag must be registered on steward decommission")
+}

--- a/cmd/cfg/cmd/steward_move_test.go
+++ b/cmd/cfg/cmd/steward_move_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMoveMultiServer creates a test server that handles:
+//   - POST /api/v1/fleet/resolve → returns stewards
+//   - POST /api/v1/stewards/{id}/move → calls perSteward(id) for status + body
+func newMoveMultiServer(t *testing.T, stewards []StewardInfo, perSteward func(id string) (int, interface{})) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve" {
+			if err := json.NewEncoder(w).Encode(struct {
+				Data []StewardInfo `json:"data"`
+			}{Data: stewards}); err != nil {
+				t.Errorf("encode resolve: %v", err)
+			}
+			return
+		}
+		// /api/v1/stewards/{id}/move
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/move") {
+			parts := strings.Split(strings.TrimSuffix(r.URL.Path, "/move"), "/")
+			id := parts[len(parts)-1]
+			status, body := perSteward(id)
+			w.WriteHeader(status)
+			if err := json.NewEncoder(w).Encode(body); err != nil {
+				t.Errorf("encode move response: %v", err)
+			}
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+}
+
+// setStewardMoveFlags sets the global steward flags for move tests and restores them
+// on cleanup.
+func setStewardMoveFlags(t *testing.T, serverURL, toTenant string, yes, jsonOut bool) {
+	t.Helper()
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	origToTenant := stewardMoveToTenant
+	origYes := stewardYes
+	origJSON := stewardMoveJSONOutput
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+		stewardMoveToTenant = origToTenant
+		stewardYes = origYes
+		stewardMoveJSONOutput = origJSON
+	})
+	stewardURL = serverURL
+	stewardTLSInsecure = true
+	stewardMoveToTenant = toTenant
+	stewardYes = yes
+	stewardMoveJSONOutput = jsonOut
+}
+
+// successMoveBody returns a standard 200 move response body.
+func successMoveBody(id, prevTenant, destTenant string) interface{} {
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"steward_id":      id,
+			"tenant_id":       destTenant,
+			"previous_tenant": prevTenant,
+			"status":          "moved",
+		},
+	}
+}
+
+// ---- multi-match all-success ------------------------------------------------
+
+func TestStewardMoveSelector_MultiMatch_AllSuccess(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newMoveMultiServer(t, stewards, func(id string) (int, interface{}) {
+		return http.StatusOK, successMoveBody(id, "src-tenant", "dest-tenant")
+	})
+	t.Cleanup(srv.Close)
+	setStewardMoveFlags(t, srv.URL, "dest-tenant", true, false)
+
+	output := captureStdout(t, func() {
+		err := runStewardMove(stewardMoveCmd, []string{"group:prod"})
+		require.NoError(t, err)
+	})
+
+	// Both stewards appear in output as moved.
+	assert.Contains(t, output, "s1")
+	assert.Contains(t, output, "s2")
+	assert.Contains(t, output, "dest-tenant")
+}
+
+func TestStewardMoveSelector_MultiMatch_AllSuccess_JSONOutput(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newMoveMultiServer(t, stewards, func(id string) (int, interface{}) {
+		return http.StatusOK, successMoveBody(id, "src-tenant", "dest-tenant")
+	})
+	t.Cleanup(srv.Close)
+	setStewardMoveFlags(t, srv.URL, "dest-tenant", true, true)
+
+	output := captureStdout(t, func() {
+		err := runStewardMove(stewardMoveCmd, []string{"group:prod"})
+		require.NoError(t, err)
+	})
+
+	// Output must be a valid JSON array with one entry per steward.
+	var entries []KeyedOutputEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array")
+	require.Len(t, entries, 2)
+
+	keys := make(map[string]bool)
+	for _, e := range entries {
+		keys[e.Key] = true
+		assert.True(t, e.Success, "entry %s should be successful", e.Key)
+		assert.Empty(t, e.Error)
+	}
+	assert.True(t, keys["host-a#s1"], "host-a#s1 must appear in output")
+	assert.True(t, keys["host-b#s2"], "host-b#s2 must appear in output")
+}
+
+// ---- multi-match partial failure --------------------------------------------
+
+func TestStewardMoveSelector_MultiMatch_PartialFailure_HumanOutput(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newMoveMultiServer(t, stewards, func(id string) (int, interface{}) {
+		if id == "s2" {
+			return http.StatusForbidden, map[string]interface{}{"error": "insufficient scope"}
+		}
+		return http.StatusOK, successMoveBody(id, "src-tenant", "dest-tenant")
+	})
+	t.Cleanup(srv.Close)
+	setStewardMoveFlags(t, srv.URL, "dest-tenant", true, false)
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runStewardMove(stewardMoveCmd, []string{"group:prod"})
+	})
+
+	// Command must exit non-zero when any host fails.
+	require.Error(t, runErr, "partial failure must make RunE return non-nil error")
+
+	// Successful steward still appears in human output.
+	assert.Contains(t, output, "s1")
+}
+
+func TestStewardMoveSelector_MultiMatch_PartialFailure_JSONOutput(t *testing.T) {
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "s2", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	srv := newMoveMultiServer(t, stewards, func(id string) (int, interface{}) {
+		if id == "s2" {
+			return http.StatusNotFound, map[string]interface{}{"error": "not found"}
+		}
+		return http.StatusOK, successMoveBody(id, "src-tenant", "dest-tenant")
+	})
+	t.Cleanup(srv.Close)
+	setStewardMoveFlags(t, srv.URL, "dest-tenant", true, true)
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runStewardMove(stewardMoveCmd, []string{"group:prod"})
+	})
+
+	// Non-zero exit even with --json.
+	require.Error(t, runErr, "partial failure must make RunE return non-nil error")
+
+	// Output is still valid JSON with both entries.
+	var entries []KeyedOutputEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array even on partial failure")
+	require.Len(t, entries, 2)
+
+	byKey := make(map[string]KeyedOutputEntry, len(entries))
+	for _, e := range entries {
+		byKey[e.Key] = e
+	}
+
+	s1 := byKey["host-a#s1"]
+	assert.True(t, s1.Success)
+	assert.Empty(t, s1.Error)
+
+	s2 := byKey["host-b#s2"]
+	assert.False(t, s2.Success)
+	assert.NotEmpty(t, s2.Error)
+}
+
+// ---- selector resolves to single match (no confirm gate) --------------------
+
+func TestStewardMoveSelector_SingleMatch_NoConfirmNeeded(t *testing.T) {
+	// A single match should succeed without --yes.
+	stewards := []StewardInfo{
+		{ID: "s1", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+	}
+
+	srv := newMoveMultiServer(t, stewards, func(id string) (int, interface{}) {
+		return http.StatusOK, successMoveBody(id, "src-tenant", "dest-tenant")
+	})
+	t.Cleanup(srv.Close)
+	setStewardMoveFlags(t, srv.URL, "dest-tenant", false, false) // yes=false
+
+	output := captureStdout(t, func() {
+		err := runStewardMove(stewardMoveCmd, []string{"s1"})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "s1")
+}
+
+// ---- --json flag registered -------------------------------------------------
+
+func TestStewardMoveCmd_JSONFlagRegistered(t *testing.T) {
+	assert.NotNil(t, stewardMoveCmd.Flags().Lookup("json"), "--json flag must be registered on steward move")
+}

--- a/cmd/cfg/cmd/steward_test.go
+++ b/cmd/cfg/cmd/steward_test.go
@@ -688,14 +688,30 @@ func TestStewardDNA_JSONOutput(t *testing.T) {
 	assert.Equal(t, rawBody, output)
 }
 
-// ---- cfg steward move tests (Issue #2342) ----
+// ---- cfg steward move tests (Issue #2342, updated for selector in #2444) ----
+
+// newSingleStewardMoveServer creates a test server serving fleet/resolve (returning
+// singleID as the only match) and the move endpoint via the given moveHandler.
+func newSingleStewardMoveServer(t *testing.T, singleID string, moveHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve" {
+			_ = json.NewEncoder(w).Encode(struct {
+				Data []StewardInfo `json:"data"`
+			}{Data: []StewardInfo{{ID: singleID}}})
+			return
+		}
+		moveHandler(w, r)
+	}))
+}
 
 func TestStewardMove_Success(t *testing.T) {
 	var requestPath string
 	var requestMethod string
 	var requestBody map[string]string
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardMoveServer(t, "steward-abc", func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
 		requestMethod = r.Method
 		_ = json.NewDecoder(r.Body).Decode(&requestBody)
@@ -709,7 +725,7 @@ func TestStewardMove_Success(t *testing.T) {
 				"status":          "moved",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -738,7 +754,7 @@ func TestStewardMove_Success(t *testing.T) {
 }
 
 func TestStewardMove_NoChange(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardMoveServer(t, "steward-abc", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -749,7 +765,7 @@ func TestStewardMove_NoChange(t *testing.T) {
 				"status":          "no_change",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -774,7 +790,7 @@ func TestStewardMove_NoChange(t *testing.T) {
 }
 
 func TestStewardMove_Forbidden_ReturnsClearError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardMoveServer(t, "steward-abc", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -783,7 +799,7 @@ func TestStewardMove_Forbidden_ReturnsClearError(t *testing.T) {
 				"message": "Insufficient scope to move steward between these tenants",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -806,7 +822,7 @@ func TestStewardMove_Forbidden_ReturnsClearError(t *testing.T) {
 }
 
 func TestStewardMove_StewardNotFound_Returns404Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardMoveServer(t, "unknown-steward", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -815,7 +831,7 @@ func TestStewardMove_StewardNotFound_Returns404Error(t *testing.T) {
 				"message": "Steward not found",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -842,6 +858,25 @@ func TestStewardMove_FlagsRegistered(t *testing.T) {
 	assert.NotNil(t, stewardMoveCmd.Flags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered")
 	assert.NotNil(t, stewardMoveCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered")
 	assert.NotNil(t, stewardMoveCmd.Flags().Lookup("to-tenant"), "--to-tenant flag must be registered")
+	assert.NotNil(t, stewardMoveCmd.Flags().Lookup("json"), "--json flag must be registered")
+}
+
+// ---- cfg steward decommission tests (Issue #2408, updated for selector in #2444) ----
+
+// newSingleStewardDecommissionServer creates a test server serving fleet/resolve (returning
+// singleID as the only match) and DELETE /api/v1/stewards/{id} via decommHandler.
+func newSingleStewardDecommissionServer(t *testing.T, singleID string, decommHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve" {
+			_ = json.NewEncoder(w).Encode(struct {
+				Data []StewardInfo `json:"data"`
+			}{Data: []StewardInfo{{ID: singleID}}})
+			return
+		}
+		decommHandler(w, r)
+	}))
 }
 
 // TestStewardDecommission_CallsDeleteEndpoint verifies that decommission issues an
@@ -850,7 +885,7 @@ func TestStewardDecommission_CallsDeleteEndpoint(t *testing.T) {
 	var requestPath string
 	var requestMethod string
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardDecommissionServer(t, "steward-abc123", func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
 		requestMethod = r.Method
 		w.Header().Set("Content-Type", "application/json")
@@ -861,7 +896,7 @@ func TestStewardDecommission_CallsDeleteEndpoint(t *testing.T) {
 				"status": "deregistered",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -887,7 +922,7 @@ func TestStewardDecommission_CallsDeleteEndpoint(t *testing.T) {
 
 // TestStewardDecommission_NotFound_ReturnsError verifies a 404 surfaces a clear error.
 func TestStewardDecommission_NotFound_ReturnsError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardDecommissionServer(t, "unknown-steward", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -896,7 +931,7 @@ func TestStewardDecommission_NotFound_ReturnsError(t *testing.T) {
 				"message": "Steward not found",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -918,7 +953,7 @@ func TestStewardDecommission_NotFound_ReturnsError(t *testing.T) {
 // TestStewardDecommission_Forbidden_ReturnsMTLSError verifies that a 403 (API-key caller
 // rejected at the Tier-3 gate) surfaces an mTLS-specific error.
 func TestStewardDecommission_Forbidden_ReturnsMTLSError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardDecommissionServer(t, "steward-abc123", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -927,7 +962,7 @@ func TestStewardDecommission_Forbidden_ReturnsMTLSError(t *testing.T) {
 				"message": "mTLS admin certificate required for this endpoint",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -948,7 +983,7 @@ func TestStewardDecommission_Forbidden_ReturnsMTLSError(t *testing.T) {
 // TestStewardDecommission_ServiceUnavailable_ReturnsRetryError verifies that a 503
 // (fleet store unavailable) surfaces a retry-later error.
 func TestStewardDecommission_ServiceUnavailable_ReturnsRetryError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardDecommissionServer(t, "steward-abc123", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -957,7 +992,7 @@ func TestStewardDecommission_ServiceUnavailable_ReturnsRetryError(t *testing.T) 
 				"message": "Fleet store unavailable",
 			},
 		})
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -978,10 +1013,10 @@ func TestStewardDecommission_ServiceUnavailable_ReturnsRetryError(t *testing.T) 
 // TestStewardDecommission_OtherHTTPError_ReturnsStatusAndBody verifies that an unexpected
 // status returns the status and response body.
 func TestStewardDecommission_OtherHTTPError_ReturnsStatusAndBody(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newSingleStewardDecommissionServer(t, "steward-abc123", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("internal server error"))
-	}))
+	})
 	defer server.Close()
 
 	origURL := stewardURL
@@ -1004,4 +1039,5 @@ func TestStewardDecommission_FlagsRegistered(t *testing.T) {
 	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("api-key"), "--api-key flag must be registered")
 	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered")
 	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered")
+	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("json"), "--json flag must be registered")
 }


### PR DESCRIPTION
## Summary

- `cfg steward move <selector>` and `cfg steward decommission <selector>` now resolve the selector against the fleet before mutating, enabling fleet-wide targeting without a manual shell loop
- Client-side fan-out via `fanOutConcurrent` (bounded at 10 concurrent calls) over existing single-ID REST endpoints — no new batch endpoint required
- Both commands route through the story-4 resolve-then-confirm gate (`resolveOrFailFast` + `confirmMultiHost`); single-match is friction-free, multi-match requires `--yes` or interactive confirmation
- Partial failures (some stewards succeed, some fail) are reported per-steward in human output (stderr) and as keyed JSON entries (`--json`); `RunE` returns non-zero if any host failed

## Specialist Review Results

- **Code Review**: PASS (0 findings)
- **Test Quality**: PASS (0 findings)  
- **Security**: PASS — no SQL injection surface (CLI), no hardcoded secrets, no unsanitized logging, no TLS violations; gosec findings are pre-existing unchanged files; architecture checks clean

## Test Plan

- [x] `go test ./cmd/cfg/cmd/...` — all tests pass
- [x] `make check-architecture` — no central provider violations
- [x] `make lint-log-injection` — no findings
- [x] Multi-match all-success for both `move` and `decommission`
- [x] Multi-match partial-failure with non-zero exit assertion for both verbs
- [x] `--json` output verified for both success and partial-failure cases
- [x] Single-match confirms no friction (no `--yes` needed)
- [x] Existing single-steward tests updated to serve fleet/resolve endpoint

Fixes #2444

🤖 Generated with [Claude Code](https://claude.com/claude-code)