### PR TITLE
api: add web login/logout with pre-session CSRF, lockout, and audit (Issue #2493)

### DIFF
--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -191,15 +191,90 @@ cookie is ignored entirely — not validated, not renewed, no `Set-Cookie` emitt
 ensures existing Bearer/API-key/mTLS clients are byte-identical before and after the
 cookie branch.
 
-**Visibility note (security A5.7):** the `webSessionManager` sessions are not listed or
-revocable via `GET /api/v1/sessions` or `DELETE /api/v1/sessions/{id}` at this merge
-point (#2492). Those endpoints operate on the `sessionManager` (cfg-CLI sessions). The
-`GET /api/v1/sessions` semantics for web sessions are deferred to #2493/#2494 when
-login/logout endpoints are added.
+**Visibility note (security A5.7):** web session tokens are not listed via
+`GET /api/v1/sessions` or revocable via `DELETE /api/v1/sessions/{id}` — those
+endpoints operate on the `cfg`-CLI `sessionManager` only. Web sessions are revoked
+server-side via `POST /api/v1/web/logout`.
 
 **CORS note (security A5.8):** the `corsMiddleware` never sets
 `Access-Control-Allow-Credentials: true`. Web session cookies are same-origin only;
 credentialed cross-origin requests are not supported and must never be enabled.
+
+### Web Login / CSRF / Lockout / Logout (Issue #2493, ADR-018 §3,4)
+
+#### Login flow
+
+```
+GET  /api/v1/web/csrf   → Set-Cookie: cfgms_csrf_pre=<token>; Secure; SameSite=Strict; Max-Age=600
+POST /api/v1/web/login  (X-CSRF-Token: <token>)
+     → Set-Cookie: cfgms_session=...; HttpOnly; Secure; SameSite=Strict; Path=/
+     → Set-Cookie: cfgms_csrf=...; Secure; SameSite=Strict; Path=/   (non-HttpOnly)
+```
+
+1. **Pre-session CSRF gate (ADR-018 §3):** `GET /api/v1/web/csrf` issues a 32-byte
+   `crypto/rand` token in `cfgms_csrf_pre` (Secure; SameSite=Strict; Max-Age=600s).
+   The browser echoes it as `X-CSRF-Token` on the login POST. The server compares
+   cookie value to header value with `subtle.ConstantTimeCompare`. Mismatch or
+   absence → 403 before any credential work.
+
+2. **Session fixation defence:** any valid `cfgms_session` cookie presented with the
+   login request is revoked server-side before the new session is issued.
+
+3. **Per-account lockout (ADR-018 §3 / #2490):** 5 consecutive verification failures
+   lock the account for 15 minutes. Locked accounts receive the identical uniform 401
+   as wrong-password (timing-equalized via dummy argon2id hash). The counter resets on
+   a successful login.
+
+4. **Credential verification:** `VerifyWebCredential` — bad user, bad password, and
+   malformed input all return the same `ErrInvalidWebCredential` with equivalent latency.
+
+5. **Fresh session:** `webSessionManager.Issue` mints a new token (32 random bytes,
+   base64url). The raw token is set in `cfgms_session` (HttpOnly) and never logged.
+
+6. **Session-bound CSRF token:** a second 32-byte `crypto/rand` value is generated,
+   stored server-side keyed by session ID, and written to `cfgms_csrf` (non-HttpOnly
+   so the SPA can read it and set `X-CSRF-Token` on subsequent mutations).
+
+7. **Response body:** always `{"ok": true}` — no token is ever included (security A5.5).
+
+#### Session-bound CSRF middleware
+
+All **unsafe cookie-authenticated** requests (POST/PUT/PATCH/DELETE on the api subrouter)
+pass through `csrfMiddleware` (applied after `authenticationMiddleware`):
+
+- Safe methods (GET, HEAD) are exempt.
+- Bearer-token, API-key, and mTLS requests are **never** CSRF-checked — only
+  cookie-authenticated requests are in scope.
+- The `X-CSRF-Token` header is compared to the server-side session-bound token
+  (`subtle.ConstantTimeCompare`). Mismatch or absence → 403.
+- Invariant: at any merge point no unsafe cookie-authenticated method is reachable
+  without this protection.
+
+The three endpoints on the **base router** (`/api/v1/web/csrf`, `/api/v1/web/login`,
+`/api/v1/web/logout`) are explicitly wrapped in `s.authDefense.Middleware` because the
+api subrouter middleware chain does not apply to base-router routes (security A5.4).
+
+#### Logout
+
+`POST /api/v1/web/logout` is CSRF-checked (session-bound token required). On success:
+- Revokes the server-side session (subsequent cookie use → 401).
+- Removes the server-side CSRF token for the session.
+- Expires both `cfgms_session` and `cfgms_csrf` cookies (`Max-Age=0`).
+
+#### Audit events
+
+Every login attempt and logout emits a structured `AuditEventAuthentication` event:
+
+| Event | Action | Result |
+|-------|--------|--------|
+| Login success | `web.login.success` | `success` |
+| Login failure (bad credentials) | `web.login.failure` | `failure` |
+| Login blocked (account locked) | `web.login.lockout` | `denied` |
+| Logout | `web.logout` | `success` |
+
+Audit payloads carry sanitized username, tenant, outcome. Credential material
+(passwords, tokens, hashes) is never included. All log lines use
+`logging.SanitizeLogValue` for any request-derived field.
 
 ### Role-Based Access Control (RBAC)
 

--- a/features/controller/api/handlers_web_session.go
+++ b/features/controller/api/handlers_web_session.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Issue #2493: web login/logout endpoints with pre-session CSRF, lockout, and audit
+// (ADR-018 §3, §4).
+//
+// Three endpoints registered on the base router (TierPublic) with explicit
+// authDefense.Middleware wrapping (security A5.4):
+//
+//	GET  /api/v1/web/csrf   — issues the ADR-018 §3 pre-session CSRF cookie
+//	POST /api/v1/web/login  — CSRF-checked, lockout-gated, credential-verified; mints session
+//	POST /api/v1/web/logout — session-CSRF-checked; server-side revocation + cookie clearing
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Cookie and header names for the web-session CSRF mechanism (ADR-018 §3).
+const (
+	cookieWebSession  = "cfgms_session"  // HttpOnly; set on login, cleared on logout
+	cookieCSRFSession = "cfgms_csrf"     // session-bound; non-HttpOnly so JS can read it
+	cookieCSRFPre     = "cfgms_csrf_pre" // pre-session; single-use, gates the login POST
+	headerCSRFToken   = "X-CSRF-Token"
+	preCSRFMaxAge     = 10 * 60 // 10 minutes TTL for the pre-session CSRF cookie
+)
+
+// webLoginRequest is the POST /api/v1/web/login body.
+type webLoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// generateCSRFToken returns 32 crypto/rand bytes encoded as base64url without padding.
+func generateCSRFToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// handleGetWebCSRF handles GET /api/v1/web/csrf (ADR-018 §3).
+// Issues a short-lived pre-session CSRF token in a Secure;SameSite=Strict cookie.
+// The browser echoes this value as X-CSRF-Token on the login POST (double-submit pattern).
+// Safe method; no authentication required.
+func (s *Server) handleGetWebCSRF(w http.ResponseWriter, r *http.Request) {
+	tok, err := generateCSRFToken()
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to generate CSRF token", "CSRF_GEN_ERROR")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieCSRFPre,
+		Value:    tok,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
+		MaxAge:   preCSRFMaxAge,
+	})
+	s.writeSuccessResponse(w, map[string]interface{}{"ok": true})
+}
+
+// handleWebLogin handles POST /api/v1/web/login (ADR-018 §3, §4).
+//
+// Sequence enforced in order:
+//  1. webSessionManager availability check → 503
+//  2. Pre-session CSRF double-submit: cfgms_csrf_pre cookie == X-CSRF-Token header → 403 on mismatch
+//  3. Parse credentials from request body
+//  4. Revoke any valid existing cfgms_session (session-fixation defence)
+//  5. Lockout gate: account locked → uniform 401 (timing-equalized via dummy argon2id)
+//  6. VerifyWebCredential → uniform 401 on any failure (bad user, bad password)
+//  7. Issue FRESH session via webSessionManager.Issue
+//  8. Generate per-session CSRF token (crypto/rand), store server-side in csrfTokens
+//  9. Set cfgms_session (HttpOnly) and cfgms_csrf (non-HttpOnly) cookies; clear cfgms_csrf_pre
+//  10. Emit sanitized audit event; response body never contains any token (security A5.5)
+func (s *Server) handleWebLogin(w http.ResponseWriter, r *http.Request) {
+	if s.webSessionManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Web session management not available", "SESSION_UNAVAILABLE")
+		return
+	}
+
+	// Step 2: pre-session CSRF double-submit check.
+	// Absent or mismatched → 403 (before any credential work).
+	preCSRFCookie, err := r.Cookie(cookieCSRFPre)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusForbidden, "CSRF token required", "CSRF_REQUIRED")
+		return
+	}
+	csrfHeader := r.Header.Get(headerCSRFToken)
+	if csrfHeader == "" || subtle.ConstantTimeCompare([]byte(preCSRFCookie.Value), []byte(csrfHeader)) != 1 {
+		s.writeErrorResponse(w, http.StatusForbidden, "CSRF token mismatch", "CSRF_MISMATCH")
+		return
+	}
+
+	// Step 3: parse credentials.
+	var req webLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid JSON body", "INVALID_JSON")
+		return
+	}
+
+	// Step 4: revoke any existing session (session-fixation defence).
+	// A pre-login cfgms_session value must never be valid post-login.
+	if existing, cookieErr := r.Cookie(cookieWebSession); cookieErr == nil {
+		if existSess, valErr := s.webSessionManager.Validate(r.Context(), existing.Value); valErr == nil {
+			if revErr := s.webSessionManager.Revoke(r.Context(), existSess.ID); revErr != nil {
+				// Session-fixation defence failure: the pre-login session may remain
+				// valid alongside the session we are about to issue. Must be observable.
+				s.logger.Warn("Web login: failed to revoke pre-login session (fixation defence)",
+					"session_id", logging.SanitizeLogValue(existSess.ID),
+					"error", logging.SanitizeLogValue(revErr.Error()))
+			}
+			s.csrfTokens.Delete(existSess.ID)
+		}
+	}
+
+	// Step 5: lockout gate (enforcement owner: #2493; state owner: #2490).
+	// A locked account returns the identical 401 as wrong-password (no disclosure).
+	// Timing equalisation: burn a dummy argon2id derivation so the locked path
+	// has the same latency as the wrong-password path.
+	if locked, _ := s.webAccountLocked(req.Username); locked {
+		_, _ = verifyWebPassword(req.Password, dummyWebAccountHash())
+		s.emitWebLoginAudit(r.Context(), req.Username, "", "web.login.lockout", business.AuditResultDenied)
+		s.logger.Warn("Web login blocked: account locked",
+			"username", logging.SanitizeLogValue(req.Username),
+			"remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Invalid credentials", "INVALID_CREDENTIALS")
+		return
+	}
+
+	// Step 6: verify credentials.
+	// ErrInvalidWebCredential is the uniform error for bad-user, bad-password, and
+	// malformed-input (ADR-018 §3 / #2490 uniformity contract).
+	principalID, tenantID, _, verErr := s.VerifyWebCredential(r.Context(), req.Username, req.Password)
+	if verErr != nil {
+		if errors.Is(verErr, ErrInvalidWebCredential) {
+			s.emitWebLoginAudit(r.Context(), req.Username, "", "web.login.failure", business.AuditResultFailure)
+			s.logger.Warn("Web login failed",
+				"username", logging.SanitizeLogValue(req.Username),
+				"remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
+		} else {
+			s.logger.Error("Web login: credential verification error",
+				"username", logging.SanitizeLogValue(req.Username),
+				"error", logging.SanitizeLogValue(verErr.Error()))
+		}
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Invalid credentials", "INVALID_CREDENTIALS")
+		return
+	}
+
+	// Step 7: issue FRESH session.
+	sess, token, issueErr := s.webSessionManager.Issue(r.Context(), principalID, "web-login", tenantID)
+	if issueErr != nil {
+		s.logger.Error("Web login: failed to issue session",
+			"principal_id", logging.SanitizeLogValue(principalID),
+			"error", issueErr)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create session", "SESSION_ERROR")
+		return
+	}
+
+	// Step 8: generate per-session CSRF token and store server-side (security A5.3).
+	csrfToken, genErr := generateCSRFToken()
+	if genErr != nil {
+		// Roll back the freshly issued session. If revocation also fails the session
+		// is orphaned in the store (client gets 500 but the token persists), so the
+		// rollback failure must be logged to make the orphan detectable.
+		if revErr := s.webSessionManager.Revoke(r.Context(), sess.ID); revErr != nil {
+			s.logger.Error("Web login: failed to roll back session after CSRF generation failure (orphaned session)",
+				"session_id", logging.SanitizeLogValue(sess.ID),
+				"error", logging.SanitizeLogValue(revErr.Error()))
+		}
+		s.logger.Error("Web login: failed to generate CSRF token", "error", genErr)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to generate CSRF token", "CSRF_GEN_ERROR")
+		return
+	}
+	s.csrfTokens.Store(sess.ID, csrfToken)
+
+	// Step 9: set cookies (security A5.1).
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieWebSession,
+		Value:    token,
+		HttpOnly: true, // token unreadable by JS
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieCSRFSession,
+		Value:    csrfToken,
+		HttpOnly: false, // non-HttpOnly by design: JS reads this to set X-CSRF-Token header
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
+	})
+	// Clear the pre-session CSRF cookie — single-use.
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieCSRFPre,
+		Value:    "",
+		MaxAge:   -1,
+		Path:     "/",
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	// Step 10: audit and respond. Token is never written to the body (security A5.5).
+	s.emitWebLoginAudit(r.Context(), req.Username, tenantID, "web.login.success", business.AuditResultSuccess)
+	s.logger.Info("Web login success",
+		"username", logging.SanitizeLogValue(req.Username),
+		"principal_id", logging.SanitizeLogValue(principalID),
+		"tenant_id", logging.SanitizeLogValue(tenantID),
+		"session_id", logging.SanitizeLogValue(sess.ID),
+		"remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
+
+	s.writeSuccessResponse(w, map[string]interface{}{"ok": true})
+}
+
+// handleWebLogout handles POST /api/v1/web/logout (ADR-018 §4).
+// CSRF-checked (session-bound X-CSRF-Token required). Revokes the server-side
+// session so subsequent cookie use returns 401. Always clears both cookies.
+func (s *Server) handleWebLogout(w http.ResponseWriter, r *http.Request) {
+	if s.webSessionManager == nil {
+		clearWebSessionCookies(w)
+		s.writeSuccessResponse(w, map[string]interface{}{"ok": true})
+		return
+	}
+
+	// Read session cookie — no cookie means nothing to revoke.
+	sessionCookie, cookieErr := r.Cookie(cookieWebSession)
+	if cookieErr != nil {
+		clearWebSessionCookies(w)
+		s.writeSuccessResponse(w, map[string]interface{}{"ok": true})
+		return
+	}
+
+	// Validate the session.
+	sess, valErr := s.webSessionManager.Validate(r.Context(), sessionCookie.Value)
+	if valErr != nil {
+		clearWebSessionCookies(w)
+		errCode := "SESSION_INVALID"
+		switch {
+		case errors.Is(valErr, session.ErrSessionRevoked):
+			errCode = "SESSION_REVOKED"
+		case errors.Is(valErr, session.ErrSessionExpired):
+			errCode = "SESSION_EXPIRED"
+		}
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Session expired or invalid", errCode)
+		return
+	}
+
+	// CSRF check: X-CSRF-Token header must match the session-bound server-side token.
+	csrfHeader := r.Header.Get(headerCSRFToken)
+	stored, _ := s.csrfTokens.Load(sess.ID)
+	storedStr, _ := stored.(string)
+	if csrfHeader == "" || storedStr == "" || subtle.ConstantTimeCompare([]byte(csrfHeader), []byte(storedStr)) != 1 {
+		s.writeErrorResponse(w, http.StatusForbidden, "CSRF token mismatch", "CSRF_MISMATCH")
+		return
+	}
+
+	// Revoke session and remove CSRF token entry.
+	if revErr := s.webSessionManager.Revoke(r.Context(), sess.ID); revErr != nil {
+		// Revocation failed: the server-side session persists and remains replayable
+		// by anyone who captured the token, even though we clear the client cookies.
+		// Must be observable so the security property violation is not silent.
+		s.logger.Warn("Web logout: failed to revoke session (session remains replayable)",
+			"session_id", logging.SanitizeLogValue(sess.ID),
+			"error", logging.SanitizeLogValue(revErr.Error()))
+	}
+	s.csrfTokens.Delete(sess.ID)
+
+	clearWebSessionCookies(w)
+
+	s.emitWebLoginAudit(r.Context(), sess.PrincipalID, sess.TenantID, "web.logout", business.AuditResultSuccess)
+	s.logger.Info("Web logout",
+		"principal_id", logging.SanitizeLogValue(sess.PrincipalID),
+		"session_id", logging.SanitizeLogValue(sess.ID),
+		"remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
+
+	s.writeSuccessResponse(w, map[string]interface{}{"ok": true})
+}
+
+// clearWebSessionCookies expires both the session and CSRF cookies (Max-Age=0).
+func clearWebSessionCookies(w http.ResponseWriter) {
+	for _, name := range []string{cookieWebSession, cookieCSRFSession} {
+		http.SetCookie(w, &http.Cookie{
+			Name:     name,
+			Value:    "",
+			MaxAge:   -1, // serialised as Max-Age=0 → delete
+			Path:     "/",
+			Secure:   true,
+			SameSite: http.SameSiteStrictMode,
+		})
+	}
+}
+
+// emitWebLoginAudit records a web-login lifecycle audit event.
+// Fields: sanitized username, tenant, outcome. Credential material is never included.
+// No-op when auditManager is nil.
+func (s *Server) emitWebLoginAudit(ctx context.Context, username, tenantID, action string, result business.AuditResult) {
+	if s.auditManager == nil {
+		return
+	}
+	if tenantID == "" {
+		tenantID = audit.SystemTenantID
+	}
+	b := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(business.AuditEventAuthentication).
+		Action(action).
+		User(logging.SanitizeLogValue(username), business.AuditUserTypeHuman).
+		Resource("web-session", logging.SanitizeLogValue(username), "").
+		Result(result).
+		Severity(business.AuditSeverityHigh)
+	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
+		s.logger.Warn("Failed to emit web login audit event",
+			"action", action,
+			"username", logging.SanitizeLogValue(username),
+			"error", logging.SanitizeLogValue(err.Error()))
+	}
+}

--- a/features/controller/api/handlers_web_session_test.go
+++ b/features/controller/api/handlers_web_session_test.go
@@ -1,0 +1,675 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Issue #2493: tests for web login/logout endpoints, pre-session CSRF, session-bound
+// CSRF middleware, per-account lockout, and sanitized audit events (ADR-018 §3,4).
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// --- helpers ---
+
+// setupWebSessionServer creates a server wired with both a web account and a web
+// session manager. The returned web account credentials can be used to drive login.
+func setupWebSessionServer(t *testing.T) (*Server, string, string) {
+	t.Helper()
+	srv := setupTestServer(t)
+
+	webCfg := session.Config{
+		IdleTimeout:     60 * time.Minute,
+		AbsoluteTimeout: 12 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	store := session.NewMemStore(webCfg, time.Now)
+	t.Cleanup(store.Close)
+	mgr := session.NewManager(webCfg, store, time.Now)
+	srv.SetWebSessionManager(mgr)
+
+	const (
+		username = "testuser"
+		password = "correcthorsebattery"
+	)
+
+	// Provision a web account via the handler (real argon2id hash).
+	admin := testAdminPrincipal()
+	rec := postWebAccount(t, srv, admin, WebAccountRequest{
+		Username:    username,
+		Password:    password,
+		TenantID:    "tenant-test",
+		Permissions: []string{"steward:list"},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, "account setup: %s", rec.Body.String())
+
+	return srv, username, password
+}
+
+// doCSRF calls GET /api/v1/web/csrf and returns the pre-session cookie value.
+func doCSRF(t *testing.T, srv *Server) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/web/csrf", nil)
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "GET /csrf body: %s", rec.Body.String())
+
+	var tok string
+	for _, c := range readSetCookies(t, rec) {
+		if c.Name == cookieCSRFPre {
+			tok = c.Value
+			break
+		}
+	}
+	require.NotEmpty(t, tok, "GET /csrf must set %s cookie", cookieCSRFPre)
+	return tok
+}
+
+// doLogin performs a login via the router and returns the recorder.
+func doLogin(t *testing.T, srv *Server, csrfToken, username, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doLoginWith(t, srv, csrfToken, username, password, "")
+}
+
+// doLoginWith performs a login and optionally presents an existing session cookie so the
+// session-fixation defence can revoke it (handleWebLogin step 4).
+func doLoginWith(t *testing.T, srv *Server, csrfToken, username, password, existingSessionTok string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/web/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerCSRFToken, csrfToken)
+	req.AddCookie(&http.Cookie{Name: cookieCSRFPre, Value: csrfToken})
+	if existingSessionTok != "" {
+		req.AddCookie(&http.Cookie{Name: cookieWebSession, Value: existingSessionTok})
+	}
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// extractCookies returns the named cookie value from the Set-Cookie response headers.
+func extractCookie(rec *httptest.ResponseRecorder, name string) string {
+	for _, c := range readSetCookies(nil, rec) {
+		if c.Name == name {
+			return c.Value
+		}
+	}
+	return ""
+}
+
+// readSetCookies parses Set-Cookie headers from the recorder response.
+func readSetCookies(t *testing.T, rec *httptest.ResponseRecorder) []*http.Cookie {
+	resp := &http.Response{Header: rec.Result().Header}
+	return resp.Cookies()
+}
+
+// doLogout sends POST /api/v1/web/logout with the session + CSRF cookies and header.
+func doLogout(t *testing.T, srv *Server, sessionTok, csrfTok string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/web/logout", nil)
+	req.Header.Set(headerCSRFToken, csrfTok)
+	req.AddCookie(&http.Cookie{Name: cookieWebSession, Value: sessionTok})
+	req.AddCookie(&http.Cookie{Name: cookieCSRFSession, Value: csrfTok})
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// --- tests ---
+
+// TestWebLogin_SuccessSetsBothCookies verifies that a correct login sets cfgms_session
+// (HttpOnly) and cfgms_csrf (non-HttpOnly), the body contains no token (security A5.5),
+// and the pre-session CSRF cookie is cleared.
+func TestWebLogin_SuccessSetsBothCookies(t *testing.T) {
+	srv, username, password := setupWebSessionServer(t)
+
+	csrfToken := doCSRF(t, srv)
+	rec := doLogin(t, srv, csrfToken, username, password)
+	require.Equal(t, http.StatusOK, rec.Code, "login body: %s", rec.Body.String())
+
+	cookies := readSetCookies(nil, rec)
+	cookieMap := make(map[string]*http.Cookie, len(cookies))
+	for _, c := range cookies {
+		cookieMap[c.Name] = c
+	}
+
+	// cfgms_session must be present and HttpOnly.
+	sess, ok := cookieMap[cookieWebSession]
+	require.True(t, ok, "cfgms_session cookie must be set")
+	assert.True(t, sess.HttpOnly, "cfgms_session must be HttpOnly")
+	assert.True(t, sess.Secure, "cfgms_session must be Secure")
+	assert.Equal(t, http.SameSiteStrictMode, sess.SameSite)
+	assert.NotEmpty(t, sess.Value)
+
+	// cfgms_csrf must be present and NOT HttpOnly (JS must be able to read it).
+	csrf, ok := cookieMap[cookieCSRFSession]
+	require.True(t, ok, "cfgms_csrf cookie must be set")
+	assert.False(t, csrf.HttpOnly, "cfgms_csrf must NOT be HttpOnly (JS reads it)")
+	assert.True(t, csrf.Secure)
+	assert.Equal(t, http.SameSiteStrictMode, csrf.SameSite)
+	assert.NotEmpty(t, csrf.Value)
+
+	// Pre-session CSRF cookie must be cleared (MaxAge ≤ 0 in Set-Cookie → browser deletes).
+	pre, ok := cookieMap[cookieCSRFPre]
+	assert.True(t, ok, "cfgms_csrf_pre should appear in response to be cleared")
+	if ok {
+		assert.LessOrEqual(t, pre.MaxAge, 0, "pre-session CSRF cookie must be cleared")
+	}
+
+	// Response body must not contain the session token (security A5.5).
+	body := rec.Body.String()
+	assert.NotContains(t, body, sess.Value, "response body must not contain the session token")
+	assert.NotContains(t, body, csrf.Value, "response body must not contain the CSRF token")
+}
+
+// TestWebLogin_UniformFailureResponse verifies that bad-password and unknown-user both
+// return the identical 401 status and INVALID_CREDENTIALS code (no enumeration).
+func TestWebLogin_UniformFailureResponse(t *testing.T) {
+	srv, username, _ := setupWebSessionServer(t)
+
+	check := func(t *testing.T, label, user, pass string) {
+		t.Helper()
+		csrfToken := doCSRF(t, srv)
+		rec := doLogin(t, srv, csrfToken, user, pass)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "%s: must be 401", label)
+		assert.Contains(t, rec.Body.String(), "INVALID_CREDENTIALS", "%s: code must be INVALID_CREDENTIALS", label)
+	}
+
+	check(t, "wrong-password", username, "wrong-password-xyz")
+	check(t, "unknown-user", "nobody-known", "anypassword")
+}
+
+// TestWebLogin_PreSessionCSRF_Required verifies that the login POST returns 403 when
+// the pre-session CSRF cookie is absent or the X-CSRF-Token header is missing/wrong.
+func TestWebLogin_PreSessionCSRF_Required(t *testing.T) {
+	srv, username, password := setupWebSessionServer(t)
+	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+
+	t.Run("no CSRF cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/login", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		// no cfgms_csrf_pre cookie, no X-CSRF-Token header
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "absent CSRF cookie must yield 403")
+		assert.Contains(t, rec.Body.String(), "CSRF")
+	})
+
+	t.Run("CSRF cookie but no header", func(t *testing.T) {
+		csrfToken := doCSRF(t, srv)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/login", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: cookieCSRFPre, Value: csrfToken})
+		// no X-CSRF-Token header
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "absent header must yield 403")
+	})
+
+	t.Run("CSRF cookie with mismatched header", func(t *testing.T) {
+		csrfToken := doCSRF(t, srv)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/login", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(headerCSRFToken, "tampered-value")
+		req.AddCookie(&http.Cookie{Name: cookieCSRFPre, Value: csrfToken})
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "mismatched CSRF must yield 403")
+	})
+
+	t.Run("CSRF check fires before credential verification", func(t *testing.T) {
+		// With correct credentials but missing CSRF, must get 403 not 200 or 401.
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/login", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		// No CSRF at all — should be rejected at the CSRF gate, not at credential verification.
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "CSRF must be checked before credentials")
+	})
+}
+
+// TestWebLogin_SessionFixation verifies that:
+// (a) Two successful logins produce distinct session tokens.
+// (b) A cfgms_session cookie value from before login is invalidated by the new login.
+func TestWebLogin_SessionFixation(t *testing.T) {
+	srv, username, password := setupWebSessionServer(t)
+
+	// First login.
+	csrf1 := doCSRF(t, srv)
+	rec1 := doLogin(t, srv, csrf1, username, password)
+	require.Equal(t, http.StatusOK, rec1.Code)
+	tok1 := extractCookie(rec1, cookieWebSession)
+	require.NotEmpty(t, tok1, "first login must set cfgms_session")
+
+	// Second login — must mint a new token and revoke tok1 (session-fixation defence).
+	csrf2 := doCSRF(t, srv)
+	rec2 := doLoginWith(t, srv, csrf2, username, password, tok1)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	tok2 := extractCookie(rec2, cookieWebSession)
+	require.NotEmpty(t, tok2, "second login must set cfgms_session")
+
+	assert.NotEqual(t, tok1, tok2, "two logins must produce distinct tokens")
+
+	// The first token must have been revoked (session fixation defence).
+	srv.mu.RLock()
+	mgr := srv.webSessionManager
+	srv.mu.RUnlock()
+	_, err := mgr.Validate(context.Background(), tok1)
+	assert.Error(t, err, "pre-login token must be invalidated by subsequent login")
+}
+
+// TestWebLogin_Lockout verifies that 5 consecutive failures lock the account and
+// subsequent attempts (including the 6th) return the uniform 401. A successful
+// login after the lockout expires resets the counter.
+func TestWebLogin_Lockout(t *testing.T) {
+	srv, username, password := setupWebSessionServer(t)
+
+	// Drain 5 consecutive failures to trigger lockout.
+	for i := 0; i < 5; i++ {
+		csrfToken := doCSRF(t, srv)
+		rec := doLogin(t, srv, csrfToken, username, "wrong-password")
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "failure %d must be 401", i+1)
+		assert.Contains(t, rec.Body.String(), "INVALID_CREDENTIALS")
+	}
+
+	// Account is now locked. Additional attempt must still return 401 (not 200 or a
+	// different error code that would reveal the lock).
+	csrfToken := doCSRF(t, srv)
+	rec := doLogin(t, srv, csrfToken, username, password) // correct password, but locked
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "locked account must return 401")
+	assert.Contains(t, rec.Body.String(), "INVALID_CREDENTIALS",
+		"locked-account code must be indistinguishable from bad-password")
+
+	// Simulate lockout expiry by directly rewinding the LockedUntil time.
+	srv.mu.Lock()
+	if state, ok := srv.webAccountLockouts[username]; ok {
+		state.LockedUntil = time.Now().Add(-1 * time.Second)
+	}
+	srv.mu.Unlock()
+
+	// Successful login after expiry must reset the counter.
+	csrfToken = doCSRF(t, srv)
+	rec = doLogin(t, srv, csrfToken, username, password)
+	assert.Equal(t, http.StatusOK, rec.Code, "login after lockout expiry must succeed")
+
+	// Lockout state should be cleared.
+	srv.mu.RLock()
+	_, stillLocked := srv.webAccountLockouts[username]
+	srv.mu.RUnlock()
+	assert.False(t, stillLocked, "lockout state must be cleared after successful login")
+}
+
+// TestWebLogout_RevokesSessionAndClearsCookies verifies that logout revokes the
+// server-side session (subsequent use returns 401), and both cookies are cleared.
+func TestWebLogout_RevokesSessionAndClearsCookies(t *testing.T) {
+	srv, username, password := setupWebSessionServer(t)
+
+	// Login to get a valid session.
+	csrfToken := doCSRF(t, srv)
+	loginRec := doLogin(t, srv, csrfToken, username, password)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	sessionTok := extractCookie(loginRec, cookieWebSession)
+	csrfTok := extractCookie(loginRec, cookieCSRFSession)
+	require.NotEmpty(t, sessionTok)
+	require.NotEmpty(t, csrfTok)
+
+	// Logout.
+	logoutRec := doLogout(t, srv, sessionTok, csrfTok)
+	assert.Equal(t, http.StatusOK, logoutRec.Code, "logout body: %s", logoutRec.Body.String())
+
+	// Both cookies must be cleared (MaxAge ≤ 0).
+	cookies := readSetCookies(nil, logoutRec)
+	cookieMap := make(map[string]*http.Cookie)
+	for _, c := range cookies {
+		cookieMap[c.Name] = c
+	}
+	for _, name := range []string{cookieWebSession, cookieCSRFSession} {
+		c, ok := cookieMap[name]
+		if assert.True(t, ok, "Set-Cookie must include %s on logout", name) {
+			assert.LessOrEqual(t, c.MaxAge, 0, "%s must be cleared (Max-Age ≤ 0)", name)
+		}
+	}
+
+	// Server-side session must be revoked — subsequent validation must fail.
+	srv.mu.RLock()
+	mgr := srv.webSessionManager
+	srv.mu.RUnlock()
+	_, err := mgr.Validate(context.Background(), sessionTok)
+	assert.Error(t, err, "revoked session must not validate")
+}
+
+// TestWebLogout_CSRFRequired verifies that logout returns 403 when X-CSRF-Token is
+// missing or mismatched.
+func TestWebLogout_CSRFRequired(t *testing.T) {
+	srv, username, password := setupWebSessionServer(t)
+
+	csrfToken := doCSRF(t, srv)
+	loginRec := doLogin(t, srv, csrfToken, username, password)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	sessionTok := extractCookie(loginRec, cookieWebSession)
+	csrfTok := extractCookie(loginRec, cookieCSRFSession)
+
+	t.Run("missing X-CSRF-Token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/logout", nil)
+		req.AddCookie(&http.Cookie{Name: cookieWebSession, Value: sessionTok})
+		// no X-CSRF-Token header
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("wrong X-CSRF-Token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/logout", nil)
+		req.Header.Set(headerCSRFToken, "tampered")
+		req.AddCookie(&http.Cookie{Name: cookieWebSession, Value: sessionTok})
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	// Valid logout to clean up.
+	rec := doLogout(t, srv, sessionTok, csrfTok)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestCSRFMiddleware_SessionBound verifies the session-bound CSRF middleware on the
+// api subrouter:
+// - GET requests are always exempt.
+// - Bearer/API-key/mTLS requests are exempt.
+// - Cookie-authenticated POST without X-CSRF-Token → 403.
+// - Cookie-authenticated POST with correct X-CSRF-Token → passes through.
+func TestCSRFMiddleware_SessionBound(t *testing.T) {
+	srv, username, password := setupWebSessionServer(t)
+
+	// Login to get a valid session + CSRF token.
+	csrfToken := doCSRF(t, srv)
+	loginRec := doLogin(t, srv, csrfToken, username, password)
+	require.Equal(t, http.StatusOK, loginRec.Code)
+
+	sessionTok := extractCookie(loginRec, cookieWebSession)
+	csrfTok := extractCookie(loginRec, cookieCSRFSession)
+	require.NotEmpty(t, sessionTok)
+	require.NotEmpty(t, csrfTok)
+
+	// Wire a canary handler on the api subrouter (POST /api/v1/stewards is already
+	// registered; using /api/v1/health GET is safe since it's exempt). Use the
+	// existing POST /api/v1/web/logout as a proxy — it's on the base router, not
+	// the api subrouter. Instead, test by wrapping directly.
+	//
+	// Direct middleware test: build the handler stack manually for a synthetic POST.
+	var reached bool
+	syntheticHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	// Stack: auth → CSRF → handler
+	stack := srv.authenticationMiddleware(srv.csrfMiddleware(syntheticHandler))
+
+	t.Run("GET is exempt", func(t *testing.T) {
+		reached = false
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+		req.AddCookie(&http.Cookie{Name: cookieWebSession, Value: sessionTok})
+		rec := httptest.NewRecorder()
+		stack.ServeHTTP(rec, req)
+		assert.True(t, reached, "GET must pass through CSRF middleware")
+	})
+
+	t.Run("cookie-auth POST without CSRF header → 403", func(t *testing.T) {
+		reached = false
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/test", nil)
+		req.AddCookie(&http.Cookie{Name: cookieWebSession, Value: sessionTok})
+		// no X-CSRF-Token
+		rec := httptest.NewRecorder()
+		stack.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.False(t, reached, "handler must not be reached when CSRF fails")
+	})
+
+	t.Run("cookie-auth POST with correct CSRF header → passes", func(t *testing.T) {
+		reached = false
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/test", nil)
+		req.AddCookie(&http.Cookie{Name: cookieWebSession, Value: sessionTok})
+		req.Header.Set(headerCSRFToken, csrfTok)
+		rec := httptest.NewRecorder()
+		stack.ServeHTTP(rec, req)
+		assert.True(t, reached, "handler must be reached when CSRF is correct")
+		assert.NotEqual(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("API-key authenticated POST is never CSRF-checked", func(t *testing.T) {
+		reached = false
+		apiKey := NewTestKey(t, srv, []string{"steward:list"})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/test", nil)
+		req.Header.Set("X-API-Key", apiKey)
+		// no X-CSRF-Token header
+		rec := httptest.NewRecorder()
+		stack.ServeHTTP(rec, req)
+		// API-key auth means isCookieAuthenticated returns false → CSRF middleware
+		// skips check → handler is reached (or 401 if the key doesn't have access).
+		// The key point: must NOT get a 403 from CSRF middleware.
+		assert.NotEqual(t, http.StatusForbidden, rec.Code,
+			"API-key requests must not be blocked by CSRF middleware (got 403 CSRF_MISMATCH)")
+	})
+}
+
+// TestWebLogin_AuditEvents verifies that login success, failure, lockout, and logout
+// each emit a sanitized log entry. Uses the auditCapturingLogger so no SQL is
+// involved (the audit manager path is tested in its own package).
+func TestWebLogin_AuditEvents(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	srv := setupTestServerWithLogger(t, capLog)
+
+	webCfg := session.Config{
+		IdleTimeout:     60 * time.Minute,
+		AbsoluteTimeout: 12 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	store := session.NewMemStore(webCfg, time.Now)
+	t.Cleanup(store.Close)
+	mgr := session.NewManager(webCfg, store, time.Now)
+	srv.SetWebSessionManager(mgr)
+
+	admin := testAdminPrincipal()
+	rec := postWebAccount(t, srv, admin, WebAccountRequest{
+		Username:    "audituser",
+		Password:    "audit-password-123",
+		TenantID:    "tenant-audit",
+		Permissions: []string{},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	clearLog := func() {
+		capLog.mu.Lock()
+		capLog.entries = nil
+		capLog.mu.Unlock()
+	}
+	hasMsg := func(substr string) bool {
+		capLog.mu.Lock()
+		defer capLog.mu.Unlock()
+		for _, e := range capLog.entries {
+			if strings.Contains(e.msg, substr) {
+				return true
+			}
+			for i := 0; i+1 < len(e.kvs); i += 2 {
+				if v, ok := e.kvs[i+1].(string); ok && strings.Contains(v, substr) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	containsRaw := func(forbidden string) bool {
+		return strings.Contains(capLog.formattedOutput(), forbidden)
+	}
+
+	t.Run("login success emits Info with sanitized username", func(t *testing.T) {
+		clearLog()
+		csrf := doCSRF(t, srv)
+		rec := doLogin(t, srv, csrf, "audituser", "audit-password-123")
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.True(t, hasMsg("Web login success"), "login success must log an Info message")
+		// Password must never appear in logs.
+		assert.False(t, containsRaw("audit-password-123"), "password must not appear in logs")
+	})
+
+	t.Run("login failure emits Warn with sanitized username", func(t *testing.T) {
+		clearLog()
+		csrf := doCSRF(t, srv)
+		rec := doLogin(t, srv, csrf, "audituser", "wrong")
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.True(t, hasMsg("Web login failed"), "login failure must emit a warning")
+		assert.False(t, containsRaw("wrong"), "submitted password must not appear in logs")
+	})
+
+	t.Run("lockout emits Warn with sanitized username", func(t *testing.T) {
+		// Reset any existing lockout from previous sub-test.
+		srv.mu.Lock()
+		delete(srv.webAccountLockouts, "audituser")
+		srv.mu.Unlock()
+
+		// Trigger lockout. Must use a valid-length password so it passes
+		// validateWebPassword and reaches recordWebAccountFailure (short passwords
+		// fail the pre-hash validation gate without touching the lockout counter).
+		for i := 0; i < 5; i++ {
+			csrf := doCSRF(t, srv)
+			doLogin(t, srv, csrf, "audituser", "wrong-password")
+		}
+
+		clearLog()
+		csrf := doCSRF(t, srv)
+		rec := doLogin(t, srv, csrf, "audituser", "audit-password-123") // correct pw, but locked
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.True(t, hasMsg("account locked"), "lockout must log a Warn message")
+
+		// Reset lockout for subsequent sub-tests.
+		srv.mu.Lock()
+		delete(srv.webAccountLockouts, "audituser")
+		srv.mu.Unlock()
+	})
+
+	t.Run("logout emits Info", func(t *testing.T) {
+		csrf := doCSRF(t, srv)
+		loginRec := doLogin(t, srv, csrf, "audituser", "audit-password-123")
+		require.Equal(t, http.StatusOK, loginRec.Code)
+		sessionTok := extractCookie(loginRec, cookieWebSession)
+		csrfTok := extractCookie(loginRec, cookieCSRFSession)
+
+		clearLog()
+		logoutRec := doLogout(t, srv, sessionTok, csrfTok)
+		require.Equal(t, http.StatusOK, logoutRec.Code)
+		assert.True(t, hasMsg("Web logout"), "logout must emit an Info message")
+		// Session token must not appear in log.
+		assert.False(t, containsRaw(sessionTok), "session token must not appear in logs")
+	})
+}
+
+// TestWebEndpoints_PublicBaseRouterRegistrations asserts that the three new endpoints
+// (GET /csrf, POST /login, POST /logout) are the only new public (base-router)
+// web-namespace registrations. They must respond without requiring authentication,
+// while arbitrary /api/v1/web/* paths must return 405 (method not allowed) or 404.
+func TestWebEndpoints_PublicBaseRouterRegistrations(t *testing.T) {
+	srv := setupTestServer(t)
+	// Wire session manager so handlers don't immediately return 503.
+	webCfg := session.Config{IdleTimeout: 60 * time.Minute, AbsoluteTimeout: 12 * time.Hour, GraceWindow: 30 * time.Second}
+	store := session.NewMemStore(webCfg, time.Now)
+	t.Cleanup(store.Close)
+	srv.SetWebSessionManager(session.NewManager(webCfg, store, time.Now))
+
+	// New registrations must respond (not 404) on their correct methods.
+	t.Run("GET /api/v1/web/csrf is accessible", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/web/csrf", nil)
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.NotEqual(t, http.StatusNotFound, rec.Code, "GET /api/v1/web/csrf must be registered")
+	})
+
+	t.Run("POST /api/v1/web/login is accessible", func(t *testing.T) {
+		// No CSRF cookie → 403 (registered and reachable, just CSRF-gated).
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/login",
+			bytes.NewBufferString(`{"username":"x","password":"y"}`))
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		// 403 (CSRF gate) confirms the endpoint is registered and publicly reachable.
+		assert.Equal(t, http.StatusForbidden, rec.Code, "POST /api/v1/web/login must be CSRF-gated (not 404)")
+	})
+
+	t.Run("POST /api/v1/web/logout is accessible", func(t *testing.T) {
+		// No session cookie → handled by logout handler (returns 200 or 401, not 404).
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/logout", nil)
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.NotEqual(t, http.StatusNotFound, rec.Code, "POST /api/v1/web/logout must be registered")
+	})
+
+	// No other web/* paths exist on the base router.
+	t.Run("unknown /api/v1/web/* path is 404 or 405", func(t *testing.T) {
+		// GET /api/v1/web/login (wrong method) → 405, not a new registered route.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/web/login", nil)
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		assert.Contains(t, []int{http.StatusMethodNotAllowed, http.StatusNotFound}, rec.Code,
+			"wrong-method requests must not succeed")
+	})
+}
+
+// TestWebLogin_RateLimited verifies that repeated unauthenticated POST /login requests
+// are eventually rate-limited by authDefense.Middleware (429 Too Many Requests).
+// This confirms the base-router authDefense wrapping is active (security A5.4).
+//
+// Note: once the rate limiter fires it blocks ALL endpoints from the same IP (including
+// /csrf), so the loop must accept 429 from either endpoint as evidence of rate limiting.
+func TestWebLogin_RateLimited(t *testing.T) {
+	srv, username, _ := setupWebSessionServer(t)
+
+	body, _ := json.Marshal(map[string]string{"username": username, "password": "wrong"})
+
+	// Hammer the login endpoint until we get 429 or exhaust a reasonable limit.
+	// The auth defense uses IP-based rate limiting; the same source IP triggers it.
+	var got429 bool
+	for i := 0; i < 200; i++ {
+		// Inline CSRF request: once the rate limiter fires, /csrf returns 429 too.
+		csrfReq := httptest.NewRequest(http.MethodGet, "/api/v1/web/csrf", nil)
+		csrfRec := httptest.NewRecorder()
+		srv.router.ServeHTTP(csrfRec, csrfReq)
+		if csrfRec.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+		require.Equal(t, http.StatusOK, csrfRec.Code, "GET /csrf (iteration %d): %s", i, csrfRec.Body.String())
+
+		var csrfToken string
+		for _, c := range readSetCookies(nil, csrfRec) {
+			if c.Name == cookieCSRFPre {
+				csrfToken = c.Value
+				break
+			}
+		}
+		require.NotEmpty(t, csrfToken, "GET /csrf must set %s cookie (iteration %d)", cookieCSRFPre, i)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/login", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(headerCSRFToken, csrfToken)
+		req.AddCookie(&http.Cookie{Name: cookieCSRFPre, Value: csrfToken})
+		rec := httptest.NewRecorder()
+		srv.router.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	assert.True(t, got429, "repeated failed login attempts must be rate-limited (429) by authDefense.Middleware")
+}

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -5,6 +5,7 @@ package api
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -37,6 +38,13 @@ const (
 	// isolation check. Set by test helpers or upstream middleware; takes precedence
 	// over URL-derived tenant. Empty means same-tenant (no cross-tenant check).
 	targetTenantContextKey contextKey = "target_tenant"
+	// cookieAuthContextKey is set to true when authentication succeeds via the
+	// cfgms_session cookie (Issue #2493: CSRF middleware uses this to distinguish
+	// cookie-authenticated requests from Bearer/API-key/mTLS requests).
+	cookieAuthContextKey contextKey = "cookie_authenticated"
+	// webSessionIDContextKey carries the session ID of a cookie-authenticated
+	// web session. Set alongside cookieAuthContextKey (Issue #2493: CSRF token lookup).
+	webSessionIDContextKey contextKey = "web_session_id"
 )
 
 // Principal represents an authenticated entity — either an mTLS admin cert, an API key,
@@ -368,6 +376,10 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 				ctx := context.WithValue(r.Context(), principalContextKey, webPrincipal)
 				ctx = context.WithValue(ctx, ctxkeys.UserIDKey, logging.SanitizeLogValue(webSess.PrincipalID))
 				ctx = context.WithValue(ctx, ctxkeys.TenantID, webSess.TenantID)
+				// Issue #2493: mark this request as cookie-authenticated so csrfMiddleware
+				// can enforce the session-bound CSRF check on unsafe methods.
+				ctx = context.WithValue(ctx, cookieAuthContextKey, true)
+				ctx = context.WithValue(ctx, webSessionIDContextKey, webSess.ID)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -819,6 +831,49 @@ func (s *Server) hasPermission(principal *Principal, permissionID string) bool {
 		}
 	}
 	return false
+}
+
+// csrfMiddleware enforces session-bound double-submit CSRF for unsafe HTTP methods on
+// cookie-authenticated requests (ADR-018 §3, security A5.3). Must run after
+// authenticationMiddleware so the cookie-auth context key is set.
+//
+//   - Safe methods (GET, HEAD) are always exempt.
+//   - Requests authenticated via Bearer token, API key, or mTLS are exempt (no cookie).
+//   - Cookie-authenticated requests for POST/PUT/PATCH/DELETE must supply X-CSRF-Token
+//     matching the server-side per-session token (constant-time compare).
+//
+// This is the only middleware that enforces CSRF for the api subrouter. The
+// login and logout endpoints on the base router enforce their own CSRF checks inline.
+func (s *Server) csrfMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Safe methods are always exempt.
+		if r.Method == http.MethodGet || r.Method == http.MethodHead {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Bearer/API-key/mTLS requests are never CSRF-checked (security A5.2).
+		if !isCookieAuthenticated(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Retrieve the session ID set by authenticationMiddleware on cookie-auth success.
+		sessID, _ := r.Context().Value(webSessionIDContextKey).(string)
+		csrfHeader := r.Header.Get(headerCSRFToken)
+		stored, _ := s.csrfTokens.Load(sessID)
+		storedStr, _ := stored.(string)
+		if csrfHeader == "" || storedStr == "" || subtle.ConstantTimeCompare([]byte(csrfHeader), []byte(storedStr)) != 1 {
+			s.writeErrorResponse(w, http.StatusForbidden, "CSRF token mismatch", "CSRF_MISMATCH")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isCookieAuthenticated reports whether this request was authenticated via the
+// cfgms_session HttpOnly cookie (set by authenticationMiddleware on cookie-auth success).
+func isCookieAuthenticated(r *http.Request) bool {
+	v, _ := r.Context().Value(cookieAuthContextKey).(bool)
+	return v
 }
 
 // extractTargetTenantFromRequest returns the tenant being targeted by this request,

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -124,6 +124,7 @@ type Server struct {
 	sessionManager                 session.Manager                       // Issue #2232: admin session token issuance/revocation
 	sessionCfg                     session.Config                        // Issue #2232: session lifecycle tunables (idle TTL, absolute cap, grace window)
 	webSessionManager              session.Manager                       // Issue #2492: second session manager for browser cookie auth (ADR-018 §1,2)
+	csrfTokens                     sync.Map                              // Issue #2493: sessionID → session-bound CSRF token; populated on login, deleted on logout/revoke
 	membershipStore                cluster.MembershipStore               // Issue #2283: cluster node membership (nil when cluster not configured)
 	clusterDraining                atomic.Bool                           // Issue #2283: true after drain is initiated; causes /health to return 503
 	batchJobStore                  business.BatchJobStore                // Issue #2296: durable batch-job persistence
@@ -415,7 +416,8 @@ func (s *Server) setupRouter() {
 	api.Use(s.authenticationMiddleware) // extract principal (API key or mTLS)
 	api.Use(s.requireTier(TierAny))     // Issue #1419: explicit Tier-1 default for the api subrouter
 	api.Use(s.validationMiddleware)
-	s.apiRouter = api // saved so Set* methods can lazy-register routes after construction
+	api.Use(s.csrfMiddleware) // Issue #2493: session-bound CSRF for unsafe cookie-auth methods
+	s.apiRouter = api         // saved so Set* methods can lazy-register routes after construction
 
 	// --- Tier 0 (TierPublic) — no authentication required ---
 	//   GET  /api/v1/health
@@ -669,6 +671,17 @@ func (s *Server) setupRouter() {
 		s.requirePermission("installer", "read")(http.HandlerFunc(s.handleUpgradeStatus))).Methods("GET")
 	stewardUpgrade.Handle("/{upgrade_id}/rollback",
 		s.requirePermission("installer", "dispatch:steward")(http.HandlerFunc(s.handleUpgradeRollback))).Methods("POST")
+
+	// Web login / CSRF / logout endpoints (Issue #2493, ADR-018 §3,4).
+	// Registered on the BASE router (TierPublic pattern) and explicitly wrapped in
+	// authDefense.Middleware. The api subrouter chain at line ~414 does NOT cover
+	// base-router routes (security A5.4), so wrapping is mandatory here.
+	s.router.Handle("/api/v1/web/csrf",
+		s.authDefense.Middleware(http.HandlerFunc(s.handleGetWebCSRF))).Methods("GET")
+	s.router.Handle("/api/v1/web/login",
+		s.authDefense.Middleware(http.HandlerFunc(s.handleWebLogin))).Methods("POST")
+	s.router.Handle("/api/v1/web/logout",
+		s.authDefense.Middleware(http.HandlerFunc(s.handleWebLogout))).Methods("POST")
 
 	// Installer package download — public, no auth required (Issue #1704).
 	// Assembles a per-platform tar.gz on the fly. The download URL is the distribution mechanism.


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/web/csrf`, `POST /api/v1/web/login`, `POST /api/v1/web/logout` (ADR-018 §3,4)
- Pre-session CSRF double-submit gates the login POST; session-bound CSRF middleware protects all unsafe cookie-authenticated api subrouter requests
- Per-account lockout (5 failures → 15-min lock) enforced at login with timing equalization via dummy argon2id hash
- Session fixation defence: any pre-login session revoked before issuing the fresh post-login session
- All three endpoints wrapped in `authDefense.Middleware` on the base router (not covered by api subrouter chain — security A5.4)
- Sanitized audit events for login success, failure, lockout, and logout; passwords and tokens never appear in logs or response bodies
- `docs/security/architecture.md` updated with full login/CSRF/logout flow documentation

## Test plan

- [x] `make test-agent-complete` passes (all Go tests, lint, cross-platform builds)
- [x] Story-review workflow: 2 rounds, 1 fix, 0 remaining findings (`passed: true`)
- [x] `TestWebLogin_SuccessSetsBothCookies` — cookie flags, pre-session cookie cleared, no token in body
- [x] `TestWebLogin_UniformFailureResponse` — bad-password and unknown-user both return 401 + INVALID_CREDENTIALS
- [x] `TestWebLogin_PreSessionCSRF_Required` — 4 sub-tests covering CSRF enforcement ordering
- [x] `TestWebLogin_SessionFixation` — first token revoked when second login presents it
- [x] `TestWebLogin_Lockout` — 5 failures → lock; correct password still 401 while locked; reset on expiry
- [x] `TestWebLogout_RevokesSessionAndClearsCookies` — revocation verified, cookies cleared
- [x] `TestWebLogout_CSRFRequired` — missing/wrong X-CSRF-Token → 403
- [x] `TestCSRFMiddleware_SessionBound` — GET exempt, API-key not blocked, cookie POST without CSRF → 403
- [x] `TestWebLogin_AuditEvents` — sanitized log assertions for all four event types
- [x] `TestWebEndpoints_PublicBaseRouterRegistrations` — only three new public endpoints registered
- [x] `TestWebLogin_RateLimited` — hammering triggers 429 from authDefense.Middleware

Fixes #2493

🤖 Generated with [Claude Code](https://claude.com/claude-code)