### PR TITLE
test: widen Revoked disconnect/reject waits to the QUIC idle floor (Issue #2592)

### DIFF
--- a/test/e2e/fleet/registration_refresh_test.go
+++ b/test/e2e/fleet/registration_refresh_test.go
@@ -156,7 +156,16 @@ func (s *FleetTestSuite) testRefreshRevoked(t *testing.T) {
 	// disconnected before proceeding. Without this, the connection registry still
 	// shows "connected" from the pre-stop gRPC session, causing a false positive
 	// in the "must NOT be connected" check below.
-	disconnectDeadline := time.Now().Add(45 * time.Second)
+	//
+	// The controller only considers a silent steward disconnected once the QUIC
+	// MaxIdleTimeout (90s, pkg/transport/quic/listener.go) elapses with no
+	// keepalive (KeepAlivePeriod 20s). On a contended CI runner the pre-revocation
+	// session can therefore linger well past a short window: a 45s bound sat below
+	// the 90s idle floor and let the stale "connected" state survive into the
+	// assertion below (Issue #2592). Wait 120s (90s idle floor + margin); the loop
+	// still returns as soon as disconnection is observed, so the happy path is
+	// unaffected.
+	disconnectDeadline := time.Now().Add(120 * time.Second)
 	for time.Now().Before(disconnectDeadline) {
 		state, _ := s.getStewardConnectionState(t, stewardID)
 		if state != "connected" {
@@ -172,9 +181,17 @@ func (s *FleetTestSuite) testRefreshRevoked(t *testing.T) {
 	// AC: steward must log the rejection message. The docker-compose retry loop
 	// exits on ErrRefreshRejected so the steward process stops and the container
 	// restarts after 5s. Wait for the log entry across restarts.
-	if !s.waitForStewardLogEntry(t, container, "Registration refresh rejected", 60*time.Second) {
+	//
+	// On restart the steward first attempts a stored-identity reconnect, which must
+	// fail against the QUIC transport before it falls through to the refresh
+	// challenge that yields the 403. That reconnect failure is bounded by the same
+	// idle/handshake timeouts (90s idle / 30s handshake), so on a contended runner
+	// the rejection can be logged well after a 60s bound (observed 66s). Wait 120s
+	// with the same margin as the disconnection wait above (Issue #2592);
+	// waitForStewardLogEntry polls and returns as soon as the line appears.
+	if !s.waitForStewardLogEntry(t, container, "Registration refresh rejected", 120*time.Second) {
 		log, _ := s.readStewardLog(t, container)
-		t.Fatalf("Revoked: steward did not log 'Registration refresh rejected' within 60s\nlog tail:\n%s",
+		t.Fatalf("Revoked: steward did not log 'Registration refresh rejected' within 120s\nlog tail:\n%s",
 			lastLines(log, 40))
 	}
 	t.Log("Revoked: steward logged refresh rejection as expected")


### PR DESCRIPTION
## Summary
De-flakes `TestFleetRegistrationRefresh/Revoked`, which was evicting merge-queue entries on contended hosted runners.

## Root cause (from merge-group run 29177692725)
The subtest failed at **line 188** (`steward reconnected after revocation — this should not happen`), **not** the rejection-log wait as originally hypothesized. The controller only marks a silent steward disconnected once the QUIC `MaxIdleTimeout` (**90s**, `pkg/transport/quic/listener.go`) elapses without a keepalive (`KeepAlivePeriod` 20s). The test waited only **45s** for that disconnection before asserting "must NOT be connected", so on a slow runner the **stale pre-revocation session** was still registered as `connected` — a false positive. The steward was correctly rejected (403 + "Registration refresh rejected" logged); it did **not** genuinely reconnect. The rejection wait (60s) also passed but only barely — 56s in the passing run, and the run failed at a 66.55s subtest.

## Fix (test-tolerance only — no production QUIC change)
- disconnection-detection wait `45s → 120s` (90s idle floor + margin)
- "Registration refresh rejected" wait `60s → 120s` (same margin)

Both loops poll and return as soon as the condition is met, so the **happy path is unchanged (~55s)** — only the contended-runner tail gets headroom. Worst-case suite stays well under the 600s test / 20m job ceilings. Out of scope per the story: production QUIC defaults (`listener.go`) and the sibling AutoAccept/Archived subtests are untouched.

## Validation
- `go vet ./test/e2e/fleet/...` — clean
- `go test -c ./test/e2e/fleet/` — compiles
- 3 consecutive green `fleet-e2e-tests` merge-group runs — to be confirmed by CI on this PR.

## ⚠️ Note: this does not fully unblock the fleet-e2e gate
Investigation found a **second, more frequent** merge-group evictor overnight — `TestFleetLauncherManagedUpgradeBrokenBinaryRollback` (3 of 4 failures, ~35s fast-fail) — which is **not** in scope for #2592 and needs its own story/investigation.

Fixes #2592

🤖 Generated with [Claude Code](https://claude.com/claude-code)