### PR TITLE
ci: skip go clean -testcache under CI + re-enable per-job Go caching on security scanners (Issue #2593)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -115,16 +115,14 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    # Cache disabled due to parallel job conflicts causing tar extraction failures
-    # - name: Cache Go modules
-    #   uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-    #   with:
-    #     path: ~/go/pkg/mod
-    #     key: ${{ runner.os }}-nancy-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-go-modules-
-    #       ${{ runner.os }}-nancy-
-    #   continue-on-error: true
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-nancy-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-nancy-
+      continue-on-error: true
 
     - name: Install Nancy
       run: make install-nancy
@@ -161,16 +159,14 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    # Cache disabled due to parallel job conflicts causing tar extraction failures
-    # - name: Cache Go modules
-    #   uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-    #   with:
-    #     path: ~/go/pkg/mod
-    #     key: ${{ runner.os }}-gosec-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-go-modules-
-    #       ${{ runner.os }}-gosec-
-    #   continue-on-error: true
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gosec-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gosec-
+      continue-on-error: true
 
     - name: Install gosec
       run: go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
@@ -240,16 +236,14 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    # Cache disabled due to parallel job conflicts causing tar extraction failures
-    # - name: Cache Go modules
-    #   uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-    #   with:
-    #     path: ~/go/pkg/mod
-    #     key: ${{ runner.os }}-staticcheck-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-go-modules-
-    #       ${{ runner.os }}-staticcheck-
-    #   continue-on-error: true
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-staticcheck-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-staticcheck-
+      continue-on-error: true
 
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@2026.1

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ test-install-cfg: build-cli
 test: fix-git-bare
 	@echo "🧪 Running Tests (Smart Mode)"
 	@echo "============================="
-	@go clean -testcache
+	@if [ "$$GITHUB_ACTIONS" != "true" ]; then go clean -testcache; fi
 	@echo "🧪 Testing OSS Build..."
 	@echo "  Testing framework (excluding modules and long-running tests)..."
 	@go test -race -short -timeout=5m $$(go list ./... | grep -v '/features/modules/' | grep -v '/test/integration' | grep -v '/test/e2e')


### PR DESCRIPTION
## Summary

- **Makefile `test` target**: `go clean -testcache` now only runs when `GITHUB_ACTIONS != "true"`, so the Go test-result cache that `actions/setup-go` restores is no longer immediately defeated on every CI run. Local developer runs are unchanged.
- **security-scan.yml**: Re-enabled the `actions/cache` steps for `nancy-scan`, `gosec-scan`, and `staticcheck-scan`. Dropped the shared `${{ runner.os }}-go-modules-` `restore-keys` fallback that was causing tar-extraction collisions under parallel execution — each job now uses only its own job-specific fallback key.

Fixes #2593

## Root cause analysis

The commented-out cache blocks in `security-scan.yml` each had two `restore-keys`:
1. `${{ runner.os }}-go-modules-` (shared across all three jobs — collision source)
2. `${{ runner.os }}-nancy-` / `-gosec-` / `-staticcheck-` (unique per job)

Under parallel execution all three jobs raced to restore the same shared fallback key, causing tar extraction failures. With only the per-job fallback remaining, no two jobs compete for the same cache key.

## Specialist Review Results

- **Code Review**: PASS (0 findings)
- **Test Quality**: PASS (0 findings)
- **Security**: PASS (0 findings)

## Test plan

- [x] `GITHUB_ACTIONS=true make test` — all results show `(cached)`, confirms `go clean -testcache` is skipped
- [x] `make test` (no env var) — runs `go clean -testcache` as before, all tests pass
- [ ] Two consecutive merge-group runs showing cache hit in each of the three scanner jobs' cache-restore step logs — to be linked as evidence post-merge per AC requirement
- [ ] Before/after wall-clock measurement posted as PR comment once CI runs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)