### PR TITLE
modules: canonical-fragment contract + owns: manifest declaration (Issue #2471)

### DIFF
--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -74,6 +74,60 @@ The `executors` field must contain exactly one element. `kind` is computed at pa
 | `network_egress` | list | External hosts/ports the module connects to |
 | `lolbin_usage_justification` | string | Why a living-off-the-land binary is needed |
 
+### `owns:` declaration (ADR-016 clause 5)
+
+The optional `owns:` list declares the object-identity namespaces this module
+authoritatively manages. Omitting `owns:` is valid and backward-compatible with
+all existing `module.yaml` files — it means the module declares no ownership.
+
+```yaml
+# module.yaml — DNA ownership declaration example
+owns:
+  - kind: service   # authority over service:* objects this module manages
+```
+
+**Semantics:** Authority is atomic at the object level. When a module owns an
+object kind, it owns every property of every object of that kind it manages —
+no sub-property co-authorship. At DNA assembly the steward excludes any object
+claimed by an active module from other DNA sources; on module uninstall,
+authority reverts. The resolver is defined in ADR-017; this field provides the
+declaration that makes resolution possible.
+
+**Adding `owns:` to a module:** Each module's own story adds its specific
+`owns:` entries (e.g. `patch` in issue #2472). The `owns:` parsing support is
+provided by this story (#2471) and is ready to use.
+
+### `Get` canonical fragment contract (ADR-016 clause 4)
+
+Every module's `Get` implementation must return a **canonical,
+deterministically-serialisable DNA fragment**. In terms of the Go code:
+
+- `ConfigState.AsMap()` must return byte-for-byte identical output on every
+  call against the same unchanged resource state.
+- Only stable desired-comparable fields are included. **Omit all ephemeral
+  runtime values**: live PIDs, current CPU/memory statistics, timestamps,
+  uptime counters, or any value that changes under the OS without a
+  cfg-driven configuration change.
+
+**Verification:** Use the helpers in `features/modules/conformance` in a
+module's own `_test.go` file:
+
+```go
+import "github.com/cfgis/cfgms/features/modules/conformance"
+
+// AssertDeterministicGet calls Get twice and asserts byte-for-byte equality
+// of the canonical JSON-encoded AsMap() output.
+conformance.AssertDeterministicGet(t, m, resourceID)
+
+// AssertNoEphemeralFields checks AsMap() keys against the banned list.
+state, _ := m.Get(ctx, resourceID)
+conformance.AssertNoEphemeralFields(t, state, conformance.DefaultBannedEphemeralFields)
+```
+
+See `features/modules/conformance/fragment_test_helper.go` for godoc and
+`features/modules/conformance/fragment_test_helper_test.go` for a worked
+example using `stdlib/file`.
+
 ## Available Modules
 
 ### What belongs in stdlib

--- a/features/modules/conformance/fragment_test_helper.go
+++ b/features/modules/conformance/fragment_test_helper.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package conformance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// DefaultBannedEphemeralFields is the conservative list of field names that
+// must not appear in ConfigState.AsMap() output per ADR-016 clause 4, which
+// prohibits ephemeral runtime values: live PIDs, current CPU/memory statistics,
+// timestamps, and uptime counters.
+var DefaultBannedEphemeralFields = []string{
+	"pid",
+	"timestamp",
+	"uptime_seconds",
+	"cpu_percent",
+	"memory_bytes",
+}
+
+// AssertDeterministicGet calls m.Get(ctx, resourceID) twice against unchanged
+// state and asserts that the canonical JSON-encoded AsMap() output is
+// byte-for-byte identical across both calls.
+//
+// Use this in a module's own test file to verify ADR-016 clause 4 compliance.
+// Determinism is proved empirically — two actual Get calls are compared — rather
+// than by asserting an encoding invariant. encoding/json is used for canonical
+// serialisation (it sorts map keys); the test does NOT rely on yaml.v3 ordering.
+//
+// If the module's Get is non-deterministic the test fails with the differing
+// encoded outputs so the caller can identify which field varies.
+func AssertDeterministicGet(t *testing.T, m modules.Module, resourceID string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	state1, err := m.Get(ctx, resourceID)
+	if err != nil {
+		t.Fatalf("AssertDeterministicGet: first Get(%q) returned error: %v", resourceID, err)
+	}
+	if state1 == nil {
+		t.Fatalf("AssertDeterministicGet: first Get(%q) returned nil state", resourceID)
+	}
+
+	state2, err := m.Get(ctx, resourceID)
+	if err != nil {
+		t.Fatalf("AssertDeterministicGet: second Get(%q) returned error: %v", resourceID, err)
+	}
+	if state2 == nil {
+		t.Fatalf("AssertDeterministicGet: second Get(%q) returned nil state", resourceID)
+	}
+
+	enc1, err := json.Marshal(state1.AsMap())
+	if err != nil {
+		t.Fatalf("AssertDeterministicGet: json.Marshal(state1.AsMap()) error: %v", err)
+	}
+
+	enc2, err := json.Marshal(state2.AsMap())
+	if err != nil {
+		t.Fatalf("AssertDeterministicGet: json.Marshal(state2.AsMap()) error: %v", err)
+	}
+
+	if !bytes.Equal(enc1, enc2) {
+		t.Errorf("AssertDeterministicGet: Get(%q) is not deterministic\nfirst:  %s\nsecond: %s",
+			resourceID, enc1, enc2)
+	}
+}
+
+// AssertNoEphemeralFields checks that state.AsMap() contains none of the
+// banned field names.
+//
+// Use this in a module's own test file to verify that ADR-016 clause 4's
+// prohibition on ephemeral fields is respected. Pass DefaultBannedEphemeralFields
+// or a module-specific extension of it as banned. Banned field examples from
+// ADR-016 clause 4: live PIDs, current CPU/memory, timestamps, uptime counters.
+func AssertNoEphemeralFields(t *testing.T, state modules.ConfigState, banned []string) {
+	t.Helper()
+
+	m := state.AsMap()
+	for _, field := range banned {
+		if _, ok := m[field]; ok {
+			t.Errorf("AssertNoEphemeralFields: AsMap() contains banned ephemeral field %q (ADR-016 clause 4)", field)
+		}
+	}
+}

--- a/features/modules/conformance/fragment_test_helper_test.go
+++ b/features/modules/conformance/fragment_test_helper_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package conformance_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/modules/conformance"
+	filemod "github.com/cfgis/cfgms/features/modules/stdlib/file"
+)
+
+// configuredFileModule creates a file module with AllowedBasePath set to basePath,
+// ready for Get calls without needing a prior Set.
+func configuredFileModule(t *testing.T, basePath string) modules.Module {
+	t.Helper()
+	m := filemod.New()
+	cfg, ok := m.(modules.Configurable)
+	if !ok {
+		t.Fatal("file module does not implement modules.Configurable")
+	}
+	// FileConfig with only AllowedBasePath is sufficient for Configure —
+	// it only reads the allowed_base_path key from AsMap().
+	baseCfg := &filemod.FileConfig{AllowedBasePath: basePath}
+	if err := cfg.Configure(baseCfg); err != nil {
+		t.Fatalf("Configure(basePath=%q): %v", basePath, err)
+	}
+	return m
+}
+
+// TestAssertDeterministicGet_FileModule verifies that AssertDeterministicGet
+// passes against the stdlib/file module, which is the canonical worked example
+// for ADR-016 clause 4 compliance.
+func TestAssertDeterministicGet_FileModule(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hello.txt")
+	if err := os.WriteFile(testFile, []byte("hello conformance"), 0644); err != nil {
+		t.Fatalf("setup: write test file: %v", err)
+	}
+
+	m := configuredFileModule(t, tmpDir)
+	conformance.AssertDeterministicGet(t, m, testFile)
+}
+
+// TestAssertDeterministicGet_AbsentResource verifies determinism when Get
+// returns an "absent" state (resource does not exist on disk).
+func TestAssertDeterministicGet_AbsentResource(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := configuredFileModule(t, tmpDir)
+	absent := filepath.Join(tmpDir, "does-not-exist.txt")
+	conformance.AssertDeterministicGet(t, m, absent)
+}
+
+// TestAssertNoEphemeralFields_FileModule verifies that AssertNoEphemeralFields
+// passes against the state returned by the stdlib/file module Get.
+func TestAssertNoEphemeralFields_FileModule(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hello.txt")
+	if err := os.WriteFile(testFile, []byte("hello conformance"), 0644); err != nil {
+		t.Fatalf("setup: write test file: %v", err)
+	}
+
+	m := configuredFileModule(t, tmpDir)
+	state, err := m.Get(context.Background(), testFile)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", testFile, err)
+	}
+	conformance.AssertNoEphemeralFields(t, state, conformance.DefaultBannedEphemeralFields)
+}

--- a/features/modules/metadata.go
+++ b/features/modules/metadata.go
@@ -105,12 +105,11 @@ func LoadModuleMetadata(filePath string) (*ModuleMetadata, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open module metadata file %s: %v", filePath, err)
 	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			// Log error but don't override original error - best effort cleanup
-			_ = err
-		}
-	}()
+	// The file is opened read-only and fully consumed by ParseModuleMetadata
+	// before this defer runs, so a Close error cannot affect the returned
+	// metadata or signal data loss (no writes were buffered). The error is
+	// intentionally discarded rather than surfaced or logged.
+	defer func() { _ = file.Close() }()
 
 	return ParseModuleMetadata(file)
 }

--- a/features/modules/metadata.go
+++ b/features/modules/metadata.go
@@ -12,6 +12,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// OwnershipDeclaration records a single object-identity namespace that a module
+// authoritatively owns, per ADR-016 clause 5. When a module declares ownership
+// of a kind, it owns every object of that kind it manages — the entire DNA
+// fragment for that object, with no sub-property co-authorship.
+type OwnershipDeclaration struct {
+	// Kind is the object-identity namespace (e.g. "service", "file", "package").
+	Kind string `yaml:"kind" json:"kind"`
+}
+
 // ModuleMetadata represents the complete metadata for a module
 // This extends the existing module.yaml format with dependency management
 type ModuleMetadata struct {
@@ -51,6 +60,12 @@ type ModuleMetadata struct {
 
 	// BehavioralEnvelope documents what the module does at runtime
 	BehavioralEnvelope *BehavioralEnvelope `yaml:"behavioral_envelope,omitempty" json:"behavioral_envelope,omitempty"`
+
+	// Owns declares the object-identity namespaces this module authoritatively
+	// manages, per ADR-016 clause 5. Optional; zero value (nil/empty) means
+	// this module declares no ownership — backward-compatible with all existing
+	// module.yaml files that predate this field.
+	Owns []OwnershipDeclaration `yaml:"owns,omitempty" json:"owns,omitempty"`
 }
 
 // BehavioralEnvelope documents the runtime behavior of a module for security auditing
@@ -410,6 +425,12 @@ func (m *ModuleMetadata) Clone() *ModuleMetadata {
 			clone.BehavioralEnvelope.NetworkEgress = make([]string, len(m.BehavioralEnvelope.NetworkEgress))
 			copy(clone.BehavioralEnvelope.NetworkEgress, m.BehavioralEnvelope.NetworkEgress)
 		}
+	}
+
+	// Deep copy ownership declarations (OwnershipDeclaration contains only strings)
+	if m.Owns != nil {
+		clone.Owns = make([]OwnershipDeclaration, len(m.Owns))
+		copy(clone.Owns, m.Owns)
 	}
 
 	return clone

--- a/features/modules/metadata_test.go
+++ b/features/modules/metadata_test.go
@@ -878,6 +878,103 @@ func TestModuleMetadata_Clone(t *testing.T) {
 	}
 }
 
+func TestParseModuleMetadata_Owns(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantOwns  []OwnershipDeclaration
+		wantCount int
+	}{
+		{
+			name: "no owns field — zero value, backward compatible",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward`,
+			wantOwns:  nil,
+			wantCount: 0,
+		},
+		{
+			name: "single owns entry",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: service`,
+			wantOwns:  []OwnershipDeclaration{{Kind: "service"}},
+			wantCount: 1,
+		},
+		{
+			name: "multiple owns entries",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: file
+  - kind: directory`,
+			wantOwns:  []OwnershipDeclaration{{Kind: "file"}, {Kind: "directory"}},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := strings.NewReader(tt.yaml)
+			metadata, err := ParseModuleMetadata(reader)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+
+			if len(metadata.Owns) != tt.wantCount {
+				t.Errorf("Owns length = %d, want %d", len(metadata.Owns), tt.wantCount)
+			}
+
+			for i, want := range tt.wantOwns {
+				if i >= len(metadata.Owns) {
+					t.Errorf("Owns[%d] missing, want kind=%q", i, want.Kind)
+					continue
+				}
+				if metadata.Owns[i].Kind != want.Kind {
+					t.Errorf("Owns[%d].Kind = %q, want %q", i, metadata.Owns[i].Kind, want.Kind)
+				}
+			}
+		})
+	}
+}
+
+func TestModuleMetadata_Clone_Owns(t *testing.T) {
+	original := &ModuleMetadata{
+		Name:      "test",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
+		Kind:      "steward",
+		Owns:      []OwnershipDeclaration{{Kind: "service"}, {Kind: "file"}},
+	}
+
+	clone := original.Clone()
+
+	if len(clone.Owns) != len(original.Owns) {
+		t.Fatalf("Clone Owns length = %d, want %d", len(clone.Owns), len(original.Owns))
+	}
+	for i, want := range original.Owns {
+		if clone.Owns[i].Kind != want.Kind {
+			t.Errorf("Clone Owns[%d].Kind = %q, want %q", i, clone.Owns[i].Kind, want.Kind)
+		}
+	}
+
+	// Verify deep copy — mutating clone must not affect original
+	clone.Owns[0].Kind = "mutated"
+	if original.Owns[0].Kind == "mutated" {
+		t.Error("Mutating clone Owns[0] affected original")
+	}
+}
+
 // Benchmark tests
 func BenchmarkLoadModuleMetadata(b *testing.B) {
 	// Create temporary metadata file

--- a/features/modules/metadata_test.go
+++ b/features/modules/metadata_test.go
@@ -512,25 +512,31 @@ func TestModuleMetadata_ToYAML(t *testing.T) {
 }
 
 func TestModuleMetadata_FromYAML(t *testing.T) {
-	yamlData := []byte(`name: from-yaml-test
+	t.Run("valid yaml", func(t *testing.T) {
+		yamlData := []byte(`name: from-yaml-test
 version: 1.0.0
 module_dependencies:
   - name: dep1
     version: "^1.0.0"`)
 
-	var metadata ModuleMetadata
-	err := metadata.FromYAML(yamlData)
-	if err != nil {
-		t.Fatalf("failed to parse YAML: %v", err)
-	}
+		var metadata ModuleMetadata
+		if err := metadata.FromYAML(yamlData); err != nil {
+			t.Fatalf("failed to parse YAML: %v", err)
+		}
+		if metadata.Name != "from-yaml-test" {
+			t.Errorf("Name = %v, expected from-yaml-test", metadata.Name)
+		}
+		if len(metadata.ModuleDependencies) != 1 {
+			t.Errorf("ModuleDependencies length = %v, expected 1", len(metadata.ModuleDependencies))
+		}
+	})
 
-	if metadata.Name != "from-yaml-test" {
-		t.Errorf("Name = %v, expected from-yaml-test", metadata.Name)
-	}
-
-	if len(metadata.ModuleDependencies) != 1 {
-		t.Errorf("ModuleDependencies length = %v, expected 1", len(metadata.ModuleDependencies))
-	}
+	t.Run("malformed yaml returns error", func(t *testing.T) {
+		var metadata ModuleMetadata
+		if err := metadata.FromYAML([]byte("name: [unclosed")); err == nil {
+			t.Error("expected error for malformed YAML, got nil")
+		}
+	})
 }
 
 func TestModuleMetadata_Validate(t *testing.T) {
@@ -999,7 +1005,9 @@ interfaces:
   - Get
   - Set`
 
-	_ = os.WriteFile(metadataFile, []byte(yamlContent), 0644) // Ignore error in benchmark setup
+	if err := os.WriteFile(metadataFile, []byte(yamlContent), 0644); err != nil {
+		b.Fatalf("setup: write benchmark file: %v", err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/features/modules/module.go
+++ b/features/modules/module.go
@@ -6,30 +6,60 @@ import (
 	"context"
 )
 
-// Module defines the core interface that all modules must implement
+// Module defines the core interface that all modules must implement.
+//
+// # ADR-016 Clause 4 — Canonical DNA Fragment Contract
+//
+// Every implementation of Get must return, for each resource it manages, a
+// canonical, deterministically-serialisable DNA fragment. Concretely:
+//
+//   - ConfigState.AsMap() must produce byte-for-byte identical output on every
+//     call against the same unchanged resource state. Implementations must not
+//     rely on map-iteration order; callers use canonical encoding (e.g. JSON
+//     with sorted keys) when comparing or hashing the result.
+//   - Only stable desired-comparable fields are included. Ephemeral runtime
+//     values must be omitted: live PIDs, current CPU/memory statistics,
+//     timestamps, uptime counters, or any value that changes under the OS
+//     without a cfg-driven configuration change.
+//
+// Use features/modules/conformance.AssertDeterministicGet and
+// AssertNoEphemeralFields in a module's own test file to verify compliance.
 type Module interface {
-	// Get returns the current configuration of a resource
+	// Get returns the current configuration of a resource.
+	//
+	// The returned ConfigState must satisfy the ADR-016 clause 4 canonical
+	// fragment contract: deterministic AsMap() output, no ephemeral fields.
 	Get(ctx context.Context, resourceID string) (ConfigState, error)
 
-	// Set updates the resource configuration to match the desired state
+	// Set updates the resource configuration to match the desired state.
 	Set(ctx context.Context, resourceID string, config ConfigState) error
 }
 
-// ConfigState defines the interface that all module configuration states must implement
+// ConfigState defines the interface that all module configuration states must implement.
+//
+// # ADR-016 Clause 4 — Canonical Serialisation Requirements
+//
+// Implementations returned by Module.Get must produce deterministic output:
+//   - AsMap() returns a stable map with no ephemeral keys; the same resource
+//     state always produces the same key set and values across calls.
+//   - ToYAML() serialises from the struct state; callers must not rely on key
+//     ordering in the YAML output — use AsMap() for comparison operations.
 type ConfigState interface {
-	// AsMap returns the configuration as a map for efficient field-by-field comparison
+	// AsMap returns the configuration as a map for efficient field-by-field comparison.
+	// All keys and values must be stable across calls on the same resource state
+	// (ADR-016 clause 4).
 	AsMap() map[string]interface{}
 
-	// ToYAML serializes the configuration to YAML for export/storage
+	// ToYAML serializes the configuration to YAML for export/storage.
 	ToYAML() ([]byte, error)
 
-	// FromYAML deserializes YAML data into the configuration
+	// FromYAML deserializes YAML data into the configuration.
 	FromYAML([]byte) error
 
-	// Validate ensures the configuration is valid
+	// Validate ensures the configuration is valid.
 	Validate() error
 
-	// GetManagedFields returns the list of fields this configuration manages
+	// GetManagedFields returns the list of fields this configuration manages.
 	GetManagedFields() []string
 }
 


### PR DESCRIPTION
## Summary

- Add `OwnershipDeclaration` struct and `Owns []OwnershipDeclaration` field to `ModuleMetadata` for ADR-016 clause 5 `owns:` manifest declaration (backward-compatible, `omitempty`)
- Add `features/modules/conformance` package with `AssertDeterministicGet` and `AssertNoEphemeralFields` exported helpers and `DefaultBannedEphemeralFields` (ADR-016 clause 4 test infrastructure)
- Add conformance tests against `stdlib/file` as the worked example
- Add ADR-016 clause 4 canonical fragment contract doc comments to `Module` and `ConfigState` interfaces in `module.go`
- Update `docs/architecture/modules/README.md` with `owns:` declaration and conformance package usage sections
- Fix `metadata.go`: replace misleading Close error comment with accurate explanatory comment
- Fix `metadata_test.go`: benchmark setup propagates `WriteFile` error; add malformed-YAML error-path subtest to `TestModuleMetadata_FromYAML`

## Test plan

- [x] `go test ./features/modules/...` — all 16+ module packages pass
- [x] `make test` — full validation gate passes (exit code 0)
- [x] Story-review workflow: security PASS, QA PASS, acceptance criteria PASS

Fixes #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)