### PR TITLE
fleet: merge controller tags into DNA-attribute map for tag: selectors (Issue #2544)

### DIFF
--- a/features/controller/fleet/storage/retention_test.go
+++ b/features/controller/fleet/storage/retention_test.go
@@ -88,8 +88,16 @@ func TestRetention_MaxRecordsPerDevice(t *testing.T) {
 func TestRetention_AgeBasedPruning(t *testing.T) {
 	logger := logging.NewLogger("error")
 	config := createTestConfig(t, BackendSQLite)
-	// Very short retention: anything older than 50ms is prunable.
-	config.RetentionPeriod = 50 * time.Millisecond
+	// Retention window of 30 minutes. The two "old" records are backdated 1h (well
+	// before the cutoff, so prunable); the "recent" record is stored at time.Now()
+	// (well after the cutoff, so retained). The 30-minute margin is intentional: the
+	// cutoff is computed as time.Now()-RetentionPeriod at prune time, which is a few
+	// microseconds-to-milliseconds after the recent record's stored-at timestamp. A
+	// tight window (e.g. 50ms) would let ordinary scheduling/DB-query latency between
+	// storing the recent record and computing the cutoff push the recent record's
+	// timestamp before the cutoff, pruning it too — a wall-clock race. The wide margin
+	// makes the old-vs-recent discrimination deterministic without altering behavior.
+	config.RetentionPeriod = 30 * time.Minute
 	config.MaxRecordsPerDevice = 0 // disable count cap — only age applies
 	config.EnableDeduplication = false
 
@@ -131,7 +139,7 @@ func TestRetention_AgeBasedPruning(t *testing.T) {
 	// Insert recent record directly via SQLiteBackend for the same reason the old records
 	// were inserted directly: manager.Store fires go m.enforceRetentionPolicy(deviceID)
 	// after every write, and that goroutine is immediately eligible to prune the two
-	// backdated records (stored at -1h, cutoff at -50ms) before the pre-prune count
+	// backdated records (stored at -1h, cutoff at -30m) before the pre-prune count
 	// assertion at line 145 runs. Bypassing manager.Store keeps the goroutine out of
 	// the picture entirely and makes the pre-prune count deterministic.
 	recentDNA := createTestDNA(deviceID, map[string]string{
@@ -162,7 +170,8 @@ func TestRetention_AgeBasedPruning(t *testing.T) {
 		t.Fatalf("expected 3 records before age pruning, got %d", len(history.Records))
 	}
 
-	// Run pruning. cutoff = now - 50ms, so old records (1h ago) are pruned.
+	// Run pruning. cutoff = now - 30m, so old records (1h ago) are pruned while the
+	// recent record (stored at now) is safely retained.
 	manager.enforceRetentionPolicy(deviceID)
 
 	// Old records must be gone; recent record must remain.

--- a/features/controller/server/batchjob_fleetquery_test.go
+++ b/features/controller/server/batchjob_fleetquery_test.go
@@ -4,6 +4,8 @@ package server
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +14,7 @@ import (
 	common "github.com/cfgis/cfgms/api/proto/common"
 	controllerFleet "github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/controller/tagstore"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -128,4 +131,167 @@ func TestServerBatchjobFleetQuery_Search_InvalidSelector(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, metas)
 	assert.Contains(t, err.Error(), "invalid selector")
+}
+
+// newTestTagStore opens a temporary SQLite-backed tag store suitable for use in unit tests.
+func newTestTagStore(t *testing.T) *tagstore.Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "tags_test.db")
+	store, err := tagstore.NewFromDSN("file:"+dbPath, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NoError(t, store.Initialize(context.Background()))
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestServerFleetStewardProvider_TagSelector verifies that after tagging steward S
+// with "github-runner" (via the #2542 store), a fleet query with parsed selector
+// tag:github-runner returns S through serverFleetStewardProvider; an untagged
+// steward is not returned. (Issue #2544 AC1)
+func TestServerFleetStewardProvider_TagSelector(t *testing.T) {
+	svc := newFleetQueryTestService(t)
+	ts := newTestTagStore(t)
+	svc.SetTagStore(ts)
+
+	// Tag only s-linux; s-windows and s-other are untagged.
+	require.NoError(t, ts.Set(context.Background(), "s-linux", []string{"github-runner"}))
+
+	provider := &serverFleetStewardProvider{svc: svc}
+	stewards := provider.GetAllStewards()
+
+	byID := make(map[string]controllerFleet.StewardData, len(stewards))
+	for _, s := range stewards {
+		byID[s.ID] = s
+	}
+
+	// s-linux must have the tag merged into its attribute map.
+	linux := byID["s-linux"]
+	assert.Equal(t, "github-runner", linux.DNAAttributes["tags"],
+		"s-linux must have tags=github-runner after merge")
+
+	// s-windows must not have any tags key.
+	windows := byID["s-windows"]
+	_, hasTag := windows.DNAAttributes["tags"]
+	assert.False(t, hasTag, "untagged steward must not have a tags attribute")
+
+	// Drive the full tag: selector path through MemoryQuery to confirm end-to-end resolution.
+	adapter := &serverBatchjobFleetQuery{svc: svc}
+	metas, err := adapter.Search(context.Background(), "tag:github-runner", "tenant-a")
+	require.NoError(t, err)
+	require.Len(t, metas, 1, "only s-linux is tagged; s-windows must not match")
+	assert.Equal(t, "s-linux", metas[0].ID)
+}
+
+// TestServerFleetStewardProvider_TagsSurviveDNARefresh verifies that controller-stored
+// tags remain resolvable after a steward's DNA is replaced wholesale. Tags are
+// controller-owned and must not be clobbered by DNA updates. (Issue #2544 AC2)
+func TestServerFleetStewardProvider_TagsSurviveDNARefresh(t *testing.T) {
+	svc := service.NewControllerService(logging.NewNoopLogger())
+	require.NoError(t, svc.RegisterSteward("s-refresh", "tenant-a", "addr-1", "online"))
+	require.True(t, svc.SetStewardDNA("s-refresh", &common.DNA{
+		Id:         "s-refresh",
+		Attributes: map[string]string{"os": "linux", "hostname": "before-refresh"},
+	}))
+
+	ts := newTestTagStore(t)
+	svc.SetTagStore(ts)
+	require.NoError(t, ts.Set(context.Background(), "s-refresh", []string{"github-runner"}))
+
+	// Wholesale DNA replacement simulates the DNA refresh cycle.
+	require.True(t, svc.SetStewardDNA("s-refresh", &common.DNA{
+		Id:         "s-refresh",
+		Attributes: map[string]string{"os": "linux", "hostname": "after-refresh"},
+	}))
+
+	adapter := &serverBatchjobFleetQuery{svc: svc}
+	metas, err := adapter.Search(context.Background(), "tag:github-runner", "tenant-a")
+	require.NoError(t, err)
+	require.Len(t, metas, 1, "tag must survive DNA refresh")
+	assert.Equal(t, "s-refresh", metas[0].ID)
+	assert.Equal(t, "after-refresh", metas[0].DNAAttributes["hostname"],
+		"refreshed hostname must be visible after DNA update")
+}
+
+// TestServerFleetStewardProvider_NoDNAAttributeMutation verifies that merging
+// controller-stored tags does not mutate the shared info.DNA.Attributes map in
+// place. Mutation would corrupt the cached DNA and is therefore load-bearing.
+// (Issue #2544 AC3)
+func TestServerFleetStewardProvider_NoDNAAttributeMutation(t *testing.T) {
+	svc := service.NewControllerService(logging.NewNoopLogger())
+	originalAttrs := map[string]string{"os": "linux", "hostname": "web-01"}
+	require.NoError(t, svc.RegisterSteward("s-mut", "tenant-a", "addr-1", "online"))
+	require.True(t, svc.SetStewardDNA("s-mut", &common.DNA{
+		Id:         "s-mut",
+		Attributes: originalAttrs,
+	}))
+
+	ts := newTestTagStore(t)
+	svc.SetTagStore(ts)
+	require.NoError(t, ts.Set(context.Background(), "s-mut", []string{"github-runner"}))
+
+	// Capture the DNA attributes map pointer before the provider call.
+	beforeKeys := make(map[string]string, len(originalAttrs))
+	for k, v := range originalAttrs {
+		beforeKeys[k] = v
+	}
+
+	provider := &serverFleetStewardProvider{svc: svc}
+	stewards := provider.GetAllStewards()
+
+	// Verify the returned StewardData has the merged tags.
+	require.Len(t, stewards, 1)
+	assert.Equal(t, "github-runner", stewards[0].DNAAttributes["tags"],
+		"returned attrs must carry merged tags")
+
+	// The original attributes map passed to SetStewardDNA must be unchanged.
+	assert.Equal(t, beforeKeys, originalAttrs,
+		"info.DNA.Attributes must not be mutated in place")
+	_, hasTags := originalAttrs["tags"]
+	assert.False(t, hasTags, "tags must not bleed into the original DNA attributes map")
+}
+
+// TestServerFleetStewardProvider_DNATagsUnion verifies that when a steward
+// already reports a "tags" attribute in its DNA, controller-stored tags are
+// unioned (not replaced). DNA tags appear first; duplicates are dropped.
+// (Issue #2544 implementation note)
+func TestServerFleetStewardProvider_DNATagsUnion(t *testing.T) {
+	svc := service.NewControllerService(logging.NewNoopLogger())
+	require.NoError(t, svc.RegisterSteward("s-union", "tenant-a", "addr-1", "online"))
+	require.True(t, svc.SetStewardDNA("s-union", &common.DNA{
+		Id:         "s-union",
+		Attributes: map[string]string{"os": "linux", "tags": "dna-tag,shared-tag"},
+	}))
+
+	ts := newTestTagStore(t)
+	svc.SetTagStore(ts)
+	// "shared-tag" is in both DNA and controller store — must appear exactly once.
+	require.NoError(t, ts.Set(context.Background(), "s-union", []string{"ctrl-tag", "shared-tag"}))
+
+	provider := &serverFleetStewardProvider{svc: svc}
+	stewards := provider.GetAllStewards()
+	require.Len(t, stewards, 1)
+
+	raw := stewards[0].DNAAttributes["tags"]
+	// Split and verify each expected tag is present, with no duplicates.
+	parts := make(map[string]int)
+	for _, tag := range splitTrimTags(raw) {
+		parts[tag]++
+	}
+	assert.Equal(t, 1, parts["dna-tag"], "dna-tag must appear once")
+	assert.Equal(t, 1, parts["ctrl-tag"], "ctrl-tag must appear once")
+	assert.Equal(t, 1, parts["shared-tag"], "shared-tag must appear exactly once (no duplicate)")
+}
+
+// splitTrimTags splits a comma-separated tag string, trims whitespace, and drops empties.
+func splitTrimTags(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var result []string
+	for _, part := range strings.Split(raw, ",") {
+		if t := strings.TrimSpace(part); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -2507,11 +2507,15 @@ type serverFleetStewardProvider struct {
 
 func (p *serverFleetStewardProvider) GetAllStewards() []controllerFleet.StewardData {
 	infos := p.svc.GetAllStewards()
+	tagStore := p.svc.TagStore()
 	result := make([]controllerFleet.StewardData, 0, len(infos))
 	for _, info := range infos {
 		var attrs map[string]string
 		if info.DNA != nil {
 			attrs = info.DNA.Attributes
+		}
+		if tagStore != nil {
+			attrs = mergeControllerTags(attrs, tagStore.TagsFor(info.ID))
 		}
 		result = append(result, controllerFleet.StewardData{
 			ID:            info.ID,
@@ -2522,6 +2526,48 @@ func (p *serverFleetStewardProvider) GetAllStewards() []controllerFleet.StewardD
 		})
 	}
 	return result
+}
+
+// mergeControllerTags returns a copy of attrs with controller-stored ctrlTags
+// merged into the "tags" key. If attrs already carries a DNA-reported "tags"
+// value, the two sets are unioned (DNA tags first, then controller tags;
+// duplicates dropped). Returns attrs unchanged when ctrlTags is empty.
+// Never mutates the input map — attrs aliases info.DNA.Attributes which is a
+// shared, cached reference; mutating it in place would corrupt the DNA cache.
+func mergeControllerTags(attrs map[string]string, ctrlTags []string) map[string]string {
+	if len(ctrlTags) == 0 {
+		return attrs
+	}
+	// Copy to avoid mutating the shared DNA.Attributes alias.
+	merged := make(map[string]string, len(attrs)+1)
+	for k, v := range attrs {
+		merged[k] = v
+	}
+	// Union DNA-reported tags with controller-stored tags; DNA tags come first.
+	seen := make(map[string]struct{})
+	var all []string
+	for _, t := range strings.Split(merged["tags"], ",") {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; !dup {
+			seen[t] = struct{}{}
+			all = append(all, t)
+		}
+	}
+	for _, t := range ctrlTags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; !dup {
+			seen[t] = struct{}{}
+			all = append(all, t)
+		}
+	}
+	merged["tags"] = strings.Join(all, ",")
+	return merged
 }
 
 // assertClusterBackendsReady verifies cluster-mode prerequisites before any state is read

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -919,6 +919,96 @@ func TestInitializeUpgradeStore_InitializeFailure_FallsBackToInMemory(t *testing
 	assertUpgradeStoreFunctional(t, ctx, store)
 }
 
+// ---------------------------------------------------------------------------
+// initializeTagStore degradation tests (Issue #2542 / #2544)
+//
+// initializeTagStore returns nil (not a fallback) on any failure — the
+// controller must start even when tag persistence is unavailable.
+// ---------------------------------------------------------------------------
+
+// TestInitializeTagStore_NoSQLitePath_ReturnsNil verifies that initializeTagStore
+// returns nil and logs a warning when the Storage config is absent or SQLitePath
+// is empty, instead of blocking controller startup.
+func TestInitializeTagStore_NoSQLitePath_ReturnsNil(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "nil Storage", cfg: &config.Config{}},
+		{name: "empty SQLitePath", cfg: &config.Config{Storage: &config.StorageConfig{SQLitePath: ""}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingLogger{}
+			store := initializeTagStore(ctx, tc.cfg, rec)
+			assert.Nil(t, store, "unconfigured SQLitePath must degrade to nil, not panic")
+			assert.True(t, rec.containsAny("not configured"),
+				"silent degradation must emit an observable warning")
+		})
+	}
+}
+
+// TestInitializeTagStore_OpenFailure_ReturnsNil verifies that initializeTagStore
+// returns nil and warns when the SQLite DSN cannot be opened (e.g. DSN points
+// at a directory rather than a writable file).
+func TestInitializeTagStore_OpenFailure_ReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	rec := &recordingLogger{}
+
+	// A directory path causes the busy_timeout PRAGMA to fail (not a valid DB file).
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{SQLitePath: t.TempDir()},
+	}
+
+	store := initializeTagStore(ctx, cfg, rec)
+	assert.Nil(t, store, "an unopenable SQLite DSN must degrade to nil")
+	assert.True(t, rec.containsAny("failed to open"),
+		"open failure must emit an observable warning")
+}
+
+// TestInitializeTagStore_InitializeFailure_ReturnsNil verifies that
+// initializeTagStore returns nil and warns when the DSN opens but schema
+// initialization fails (corrupt/non-SQLite file content).
+func TestInitializeTagStore_InitializeFailure_ReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	rec := &recordingLogger{}
+
+	dbPath := filepath.Join(t.TempDir(), "corrupt_tags.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("not a sqlite database, just raw bytes"), 0o600))
+
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{SQLitePath: dbPath},
+	}
+
+	store := initializeTagStore(ctx, cfg, rec)
+	assert.Nil(t, store, "a schema-init failure must degrade to nil")
+	assert.True(t, rec.containsAny("failed to initialize"),
+		"initialize failure must emit an observable warning")
+}
+
+// TestInitializeTagStore_HappyPath_ReturnsUsableStore verifies that a valid
+// SQLitePath produces a non-nil store that accepts tag round-trips.
+func TestInitializeTagStore_HappyPath_ReturnsUsableStore(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "tags.db")
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{SQLitePath: dbPath},
+	}
+
+	store := initializeTagStore(ctx, cfg, logging.NewNoopLogger())
+	require.NotNil(t, store, "valid SQLitePath must return a non-nil store")
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Round-trip: store must accept writes and serve reads.
+	require.NoError(t, store.Set(ctx, "steward-1", []string{"env-prod"}))
+	tags, err := store.Get(ctx, "steward-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"env-prod"}, tags)
+}
+
 // assertUpgradeStoreFunctional performs a round-trip write/read to prove the
 // fallback store is genuinely usable, not merely non-nil.
 func assertUpgradeStoreFunctional(t *testing.T, ctx context.Context, store business.UpgradeStore) {

--- a/features/steward/script_relay/relay_test.go
+++ b/features/steward/script_relay/relay_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -25,6 +26,21 @@ import (
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// testIDCounter guarantees each execution ID minted within a single test
+// binary is distinct.
+var testIDCounter int64
+
+// uniqueExecID returns a process-unique execution ID derived from base. The
+// per-execution socket path is deterministic (/tmp/cfgms-<id>/api.sock), so two
+// relays sharing an execution ID would bind the same path and the second
+// net.Listen fails with EADDRINUSE. Fixed IDs collide when the harness runs this
+// package in overlapping or concurrent test-binary invocations (smart-mode
+// selection pass + full pass); folding in the PID and a per-process counter
+// makes every socket path unique so no two invocations can ever collide.
+func uniqueExecID(base string) string {
+	return fmt.Sprintf("%s-%d-%d", base, os.Getpid(), atomic.AddInt64(&testIDCounter, 1))
+}
 
 // newTestRelay creates a Relay for testing. It captures published events and
 // returns a thread-safe accessor function for reading them. The relay is
@@ -73,7 +89,7 @@ func statUID(t *testing.T, path string) uint32 {
 // 0600 socket owned by the execution UID, and that Stop removes them
 // (AC1 — socket lifecycle and ownership).
 func TestRelay_SocketCreation(t *testing.T) {
-	execID := "test-exec-socket"
+	execID := uniqueExecID("test-exec-socket")
 	r, _ := newTestRelay(t, execID)
 
 	sockPath := r.SocketPath()
@@ -114,7 +130,7 @@ func TestRelay_SocketCreation_ChownsToExecutionUID(t *testing.T) {
 
 	// UID 1 (daemon/bin) exists on every POSIX system and is never root.
 	const execUID = 1
-	r, _ := newTestRelayWithUID(t, "test-exec-chown", execUID)
+	r, _ := newTestRelayWithUID(t, uniqueExecID("test-exec-chown"), execUID)
 	defer r.Stop()
 
 	sockPath := r.SocketPath()
@@ -144,12 +160,13 @@ func TestNewRelay_InvalidUIDChownFails(t *testing.T) {
 	}
 
 	publish := func(_ context.Context, _ *cpTypes.Event) {}
-	_, err := NewRelay("test-exec-badchown", "steward-1", 0, publish, logging.NewNoopLogger())
+	execID := uniqueExecID("test-exec-badchown")
+	_, err := NewRelay(execID, "steward-1", 0, publish, logging.NewNoopLogger())
 	require.Error(t, err, "NewRelay must fail when the socket cannot be chowned to the execution UID")
 	assert.Contains(t, err.Error(), "chown")
 
 	// The failed socket directory must not be left behind.
-	sockDir := filepath.Join(os.TempDir(), "cfgms-test-exec-badchown")
+	sockDir := filepath.Join(os.TempDir(), "cfgms-"+execID)
 	_, statErr := os.Stat(sockDir)
 	assert.True(t, os.IsNotExist(statErr), "socket directory must be cleaned up after a failed chown")
 }
@@ -158,7 +175,7 @@ func TestNewRelay_InvalidUIDChownFails(t *testing.T) {
 // script connects, sends HTTP request, relay publishes event, response is
 // delivered, script receives HTTP response.
 func TestRelay_RequestResponseCycle(t *testing.T) {
-	execID := "test-exec-cycle"
+	execID := uniqueExecID("test-exec-cycle")
 	r, capturedEvents := newTestRelay(t, execID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -235,7 +252,7 @@ func TestRelay_RequestResponseCycle(t *testing.T) {
 // TestRelay_StopCancelsWaiting verifies that Stop unblocks a relay goroutine
 // waiting for a response.
 func TestRelay_StopCancelsWaiting(t *testing.T) {
-	execID := "test-exec-stop"
+	execID := uniqueExecID("test-exec-stop")
 	r, _ := newTestRelay(t, execID)
 
 	ctx := context.Background()
@@ -268,7 +285,7 @@ func TestRelay_StopCancelsWaiting(t *testing.T) {
 // TestRelay_ExecutionIDInEvent verifies the execution_id in the event Details
 // matches the relay's bound execution_id (never from the request body).
 func TestRelay_ExecutionIDInEvent(t *testing.T) {
-	execID := "bound-exec-id"
+	execID := uniqueExecID("bound-exec-id")
 	r, capturedEvents := newTestRelay(t, execID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)


### PR DESCRIPTION
## Summary

- `serverFleetStewardProvider.GetAllStewards()` now calls `mergeControllerTags()` to inject controller-stored tags (from `tagstore.Store`) into the flattened `DNAAttributes` map returned to the fleet selector engine. The existing `tag:<value>` selector matcher resolves against this merged map with no changes to matcher logic.
- `mergeControllerTags()` creates a fresh copy of `info.DNA.Attributes` before writing, so the shared DNA cache is never mutated in place (AC3).
- When a steward self-reports tags in its DNA, those sets are unioned with controller-stored tags — DNA tags first, then controller tags, duplicates dropped (AC2 tag survival + union correctness).
- Tags survive DNA refresh: the merge happens at query time, not stored in DNA, so a DNA refresh cannot overwrite controller-assigned tags.

## Acceptance criteria

| AC | Test | Status |
|----|------|--------|
| AC1 — `tag:github-runner` selector returns only tagged steward | `TestServerFleetStewardProvider_TagSelector` | ✅ |
| AC2 — tags survive DNA refresh | `TestServerFleetStewardProvider_TagsSurviveDNARefresh` | ✅ |
| AC3 — no DNA attribute mutation | `TestServerFleetStewardProvider_NoDNAAttributeMutation` | ✅ |
| AC+ — DNA+controller tag union | `TestServerFleetStewardProvider_DNATagsUnion` | ✅ |
| `initializeTagStore` degradation paths | 4 tests in `server_test.go` | ✅ |

## Pre-existing flaky test fixes (uncovered by make test-agent-complete)

- **`features/controller/fleet/storage`** — `TestRetention_AgeBasedPruning` used a 50 ms `RetentionPeriod` that was a wall-clock race under CI load; widened to 30 minutes to make the old/recent boundary deterministic.
- **`features/steward/script_relay`** — relay tests used fixed execution IDs whose socket paths collided when the test binary ran twice (smart-mode pass + full pass in `make test-agent-complete`); replaced with `uniqueExecID()` (PID + atomic counter).

## Story-review results

Passed after 3 review rounds / 2 fix cycles:
- **Security**: PASS (no new SQL/secrets/logging/TLS surface; architecture clean)
- **QA Code Review**: PASS (no mocks, no t.Skip, real components throughout)
- **QA Test Runner**: PASS (`make test-agent-complete` exit 0, 183 packages)

> **Note:** CodeQL results require the PR to be open — run `scripts/pr-security-findings.sh` once CI starts; GHAS is a required merge check.

Fixes #2544

🤖 Generated with [Claude Code](https://claude.com/claude-code)