### PR TITLE
steward: create durable log dir in linuxManager.Install (Issue #2483)

### DIFF
--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cfgis/cfgms/pkg/version"
@@ -33,6 +35,12 @@ const (
 	linuxSystemdUnit = "/etc/systemd/system/cfgms-steward.service"
 	linuxServiceName = "cfgms-steward"
 	linuxCACertPath  = "/etc/cfgms/controller-ca.crt"
+	// linuxLogDir is the platform-conventional log directory for the CFGMS steward.
+	// CFGMS_INSTALL_PREFIX is respected for test isolation (see platformLogDir).
+	linuxLogDir = "/var/log/cfgms"
+	// linuxServiceUser is the OS user that owns the log directory, matching the
+	// user created by tier1-bootstrap.sh.
+	linuxServiceUser = "cfgms"
 )
 
 // platformCACertPath returns the path where the CA cert is written, respecting
@@ -42,6 +50,48 @@ func platformCACertPath() string {
 		return filepath.Join(prefix, linuxCACertPath)
 	}
 	return linuxCACertPath
+}
+
+// platformLogDir returns the steward log directory, respecting CFGMS_INSTALL_PREFIX
+// for test isolation.
+func platformLogDir() string {
+	if prefix := os.Getenv("CFGMS_INSTALL_PREFIX"); prefix != "" {
+		return filepath.Join(prefix, linuxLogDir)
+	}
+	return linuxLogDir
+}
+
+// serviceUserIDs looks up the OS user by name and returns its uid and gid.
+func serviceUserIDs(name string) (uid, gid int, err error) {
+	u, err := user.Lookup(name)
+	if err != nil {
+		return 0, 0, fmt.Errorf("service user %q not found: %w", name, err)
+	}
+	uid64, err := strconv.ParseInt(u.Uid, 10, 0)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid uid %q for user %q: %w", u.Uid, name, err)
+	}
+	gid64, err := strconv.ParseInt(u.Gid, 10, 0)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid gid %q for user %q: %w", u.Gid, name, err)
+	}
+	return int(uid64), int(gid64), nil
+}
+
+// createLogDir creates dir with mode 0750 and ownership uid:gid. Idempotent:
+// if the directory already exists the mode and ownership are still applied.
+func createLogDir(dir string, uid, gid int) error {
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("failed to create log directory %s: %w", dir, err)
+	}
+	// Chmod explicitly to enforce 0750 regardless of process umask.
+	if err := os.Chmod(dir, 0750); err != nil {
+		return fmt.Errorf("failed to set permissions on log directory %s: %w", dir, err)
+	}
+	if err := os.Chown(dir, uid, gid); err != nil {
+		return fmt.Errorf("failed to set ownership of log directory %s: %w", dir, err)
+	}
+	return nil
 }
 
 func newManager(binaryPath string) Manager {
@@ -110,6 +160,19 @@ func (m *linuxManager) Install(token, controllerURL, caCertPEM, expectedFingerpr
 	fmt.Printf("Staging steward %s under %s...\n", ver, linuxLauncherRoot)
 	if out, err := exec.Command(linuxLauncherPath, "swap", "--root", linuxLauncherRoot, ver, m.binaryPath).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to stage steward binary via launcher: %w\n%s", err, out)
+	}
+
+	// Create the log directory before registering the service. The systemd unit
+	// sets CFGMS_LOG_DIR=/var/log/cfgms; the directory must exist when the service
+	// starts or the steward falls back to the ephemeral /tmp/cfgms path (Issue #2483).
+	uid, gid, err := serviceUserIDs(linuxServiceUser)
+	if err != nil {
+		return fmt.Errorf("service user lookup: %w — create the %q OS user before running install", err, linuxServiceUser)
+	}
+	logDir := platformLogDir()
+	fmt.Printf("Creating log directory %s...\n", logDir)
+	if err := createLogDir(logDir, uid, gid); err != nil {
+		return fmt.Errorf("failed to prepare log directory: %w", err)
 	}
 
 	// Write CA cert before registering the service so the service finds it on first start.

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -7,8 +7,10 @@ package service
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -176,4 +178,80 @@ func TestGenerateSystemdUnitSetsLogDir(t *testing.T) {
 	unit := generateSystemdUnit("tok_test", "")
 	assert.Contains(t, unit, "Environment=CFGMS_LOG_DIR=/var/log/cfgms",
 		"systemd unit must set the platform-conventional log directory")
+}
+
+// TestLinuxInstallCreatesLogDir is the required acceptance test for Issue #2483:
+// cfgms-steward install must create /var/log/cfgms (mode 0750, owned by the service
+// user) before writing and starting the systemd unit. createLogDir is exercised
+// directly here because the full Install path requires root and a launcher binary;
+// the directory-creation logic is self-contained and this is the pattern used by
+// the analogous TestLinuxInstallCACertWritten.
+func TestLinuxInstallCreatesLogDir(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "var", "log", "cfgms")
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+
+	require.NoError(t, createLogDir(logDir, uid, gid))
+
+	info, err := os.Stat(logDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir(), "log path must be a directory")
+	assert.Equal(t, os.FileMode(0750), info.Mode().Perm(),
+		"log directory must have mode 0750 (owner rwx, group rx, no world access)")
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "expected *syscall.Stat_t from FileInfo.Sys()")
+	assert.Equal(t, uint32(uid), stat.Uid, "log directory must be owned by the service user uid")
+	assert.Equal(t, uint32(gid), stat.Gid, "log directory must be owned by the service group gid")
+}
+
+// TestLinuxInstallCreatesLogDirIdempotent verifies that createLogDir corrects the
+// directory mode even when the directory already exists with wrong permissions.
+func TestLinuxInstallCreatesLogDirIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "var", "log", "cfgms")
+	require.NoError(t, os.MkdirAll(logDir, 0777))
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+	require.NoError(t, createLogDir(logDir, uid, gid))
+
+	info, err := os.Stat(logDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0750), info.Mode().Perm(),
+		"createLogDir must enforce mode 0750 even when directory already exists")
+}
+
+// TestPlatformLogDirPrefix verifies that platformLogDir respects CFGMS_INSTALL_PREFIX
+// for test isolation, mirroring the platformCACertPath pattern.
+func TestPlatformLogDirPrefix(t *testing.T) {
+	prefix := t.TempDir()
+	t.Setenv("CFGMS_INSTALL_PREFIX", prefix)
+	assert.Equal(t, filepath.Join(prefix, linuxLogDir), platformLogDir())
+}
+
+func TestPlatformLogDirNoPrefix(t *testing.T) {
+	t.Setenv("CFGMS_INSTALL_PREFIX", "")
+	assert.Equal(t, linuxLogDir, platformLogDir())
+}
+
+// TestServiceUserIDs verifies that serviceUserIDs returns the correct uid/gid.
+// Uses the current process user (always exists) rather than the cfgms service user
+// which may not be present in test environments.
+func TestServiceUserIDs(t *testing.T) {
+	cur, err := user.Current()
+	require.NoError(t, err)
+
+	uid, gid, err := serviceUserIDs(cur.Username)
+	require.NoError(t, err)
+	assert.Equal(t, os.Getuid(), uid)
+	assert.Equal(t, os.Getgid(), gid)
+}
+
+func TestServiceUserIDsNotFound(t *testing.T) {
+	_, _, err := serviceUserIDs("cfgms-nonexistent-test-user-xyzzy")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -589,7 +589,14 @@ func newTestWorkflowHandlerAndEngine(t *testing.T) (*WorkflowHandler, cfgconfig.
 
 // createAndExecuteWorkflow is a test helper that creates a workflow then executes it,
 // returning the execution ID. Uses the provided router and tenant ID.
-func createAndExecuteWorkflow(t *testing.T, router *mux.Router, wfName, tenantID string, longRunning bool) string {
+//
+// For long-running (delay-step) workflows the async execution goroutine would
+// otherwise remain parked in the engine's delay step for the full delay duration
+// after the test returns, because the httptest request context is never cancelled.
+// A t.Cleanup cancels the execution so its goroutine unwinds promptly at test end
+// instead of leaking (which previously showed up as goroutines stuck in
+// executeDelayStep and added scheduler pressure to the rest of the package).
+func createAndExecuteWorkflow(t *testing.T, router *mux.Router, eng *workflow.Engine, wfName, tenantID string, longRunning bool) string {
 	t.Helper()
 
 	// Create workflow
@@ -628,6 +635,13 @@ func createAndExecuteWorkflow(t *testing.T, router *mux.Router, wfName, tenantID
 	require.NoError(t, json.Unmarshal(execRec.Body.Bytes(), &execResp))
 	execID, ok := execResp["execution_id"].(string)
 	require.True(t, ok && execID != "", "execution_id must be non-empty")
+
+	// Ensure the async execution goroutine is torn down when the test ends so a
+	// long delay step cannot outlive the test. Cancelling an already-terminal
+	// execution is a no-op.
+	if eng != nil {
+		t.Cleanup(func() { _ = eng.CancelExecution(execID) })
+	}
 	return execID
 }
 
@@ -649,11 +663,11 @@ func TestWorkflowHandler_CancelExecution_UnknownExecID_Returns404(t *testing.T) 
 }
 
 func TestWorkflowHandler_CancelExecution_RunningExecution_Returns200(t *testing.T) {
-	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
 	router := newWorkflowRouter(h)
 
 	// Use a long-running delay step so the execution stays non-terminal.
-	execID := createAndExecuteWorkflow(t, router, "long-wf", "test-tenant", true)
+	execID := createAndExecuteWorkflow(t, router, engine, "long-wf", "test-tenant", true)
 
 	req := httptest.NewRequest("POST", "/workflows/long-wf/executions/"+execID+"/cancel", nil)
 	req = withTenantContext(req, "test-tenant")
@@ -695,7 +709,7 @@ func TestWorkflowHandler_CancelExecution_TerminalExecution_Returns409(t *testing
 	router := newWorkflowRouter(h)
 
 	// Task step with no module name fails immediately → terminal state reached quickly.
-	execID := createAndExecuteWorkflow(t, router, "quick-wf", "test-tenant", false)
+	execID := createAndExecuteWorkflow(t, router, engine, "quick-wf", "test-tenant", false)
 	waitForTerminalState(t, engine, execID)
 
 	req := httptest.NewRequest("POST", "/workflows/quick-wf/executions/"+execID+"/cancel", nil)
@@ -710,11 +724,11 @@ func TestWorkflowHandler_CancelExecution_TerminalExecution_Returns409(t *testing
 }
 
 func TestWorkflowHandler_CancelExecution_CrossTenant_Returns403(t *testing.T) {
-	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
 	router := newWorkflowRouter(h)
 
 	// Create and execute the workflow in tenant A with a long delay so it stays non-terminal.
-	execID := createAndExecuteWorkflow(t, router, "xsec-cancel-wf", "tenant-a", true)
+	execID := createAndExecuteWorkflow(t, router, engine, "xsec-cancel-wf", "tenant-a", true)
 
 	// Tenant B tries to cancel tenant A's execution. tenant-b has no workflow
 	// named "xsec-cancel-wf" in its config namespace → 403.
@@ -729,10 +743,10 @@ func TestWorkflowHandler_CancelExecution_CrossTenant_Returns403(t *testing.T) {
 // --- get execution ------------------------------------------------------------
 
 func TestWorkflowHandler_GetExecution_CorrectRecord_Returns200(t *testing.T) {
-	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
 	router := newWorkflowRouter(h)
 
-	execID := createAndExecuteWorkflow(t, router, "get-exec-wf", "test-tenant", true)
+	execID := createAndExecuteWorkflow(t, router, engine, "get-exec-wf", "test-tenant", true)
 
 	req := httptest.NewRequest("GET", "/workflows/get-exec-wf/executions/"+execID, nil)
 	req = withTenantContext(req, "test-tenant")
@@ -748,11 +762,11 @@ func TestWorkflowHandler_GetExecution_CorrectRecord_Returns200(t *testing.T) {
 }
 
 func TestWorkflowHandler_GetExecution_CrossTenant_Returns403(t *testing.T) {
-	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
 	router := newWorkflowRouter(h)
 
 	// Create and execute the workflow in tenant A.
-	execID := createAndExecuteWorkflow(t, router, "xsec-wf", "tenant-a", true)
+	execID := createAndExecuteWorkflow(t, router, engine, "xsec-wf", "tenant-a", true)
 
 	// Tenant B tries to access tenant A's execution.
 	// tenant-b has no workflow named "xsec-wf" → 403.

--- a/features/workflow/engine_http.go
+++ b/features/workflow/engine_http.go
@@ -130,11 +130,21 @@ func (e *Engine) executeDelayStep(ctx context.Context, step Step, execution *Wor
 		"duration", step.Delay.Duration,
 		"message", message)
 
-	// Wait for the specified duration or context cancellation
+	// Wait for the specified duration or context cancellation.
+	//
+	// Use an explicit timer (stopped on return) rather than time.After: time.After
+	// leaks its underlying timer and goroutine until the full duration elapses even
+	// when the context is cancelled first. For long delays cancelled early (e.g. a
+	// cancelled or abandoned execution) that leak keeps a goroutine parked in this
+	// select for the whole duration, which surfaces as "stuck in executeDelayStep"
+	// goroutines in dumps. Stopping the timer releases it immediately on cancellation.
+	timer := time.NewTimer(step.Delay.Duration)
+	defer timer.Stop()
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(step.Delay.Duration):
+	case <-timer.C:
 		// Delay completed successfully
 	}
 


### PR DESCRIPTION
## Summary

- `linuxManager.Install()` now creates `/var/log/cfgms` (mode 0750, owned by the `cfgms` service user) before writing or activating the systemd unit, making the install path self-sufficient without requiring `tier1-bootstrap.sh` to have run first.
- Three new helpers (`platformLogDir`, `serviceUserIDs`, `createLogDir`) follow the established `platformCACertPath` pattern, with `CFGMS_INSTALL_PREFIX` support for test isolation.
- Bundled: fixes a pre-existing goroutine leak in `features/workflow/engine_http.go` (timer not stopped on context cancellation) and leaked test executions in `features/controller/api/handlers_workflows_test.go` that were causing the `features/controller/api` test package to hit its 5-minute timeout.

Fixes #2483

## Specialist Review Results

| Lens | Verdict |
|------|---------|
| Code review | PASS (warning: controllerURL injection — pre-existing, out of scope) |
| Test quality | PASS (warning: idempotent test could also assert ownership — informational) |
| Security | PASS |

story-review workflow: **passed: true**, 2 review rounds, 1 fix round (goroutine leak), 0 remaining findings.

## Test plan

- [x] `go test ./cmd/steward/service/...` — all 26 tests pass including new `TestLinuxInstallCreatesLogDir`, `TestLinuxInstallCreatesLogDirIdempotent`, `TestPlatformLogDirPrefix/NoPrefix`, `TestServiceUserIDs/NotFound`
- [x] `TestGenerateSystemdUnitSetsLogDir` (Issue #2378, unchanged) still passes
- [x] `make test` passes (goroutine leak fix resolves `features/controller/api` 5m timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)