### PR TITLE
modules: github_runner converge from stored config via work_dir (Issue #2481)

### DIFF
--- a/features/modules/extended/github_runner/config.go
+++ b/features/modules/extended/github_runner/config.go
@@ -98,6 +98,9 @@ func (c *RunnerConfig) Validate() error {
 	if strings.TrimSpace(c.WorkDir) == "" {
 		return fmt.Errorf("%w: work_dir is required", modules.ErrInvalidInput)
 	}
+	if !filepath.IsAbs(c.WorkDir) {
+		return fmt.Errorf("%w: work_dir %q must be an absolute path", modules.ErrInvalidInput, c.WorkDir)
+	}
 	if !serviceNamePattern.MatchString(c.ServiceName) {
 		return fmt.Errorf("%w: service_name %q contains invalid characters", modules.ErrInvalidInput, c.ServiceName)
 	}

--- a/features/modules/extended/github_runner/module.go
+++ b/features/modules/extended/github_runner/module.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -78,6 +79,11 @@ type runnerModule struct {
 
 	executor  runnerServiceExecutor
 	installer agentInstaller
+
+	// mu protects workDir, which is populated by Configure and read by Get.
+	// Configure, Get, and Set can be called from different goroutines.
+	mu      sync.RWMutex
+	workDir string
 }
 
 // New creates a github_runner module wired with the platform service executor
@@ -94,8 +100,9 @@ func newModule(exec runnerServiceExecutor, inst agentInstaller) *runnerModule {
 }
 
 // Configure implements modules.Configurable. It validates the desired runner
-// configuration before any Get/Set so a malformed config is rejected without
-// touching the host. No secrets are read — the module is token-free.
+// configuration and stores the work_dir so Get() uses the correct absolute path
+// regardless of the resource name passed by the executor. No secrets are read —
+// the module is token-free.
 func (m *runnerModule) Configure(config modules.ConfigState) error {
 	if config == nil {
 		return fmt.Errorf("%w: config must not be nil", modules.ErrInvalidInput)
@@ -104,20 +111,37 @@ func (m *runnerModule) Configure(config modules.ConfigState) error {
 	if err != nil {
 		return err
 	}
-	return rc.Validate()
+	if err := rc.Validate(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.workDir = rc.WorkDir
+	m.mu.Unlock()
+	return nil
 }
 
-// Get returns the current observed state of the runner identified by resourceID
-// (the resourceID is the runner's work directory, the stable host-side identity).
-// It is network-free: version and labels come from the module's on-disk state
-// marker, service state from the OS service manager.
+// Get returns the current observed state of the runner. The install path and
+// state marker location are determined by work_dir from Configure (the desired
+// config), not by resourceID. This is necessary because controller resource-name
+// validation forbids "/" and "." in resource names, so resourceID is opaque and
+// cannot encode an absolute path. Configure must be called before Get (the
+// executor always does this); if it was not called, resourceID is used as a
+// fallback so existing test paths that call Get directly continue to work.
 func (m *runnerModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
 	if resourceID == "" {
 		return nil, modules.ErrInvalidResourceID
 	}
+
+	m.mu.RLock()
+	workDir := m.workDir
+	m.mu.RUnlock()
+	if workDir == "" {
+		workDir = resourceID
+	}
+
 	logger := m.GetEffectiveLogger(logging.ForModule("github_runner"))
 
-	st, err := readState(resourceID)
+	st, err := readState(workDir)
 	if err != nil {
 		return nil, fmt.Errorf("read runner state: %w", err)
 	}
@@ -125,7 +149,7 @@ func (m *runnerModule) Get(ctx context.Context, resourceID string) (modules.Conf
 	cur := &RunnerConfig{
 		Version:   st.Version,
 		Labels:    st.Labels,
-		WorkDir:   resourceID,
+		WorkDir:   workDir,
 		Installed: st.Version != "",
 	}
 
@@ -209,7 +233,7 @@ func (m *runnerModule) Set(ctx context.Context, resourceID string, config module
 	}
 	logger := m.GetEffectiveLogger(logging.ForModule("github_runner"))
 
-	st, err := readState(resourceID)
+	st, err := readState(desired.WorkDir)
 	if err != nil {
 		return fmt.Errorf("read runner state: %w", err)
 	}
@@ -224,7 +248,7 @@ func (m *runnerModule) Set(ctx context.Context, resourceID string, config module
 			URL:     desired.AgentURL,
 			SHA256:  desired.AgentSHA256,
 			Version: desired.Version,
-			WorkDir: resourceID,
+			WorkDir: desired.WorkDir,
 			Format:  archiveFormatForOS(),
 		}); ierr != nil {
 			return fmt.Errorf("install runner agent: %w", ierr)
@@ -236,7 +260,7 @@ func (m *runnerModule) Set(ctx context.Context, resourceID string, config module
 	st.Labels = append([]string(nil), desired.Labels...)
 	sort.Strings(st.Labels)
 	st.ServiceName = desired.ServiceName
-	if werr := writeState(resourceID, st); werr != nil {
+	if werr := writeState(desired.WorkDir, st); werr != nil {
 		return fmt.Errorf("write runner state: %w", werr)
 	}
 

--- a/features/modules/extended/github_runner/module_test.go
+++ b/features/modules/extended/github_runner/module_test.go
@@ -82,7 +82,8 @@ func validConfig(workDir, serviceName string) *RunnerConfig {
 }
 
 func TestRunnerConfig_Validate(t *testing.T) {
-	base := validConfig("/opt/runner", "actions.runner.acme-repo.host1.service")
+	workDir := t.TempDir()
+	base := validConfig(workDir, "actions.runner.acme-repo.host1.service")
 	if err := base.Validate(); err != nil {
 		t.Fatalf("valid config rejected: %v", err)
 	}
@@ -97,7 +98,7 @@ func TestRunnerConfig_Validate(t *testing.T) {
 		"bad label":         func(c *RunnerConfig) { c.Labels = []string{"ok", "has space"} },
 	}
 	for name, mutate := range cases {
-		c := validConfig("/opt/runner", "actions.runner.acme-repo.host1.service")
+		c := validConfig(workDir, "actions.runner.acme-repo.host1.service")
 		mutate(c)
 		if err := c.Validate(); err == nil {
 			t.Errorf("%s: expected validation error, got nil", name)
@@ -149,11 +150,12 @@ func TestSchema_NoRegistrationTokenField(t *testing.T) {
 }
 
 func TestConfigure_RejectsInvalid(t *testing.T) {
+	workDir := t.TempDir()
 	m := newModule(&testServiceExecutor{}, newHTTPInstaller())
-	if err := m.Configure(validConfig("/opt/runner", "svc")); err != nil {
+	if err := m.Configure(validConfig(workDir, "svc")); err != nil {
 		t.Fatalf("Configure rejected a valid config: %v", err)
 	}
-	bad := validConfig("/opt/runner", "svc")
+	bad := validConfig(workDir, "svc")
 	bad.AgentSHA256 = "nope"
 	if err := m.Configure(bad); err == nil {
 		t.Fatal("Configure accepted an invalid config")

--- a/features/modules/extended/github_runner/module_test.go
+++ b/features/modules/extended/github_runner/module_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -87,12 +88,13 @@ func TestRunnerConfig_Validate(t *testing.T) {
 	}
 
 	cases := map[string]func(*RunnerConfig){
-		"missing version":  func(c *RunnerConfig) { c.Version = "" },
-		"non-http url":     func(c *RunnerConfig) { c.AgentURL = "ftp://x/y" },
-		"short sha":        func(c *RunnerConfig) { c.AgentSHA256 = "abc" },
-		"missing work_dir": func(c *RunnerConfig) { c.WorkDir = "" },
-		"bad service_name": func(c *RunnerConfig) { c.ServiceName = "-bad name" },
-		"bad label":        func(c *RunnerConfig) { c.Labels = []string{"ok", "has space"} },
+		"missing version":   func(c *RunnerConfig) { c.Version = "" },
+		"non-http url":      func(c *RunnerConfig) { c.AgentURL = "ftp://x/y" },
+		"short sha":         func(c *RunnerConfig) { c.AgentSHA256 = "abc" },
+		"missing work_dir":  func(c *RunnerConfig) { c.WorkDir = "" },
+		"relative work_dir": func(c *RunnerConfig) { c.WorkDir = "relative/path" },
+		"bad service_name":  func(c *RunnerConfig) { c.ServiceName = "-bad name" },
+		"bad label":         func(c *RunnerConfig) { c.Labels = []string{"ok", "has space"} },
 	}
 	for name, mutate := range cases {
 		c := validConfig("/opt/runner", "actions.runner.acme-repo.host1.service")
@@ -404,5 +406,91 @@ func TestModule_Get_InvalidResourceID(t *testing.T) {
 	m := newModule(&testServiceExecutor{}, newHTTPInstaller())
 	if _, err := m.Get(context.Background(), ""); err == nil {
 		t.Fatal("Get accepted an empty resource ID")
+	}
+}
+
+// TestModule_StoredConfig_ConvergesViaWorkDir verifies that a charset-safe
+// resource name (no "/" or ".") paired with an absolute work_dir in the config
+// causes the module to install and read state from work_dir — not from a
+// relative path derived from the resource name. This is the production shape:
+// controllers reject resource names containing "/" or ".", but work_dir is an
+// absolute path. Both acceptance criteria are verified here:
+//
+//  1. Set installs to work_dir and writes the state marker there.
+//  2. A pre-existing agent + marker at work_dir is recognised as installed
+//     (no reinstall on the second Set).
+func TestModule_StoredConfig_ConvergesViaWorkDir(t *testing.T) {
+	srv, url, sha := agentServer(t)
+	defer srv.Close()
+
+	workDir := t.TempDir()
+	exec := &testServiceExecutor{installed: true, makeRunOnSet: true}
+	m, inst := moduleFor(exec, srv)
+
+	// charset-safe opaque resource name — no "/" or "." allowed by controller
+	const resourceID = "github-runner"
+	// Guard against a stale artifact from a pre-fix run (where the module used
+	// resourceID as the path) leaking into this assertion.
+	t.Cleanup(func() {
+		if err := os.RemoveAll(resourceID); err != nil {
+			t.Logf("warning: cleanup of stale test artifact %q: %v", resourceID, err)
+		}
+	})
+
+	cfg := validConfig(workDir, "actions.runner.acme-repo.host1.service")
+	cfg.AgentURL = url
+	cfg.AgentSHA256 = sha
+
+	ctx := context.Background()
+
+	// Executor calls Configure before Get; replicate that here.
+	if err := m.Configure(cfg); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	// Set with the opaque resource name — must install to work_dir, not "github-runner/".
+	if err := m.Set(ctx, resourceID, cfg); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if inst.calls != 1 {
+		t.Fatalf("installer called %d times, want 1", inst.calls)
+	}
+
+	// State marker must be written under work_dir, not under the resource-name directory.
+	if _, err := os.Stat(filepath.Join(workDir, stateFileName)); err != nil {
+		t.Fatalf("state marker not written to work_dir %q: %v", workDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(resourceID, stateFileName)); err == nil {
+		t.Fatalf("state marker incorrectly written to relative resource-name path %q", filepath.Join(resourceID, stateFileName))
+	}
+
+	// Get must read from work_dir (wired via Configure) and report installed.
+	state, err := m.Get(ctx, resourceID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	rc := state.(*RunnerConfig)
+	if !rc.Installed {
+		t.Error("Get: agent at work_dir not recognised as installed")
+	}
+	if rc.WorkDir != workDir {
+		t.Errorf("Get: WorkDir = %q, want %q", rc.WorkDir, workDir)
+	}
+
+	// Test must confirm no drift.
+	ok, err := m.Test(ctx, resourceID, cfg)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if !ok {
+		t.Fatal("Test reported drift after converging via work_dir")
+	}
+
+	// Pre-existing agent: second Set must not re-download.
+	if err := m.Set(ctx, resourceID, cfg); err != nil {
+		t.Fatalf("second Set: %v", err)
+	}
+	if inst.calls != 1 {
+		t.Fatalf("second Set re-downloaded agent (installer calls=%d, want 1)", inst.calls)
 	}
 }


### PR DESCRIPTION
## Summary

- `Configure()` now stores `work_dir` from the desired config in a mutex-protected `workDir` field on the module struct, so `Get()` and `Set()` use the absolute install path regardless of the opaque resource name passed by the executor
- `Get()` reads `m.workDir` (set by `Configure`), falling back to `resourceID` only when `Configure` has not yet been called (preserves backward-compat for existing direct-call tests)
- `Set()` uses `desired.WorkDir` for `readState`, `installSource.WorkDir`, and `writeState` — no more silent install to a relative directory named after the resource
- `Validate()` now rejects relative `work_dir` paths via `filepath.IsAbs`
- New test `TestModule_StoredConfig_ConvergesViaWorkDir` proves the fix: a charset-safe resource name (`"github-runner"`, no `/` or `.`) paired with an absolute `work_dir` causes state to be written and read at `work_dir`, not at a relative resource-name path

## Root Cause

Controller resource-name validation forbids `/` and `.` in resource names. A resource named `github-runner` with `work_dir: /opt/actions-runner` was installing to a relative `github-runner/` directory, making an existing agent at `/opt/actions-runner` invisible to `Get()` and triggering a re-install on every convergence.

## Test Plan

- [x] `go test -race -short ./features/modules/extended/github_runner/...` — all 19 tests pass including new `TestModule_StoredConfig_ConvergesViaWorkDir`
- [x] `golangci-lint run ./features/modules/extended/github_runner/...` — 0 issues
- [x] Story-review: security-engineer PASS, qa-code-reviewer PASS
- [x] `features/controller/api` 300s timeout in `make test-agent-complete` is pre-existing (exists on `develop` tip, no dependency on github_runner module)

Fixes #2481

🤖 Generated with [Claude Code](https://claude.com/claude-code)