### PR TITLE
test: fix native-build 5m -race timeout panic on hosted macOS/Windows (Issue #2591)

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -117,11 +117,19 @@ jobs:
       # Windows runs -short WITHOUT -race to keep this compile-validation job fast;
       # race coverage is fully exercised on the Linux unit-tests + integration-tests
       # jobs. Linux/macOS run with -race here.
+      #
+      # Timeout set to 8m (from 5m) — Issue #2591: features/controller/api grew to
+      # 89 files / ~25k LOC with CPU-intensive tests (argon2id credential hashing,
+      # TLS certificate rotation). Measured wall-clock on a 16-core Linux dev
+      # container: ~42s; 2–3 vCPU macOS/Windows hosted runners at ~7× overhead
+      # were hitting the 5m wall consistently. The argon2id TestMain override
+      # (Issue #2591) removes the largest hot path; 8m provides a safe margin for
+      # the remaining certificate-rotation tests and Windows file-I/O overhead.
       run: |
         if [ "${{ matrix.platform }}" = "Windows" ]; then
-          go test -short -timeout=5m ./pkg/... ./features/...
+          go test -short -timeout=8m ./pkg/... ./features/...
         else
-          go test -race -short -timeout=5m ./pkg/... ./features/...
+          go test -race -short -timeout=8m ./pkg/... ./features/...
         fi
 
     - name: Upload Build Artifacts

--- a/features/controller/api/handlers_web_accounts.go
+++ b/features/controller/api/handlers_web_accounts.go
@@ -58,15 +58,27 @@ const (
 	webAccountMaxConsecutiveFailures = 5
 	webAccountLockoutDuration        = 15 * time.Minute
 
-	// argon2id cost parameters — current OWASP-recommended settings (19 MiB memory,
-	// 2 iterations, 1 lane). They are encoded into the stored PHC string, so they
-	// can be raised later without breaking existing hashes: verification always
-	// derives with the parameters parsed from the hash itself.
-	webArgon2Time    uint32 = 2
-	webArgon2Memory  uint32 = 19 * 1024 // KiB (19 MiB)
-	webArgon2Threads uint8  = 1
-	webArgon2SaltLen        = 16
-	webArgon2KeyLen  uint32 = 32
+	// argon2id production cost parameters — OWASP-recommended settings (19 MiB memory,
+	// 2 iterations, 1 lane). Named *Default so tests can reference the intended
+	// production values even when the active vars are overridden to minimal values
+	// for CI speed (Issue #2591). TestWebAccounts_HashParametersEncodedInPHCString
+	// pins these to the OWASP values.
+	webArgon2TimeDefault    uint32 = 2
+	webArgon2MemoryDefault  uint32 = 19 * 1024 // KiB (19 MiB)
+	webArgon2ThreadsDefault uint8  = 1
+	webArgon2SaltLen               = 16
+	webArgon2KeyLen         uint32 = 32
+)
+
+// webArgon2Time/Memory/Threads are the active cost parameters used by hashWebPassword
+// and dummyWebAccountHash. Initialized to the OWASP production defaults; the test
+// suite's TestMain substitutes minimal values (t=1, 64 KiB) to avoid timeout panics
+// on 2-3 vCPU hosted macOS/Windows runners where OWASP-cost argon2id ops are
+// disproportionately slow under -race instrumentation (Issue #2591).
+var (
+	webArgon2Time    = webArgon2TimeDefault
+	webArgon2Memory  = webArgon2MemoryDefault
+	webArgon2Threads = webArgon2ThreadsDefault
 )
 
 // webUsernameRegex keeps usernames log- and path-safe (security A4.1): usernames

--- a/features/controller/api/handlers_web_accounts_test.go
+++ b/features/controller/api/handlers_web_accounts_test.go
@@ -523,15 +523,19 @@ func TestWebAccounts_VerifyRejectsMalformedInputsUniformly(t *testing.T) {
 	}
 }
 
-// TestWebAccounts_HashParametersEncodedInPHCString pins the argon2id cost parameters
-// into the stored PHC string so they can be raised later without breaking existing
-// hashes, and confirms verification honors the parameters parsed from the hash.
+// TestWebAccounts_HashParametersEncodedInPHCString pins the argon2id OWASP cost
+// parameters and verifies that encodeArgon2idHash embeds them into the PHC string.
+// Uses the *Default constants directly (not the active webArgon2* vars) so the test
+// remains independent of the minimal-cost TestMain override (Issue #2591).
 func TestWebAccounts_HashParametersEncodedInPHCString(t *testing.T) {
-	phc, err := hashWebPassword("parameter-check-password")
-	require.NoError(t, err)
+	// Derive with the production-default (OWASP) cost to verify the PHC prefix.
+	// encodeArgon2idHash takes an explicit salt so no crypto/rand import is needed.
+	phc := encodeArgon2idHash("parameter-check-password",
+		[]byte("cfgms-param-test"), // 16-byte deterministic test vector
+		webArgon2TimeDefault, webArgon2MemoryDefault, webArgon2ThreadsDefault)
 
 	assert.True(t, strings.HasPrefix(phc, "$argon2id$v=19$m=19456,t=2,p=1$"),
-		"PHC string must encode the OWASP-recommended argon2id parameters, got %q", phc)
+		"OWASP production parameters must encode correctly in the PHC string, got %q", phc)
 
 	ok, err := verifyWebPassword("parameter-check-password", phc)
 	require.NoError(t, err)

--- a/features/controller/api/testmain_test.go
+++ b/features/controller/api/testmain_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Issue #2591: reduce argon2id cost for the test suite so the package does not
+// hit the 5-minute wall on 2–3 vCPU GitHub-hosted macOS/Windows runners.
+//
+// Root cause: features/controller/api grew to 89 files / ~25k LOC with repeated
+// argon2id KDF calls across ~400 test cases (account creation + every login
+// attempt). TestWebLogin_RateLimited alone drives up to 100 consecutive KDF calls
+// for timing-uniformity on the locked-account path. At OWASP production cost
+// (19 MiB, t=2) each call takes ~22 ms on a 16-core dev container; on a 2-vCPU
+// hosted runner with -race instrumentation the per-call overhead is 10–15×,
+// pushing the full suite past the 5-minute timeout.
+//
+// Fix: TestMain (runs once before the first Test* function) overrides the active
+// cost vars to the minimum functional values. The full argon2id code path —
+// hash derivation, PHC encoding, constant-time comparison — is still exercised.
+// The OWASP production values are pinned separately by
+// TestWebAccounts_HashParametersEncodedInPHCString, which calls
+// encodeArgon2idHash with the *Default constants directly.
+package api
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Minimal argon2id cost: functional but fast. Each KDF call drops from ~22 ms
+	// (production, 19 MiB) to < 1 ms (64 KiB), eliminating the timeout risk on
+	// contended 2-vCPU hosted runners without skipping any code path.
+	webArgon2Time = 1
+	webArgon2Memory = 64 // 64 KiB — lowest memory that still exercises the KDF
+	webArgon2Threads = 1
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

- **Root cause identified:** `features/controller/api` accumulated repeated argon2id KDF calls across ~400 test cases. `TestWebLogin_RateLimited` drives up to 100 consecutive `verifyWebPassword` calls on the locked-account timing-uniformity path. At OWASP production cost (19 MiB, t=2) each call takes ~22 ms on a dev container; on 2–3 vCPU GitHub-hosted macOS/Windows runners with `-race` the per-call overhead is 10–15×, pushing the full suite past the 5-minute wall. Windows (no `-race`) also hit it because the runner is ~7× slower overall (I/O + CPU) and 42s × 7 ≈ 294s overflows 300s on a loaded queue machine.
- **Fix 1 (root cause):** Added `TestMain` in `features/controller/api/testmain_test.go` that overrides the active `webArgon2Time/Memory/Threads` vars to minimal functional values (t=1, 64 KiB) before any test runs. The full argon2id code path is still exercised. Measured: full suite 42s → 24s (43% faster); `TestWebLogin_RateLimited` alone 2.18s → 0.05s (44×). Production code unchanged — `webArgon2*Default` constants hold the OWASP values; vars are initialized to them; `TestMain` only fires in test binaries.
- **Fix 2 (safety net):** Bumped `-timeout=5m` to `-timeout=8m` in the `native-builds` job for both platforms, with inline justification comment following the style of the existing Windows `-race` carve-out. `-race` coverage on Linux/macOS is unchanged.
- `TestWebAccounts_HashParametersEncodedInPHCString` updated to call `encodeArgon2idHash` with the `*Default` constants directly, so it pins the OWASP PHC prefix independently of the `TestMain` override.

## Specialist Review Results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

All 3 lenses passed in round 1 with zero findings.

## Test plan

- [x] `go test -short ./features/controller/api/...` passes (24s, down from 42s)
- [x] `TestWebLogin_RateLimited` 2.18s → 0.05s (44× faster)
- [x] `TestWebAccounts_HashParametersEncodedInPHCString` still pins OWASP PHC prefix
- [x] All web account and web session tests pass
- [x] Production code compiles clean; `webArgon2*Default` consts hold OWASP values
- [ ] 3 consecutive green `native-builds` merge-group runs to be linked post-merge (per AC)

Fixes #2591

🤖 Generated with [Claude Code](https://claude.com/claude-code)