### PR TITLE
github_runner: self-resolve service_name from owner/repo + hostname (Issue #2547)

### DIFF
--- a/features/modules/extended/github_runner/README.md
+++ b/features/modules/extended/github_runner/README.md
@@ -39,20 +39,78 @@ Schema (`runner` resource):
 | `agent_sha256` | yes | Operator-pinned expected SHA-256 (64-char hex). Verified directly — **no network hash lookup** |
 | `labels` | no | Desired runner label set |
 | `work_dir` | yes | Absolute install directory; also the resource ID |
-| `service_name` | yes | OS service name (systemd unit on Linux, SCM service on Windows) |
+| `owner` | conditional | GitHub organization or user owning the repository. Required when `service_name` is not set |
+| `repo` | conditional | GitHub repository name (without owner prefix). Required when `service_name` is not set |
+| `service_name` | no | OS service name (systemd unit on Linux, SCM service on Windows). When omitted, derived from `owner`, `repo`, and the host's hostname |
+
+### Optional service_name and automatic derivation
+
+`service_name` is optional. When omitted, `owner` and `repo` become required and
+the module derives the OS service name at convergence time as:
+
+```
+actions.runner.<owner>-<repo>.<hostname>
+```
+
+where `<hostname>` is the steward host's hostname obtained via `os.Hostname()`,
+and any characters not in `[a-zA-Z0-9._@-]` in the owner, repo, or hostname are
+replaced with `-` before composition. The derived name is validated against the
+service-name character pattern; if it exceeds the length limit (255 characters)
+`Set` returns a validation error.
+
+This derivation allows a **single shared role config** (with `owner` + `repo` but
+no `service_name`) to converge correctly on any number of runner hosts — each host
+produces its own host-unique service name without per-machine config overrides.
+
+### Registration-name coupling (load-bearing)
+
+The GitHub runner's `config.sh` / `config.cmd` register step creates the OS
+service as `actions.runner.<owner>-<repo>.<runner-name>`. The `<runner-name>` is
+the name given to the runner at registration time.
+
+**Contract:** the runner must be registered with its `<runner-name>` equal to the
+steward host's hostname (the value returned by `os.Hostname()`). The module
+derives the service name using the same hostname via `os.Hostname()`, so the
+derived name exactly matches the service name that registration produced.
+
+If the service name derived by this module does not match the name created at
+registration, `Get` will query a non-existent service and report
+`installed: false` indefinitely. Ensure the registration step uses the hostname
+as the runner name (the S6 live-proof workflow enforces this by registering the
+runner with `--name $(hostname)`).
 
 ## Usage examples
 
+### Explicit service_name (per-machine config)
+
 ```yaml
-# A Linux CI runner host (see examples/ci-runners for the full walkthrough)
+# A Linux CI runner host with an explicit service name
 resource: runner
-work_dir: /opt/actions-runner          # also the resource ID
+work_dir: /opt/actions-runner
 config:
   version: "2.319.1"
   agent_url: "https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-linux-x64-2.319.1.tar.gz"
   agent_sha256: "<64-char hex pinned by the operator>"
   labels: ["self-hosted", "linux", "ci"]
   service_name: "actions.runner.acme-repo.host1.service"
+```
+
+### Shared role config with derived service_name
+
+```yaml
+# One role config that works on any number of runner hosts.
+# service_name is omitted; the module derives it from owner, repo, and hostname.
+# Registration must use the runner name equal to the host's hostname.
+resource: runner
+work_dir: /opt/actions-runner
+config:
+  version: "2.319.1"
+  agent_url: "https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-linux-x64-2.319.1.tar.gz"
+  agent_sha256: "<64-char hex pinned by the operator>"
+  labels: ["self-hosted", "linux", "ci"]
+  owner: "acme-org"
+  repo: "myrepo"
+  # service_name is omitted; derived as actions.runner.acme-org-myrepo.<hostname>
 ```
 
 `Set` downloads the agent at the pinned `version`, verifies its SHA-256, unpacks
@@ -93,9 +151,11 @@ managers used to converge the already-registered runner service:
 - **Windows** — `sc.exe` against the runner SCM service
 
 Argument lists are fully static except `service_name`, which is validated against
-`^[a-zA-Z0-9][a-zA-Z0-9._@-]{0,254}$` before use. No command-string composition,
-no `iex` / `-Command` / `-EncodedCommand`. The vendor `config.cmd` / `config.sh`
-register tool is **not** invoked by this module.
+`^[a-zA-Z0-9][a-zA-Z0-9._@-]{0,254}$` before use (for explicit names) or
+derived via `sanitizeComponent` (which enforces the same character set) for
+auto-derived names. No command-string composition, no `iex` / `-Command` /
+`-EncodedCommand`. The vendor `config.cmd` / `config.sh` register tool is
+**not** invoked by this module.
 
 ## Platforms
 
@@ -108,7 +168,7 @@ compiles everywhere.
 | File | Role |
 |------|------|
 | `module.go` | `Module` (Get/Set), `Configurable`, and `Test`; convergence logic |
-| `config.go` | `RunnerConfig` (`ConfigState`) + the on-disk drift state marker |
+| `config.go` | `RunnerConfig` (`ConfigState`) + the on-disk drift state marker + service-name derivation |
 | `install.go` | download (net/http) + SHA-256 verify + stdlib unpack |
 | `service_linux.go` / `service_windows.go` / `service_stub.go` | platform service executors |
 | `module.yaml` / `schema.yaml` | signed manifest + resource schema |

--- a/features/modules/extended/github_runner/config.go
+++ b/features/modules/extended/github_runner/config.go
@@ -49,8 +49,16 @@ type RunnerConfig struct {
 	Labels []string `yaml:"labels,omitempty"`
 	// WorkDir is the absolute install directory; it is also the resource ID.
 	WorkDir string `yaml:"work_dir"`
-	// ServiceName is the OS service name of the runner service.
-	ServiceName string `yaml:"service_name"`
+	// Owner is the GitHub organization or user owning the repository.
+	// Used with Repo to derive the OS service name when ServiceName is empty.
+	Owner string `yaml:"owner,omitempty"`
+	// Repo is the GitHub repository name (without owner prefix).
+	// Used with Owner to derive the OS service name when ServiceName is empty.
+	Repo string `yaml:"repo,omitempty"`
+	// ServiceName is the OS service name of the runner service. Optional: when
+	// empty, Owner and Repo must be set and the name is derived as
+	// actions.runner.<owner>-<repo>.<hostname> at convergence time.
+	ServiceName string `yaml:"service_name,omitempty"`
 
 	// Observed-only fields, populated by Get (never read from operator config).
 	Installed      bool `yaml:"installed,omitempty"`
@@ -65,6 +73,8 @@ func (c *RunnerConfig) AsMap() map[string]interface{} {
 	labels := append([]string(nil), c.Labels...)
 	return map[string]interface{}{
 		"version":         c.Version,
+		"owner":           c.Owner,
+		"repo":            c.Repo,
 		"labels":          labels,
 		"work_dir":        c.WorkDir,
 		"service_name":    c.ServiceName,
@@ -101,8 +111,19 @@ func (c *RunnerConfig) Validate() error {
 	if !filepath.IsAbs(c.WorkDir) {
 		return fmt.Errorf("%w: work_dir %q must be an absolute path", modules.ErrInvalidInput, c.WorkDir)
 	}
-	if !serviceNamePattern.MatchString(c.ServiceName) {
-		return fmt.Errorf("%w: service_name %q contains invalid characters", modules.ErrInvalidInput, c.ServiceName)
+	// service_name is optional: when set it must match the pattern; when absent,
+	// owner and repo are required so the name can be derived at convergence time.
+	if c.ServiceName != "" {
+		if !serviceNamePattern.MatchString(c.ServiceName) {
+			return fmt.Errorf("%w: service_name %q contains invalid characters", modules.ErrInvalidInput, c.ServiceName)
+		}
+	} else {
+		if strings.TrimSpace(c.Owner) == "" {
+			return fmt.Errorf("%w: owner is required when service_name is not set", modules.ErrInvalidInput)
+		}
+		if strings.TrimSpace(c.Repo) == "" {
+			return fmt.Errorf("%w: repo is required when service_name is not set", modules.ErrInvalidInput)
+		}
 	}
 	for _, l := range c.Labels {
 		if !labelPattern.MatchString(l) {
@@ -117,6 +138,37 @@ func (c *RunnerConfig) GetManagedFields() []string {
 	return []string{"version", "labels", "service_running", "service_enabled"}
 }
 
+// sanitizeComponent replaces any character not permitted by serviceNamePattern
+// with '-' so that owner, repo, and hostname values are safe to embed in a
+// derived service name without violating the pattern's character set.
+func sanitizeComponent(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			r == '.' || r == '_' || r == '@' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// ResolveServiceName returns the effective OS service name for this config.
+// When ServiceName is set explicitly it is returned unchanged. When ServiceName
+// is empty, the name is derived as
+//
+//	actions.runner.<owner>-<repo>.<hostname>
+//
+// where owner, repo, and hostname are sanitized to the serviceNamePattern
+// character set (disallowed chars replaced with '-').
+func (c *RunnerConfig) ResolveServiceName(hostname string) string {
+	if c.ServiceName != "" {
+		return c.ServiceName
+	}
+	return "actions.runner." + sanitizeComponent(c.Owner) + "-" + sanitizeComponent(c.Repo) + "." + sanitizeComponent(hostname)
+}
+
 // fromMap populates the config from a generic AsMap (used when the engine passes
 // a non-RunnerConfig ConfigState).
 func (c *RunnerConfig) fromMap(m map[string]interface{}) error {
@@ -124,6 +176,8 @@ func (c *RunnerConfig) fromMap(m map[string]interface{}) error {
 	c.AgentURL, _ = m["agent_url"].(string)
 	c.AgentSHA256, _ = m["agent_sha256"].(string)
 	c.WorkDir, _ = m["work_dir"].(string)
+	c.Owner, _ = m["owner"].(string)
+	c.Repo, _ = m["repo"].(string)
 	c.ServiceName, _ = m["service_name"].(string)
 	switch v := m["labels"].(type) {
 	case []string:

--- a/features/modules/extended/github_runner/config_test.go
+++ b/features/modules/extended/github_runner/config_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package github_runner
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeComponent(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"hello", "hello"},
+		{"my.host", "my.host"},
+		{"my_host", "my_host"},
+		{"my-host", "my-host"},
+		{"my@host", "my@host"},
+		{"my host", "my-host"},
+		{"org/repo", "org-repo"},
+		{"host#1", "host-1"},
+		{"org!@#$", "org-@--"},
+	}
+	for _, tc := range cases {
+		if got := sanitizeComponent(tc.input); got != tc.want {
+			t.Errorf("sanitizeComponent(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestResolveServiceName_Derived(t *testing.T) {
+	cfg := &RunnerConfig{Owner: "myorg", Repo: "myrepo"}
+	want := "actions.runner.myorg-myrepo.myhost"
+	if got := cfg.ResolveServiceName("myhost"); got != want {
+		t.Errorf("ResolveServiceName = %q, want %q", got, want)
+	}
+}
+
+func TestResolveServiceName_ExplicitHonored(t *testing.T) {
+	const explicit = "actions.runner.my-org.my-repo.explicit.service"
+	cfg := &RunnerConfig{
+		Owner:       "myorg",
+		Repo:        "myrepo",
+		ServiceName: explicit,
+	}
+	if got := cfg.ResolveServiceName("somehostname"); got != explicit {
+		t.Errorf("ResolveServiceName = %q, want explicit %q", got, explicit)
+	}
+}
+
+func TestResolveServiceName_SanitizesComponents(t *testing.T) {
+	cases := []struct {
+		owner, repo, hostname, want string
+	}{
+		{"my org", "my repo", "my host", "actions.runner.my-org-my-repo.my-host"},
+		{"org/sub", "my/repo", "host.local", "actions.runner.org-sub-my-repo.host.local"},
+	}
+	for _, tc := range cases {
+		cfg := &RunnerConfig{Owner: tc.owner, Repo: tc.repo}
+		got := cfg.ResolveServiceName(tc.hostname)
+		if got != tc.want {
+			t.Errorf("owner=%q repo=%q hostname=%q: got %q, want %q",
+				tc.owner, tc.repo, tc.hostname, got, tc.want)
+		}
+	}
+}
+
+func TestValidate_ServiceName_OptionalWithOwnerRepo(t *testing.T) {
+	workDir := t.TempDir()
+	cfg := &RunnerConfig{
+		Version:     "2.319.1",
+		AgentURL:    "https://example.invalid/runner.tar.gz",
+		AgentSHA256: strings.Repeat("a", 64),
+		WorkDir:     workDir,
+		Owner:       "myorg",
+		Repo:        "myrepo",
+		// ServiceName intentionally empty
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config with owner+repo but no service_name rejected: %v", err)
+	}
+}
+
+func TestValidate_ServiceName_MissingOwner(t *testing.T) {
+	workDir := t.TempDir()
+	cfg := &RunnerConfig{
+		Version:     "2.319.1",
+		AgentURL:    "https://example.invalid/runner.tar.gz",
+		AgentSHA256: strings.Repeat("a", 64),
+		WorkDir:     workDir,
+		Repo:        "myrepo",
+		// Owner and ServiceName both empty
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate accepted empty service_name with no owner")
+	}
+}
+
+func TestValidate_ServiceName_MissingRepo(t *testing.T) {
+	workDir := t.TempDir()
+	cfg := &RunnerConfig{
+		Version:     "2.319.1",
+		AgentURL:    "https://example.invalid/runner.tar.gz",
+		AgentSHA256: strings.Repeat("a", 64),
+		WorkDir:     workDir,
+		Owner:       "myorg",
+		// Repo and ServiceName both empty
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate accepted empty service_name with no repo")
+	}
+}
+
+func TestValidate_ServiceName_BothEmptyAndMissingOwnerRepo(t *testing.T) {
+	workDir := t.TempDir()
+	cfg := &RunnerConfig{
+		Version:     "2.319.1",
+		AgentURL:    "https://example.invalid/runner.tar.gz",
+		AgentSHA256: strings.Repeat("a", 64),
+		WorkDir:     workDir,
+		// Owner, Repo, and ServiceName all empty
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate accepted empty service_name with no owner or repo")
+	}
+}

--- a/features/modules/extended/github_runner/module.go
+++ b/features/modules/extended/github_runner/module.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 
@@ -231,6 +232,19 @@ func (m *runnerModule) Set(ctx context.Context, resourceID string, config module
 	if err := desired.Validate(); err != nil {
 		return err
 	}
+
+	// Resolve the effective service name. When service_name is empty the module
+	// derives it from owner, repo, and the steward's own hostname at convergence
+	// time (the module runs as a subprocess on the host per ADR-006).
+	hostname, herr := os.Hostname()
+	if herr != nil {
+		return fmt.Errorf("get hostname for service name derivation: %w", herr)
+	}
+	resolvedServiceName := desired.ResolveServiceName(hostname)
+	if !serviceNamePattern.MatchString(resolvedServiceName) {
+		return fmt.Errorf("%w: derived service_name %q violates serviceNamePattern (check owner/repo/hostname length)", modules.ErrInvalidInput, resolvedServiceName)
+	}
+
 	logger := m.GetEffectiveLogger(logging.ForModule("github_runner"))
 
 	st, err := readState(desired.WorkDir)
@@ -256,10 +270,10 @@ func (m *runnerModule) Set(ctx context.Context, resourceID string, config module
 		st.Version = desired.Version
 	}
 
-	// Record desired labels + service name so drift is resolved locally.
+	// Record desired labels + resolved service name so drift is resolved locally.
 	st.Labels = append([]string(nil), desired.Labels...)
 	sort.Strings(st.Labels)
-	st.ServiceName = desired.ServiceName
+	st.ServiceName = resolvedServiceName
 	if werr := writeState(desired.WorkDir, st); werr != nil {
 		return fmt.Errorf("write runner state: %w", werr)
 	}
@@ -267,19 +281,19 @@ func (m *runnerModule) Set(ctx context.Context, resourceID string, config module
 	// Ensure the service is enabled + running. Skipped when the service is not
 	// yet registered (the provisioning workflow registers it on first standup);
 	// in that case Get/Test report drift until registration completes.
-	status, serr := m.executor.status(ctx, desired.ServiceName)
+	status, serr := m.executor.status(ctx, resolvedServiceName)
 	if serr != nil {
-		return fmt.Errorf("query runner service %q: %w", logging.SanitizeLogValue(desired.ServiceName), serr)
+		return fmt.Errorf("query runner service %q: %w", logging.SanitizeLogValue(resolvedServiceName), serr)
 	}
 	if status.Installed {
-		if eerr := m.executor.ensure(ctx, desired.ServiceName, true, true); eerr != nil {
-			return fmt.Errorf("ensure runner service %q: %w", logging.SanitizeLogValue(desired.ServiceName), eerr)
+		if eerr := m.executor.ensure(ctx, resolvedServiceName, true, true); eerr != nil {
+			return fmt.Errorf("ensure runner service %q: %w", logging.SanitizeLogValue(resolvedServiceName), eerr)
 		}
 	} else {
 		logger.WarnCtx(ctx, "runner service not yet registered; agent staged, awaiting provisioning registration",
 			"operation", "github_runner_set",
 			"resource_id", logging.SanitizeLogValue(resourceID),
-			"service_name", logging.SanitizeLogValue(desired.ServiceName))
+			"service_name", logging.SanitizeLogValue(resolvedServiceName))
 	}
 
 	logger.InfoCtx(ctx, "github_runner converged",

--- a/features/modules/extended/github_runner/module_test.go
+++ b/features/modules/extended/github_runner/module_test.go
@@ -18,6 +18,20 @@ import (
 	"github.com/cfgis/cfgms/features/modules"
 )
 
+// validConfigOwnerRepo builds a RunnerConfig with owner+repo instead of an
+// explicit service_name, for use in derivation tests.
+func validConfigOwnerRepo(workDir, owner, repo string) *RunnerConfig {
+	return &RunnerConfig{
+		Version:     "2.319.1",
+		AgentURL:    "https://example.invalid/runner.tar.gz",
+		AgentSHA256: strings.Repeat("a", 64),
+		Labels:      []string{"linux", "ci", "self-hosted"},
+		WorkDir:     workDir,
+		Owner:       owner,
+		Repo:        repo,
+	}
+}
+
 // errEnsureBoom is a sentinel the test service executor returns to verify Set
 // propagates a service-convergence failure.
 var errEnsureBoom = errors.New("ensure failed (test)")
@@ -494,5 +508,131 @@ func TestModule_StoredConfig_ConvergesViaWorkDir(t *testing.T) {
 	}
 	if inst.calls != 1 {
 		t.Fatalf("second Set re-downloaded agent (installer calls=%d, want 1)", inst.calls)
+	}
+}
+
+// TestModule_Set_DerivedServiceName verifies that when service_name is absent
+// (owner+repo present) Set derives actions.runner.<owner>-<repo>.<hostname> and
+// records it in the state marker so subsequent Get/Test use the correct name.
+func TestModule_Set_DerivedServiceName(t *testing.T) {
+	srv, url, sha := agentServer(t)
+	defer srv.Close()
+	workDir := t.TempDir()
+	exec := &testServiceExecutor{installed: true, makeRunOnSet: true}
+	m, _ := moduleFor(exec, srv)
+
+	cfg := validConfigOwnerRepo(workDir, "myorg", "myrepo")
+	cfg.AgentURL, cfg.AgentSHA256 = url, sha
+
+	ctx := context.Background()
+	if err := m.Set(ctx, workDir, cfg); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("os.Hostname: %v", err)
+	}
+	wantSvcName := "actions.runner." + sanitizeComponent("myorg") + "-" + sanitizeComponent("myrepo") + "." + sanitizeComponent(hostname)
+
+	st, err := readState(workDir)
+	if err != nil {
+		t.Fatalf("readState: %v", err)
+	}
+	if st.ServiceName != wantSvcName {
+		t.Errorf("state service_name = %q, want %q", st.ServiceName, wantSvcName)
+	}
+
+	// Get must report state keyed by the derived name (via state marker).
+	state, err := m.Get(ctx, workDir)
+	if err != nil {
+		t.Fatalf("Get after derived-name Set: %v", err)
+	}
+	rc := state.(*RunnerConfig)
+	if rc.ServiceName != wantSvcName {
+		t.Errorf("Get service_name = %q, want derived %q", rc.ServiceName, wantSvcName)
+	}
+}
+
+// TestModule_Set_ExplicitServiceName_Honored verifies that an explicit
+// service_name bypasses derivation and is stored verbatim in the state marker.
+func TestModule_Set_ExplicitServiceName_Honored(t *testing.T) {
+	srv, url, sha := agentServer(t)
+	defer srv.Close()
+	workDir := t.TempDir()
+	exec := &testServiceExecutor{installed: true, makeRunOnSet: true}
+	m, _ := moduleFor(exec, srv)
+
+	const explicitSvcName = "actions.runner.acme-myrepo.dedicated-host.service"
+	cfg := validConfig(workDir, explicitSvcName)
+	cfg.AgentURL, cfg.AgentSHA256 = url, sha
+
+	ctx := context.Background()
+	if err := m.Set(ctx, workDir, cfg); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	st, err := readState(workDir)
+	if err != nil {
+		t.Fatalf("readState: %v", err)
+	}
+	if st.ServiceName != explicitSvcName {
+		t.Errorf("state service_name = %q, want explicit %q", st.ServiceName, explicitSvcName)
+	}
+}
+
+// TestModule_Set_DerivedServiceName_TooLong verifies that a derived service
+// name that exceeds the serviceNamePattern length limit is rejected with a
+// clear error, not silently truncated.
+func TestModule_Set_DerivedServiceName_TooLong(t *testing.T) {
+	workDir := t.TempDir()
+	exec := &testServiceExecutor{}
+	m := newModule(exec, newHTTPInstaller())
+
+	// Derive a name that will be much longer than 255 chars.
+	longRepo := strings.Repeat("a", 300)
+	cfg := &RunnerConfig{
+		Version:     "2.319.1",
+		AgentURL:    "https://example.invalid/runner.tar.gz",
+		AgentSHA256: strings.Repeat("a", 64),
+		WorkDir:     workDir,
+		Owner:       "myorg",
+		Repo:        longRepo,
+	}
+
+	err := m.Set(context.Background(), workDir, cfg)
+	if err == nil {
+		t.Fatal("Set accepted a config whose derived service name exceeds the length limit")
+	}
+	if !errors.Is(err, modules.ErrInvalidInput) {
+		t.Errorf("Set error = %v, want to wrap modules.ErrInvalidInput", err)
+	}
+}
+
+// TestModule_Configure_EmptyServiceName_WithOwnerRepo verifies that Configure
+// accepts a config where service_name is absent but owner+repo are set.
+func TestModule_Configure_EmptyServiceName_WithOwnerRepo(t *testing.T) {
+	workDir := t.TempDir()
+	m := newModule(&testServiceExecutor{}, newHTTPInstaller())
+	cfg := validConfigOwnerRepo(workDir, "myorg", "myrepo")
+	if err := m.Configure(cfg); err != nil {
+		t.Fatalf("Configure rejected valid owner+repo config: %v", err)
+	}
+}
+
+// TestModule_Configure_EmptyServiceName_MissingOwnerRepo verifies that Configure
+// rejects a config where service_name is absent and owner+repo are also absent.
+func TestModule_Configure_EmptyServiceName_MissingOwnerRepo(t *testing.T) {
+	workDir := t.TempDir()
+	m := newModule(&testServiceExecutor{}, newHTTPInstaller())
+	cfg := &RunnerConfig{
+		Version:     "2.319.1",
+		AgentURL:    "https://example.invalid/runner.tar.gz",
+		AgentSHA256: strings.Repeat("a", 64),
+		WorkDir:     workDir,
+		// ServiceName, Owner, and Repo all empty
+	}
+	if err := m.Configure(cfg); err == nil {
+		t.Fatal("Configure accepted a config with no service_name, owner, or repo")
 	}
 }

--- a/features/modules/extended/github_runner/schema.yaml
+++ b/features/modules/extended/github_runner/schema.yaml
@@ -12,7 +12,6 @@ resources:
       - agent_url
       - agent_sha256
       - work_dir
-      - service_name
     properties:
       version:
         type: string
@@ -37,9 +36,24 @@ resources:
       work_dir:
         type: string
         description: Absolute install directory for the runner agent (also the resource ID).
+      owner:
+        type: string
+        description: >
+          GitHub organization or user owning the repository. Required when
+          service_name is not set; used with repo to derive the service name as
+          actions.runner.<owner>-<repo>.<hostname>.
+      repo:
+        type: string
+        description: >
+          GitHub repository name (without the owner prefix). Required when
+          service_name is not set; used with owner to derive the service name as
+          actions.runner.<owner>-<repo>.<hostname>.
       service_name:
         type: string
         description: >
           OS service name of the runner service (systemd unit on Linux, SCM
           service on Windows), e.g. "actions.runner.acme-repo.host1.service".
+          Optional: when omitted, owner and repo must be set and the module
+          derives the name as actions.runner.<owner>-<repo>.<hostname> at
+          convergence time, producing a host-unique name from a shared role config.
         pattern: "^[a-zA-Z0-9][a-zA-Z0-9._@-]{0,254}$"


### PR DESCRIPTION
## Summary

- Adds `owner` and `repo` fields to `RunnerConfig` (org-scoped; belong in the shared role config)
- Makes `service_name` optional: when absent, `owner`+`repo` become required and the module derives `actions.runner.<owner>-<repo>.<hostname>` at convergence time via `os.Hostname()`
- Owner/repo/hostname components are sanitized (disallowed chars → `-`) so the derived name always satisfies `serviceNamePattern`; names exceeding 255 chars are rejected with `ErrInvalidInput`
- Explicit `service_name` continues to pass through unchanged
- Documents the registration-name coupling contract in the README (runner must be registered with `--name $(hostname)` for the derived name to match the OS service)

Fixes #2547

## Specialist review results

All three lenses passed in a single round with zero findings:
- **Code review**: PASS
- **Test quality**: PASS  
- **Security**: PASS

## Test plan

- [x] `TestResolveServiceName_Derived` — `owner`+`repo`+hostname → `actions.runner.<owner>-<repo>.<hostname>`
- [x] `TestResolveServiceName_ExplicitHonored` — explicit `service_name` returned unchanged
- [x] `TestResolveServiceName_SanitizesComponents` — disallowed chars replaced with `-`
- [x] `TestValidate_ServiceName_OptionalWithOwnerRepo` — config with `owner`+`repo` but no `service_name` validates
- [x] `TestValidate_ServiceName_MissingOwner` / `MissingRepo` / `BothEmptyAndMissingOwnerRepo` — clear error on missing fields
- [x] `TestModule_Set_DerivedServiceName` — Set records derived name in state marker; Get reads it back
- [x] `TestModule_Set_ExplicitServiceName_Honored` — explicit name stored verbatim
- [x] `TestModule_Set_DerivedServiceName_TooLong` — >255-char derived name rejected with `ErrInvalidInput`
- [x] `TestModule_Configure_EmptyServiceName_WithOwnerRepo` / `MissingOwnerRepo` — Configure gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)