### PR TITLE
ci: route unit-tests to ubuntu-latest; keep integration-tests self-hosted (Issue #2501)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,46 +35,22 @@ env:
 jobs:
   # Fast unit tests - runs on every push/PR
   #
-  # runs-on routing (#2337, epic #565): internal events (push, merge_group,
-  # non-fork pull_request) run on the CFGMS-managed self-hosted Linux runner;
-  # fork PRs and workflow_dispatch (no fork property) stay on GitHub-hosted.
-  # The full label set targets the Linux runner specifically — a bare
-  # 'self-hosted' would also match the Windows runner.
-  #
-  # SECURITY: this expression is convenience routing, NOT the security
-  # boundary — a fork PR executes the FORK's copy of this file and could
-  # rewrite it. The enforcing control is the repository Actions setting
-  # "Require approval for ALL external contributors" (fork-PR workflow runs
-  # need maintainer approval before any runner is assigned). Do not weaken
-  # that setting while self-hosted runners are attached to this public repo.
+  # runs-on routing (#2337, #2501, epic #565): always ubuntu-latest for all
+  # events. Measured 2026-07-09: GitHub-hosted queue ~6s vs self-hosted
+  # 193–433s under merge-queue burst; hosted exec ~15% faster (511s vs 610s).
+  # Moving unit-tests to hosted frees self-hosted pool capacity for
+  # integration-tests where self-hosted exec is 2–3.5× faster than hosted.
   unit-tests:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.event_name == 'workflow_dispatch') && '"ubuntu-latest"' || '["self-hosted", "Linux", "cfgms"]') }}
-    # The self-hosted runner VM is itself a CFGMS-managed steward endpoint, so
-    # host-state-sensitive tests (platform CA path, launcher state) would read
-    # the live steward's files — the container keeps the job hermetic there.
-    # The whole container object is conditional: 'null' on the hosted/fork path
-    # (no container at all — hosted runners are already hermetic), the golang
-    # image on the self-hosted path. Options: --user 1000 matches the runner
-    # user (workspace writable; chmod-based failure-injection tests work);
-    # /etc/passwd + /etc/group read-only so UID 1000 resolves to a named user
-    # (os/user lookups); /opt/ci-tools carries static host-staged binaries the
-    # golang image lacks but hosted runners ship (jq for the script tests).
-    container: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.event_name == 'workflow_dispatch') && 'null' || '{"image":"golang:1.26.5-bookworm","options":"--user 1000:1000 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v /opt/ci-tools:/opt/ci-tools:ro"}') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-    - name: Mark workspace safe for git (container UID differs from host mount)
-      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-    - name: Add host-staged CI tools to PATH (no-op unless /opt/ci-tools is mounted)
-      run: if [ -d /opt/ci-tools ]; then echo /opt/ci-tools >> "$GITHUB_PATH"; fi
 
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ env.GO_VERSION }}
-    
+
     - name: Cache Go modules
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -85,10 +61,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-modules-
       continue-on-error: true
-    
+
     - name: Install dependencies
       run: go mod download
-    
+
     - name: Start Linux resource sampler (self-hosted only, best-effort)
       if: github.event_name != 'workflow_dispatch' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
       continue-on-error: true
@@ -126,11 +102,24 @@ jobs:
         retention-days: 30
 
   # Integration tests - runs on PRs to develop/main, workflow_dispatch, or push to main
-  # runs-on routing (#2337): same fork-gated self-hosted routing as unit-tests.
+  #
+  # runs-on routing (#2337, epic #565): fork-gated self-hosted routing — internal
+  # events (push, merge_group, non-fork pull_request) run on the CFGMS-managed
+  # self-hosted Linux runner; fork PRs and workflow_dispatch (no fork property)
+  # stay on GitHub-hosted. The full label set targets the Linux runner specifically
+  # — a bare 'self-hosted' would also match the Windows runner.
+  #
+  # SECURITY: this expression is convenience routing, NOT the security
+  # boundary — a fork PR executes the FORK's copy of this file and could
+  # rewrite it. The enforcing control is the repository Actions setting
+  # "Require approval for ALL external contributors" (fork-PR workflow runs
+  # need maintainer approval before any runner is assigned). Do not weaken
+  # that setting while self-hosted runners are attached to this public repo.
   integration-tests:
     runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.event_name == 'workflow_dispatch') && '"ubuntu-latest"' || '["self-hosted", "Linux", "cfgms"]') }}
-    # Hermetic container for the same reason as unit-tests (steward-enrolled
-    # runner VM host state must not leak into tests); self-hosted path only.
+    # Hermetic container: the self-hosted runner VM is a CFGMS-managed steward
+    # endpoint — without a container, host state (platform CA path, launcher
+    # state) would leak into tests; self-hosted path only.
     # The whole container object is conditional: 'null' on the hosted/fork path
     # (no container at all — hosted runners are already hermetic), the golang
     # image on the self-hosted path. Options: --user 1000 matches the runner

--- a/cmd/steward/dex_spike.go
+++ b/cmd/steward/dex_spike.go
@@ -62,8 +62,10 @@ func buildDexSpikeCommand() *cobra.Command {
 			report, err := collector.Run(ctx)
 			if err != nil {
 				if errors.Is(err, dex.ErrPlatformNotSupported) {
-					fmt.Fprintln(cmd.OutOrStdout(),
-						"dex-spike: platform not supported — ETW/WMI acquisition requires Windows.")
+					if _, werr := fmt.Fprintln(cmd.OutOrStdout(),
+						"dex-spike: platform not supported — ETW/WMI acquisition requires Windows."); werr != nil {
+						return fmt.Errorf("dex-spike write output: %w", werr)
+					}
 					return nil
 				}
 				return fmt.Errorf("dex-spike run: %w", err)
@@ -74,7 +76,9 @@ func buildDexSpikeCommand() *cobra.Command {
 				enc.SetIndent("", "  ")
 				return enc.Encode(report)
 			}
-			fmt.Fprint(cmd.OutOrStdout(), report.String())
+			if _, werr := fmt.Fprint(cmd.OutOrStdout(), report.String()); werr != nil {
+				return fmt.Errorf("dex-spike write output: %w", werr)
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary

- Routes `unit-tests` to `ubuntu-latest` for all events (push, merge_group, pull_request), removing the conditional self-hosted/hosted expression and its associated golang container block
- Updates `integration-tests` routing comment to carry the full self-hosted rationale and the fork-gate security note (previously lived in the unit-tests comment block)
- Fixes a pre-existing `golangci-lint` errcheck finding in `cmd/steward/dex_spike.go` uncovered by the comprehensive test gate

## Evidence (measured 2026-07-09)

| unit-tests | GitHub-hosted (n=20) | Self-hosted 3×6vCPU |
|---|---|---|
| Queue median | 6s | 193–433s (burst) |
| Exec median | 511s | 610s |
| **Total** | **520s** | **804s** |

Hosted is strictly better: near-zero queue under any merge-queue burst and ~15% faster execution. Moving unit-tests to hosted frees self-hosted pool capacity for integration-tests where self-hosted exec is 2–3.5× faster.

## Reviewer Results

| Lens | Round 1 | Round 2 |
|---|---|---|
| Code review | PASS | — |
| Test quality | FAIL (errcheck in dex_spike.go) | PASS |
| Security | PASS | — |

**Aggregate verdict: PASS** (story-review workflow, 2 rounds, 1 fix round, 0 remaining findings)

## Post-merge re-measurement required

Per AC #2: after merge, record unit-tests total median (baseline ≤520s) and integration-tests self-hosted queue median (should be materially below 1317s measured 2026-07-09) in a follow-up comment on this PR.

## Test plan

- [x] `make test` passes locally
- [x] `make test-agent-complete` passes (via story-review workflow)
- [ ] Post-merge: verify unit-tests and integration-tests timing in GitHub Actions

Fixes #2501