### PR TITLE
pipeline: require explicit PASS verdict before enqueue (Issue #2588)

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -107,7 +107,7 @@ All required CI checks must pass before reviewing code:
 
 - ALL PASSING → continue to Phase 2.1
 - ANY FAILING → verdict is FAIL, stop here. Report which checks failed.
-- ANY PENDING → verdict is WAIT, stop here. Report which checks are pending.
+- ANY PENDING → verdict is WAIT, stop here. Report which checks are pending. **Do NOT post the structured review comment** (the one containing `<!-- cfgms-acceptance-review -->` or the `## Acceptance Review` heading) — those markers signal a *completed* review and would cause the PO preflight to treat this PR as permanently reviewed once CI goes green, skipping re-spawn of the acceptance reviewer. Instead, either omit the comment entirely and report pending checks via your completion message, or post a plain comment using a heading like `## CI Status — Checks Pending` that does not contain `<!-- cfgms-acceptance-review -->` or the `## Acceptance Review` heading.
 
 ## Phase 2.1: GitHub Advanced Security Findings (BLOCKING)
 

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -1443,8 +1443,41 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
                     })
                 continue
 
-            # Review passed (or verdict unparseable). Flag as stuck if CI green
-            # + mergeable but not in queue and not already auto-merge-enabled.
+            # Issue #2588: A review comment with no parseable verdict (verdict=None)
+            # means the reviewer posted a WAIT (CI still pending when they ran) or
+            # an unstructured comment that doesn't match _REVIEW_VERDICT_RE.
+            # This must NOT fall through to enqueue_merge — that would permanently
+            # skip re-spawning the acceptance reviewer once CI goes green.
+            # Route to spawn_acceptance_reviewer so the reviewer issues a definitive
+            # PASS or FAIL before this PR can enter the merge queue.
+            if verdict is None:
+                if overall == "green":
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "spawn_acceptance_reviewer",
+                        "reason": "acceptance-review comment present but verdict is WAIT or unparseable — re-spawn to obtain a definitive PASS or FAIL before enqueueing",
+                    })
+                elif overall == "pending":
+                    pending = pr["ci_summary"]["pending_checks"][:3]
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "defer",
+                        "reason": f"acceptance-review comment present but no parseable verdict; CI pending: {', '.join(pending)}",
+                    })
+                else:
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "skip",
+                        "reason": "acceptance-review comment present but no parseable verdict; CI red — fix cycle owns this",
+                    })
+                continue
+
+            # Only reaches here when verdict == "pass" and no fix commit landed
+            # after the review (prior PASS is still valid). Flag as stuck if CI
+            # green + mergeable but not in queue and not already auto-merge-enabled.
             if (
                 overall == "green"
                 and pr.get("mergeable") == "MERGEABLE"

--- a/.claude/scripts/tests/test-preflight-external-pr.py
+++ b/.claude/scripts/tests/test-preflight-external-pr.py
@@ -269,10 +269,11 @@ class TestComputeReviewRecommendationsExternalPR(unittest.TestCase):
     def _make_summary(self, pr_num=999, story_num=None, is_external=True,
                       is_released=False, is_draft=False, ci_overall="green",
                       has_review=False, wip_failed=False, merge_state="CLEAN",
-                      mergeable="MERGEABLE"):
+                      mergeable="MERGEABLE", author_login="external-user"):
         return {
             "pr": pr_num,
             "story_number": story_num,
+            "author_login": author_login,
             "is_external": is_external,
             "is_released": is_released,
             "is_draft": is_draft,
@@ -296,11 +297,14 @@ class TestComputeReviewRecommendationsExternalPR(unittest.TestCase):
 
     def test_external_unreleased_pr_is_skipped(self):
         """AC3: unreleased external PR → action=skip (quarantined, never reviewed/merged)."""
-        summaries = [self._make_summary(is_external=True, is_released=False)]
+        summaries = [self._make_summary(is_external=True, is_released=False,
+                                        author_login="external-user")]
         recs = self.pf.compute_review_recommendations(summaries, set())
         self.assertEqual(len(recs), 1)
         self.assertEqual(recs[0]["action"], "skip")
         self.assertIn("external", recs[0]["reason"].lower())
+        # Verify the author login appears in the quarantine reason (not silently 'unknown').
+        self.assertIn("external-user", recs[0]["reason"])
 
     def test_external_released_pr_proceeds_to_review(self):
         """AC5: validly released external PR (human-reviewed:ok by push+) proceeds normally."""
@@ -494,6 +498,92 @@ class TestIsTrustedReviewComment(unittest.TestCase):
         ]
         verdict, _ = self.pf.latest_review(comments)
         self.assertEqual(verdict, "fail")
+
+
+class TestWaitVerdictReviewRecommendations(unittest.TestCase):
+    """Issue #2588: WAIT verdict (verdict=None) must route to spawn_acceptance_reviewer,
+    not enqueue_merge.
+
+    Covers the three required cases from the acceptance criteria:
+    (a) has_review=True, verdict=None, CI=green → spawn_acceptance_reviewer
+    (b) has_review=True, verdict="pass", CI=green → enqueue_merge (regression guard)
+    (c) has_review=True, verdict="fail" → skip/unchanged (regression guard)
+    """
+
+    def setUp(self):
+        self.pf = _load_preflight()
+
+    def _make_summary(self, pr_num=101, story_num=42, has_review=False,
+                      verdict=None, ci_overall="green", auto_merge=False,
+                      merge_state="CLEAN", mergeable="MERGEABLE"):
+        """Build a pr_summary dict for an internal, non-draft PR with controllable review state."""
+        pending_checks = ["unit-tests"] if ci_overall == "pending" else []
+        failed_checks = ["unit-tests"] if ci_overall == "red" else []
+        return {
+            "pr": pr_num,
+            "story_number": story_num,
+            "is_external": False,
+            "is_released": False,
+            "is_draft": False,
+            "wip_session_failed": False,
+            "has_acceptance_review_comment": has_review,
+            "latest_review_verdict": verdict,
+            "latest_review_comment_date": None,
+            "latest_commit_date": None,
+            "merge_state_status": merge_state,
+            "mergeable": mergeable,
+            "auto_merge_enabled": auto_merge,
+            "ci_summary": {
+                "overall": ci_overall,
+                "pass": 4 if ci_overall == "green" else 0,
+                "pending": 1 if ci_overall == "pending" else 0,
+                "fail": 1 if ci_overall == "red" else 0,
+                "skipped": 0,
+                "pending_checks": pending_checks,
+                "failed_checks": failed_checks,
+            },
+        }
+
+    # (a) The bug: WAIT verdict (verdict=None) must NOT enqueue
+    def test_wait_verdict_green_ci_spawns_reviewer(self):
+        """AC (a): has_review=True + verdict=None + CI=green → spawn_acceptance_reviewer, not enqueue_merge."""
+        summaries = [self._make_summary(has_review=True, verdict=None, ci_overall="green")]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "spawn_acceptance_reviewer",
+                         f"Expected spawn_acceptance_reviewer but got {recs[0]['action']!r}: {recs[0]['reason']!r}")
+
+    def test_wait_verdict_pending_ci_defers(self):
+        """WAIT verdict + pending CI → defer (not spawn; CI not green yet)."""
+        summaries = [self._make_summary(has_review=True, verdict=None, ci_overall="pending")]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "defer")
+
+    def test_wait_verdict_red_ci_skips(self):
+        """WAIT verdict + red CI → skip (fix cycle owns it)."""
+        summaries = [self._make_summary(has_review=True, verdict=None, ci_overall="red")]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "skip")
+
+    # (b) Regression guard: explicit PASS must still produce enqueue_merge
+    def test_pass_verdict_green_ci_enqueues(self):
+        """AC (b): has_review=True + verdict='pass' + CI=green → enqueue_merge (regression guard)."""
+        summaries = [self._make_summary(has_review=True, verdict="pass", ci_overall="green")]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "enqueue_merge",
+                         f"Expected enqueue_merge but got {recs[0]['action']!r}: {recs[0]['reason']!r}")
+
+    # (c) Regression guard: FAIL path unchanged
+    def test_fail_verdict_no_fix_commit_skips(self):
+        """AC (c): has_review=True + verdict='fail' + no fix commit landed → skip (regression guard)."""
+        summaries = [self._make_summary(has_review=True, verdict="fail", ci_overall="green")]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "skip")
+        self.assertIn("fail", recs[0]["reason"].lower())
 
 
 if __name__ == "__main__":

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -2681,8 +2681,10 @@ else:
     print("FAIL_C: plain comment accepted as trusted — expected False")
     sys.exit(1)
 
-# Part D: compute_review_recommendations does NOT recommend spawn_acceptance_reviewer
-# for a PR whose comment matches the heading (PR #1589 regression test)
+# Part D: a review comment with NO parseable verdict (WAIT / sentinel-only) is
+# NOT a completed review — it must route back to spawn_acceptance_reviewer,
+# never enqueue_merge (Issue #2588). Supersedes the pre-#2588 expectation from
+# the PR #1589 scenario, where comment-presence alone counted as reviewed.
 pr_summary = {
     "pr": 1589,
     "story_number": 1570,
@@ -2702,10 +2704,27 @@ if not recs:
     print("FAIL_D: compute_review_recommendations returned empty list")
     sys.exit(1)
 action = recs[0].get("action", "")
-if action != "spawn_acceptance_reviewer":
-    print(f"PASS_D: PR #1589 with existing review comment gets action={action!r} (not spawn_acceptance_reviewer)")
+if action == "spawn_acceptance_reviewer":
+    print("PASS_D: PR #1589 with review comment but NO parseable verdict routes to spawn_acceptance_reviewer (Issue #2588)")
 else:
-    print("FAIL_D: PR #1589 recommended spawn_acceptance_reviewer despite existing review comment")
+    print(f"FAIL_D: PR #1589 with verdict-less review comment got action={action!r} — expected spawn_acceptance_reviewer (Issue #2588)")
+    sys.exit(1)
+
+# Part E: an explicit PASS verdict (comment predates no commits) still routes to
+# enqueue_merge — regression guard for the #2588 tightened condition
+# (verdict == "pass", not merely != "fail").
+pr_summary_pass = dict(pr_summary)
+pr_summary_pass["pr"] = 1590
+pr_summary_pass["latest_review_verdict"] = "pass"
+recs = mod.compute_review_recommendations([pr_summary_pass], set(), set())
+if not recs:
+    print("FAIL_E: compute_review_recommendations returned empty list")
+    sys.exit(1)
+action = recs[0].get("action", "")
+if action == "enqueue_merge":
+    print("PASS_E: PR #1590 with explicit PASS verdict still routes to enqueue_merge")
+else:
+    print(f"FAIL_E: PR #1590 with PASS verdict got action={action!r} — expected enqueue_merge")
     sys.exit(1)
 PYEOF
 


### PR DESCRIPTION
## Summary

- **Root cause**: `compute_review_recommendations()` routed a PR to `enqueue_merge` whenever `has_acceptance_review_comment=True` and `verdict != "fail"`. This silently included `verdict=None` — produced when the acceptance reviewer posts a WAIT comment (CI pending) or any comment whose text doesn't match `_REVIEW_VERDICT_RE`. Once CI turned green, the PO would enqueue with no completed acceptance-criteria verification.
- **Fix**: Added an explicit `if verdict is None:` block before the `enqueue_merge` path. Routes to `spawn_acceptance_reviewer` (CI green), `defer` (CI pending), or `skip` (CI red). The `enqueue_merge` path now only executes when `verdict == "pass"`.
- **acceptance-reviewer.md Phase 2**: Made the WAIT path explicit — forbids posting the `<!-- cfgms-acceptance-review -->` sentinel or `## Acceptance Review` heading when CI is pending, since those markers signal a completed review.
- **Fixture fix**: Added `author_login` to `TestComputeReviewRecommendationsExternalPR._make_summary` (was silently producing "unknown" in quarantine reason) and added assertion verifying the login appears.

## Specialist Review Results

| Lens | Verdict |
|------|---------|
| Code Review | PASS |
| Test Quality | PASS |
| Security | PASS |

All three adversarial review lenses returned PASS. One MEDIUM finding (missing `author_login` in existing fixture) was identified and fixed before commit.

## Test plan

- [x] `test_wait_verdict_green_ci_spawns_reviewer` — AC(a): WAIT+green → `spawn_acceptance_reviewer` (not `enqueue_merge`)
- [x] `test_pass_verdict_green_ci_enqueues` — AC(b): PASS+green → `enqueue_merge` (regression guard)
- [x] `test_fail_verdict_no_fix_commit_skips` — AC(c): FAIL+no-fix → skip (regression guard)
- [x] `test_wait_verdict_pending_ci_defers` — WAIT+pending → defer
- [x] `test_wait_verdict_red_ci_skips` — WAIT+red → skip
- [x] All 44 preflight tests pass
- [x] `make test-complete` passes

Fixes #2588

🤖 Generated with [Claude Code](https://claude.com/claude-code)