### PR TITLE
build: enforce installer-payload directory/manifest boundary (Issue #2470)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ STDLIB_MODULES := \
 # See scripts/check-stdlib-payload-boundary.sh and ADR-016 clause 3.
 .PHONY: check-stdlib-payload-boundary
 check-stdlib-payload-boundary:
-	@./scripts/check-stdlib-payload-boundary.sh
+	@bash ./scripts/check-stdlib-payload-boundary.sh
 
 .PHONY: build-stdlib-modules
 build-stdlib-modules: check-stdlib-payload-boundary

--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,14 @@ STDLIB_MODULES := \
 	script \
 	service
 
+# Stdlib payload boundary check: all five sources of stdlib module names must agree.
+# See scripts/check-stdlib-payload-boundary.sh and ADR-016 clause 3.
+.PHONY: check-stdlib-payload-boundary
+check-stdlib-payload-boundary:
+	@./scripts/check-stdlib-payload-boundary.sh
+
 .PHONY: build-stdlib-modules
-build-stdlib-modules:
+build-stdlib-modules: check-stdlib-payload-boundary
 	@echo "Building stdlib module binaries..."
 	@for module in $(STDLIB_MODULES); do \
 		echo "  Building cfgms-module-$$module..."; \
@@ -706,7 +712,7 @@ validate-providers:
 	echo ""
 
 # Pre-commit validation (smart tests + quality gates + SECRET SCANNING + ARCHITECTURE + LICENSE)
-test-commit: test lint lint-log-injection check-license-headers security-precommit check-architecture security-scan
+test-commit: test lint lint-log-injection check-license-headers security-precommit check-architecture check-stdlib-payload-boundary security-scan
 	@echo ""
 	@echo "✅ PRE-COMMIT VALIDATION FINISHED"
 	@echo "===================================="
@@ -715,6 +721,7 @@ test-commit: test lint lint-log-injection check-license-headers security-precomm
 	@echo "- ✅ License headers validated"
 	@echo "- ✅ Secret scanning passed (no secrets in staged files)"
 	@echo "- ✅ Architecture compliance passed (no central provider violations)"
+	@echo "- ✅ Stdlib payload boundary validated (all five sources agree)"
 	@echo "- ✅ Security scanning passed (vulnerabilities)"
 	@echo ""
 	@echo "🎯 Code is validated and ready for commit/PR"

--- a/build/darwin/build-pkg.sh
+++ b/build/darwin/build-pkg.sh
@@ -158,7 +158,14 @@ chmod 755 "$PAYLOAD_DIR/usr/local/bin/cfgms-launcher"
 echo "  Launcher payload: $PAYLOAD_DIR/usr/local/bin/cfgms-launcher"
 
 # Install stdlib module binaries into the payload tree.
-STDLIB_MODULES=(cfgms-module-file cfgms-module-service cfgms-module-package cfgms-module-script cfgms-module-firewall cfgms-module-patch)
+STDLIB_MODULES=(
+    cfgms-module-file
+    cfgms-module-firewall
+    cfgms-module-package
+    cfgms-module-patch
+    cfgms-module-script
+    cfgms-module-service
+)
 MODULES_PAYLOAD_DIR="$PAYLOAD_DIR/usr/local/lib/cfgms/modules"
 mkdir -p "$MODULES_PAYLOAD_DIR"
 for module_bin in "${STDLIB_MODULES[@]}"; do

--- a/build/linux/install.sh
+++ b/build/linux/install.sh
@@ -143,7 +143,14 @@ fi
 
 # ── Install stdlib module binaries ────────────────────────────────────────────
 
-STDLIB_MODULES=(cfgms-module-file cfgms-module-service cfgms-module-package cfgms-module-script cfgms-module-firewall cfgms-module-patch)
+STDLIB_MODULES=(
+    cfgms-module-file
+    cfgms-module-firewall
+    cfgms-module-package
+    cfgms-module-patch
+    cfgms-module-script
+    cfgms-module-service
+)
 MODULES_INSTALL_DIR="${INSTALL_PREFIX}/usr/local/lib/cfgms/modules"
 
 install -d "$MODULES_INSTALL_DIR"

--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -89,6 +89,18 @@ Two carve-outs:
 
 Everything else — however useful — is an `extended` module, built as a standalone bundle and pulled on demand (see [distribution.md](distribution.md) and [ADR-006](../decisions/006-module-packaging-and-distribution.md)). Changing the stdlib set is an ADR-level decision. **[ADR-016](../decisions/016-steward-module-foundation.md) is authoritative** for the criterion, the current members, and the `stdlib/` ↔ `extended/` repository split.
 
+### Stdlib membership is enforced by the build
+
+Adding or removing a module from stdlib requires **five coordinated changes**, each enforced by `make check-stdlib-payload-boundary` (wired into `make test-commit`):
+
+1. `features/modules/stdlib/<name>/` — the module directory
+2. `Makefile` `STDLIB_MODULES` variable — drives compilation
+3. `build/windows/cfgms-steward.wxs` — Windows MSI installer `<Component>` block (alphabetical insertion order)
+4. `build/linux/install.sh` `STDLIB_MODULES` array — Linux install-script payload (one name per line, alphabetical)
+5. `build/darwin/build-pkg.sh` `STDLIB_MODULES` array — macOS `.pkg` payload (one name per line, alphabetical)
+
+The build fails if any of the five disagree. New entries in `.wxs`, `install.sh`, and `build-pkg.sh` must be inserted in alphabetical order by module name (not appended at the end).
+
 ### Current stdlib members
 
 Shipped in the steward installer, all `executors: [steward]` (closed set — see ADR-016):

--- a/docs/development/commands-reference.md
+++ b/docs/development/commands-reference.md
@@ -208,6 +208,19 @@ make lint
 # Equivalent to: golangci-lint run
 ```
 
+### Invariant Checks
+
+```bash
+# Check central provider architecture compliance (no duplicate cross-cutting concerns)
+make check-architecture
+
+# Check stdlib payload boundary: all five sources of stdlib module names must agree
+# (features/modules/stdlib/ dir, Makefile, .wxs, install.sh, build-pkg.sh)
+make check-stdlib-payload-boundary
+```
+
+Both checks run automatically as part of `make test-commit`.
+
 ## Protocol Buffers
 
 ### Proto Generation

--- a/scripts/check-stdlib-payload-boundary.sh
+++ b/scripts/check-stdlib-payload-boundary.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Enforce the installer-payload directory/manifest boundary (ADR-016 clause 3).
+#
+# All five sources that enumerate stdlib modules must agree exactly:
+#   1. features/modules/stdlib/  — directory listing (authoritative by ADR-016)
+#   2. Makefile STDLIB_MODULES   — drives build-stdlib-modules compilation
+#   3. build/windows/cfgms-steward.wxs — Windows MSI installer payload
+#   4. build/linux/install.sh STDLIB_MODULES  — Linux install-script payload
+#   5. build/darwin/build-pkg.sh STDLIB_MODULES — macOS .pkg payload
+#
+# Exit code: 0 = all five agree, 1 = any disagreement detected.
+# Usage: ./scripts/check-stdlib-payload-boundary.sh
+#
+# The REPO_ROOT environment variable can override the detected root (used by tests).
+
+set -euo pipefail
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+
+if [[ -n "${REPO_ROOT:-}" ]]; then
+    ROOT="$REPO_ROOT"
+else
+    ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+MAKEFILE="$ROOT/Makefile"
+WXS_FILE="$ROOT/build/windows/cfgms-steward.wxs"
+INSTALL_SH="$ROOT/build/linux/install.sh"
+BUILD_PKG_SH="$ROOT/build/darwin/build-pkg.sh"
+STDLIB_DIR="$ROOT/features/modules/stdlib"
+
+# ── Extraction helpers ────────────────────────────────────────────────────────
+
+# Sort a newline-separated list of module names and remove empty lines.
+normalize() {
+    sort | grep -v '^$' || true
+}
+
+# Extract module names from the stdlib directory (one name per line, sorted).
+extract_dir() {
+    if [[ ! -d "$STDLIB_DIR" ]]; then
+        echo "ERROR: stdlib directory not found: $STDLIB_DIR" >&2
+        exit 1
+    fi
+    find "$STDLIB_DIR" -mindepth 1 -maxdepth 1 -type d | sed 's|.*/||' | normalize
+}
+
+# Extract module names from the Makefile STDLIB_MODULES variable.
+# Handles both single-line and multi-line (backslash-continued) forms.
+extract_makefile() {
+    if [[ ! -f "$MAKEFILE" ]]; then
+        echo "ERROR: Makefile not found: $MAKEFILE" >&2
+        exit 1
+    fi
+    # Collect the continuation block: the STDLIB_MODULES := ... line(s).
+    # cont is set before gsub so the backslash check precedes the strip.
+    awk '
+        /^STDLIB_MODULES[[:space:]]*:=/ { in_block=1; sub(/^STDLIB_MODULES[[:space:]]*:=[[:space:]]*/,""); }
+        in_block {
+            cont = ($0 ~ /\\[[:space:]]*$/)
+            gsub(/\\[[:space:]]*$/, "")
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+            if ($0 != "") print $0
+            if (!cont) in_block=0
+        }
+    ' "$MAKEFILE" | normalize
+}
+
+# Extract module names from the WiX .wxs file.
+# Pattern: Name="cfgms-module-<name>.exe" inside the MODULESDIR block.
+# Uses grep+sed — no xmllint dependency required.
+extract_wxs() {
+    if [[ ! -f "$WXS_FILE" ]]; then
+        echo "ERROR: WiX file not found: $WXS_FILE" >&2
+        exit 1
+    fi
+    grep -o 'Name="cfgms-module-[^.]*\.exe"' "$WXS_FILE" \
+        | sed 's/Name="cfgms-module-//;s/\.exe"//' \
+        | normalize
+}
+
+# Extract module names from a bash STDLIB_MODULES=(…) array in the given file.
+# Handles both single-line and multi-line (one-name-per-line) forms.
+# Strips the cfgms-module- prefix so the result is bare module names.
+extract_bash_array() {
+    local file="$1"
+    if [[ ! -f "$file" ]]; then
+        echo "ERROR: file not found: $file" >&2
+        exit 1
+    fi
+    # Collect everything inside STDLIB_MODULES=( … )
+    awk '
+        /STDLIB_MODULES=\(/ { in_block=1; sub(/.*STDLIB_MODULES=\(/,""); }
+        in_block {
+            # stop at closing paren
+            if (/\)/) { sub(/\).*/,""); in_block=0 }
+            n = split($0, words)
+            for (i=1; i<=n; i++) { if (words[i] != "") print words[i] }
+        }
+    ' "$file" \
+        | sed 's/^cfgms-module-//' \
+        | normalize
+}
+
+# ── Collect the five sets ─────────────────────────────────────────────────────
+
+DIR_MODULES=$(extract_dir)
+MAKEFILE_MODULES=$(extract_makefile)
+WXS_MODULES=$(extract_wxs)
+INSTALL_SH_MODULES=$(extract_bash_array "$INSTALL_SH")
+BUILD_PKG_MODULES=$(extract_bash_array "$BUILD_PKG_SH")
+
+# ── Compare all pairs using comm ──────────────────────────────────────────────
+
+FAILED=0
+DIAGNOSTICS=""
+
+# compare_pair <label-a> <set-a> <label-b> <set-b>
+# Prints diagnostics if the two sorted sets differ; sets FAILED=1.
+compare_pair() {
+    local label_a="$1"
+    local set_a="$2"
+    local label_b="$3"
+    local set_b="$4"
+
+    local only_in_a only_in_b
+    only_in_a=$(comm -23 <(echo "$set_a") <(echo "$set_b"))
+    only_in_b=$(comm -13 <(echo "$set_a") <(echo "$set_b"))
+
+    if [[ -n "$only_in_a" || -n "$only_in_b" ]]; then
+        FAILED=1
+        DIAGNOSTICS+="  ❌ $label_a vs $label_b differ:\n"
+        if [[ -n "$only_in_a" ]]; then
+            while IFS= read -r m; do
+                [[ -z "$m" ]] && continue
+                DIAGNOSTICS+="       only in $label_a: $m\n"
+            done <<< "$only_in_a"
+        fi
+        if [[ -n "$only_in_b" ]]; then
+            while IFS= read -r m; do
+                [[ -z "$m" ]] && continue
+                DIAGNOSTICS+="       only in $label_b: $m\n"
+            done <<< "$only_in_b"
+        fi
+    fi
+}
+
+echo "🔍 Checking stdlib payload boundary (ADR-016 clause 3)..."
+echo ""
+
+compare_pair "stdlib/ dir"  "$DIR_MODULES"      "Makefile"      "$MAKEFILE_MODULES"
+compare_pair "Makefile"     "$MAKEFILE_MODULES"  "WiX .wxs"     "$WXS_MODULES"
+compare_pair "WiX .wxs"    "$WXS_MODULES"       "install.sh"    "$INSTALL_SH_MODULES"
+compare_pair "install.sh"   "$INSTALL_SH_MODULES" "build-pkg.sh" "$BUILD_PKG_MODULES"
+
+# Also check build-pkg.sh vs dir (catches a module only in build-pkg.sh)
+compare_pair "build-pkg.sh" "$BUILD_PKG_MODULES" "stdlib/ dir"  "$DIR_MODULES"
+
+if [[ "$FAILED" -eq 0 ]]; then
+    echo "✅ All five stdlib payload sources agree:"
+    while IFS= read -r m; do
+        [[ -z "$m" ]] && continue
+        echo "   - $m"
+    done <<< "$DIR_MODULES"
+    echo ""
+    exit 0
+fi
+
+echo "❌ STDLIB PAYLOAD BOUNDARY VIOLATION"
+echo "========================================"
+echo ""
+echo "The following sources disagree on the stdlib module set."
+echo "Every stdlib module requires an entry in all five places:"
+echo "  1. features/modules/stdlib/<name>/ directory"
+echo "  2. Makefile STDLIB_MODULES variable"
+echo "  3. build/windows/cfgms-steward.wxs (cfgms-module-<name>.exe Component)"
+echo "  4. build/linux/install.sh STDLIB_MODULES array (cfgms-module-<name>)"
+echo "  5. build/darwin/build-pkg.sh STDLIB_MODULES array (cfgms-module-<name>)"
+echo ""
+echo "Disagreements found:"
+printf "%b" "$DIAGNOSTICS"
+echo ""
+echo "Fix: add/remove the module entry from ALL five sources, then re-run"
+echo "     make check-stdlib-payload-boundary"
+exit 1

--- a/test/unit/build/stdlib_payload_boundary_test.go
+++ b/test/unit/build/stdlib_payload_boundary_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package build_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// repoRoot locates the workspace root by walking up from this file's location.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	// test/unit/build/stdlib_payload_boundary_test.go → ../../.. = repo root
+	root := filepath.Join(filepath.Dir(file), "..", "..", "..")
+	abs, err := filepath.Abs(root)
+	require.NoError(t, err)
+	return abs
+}
+
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(repoRoot(t), "scripts", "check-stdlib-payload-boundary.sh")
+}
+
+// runScript executes the boundary-check script with REPO_ROOT overridden to the
+// given root directory.  It returns (exitCode, combined output).
+func runScript(t *testing.T, repoOverride string) (int, string) {
+	t.Helper()
+	cmd := exec.Command("bash", scriptPath(t))
+	cmd.Env = append(os.Environ(), "REPO_ROOT="+repoOverride)
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected exec error: %v", err)
+		}
+	}
+	return exitCode, string(out)
+}
+
+// TestRealRepo verifies that the script exits 0 against the actual repository tree.
+// All four payload lists and the stdlib/ directory must agree on the six current
+// stdlib modules.
+func TestRealRepo(t *testing.T) {
+	root := repoRoot(t)
+	code, out := runScript(t, root)
+	assert.Equal(t, 0, code, "check-stdlib-payload-boundary should pass on the real repo tree\nOutput:\n%s", out)
+}
+
+// fixtureTree builds a minimal but structurally correct repository fixture under
+// t.TempDir(), with exactly the modules given in `modules`.
+type fixtureOpts struct {
+	// stdlibDirs names the directories to create under features/modules/stdlib/
+	stdlibDirs []string
+	// makefileModules is the space-separated STDLIB_MODULES value
+	makefileModules []string
+	// wxsModules are the module names (without cfgms-module- prefix or .exe suffix)
+	// that appear as <File … Name="cfgms-module-X.exe" …/> inside MODULESDIR
+	wxsModules []string
+	// installShModules are the cfgms-module-X names in install.sh STDLIB_MODULES
+	installShModules []string
+	// buildPkgModules are the cfgms-module-X names in build-pkg.sh STDLIB_MODULES
+	buildPkgModules []string
+}
+
+func buildFixture(t *testing.T, opts fixtureOpts) string {
+	t.Helper()
+	root := t.TempDir()
+
+	// features/modules/stdlib/<name>/
+	stdlibBase := filepath.Join(root, "features", "modules", "stdlib")
+	require.NoError(t, os.MkdirAll(stdlibBase, 0o755))
+	for _, name := range opts.stdlibDirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(stdlibBase, name), 0o755))
+	}
+
+	// Makefile — only the STDLIB_MODULES variable line matters to the script
+	makefileContent := "STDLIB_MODULES := \\\n"
+	for i, m := range opts.makefileModules {
+		if i < len(opts.makefileModules)-1 {
+			makefileContent += fmt.Sprintf("\t%s \\\n", m)
+		} else {
+			makefileContent += fmt.Sprintf("\t%s\n", m)
+		}
+	}
+	makefileContent += "\nbuild-stdlib-modules:\n\t@echo building\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Makefile"), []byte(makefileContent), 0o644))
+
+	// build/windows/cfgms-steward.wxs — minimal structure
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "build", "windows"), 0o755))
+	wxsComponents := ""
+	for _, m := range opts.wxsModules {
+		capitalized := strings.ToUpper(m[:1]) + m[1:]
+		wxsComponents += fmt.Sprintf(`          <Component Id="Module%s" Guid="*">
+            <File Id="Module%sExe" Source="$(var.ModulesDir)\cfgms-module-%s.exe" Name="cfgms-module-%s.exe" KeyPath="yes" />
+          </Component>
+`, capitalized, capitalized, m, m)
+	}
+	wxsContent := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="CFGMS Steward">
+    <StandardDirectory Id="ProgramFiles6432Folder">
+      <Directory Id="INSTALLDIR" Name="CFGMS">
+        <Directory Id="MODULESDIR" Name="modules">
+%s        </Directory>
+      </Directory>
+    </StandardDirectory>
+  </Package>
+</Wix>
+`, wxsComponents)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "build", "windows", "cfgms-steward.wxs"), []byte(wxsContent), 0o644))
+
+	// build/linux/install.sh — minimal structure with STDLIB_MODULES array
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "build", "linux"), 0o755))
+	installShLines := "#!/bin/bash\n# Install stdlib module binaries\nSTDLIB_MODULES=(\n"
+	for _, m := range opts.installShModules {
+		installShLines += fmt.Sprintf("    %s\n", m)
+	}
+	installShLines += ")\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "build", "linux", "install.sh"), []byte(installShLines), 0o755))
+
+	// build/darwin/build-pkg.sh — minimal structure with STDLIB_MODULES array
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "build", "darwin"), 0o755))
+	buildPkgLines := "#!/bin/bash\n# Install stdlib module binaries into the payload tree.\nSTDLIB_MODULES=(\n"
+	for _, m := range opts.buildPkgModules {
+		buildPkgLines += fmt.Sprintf("    %s\n", m)
+	}
+	buildPkgLines += ")\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "build", "darwin", "build-pkg.sh"), []byte(buildPkgLines), 0o755))
+
+	return root
+}
+
+var sixModules = []string{"file", "firewall", "package", "patch", "script", "service"}
+
+func sixModulesWithPrefix() []string {
+	result := make([]string, len(sixModules))
+	for i, m := range sixModules {
+		result[i] = "cfgms-module-" + m
+	}
+	return result
+}
+
+// TestFixtureBaseline verifies that the fixture builder itself produces a
+// consistent tree that the script accepts (exit 0).
+func TestFixtureBaseline(t *testing.T) {
+	root := buildFixture(t, fixtureOpts{
+		stdlibDirs:       sixModules,
+		makefileModules:  sixModules,
+		wxsModules:       sixModules,
+		installShModules: sixModulesWithPrefix(),
+		buildPkgModules:  sixModulesWithPrefix(),
+	})
+	code, out := runScript(t, root)
+	assert.Equal(t, 0, code, "consistent fixture should pass\nOutput:\n%s", out)
+}
+
+// TestStrayStdlibDirectory verifies that a directory under features/modules/stdlib/
+// not present in any of the four lists causes the script to fail with a diagnostic.
+func TestStrayStdlibDirectory(t *testing.T) {
+	dirs := append([]string{"stray"}, sixModules...)
+	root := buildFixture(t, fixtureOpts{
+		stdlibDirs:       dirs,
+		makefileModules:  sixModules,
+		wxsModules:       sixModules,
+		installShModules: sixModulesWithPrefix(),
+		buildPkgModules:  sixModulesWithPrefix(),
+	})
+	code, out := runScript(t, root)
+	assert.NotEqual(t, 0, code, "stray stdlib dir should cause failure\nOutput:\n%s", out)
+	assert.Contains(t, out, "stray", "diagnostic should mention the stray module name")
+}
+
+// TestMakefileEntryMissingFromWXS verifies that a module in the Makefile but
+// absent from the WiX .wxs causes the script to fail.
+func TestMakefileEntryMissingFromWXS(t *testing.T) {
+	// extramodule appears in Makefile, stdlib dir, install.sh, build-pkg.sh but NOT wxs
+	extraMods := append(sixModules, "extramodule")
+	extraModsWithPrefix := append(sixModulesWithPrefix(), "cfgms-module-extramodule")
+	root := buildFixture(t, fixtureOpts{
+		stdlibDirs:       extraMods,
+		makefileModules:  extraMods,
+		wxsModules:       sixModules, // missing extramodule
+		installShModules: extraModsWithPrefix,
+		buildPkgModules:  extraModsWithPrefix,
+	})
+	code, out := runScript(t, root)
+	assert.NotEqual(t, 0, code, "Makefile entry missing from wxs should fail\nOutput:\n%s", out)
+	assert.Contains(t, out, "extramodule", "diagnostic should mention the missing module name")
+}
+
+// TestWXSEntryMissingFromInstallSh verifies that a module in the WiX .wxs but
+// absent from install.sh causes the script to fail.
+func TestWXSEntryMissingFromInstallSh(t *testing.T) {
+	// extramodule appears in wxs (and Makefile, stdlib, build-pkg.sh) but NOT install.sh
+	extraMods := append(sixModules, "extramodule")
+	extraModsWithPrefix := append(sixModulesWithPrefix(), "cfgms-module-extramodule")
+	root := buildFixture(t, fixtureOpts{
+		stdlibDirs:       extraMods,
+		makefileModules:  extraMods,
+		wxsModules:       extraMods,
+		installShModules: sixModulesWithPrefix(), // missing extramodule
+		buildPkgModules:  extraModsWithPrefix,
+	})
+	code, out := runScript(t, root)
+	assert.NotEqual(t, 0, code, "wxs entry missing from install.sh should fail\nOutput:\n%s", out)
+	assert.Contains(t, out, "extramodule", "diagnostic should mention the missing module name")
+}
+
+// TestInstallShEntryMissingFromBuildPkg verifies that a module in install.sh but
+// absent from build-pkg.sh causes the script to fail.
+func TestInstallShEntryMissingFromBuildPkg(t *testing.T) {
+	// extramodule appears in install.sh (and Makefile, stdlib, wxs) but NOT build-pkg.sh
+	extraMods := append(sixModules, "extramodule")
+	extraModsWithPrefix := append(sixModulesWithPrefix(), "cfgms-module-extramodule")
+	root := buildFixture(t, fixtureOpts{
+		stdlibDirs:       extraMods,
+		makefileModules:  extraMods,
+		wxsModules:       extraMods,
+		installShModules: extraModsWithPrefix,
+		buildPkgModules:  sixModulesWithPrefix(), // missing extramodule
+	})
+	code, out := runScript(t, root)
+	assert.NotEqual(t, 0, code, "install.sh entry missing from build-pkg.sh should fail\nOutput:\n%s", out)
+	assert.Contains(t, out, "extramodule", "diagnostic should mention the missing module name")
+}
+
+// TestEntryInListButNotStdlibDir verifies that a module listed in the Makefile
+// but without a directory under features/modules/stdlib/ causes failure.
+func TestEntryInListButNotStdlibDir(t *testing.T) {
+	// "ghost" appears in all four lists but has no stdlib directory
+	extraMods := append(sixModules, "ghost")
+	extraModsWithPrefix := append(sixModulesWithPrefix(), "cfgms-module-ghost")
+	root := buildFixture(t, fixtureOpts{
+		stdlibDirs:       sixModules, // missing ghost directory
+		makefileModules:  extraMods,
+		wxsModules:       extraMods,
+		installShModules: extraModsWithPrefix,
+		buildPkgModules:  extraModsWithPrefix,
+	})
+	code, out := runScript(t, root)
+	assert.NotEqual(t, 0, code, "list entry without stdlib dir should fail\nOutput:\n%s", out)
+	assert.Contains(t, out, "ghost", "diagnostic should mention the missing module name")
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/check-stdlib-payload-boundary.sh` — standalone script that extracts stdlib module names from all five sources (stdlib/ directory, Makefile STDLIB_MODULES, WiX .wxs, install.sh, build-pkg.sh) and fails with a clear pairwise diagnostic if any two disagree
- Wires `check-stdlib-payload-boundary` as a prerequisite of `build-stdlib-modules` and into `test-commit` (same position as `check-architecture`)
- Reformats `build/linux/install.sh` and `build/darwin/build-pkg.sh` STDLIB_MODULES arrays to one-name-per-line alphabetical order (conflict-safe for concurrent module additions in #2474-#2477)
- Adds fixture-based Go tests covering all mismatch scenarios: stray stdlib directory, Makefile entry missing from .wxs, .wxs entry missing from install.sh, install.sh entry missing from build-pkg.sh, and list entry without stdlib directory
- Docs updated: modules/README.md documents the five-source rule + alphabetical insertion order; commands-reference.md adds the new make target

## Test plan

- [ ] `make check-stdlib-payload-boundary` exits 0 on current tree (six modules, all five sources agree)
- [ ] All 7 tests in `test/unit/build/` pass (TestRealRepo + 6 fixture-based mismatch tests)
- [ ] `build-stdlib-modules` depends on `check-stdlib-payload-boundary`
- [ ] `test-commit` includes `check-stdlib-payload-boundary`
- [ ] `make test` exits 0
- [ ] `make lint` exits 0 (0 issues)
- [ ] Security review: PASS (specialist agent — no blocking findings)
- [ ] Code quality review: PASS (specialist agent — no blocking findings)

## Specialist review results

| Reviewer | Verdict | Notes |
|----------|---------|-------|
| Security | **PASS** | No blocking findings. Non-blocking gosec warnings are test-fixture file permissions (G301/G306) and subprocess in test code (G204), both excluded by the project's gosec config. No secrets, no injection, no TLS issues. |
| Code quality | **PASS** | No blocking findings. Warnings addressed: replaced `find -printf` with portable `sed 's\|.*/\|\|'`, replaced `fmt.Sprintf` with no verbs with bare string literal. |

Fixes #2470

🤖 Generated with [Claude Code](https://claude.com/claude-code)