### PR TITLE
test: make tier1-smoke-test pass on Windows/MSYS via cfg + python3 mTLS, no Schannel (Issue #2458)

### DIFF
--- a/scripts/tier1-smoke-test.sh
+++ b/scripts/tier1-smoke-test.sh
@@ -27,6 +27,10 @@ set -uo pipefail
 
 BUNDLE_PATH="${CFGMS_ADMIN_BUNDLE:-/etc/cfgms/admin.bundle.yaml}"
 CONTROLLER_URL=""
+# CFG_BIN is the cfg client used for the health check (mTLS via crypto/tls/PEM,
+# never curl+Schannel — see #2458). Override with CFGMS_CFG_BIN when the binary is
+# not on PATH (e.g. the test harness points at a freshly-built ./bin/cfg).
+CFG_BIN="${CFGMS_CFG_BIN:-cfg}"
 PASS_COUNT=0
 FAIL_COUNT=0
 
@@ -250,27 +254,54 @@ _record_fail() {
   FAIL_COUNT=$((FAIL_COUNT + 1))
 }
 
-# --- Check 1: health endpoint returns 200 ---
-_health_code="000"
-_health_code=$(curl \
-  --cert "$CERT_FILE" --key "$KEY_FILE" --cacert "$CA_FILE" \
-  -s -o /dev/null -w "%{http_code}" \
-  "${CONTROLLER_URL}/api/v1/health" 2>/dev/null) || _health_code="000"
-
-if [[ "$_health_code" == "200" ]]; then
-  _record_pass "health: GET /api/v1/health"
+# --- Check 1: controller health via the cfg client ---
+# cfg builds mTLS from the admin bundle through pkg/cert / crypto/tls (PEM,
+# cross-platform) and hits GET /api/v1/health/detailed, returning non-zero when
+# the controller is unreachable or not healthy. This dogfoods the exact client
+# operators use and never touches curl/Schannel (#2458 RC2).
+if _health_out=$("$CFG_BIN" controller status --bundle "$BUNDLE_PATH" --url "$CONTROLLER_URL" 2>&1); then
+  _record_pass "health: cfg controller status"
 else
-  _record_fail "health: GET /api/v1/health" "expected HTTP 200, got ${_health_code}"
+  _record_fail "health: cfg controller status" \
+    "controller unhealthy/unreachable: $(printf '%s' "$_health_out" | tr '\n' ' ' | cut -c1-200)"
 fi
 
 # --- Checks 2-4: required tenant existence ---
 _check_tenant() {
   local tenant_id="$1"
-  local code="000"
-  code=$(curl \
-    --cert "$CERT_FILE" --key "$KEY_FILE" --cacert "$CA_FILE" \
-    -s -o /dev/null -w "%{http_code}" \
-    "${CONTROLLER_URL}/api/v1/tenants/${tenant_id}" 2>/dev/null) || code="000"
+  local code
+  # mTLS GET via python3's ssl module (OpenSSL-backed PEM on every OS — no
+  # curl/Schannel). cfg has no `tenant get` subcommand today (only the
+  # GetTenantViaAPI client method is wired), so per #2458's AC this check uses the
+  # permitted python3 stdlib fallback "where cfg can't express the check".
+  # Pass the PEM material as CONTENT (not file paths): a native (non-MSYS) python3
+  # on Windows cannot open an MSYS-style /tmp/... path passed via env var, so
+  # python writes the certs to its own temp files (native paths) and loads those.
+  # This keeps the check cross-platform without any MSYS path conversion.
+  code=$(CT_URL="${CONTROLLER_URL}/api/v1/tenants/${tenant_id}" \
+    CT_CERT_PEM="$(cat "$CERT_FILE")" CT_KEY_PEM="$(cat "$KEY_FILE")" CT_CA_PEM="$(cat "$CA_FILE")" \
+    python3 - <<'PYTHON' 2>/dev/null
+import os, ssl, tempfile, urllib.request, urllib.error
+d = tempfile.mkdtemp()
+paths = {}
+for name, env in (('cert', 'CT_CERT_PEM'), ('key', 'CT_KEY_PEM'), ('ca', 'CT_CA_PEM')):
+    p = os.path.join(d, name + '.pem')
+    with open(p, 'w') as fh:
+        fh.write(os.environ[env])
+    paths[name] = p
+ctx = ssl.create_default_context(cafile=paths['ca'])
+ctx.load_cert_chain(certfile=paths['cert'], keyfile=paths['key'])
+req = urllib.request.Request(os.environ['CT_URL'], method='GET')
+try:
+    with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+        print(r.status)
+except urllib.error.HTTPError as e:
+    print(e.code)
+except Exception:
+    print('000')
+PYTHON
+)
+  [[ -z "$code" ]] && code="000"
 
   if [[ "$code" == "200" ]]; then
     _record_pass "tenant-exists: ${tenant_id}"

--- a/scripts/tier1-smoke-test.sh
+++ b/scripts/tier1-smoke-test.sh
@@ -5,7 +5,9 @@
 # expected health response, and presence of three required tenants on a live
 # Tier 1 controller after a bootstrap run.
 #
-# Dependencies (runtime): bash >=4, curl, python3 (standard on Debian/Ubuntu)
+# Dependencies (runtime): bash >=4, cfg (on PATH or via CFGMS_CFG_BIN), python3
+#                         (curl is no longer used — mTLS goes through cfg/python3
+#                         with crypto/tls/OpenSSL PEM, never curl+Schannel; #2458)
 #
 # NOTE: Story #1848 (cfg tenant create + GET /api/v1/tenants/{id}) must be
 #       merged and run before the tenant-existence checks here can pass on a
@@ -280,25 +282,32 @@ _check_tenant() {
   # This keeps the check cross-platform without any MSYS path conversion.
   code=$(CT_URL="${CONTROLLER_URL}/api/v1/tenants/${tenant_id}" \
     CT_CERT_PEM="$(cat "$CERT_FILE")" CT_KEY_PEM="$(cat "$KEY_FILE")" CT_CA_PEM="$(cat "$CA_FILE")" \
-    python3 - <<'PYTHON' 2>/dev/null
-import os, ssl, tempfile, urllib.request, urllib.error
-d = tempfile.mkdtemp()
-paths = {}
-for name, env in (('cert', 'CT_CERT_PEM'), ('key', 'CT_KEY_PEM'), ('ca', 'CT_CA_PEM')):
-    p = os.path.join(d, name + '.pem')
-    with open(p, 'w') as fh:
-        fh.write(os.environ[env])
-    paths[name] = p
-ctx = ssl.create_default_context(cafile=paths['ca'])
-ctx.load_cert_chain(certfile=paths['cert'], keyfile=paths['key'])
-req = urllib.request.Request(os.environ['CT_URL'], method='GET')
-try:
-    with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
-        print(r.status)
-except urllib.error.HTTPError as e:
-    print(e.code)
-except Exception:
-    print('000')
+    python3 - <<'PYTHON'
+import os, ssl, sys, tempfile, urllib.request, urllib.error
+# TemporaryDirectory removes the written cert/key/CA (including the admin's
+# private key) when the block exits — never leave key material on disk, matching
+# the outer script's trap. The request runs inside the block while the files
+# exist; load_cert_chain has already read them into the context.
+with tempfile.TemporaryDirectory() as d:
+    paths = {}
+    for name, env in (('cert', 'CT_CERT_PEM'), ('key', 'CT_KEY_PEM'), ('ca', 'CT_CA_PEM')):
+        p = os.path.join(d, name + '.pem')
+        with open(p, 'w') as fh:
+            fh.write(os.environ[env])
+        paths[name] = p
+    ctx = ssl.create_default_context(cafile=paths['ca'])
+    ctx.load_cert_chain(certfile=paths['cert'], keyfile=paths['key'])
+    req = urllib.request.Request(os.environ['CT_URL'], method='GET')
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+            print(r.status)
+    except urllib.error.HTTPError as e:
+        print(e.code)
+    except Exception as e:
+        # Non-HTTP failure (TLS handshake, connect, timeout): report 000 on
+        # stdout and surface the reason on stderr for diagnosability.
+        print('000')
+        print(f'tenant-check error: {type(e).__name__}: {e}', file=sys.stderr)
 PYTHON
 )
   [[ -z "$code" ]] && code="000"

--- a/scripts/tier1-smoke-test_test.sh
+++ b/scripts/tier1-smoke-test_test.sh
@@ -4,7 +4,7 @@
 # Starts a stub HTTPS server (Python ssl) with generated test certs to cover
 # both the all-pass path and several failure modes without a real controller.
 #
-# Dependencies: bash >=4, openssl, python3, curl
+# Dependencies: bash >=4, openssl, python3, go (to build cfg for the health check)
 #
 # Exit codes: 0 = all tests passed, 1 = any test failed
 
@@ -12,6 +12,25 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SMOKE="$SCRIPT_DIR/tier1-smoke-test.sh"
+
+# Build the cfg client the smoke test uses for its health check (#2458 RC2).
+# cfg does mTLS via crypto/tls (PEM, cross-platform) — the whole point is to
+# avoid curl+Schannel on Windows. `go build -o <dir>/` names the binary per-OS
+# (cfg / cfg.exe). The smoke test picks it up via CFGMS_CFG_BIN.
+CFG_BUILD_DIR="$(mktemp -d)"
+if command -v go >/dev/null 2>&1; then
+  ( cd "$SCRIPT_DIR/.." && go build -o "$CFG_BUILD_DIR/" ./cmd/cfg ) 2>/dev/null || true
+fi
+if [[ -x "$CFG_BUILD_DIR/cfg" ]]; then
+  export CFGMS_CFG_BIN="$CFG_BUILD_DIR/cfg"
+elif [[ -x "$CFG_BUILD_DIR/cfg.exe" ]]; then
+  export CFGMS_CFG_BIN="$CFG_BUILD_DIR/cfg.exe"
+elif command -v cfg >/dev/null 2>&1; then
+  export CFGMS_CFG_BIN="cfg"
+else
+  echo "ERROR: could not build or find the cfg client (need 'go' or 'cfg' on PATH)" >&2
+  exit 1
+fi
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -54,8 +73,15 @@ _setup_certs() {
   printf "extendedKeyUsage=clientAuth\n" > "$d/client.ext"
 
   # CA
+  # The CA cert MUST carry basicConstraints CA:TRUE + keyUsage keyCertSign, or a
+  # strict verifier (Python's ssl on OpenSSL 3.x, used by the tenant check) rejects
+  # the chain with "CA cert does not include key usage extension". Go's crypto/tls
+  # (the cfg health check) and old curl accept a plain self-signed cert leniently,
+  # but the test CA must be a real CA for every client. (#2458)
   openssl req -x509 -newkey rsa:2048 -keyout "$d/ca.key" -out "$d/ca.crt" \
-    -days 1 -nodes -subj "/CN=Test CA" 2>/dev/null
+    -days 1 -nodes -subj "/CN=Test CA" \
+    -addext "basicConstraints=critical,CA:TRUE" \
+    -addext "keyUsage=critical,keyCertSign,cRLSign" 2>/dev/null
 
   # Server cert with Subject Alternative Name so curl trusts 127.0.0.1
   openssl req -newkey rsa:2048 -keyout "$d/server.key" -out "$d/server.csr" \
@@ -159,7 +185,9 @@ present = TENANTS.get(MODE, TENANTS['all-pass'])
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         try:
-            if self.path == '/api/v1/health':
+            if self.path in ('/api/v1/health', '/api/v1/health/detailed'):
+                # /health/detailed is what `cfg controller status` requests; both
+                # paths mirror the same healthy/unhealthy behavior.
                 if MODE == 'health-fail':
                     self.send_response(503)
                     self.end_headers()
@@ -498,7 +526,7 @@ if [[ ! -f "$SMOKE" ]]; then
 fi
 
 TMPDIR_ROOT=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_ROOT"; _stop_server' EXIT
+trap 'rm -rf "$TMPDIR_ROOT" "$CFG_BUILD_DIR"; _stop_server' EXIT
 
 echo "tier1-smoke-test fixture tests"
 echo "=============================="

--- a/scripts/tier1-smoke-test_test.sh
+++ b/scripts/tier1-smoke-test_test.sh
@@ -18,8 +18,12 @@ SMOKE="$SCRIPT_DIR/tier1-smoke-test.sh"
 # avoid curl+Schannel on Windows. `go build -o <dir>/` names the binary per-OS
 # (cfg / cfg.exe). The smoke test picks it up via CFGMS_CFG_BIN.
 CFG_BUILD_DIR="$(mktemp -d)"
+CFG_BUILD_ERR=""
 if command -v go >/dev/null 2>&1; then
-  ( cd "$SCRIPT_DIR/.." && go build -o "$CFG_BUILD_DIR/" ./cmd/cfg ) 2>/dev/null || true
+  # Capture the build error rather than discarding it, so a real compile failure
+  # (go present but build broken) is surfaced below instead of the misleading
+  # "no go/cfg on PATH" message.
+  CFG_BUILD_ERR=$( cd "$SCRIPT_DIR/.." && go build -o "$CFG_BUILD_DIR/" ./cmd/cfg 2>&1 ) || true
 fi
 if [[ -x "$CFG_BUILD_DIR/cfg" ]]; then
   export CFGMS_CFG_BIN="$CFG_BUILD_DIR/cfg"
@@ -29,6 +33,7 @@ elif command -v cfg >/dev/null 2>&1; then
   export CFGMS_CFG_BIN="cfg"
 else
   echo "ERROR: could not build or find the cfg client (need 'go' or 'cfg' on PATH)" >&2
+  [[ -n "$CFG_BUILD_ERR" ]] && echo "go build error was:" >&2 && echo "$CFG_BUILD_ERR" >&2
   exit 1
 fi
 

--- a/scripts/tier1-smoke-test_test.sh
+++ b/scripts/tier1-smoke-test_test.sh
@@ -35,6 +35,24 @@ _fail() {
 # ---------------------------------------------------------------------------
 _setup_certs() {
   local d="$1"
+
+  # On Git-Bash/MSYS the runtime auto-converts POSIX-looking arguments to Windows
+  # paths before handing them to the native openssl.exe. That corrupts the leading
+  # '/' of openssl's -subj value ("/CN=Test CA" becomes
+  # "C:/Program Files/Git/CN=Test CA" -> "subject name is expected to be in the
+  # format /type0=value0/..."). Excluding only /CN= arguments keeps the -subj DN
+  # intact while still letting real path arguments (keys, certs, extfiles) convert
+  # normally. The variable is ignored on Linux/macOS, so setting it here is safe on
+  # every host.
+  local MSYS2_ARG_CONV_EXCL="/CN="
+  export MSYS2_ARG_CONV_EXCL
+
+  # Extension files are written to the scratch dir instead of process substitution
+  # (-extfile <(printf ...)), which resolves to /proc/<pid>/fd/NN — unavailable in
+  # the MSYS shell ("Can't open /proc/<pid>/fd/63 for reading").
+  printf "subjectAltName=IP:127.0.0.1,DNS:localhost\n" > "$d/server.ext"
+  printf "extendedKeyUsage=clientAuth\n" > "$d/client.ext"
+
   # CA
   openssl req -x509 -newkey rsa:2048 -keyout "$d/ca.key" -out "$d/ca.crt" \
     -days 1 -nodes -subj "/CN=Test CA" 2>/dev/null
@@ -44,14 +62,14 @@ _setup_certs() {
     -nodes -subj "/CN=127.0.0.1" 2>/dev/null
   openssl x509 -req -in "$d/server.csr" -CA "$d/ca.crt" -CAkey "$d/ca.key" \
     -CAcreateserial -out "$d/server.crt" -days 1 \
-    -extfile <(printf "subjectAltName=IP:127.0.0.1,DNS:localhost\n") 2>/dev/null
+    -extfile "$d/server.ext" 2>/dev/null
 
   # Client cert (mTLS)
   openssl req -newkey rsa:2048 -keyout "$d/client.key" -out "$d/client.csr" \
     -nodes -subj "/CN=admin" 2>/dev/null
   openssl x509 -req -in "$d/client.csr" -CA "$d/ca.crt" -CAkey "$d/ca.key" \
     -CAcreateserial -out "$d/client.crt" -days 1 \
-    -extfile <(printf "extendedKeyUsage=clientAuth\n") 2>/dev/null
+    -extfile "$d/client.ext" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make `scripts/tier1-smoke-test.sh` + its fixture harness run **and pass** on Windows/Git-Bash (MSYS), so `make test-quality` (the story-review tests lens) no longer aborts on Windows self-dispatch hosts. Fixes #2458 (epic #565). **No product code touched — change is confined to the two test scripts.**

## Two root causes, both fixed

**RC1 — MSYS-hostile openssl** (cert generation): `-subj '/CN=...'` path-mangling and `-extfile <(...)` process substitution aborted `_setup_certs()`. Fixed with `MSYS2_ARG_CONV_EXCL="/CN="` + scratch-dir ext files (no-op on Linux).

**RC2 — curl+Schannel can't do PEM client-cert mTLS.** Replaced the two `curl --cert/--key/--cacert` calls with clients that use OpenSSL/PEM, never Schannel:
- **Health → `cfg controller status`** (`GET /api/v1/health/detailed` over the admin bundle; cfg builds mTLS via `pkg/cert`/`crypto/tls`). Dogfoods the exact client operators use.
- **Tenant existence → python3 stdlib `ssl`** (OpenSSL PEM). `cfg` has no `tenant get` subcommand today (only the `GetTenantViaAPI` client method is wired), so per the AC this uses the permitted python3 fallback "where cfg can't express the check."

## Windows gotchas chased down
- Native Windows python3 can't open MSYS `/tmp` paths passed via env → pass PEM **content**, python writes its own native temp files (in a `TemporaryDirectory` that's cleaned up — no key material left on disk).
- Python's strict OpenSSL-3 verifier rejected the plain self-signed test CA (`CA cert does not include key usage extension`) → the test CA now carries `basicConstraints=CA:TRUE` + `keyUsage=keyCertSign` (a *more* correct CA; Go/old-curl accepted the plain one leniently).

## Harness
- Stub server now serves `/api/v1/health/detailed` (what `cfg controller status` requests) mirroring `/api/v1/health`.
- Builds `cfg` (`go build -o <dir>/`, per-OS name) into a temp dir and exports `CFGMS_CFG_BIN`; the go-build error is surfaced on failure.

## Result
**On a Windows/Git-Bash host: 18 passed, 0 failed, exit 0.** No `curl` PEM client-cert call or Schannel dependency remains; no Windows-specific TLS machinery (no PKCS#12/cert store/alternate curl); no fixture assertion weakened or skipped. Cross-platform by construction (cfg is Go; python3 ssl is stdlib; the MSYS/CA bits are Linux-safe) — CI validates the Linux run.

## Review
Pre-PR adversarial team (acceptance + QA + security) all **PASS**. One QA-blocking finding — the tenant check leaked the admin private key to disk via `mkdtemp` — was fixed (`TemporaryDirectory`) and empirically re-verified (zero leaked temp dirs across 12 tenant checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)