### PR TITLE
docs: refresh linux-runner.cfg to validated host contract (Issue #2484)

### DIFF
--- a/examples/ci-runners/README.md
+++ b/examples/ci-runners/README.md
@@ -58,8 +58,63 @@ cfg config upload linux-runner.cfg --steward ci-runner-linux-01
 cfg config upload windows-runner.cfg --steward ci-runner-windows-01
 ```
 
-The `github_runner` module fetches the agent archive, verifies the SHA-256,
-installs it under `work_dir`, and manages the runner service.
+#### Host dependencies (Linux)
+
+`linux-runner.cfg` carries a host-deps layer that provisions the bare-host
+requirements the golang container jobs need. Without it, runner VMs boot
+under-provisioned and jobs fail at Docker launch or tool resolution — the
+root cause of the cfgms-ci-lin-02/03 incident (2026-07-08).
+
+The host-deps resources and the workflow contract they satisfy:
+
+| Resource | Module | What it provides | Workflow contract line |
+|---|---|---|---|
+| `host-build-deps` | `script` (interim¹) | `docker.io git make gcc` via apt | container runtime |
+| `docker-service` | `service` | Docker daemon enabled + running | container launch |
+| `runner-docker-group` | `script` (interim²) | runner OS user → docker group | `--user 1000:1000` |
+| `ci-tools-dir` | `script` (interim¹) | `/opt/ci-tools/jq` static binary | `-v /opt/ci-tools:/opt/ci-tools:ro` |
+
+**Why the docker group step matters:** each job container is launched with
+`--user 1000:1000` and `/etc/group` bind-mounted read-only from the host
+(`.github/workflows/test-suite.yml:62,141`). For the container to reach the
+Docker socket, UID 1000 must be a member of the `docker` group **on the
+host** — not just inside the container. Without it, the runner fails with
+`usermod: group 'docker' does not exist` at enrollment (story #2479).
+
+> ¹ `host-build-deps` and `ci-tools-dir` are script-shaped pending the
+> package module apt-backend fix (story #2478). Replace with `package` +
+> `file` resources once #2478 is merged.
+>
+> ² `runner-docker-group` is script-shaped due to the script module
+> exit-semantics bug with idempotent commands (story #2479); the `|| true`
+> guard works around it until #2479 is fixed.
+
+#### Workflow contract
+
+Jobs in this repository run inside a `golang:1.26.5-bookworm` container on
+the self-hosted runner host. The full container spec, as declared in
+`.github/workflows/test-suite.yml:62,141`:
+
+```
+image:   golang:1.26.5-bookworm
+options: --user 1000:1000
+         -v /etc/passwd:/etc/passwd:ro
+         -v /etc/group:/etc/group:ro
+         -v /opt/ci-tools:/opt/ci-tools:ro
+```
+
+The `runs-on` selector that routes jobs to this runner
+(`.github/workflows/test-suite.yml:51,131`):
+
+```
+["self-hosted", "Linux", "cfgms"]
+```
+
+The runner label set in `linux-runner.cfg` must match these exactly.
+`Linux` and `cfgms` are routing labels — lowercase `linux` or a missing
+`cfgms` label causes jobs to fall through to GitHub-hosted runners.
+
+#### Runner cfg placeholders
 
 Before uploading, edit the cfg to set:
 
@@ -68,6 +123,10 @@ Before uploading, edit the cfg to set:
 - `config.agent_url` — the download URL matching the version and OS/arch.
 - `config.agent_sha256` — the SHA-256 of the archive (lowercase hex, 64 chars).
   Verify with `sha256sum` (Linux) or `Get-FileHash` (Windows).
+- `runner-docker-group` script — replace `<RUNNER_USER>` with the OS user
+  the runner agent runs as.
+- `ci-tools-dir` script — replace `<JQ_VERSION>` and `<JQ_SHA256_64HEX>`
+  with the pinned jq version and its SHA-256.
 
 Module field names come from
 [`features/modules/extended/github_runner/config.go`](../../features/modules/extended/github_runner/config.go).

--- a/examples/ci-runners/linux-runner.cfg
+++ b/examples/ci-runners/linux-runner.cfg
@@ -8,20 +8,120 @@
 #
 # NO SECRETS in this file. GitHub App credentials are stored in the CFGMS
 # secrets provider, not here. See github-app-secrets.example.yaml.
+#
+# Workflow contract (source of truth):
+#   .github/workflows/test-suite.yml:51,131  — runs-on: ["self-hosted","Linux","cfgms"]
+#   .github/workflows/test-suite.yml:62,141  — container: golang:1.26.5-bookworm
+#                                               options: --user 1000:1000
+#                                                        -v /etc/passwd:/etc/passwd:ro
+#                                                        -v /etc/group:/etc/group:ro
+#                                                        -v /opt/ci-tools:/opt/ci-tools:ro
+# Every host-deps resource below exists to satisfy one of these contract lines.
 
 steward:
   id: "ci-runner-linux-01"    # CHANGE: set to the actual enrolled steward hostname
   mode: "standalone"
 
 resources:
-  # ── GitHub Actions Runner ────────────────────────────────────────────────────
+  # ── Host Dependencies ─────────────────────────────────────────────────────
+  # The resources below provision the bare-host layer that golang container
+  # jobs require. Without them, runner VMs start under-provisioned and jobs
+  # fail at Docker launch or tool resolution — the root cause of the
+  # cfgms-ci-lin-02/03 incident (2026-07-08).
+
+  # Build-tool packages required by the runner host:
+  #   docker.io  — container runtime; the golang job container runs on this
+  #   git        — workspace checkout inside the runner agent
+  #   make/gcc   — referenced by test helpers that call host toolchain paths
+  #
+  # INTERIM: script-shaped pending the package module apt-backend fix
+  # (story #2478). Replace with a `package` resource once #2478 is merged.
+  - name: "host-build-deps"
+    module: "script"
+    config:
+      interpreter: "/bin/bash"
+      script: |
+        set -euo pipefail
+        apt-get update -qq
+        apt-get install -y --no-install-recommends docker.io git make gcc
+
+  # Docker daemon — must be running before the runner agent starts so that
+  # the golang job container can be launched.
+  - name: "docker-service"
+    module: "service"
+    config:
+      name: "docker"
+      enabled: true
+      running: true
+
+  # Add the runner OS user to the docker group.
+  #
+  # Why this is required: .github/workflows/test-suite.yml:62,141 mounts
+  # /etc/group read-only from the HOST into each job container. The container
+  # runs as UID 1000:1000 (--user 1000:1000). For Docker socket access to
+  # work from inside the container, UID 1000 must be a member of the `docker`
+  # group ON THE HOST — not just inside the container. This was the exact
+  # failure behind "usermod: group 'docker' does not exist" (story #2479):
+  # the docker group did not yet exist when the runner enrolled because
+  # docker.io had not been installed.
+  #
+  # INTERIM: script-shaped for two reasons:
+  #   1. The docker group is created by the host-build-deps resource above;
+  #      this resource must run after it — enforced by its position here.
+  #   2. The script module has an exit-semantics bug for idempotent ops
+  #      (story #2479). The `|| true` guard keeps usermod idempotent until
+  #      #2479 is fixed.
+  - name: "runner-docker-group"
+    module: "script"
+    config:
+      interpreter: "/bin/bash"
+      script: |
+        set -euo pipefail
+        # CHANGE: Replace <RUNNER_USER> with the OS user the runner agent runs
+        # as (typically the user declared in the github_runner module config or
+        # the default "runner" account created at enrollment).
+        usermod -aG docker <RUNNER_USER> || true
+
+  # /opt/ci-tools: host-staged static binaries the golang container image
+  # does not ship. Mounted read-only into each job container by the workflow
+  # contract (.github/workflows/test-suite.yml:62,141 —
+  # -v /opt/ci-tools:/opt/ci-tools:ro). Added to $GITHUB_PATH by the
+  # "Add host-staged CI tools to PATH" step in each job.
+  #
+  # Currently carries: jq (static build, pinned version) — used by script
+  # tests in the test suite.
+  #
+  # INTERIM: script-shaped pending the package module apt-backend fix
+  # (story #2478). Replace with a `package` resource + `file` resource once
+  # #2478 is merged.
+  - name: "ci-tools-dir"
+    module: "script"
+    config:
+      interpreter: "/bin/bash"
+      script: |
+        set -euo pipefail
+        mkdir -p /opt/ci-tools
+
+        # CHANGE: Replace <JQ_VERSION> and <JQ_SHA256> with pinned values.
+        # Example: jq 1.7.1, linux-amd64.
+        # Verify after download: sha256sum /opt/ci-tools/jq
+        JQ_VERSION="<JQ_VERSION>"
+        JQ_SHA256="<JQ_SHA256_64HEX>"
+        JQ_URL="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
+
+        curl -fsSL -o /tmp/jq-download "${JQ_URL}"
+        echo "${JQ_SHA256}  /tmp/jq-download" | sha256sum --check --strict
+        install -m 0755 /tmp/jq-download /opt/ci-tools/jq
+        rm -f /tmp/jq-download
+
+  # ── GitHub Actions Runner ─────────────────────────────────────────────────
   # Installs and manages the GitHub Actions self-hosted runner agent as a
   # persistent Linux service.
   #
   # The module fetches the agent archive, verifies the SHA-256, installs it
-  # under work_dir, and registers the service. Registration (the one-time token
-  # exchange) is handled by the controller workflow — the module only manages
-  # the installed agent state.
+  # under work_dir, and registers the service. Registration (the one-time
+  # token exchange) is handled by the controller workflow — the module only
+  # manages the installed agent state.
   #
   # Field reference: features/modules/extended/github_runner/config.go
 
@@ -29,16 +129,17 @@ resources:
     module: "github_runner"
     config:
       # Pinned runner agent version — update when bumping the runner.
-      # CHANGE: Set to the desired GitHub Actions runner release.
-      version: "2.319.1"
+      # Fleet currently runs 2.335.1 (validated cfgms-ci-lin-02/03,
+      # 2026-07-08). CHANGE: Set to the desired GitHub Actions runner release.
+      version: "2.335.1"
 
       # Download URL for the agent archive at the pinned version.
       # CHANGE: Update to match your pinned version and architecture.
-      agent_url: "https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-linux-x64-2.319.1.tar.gz"
+      agent_url: "https://github.com/actions/runner/releases/download/v2.335.1/actions-runner-linux-x64-2.335.1.tar.gz"
 
       # Expected SHA-256 of the archive (lowercase hex, 64 chars).
       # CHANGE: Replace with the actual sha256sum of the archive.
-      # Verify: sha256sum actions-runner-linux-x64-2.319.1.tar.gz
+      # Verify: sha256sum actions-runner-linux-x64-2.335.1.tar.gz
       agent_sha256: "PLACEHOLDER_SHA256_64HEX"
 
       # Absolute install directory on the runner VM.
@@ -48,7 +149,12 @@ resources:
       service_name: "github-runner"
 
       # Runner labels surfaced to GitHub Actions workflow selectors.
+      # Workflows in this repo select on ["self-hosted","Linux","cfgms"]
+      # (.github/workflows/test-suite.yml:51,131). "Linux" and "cfgms" are
+      # the routing labels — lowercase "linux" or absent "cfgms" breaks job
+      # routing to this runner.
       labels:
         - "self-hosted"
-        - "linux"
-        - "x64"
+        - "Linux"
+        - "X64"
+        - "cfgms"


### PR DESCRIPTION
## Summary

- Bumps `github_runner` agent version to 2.335.1 (placeholder sha) — fleet currently runs this version, validated on cfgms-ci-lin-02/03 (2026-07-08)
- Fixes runner labels to `["self-hosted","Linux","cfgms"]` — lowercase `linux` and missing `cfgms` were silently breaking workflow routing
- Adds the missing host-deps layer (docker.io/git/make/gcc packages, docker service, runner-user→docker group, `/opt/ci-tools/jq`) whose absence caused the cfgms-ci-lin-02/03 under-provisioning incident
- Updates README with host-deps table, workflow contract section (traceable to `test-suite.yml` line ranges), and per-placeholder guidance

## Specialist review results

- **Code review**: PASS
- **Test quality**: PASS (1 fix round — tests lens flagged a nit in round 1, resolved)
- **Security**: PASS
- `make test`: 211/211 passed

## Test plan

- [ ] Verify `linux-runner.cfg` placeholder values are clearly marked CHANGE
- [ ] Verify no real hostnames/IPs/tenant values in the example
- [ ] Confirm `make test` passes (done: 211/211 ✓)
- [ ] Confirm labels match `["self-hosted","Linux","cfgms"]` selector in `test-suite.yml:51,131`
- [ ] Confirm host-deps comments cite stories #2478 and #2479 for interim resources

Fixes #2484

🤖 Generated with [Claude Code](https://claude.com/claude-code)