### PR TITLE
cli: status, dna, logs, modules selector-based read-only fan-out

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -355,18 +355,19 @@ func runStewardDecommission(_ *cobra.Command, args []string) error {
 	return overallErr
 }
 
-// stewardLogsCmd pulls recent log entries from a steward via the controller REST API.
+// stewardLogsCmd pulls recent log entries from one or more stewards via the controller REST API.
 var stewardLogsCmd = &cobra.Command{
-	Use:   "logs <id>",
-	Short: "Pull recent log entries from a steward",
-	Long: `Pull recent log entries from the controller's log-pull endpoint for a steward.
+	Use:   "logs <selector>",
+	Short: "Pull recent log entries from stewards matching a selector",
+	Long: `Pull recent log entries from the controller's log-pull endpoint for every steward the selector matches.
 
 Note: Log pull is not yet available. Collect logs directly from the steward host.
 
 Examples:
   cfg steward logs <steward-id>
   cfg steward logs <steward-id> --tail 50 --level WARN
-  cfg steward logs <steward-id> --since 1h --module file`,
+  cfg steward logs <steward-id> --since 1h --module file
+  cfg steward logs os:linux --tail 20`,
 	Args: cobra.ExactArgs(1),
 	RunE: runStewardLogs,
 }
@@ -496,12 +497,23 @@ func runStewardMove(_ *cobra.Command, args []string) error {
 	return overallErr
 }
 
+// logsNotImplementedPayload is the sentinel returned by the fan-out action when a
+// steward reports 501 (log pull not yet available). It lets the output phase
+// distinguish "not implemented" from a genuine read failure without forcing a
+// non-zero exit — matching the pre-selector single-ID behaviour.
+var logsNotImplementedPayload = json.RawMessage(`{"status":"not_implemented"}`)
+
 func runStewardLogs(_ *cobra.Command, args []string) error {
-	stewardID := args[0]
+	selector := args[0]
 
 	client, err := getStewardClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
+	if err != nil {
+		return err
 	}
 
 	v := url.Values{}
@@ -515,58 +527,97 @@ func runStewardLogs(_ *cobra.Command, args []string) error {
 	if stewardLogsModule != "" {
 		v.Set("module", stewardLogsModule)
 	}
-	path := "/api/v1/stewards/" + stewardID + "/logs?" + v.Encode()
+	queryStr := v.Encode()
 
-	resp, err := client.Get(context.Background(), path)
-	if err != nil {
-		return fmt.Errorf("failed to fetch logs: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
-		}
-	}()
+	results, overallErr := fanOutConcurrent(context.Background(), matches,
+		func(ctx context.Context, s StewardInfo) (json.RawMessage, error) {
+			path := "/api/v1/stewards/" + s.ID + "/logs?" + queryStr
+			resp, err := client.Get(ctx, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch logs: %w", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+				}
+			}()
 
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("steward %s not found", stewardID)
-	}
+			if resp.StatusCode == http.StatusNotFound {
+				return nil, fmt.Errorf("steward %s not found", s.ID)
+			}
+			if resp.StatusCode == http.StatusNotImplemented {
+				return logsNotImplementedPayload, nil
+			}
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return nil, fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+			}
 
-	if resp.StatusCode == http.StatusNotImplemented {
-		fmt.Println("Log pull not yet available for this steward. Collect logs directly from the host.")
-		return nil
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response: %w", err)
+			}
+			return body, nil
+		})
 
 	if stewardLogsJSON {
-		_, err := os.Stdout.Write(body)
-		return err
+		entries := keyedOutput(matches, results)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			return err
+		}
+		return overallErr
 	}
 
-	var apiResp struct {
-		Lines []struct {
-			Timestamp string `json:"timestamp"`
-			Level     string `json:"level"`
-			Module    string `json:"module"`
-			Message   string `json:"message"`
-		} `json:"lines"`
-	}
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
+	for _, m := range matches {
+		key := stewardKey(m)
+		r := results[key]
+		if r.Err != nil {
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr, "error: %s: %v\n", key, r.Err)
+			}
+			continue
+		}
+
+		if len(matches) > 1 {
+			fmt.Printf("=== %s ===\n", key)
+		}
+
+		var statusCheck struct {
+			Status string `json:"status"`
+		}
+		if json.Unmarshal(r.Payload, &statusCheck) == nil && statusCheck.Status == "not_implemented" {
+			fmt.Println("Log pull not yet available for this steward. Collect logs directly from the host.")
+			continue
+		}
+
+		var apiResp struct {
+			Lines []struct {
+				Timestamp string `json:"timestamp"`
+				Level     string `json:"level"`
+				Module    string `json:"module"`
+				Message   string `json:"message"`
+			} `json:"lines"`
+		}
+		if err := json.Unmarshal(r.Payload, &apiResp); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: failed to parse response: %v\n", key, err)
+			continue
+		}
+
+		for _, line := range apiResp.Lines {
+			fmt.Printf("%s [%s] [%s] %s\n", line.Timestamp, line.Level, line.Module, line.Message)
+		}
 	}
 
-	for _, line := range apiResp.Lines {
-		fmt.Printf("%s [%s] [%s] %s\n", line.Timestamp, line.Level, line.Module, line.Message)
+	if overallErr != nil && len(matches) == 1 {
+		for _, r := range results {
+			if r.Err != nil {
+				return r.Err
+			}
+		}
 	}
-	return nil
+	return overallErr
 }
 
 func init() {
@@ -775,14 +826,15 @@ type stewardEntry struct {
 	} `json:"dna,omitempty"`
 }
 
-// stewardStatusCmd shows detailed status for a single steward.
+// stewardStatusCmd shows detailed status for every steward a selector matches.
 var stewardStatusCmd = &cobra.Command{
-	Use:   "status <id>",
-	Short: "Show detailed status for a steward",
-	Long: `Display full details for a single steward registered with the controller.
+	Use:   "status <selector>",
+	Short: "Show detailed status for stewards matching a selector",
+	Long: `Display full details for every steward the selector matches.
 
 Prints labelled fields including id, status, last_seen, version, hostname, OS,
-connection state, and other available metadata.
+connection state, and other available metadata. With --json, emits a
+keyed-by-steward JSON array (one entry per matched steward).
 
 Examples:
   # Show status using admin bundle (mTLS auto-discovery)
@@ -792,15 +844,18 @@ Examples:
   cfg steward status <steward-id> --url=https://controller.example.com
 
   # Show status as JSON
-  cfg steward status <steward-id> --json`,
+  cfg steward status <steward-id> --json
+
+  # Fan out to all linux stewards
+  cfg steward status os:linux`,
 	Args: cobra.ExactArgs(1),
 	RunE: runStewardStatus,
 }
 
-// stewardDNACmd shows the DNA snapshot for a single steward.
+// stewardDNACmd shows the DNA snapshot for every steward a selector matches.
 var stewardDNACmd = &cobra.Command{
-	Use:   "dna <id>",
-	Short: "Show DNA snapshot for a steward",
+	Use:   "dna <selector>",
+	Short: "Show DNA snapshot for stewards matching a selector",
 	Long: `Display the most recent DNA snapshot for a steward registered with the controller.
 
 Use --attribute to retrieve a single dotted-path attribute value for scripted probes.
@@ -828,94 +883,137 @@ type stewardDNAInfo struct {
 	Attributes   map[string]string `json:"attributes,omitempty"`
 }
 
-func runStewardDNA(cmd *cobra.Command, args []string) error {
-	stewardID := args[0]
+func runStewardDNA(_ *cobra.Command, args []string) error {
+	selector := args[0]
 
 	client, err := getStewardClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	path := "/api/v1/stewards/" + stewardID + "/dna"
-	if stewardDNAAttribute != "" {
-		path += "?attribute=" + url.QueryEscape(stewardDNAAttribute)
-	}
-
-	resp, err := client.Get(context.Background(), path)
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
 	if err != nil {
-		return fmt.Errorf("failed to fetch steward DNA: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode == http.StatusNotFound {
-		if stewardDNAAttribute != "" {
-			return fmt.Errorf("attribute %q not found for steward %s", stewardDNAAttribute, stewardID)
-		}
-		return fmt.Errorf("steward %s not found or has no DNA snapshot", stewardID)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Single attribute: the handler returns {"value":"<val>"} directly (no data wrapper).
-	if stewardDNAAttribute != "" {
-		var attrResp struct {
-			Value string `json:"value"`
-		}
-		if err := json.Unmarshal(body, &attrResp); err != nil {
-			return fmt.Errorf("failed to parse attribute response: %w", err)
-		}
-		fmt.Println(attrResp.Value)
-		return nil
-	}
-
-	if stewardDNAJSONOutput {
-		_, err := os.Stdout.Write(body)
 		return err
 	}
 
-	var apiResp struct {
-		Data stewardDNAInfo `json:"data"`
-	}
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
+	results, overallErr := fanOutConcurrent(context.Background(), matches,
+		func(ctx context.Context, s StewardInfo) (json.RawMessage, error) {
+			path := "/api/v1/stewards/" + s.ID + "/dna"
+			if stewardDNAAttribute != "" {
+				path += "?attribute=" + url.QueryEscape(stewardDNAAttribute)
+			}
+
+			resp, err := client.Get(ctx, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch steward DNA: %w", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+				}
+			}()
+
+			if resp.StatusCode == http.StatusNotFound {
+				if stewardDNAAttribute != "" {
+					return nil, fmt.Errorf("attribute %q not found for steward %s", stewardDNAAttribute, s.ID)
+				}
+				return nil, fmt.Errorf("steward %s not found or has no DNA snapshot", s.ID)
+			}
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return nil, fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response: %w", err)
+			}
+			return body, nil
+		})
+
+	if stewardDNAJSONOutput {
+		entries := keyedOutput(matches, results)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			return err
+		}
+		return overallErr
 	}
 
-	d := apiResp.Data
-	fmt.Printf("Hostname:      %s\n", d.Hostname)
-	fmt.Printf("OS:            %s\n", d.OS)
-	if d.Architecture != "" {
-		fmt.Printf("Architecture:  %s\n", d.Architecture)
+	for _, m := range matches {
+		key := stewardKey(m)
+		r := results[key]
+		if r.Err != nil {
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr, "error: %s: %v\n", key, r.Err)
+			}
+			continue
+		}
+
+		// --attribute: print "<key>: <value>" per steward in multi-match,
+		// just "<value>" in single-match (backward compatible).
+		if stewardDNAAttribute != "" {
+			var attrResp struct {
+				Value string `json:"value"`
+			}
+			if err := json.Unmarshal(r.Payload, &attrResp); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %s: failed to parse attribute response: %v\n", key, err)
+				continue
+			}
+			if len(matches) > 1 {
+				fmt.Printf("%s: %s\n", key, attrResp.Value)
+			} else {
+				fmt.Println(attrResp.Value)
+			}
+			continue
+		}
+
+		if len(matches) > 1 {
+			fmt.Printf("=== %s ===\n", key)
+		}
+
+		var apiResp struct {
+			Data stewardDNAInfo `json:"data"`
+		}
+		if err := json.Unmarshal(r.Payload, &apiResp); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: failed to parse response: %v\n", key, err)
+			continue
+		}
+
+		d := apiResp.Data
+		fmt.Printf("Hostname:      %s\n", d.Hostname)
+		fmt.Printf("OS:            %s\n", d.OS)
+		if d.Architecture != "" {
+			fmt.Printf("Architecture:  %s\n", d.Architecture)
+		}
+		if d.CollectedAt != "" {
+			fmt.Printf("CollectedAt:   %s\n", d.CollectedAt)
+		}
+		for k, v := range d.Attributes {
+			fmt.Printf("%s=%s\n", k, v)
+		}
 	}
-	if d.CollectedAt != "" {
-		fmt.Printf("CollectedAt:   %s\n", d.CollectedAt)
+
+	if overallErr != nil && len(matches) == 1 {
+		for _, r := range results {
+			if r.Err != nil {
+				return r.Err
+			}
+		}
 	}
-	for k, v := range d.Attributes {
-		fmt.Printf("%s=%s\n", k, v)
-	}
-	return nil
+	return overallErr
 }
 
-// stewardModulesCmd lists modules currently loaded by a named steward.
+// stewardModulesCmd lists modules currently loaded by every steward a selector matches.
 var stewardModulesCmd = &cobra.Command{
-	Use:   "modules <id>",
-	Short: "List modules loaded by a steward",
-	Long: `Display the modules currently loaded by a named steward.
+	Use:   "modules <selector>",
+	Short: "List modules loaded by stewards matching a selector",
+	Long: `Display the modules currently loaded by every steward the selector matches.
 
-Retrieves module data from the steward's DNA attributes reported to the controller.
-When the steward does not report module data, a 501 response is returned and the
-command exits 0 with an informational message.
+Retrieves module data from each steward's DNA attributes reported to the controller.
+When a steward does not report module data, a 501 response is returned and the
+entry exits 0 with an informational message.
 
 Examples:
   # List modules using admin bundle (mTLS auto-discovery)
@@ -925,7 +1023,10 @@ Examples:
   cfg steward modules <steward-id> --url=https://controller.example.com
 
   # Output raw JSON
-  cfg steward modules <steward-id> --json`,
+  cfg steward modules <steward-id> --json
+
+  # Fan out to all linux stewards
+  cfg steward modules os:linux`,
 	Args: cobra.ExactArgs(1),
 	RunE: runStewardModules,
 }
@@ -948,148 +1049,237 @@ type stewardStatusInfo struct {
 	} `json:"dna,omitempty"`
 }
 
-func runStewardStatus(cmd *cobra.Command, args []string) error {
-	stewardID := args[0]
+func runStewardStatus(_ *cobra.Command, args []string) error {
+	selector := args[0]
 
 	client, err := getStewardClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	resp, err := client.Get(context.Background(), "/api/v1/stewards/"+stewardID)
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
 	if err != nil {
-		return fmt.Errorf("failed to fetch steward: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("steward %s not found", stewardID)
+		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
-	}
+	results, overallErr := fanOutConcurrent(context.Background(), matches,
+		func(ctx context.Context, s StewardInfo) (json.RawMessage, error) {
+			resp, err := client.Get(ctx, "/api/v1/stewards/"+s.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch steward: %w", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+				}
+			}()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
+			if resp.StatusCode == http.StatusNotFound {
+				return nil, fmt.Errorf("steward %s not found", s.ID)
+			}
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return nil, fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response: %w", err)
+			}
+			return body, nil
+		})
 
 	if stewardStatusJSONOutput {
-		_, err := os.Stdout.Write(body)
-		return err
+		entries := keyedOutput(matches, results)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			return err
+		}
+		return overallErr
 	}
 
-	var apiResp struct {
-		Data stewardStatusInfo `json:"data"`
-	}
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
-	}
+	for _, m := range matches {
+		key := stewardKey(m)
+		r := results[key]
+		if r.Err != nil {
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr, "error: %s: %v\n", key, r.Err)
+			}
+			continue
+		}
 
-	s := apiResp.Data
-	fmt.Printf("ID:               %s\n", s.ID)
-	fmt.Printf("Status:           %s\n", s.Status)
-	fmt.Printf("Connection:       %s\n", s.ConnectionState)
-	lastSeen := ""
-	if !s.LastSeen.IsZero() {
-		lastSeen = s.LastSeen.Format("2006-01-02 15:04:05")
-	}
-	fmt.Printf("Last Seen:        %s\n", lastSeen)
-	fmt.Printf("Version:          %s\n", s.Version)
-	if s.DNA != nil {
-		fmt.Printf("Hostname:         %s\n", s.DNA.Hostname)
-		fmt.Printf("OS:               %s\n", s.DNA.OS)
-		if s.DNA.Architecture != "" {
-			fmt.Printf("Architecture:     %s\n", s.DNA.Architecture)
+		if len(matches) > 1 {
+			fmt.Printf("=== %s ===\n", key)
+		}
+
+		var apiResp struct {
+			Data stewardStatusInfo `json:"data"`
+		}
+		if err := json.Unmarshal(r.Payload, &apiResp); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: failed to parse result: %v\n", key, err)
+			continue
+		}
+
+		s := apiResp.Data
+		fmt.Printf("ID:               %s\n", s.ID)
+		fmt.Printf("Status:           %s\n", s.Status)
+		fmt.Printf("Connection:       %s\n", s.ConnectionState)
+		lastSeen := ""
+		if !s.LastSeen.IsZero() {
+			lastSeen = s.LastSeen.Format("2006-01-02 15:04:05")
+		}
+		fmt.Printf("Last Seen:        %s\n", lastSeen)
+		fmt.Printf("Version:          %s\n", s.Version)
+		if s.DNA != nil {
+			fmt.Printf("Hostname:         %s\n", s.DNA.Hostname)
+			fmt.Printf("OS:               %s\n", s.DNA.OS)
+			if s.DNA.Architecture != "" {
+				fmt.Printf("Architecture:     %s\n", s.DNA.Architecture)
+			}
+		}
+		if s.TenantID != "" {
+			fmt.Printf("Tenant ID:        %s\n", s.TenantID)
+		}
+		if s.Group != "" {
+			fmt.Printf("Group:            %s\n", s.Group)
 		}
 	}
-	if s.TenantID != "" {
-		fmt.Printf("Tenant ID:        %s\n", s.TenantID)
+
+	if overallErr != nil && len(matches) == 1 {
+		for _, r := range results {
+			if r.Err != nil {
+				return r.Err
+			}
+		}
 	}
-	if s.Group != "" {
-		fmt.Printf("Group:            %s\n", s.Group)
-	}
-	return nil
+	return overallErr
 }
 
-func runStewardModules(cmd *cobra.Command, args []string) error {
-	stewardID := args[0]
+// modulesNotImplementedPayload is the sentinel returned by the fan-out action
+// when a steward reports 501 (module list not yet available). Mirrors the
+// logsNotImplementedPayload pattern so the output phase can distinguish
+// "not implemented" from a genuine read failure without forcing a non-zero exit.
+var modulesNotImplementedPayload = json.RawMessage(`{"status":"not_implemented"}`)
+
+func runStewardModules(_ *cobra.Command, args []string) error {
+	selector := args[0]
 
 	client, err := getStewardClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	resp, err := client.Get(context.Background(), "/api/v1/stewards/"+stewardID+"/modules")
+	matches, err := resolveOrFailFast(context.Background(), client, selector)
 	if err != nil {
-		return fmt.Errorf("failed to fetch steward modules: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("steward %s not found", stewardID)
+		return err
 	}
 
-	if resp.StatusCode == http.StatusNotImplemented {
-		fmt.Println("Module list not available for this steward. Upgrade the steward to a version that reports module DNA attributes.")
-		return nil
-	}
+	results, overallErr := fanOutConcurrent(context.Background(), matches,
+		func(ctx context.Context, s StewardInfo) (json.RawMessage, error) {
+			resp, err := client.Get(ctx, "/api/v1/stewards/"+s.ID+"/modules")
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch steward modules: %w", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+				}
+			}()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
-	}
+			if resp.StatusCode == http.StatusNotFound {
+				return nil, fmt.Errorf("steward %s not found", s.ID)
+			}
+			if resp.StatusCode == http.StatusNotImplemented {
+				return modulesNotImplementedPayload, nil
+			}
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return nil, fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+			}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response: %w", err)
+			}
+			return body, nil
+		})
 
 	if stewardModulesJSON {
-		_, err := os.Stdout.Write(body)
-		return err
+		entries := keyedOutput(matches, results)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			return err
+		}
+		return overallErr
 	}
 
-	var apiResp struct {
-		Data struct {
-			Modules []struct {
-				Name    string `json:"name"`
-				Version string `json:"version,omitempty"`
-			} `json:"modules"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
-	}
+	for _, m := range matches {
+		key := stewardKey(m)
+		r := results[key]
+		if r.Err != nil {
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr, "error: %s: %v\n", key, r.Err)
+			}
+			continue
+		}
 
-	if len(apiResp.Data.Modules) == 0 {
-		fmt.Println("No modules loaded.")
-		return nil
-	}
+		if len(matches) > 1 {
+			fmt.Printf("=== %s ===\n", key)
+		}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(w, "NAME\tVERSION"); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(w, "----\t-------"); err != nil {
-		return err
-	}
-	for _, m := range apiResp.Data.Modules {
-		if _, err := fmt.Fprintf(w, "%s\t%s\n", m.Name, m.Version); err != nil {
+		var statusCheck struct {
+			Status string `json:"status"`
+		}
+		if json.Unmarshal(r.Payload, &statusCheck) == nil && statusCheck.Status == "not_implemented" {
+			fmt.Println("Module list not available for this steward. Upgrade the steward to a version that reports module DNA attributes.")
+			continue
+		}
+
+		var apiResp struct {
+			Data struct {
+				Modules []struct {
+					Name    string `json:"name"`
+					Version string `json:"version,omitempty"`
+				} `json:"modules"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(r.Payload, &apiResp); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: failed to parse response: %v\n", key, err)
+			continue
+		}
+
+		if len(apiResp.Data.Modules) == 0 {
+			fmt.Println("No modules loaded.")
+			continue
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		if _, err := fmt.Fprintln(w, "NAME\tVERSION"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, "----\t-------"); err != nil {
+			return err
+		}
+		for _, mod := range apiResp.Data.Modules {
+			if _, err := fmt.Fprintf(w, "%s\t%s\n", mod.Name, mod.Version); err != nil {
+				return err
+			}
+		}
+		if err := w.Flush(); err != nil {
 			return err
 		}
 	}
-	return w.Flush()
+
+	if overallErr != nil && len(matches) == 1 {
+		for _, r := range results {
+			if r.Err != nil {
+				return r.Err
+			}
+		}
+	}
+	return overallErr
 }
 
 func runStewardList(cmd *cobra.Command, args []string) error {

--- a/cmd/cfg/cmd/steward_test.go
+++ b/cmd/cfg/cmd/steward_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -413,6 +414,53 @@ func TestStewardModules_JSONFlag(t *testing.T) {
 	require.Len(t, entries, 1)
 	assert.True(t, entries[0].Success)
 	assert.Contains(t, output, "file")
+}
+
+func TestStewardLogs_JSONFlag(t *testing.T) {
+	now := time.Now().UTC()
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"lines": []map[string]string{
+				{
+					"timestamp": now.Format(time.RFC3339),
+					"level":     "info",
+					"module":    "file",
+					"message":   "convergence-complete",
+				},
+			},
+		})
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	origJSON := stewardLogsJSON
+	origTail := stewardLogsTail
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+		stewardLogsJSON = origJSON
+		stewardLogsTail = origTail
+	})
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardLogsJSON = true
+	stewardLogsTail = 100
+
+	output := captureStdout(t, func() {
+		err := runStewardLogs(stewardLogsCmd, []string{"steward-abc123"})
+		require.NoError(t, err)
+	})
+
+	// --json emits a keyed-by-steward array (story 4 schema).
+	var entries []KeyedOutputEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array")
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Success)
+	assert.Contains(t, output, "convergence-complete")
 }
 
 func TestStewardModules_HappyPath(t *testing.T) {
@@ -1104,4 +1152,446 @@ func TestStewardDecommission_FlagsRegistered(t *testing.T) {
 	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered")
 	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered")
 	assert.NotNil(t, stewardDecommissionCmd.Flags().Lookup("json"), "--json flag must be registered")
+}
+
+// ---- multi-match selector fan-out tests (Issue #2445) ----
+
+// wrapWithMultiResolve wraps an http.HandlerFunc so that POST /api/v1/fleet/resolve
+// returns all provided stewards. All other requests are delegated to next.
+func wrapWithMultiResolve(t *testing.T, stewards []StewardInfo, next http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve" {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(struct {
+				Data []StewardInfo `json:"data"`
+			}{Data: stewards}); err != nil {
+				t.Errorf("encode resolve: %v", err)
+			}
+			return
+		}
+		next(w, r)
+	}
+}
+
+// stewardIDFromPath extracts the steward ID from URLs of the form
+// /api/v1/stewards/{id}[/suffix].
+func stewardIDFromPath(path string) string {
+	parts := strings.SplitN(path, "/", 6)
+	if len(parts) >= 5 {
+		return parts[4]
+	}
+	return ""
+}
+
+// TestStewardStatus_MultiMatchFanOut verifies that the status command fans out
+// over all stewards matched by a selector and aggregates results.
+func TestStewardStatus_MultiMatchFanOut(t *testing.T) {
+	twoStewards := []StewardInfo{
+		{ID: "sw-aaa", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "sw-bbb", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	t.Run("human output is host-prefixed for two-steward match", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"id": id, "status": "connected"},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+
+		output := captureStdout(t, func() {
+			err := runStewardStatus(stewardStatusCmd, []string{"os:linux"})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "=== host-a#sw-aaa ===")
+		assert.Contains(t, output, "=== host-b#sw-bbb ===")
+		assert.Contains(t, output, "sw-aaa")
+		assert.Contains(t, output, "sw-bbb")
+	})
+
+	t.Run("json output has keyed entry for each matched steward", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"id": id, "status": "connected"},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origJSON := stewardStatusJSONOutput
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardStatusJSONOutput = origJSON
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardStatusJSONOutput = true
+
+		output := captureStdout(t, func() {
+			err := runStewardStatus(stewardStatusCmd, []string{"os:linux"})
+			require.NoError(t, err)
+		})
+
+		var entries []KeyedOutputEntry
+		require.NoError(t, json.Unmarshal([]byte(output), &entries))
+		require.Len(t, entries, 2)
+		assert.True(t, entries[0].Success)
+		assert.True(t, entries[1].Success)
+		keys := []string{entries[0].Key, entries[1].Key}
+		assert.Contains(t, keys, "host-a#sw-aaa")
+		assert.Contains(t, keys, "host-b#sw-bbb")
+	})
+
+	t.Run("partial failure is reported per-steward and exits non-zero", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			if id == "sw-bbb" {
+				// Simulate steward going offline between resolve and fetch.
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"id": id, "status": "connected"},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+
+		var err error
+		output := captureStdout(t, func() {
+			err = runStewardStatus(stewardStatusCmd, []string{"os:linux"})
+		})
+
+		require.Error(t, err, "command must exit non-zero when any steward fetch fails")
+		// The successful steward's output is still printed.
+		assert.Contains(t, output, "sw-aaa")
+	})
+}
+
+// TestStewardDNA_MultiMatchFanOut verifies that the dna command fans out over
+// all matched stewards and aggregates results.
+func TestStewardDNA_MultiMatchFanOut(t *testing.T) {
+	twoStewards := []StewardInfo{
+		{ID: "sw-aaa", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "sw-bbb", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	t.Run("human output is host-prefixed for two-steward match", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"hostname": id + "-host", "os": "linux"},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origAttr := stewardDNAAttribute
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardDNAAttribute = origAttr
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardDNAAttribute = ""
+
+		output := captureStdout(t, func() {
+			err := runStewardDNA(stewardDNACmd, []string{"os:linux"})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "=== host-a#sw-aaa ===")
+		assert.Contains(t, output, "=== host-b#sw-bbb ===")
+	})
+
+	t.Run("json output has keyed entry for each matched steward", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"hostname": id + "-host", "os": "linux"},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origJSON := stewardDNAJSONOutput
+		origAttr := stewardDNAAttribute
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardDNAJSONOutput = origJSON
+			stewardDNAAttribute = origAttr
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardDNAJSONOutput = true
+		stewardDNAAttribute = ""
+
+		output := captureStdout(t, func() {
+			err := runStewardDNA(stewardDNACmd, []string{"os:linux"})
+			require.NoError(t, err)
+		})
+
+		var entries []KeyedOutputEntry
+		require.NoError(t, json.Unmarshal([]byte(output), &entries))
+		require.Len(t, entries, 2)
+		keys := []string{entries[0].Key, entries[1].Key}
+		assert.Contains(t, keys, "host-a#sw-aaa")
+		assert.Contains(t, keys, "host-b#sw-bbb")
+	})
+
+	t.Run("attribute mode returns one keyed value per matched steward", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// Both return different attribute values for distinctiveness.
+			val := "linux"
+			if id == "sw-bbb" {
+				val = "windows"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"value": val})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origAttr := stewardDNAAttribute
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardDNAAttribute = origAttr
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardDNAAttribute = "os"
+
+		output := captureStdout(t, func() {
+			err := runStewardDNA(stewardDNACmd, []string{"all"})
+			require.NoError(t, err)
+		})
+
+		// Multi-match --attribute must prefix each value with the steward key.
+		assert.Contains(t, output, "host-a#sw-aaa: linux")
+		assert.Contains(t, output, "host-b#sw-bbb: windows")
+	})
+
+	t.Run("partial failure exits non-zero", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			if id == "sw-bbb" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"hostname": "host-a", "os": "linux"},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origAttr := stewardDNAAttribute
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardDNAAttribute = origAttr
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardDNAAttribute = ""
+
+		err := runStewardDNA(stewardDNACmd, []string{"all"})
+		require.Error(t, err, "command must exit non-zero when any steward fetch fails")
+	})
+}
+
+// TestStewardLogs_MultiMatchFanOut verifies that the logs command fans out over
+// all stewards matched by a selector.
+func TestStewardLogs_MultiMatchFanOut(t *testing.T) {
+	twoStewards := []StewardInfo{
+		{ID: "sw-aaa", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "sw-bbb", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	t.Run("two stewards fan out and produce host-prefixed output", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"lines": []map[string]string{
+					{"timestamp": "2026-01-01T00:00:00Z", "level": "INFO", "module": "core", "message": "ok"},
+				},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origTail := stewardLogsTail
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardLogsTail = origTail
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardLogsTail = 10
+
+		output := captureStdout(t, func() {
+			err := runStewardLogs(stewardLogsCmd, []string{"os:linux"})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "=== host-a#sw-aaa ===")
+		assert.Contains(t, output, "=== host-b#sw-bbb ===")
+	})
+
+	t.Run("partial failure exits non-zero", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			if id == "sw-bbb" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"lines": []interface{}{}})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origTail := stewardLogsTail
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardLogsTail = origTail
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardLogsTail = 10
+
+		err := runStewardLogs(stewardLogsCmd, []string{"os:linux"})
+		require.Error(t, err, "command must exit non-zero when any steward fetch fails")
+	})
+}
+
+// TestStewardModules_MultiMatchFanOut verifies that the modules command fans out
+// over all stewards matched by a selector.
+func TestStewardModules_MultiMatchFanOut(t *testing.T) {
+	twoStewards := []StewardInfo{
+		{ID: "sw-aaa", DNA: &StewardInfoDNA{Hostname: "host-a"}},
+		{ID: "sw-bbb", DNA: &StewardInfoDNA{Hostname: "host-b"}},
+	}
+
+	t.Run("two stewards fan out and produce host-prefixed output", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"modules": []map[string]string{{"name": "file", "version": "1.0"}},
+				},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+
+		output := captureStdout(t, func() {
+			err := runStewardModules(stewardModulesCmd, []string{"os:linux"})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "=== host-a#sw-aaa ===")
+		assert.Contains(t, output, "=== host-b#sw-bbb ===")
+		assert.Contains(t, output, "file")
+	})
+
+	t.Run("partial failure exits non-zero", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := stewardIDFromPath(r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			if id == "sw-bbb" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"modules": []interface{}{}},
+			})
+		})
+		server := httptest.NewServer(wrapWithMultiResolve(t, twoStewards, inner))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+
+		err := runStewardModules(stewardModulesCmd, []string{"os:linux"})
+		require.Error(t, err, "command must exit non-zero when any steward fetch fails")
+	})
 }

--- a/cmd/cfg/cmd/steward_test.go
+++ b/cmd/cfg/cmd/steward_test.go
@@ -13,6 +13,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// wrapWithResolve wraps an http.HandlerFunc so that POST /api/v1/fleet/resolve
+// returns a single-element fleet containing the given stewardID (with no DNA).
+// All other requests are delegated to the wrapped handler. This lets existing
+// single-ID tests work correctly now that the commands call resolveOrFailFast
+// before issuing per-steward requests.
+func wrapWithResolve(t *testing.T, stewardID string, next http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/fleet/resolve" {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(struct {
+				Data []StewardInfo `json:"data"`
+			}{Data: []StewardInfo{{ID: stewardID}}}); err != nil {
+				t.Errorf("encode resolve: %v", err)
+			}
+			return
+		}
+		next(w, r)
+	}
+}
+
 func TestStewardList_CallsGetStewardsEndpoint(t *testing.T) {
 	now := time.Now().UTC()
 	stewards := []map[string]interface{}{
@@ -126,7 +147,7 @@ func TestStewardStatusCommand(t *testing.T) {
 	t.Run("happy path prints labelled fields", func(t *testing.T) {
 		now := time.Now().UTC()
 		var requestPath string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestPath = r.URL.Path
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -147,7 +168,8 @@ func TestStewardStatusCommand(t *testing.T) {
 				},
 				"timestamp": now,
 			})
-		}))
+		})
+		server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
 		defer server.Close()
 
 		origURL := stewardURL
@@ -180,11 +202,13 @@ func TestStewardStatusCommand(t *testing.T) {
 	})
 
 	t.Run("unknown id 404 returns not found error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Resolve returns the steward, then the status fetch returns 404.
+		innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "steward not found"})
-		}))
+		})
+		server := httptest.NewServer(wrapWithResolve(t, "nonexistent-steward-id", innerHandler))
 		defer server.Close()
 
 		origURL := stewardURL
@@ -203,11 +227,12 @@ func TestStewardStatusCommand(t *testing.T) {
 	})
 
 	t.Run("non-ok non-404 status returns error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
-		}))
+		})
+		server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
 		defer server.Close()
 
 		origURL := stewardURL
@@ -224,9 +249,9 @@ func TestStewardStatusCommand(t *testing.T) {
 		assert.Contains(t, err.Error(), "500")
 	})
 
-	t.Run("json flag emits raw JSON response", func(t *testing.T) {
+	t.Run("json flag emits keyed JSON response", func(t *testing.T) {
 		now := time.Now().UTC()
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -236,7 +261,8 @@ func TestStewardStatusCommand(t *testing.T) {
 				},
 				"timestamp": now,
 			})
-		}))
+		})
+		server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
 		defer server.Close()
 
 		origURL := stewardURL
@@ -256,8 +282,11 @@ func TestStewardStatusCommand(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		var parsed map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+		// --json now emits a keyed-by-steward array (story 4 schema).
+		var entries []KeyedOutputEntry
+		require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array")
+		require.Len(t, entries, 1)
+		assert.True(t, entries[0].Success)
 		assert.Contains(t, output, "steward-abc123")
 	})
 }
@@ -266,7 +295,7 @@ func TestStewardStatusCommand(t *testing.T) {
 // API path and prints the 501 unavailability message without erroring.
 func TestStewardModules_CallsEndpoint(t *testing.T) {
 	var requestPath string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotImplemented)
@@ -276,7 +305,8 @@ func TestStewardModules_CallsEndpoint(t *testing.T) {
 				"message": "steward does not report loaded modules in DNA; ensure steward version supports module DNA attributes",
 			},
 		})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
@@ -299,13 +329,15 @@ func TestStewardModules_CallsEndpoint(t *testing.T) {
 }
 
 func TestStewardModules_NotFound(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Resolve returns the steward; then the modules fetch returns 404.
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": map[string]string{"code": "STEWARD_NOT_FOUND", "message": "Steward not found"},
 		})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "nonexistent-steward", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
@@ -323,11 +355,12 @@ func TestStewardModules_NotFound(t *testing.T) {
 }
 
 func TestStewardModules_NonOKStatusReturnsError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
@@ -346,14 +379,15 @@ func TestStewardModules_NonOKStatusReturnsError(t *testing.T) {
 
 func TestStewardModules_JSONFlag(t *testing.T) {
 	now := time.Now().UTC()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"data":      map[string]interface{}{"modules": []map[string]string{{"name": "file"}}},
 			"timestamp": now,
 		})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
@@ -373,15 +407,18 @@ func TestStewardModules_JSONFlag(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	var parsed map[string]interface{}
-	require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+	// --json now emits a keyed-by-steward array (story 4 schema).
+	var entries []KeyedOutputEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array")
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Success)
 	assert.Contains(t, output, "file")
 }
 
 func TestStewardModules_HappyPath(t *testing.T) {
 	now := time.Now().UTC()
 	var requestPath string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -395,7 +432,8 @@ func TestStewardModules_HappyPath(t *testing.T) {
 			},
 			"timestamp": now,
 		})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc123", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
@@ -421,7 +459,7 @@ func TestStewardModules_HappyPath(t *testing.T) {
 
 func TestStewardLogs_CallsEndpoint(t *testing.T) {
 	var requestPath string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotImplemented)
@@ -429,7 +467,8 @@ func TestStewardLogs_CallsEndpoint(t *testing.T) {
 			"code":    "LOGS_UNAVAILABLE",
 			"message": "steward log pull not yet supported; collect logs directly from the steward host",
 		})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
@@ -454,44 +493,53 @@ func TestStewardLogs_CallsEndpoint(t *testing.T) {
 }
 
 func TestStewardLogs_HandlesNotImplemented(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotImplemented)
 		_ = json.NewEncoder(w).Encode(map[string]string{"code": "LOGS_UNAVAILABLE"})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
 	origInsecure := stewardTLSInsecure
+	origTail := stewardLogsTail
 	t.Cleanup(func() {
 		stewardURL = origURL
 		stewardTLSInsecure = origInsecure
+		stewardLogsTail = origTail
 	})
 	stewardURL = server.URL
 	stewardTLSInsecure = true
+	stewardLogsTail = 100
 
 	err := runStewardLogs(stewardLogsCmd, []string{"steward-abc"})
 	assert.NoError(t, err, "501 response must not return an error")
 }
 
 func TestStewardLogs_NotFound(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Resolve returns the steward; then the logs fetch returns 404.
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": map[string]string{"code": "STEWARD_NOT_FOUND", "message": "Steward not found"},
 		})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "nonexistent-steward", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
 	origInsecure := stewardTLSInsecure
+	origTail := stewardLogsTail
 	t.Cleanup(func() {
 		stewardURL = origURL
 		stewardTLSInsecure = origInsecure
+		stewardLogsTail = origTail
 	})
 	stewardURL = server.URL
 	stewardTLSInsecure = true
+	stewardLogsTail = 100
 
 	err := runStewardLogs(stewardLogsCmd, []string{"nonexistent-steward"})
 	require.Error(t, err)
@@ -499,21 +547,25 @@ func TestStewardLogs_NotFound(t *testing.T) {
 }
 
 func TestStewardLogs_NonOKStatusReturnsError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
-	}))
+	})
+	server := httptest.NewServer(wrapWithResolve(t, "steward-abc", innerHandler))
 	defer server.Close()
 
 	origURL := stewardURL
 	origInsecure := stewardTLSInsecure
+	origTail := stewardLogsTail
 	t.Cleanup(func() {
 		stewardURL = origURL
 		stewardTLSInsecure = origInsecure
+		stewardLogsTail = origTail
 	})
 	stewardURL = server.URL
 	stewardTLSInsecure = true
+	stewardLogsTail = 100
 
 	err := runStewardLogs(stewardLogsCmd, []string{"steward-abc"})
 	require.Error(t, err)
@@ -543,7 +595,7 @@ func TestStewardList_UsesBundleClientPattern(t *testing.T) {
 // GET /api/v1/stewards/<id>/dna and that the tabular output contains "Hostname".
 func TestStewardDNA_CallsEndpoint(t *testing.T) {
 	var requestPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -559,7 +611,8 @@ func TestStewardDNA_CallsEndpoint(t *testing.T) {
 			},
 			"timestamp": time.Now().UTC(),
 		})
-	}))
+	})
+	srv := httptest.NewServer(wrapWithResolve(t, "steward-abc", innerHandler))
 	defer srv.Close()
 
 	origURL := stewardURL
@@ -589,15 +642,16 @@ func TestStewardDNA_CallsEndpoint(t *testing.T) {
 }
 
 // TestStewardDNA_AttributeFlag verifies that --attribute appends the query parameter
-// and prints only the raw value (no label).
+// and prints only the raw value (no label) for a single-match selector.
 func TestStewardDNA_AttributeFlag(t *testing.T) {
 	var requestURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestURL = r.URL.String()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]string{"value": "linux"})
-	}))
+	})
+	srv := httptest.NewServer(wrapWithResolve(t, "steward-xyz", innerHandler))
 	defer srv.Close()
 
 	origURL := stewardURL
@@ -622,18 +676,20 @@ func TestStewardDNA_AttributeFlag(t *testing.T) {
 	})
 
 	assert.Contains(t, requestURL, "attribute=os")
+	// Single match with --attribute: plain value (backward compatible).
 	assert.Equal(t, "linux\n", output)
 }
 
 // TestStewardDNA_AttributeNotFound verifies non-zero exit (error) when the server returns 404.
 func TestStewardDNA_AttributeNotFound(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": map[string]string{"code": "DNA_ATTRIBUTE_NOT_FOUND", "message": "attribute not found"},
 		})
-	}))
+	})
+	srv := httptest.NewServer(wrapWithResolve(t, "steward-abc", innerHandler))
 	defer srv.Close()
 
 	origURL := stewardURL
@@ -654,14 +710,17 @@ func TestStewardDNA_AttributeNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "nonexistent")
 }
 
-// TestStewardDNA_JSONOutput verifies that --json writes the raw response body to stdout.
+// TestStewardDNA_JSONOutput verifies that --json emits a keyed-by-steward JSON array
+// (story 4 schema) with the raw DNA payload embedded per entry.
 func TestStewardDNA_JSONOutput(t *testing.T) {
-	rawBody := `{"data":{"hostname":"myhost","os":"linux"},"timestamp":"2026-06-09T10:00:00Z"}`
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(rawBody))
-	}))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{"hostname": "myhost", "os": "linux"},
+		})
+	})
+	srv := httptest.NewServer(wrapWithResolve(t, "steward-abc", innerHandler))
 	defer srv.Close()
 
 	origURL := stewardURL
@@ -685,7 +744,12 @@ func TestStewardDNA_JSONOutput(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	assert.Equal(t, rawBody, output)
+	// --json now emits a keyed-by-steward array (story 4 schema).
+	var entries []KeyedOutputEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entries), "output must be a valid JSON array")
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Success)
+	assert.Contains(t, output, "myhost")
 }
 
 // ---- cfg steward move tests (Issue #2342, updated for selector in #2444) ----


### PR DESCRIPTION
Fixes #2445

Agent session failed with exit code 1. Review container logs for details.