### PR TITLE
ci: stop classifying .claude executable code as docs-only (Issue #2586)

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.claude/**'
+      - '.claude/**/*.md'   # .claude markdown only — executable pipeline code under .claude/ (scripts, workflows) gets real CI (Issue #2586)
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'docs/**'
       - '*.md'
-      - '.claude/**'
+      - '.claude/**/*.md'   # .claude markdown only — executable pipeline code under .claude/ (scripts, workflows) gets real CI (Issue #2586)
       - '.gitignore'
       - '.editorconfig'
       - 'LICENSE'
@@ -19,7 +19,7 @@ on:
     paths:
       - 'docs/**'
       - '*.md'
-      - '.claude/**'
+      - '.claude/**/*.md'   # .claude markdown only — executable pipeline code under .claude/ (scripts, workflows) gets real CI (Issue #2586)
       - '.gitignore'
       - '.editorconfig'
       - 'LICENSE'

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.claude/**'
+      - '.claude/**/*.md'   # .claude markdown only — executable pipeline code under .claude/ (scripts, workflows) gets real CI (Issue #2586)
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.claude/**'
+      - '.claude/**/*.md'   # .claude markdown only — executable pipeline code under .claude/ (scripts, workflows) gets real CI (Issue #2586)
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'              # Root-level markdown only (README.md, CONTRIBUTING.md)
-      - '.claude/**'
+      - '.claude/**/*.md'   # .claude markdown only — executable pipeline code under .claude/ (scripts, workflows) gets real CI (Issue #2586)
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'


### PR DESCRIPTION
## Summary

- Replaces the `.claude/**` blanket with `.claude/**/*.md` in the four code workflows' `paths-ignore` (test-suite, production-gates, cross-platform-build, security-scan) and in documentation.yml's `paths` allowlist (both `pull_request` and `push` triggers)
- Markdown under `.claude/` (agent definitions, commands, skills) keeps the docs-only fast path; executable pipeline code (`.claude/scripts/*.py|sh`, `.claude/workflows/*.js`, settings) now triggers real CI on the PR

## Incident this closes (measured 2026-07-12)

PR #2597 changed `.claude/scripts/po-cycle-preflight.py` semantics. Because its diff was entirely under `.claude/**`, code workflows were path-skipped and its green `unit-tests` check was documentation.yml's docs-only **stub** (job log: "Documentation-only PR detected — skipping code unit tests"). The real suite first executed inside the merge queue, failed deterministically (`test-scripts.sh` FAIL_D — pre-existing regression test asserting the old semantics), and the PR was evicted and silently re-enqueued in a loop, evicting every queue entry built behind it (4 Test Suite Validation merge-group failures 00:48–01:41 UTC).

## Coherence with required checks

- A `.claude`-scripts-only PR now gets its required contexts (`unit-tests`, `integration-tests`, `Build Gate`, `security-deployment-gate`, `Controller Integration Tests (Linux)`, `trivy-scan`) from the **real** workflows — documentation.yml correctly does not fire, so no stub/real name collision
- `fleet-e2e-tests` remains `merge_group`-only (#2550), unchanged — PR-side absence of that context is already the norm for code PRs
- Markdown-only `.claude` PRs behave exactly as before (stubs fire, code workflows skip)
- Mixed md+script PRs: both fire — same as today's mixed docs+code PRs

## Test plan

- [x] Edited lines verified well-formed (single-quoted glob + comment, consistent indentation)
- [ ] This PR itself exercises the code path: it touches `.github/workflows/**", so all real code workflows must fire and pass here (no stubs)
- [ ] Post-merge: verify a `.claude/scripts`-only PR (#2589's upcoming PR is one) runs real unit-tests PR-side

Part of #2586 (desired state 5 — latent breakage; complements the PR/queue trigger work in #2595).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G21VodMHskAZMRmJTq9QbD