### PR TITLE
hyperv: cluster-visible (CSV) provisioning record for ha_role VMs (Issue #2447)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -326,6 +326,39 @@ matches the **correlation identity** baked into the rendered answer file. The
 provisioning record carries this correlation value; the controller also flips the
 record to `failed` when `completion.timeout` elapses with no matching registration.
 
+### Cluster-visible provisioning record for `ha_role` VMs (#2447, ADR-009 A1.4 Option A)
+
+For a standalone VM the provisioning record is **host-local** — it lives only on
+the node doing the install. For an `ha_role` VM whose primary VHD is on a Cluster
+Shared Volume, the record is instead **cluster-visible**: it is persisted as JSON
+beside the VM's VHD at
+
+```
+<dir(vhd_path)>\.cfgms-provision\<vm_name>.json
+```
+
+Because the CSV is mounted on **every** member node, this record is readable
+across the cluster. That closes a mid-provision failover window: if the CNO owner
+fails over **while an install is in flight**, the new owner's convergence reads
+the non-terminal record (`creating`/`installing`/`finalizing`) on the shared CSV,
+recognises the role as an in-progress attempt owned elsewhere, and
+**surfaces-and-waits** — it issues no `New-VM` and audits the skip as
+`vm-provision-skip-in-progress-elsewhere`. Without the shared record the new owner
+would see an absent VM with no local record and create a **duplicate** — exactly
+the failure Option A prevents. There is **no auto-resume** of another node's
+attempt; surface-and-wait is the only behavior on an unattributable in-progress
+record.
+
+Routing is automatic and scoped: only `ha_role`+CSV VMs use the CSV store; every
+other VM keeps the configured host-local store, unchanged. The record is written
+crash-safely (temp file + atomic rename) so a failover reading it mid-write never
+observes a truncated record. Reads of the **cluster-visible** record are
+**fail-loud** — if it cannot be read, creation does not proceed while the cluster
+record state is unknown; host-local record reads keep their historical
+swallow-on-error behavior. (Cluster-visible ≠ controller-visible: the
+controller-side completion reconciler still reads its own store — that wiring is a
+separate, pre-existing concern.)
+
 ### How the answer file is delivered (host-native seed VHDX)
 
 The unattended answer file is delivered on a **secondary VHDX seed disk** attached

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -80,6 +80,14 @@ type hypervModule struct {
 	// WithProvisionStore.
 	provisionStore ProvisionStore
 
+	// csvProvisionStore, when non-nil, overrides the CSV-backed store that
+	// storeFor constructs for an ha_role+CSV VM (ADR-009 A1.4 Option A, #2447).
+	// In production it is nil and storeFor builds one rooted at the VM's CSV home
+	// per convergence; tests inject a fake here to assert routing and drive the
+	// surface-and-wait behavior without a real CSV mount (mirrors the
+	// provisionStore/WithProvisionStore seam).
+	csvProvisionStore ProvisionStore
+
 	// fallbackMoveStore backs the storage-location move records (#2411) when
 	// provisionStore does not implement MoveStore (both in-repo stores do; this
 	// exists so a custom ProvisionStore cannot panic the move path). Lazily
@@ -166,6 +174,18 @@ func WithProvisionStore(s ProvisionStore) HypervOption {
 	return func(m *hypervModule) {
 		if s != nil {
 			m.provisionStore = s
+		}
+	}
+}
+
+// WithCSVProvisionStore overrides the CSV-backed ProvisionStore that storeFor
+// otherwise constructs per-VM for an ha_role+CSV VM (#2447). Tests inject a fake
+// to assert store routing and drive the mid-provision-failover surface-and-wait
+// path without a real Cluster Shared Volume. A nil store is ignored.
+func WithCSVProvisionStore(s ProvisionStore) HypervOption {
+	return func(m *hypervModule) {
+		if s != nil {
+			m.csvProvisionStore = s
 		}
 	}
 }

--- a/features/modules/hyperv/provision.go
+++ b/features/modules/hyperv/provision.go
@@ -110,17 +110,48 @@ func (s *memProvisionStore) DeleteProvision(_ context.Context, vmName string) er
 	return nil
 }
 
+// usesCSVStore reports whether cfg's provisioning record is cluster-visible
+// (CSV-backed): an ha_role VM whose primary VHD is on a Cluster Shared Volume.
+// This is the single routing predicate — storeFor and the isOwnIncompleteAttempt
+// fail-loud scope must agree on it. An ha_role VM with a non-CSV vhd_path (rare,
+// and ErrInvalidHARoleSeedDir already constrains the common case) keeps the
+// host-local store.
+func (m *hypervModule) usesCSVStore(cfg *VMConfig) bool {
+	return cfg != nil && cfg.HARole != nil && isUnderCSV(cfg.VHDPath)
+}
+
+// storeFor selects the ProvisionStore for cfg. An ha_role+CSV VM routes to the
+// cluster-visible CSV store (records persisted beside the VM's VHD, readable from
+// any member node's CSV mount) so a mid-provision CNO failover reads the
+// in-progress record and surfaces-and-waits instead of creating a duplicate VM
+// (ADR-009 Amendment 1 A1.4, Option A). Every other VM keeps the configured
+// host-local store. Test seam: an injected m.csvProvisionStore wins for the CSV
+// branch (mirrors the m.provisionStore injection seam), so routing is assertable
+// against a fake without touching the filesystem.
+//
+// The CSV home dir is computed with vmHomeDir (NOT filepath.Dir, which mangles an
+// always-Windows vhd_path on the Linux CI host — Issue #2044).
+func (m *hypervModule) storeFor(cfg *VMConfig) ProvisionStore {
+	if m.usesCSVStore(cfg) {
+		if m.csvProvisionStore != nil {
+			return m.csvProvisionStore
+		}
+		return newCSVProvisionStore(vmHomeDir(cfg.VHDPath))
+	}
+	if m.provisionStore == nil {
+		m.provisionStore = NewMemProvisionStore()
+	}
+	return m.provisionStore
+}
+
 // loadOrInitProvision returns the existing provisioning record for vmName, or
 // initialises a fresh one at absent when none exists. A freshly initialised
 // record carries StartedAt and the correlation identity baked from the VM name
 // (the expected enrollment label per ADR-009 §8) so the controller-side
 // reconciler (#2050) can match a registered steward to this VM. It is NOT
 // persisted until advanceProvision writes a state.
-func (m *hypervModule) loadOrInitProvision(ctx context.Context, vmName string) (*ProvisionRecord, error) {
-	if m.provisionStore == nil {
-		m.provisionStore = NewMemProvisionStore()
-	}
-	record, err := m.provisionStore.GetProvision(ctx, vmName)
+func (m *hypervModule) loadOrInitProvision(ctx context.Context, cfg *VMConfig, vmName string) (*ProvisionRecord, error) {
+	record, err := m.storeFor(cfg).GetProvision(ctx, vmName)
 	if err == nil {
 		return record, nil
 	}
@@ -140,15 +171,12 @@ func (m *hypervModule) loadOrInitProvision(ctx context.Context, vmName string) (
 // advanceProvision sets the record to newState, stamps UpdatedAt, persists it,
 // and emits a structured log event. It mutates the passed record in place so
 // the caller's subsequent state checks see the new state.
-func (m *hypervModule) advanceProvision(ctx context.Context, vmName string, record *ProvisionRecord, newState ProvisionState) error {
-	if m.provisionStore == nil {
-		m.provisionStore = NewMemProvisionStore()
-	}
+func (m *hypervModule) advanceProvision(ctx context.Context, cfg *VMConfig, vmName string, record *ProvisionRecord, newState ProvisionState) error {
 	prev := record.State
 	record.State = newState
 	record.UpdatedAt = time.Now().UTC()
 	record.LastError = ""
-	if err := m.provisionStore.SetProvision(ctx, record); err != nil {
+	if err := m.storeFor(cfg).SetProvision(ctx, record); err != nil {
 		return err
 	}
 	if logger, ok := m.GetLogger(); ok {
@@ -165,17 +193,14 @@ func (m *hypervModule) advanceProvision(ctx context.Context, vmName string, reco
 // LastError set), persists it, emits a structured log event, and returns the
 // original error so the caller can propagate it. The error message is not
 // exposed via the log at error-detail level beyond the sanitized value.
-func (m *hypervModule) failProvision(ctx context.Context, vmName string, record *ProvisionRecord, cause error) error {
-	if m.provisionStore == nil {
-		m.provisionStore = NewMemProvisionStore()
-	}
+func (m *hypervModule) failProvision(ctx context.Context, cfg *VMConfig, vmName string, record *ProvisionRecord, cause error) error {
 	record.State = ProvisionStateFailed
 	record.UpdatedAt = time.Now().UTC()
 	if cause != nil {
 		record.LastError = cause.Error()
 	}
 	// Persist best-effort; the original cause is the error we surface.
-	_ = m.provisionStore.SetProvision(ctx, record)
+	_ = m.storeFor(cfg).SetProvision(ctx, record)
 	if logger, ok := m.GetLogger(); ok {
 		logger.Warn("hyperv: provisioning failed",
 			"vm_name", logging.SanitizeLogValue(vmName),
@@ -193,21 +218,35 @@ func (m *hypervModule) failProvision(ctx context.Context, vmName string, record 
 // waited-on (never auto-destroyed), while a real existing VM is left untouched.
 //
 // A missing record, or a record in a terminal state (absent/ready/failed/
-// degraded), returns false. A store read error is treated as "no in-progress
-// attempt" (false) — the caller's downstream gating is conservative regardless.
-func (m *hypervModule) isOwnIncompleteAttempt(ctx context.Context, vmName string) bool {
-	if m.provisionStore == nil {
-		return false
+// degraded), returns (false, nil).
+//
+// Read-error handling is ASYMMETRIC by store, and this asymmetry is deliberate
+// (#2447): for the cluster-visible CSV store the record is LOAD-BEARING for
+// cluster duplicate-prevention — an unreadable record must fail LOUD (return the
+// error) so createVM never fires while the cluster record state is unknown (the
+// exact duplicate a mid-provision CNO failover would otherwise cause). For the
+// host-local store the record is not load-bearing, so the historical
+// swallow-on-error semantics are preserved byte-for-byte: a read error is treated
+// as "no in-progress attempt" (false, nil) and the create path proceeds.
+func (m *hypervModule) isOwnIncompleteAttempt(ctx context.Context, cfg *VMConfig) (bool, error) {
+	record, err := m.storeFor(cfg).GetProvision(ctx, cfg.Name)
+	if errors.Is(err, ErrProvisionNotFound) {
+		return false, nil
 	}
-	record, err := m.provisionStore.GetProvision(ctx, vmName)
-	if err != nil || record == nil {
-		return false
+	if err != nil {
+		if m.usesCSVStore(cfg) {
+			return false, err // CSV record load-bearing → fail loud
+		}
+		return false, nil // host-local → preserve swallow-on-error
+	}
+	if record == nil {
+		return false, nil
 	}
 	switch record.State {
 	case ProvisionStateCreating, ProvisionStateInstalling, ProvisionStateFinalizing:
-		return true
+		return true, nil
 	default:
-		return false
+		return false, nil
 	}
 }
 
@@ -219,15 +258,12 @@ func (m *hypervModule) isOwnIncompleteAttempt(ctx context.Context, vmName string
 // delete-and-rebuilds — degradation is observed and reported, not remediated.
 // observedState is the raw VM power/health state string and is sanitised before
 // it reaches any log field.
-func (m *hypervModule) degradeProvision(ctx context.Context, vmName string, record *ProvisionRecord, observedState string) error {
-	if m.provisionStore == nil {
-		m.provisionStore = NewMemProvisionStore()
-	}
+func (m *hypervModule) degradeProvision(ctx context.Context, cfg *VMConfig, vmName string, record *ProvisionRecord, observedState string) error {
 	prev := record.State
 	record.State = ProvisionStateDegraded
 	record.UpdatedAt = time.Now().UTC()
 	record.LastError = "hyperv: VM in broken state: " + observedState
-	if err := m.provisionStore.SetProvision(ctx, record); err != nil {
+	if err := m.storeFor(cfg).SetProvision(ctx, record); err != nil {
 		return err
 	}
 	if logger, ok := m.GetLogger(); ok {

--- a/features/modules/hyperv/provision_csv.go
+++ b/features/modules/hyperv/provision_csv.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// csvProvisionSubdir is the directory (under a VM's home dir) that holds the
+// cluster-visible provisioning records. A leading dot keeps it out of the way of
+// the VM's own files on the CSV.
+const csvProvisionSubdir = ".cfgms-provision"
+
+// csvProvisionStore is a ProvisionStore that persists each ProvisionRecord as
+// JSON on the same Cluster Shared Volume as the VM's primary VHD, at
+// <homeDir>/.cfgms-provision/<vm_name>.json. Because the CSV is mounted on every
+// member node, the record is readable from any node — so after a CNO failover
+// mid-provision the new owner reads the in-progress record and surfaces-and-waits
+// (ADR-009 Amendment 1 A1.4, Option A) instead of creating a duplicate VM.
+//
+// homeDir is dir(vhd_path), computed by the caller via vmHomeDir (NOT
+// filepath.Dir, which mangles an always-Windows vhd_path on the Linux CI host —
+// Issue #2044). Within the store, filepath.Join/os are OS-native: in production
+// homeDir is a real Windows CSV path on the Windows steward; in tests it is a
+// real local temp dir — filepath.Join is correct for both.
+type csvProvisionStore struct {
+	homeDir string
+}
+
+// newCSVProvisionStore returns a store rooted at a VM's home directory. Path
+// validity is checked lazily at each operation (fail-loud on use) rather than at
+// construction, because storeFor returns a ProvisionStore without an error path.
+func newCSVProvisionStore(homeDir string) *csvProvisionStore {
+	return &csvProvisionStore{homeDir: homeDir}
+}
+
+// recordDir returns <homeDir>/.cfgms-provision, rejecting an empty or UNC home
+// dir (the record must live on a local/CSV drive next to the VHD, never on an
+// arbitrary network share — same invariant as ErrInvalidSeedPath).
+func (s *csvProvisionStore) recordDir() (string, error) {
+	if s.homeDir == "" || strings.HasPrefix(s.homeDir, `\\`) || strings.HasPrefix(s.homeDir, `//`) {
+		return "", ErrInvalidSeedPath
+	}
+	return filepath.Join(s.homeDir, csvProvisionSubdir), nil
+}
+
+// recordPath returns the JSON path for a VM's record, guarding vmName against
+// path traversal / separator injection (it becomes a filename).
+func (s *csvProvisionStore) recordPath(vmName string) (string, error) {
+	dir, err := s.recordDir()
+	if err != nil {
+		return "", err
+	}
+	if vmName == "" || strings.ContainsAny(vmName, `\/`) || strings.Contains(vmName, "..") {
+		return "", ErrInvalidSeedPath
+	}
+	return filepath.Join(dir, vmName+".json"), nil
+}
+
+func (s *csvProvisionStore) GetProvision(_ context.Context, vmName string) (*ProvisionRecord, error) {
+	path, err := s.recordPath(vmName)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, ErrProvisionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: read provision record %q: %w", vmName, err)
+	}
+	var rec ProvisionRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, fmt.Errorf("hyperv: parse provision record %q: %w", vmName, err)
+	}
+	// rec is already a local copy; return its address (copy-on-read).
+	return &rec, nil
+}
+
+// SetProvision writes the record crash-safely: a temp file in the same directory
+// is fully written, then os.Rename'd over the final path. A CNO failover reading
+// the record mid-write therefore observes either the old record or the new one,
+// never a truncated one — the store must not introduce the very partial-write
+// window Option A exists to close.
+func (s *csvProvisionStore) SetProvision(_ context.Context, record *ProvisionRecord) error {
+	dir, err := s.recordDir()
+	if err != nil {
+		return err
+	}
+	path, err := s.recordPath(record.VMName)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("hyperv: create provision dir: %w", err)
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("hyperv: encode provision record %q: %w", record.VMName, err)
+	}
+	tmp, err := os.CreateTemp(dir, "."+record.VMName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("hyperv: create temp provision record %q: %w", record.VMName, err)
+	}
+	tmpName := tmp.Name()
+	if _, werr := tmp.Write(data); werr != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("hyperv: write provision record %q: %w", record.VMName, werr)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("hyperv: close provision record %q: %w", record.VMName, cerr)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("hyperv: commit provision record %q: %w", record.VMName, err)
+	}
+	return nil
+}
+
+func (s *csvProvisionStore) DeleteProvision(_ context.Context, vmName string) error {
+	path, err := s.recordPath(vmName)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrProvisionNotFound
+		}
+		return fmt.Errorf("hyperv: delete provision record %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// ListProvisions returns snapshot copies of every record in the store's
+// directory. A missing directory (no VM ever provisioned here) is an empty list,
+// not an error.
+func (s *csvProvisionStore) ListProvisions(_ context.Context) ([]*ProvisionRecord, error) {
+	dir, err := s.recordDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: list provision records: %w", err)
+	}
+	var out []*ProvisionRecord
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, rerr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if rerr != nil {
+			return nil, fmt.Errorf("hyperv: read provision record %q: %w", e.Name(), rerr)
+		}
+		var rec ProvisionRecord
+		if uerr := json.Unmarshal(data, &rec); uerr != nil {
+			return nil, fmt.Errorf("hyperv: parse provision record %q: %w", e.Name(), uerr)
+		}
+		cp := rec
+		out = append(out, &cp)
+	}
+	return out, nil
+}

--- a/features/modules/hyperv/provision_csv.go
+++ b/features/modules/hyperv/provision_csv.go
@@ -42,10 +42,21 @@ func newCSVProvisionStore(homeDir string) *csvProvisionStore {
 
 // recordDir returns <homeDir>/.cfgms-provision, rejecting an empty or UNC home
 // dir (the record must live on a local/CSV drive next to the VHD, never on an
-// arbitrary network share — same invariant as ErrInvalidSeedPath).
+// arbitrary network share — same invariant as ErrInvalidSeedPath) AND any homeDir
+// containing a ".." segment. The ".." guard is load-bearing, not cosmetic:
+// vmHomeDir does not Clean the path and vhdPathPattern permits "..", so a
+// vhd_path like C:\ClusterStorage\Vol1\..\..\Windows\x.vhdx passes isUnderCSV
+// (raw prefix match) yet filepath.Join would Clean it to an off-CSV location —
+// silently defeating the cluster-visibility invariant this store exists to
+// provide (the record would land host-local, invisible to a post-failover owner).
 func (s *csvProvisionStore) recordDir() (string, error) {
 	if s.homeDir == "" || strings.HasPrefix(s.homeDir, `\\`) || strings.HasPrefix(s.homeDir, `//`) {
 		return "", ErrInvalidSeedPath
+	}
+	for _, seg := range strings.FieldsFunc(s.homeDir, func(r rune) bool { return r == '\\' || r == '/' }) {
+		if seg == ".." {
+			return "", ErrInvalidSeedPath
+		}
 	}
 	return filepath.Join(s.homeDir, csvProvisionSubdir), nil
 }
@@ -97,7 +108,7 @@ func (s *csvProvisionStore) SetProvision(_ context.Context, record *ProvisionRec
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("hyperv: create provision dir: %w", err)
 	}
 	data, err := json.MarshalIndent(record, "", "  ")

--- a/features/modules/hyperv/provision_csv_test.go
+++ b/features/modules/hyperv/provision_csv_test.go
@@ -143,7 +143,13 @@ func TestCSVProvisionStore_AtomicWrite(t *testing.T) {
 // drive, never a network share — the ErrInvalidSeedPath precedent).
 func TestCSVProvisionStore_InvalidHomeDir(t *testing.T) {
 	ctx := context.Background()
-	for _, home := range []string{"", `\\server\share\vm`, `//server/share/vm`} {
+	for _, home := range []string{
+		"",
+		`\\server\share\vm`,                    // UNC (backslash)
+		`//server/share/vm`,                    // UNC (forward slash)
+		`C:\ClusterStorage\Vol1\..\..\Windows`, // .. traversal escaping the CSV
+		`C:\ClusterStorage\Vol1\..`,            // .. segment
+	} {
 		s := newCSVProvisionStore(home)
 		_, gErr := s.GetProvision(ctx, "vm")
 		assert.ErrorIs(t, gErr, ErrInvalidSeedPath, "home=%q Get", home)

--- a/features/modules/hyperv/provision_csv_test.go
+++ b/features/modules/hyperv/provision_csv_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The CSV ProvisionStore is exercised against a real local temp dir (standing in
+// for a VM's CSV home directory) — real file IO, no mocks, per the ProvisionStore
+// contract memProvisionStore also satisfies.
+
+func ccsRecord(name string, state ProvisionState) *ProvisionRecord {
+	now := time.Now().UTC().Truncate(time.Second)
+	return &ProvisionRecord{
+		VMName:        name,
+		State:         state,
+		CorrelationID: name,
+		StartedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+// TestCSVProvisionStore_SetGetRoundTrip: a written record reads back byte-equal
+// and lands at <home>/.cfgms-provision/<name>.json.
+func TestCSVProvisionStore_SetGetRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	s := newCSVProvisionStore(home)
+
+	rec := ccsRecord("vm-a", ProvisionStateInstalling)
+	rec.LastError = "mid-flight"
+	require.NoError(t, s.SetProvision(ctx, rec))
+
+	got, err := s.GetProvision(ctx, "vm-a")
+	require.NoError(t, err)
+	assert.Equal(t, rec.VMName, got.VMName)
+	assert.Equal(t, rec.State, got.State)
+	assert.Equal(t, rec.CorrelationID, got.CorrelationID)
+	assert.Equal(t, "mid-flight", got.LastError)
+	assert.True(t, rec.StartedAt.Equal(got.StartedAt), "StartedAt round-trips")
+
+	// The record file lives beside the VHD, under the dotfile subdir.
+	assert.FileExists(t, filepath.Join(home, csvProvisionSubdir, "vm-a.json"))
+}
+
+// TestCSVProvisionStore_CopyOnRead: a returned record is an independent copy —
+// mutating it must not change the stored record (memProvisionStore contract).
+func TestCSVProvisionStore_CopyOnRead(t *testing.T) {
+	ctx := context.Background()
+	s := newCSVProvisionStore(t.TempDir())
+	require.NoError(t, s.SetProvision(ctx, ccsRecord("vm-b", ProvisionStateInstalling)))
+
+	got, err := s.GetProvision(ctx, "vm-b")
+	require.NoError(t, err)
+	got.State = ProvisionStateFailed // mutate the caller's copy
+
+	again, err := s.GetProvision(ctx, "vm-b")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, again.State,
+		"mutating a read copy must not affect the store")
+}
+
+// TestCSVProvisionStore_GetMissing_NotFound: a missing record is ErrProvisionNotFound
+// (distinct from an IO error — this is what lets isOwnIncompleteAttempt treat a
+// clean absence as "no attempt, proceed" while a real IO error fails loud).
+func TestCSVProvisionStore_GetMissing_NotFound(t *testing.T) {
+	_, err := newCSVProvisionStore(t.TempDir()).GetProvision(context.Background(), "nope")
+	assert.ErrorIs(t, err, ErrProvisionNotFound)
+}
+
+// TestCSVProvisionStore_Delete: delete removes the record; deleting a missing one
+// is ErrProvisionNotFound.
+func TestCSVProvisionStore_Delete(t *testing.T) {
+	ctx := context.Background()
+	s := newCSVProvisionStore(t.TempDir())
+	require.NoError(t, s.SetProvision(ctx, ccsRecord("vm-c", ProvisionStateReady)))
+
+	require.NoError(t, s.DeleteProvision(ctx, "vm-c"))
+	_, err := s.GetProvision(ctx, "vm-c")
+	assert.ErrorIs(t, err, ErrProvisionNotFound)
+	assert.ErrorIs(t, s.DeleteProvision(ctx, "vm-c"), ErrProvisionNotFound)
+}
+
+// TestCSVProvisionStore_ListSnapshot: List returns independent copies of every
+// record; a missing directory is an empty list (not an error).
+func TestCSVProvisionStore_ListSnapshot(t *testing.T) {
+	ctx := context.Background()
+	s := newCSVProvisionStore(t.TempDir())
+
+	empty, err := s.ListProvisions(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, empty, "no directory yet → empty list, not an error")
+
+	require.NoError(t, s.SetProvision(ctx, ccsRecord("vm-d1", ProvisionStateInstalling)))
+	require.NoError(t, s.SetProvision(ctx, ccsRecord("vm-d2", ProvisionStateFinalizing)))
+
+	list, err := s.ListProvisions(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	for _, r := range list {
+		r.State = ProvisionStateFailed // mutate the snapshot
+	}
+	again, err := s.ListProvisions(ctx)
+	require.NoError(t, err)
+	for _, r := range again {
+		assert.NotEqual(t, ProvisionStateFailed, r.State,
+			"ListProvisions must return copies; mutating them must not affect the store")
+	}
+}
+
+// TestCSVProvisionStore_AtomicWrite: overwriting a record leaves exactly one valid
+// JSON file and no leftover temp files — the write is commit-by-rename, so a
+// concurrent reader never sees a partial record (the window Option A closes).
+func TestCSVProvisionStore_AtomicWrite(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	s := newCSVProvisionStore(home)
+
+	require.NoError(t, s.SetProvision(ctx, ccsRecord("vm-e", ProvisionStateCreating)))
+	require.NoError(t, s.SetProvision(ctx, ccsRecord("vm-e", ProvisionStateInstalling)))
+
+	entries, err := os.ReadDir(filepath.Join(home, csvProvisionSubdir))
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the committed record file must remain — no leftover temp files")
+	assert.Equal(t, "vm-e.json", entries[0].Name())
+
+	got, err := s.GetProvision(ctx, "vm-e")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, got.State)
+}
+
+// TestCSVProvisionStore_InvalidHomeDir: an empty or UNC home dir is rejected at
+// every operation with ErrInvalidSeedPath (the record must live on a local/CSV
+// drive, never a network share — the ErrInvalidSeedPath precedent).
+func TestCSVProvisionStore_InvalidHomeDir(t *testing.T) {
+	ctx := context.Background()
+	for _, home := range []string{"", `\\server\share\vm`, `//server/share/vm`} {
+		s := newCSVProvisionStore(home)
+		_, gErr := s.GetProvision(ctx, "vm")
+		assert.ErrorIs(t, gErr, ErrInvalidSeedPath, "home=%q Get", home)
+		assert.ErrorIs(t, s.SetProvision(ctx, ccsRecord("vm", ProvisionStateCreating)), ErrInvalidSeedPath, "home=%q Set", home)
+		assert.ErrorIs(t, s.DeleteProvision(ctx, "vm"), ErrInvalidSeedPath, "home=%q Delete", home)
+		_, lErr := s.ListProvisions(ctx)
+		assert.ErrorIs(t, lErr, ErrInvalidSeedPath, "home=%q List", home)
+	}
+}
+
+// TestCSVProvisionStore_VMNameTraversalRejected: a vmName that would escape the
+// record dir (separators or ..) is rejected — vmName becomes a filename.
+func TestCSVProvisionStore_VMNameTraversalRejected(t *testing.T) {
+	ctx := context.Background()
+	s := newCSVProvisionStore(t.TempDir())
+	for _, bad := range []string{`..\evil`, `sub/evil`, "..", ""} {
+		_, err := s.GetProvision(ctx, bad)
+		assert.ErrorIs(t, err, ErrInvalidSeedPath, "vmName=%q", bad)
+	}
+}
+
+// TestCSVProvisionStore_SatisfiesInterface: compile-time + runtime confirmation
+// the CSV store is a ProvisionStore (the interface storeFor returns).
+func TestCSVProvisionStore_SatisfiesInterface(t *testing.T) {
+	var _ ProvisionStore = newCSVProvisionStore(t.TempDir())
+	_, err := newCSVProvisionStore(t.TempDir()).GetProvision(context.Background(), "x")
+	assert.True(t, errors.Is(err, ErrProvisionNotFound))
+}

--- a/features/modules/hyperv/provision_test.go
+++ b/features/modules/hyperv/provision_test.go
@@ -262,10 +262,15 @@ func TestProvisionRecord_LastError(t *testing.T) {
 func TestIsOwnIncompleteAttempt(t *testing.T) {
 	ctx := context.Background()
 	m := &hypervModule{provisionStore: NewMemProvisionStore()}
+	// Non-ha_role / non-CSV cfg → storeFor resolves the host-local store, so
+	// every read here exercises the preserved swallow-on-error semantics: err is
+	// always nil (a NotFound is (false, nil), not an error).
+	cfg := &VMConfig{Name: "vm-x"}
 
-	// No record → false.
-	assert.False(t, m.isOwnIncompleteAttempt(ctx, "vm-x"),
-		"no provisioning record must report not-in-progress")
+	// No record → (false, nil).
+	own, err := m.isOwnIncompleteAttempt(ctx, cfg)
+	require.NoError(t, err)
+	assert.False(t, own, "no provisioning record must report not-in-progress")
 
 	cases := []struct {
 		state ProvisionState
@@ -283,8 +288,9 @@ func TestIsOwnIncompleteAttempt(t *testing.T) {
 		require.NoError(t, m.provisionStore.SetProvision(ctx, &ProvisionRecord{
 			VMName: "vm-x", State: tc.state, CorrelationID: "vm-x",
 		}))
-		assert.Equal(t, tc.want, m.isOwnIncompleteAttempt(ctx, "vm-x"),
-			"isOwnIncompleteAttempt for state %q", tc.state)
+		got, gerr := m.isOwnIncompleteAttempt(ctx, cfg)
+		require.NoError(t, gerr, "host-local reads never fail loud")
+		assert.Equal(t, tc.want, got, "isOwnIncompleteAttempt for state %q", tc.state)
 	}
 }
 

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -803,9 +803,12 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 
 	if state == "absent" {
 		// Snapshot current state for the audit before-capture (best-effort: nil is
-		// acceptable if the VM is already absent or the host is unreachable).
+		// acceptable if the VM is already absent or the host is unreachable). cur
+		// also carries the removed VM's HARole + VHDPath, used below to route the
+		// provisioning-record delete to the same store it was written to.
 		var deleteBefore map[string]interface{}
-		if cur, gErr := m.getVM(ctx, vmName); gErr == nil && cur != nil && cur.State != "absent" {
+		cur, gErr := m.getVM(ctx, vmName)
+		if gErr == nil && cur != nil && cur.State != "absent" {
 			deleteBefore = map[string]interface{}{
 				"cpu":       cur.CPUCount,
 				"memory_mb": cur.MemoryMB,
@@ -817,11 +820,11 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		}
 		// Delete the provisioning record so a subsequent source: declaration
 		// provisions cleanly without hitting the surface-and-wait wedge.
-		// Mirrors the on_existing: recreate path in applySourceGated.
-		if m.provisionStore != nil {
-			if err := m.provisionStore.DeleteProvision(ctx, vmName); err != nil && !errors.Is(err, ErrProvisionNotFound) {
-				return err
-			}
+		// Mirrors the on_existing: recreate path in applySourceGated. Route via
+		// storeFor(cur) so an ha_role+CSV VM's record is deleted from the CSV
+		// store it was written to; cur may be nil (already absent) → host-local.
+		if err := m.storeFor(cur).DeleteProvision(ctx, vmName); err != nil && !errors.Is(err, ErrProvisionNotFound) {
+			return err
 		}
 		// Delete any storage-move record (#2411) so a later same-named VM
 		// starts clean rather than inheriting an in-flight/failed move.
@@ -1106,11 +1109,26 @@ func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName st
 		// (surface-and-wait, ADR-009 §2): the install may simply be mid-flight
 		// and a half-built VM transiently absent from Get-VM. We do NOT re-issue
 		// New-VM — that is what protects against thrashing an in-progress build.
-		if m.isOwnIncompleteAttempt(ctx, vmName) {
+		own, ownErr := m.isOwnIncompleteAttempt(ctx, cfg)
+		if ownErr != nil {
+			// CSV (cluster-visible) record was unreadable → fail loud. Creation
+			// must NOT proceed while the cluster record state is unknown, or a
+			// mid-provision CNO failover could produce the duplicate Option A
+			// exists to prevent. (Host-local reads never reach here — they swallow.)
+			return fmt.Errorf("hyperv: cannot determine provisioning state for VM %q: %w", vmName, ownErr)
+		}
+		if own {
+			// An in-progress record exists. On this node it may be our own mid-flight
+			// build; on a NEW CNO owner after a failover it is another node's in-flight
+			// attempt visible via the CSV record. Both surface-and-wait (no auto-retry,
+			// no New-VM) — the record on the CSV is what lets the new owner see it.
 			if logger, ok := m.GetLogger(); ok {
 				logger.Warn("hyperv: in-progress provisioning attempt; surface-and-wait (no auto-retry)",
 					"vm_name", logging.SanitizeLogValue(vmName))
 			}
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+				"vm-provision-skip-in-progress-elsewhere", "vm:"+vmName, nil,
+				map[string]interface{}{"reason": "provision in progress"}, nil)
 			return nil
 		}
 		// No in-progress record → normal create-from-source path.
@@ -1148,10 +1166,10 @@ func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName st
 		if err := m.removeVM(ctx, vmName, recreateBefore); err != nil {
 			return err
 		}
-		if m.provisionStore != nil {
-			if err := m.provisionStore.DeleteProvision(ctx, vmName); err != nil && !errors.Is(err, ErrProvisionNotFound) {
-				return err
-			}
+		// Route via storeFor(cfg): an ha_role+CSV recreate must reset the
+		// cluster-visible record, not a stale host-local one.
+		if err := m.storeFor(cfg).DeleteProvision(ctx, vmName); err != nil && !errors.Is(err, ErrProvisionNotFound) {
+			return err
 		}
 		if err := m.createVM(ctx, vmName, hostName, cfg); err != nil {
 			return err
@@ -1172,11 +1190,11 @@ func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName st
 		// Existing-but-broken VM → surface as degraded (ADR-009 §2). Never
 		// delete-and-rebuild. The record records the observed state so the
 		// operator (and the controller-side reconciler) can see it.
-		record, err := m.loadOrInitProvision(ctx, vmName)
+		record, err := m.loadOrInitProvision(ctx, cfg, vmName)
 		if err != nil {
 			return err
 		}
-		return m.degradeProvision(ctx, vmName, record, currentVM.State)
+		return m.degradeProvision(ctx, cfg, vmName, record, currentVM.State)
 	}
 
 	// Existing healthy VM → source is inert. Log the inert decision, then drive

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -353,7 +353,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	// Resolve the provisioning record. Resuming from an in-progress record must
 	// NOT restart from absent (ADR-009 §2 safety invariant): if a record exists
 	// at installing/finalizing, the steps below have already run and we leave it.
-	record, err := m.loadOrInitProvision(ctx, vmName)
+	record, err := m.loadOrInitProvision(ctx, cfg, vmName)
 	if err != nil {
 		return err
 	}
@@ -369,7 +369,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	}
 
 	// absent → creating once the VM and disks exist.
-	if err := m.advanceProvision(ctx, vmName, record, ProvisionStateCreating); err != nil {
+	if err := m.advanceProvision(ctx, cfg, vmName, record, ProvisionStateCreating); err != nil {
 		return err
 	}
 
@@ -388,7 +388,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"Template": template,
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set firmware for VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: set firmware for VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, nil)
 	}
@@ -406,9 +406,9 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		if err := m.execStartVM(ctx, cfgResourceID, hostName,
 			map[string]interface{}{"state": "stopped"},
 			map[string]interface{}{"state": "running"}); err != nil {
-			return m.failProvision(ctx, vmName, record, err)
+			return m.failProvision(ctx, cfg, vmName, record, err)
 		}
-		return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)
+		return m.advanceProvision(ctx, cfg, vmName, record, ProvisionStateInstalling)
 	}
 
 	// Render the unattended answer file (os_family dispatch): linux → preseed
@@ -417,7 +417,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	// steward (ADR-009 §8). Per-VM vars + secrets substituted at render time.
 	answerContent, renderErr := m.renderSeedAnswerFile(ctx, vmName, cfg.Source, record.CorrelationID)
 	if renderErr != nil {
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: render answer file for VM %q: %w", vmName, renderErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: render answer file for VM %q: %w", vmName, renderErr))
 	}
 
 	// Answer-file delivery is os_family-specific. Windows: the new Server 2025
@@ -428,7 +428,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	if cfg.Source.OSFamily == "windows" {
 		isoPath := answerISOPath(vmName, cfg.VHDPath, m.seedDir)
 		if err := validateSeedPath(isoPath); err != nil {
-			return m.failProvision(ctx, vmName, record, err)
+			return m.failProvision(ctx, cfg, vmName, record, err)
 		}
 		if _, psErr := m.transport.ExecutePS(ctx, psBuildAnswerIso, map[string]string{
 			"IsoPath":    isoPath,
@@ -438,7 +438,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"CASrc":      m.enrollCAPath,
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: build answer ISO for VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: build answer ISO for VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psAttachDVD, map[string]string{
@@ -446,25 +446,25 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"ISOPath": isoPath,
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach answer ISO to VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: attach answer ISO to VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, nil)
 	} else {
 		seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
 		if err := validateSeedPath(seedPath); err != nil {
-			return m.failProvision(ctx, vmName, record, err)
+			return m.failProvision(ctx, cfg, vmName, record, err)
 		}
 		if _, psErr := m.transport.ExecutePS(ctx, psNewSeedVHD, map[string]string{
 			"Path":      seedPath,
 			"SizeBytes": "268435456",
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create seed VHDX for VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: create seed VHDX for VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{"Path": seedPath}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format seed VHDX for VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: format seed VHDX for VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
@@ -475,7 +475,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"CASrc":      "",
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
@@ -483,7 +483,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"SeedPath": seedPath,
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach seed disk to VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: attach seed disk to VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, nil)
 	}
@@ -494,7 +494,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		"ISOPath": cfg.Source.ISO,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach install ISO to VM %q: %w", vmName, psErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: attach install ISO to VM %q: %w", vmName, psErr))
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, nil)
 
@@ -507,7 +507,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"ISOPath": cfg.Source.ISO,
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set DVD first boot for VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: set DVD first boot for VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, nil)
 	}
@@ -518,7 +518,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	if err := m.execStartVM(ctx, cfgResourceID, hostName,
 		map[string]interface{}{"state": "stopped"},
 		map[string]interface{}{"state": "running"}); err != nil {
-		return m.failProvision(ctx, vmName, record, err)
+		return m.failProvision(ctx, cfg, vmName, record, err)
 	}
 
 	// Windows: drive the keyboard past the install media's "Press any key to
@@ -537,7 +537,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		}
 	}
 
-	return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)
+	return m.advanceProvision(ctx, cfg, vmName, record, ProvisionStateInstalling)
 }
 
 // cloudInitMetaData returns the minimal NoCloud meta-data document for a VM.
@@ -566,7 +566,7 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 	// cloud-init profile). CorrelationID is baked in for controller-side matching.
 	userData, renderErr := m.renderSeedAnswerFile(ctx, vmName, cfg.Source, record.CorrelationID)
 	if renderErr != nil {
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: render cloud-init user-data for VM %q: %w", vmName, renderErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: render cloud-init user-data for VM %q: %w", vmName, renderErr))
 	}
 	metaData := cloudInitMetaData(vmName, record.CorrelationID)
 
@@ -577,14 +577,14 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 	// path — Mount-VHD against a CSV-resident VHDX hangs (seed_dir handles this).
 	seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
 	if err := validateSeedPath(seedPath); err != nil {
-		return m.failProvision(ctx, vmName, record, err)
+		return m.failProvision(ctx, cfg, vmName, record, err)
 	}
 	if _, psErr := m.transport.ExecutePS(ctx, psNewSeedVHD, map[string]string{
 		"Path":      seedPath,
 		"SizeBytes": "268435456",
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create CIDATA seed VHDX for VM %q: %w", vmName, psErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: create CIDATA seed VHDX for VM %q: %w", vmName, psErr))
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, nil)
 	if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{
@@ -592,7 +592,7 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 		"Label": cidataVolumeLabel,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format CIDATA seed VHDX for VM %q: %w", vmName, psErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: format CIDATA seed VHDX for VM %q: %w", vmName, psErr))
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, nil)
 	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
@@ -609,7 +609,7 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 		"CASrc":        m.enrollCAPath,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write cloud-init seed for VM %q: %w", vmName, psErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: write cloud-init seed for VM %q: %w", vmName, psErr))
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, nil)
 	if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
@@ -617,7 +617,7 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 		"SeedPath": seedPath,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach CIDATA seed to VM %q: %w", vmName, psErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: attach CIDATA seed to VM %q: %w", vmName, psErr))
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, nil)
 
@@ -630,7 +630,7 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 			"VHDPath": cfg.VHDPath,
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, psErr)
-			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set OS-disk first boot for VM %q: %w", vmName, psErr))
+			return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: set OS-disk first boot for VM %q: %w", vmName, psErr))
 		}
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, nil)
 	}
@@ -685,7 +685,7 @@ func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName s
 	if cfg.Source == nil {
 		return nil
 	}
-	record, err := m.loadOrInitProvision(ctx, vmName)
+	record, err := m.loadOrInitProvision(ctx, cfg, vmName)
 	if err != nil {
 		return err
 	}
@@ -712,13 +712,13 @@ func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName s
 	// Detach the seed VHDX so the answer file is gone on the next boot.
 	seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
 	if vErr := validateSeedPath(seedPath); vErr != nil {
-		return m.failProvision(ctx, vmName, record, vErr)
+		return m.failProvision(ctx, cfg, vmName, record, vErr)
 	}
 	if _, psErr := m.transport.ExecutePS(ctx, psDetachSeedVHD, map[string]string{
 		"Path": seedPath,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", "vm:"+vmName, nil, nil, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: detach seed VHDX for VM %q: %w", vmName, psErr))
+		return m.failProvision(ctx, cfg, vmName, record, fmt.Errorf("hyperv: detach seed VHDX for VM %q: %w", vmName, psErr))
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", "vm:"+vmName, nil, nil, nil)
 
@@ -759,7 +759,7 @@ func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName s
 	}
 
 	// Advance installing → finalizing. ready is controller-side (#2050).
-	return m.advanceProvision(ctx, vmName, record, ProvisionStateFinalizing)
+	return m.advanceProvision(ctx, cfg, vmName, record, ProvisionStateFinalizing)
 }
 
 // installSettleDuration returns half of the parsed completion.timeout, the

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -799,13 +799,10 @@ func (m *hypervModule) vmIsRunning(ctx context.Context, vmName string) (bool, er
 // the VM's VHD path is known from the module cache, the path fails validation
 // and that file is silently skipped.
 func (m *hypervModule) sweepStaleSeedMedia(ctx context.Context) {
-	if m.provisionStore == nil || m.transport == nil {
+	if m.transport == nil {
 		return
 	}
-	records, err := m.provisionStore.ListProvisions(ctx)
-	if err != nil {
-		return
-	}
+	records := m.provisionRecordsForSweep(ctx)
 	for _, rec := range records {
 		if rec.State == ProvisionStateAbsent {
 			continue
@@ -841,4 +838,57 @@ func (m *hypervModule) sweepStaleSeedMedia(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// provisionRecordsForSweep returns the union of provision records this module may
+// hold stale HOST-LOCAL seed media for: the configured host-local store, PLUS the
+// cluster-visible CSV store of every ha_role+CSV VM in the module's cache — those
+// records live on the CSV, not the host-local store, so a host-local-only list
+// would silently stop TTL-sweeping seed media (which can carry a join token) for
+// exactly the ha_role class #2447 targets. Deduplicated by VM name (host-local
+// wins). CSV homes are listed once each; store IO happens after the cache lock is
+// released.
+func (m *hypervModule) provisionRecordsForSweep(ctx context.Context) []*ProvisionRecord {
+	seen := map[string]bool{}
+	var out []*ProvisionRecord
+	add := func(recs []*ProvisionRecord) {
+		for _, r := range recs {
+			if r == nil || seen[r.VMName] {
+				continue
+			}
+			seen[r.VMName] = true
+			out = append(out, r)
+		}
+	}
+
+	if m.provisionStore != nil {
+		if recs, err := m.provisionStore.ListProvisions(ctx); err == nil {
+			add(recs)
+		}
+	}
+
+	// Snapshot the ha_role+CSV configs under the cache lock, then list each
+	// distinct CSV home OUTSIDE the lock (ListProvisions does disk IO).
+	m.vmsMu.RLock()
+	var csvCfgs []VMConfig
+	for _, cfg := range m.vms {
+		c := cfg
+		if m.usesCSVStore(&c) {
+			csvCfgs = append(csvCfgs, c)
+		}
+	}
+	m.vmsMu.RUnlock()
+
+	listedHome := map[string]bool{}
+	for i := range csvCfgs {
+		home := vmHomeDir(csvCfgs[i].VHDPath)
+		if listedHome[home] {
+			continue
+		}
+		listedHome[home] = true
+		if recs, err := m.storeFor(&csvCfgs[i]).ListProvisions(ctx); err == nil {
+			add(recs)
+		}
+	}
+	return out
 }

--- a/features/modules/hyperv/vm_provision_csv_test.go
+++ b/features/modules/hyperv/vm_provision_csv_test.go
@@ -176,6 +176,36 @@ func TestProvision_NonHARole_UsesConfiguredStore(t *testing.T) {
 	assert.False(t, own, "a swallowed host-local error reports no in-progress attempt → create proceeds")
 }
 
+// TestProvisionRecordsForSweep_IncludesCSVRecords (#2447): the stale-seed-media
+// TTL sweep must see ha_role+CSV records too — they live in the CSV store, not the
+// host-local one, so a host-local-only list would silently stop TTL-sweeping
+// join-token-bearing seed media for exactly the ha_role class this story targets.
+func TestProvisionRecordsForSweep_IncludesCSVRecords(t *testing.T) {
+	ctx := context.Background()
+
+	host := NewMemProvisionStore()
+	require.NoError(t, host.SetProvision(ctx, ccsRecord("plain-vm", ProvisionStateInstalling)))
+
+	csv := NewMemProvisionStore()
+	require.NoError(t, csv.SetProvision(ctx, ccsRecord("ha-vm", ProvisionStateInstalling)))
+
+	m := &hypervModule{
+		provisionStore:    host,
+		csvProvisionStore: csv,
+		vms:               make(map[string]VMConfig),
+	}
+	// The ha_role+CSV VM is in the module's converge cache, so the sweep must
+	// consult its CSV store.
+	m.vms["ha-vm"] = VMConfig{Name: "ha-vm", VHDPath: csvVHDPath, HARole: &HARoleConfig{ClusterName: "lab-hv"}}
+
+	names := map[string]bool{}
+	for _, r := range m.provisionRecordsForSweep(ctx) {
+		names[r.VMName] = true
+	}
+	assert.True(t, names["plain-vm"], "host-local records must be swept")
+	assert.True(t, names["ha-vm"], "ha_role+CSV records must be swept (regression: #2447)")
+}
+
 // TestSetVM_FailoverMidProvision_CSVRecordDir confirms the production path (no
 // injected store) computes the CSV record directory from the VM's CSV home via
 // vmHomeDir — dir(vhd_path)/.cfgms-provision — not filepath.Dir (Issue #2044).

--- a/features/modules/hyperv/vm_provision_csv_test.go
+++ b/features/modules/hyperv/vm_provision_csv_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Issue #2447: cluster-visible (CSV) provisioning record for ha_role VMs ─────
+//
+// storeFor routes an ha_role+CSV VM's provisioning record to the cluster-visible
+// CSV store so a mid-provision CNO failover reads the in-progress record and
+// surfaces-and-waits (ADR-009 A1.4 Option A) instead of creating a duplicate.
+
+// errProvisionStore is a ProvisionStore whose every operation fails — used to
+// prove the fail-loud (CSV) vs swallow (host-local) asymmetry.
+type errProvisionStore struct{ err error }
+
+func (e errProvisionStore) GetProvision(context.Context, string) (*ProvisionRecord, error) {
+	return nil, e.err
+}
+func (e errProvisionStore) SetProvision(context.Context, *ProvisionRecord) error { return e.err }
+func (e errProvisionStore) DeleteProvision(context.Context, string) error        { return e.err }
+func (e errProvisionStore) ListProvisions(context.Context) ([]*ProvisionRecord, error) {
+	return nil, e.err
+}
+
+const csvVHDPath = `C:\ClusterStorage\CSV01\vol\ha-vm.vhdx`
+
+// TestStoreFor_RoutesHARoleCSVToInjectedStore (AC1): only an ha_role VM whose VHD
+// is on a CSV routes to the injected CSV store; every other shape keeps the
+// configured host-local store.
+func TestStoreFor_RoutesHARoleCSVToInjectedStore(t *testing.T) {
+	host := NewMemProvisionStore()
+	csv := NewMemProvisionStore()
+	m := &hypervModule{provisionStore: host, csvProvisionStore: csv}
+
+	haCSV := &VMConfig{Name: "ha", VHDPath: csvVHDPath, HARole: &HARoleConfig{ClusterName: "lab-hv"}}
+	assert.Same(t, csv, m.storeFor(haCSV), "ha_role + CSV vhd → CSV store")
+
+	plain := &VMConfig{Name: "plain", VHDPath: `C:\VMs\plain.vhdx`}
+	assert.Same(t, host, m.storeFor(plain), "non-ha_role → host-local store")
+
+	haNonCSV := &VMConfig{Name: "ha2", VHDPath: `C:\VMs\ha2.vhdx`, HARole: &HARoleConfig{ClusterName: "lab-hv"}}
+	assert.Same(t, host, m.storeFor(haNonCSV), "ha_role but non-CSV vhd → host-local store")
+
+	assert.Same(t, host, m.storeFor(nil), "nil cfg → host-local store")
+}
+
+// haCSVSourceModule wires a module as the CNO owner (NODE1) of an ha_role+CSV
+// source VM whose role does not yet exist cluster-wide, with the given CSV store
+// injected. The transport answers the 4 reads on the create path up to (but not
+// including) any New-VM: getVM(absent) + membership probe(empty) + CNO owner +
+// role owners. Any New-VM beyond that is a gate violation.
+func haCSVSourceModule(t *testing.T, csvStore ProvisionStore) (*hypervModule, *testWinRMTransport, *fakeAuditStore) {
+	t.Helper()
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"found":false}`,   // getVM: locally absent
+		`{"owners":{}}`,     // getVM membership probe: role absent cluster-wide
+		`{"owner":"NODE1"}`, // #2421 ownership helper: this node owns the CNO
+		`{"owners":{}}`,     // #2421 ownership helper: role owners
+	}}
+	m := vmModuleWithTransport(transport, "t-2447")
+	m.clusterName = "lab-hv"
+	m.nodeHostname = "NODE1"
+	m.seedDir = `C:\cfgms\seed` // host-local (satisfies the ha_role CSV seed rule)
+	m.csvProvisionStore = csvStore
+	mgr, store := newFakeAuditManager(t)
+	m.auditMgr = mgr
+	m.stewardID = "steward-2447"
+	return m, transport, store
+}
+
+func haCSVSourceVM() *VMConfig {
+	return &VMConfig{
+		Name:       "ha-vm",
+		MemoryMB:   4096,
+		CPUCount:   2,
+		VHDPath:    csvVHDPath,
+		SwitchName: "Default Switch",
+		Generation: 2,
+		State:      "running",
+		HARole:     &HARoleConfig{ClusterName: "lab-hv"},
+		Source: &SourceConfig{
+			Image:      `C:\images\debian.raw`,
+			OSFamily:   "linux",
+			Completion: CompletionConfig{Mode: "steward-registration", Timeout: "10m"},
+		},
+	}
+}
+
+// TestSetVM_FailoverMidProvision_NewOwnerSurfacesAndWaits (REQUIRED, #2447): a new
+// CNO owner converging an ha_role source VM whose CSV record shows another node's
+// in-flight attempt (installing) issues ZERO create/provision transport calls and
+// audits the surface-and-wait skip — the duplicate a mid-provision failover would
+// otherwise cause.
+func TestSetVM_FailoverMidProvision_NewOwnerSurfacesAndWaits(t *testing.T) {
+	ctx := context.Background()
+
+	// The cluster-visible record another node wrote mid-provision, seeded in the
+	// CSV-routed store this (new-owner) node reads.
+	csv := NewMemProvisionStore()
+	require.NoError(t, csv.SetProvision(ctx, &ProvisionRecord{
+		VMName:        "ha-vm",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "ha-vm",
+		StartedAt:     time.Now().UTC().Add(-5 * time.Minute),
+		UpdatedAt:     time.Now().UTC().Add(-5 * time.Minute),
+	}))
+
+	m, transport, store := haCSVSourceModule(t, csv)
+
+	require.NoError(t, m.Set(ctx, "vm:ha-vm", haCSVSourceVM()),
+		"surface-and-wait is a clean no-op, never an error")
+
+	assert.Equal(t, 0, countCmd(transport, psCreateVM),
+		"the new owner must NOT create — the CSV record shows an in-flight attempt elsewhere")
+
+	require.NoError(t, m.auditMgr.Flush(ctx))
+	skips := auditEntriesByActionCT(store.captured(), "vm-provision-skip-in-progress-elsewhere")
+	require.Len(t, skips, 1, "the surface-and-wait skip must be audited")
+}
+
+// TestSetVM_CSVRecordReadError_FailsLoud (REQUIRED, #2447): an unreadable CSV
+// record propagates as a setVM error and no VM is created — creation must never
+// proceed while cluster-visible record state is unknown.
+func TestSetVM_CSVRecordReadError_FailsLoud(t *testing.T) {
+	ctx := context.Background()
+	m, transport, _ := haCSVSourceModule(t, errProvisionStore{err: errors.New("csv record unreadable")})
+
+	err := m.Set(ctx, "vm:ha-vm", haCSVSourceVM())
+	require.Error(t, err, "an unreadable cluster-visible record must fail the Set, not be swallowed")
+	assert.Contains(t, err.Error(), "csv record unreadable")
+	assert.Equal(t, 0, countCmd(transport, psCreateVM),
+		"no create may proceed while CSV record state is unknown")
+}
+
+// TestProvision_NonHARole_UsesConfiguredStore (REQUIRED, #2447): non-ha_role
+// provisioning touches ONLY the configured host-local store — nothing is written
+// under .cfgms-provision — AND the host-local read keeps its swallow-on-error
+// semantics (a GetProvision error yields (false, nil), so the create path
+// proceeds). Regression guard for both the routing predicate and the fail-loud
+// scope boundary.
+func TestProvision_NonHARole_UsesConfiguredStore(t *testing.T) {
+	ctx := context.Background()
+
+	// Routing: a non-ha_role accessor call writes to the host-local store and
+	// never touches the injected CSV store's directory.
+	home := t.TempDir()
+	host := NewMemProvisionStore()
+	m := &hypervModule{provisionStore: host, csvProvisionStore: newCSVProvisionStore(home)}
+
+	plain := &VMConfig{Name: "plain-vm", VHDPath: `C:\VMs\plain-vm.vhdx`}
+	rec, err := m.loadOrInitProvision(ctx, plain, "plain-vm")
+	require.NoError(t, err)
+	require.NoError(t, m.advanceProvision(ctx, plain, "plain-vm", rec, ProvisionStateCreating))
+
+	got, err := host.GetProvision(ctx, "plain-vm")
+	require.NoError(t, err, "the non-ha_role record must land in the configured host-local store")
+	assert.Equal(t, ProvisionStateCreating, got.State)
+	assert.NoDirExists(t, filepath.Join(home, csvProvisionSubdir),
+		"a non-ha_role VM must write nothing under .cfgms-provision")
+
+	// Fail-loud scope boundary: a host-local read error is SWALLOWED (false, nil),
+	// unchanged from before #2447 — only the CSV store fails loud.
+	mErr := &hypervModule{provisionStore: errProvisionStore{err: errors.New("host store down")}}
+	own, err := mErr.isOwnIncompleteAttempt(ctx, plain)
+	require.NoError(t, err, "a host-local read error must NOT fail loud (preserved swallow semantics)")
+	assert.False(t, own, "a swallowed host-local error reports no in-progress attempt → create proceeds")
+}
+
+// TestSetVM_FailoverMidProvision_CSVRecordDir confirms the production path (no
+// injected store) computes the CSV record directory from the VM's CSV home via
+// vmHomeDir — dir(vhd_path)/.cfgms-provision — not filepath.Dir (Issue #2044).
+func TestSetVM_FailoverMidProvision_CSVRecordDir(t *testing.T) {
+	m := &hypervModule{provisionStore: NewMemProvisionStore()}
+	store := m.storeFor(&VMConfig{Name: "ha-vm", VHDPath: csvVHDPath, HARole: &HARoleConfig{ClusterName: "lab-hv"}})
+	csv, ok := store.(*csvProvisionStore)
+	require.True(t, ok, "ha_role+CSV must resolve to a *csvProvisionStore in production")
+	assert.Equal(t, `C:\ClusterStorage\CSV01\vol`, csv.homeDir,
+		"the record home must be dir(vhd_path) via vmHomeDir, not filepath.Dir")
+}


### PR DESCRIPTION
## Summary

Implements **ADR-009 Amendment 1 A1.4, Option A** (founder-ratified 2026-07-08) for epic **#2418**: an `ha_role` VM's per-VM provisioning record is **cluster-visible** — persisted on the same CSV as the VM's primary VHD — so a CNO failover **mid-provision** cannot produce a duplicate VM. The new owner reads the non-terminal record from the shared CSV and **surfaces-and-waits** instead of creating.

## Changes

- **`provision_csv.go`** (new) — `csvProvisionStore`, a `ProvisionStore` persisting each record as JSON at `<dir(vhd_path)>\.cfgms-provision\<vm_name>.json`. Crash-safe writes (temp file + atomic `os.Rename`), copy-on-read, snapshot `ListProvisions` (missing-dir → empty), and path guards: UNC/empty rejection, **`..`-segment rejection** (so a crafted `vhd_path` can't `filepath.Join`-Clean off-CSV), and `vmName` traversal guard — all via `ErrInvalidSeedPath`.
- **`provision.go`** — `storeFor(cfg)` + `usesCSVStore(cfg)` route `ha_role`+CSV VMs to the CSV store, everything else to the configured host-local store. **All five record accessors** resolve their store via `storeFor` — no direct `m.provisionStore` read remains on any `ha_role` path. `isOwnIncompleteAttempt` now returns `(bool, error)`: **fail-loud** for the load-bearing CSV store, byte-for-byte **swallow-on-error** preserved for host-local.
- **`vm.go`** — `applySourceGated` checks the `isOwnIncompleteAttempt` error **before** `createVM` (never `New-VM` while CSV record state is unknown) and audits the skip as `vm-provision-skip-in-progress-elsewhere`; both `DeleteProvision` sites route via `storeFor`.
- **`vm_provision.go`** — `cfg` threaded through the ~25 accessor call sites; `sweepStaleSeedMedia` now unions host-local **and** CSV records (`provisionRecordsForSweep`) so the join-token TTL backstop keeps working for `ha_role`+CSV VMs.
- **`module.go`** — `WithCSVProvisionStore` injection seam (mirrors `WithProvisionStore`).
- **Tests** — `provision_csv_test.go` (store contract, atomicity, path guards incl. `..`), `vm_provision_csv_test.go` (routing AC, the 3 REQUIRED tests, sweep-includes-CSV regression test), `provision_test.go` updated for the new signature.
- **README** — cluster-visible record location + failover surface-and-wait behavior.

Path derivation reuses `vmHomeDir` (not `filepath.Dir` — Issue #2044). CSV store is **not** a `MoveStore` (storage-move records stay put); controller-side completion wiring unchanged (out of scope).

## Test results

- Full `features/modules/hyperv` package tests pass, **including `-race`**; the 3 REQUIRED tests pass. `go build ./...`, `make check-architecture`, `gofmt`, `go vet` all clean.
- Lint/secret/dep scanners (golangci-lint/gitleaks/gosec-secret/trivy) are absent on the self-dispatch Windows host → deferred to CI. `gosec` (present) reported no CRITICAL/HIGH after fixes.

## Review

Parallel adversarial **QA + security** review run pre-PR:
- **QA:** found 1 blocking issue (`sweepStaleSeedMedia` not routed → stale join-token seed media never swept for `ha_role`+CSV) — **fixed** (`provisionRecordsForSweep` + regression test) and re-verified.
- **Security:** PASS, 0 blocking; 1 MEDIUM (`..` traversal in `homeDir` could defeat cluster-visibility) — **fixed** (segment guard + tests); 1 LOW (dir `0o755`→`0o750`) — **fixed**.

### Known edge (documented, non-blocking)
A `state: absent` convergence on a **non-owning** node where `Get-VM` reports the VM not-found returns a `cfg` with `HARole` set but empty `VHDPath`, so the record delete routes host-local and a non-terminal CSV record could linger until the owner's provision reaches a terminal state or it's cleaned manually. Narrow operational race; noted for a possible follow-up.

## ⚠️ Live validation

The cross-node CSV-visibility + mid-provision-failover surface-and-wait is covered live by the epic runbook (`docs/testing/hyperv-cluster-cascade-runbook.md`, added in #2426) and needs a cluster-admin run on cfg-lab. The mergeable code + REQUIRED unit tests (which run in `make test-complete`) are complete and gate-verified here.

Fixes #2447

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>