### PR TITLE
api: config upload validation failures return 400 VALIDATION_ERROR (Issue #2482)

### DIFF
--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -23,6 +23,7 @@ import (
 	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/features/controller/modules/resolution"
+	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -540,6 +541,26 @@ func (s *Server) handleUpdateStewardConfig(w http.ResponseWriter, r *http.Reques
 		s.logger.Info("Received configuration in JSON format", "steward_id", stewardIDForLog, "resources", len(config.Resources))
 	}
 
+	// Validate resource names at the handler boundary before any storage-side
+	// effect. An invalid name (e.g. containing a dot like "docker.io") is a
+	// client input error, not a storage fault: reject it with 400
+	// VALIDATION_ERROR here rather than letting it reach SetConfiguration and
+	// surface as a generic 500 STORAGE_ERROR. The offending name is
+	// config-derived and therefore safe to echo back to the caller so the
+	// client can self-diagnose without server logs. (Issue #2482)
+	for i, resource := range config.Resources {
+		if !identifierRegex.MatchString(resource.Name) {
+			s.logger.Warn("Invalid resource name in config upload",
+				"steward_id", stewardIDForLog,
+				"resource_index", i,
+				"resource_name", logging.SanitizeLogValue(resource.Name))
+			s.writeErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("Invalid resource name %q: must contain only alphanumeric characters, hyphens, and underscores", resource.Name),
+				"VALIDATION_ERROR")
+			return
+		}
+	}
+
 	// Resolve the tenant the config is stored under. This endpoint targets a
 	// specific steward, so the config must be stored under THAT steward's
 	// tenant — not the caller's. An admin in tenant "default" may push config
@@ -595,6 +616,15 @@ func (s *Server) handleUpdateStewardConfig(w http.ResponseWriter, r *http.Reques
 
 	// Store configuration using V2 durable config service
 	if err := s.configService.SetConfiguration(r.Context(), tenantID, stewardID, &config); err != nil {
+		var ve *service.ValidationFailedError
+		if errors.As(err, &ve) {
+			s.logger.Warn("Configuration validation failed",
+				"steward_id", stewardIDForLog,
+				"tenant_id", tenantIDForLog,
+				"error_count", len(ve.Errors))
+			s.writeErrorResponse(w, http.StatusBadRequest, ve.Error(), "VALIDATION_ERROR")
+			return
+		}
 		s.logger.Error("Failed to store configuration",
 			"steward_id", stewardIDForLog,
 			"tenant_id", tenantIDForLog,

--- a/features/controller/api/handlers_stewards_config_upload_test.go
+++ b/features/controller/api/handlers_stewards_config_upload_test.go
@@ -6,7 +6,9 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,7 +16,47 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/pkg/logging"
+	storageifaces "github.com/cfgis/cfgms/pkg/storage/interfaces"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
+
+// storeWriteFailingConfigStore is a real ConfigStore whose StoreConfig always
+// fails, simulating a durable-storage write error without touching read paths.
+// All other operations delegate to the embedded real store.
+type storeWriteFailingConfigStore struct {
+	cfgconfig.ConfigStore
+}
+
+func (f *storeWriteFailingConfigStore) StoreConfig(context.Context, *cfgconfig.ConfigEntry) error {
+	return errors.New("storage backend unavailable")
+}
+
+// useStorageWriteFailingConfigService replaces the server's config service with one
+// backed by a store that fails only on StoreConfig writes. This lets tests exercise
+// the 500 STORAGE_ERROR branch in handleUpdateStewardConfig without mocking.
+func useStorageWriteFailingConfigService(t *testing.T, server *Server) {
+	t.Helper()
+	sm := pkgtesting.SetupTestStorage(t)
+	composite := storageifaces.NewStorageManagerFromStores(
+		&storeWriteFailingConfigStore{ConfigStore: sm.GetConfigStore()},
+		sm.GetAuditStore(),
+		sm.GetRBACStore(),
+		sm.GetTenantStore(),
+		sm.GetClientTenantStore(),
+		sm.GetRegistrationTokenStore(),
+		sm.GetSessionStore(),
+		sm.GetStewardStore(),
+		sm.GetCommandStore(),
+		sm.GetTriggerStore(),
+		sm.GetPushStore(),
+	)
+	logger := logging.NewNoopLogger()
+	server.configService = service.NewConfigurationServiceV2(logger, composite, service.NewControllerService(logger))
+}
 
 // TestHandleUpdateStewardConfig_InvalidResourceName_Returns400 verifies that a config
 // upload with an invalid resource name (dot in name, e.g. "docker.io") returns HTTP 400
@@ -62,6 +104,61 @@ resources:
 		"message must name the invalid resource so the client can diagnose without server logs")
 }
 
+// TestHandleUpdateStewardConfig_ServiceValidationFailure_Returns400 verifies the
+// errors.As(err, &ve) routing branch: a config whose resource names all pass the
+// handler-level identifierRegex but which fails a service-layer validator (two
+// resources sharing the same name -> DUPLICATE_RESOURCE_NAME) makes SetConfiguration
+// itself return a *service.ValidationFailedError. The handler must translate that
+// into HTTP 400 VALIDATION_ERROR, not 500 STORAGE_ERROR (Issue #2482).
+func TestHandleUpdateStewardConfig_ServiceValidationFailure_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:write-config"}, "test-tenant", 5*time.Minute)
+
+	// Both resource names are individually valid (pass the handler regex) but
+	// collide, which only the service-layer validator detects.
+	body := []byte(`
+steward:
+  id: test-steward-dup-rsrc
+  mode: controller
+  logging:
+    level: info
+    format: text
+  error_handling:
+    module_load_failure: continue
+    resource_failure: warn
+    configuration_error: fail
+modules:
+  file: file
+resources:
+  - name: duplicated-name
+    module: file
+    config:
+      path: /tmp/a
+      content: a
+  - name: duplicated-name
+    module: file
+    config:
+      path: /tmp/b
+      content: b
+`)
+
+	req := httptest.NewRequest("PUT", "/api/v1/stewards/test-steward-dup-rsrc/config", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/yaml")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code,
+		"service-layer validation failure must return 400, not 5xx; body: %s", rec.Body.String())
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "VALIDATION_ERROR", resp.Error.Code,
+		"code must be VALIDATION_ERROR, not STORAGE_ERROR")
+	assert.Contains(t, resp.Error.Message, "validation failed",
+		"message must carry the service-layer validation summary")
+}
+
 // TestHandleUpdateStewardConfig_ValidConfig_Returns200 verifies that a well-formed
 // config upload succeeds (Issue #2482 — regression guard that the fix does not
 // accidentally block valid uploads).
@@ -98,4 +195,51 @@ resources:
 
 	require.Equal(t, http.StatusOK, rec.Code,
 		"valid config must be accepted; body: %s", rec.Body.String())
+}
+
+// TestHandleUpdateStewardConfig_StorageError_Returns500 verifies that a genuine
+// storage-layer failure (not a validation failure) still returns HTTP 500 with
+// code STORAGE_ERROR after the Issue #2482 fix — i.e. the fix does not convert
+// real storage errors into 400s (AC1 regression guard, [REQUIRED TEST]).
+func TestHandleUpdateStewardConfig_StorageError_Returns500(t *testing.T) {
+	server := setupTestServer(t)
+	useStorageWriteFailingConfigService(t, server)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:write-config"}, "test-tenant", 5*time.Minute)
+
+	// Submit a config that passes all validation (valid resource name, valid YAML,
+	// required fields present) so the only failure is the underlying StoreConfig call.
+	body := []byte(`
+steward:
+  id: test-steward-storage-err
+  mode: controller
+  logging:
+    level: info
+    format: text
+  error_handling:
+    module_load_failure: continue
+    resource_failure: warn
+    configuration_error: fail
+modules:
+  file: file
+resources:
+  - name: valid-resource
+    module: file
+    config:
+      path: /tmp/test
+      content: hello
+`)
+
+	req := httptest.NewRequest("PUT", "/api/v1/stewards/test-steward-storage-err/config", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/yaml")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code,
+		"storage failure must return 500, not 400; body: %s", rec.Body.String())
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "STORAGE_ERROR", resp.Error.Code,
+		"storage failure must report STORAGE_ERROR, not VALIDATION_ERROR")
 }

--- a/features/controller/api/handlers_stewards_config_upload_test.go
+++ b/features/controller/api/handlers_stewards_config_upload_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Tests for handleUpdateStewardConfig validation-vs-storage error routing (Issue #2482).
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleUpdateStewardConfig_InvalidResourceName_Returns400 verifies that a config
+// upload with an invalid resource name (dot in name, e.g. "docker.io") returns HTTP 400
+// with code VALIDATION_ERROR and the specific failed-field detail in the message, not
+// 500 STORAGE_ERROR (Issue #2482).
+func TestHandleUpdateStewardConfig_InvalidResourceName_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:write-config"}, "test-tenant", 5*time.Minute)
+
+	body := []byte(`
+steward:
+  id: test-steward-invalid-rsrc
+  mode: controller
+  logging:
+    level: info
+    format: text
+  error_handling:
+    module_load_failure: continue
+    resource_failure: warn
+    configuration_error: fail
+modules:
+  file: file
+resources:
+  - name: docker.io
+    module: file
+    config:
+      path: /tmp/test
+      content: x
+`)
+
+	req := httptest.NewRequest("PUT", "/api/v1/stewards/test-steward-invalid-rsrc/config", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/yaml")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code,
+		"validation failure must return 400, not 5xx; body: %s", rec.Body.String())
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "VALIDATION_ERROR", resp.Error.Code,
+		"code must be VALIDATION_ERROR, not STORAGE_ERROR")
+	assert.Contains(t, resp.Error.Message, "docker.io",
+		"message must name the invalid resource so the client can diagnose without server logs")
+}
+
+// TestHandleUpdateStewardConfig_ValidConfig_Returns200 verifies that a well-formed
+// config upload succeeds (Issue #2482 — regression guard that the fix does not
+// accidentally block valid uploads).
+func TestHandleUpdateStewardConfig_ValidConfig_Returns200(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:write-config"}, "test-tenant", 5*time.Minute)
+
+	body := []byte(`
+steward:
+  id: test-steward-valid
+  mode: controller
+  logging:
+    level: info
+    format: text
+  error_handling:
+    module_load_failure: continue
+    resource_failure: warn
+    configuration_error: fail
+modules:
+  file: file
+resources:
+  - name: my-managed-file
+    module: file
+    config:
+      path: /tmp/managed
+      content: hello
+`)
+
+	req := httptest.NewRequest("PUT", "/api/v1/stewards/test-steward-valid/config", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/yaml")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"valid config must be accepted; body: %s", rec.Body.String())
+}

--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +24,26 @@ import (
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
+
+// ValidationFailedError is returned by SetConfiguration when the supplied
+// configuration fails pre-storage validation. The Errors slice contains only
+// config-derived validation failures (e.g. INVALID_RESOURCE_NAME) — infrastructure
+// errors such as TENANT_LOOKUP_ERROR are stripped before the error is constructed
+// and logged separately, so this type is safe to forward to the API caller.
+type ValidationFailedError struct {
+	Errors []config.ValidationError
+}
+
+func (e *ValidationFailedError) Error() string {
+	if len(e.Errors) == 0 {
+		return "configuration validation failed"
+	}
+	msgs := make([]string, len(e.Errors))
+	for i, ve := range e.Errors {
+		msgs[i] = fmt.Sprintf("%s: %s", ve.Field, ve.Message)
+	}
+	return "configuration validation failed: " + strings.Join(msgs, "; ")
+}
 
 // clusterRegistryAdapter adapts *ControllerService to the clusterMembership interface
 // expected by pkg/config.InheritanceResolver. It builds a fresh Registry snapshot on
@@ -314,11 +335,24 @@ func (s *ConfigurationServiceV2) SetConfiguration(ctx context.Context, tenantID,
 	// Validate configuration before storing
 	validationResult := s.validationManager.ValidateConfiguration(ctx, tenantID, stewardID, config)
 	if !validationResult.Valid {
-		var errorMessages []string
-		for _, err := range validationResult.Errors {
-			errorMessages = append(errorMessages, fmt.Sprintf("%s: %s", err.Field, err.Message))
+		// Separate config-derived errors (safe to return) from infrastructure errors.
+		// TENANT_LOOKUP_ERROR wraps a raw storage backend message that must not be
+		// forwarded to the caller; it is logged here instead.
+		vfe := &ValidationFailedError{}
+		for _, e := range validationResult.Errors {
+			if e.Code == "TENANT_LOOKUP_ERROR" {
+				s.logger.Error("Infrastructure error during configuration validation",
+					"tenant_id", logging.SanitizeLogValue(tenantID),
+					"steward_id", logging.SanitizeLogValue(stewardID),
+					"code", e.Code)
+				continue
+			}
+			vfe.Errors = append(vfe.Errors, e)
 		}
-		return fmt.Errorf("configuration validation failed: %v", errorMessages)
+		if len(vfe.Errors) > 0 {
+			return vfe
+		}
+		return fmt.Errorf("configuration validation failed: infrastructure error")
 	}
 
 	// Log validation warnings

--- a/features/controller/service/config_service_v2_validation_test.go
+++ b/features/controller/service/config_service_v2_validation_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Tests for ValidationFailedError formatting and the SetConfiguration
+// TENANT_LOOKUP_ERROR filtering logic (Issue #2482).
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/config"
+	"github.com/cfgis/cfgms/pkg/logging"
+	storageifaces "github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// tenantLookupFailureMessage is a distinctive raw backend error surfaced by
+// tenantLookupFailingStore. It must not contain "not found" so that
+// validateTenantContext classifies it as a real store error (TENANT_LOOKUP_ERROR)
+// rather than a benign absent-tenant condition. Tests assert this string never
+// reaches the caller-visible error.
+const tenantLookupFailureMessage = "tenant backend connection refused"
+
+// tenantLookupFailingStore is a real TenantStore whose GetTenant always returns a
+// non-not-found error, driving the validation layer to emit a TENANT_LOOKUP_ERROR.
+// Every other operation delegates to the embedded real store.
+type tenantLookupFailingStore struct {
+	business.TenantStore
+}
+
+func (s *tenantLookupFailingStore) GetTenant(context.Context, string) (*business.TenantData, error) {
+	return nil, errors.New(tenantLookupFailureMessage)
+}
+
+// newServiceWithFailingTenantLookup builds a ConfigurationServiceV2 whose tenant
+// store fails GetTenant with a raw backend error, without mocking: all stores are
+// real, only the tenant lookup is wrapped to force the infrastructure-error path.
+func newServiceWithFailingTenantLookup(t *testing.T) *ConfigurationServiceV2 {
+	t.Helper()
+	sm := pkgtesting.SetupTestStorage(t)
+	composite := storageifaces.NewStorageManagerFromStores(
+		sm.GetConfigStore(),
+		sm.GetAuditStore(),
+		sm.GetRBACStore(),
+		&tenantLookupFailingStore{TenantStore: sm.GetTenantStore()},
+		sm.GetClientTenantStore(),
+		sm.GetRegistrationTokenStore(),
+		sm.GetSessionStore(),
+		sm.GetStewardStore(),
+		sm.GetCommandStore(),
+		sm.GetTriggerStore(),
+		sm.GetPushStore(),
+	)
+	svc := NewConfigurationServiceV2(logging.NewNoopLogger(), composite, nil)
+	t.Cleanup(svc.Close)
+	return svc
+}
+
+// TestValidationFailedError_Error_WithErrors verifies the multi-error formatting
+// branch of ValidationFailedError.Error(): every field/message pair is joined into
+// the human-readable summary (Issue #2482).
+func TestValidationFailedError_Error_WithErrors(t *testing.T) {
+	vfe := &ValidationFailedError{
+		Errors: []config.ValidationError{
+			{Field: "resources[0].name", Message: "Invalid resource name format: docker.io", Code: "INVALID_RESOURCE_NAME"},
+			{Field: "resources[1].module", Message: "Module name is required", Code: "MISSING_MODULE_NAME"},
+		},
+	}
+
+	msg := vfe.Error()
+
+	assert.Equal(t,
+		"configuration validation failed: resources[0].name: Invalid resource name format: docker.io; resources[1].module: Module name is required",
+		msg)
+}
+
+// TestValidationFailedError_Error_Empty verifies the zero-errors branch of
+// ValidationFailedError.Error() returns the generic summary (Issue #2482).
+func TestValidationFailedError_Error_Empty(t *testing.T) {
+	vfe := &ValidationFailedError{}
+	assert.Equal(t, "configuration validation failed", vfe.Error())
+
+	vfeNilSlice := &ValidationFailedError{Errors: nil}
+	assert.Equal(t, "configuration validation failed", vfeNilSlice.Error())
+}
+
+// TestSetConfiguration_InfraOnlyError_ReturnsSentinel exercises SetConfiguration
+// branch (a): when the only validation error is a TENANT_LOOKUP_ERROR, the config
+// itself is valid, so vfe.Errors ends up empty and the function must return the
+// generic infrastructure-error sentinel — NOT a *ValidationFailedError — and must
+// not leak the raw tenant backend message to the caller (Issue #2482).
+func TestSetConfiguration_InfraOnlyError_ReturnsSentinel(t *testing.T) {
+	svc := newServiceWithFailingTenantLookup(t)
+	cfg := createTestStewardConfig("infra-only-steward")
+
+	err := svc.SetConfiguration(context.Background(), "some-tenant", "infra-only-steward", cfg)
+
+	require.Error(t, err)
+
+	var vfe *ValidationFailedError
+	assert.False(t, errors.As(err, &vfe),
+		"a purely-infrastructure failure must not surface as a *ValidationFailedError")
+
+	assert.Contains(t, err.Error(), "infrastructure error")
+	assert.NotContains(t, err.Error(), tenantLookupFailureMessage,
+		"raw tenant backend message must never reach the caller")
+}
+
+// TestSetConfiguration_MixedErrors_StripsInfra exercises SetConfiguration branch
+// (b): when validation yields both a TENANT_LOOKUP_ERROR and a genuine
+// config-derived error, the returned error must be a *ValidationFailedError that
+// contains only the config-derived error(s) with the infrastructure entry stripped
+// and its raw backend message absent from the caller-visible output (Issue #2482).
+func TestSetConfiguration_MixedErrors_StripsInfra(t *testing.T) {
+	svc := newServiceWithFailingTenantLookup(t)
+
+	// Duplicate resource names pass individual name-format validation but trigger a
+	// DUPLICATE_RESOURCE_NAME config-derived error at the service layer.
+	cfg := createTestStewardConfig("mixed-error-steward")
+	cfg.Resources[1].Name = cfg.Resources[0].Name
+
+	err := svc.SetConfiguration(context.Background(), "some-tenant", "mixed-error-steward", cfg)
+
+	require.Error(t, err)
+
+	var vfe *ValidationFailedError
+	require.True(t, errors.As(err, &vfe),
+		"a config-derived validation error must surface as a *ValidationFailedError")
+
+	require.NotEmpty(t, vfe.Errors)
+	for _, ve := range vfe.Errors {
+		assert.NotEqual(t, "TENANT_LOOKUP_ERROR", ve.Code,
+			"infrastructure error code must be stripped from the caller-visible error")
+	}
+
+	foundDuplicate := false
+	for _, ve := range vfe.Errors {
+		if ve.Code == "DUPLICATE_RESOURCE_NAME" {
+			foundDuplicate = true
+		}
+	}
+	assert.True(t, foundDuplicate, "config-derived DUPLICATE_RESOURCE_NAME must be preserved")
+
+	assert.NotContains(t, err.Error(), tenantLookupFailureMessage,
+		"raw tenant backend message must never reach the caller")
+}


### PR DESCRIPTION
## Summary

- `PUT /api/v1/stewards/{id}/config` now returns **HTTP 400 VALIDATION_ERROR** with field-level detail when submitted config is invalid (e.g. resource name `docker.io` containing a dot), instead of HTTP 500 STORAGE_ERROR
- Adds `ValidationFailedError` sentinel type in the service layer so `SetConfiguration` can signal config-derived failures distinctly from real storage errors — `errors.As` routing in the handler maps them to 400 vs. 500 respectively
- Infrastructure error codes (`TENANT_LOOKUP_ERROR`) are stripped before the error reaches the client and logged server-side, preventing storage backend path disclosure
- Handler-level resource name pre-check provides an early 400 exit before any storage path is reached

## Test plan

- [ ] `TestHandleUpdateStewardConfig_InvalidResourceName_Returns400` — invalid resource name (`docker.io`) → 400 VALIDATION_ERROR with message containing the offending name
- [ ] `TestHandleUpdateStewardConfig_ValidConfig_Returns200` — well-formed config → 200 OK
- [ ] `make test-agent-complete` — all CI-equivalent checks pass (validated twice by story-review workflow)
- [ ] Real storage errors still surface as 500 STORAGE_ERROR (no regression on the error path)

Fixes #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)