### PR TITLE
ci: CodeQL summary-gate — stable required context on all events (Issue #2609)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -173,3 +173,40 @@ jobs:
         echo "- ✅ Data flow and control flow" >> $GITHUB_STEP_SUMMARY
         echo "- ✅ Security vulnerabilities" >> $GITHUB_STEP_SUMMARY
         echo "- ✅ Code quality issues" >> $GITHUB_STEP_SUMMARY
+
+  # ── CodeQL gate (Issue #2609 / Epic #2586) ────────────────────────────────
+  # A single stable `CodeQL` status context, emitted on the SAME events as the
+  # analysis above (PR with Go changes, merge_group, push, schedule). This
+  # closes the gap that bricked the merge queue: the real analysis reports as
+  # `CodeQL Analysis (go)` (job name × matrix language), and NOTHING emitted a
+  # plain `CodeQL` context on merge_group (codeql-stub.yml is pull_request-only
+  # by design, and GitHub's native code-scanning `CodeQL` status is PR-only),
+  # so a `CodeQL`-required merge queue waited forever for a context that never
+  # arrived. This gate provides it.
+  #
+  # `needs: [analyze]` makes the gate green ONLY when every matrix language
+  # passes, so adding a language later (e.g. javascript for the frontend) is
+  # gated automatically with no branch-protection ruleset change — the whole
+  # point of an aggregation gate over a language-pinned required context. On
+  # non-Go pull requests this workflow is path-filtered out entirely and
+  # codeql-stub.yml owns the `CodeQL` context (exact-complement paths).
+  codeql-summary:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    needs: [analyze]
+    if: always()
+    steps:
+      - name: CodeQL gate
+        env:
+          # needs.analyze.result is a fixed job-result enum (success/failure/
+          # cancelled/skipped), not user input — but pass it via env to keep
+          # ${{ }} out of the run: script (zizmor template-injection lint).
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
+        run: |
+          echo "CodeQL analyze matrix result: ${ANALYZE_RESULT}"
+          if [ "${ANALYZE_RESULT}" = "success" ]; then
+            echo "CodeQL gate: PASS — all analyzed languages clean"
+            exit 0
+          fi
+          echo "CodeQL gate: FAIL — analyze result was '${ANALYZE_RESULT}'"
+          exit 1


### PR DESCRIPTION
## Summary
Adds a `codeql-summary` job (context name **`CodeQL`**) to `codeql-analysis.yml` so a single, stable `CodeQL` status reports on **every** event — Go PRs, **merge_group**, push, schedule — closing the gap that bricked the merge queue.

## Background
The queue deadlocked (~6h on 2026-07-12) because the required context `CodeQL` never appears on merge_group commits: the real analysis reports as `CodeQL Analysis (go)`, `codeql-stub.yml` is pull_request-only by design, and GitHub's native code-scanning `CodeQL` status is PR-only. A stopgap ruleset change (require `CodeQL Analysis (go)`) is already live; this is the durable fix.

## Why an aggregation gate (not a language-pinned context)
Frontend is imminent → a `javascript` CodeQL language is coming. A required context pinned to `CodeQL Analysis (go)` would gate Go but **silently ignore** the JS scan. This gate uses `needs: [analyze]`, so it's green only when *every* matrix language passes — adding a language needs **zero** ruleset change.

## Scope note vs the story
The story listed `documentation.yml` as in-scope; on inspection that's unnecessary — **`codeql-stub.yml`** already owns the `CodeQL` context for non-Go PRs (exact-complement paths). So the fix is one job in the analysis workflow. Nothing in `documentation.yml` changes.

## Post-merge step (deliberately NOT in this PR)
After this merges **and** a real merge_group run shows the `CodeQL` context present + green, repoint the develop ruleset required context `CodeQL Analysis (go)` → `CodeQL`. Repointing before the gate is on develop would re-brick the queue — the exact failure mode this fixes. I'll do that step + link the evidence.

## Validation
- YAML parses; job `codeql-summary` name=`CodeQL`, `needs: [analyze]`, `if: always()`, triggers include `merge_group`.
- `${{ }}` kept out of the `run:` script (passed via `env:`) for zizmor.
- This PR merges cleanly under the current ruleset (`CodeQL Analysis (go)` still required and green); the new `CodeQL` context runs but isn't required yet.

Fixes #2609

🤖 Generated with [Claude Code](https://claude.com/claude-code)