### PR TITLE
ci: route Windows CI to hosted + fix Docker build caching (Issues #2559 #2560)

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -63,22 +63,13 @@ jobs:
         echo "- macOS (AMD64, ARM64)" >> $GITHUB_STEP_SUMMARY
         echo "- Windows (AMD64)" >> $GITHUB_STEP_SUMMARY
 
-  # Native build tests on each platform
+  # Native build tests on each platform — all on GitHub-hosted runners.
   #
-  # Windows routing (#2337, #2503, epic #565): only merge_group (merge-gating)
-  # builds run natively on the CFGMS-managed self-hosted Windows runner. ALL
-  # pull_request events (fork or not) and workflow_dispatch use GitHub-hosted
-  # windows-latest — PR Windows builds are advisory (the merge queue re-runs
-  # everything self-hosted at merge time), so routing them to hosted removes
-  # roughly half the self-hosted Windows load without touching the merge-critical
-  # path. Linux and macOS stay hosted unconditionally. The whole include list is
-  # selected via fromJSON because individual matrix entries cannot carry
-  # conditions.
-  #
-  # SECURITY: routing pull_request to hosted is convenience/load management, NOT
-  # the security boundary — fork PRs run the fork's workflow copy regardless. The
-  # enforcing control is the repository Actions setting "Require approval for ALL
-  # external contributors"; do not weaken it while self-hosted runners are attached.
+  # Windows CI runs on hosted windows-latest (#2559, epic #565): the self-hosted
+  # Windows runner was measurably ~2x slower than hosted and, sharing hardware with
+  # a Linux runner, starved Linux CI — so Windows was routed off it. Hosted runners
+  # have effectively unlimited concurrency, so no self-hosted/hosted picker is
+  # needed. Linux and macOS were already hosted.
   native-builds:
     name: Native Build (${{ matrix.platform }})
     permissions:
@@ -86,7 +77,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON((github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && '[{"os":"ubuntu-latest","platform":"Linux"},{"os":"macos-latest","platform":"macOS"},{"os":"windows-latest","platform":"Windows"}]' || '[{"os":"ubuntu-latest","platform":"Linux"},{"os":"macos-latest","platform":"macOS"},{"os":["self-hosted","Windows","cfgms"],"platform":"Windows"}]') }}
+        include:
+          - os: ubuntu-latest
+            platform: Linux
+          - os: macos-latest
+            platform: macOS
+          - os: windows-latest
+            platform: Windows
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -109,12 +106,6 @@ jobs:
     - name: Download dependencies
       run: go mod download
 
-    - name: Start Windows resource sampler (self-hosted Windows only, best-effort)
-      if: matrix.platform == 'Windows' && github.event_name != 'workflow_dispatch' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-      continue-on-error: true
-      shell: powershell
-      run: .github\scripts\resource-sampler.ps1 -Mode Start -StateDir "$env:RUNNER_TEMP\resource-sampler"
-
     - name: Build All Binaries
       shell: bash
       run: make build
@@ -123,11 +114,9 @@ jobs:
       shell: bash
       env:
         CFGMS_TEST_INTEGRATION: "0"  # Disable integration tests (no Docker infrastructure in cross-platform CI)
-      # The Go race detector (ThreadSanitizer) reserves a large shadow-memory
-      # region the self-hosted Windows runner cannot allocate (Windows error
-      # 1455 / ERROR_COMMITMENT_LIMIT). Race coverage is fully exercised on the
-      # Linux unit-tests + integration-tests jobs; the Windows native build
-      # validates compile + test-pass without -race.
+      # Windows runs -short WITHOUT -race to keep this compile-validation job fast;
+      # race coverage is fully exercised on the Linux unit-tests + integration-tests
+      # jobs. Linux/macOS run with -race here.
       run: |
         if [ "${{ matrix.platform }}" = "Windows" ]; then
           go test -short -timeout=5m ./pkg/... ./features/...
@@ -141,21 +130,6 @@ jobs:
         name: binaries-${{ matrix.platform }}
         path: bin/
         retention-days: 5
-
-    - name: Report Windows resource profile (self-hosted Windows only, best-effort)
-      if: always() && matrix.platform == 'Windows' && github.event_name != 'workflow_dispatch' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-      continue-on-error: true
-      shell: powershell
-      run: .github\scripts\resource-sampler.ps1 -Mode Report -StateDir "$env:RUNNER_TEMP\resource-sampler" -ArtifactOut "resource-samples-native-windows.txt"
-
-    - name: Upload resource samples (self-hosted Windows only)
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      if: always() && matrix.platform == 'Windows' && github.event_name != 'workflow_dispatch' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-      continue-on-error: true
-      with:
-        name: resource-samples-native-windows
-        path: resource-samples-native-windows.txt
-        retention-days: 30
 
   # Integration tests with Docker infrastructure (Linux only)
   integration-tests:

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM golang:1.26.5-alpine3.23 AS builder
 
@@ -11,13 +12,16 @@ WORKDIR /src
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy source code
 COPY . .
 
-# Build controller
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o controller ./cmd/controller
+# Build controller (GOCACHE + module cache mounts warm across builds; CGO_ENABLED=0
+# already yields a static binary, so -a/-installsuffix are unneeded and only force
+# cold recompiles)
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux go build -o controller ./cmd/controller
 
 # Final stage - pinned to Alpine 3.23 (latest stable as of 2025-12)
 FROM alpine:3.23

--- a/cmd/steward/Dockerfile
+++ b/cmd/steward/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM golang:1.26.5-alpine3.23 AS builder
 
@@ -11,14 +12,17 @@ WORKDIR /src
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy source code
 COPY . .
 
-# Build steward with compile-time controller URL
+# Build steward with compile-time controller URL (GOCACHE + module cache mounts warm
+# across builds; CGO_ENABLED=0 already yields a static binary, so -a/-installsuffix
+# are unneeded and only force cold recompiles)
 ARG STEWARD_CONTROLLER_URL=https://localhost:9080
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-s -w -X main.ControllerURL=${STEWARD_CONTROLLER_URL}" \
     -o steward ./cmd/steward
 

--- a/cmd/steward/Dockerfile.debian
+++ b/cmd/steward/Dockerfile.debian
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM golang:1.26.4-alpine3.23 AS builder
 
@@ -11,19 +12,23 @@ WORKDIR /src
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy source code
 COPY . .
 
-# Build steward with compile-time controller URL
+# Build steward with compile-time controller URL (GOCACHE + module cache mounts warm
+# across builds; CGO_ENABLED=0 already yields a static binary, so -a/-installsuffix
+# are unneeded and only force cold recompiles)
 ARG STEWARD_CONTROLLER_URL=https://localhost:9080
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-s -w -X main.ControllerURL=${STEWARD_CONTROLLER_URL}" \
     -o steward ./cmd/steward
 
 # Build the steward launcher (Issue #1948: required for upgrade swap in fleet E2E tests)
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-s -w" \
     -o cfgms-launcher ./cmd/cfgms-steward-launcher
 


### PR DESCRIPTION
## Summary

CI-performance work under epic #565, combined into one PR (one CI run). Grounded
in the runner-topology measurements from 2026-07-10.

Fixes #2559
Fixes #2560

## #2559 — route Windows CI to GitHub-hosted runners

Measured: the self-hosted Windows runner ran `native-builds` **~2× slower** than
GH-hosted `windows-latest` (~22m vs ~10m) **and**, sharing hardware with a Linux
runner, its ~20-min builds **starved Linux CI** (the source of the 4.5→13.6m
unit-tests variance).

- `cross-platform-build.yml` `native-builds`: Windows now always runs on
  `windows-latest` — dropped the `fromJSON` conditional that selected
  `["self-hosted","Windows","cfgms"]` on `merge_group`. The matrix is now a plain
  static list.
- Removed the now-dead self-hosted-Windows-only resource-sampler steps.
- No self-hosted Windows label remains in any workflow. Hosted runners have
  effectively unlimited concurrency, so **no prefer-self-hosted picker is needed**.
- Windows still runs `go test -short` without `-race` (kept fast; race is covered
  on the Linux jobs) — comment updated to drop the stale self-hosted rationale.

_Ops follow-up (not in this PR — not a repo artifact): the physical Windows box
can be retired from the cluster or repurposed as a cfg-managed node._

## #2560 — fix Docker build caching (was defeating GOCACHE)

The steward/controller Dockerfiles built with `go build -a -installsuffix cgo`
(forces a full stdlib+tree recompile, **defeating GOCACHE**) and had no BuildKit
cache mount — so every integration-tests / fleet-e2e / docker-security run rebuilt
the world cold. #2551's GOCACHE work could not help these jobs.

- `cmd/controller/Dockerfile`, `cmd/steward/Dockerfile`,
  `cmd/steward/Dockerfile.debian`: add `# syntax=docker/dockerfile:1`, drop
  `-a -installsuffix cgo` (redundant with `CGO_ENABLED=0`, which already yields a
  static binary), and add BuildKit cache mounts for `/root/.cache/go-build` +
  `/go/pkg/mod` on the build and `go mod download` steps.
- All these images build via `docker compose -f docker-compose.test.yml` (compose
  v2 = BuildKit; the HA Makefile target sets `DOCKER_BUILDKIT=1`); confirmed no
  legacy-builder path. Binaries stay static `CGO_ENABLED=0`.

## Validation

- `actionlint` clean on `cross-platform-build.yml`.
- `make test` passes (210/0).
- **Docker image builds are validated by this PR's own CI** (cross-platform
  "Integration Tests (Docker)" + production-gates integration jobs build the
  images via compose on `pull_request`) — docker was not available in the
  authoring environment, so this is the build gate for the Dockerfile changes.
