### PR TITLE
controller: persist DNA received over the data plane (fix reconcile black hole, Issue #2616)

### DIFF
--- a/features/controller/server/composite_handler_test.go
+++ b/features/controller/server/composite_handler_test.go
@@ -150,7 +150,7 @@ func TestComposite_SyncDNA_NilHandler(t *testing.T) {
 func TestComposite_SyncDNA_WithHandler(t *testing.T) {
 	cp := newRecordingHandler()
 	logger := logging.NewNoopLogger()
-	dnaHandler := controllerTransport.NewDNAHandler(logger, controllerTransport.NewTenantQueue())
+	dnaHandler := controllerTransport.NewDNAHandler(logger, controllerTransport.NewTenantQueue(), nil)
 	composite := newCompositeTransportServer(cp, dnaHandler, nil, nil, nil, nil)
 
 	// Empty stream with background context (no mTLS peer) → Unauthenticated from handler.

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -1609,7 +1609,7 @@ func (s *Server) Start() error {
 		}
 
 		tenantQueue := controllerTransport.NewTenantQueue()
-		dnaHandler := controllerTransport.NewDNAHandler(s.logger, tenantQueue)
+		dnaHandler := controllerTransport.NewDNAHandler(s.logger, tenantQueue, s.controllerService)
 		bulkHandler := controllerTransport.NewBulkHandler(s.logger, tenantQueue)
 		logStreamHandler := controllerTransport.NewLogStreamHandler(
 			s.stewardEventManager,

--- a/features/controller/transport/dna_handler.go
+++ b/features/controller/transport/dna_handler.go
@@ -3,8 +3,11 @@
 package transport
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -12,20 +15,33 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
+	common "github.com/cfgis/cfgms/api/proto/common"
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	dptypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 )
 
-// DNAHandler handles DNA sync RPCs from stewards.
-type DNAHandler struct {
-	logger logging.Logger
-	queue  *TenantQueue
+// DNAPersister persists a fully-reassembled DNA snapshot received over the data
+// plane. It is implemented by *service.ControllerService (SyncDNA), which stores
+// the snapshot durably (append-only version history) and fires the reconcile
+// post-sync hook (#2524). A nil persister disables persistence (used by tests
+// that exercise only the receive/validation behavior).
+type DNAPersister interface {
+	SyncDNA(ctx context.Context, dna *common.DNA) (*common.Status, error)
 }
 
-// NewDNAHandler creates a new DNA sync handler.
-func NewDNAHandler(logger logging.Logger, queue *TenantQueue) *DNAHandler {
-	return &DNAHandler{logger: logger, queue: queue}
+// DNAHandler handles DNA sync RPCs from stewards.
+type DNAHandler struct {
+	logger    logging.Logger
+	queue     *TenantQueue
+	persister DNAPersister
+}
+
+// NewDNAHandler creates a new DNA sync handler. persister may be nil to disable
+// persistence (the handler then only receives + validates the stream).
+func NewDNAHandler(logger logging.Logger, queue *TenantQueue, persister DNAPersister) *DNAHandler {
+	return &DNAHandler{logger: logger, queue: queue, persister: persister}
 }
 
 // HandleGRPC processes a SyncDNA RPC on the shared gRPC-over-QUIC server.
@@ -38,6 +54,11 @@ func NewDNAHandler(logger logging.Logger, queue *TenantQueue) *DNAHandler {
 // Per-tenant back-pressure: after steward ID validation on the first chunk,
 // Acquire is called with the chunk's tenant_id. If the tenant's queue is full
 // (MaxConcurrentPerTenant in-flight), the RPC is rejected with ResourceExhausted.
+//
+// The full snapshot streamed by the steward (sync_dna is always a full snapshot,
+// Delta=false) is reassembled and PERSISTED via the configured DNAPersister —
+// without this the controller-initiated reconcile (#2524) would loop forever
+// because the synced DNA was never stored (Issue #2616).
 func (h *DNAHandler) HandleGRPC(stream grpc.ClientStreamingServer[transportpb.DNAChunk, transportpb.DNASyncResponse]) error {
 	ctx := stream.Context()
 
@@ -76,22 +97,85 @@ func (h *DNAHandler) HandleGRPC(stream grpc.ClientStreamingServer[transportpb.DN
 	}
 	defer h.queue.Release(tenantID)
 
-	chunkCount := 1
+	chunks := []*transportpb.DNAChunk{firstChunk}
 	for {
-		_, err := stream.Recv()
-		if err == io.EOF {
+		chunk, recvErr := stream.Recv()
+		if recvErr == io.EOF {
 			break
 		}
-		if err != nil {
-			return fmt.Errorf("failed to receive DNA chunk: %w", err)
+		if recvErr != nil {
+			return fmt.Errorf("failed to receive DNA chunk: %w", recvErr)
 		}
-		chunkCount++
+		chunks = append(chunks, chunk)
 	}
 
-	h.logger.Info("DNA sync received", "chunks", chunkCount, "peer_id", peerID)
+	h.logger.Info("DNA sync received", "chunks", len(chunks), "peer_id", peerID)
+
+	// No persistence configured (test / degenerate). Accept without reassembly —
+	// production always wires a persister (server.go).
+	if h.persister == nil {
+		h.logger.Warn("DNA sync received but no persister configured; not stored", "peer_id", peerID)
+		return stream.SendAndClose(&transportpb.DNASyncResponse{Accepted: true, Message: "accepted"})
+	}
+
+	dna, rErr := reassembleDNA(chunks, peerID)
+	if rErr != nil {
+		return status.Errorf(codes.InvalidArgument, "failed to reassemble DNA: %v", rErr)
+	}
+
+	if _, pErr := h.persister.SyncDNA(ctx, dna); pErr != nil {
+		return fmt.Errorf("failed to persist synced DNA for %s: %w", peerID, pErr)
+	}
+
+	h.logger.Info("DNA sync persisted", "peer_id", peerID, "attributes", dna.GetAttributeCount())
 
 	return stream.SendAndClose(&transportpb.DNASyncResponse{
 		Accepted: true,
 		Message:  "accepted",
 	})
+}
+
+// reassembleDNA concatenates the chunk payloads (ordered by ChunkIndex) into the
+// JSON-encoded DNATransfer the steward streamed, then decodes its Attributes into
+// a common.DNA. It mirrors dnaTransferToChunks on the send side: the whole
+// DNATransfer is JSON-marshalled and split into ≤64 KB DNAChunk.Data segments,
+// and DNATransfer.Attributes is itself the JSON of the attribute map.
+func reassembleDNA(chunks []*transportpb.DNAChunk, stewardID string) (*common.DNA, error) {
+	if len(chunks) == 0 {
+		return nil, fmt.Errorf("no DNA chunks")
+	}
+	total := int(chunks[0].GetTotalChunks())
+	if total != len(chunks) {
+		return nil, fmt.Errorf("chunk count %d does not match total_chunks %d", len(chunks), total)
+	}
+	sort.Slice(chunks, func(i, j int) bool {
+		return chunks[i].GetChunkIndex() < chunks[j].GetChunkIndex()
+	})
+
+	var payload []byte
+	for i, c := range chunks {
+		if int(c.GetChunkIndex()) != i {
+			return nil, fmt.Errorf("non-contiguous chunk sequence: expected index %d, got %d", i, c.GetChunkIndex())
+		}
+		payload = append(payload, c.GetData()...)
+	}
+
+	attrs := map[string]string{}
+	if len(payload) > 0 {
+		var transfer dptypes.DNATransfer
+		if err := json.Unmarshal(payload, &transfer); err != nil {
+			return nil, fmt.Errorf("unmarshal DNATransfer: %w", err)
+		}
+		if len(transfer.Attributes) > 0 {
+			if err := json.Unmarshal(transfer.Attributes, &attrs); err != nil {
+				return nil, fmt.Errorf("unmarshal DNA attributes: %w", err)
+			}
+		}
+	}
+
+	return &common.DNA{
+		Id:             stewardID,
+		Attributes:     attrs,
+		AttributeCount: int32(len(attrs)), //nolint:gosec // attribute counts are far below int32 max
+	}, nil
 }

--- a/features/controller/transport/dna_handler_test.go
+++ b/features/controller/transport/dna_handler_test.go
@@ -5,6 +5,7 @@ package transport
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"io"
 	"testing"
@@ -16,11 +17,109 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	common "github.com/cfgis/cfgms/api/proto/common"
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
+	dptypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 )
+
+// stubPersister captures the DNA handed to SyncDNA (for the #2616 black-hole tests).
+type stubPersister struct {
+	got *common.DNA
+	err error
+}
+
+func (s *stubPersister) SyncDNA(_ context.Context, dna *common.DNA) (*common.Status, error) {
+	s.got = dna
+	return &common.Status{Code: common.Status_OK}, s.err
+}
+
+// dnaChunksFor marshals attrs as a full-snapshot DNATransfer and splits the JSON
+// into `parts` contiguous DNAChunks — mirroring the steward send path.
+func dnaChunksFor(t *testing.T, stewardID string, attrs map[string]string, parts int) []*transportpb.DNAChunk {
+	t.Helper()
+	attrJSON, err := json.Marshal(attrs)
+	require.NoError(t, err)
+	payload, err := json.Marshal(&dptypes.DNATransfer{StewardID: stewardID, TenantID: "t1", Attributes: attrJSON})
+	require.NoError(t, err)
+	if parts < 1 {
+		parts = 1
+	}
+	size := (len(payload) + parts - 1) / parts
+	chunks := make([]*transportpb.DNAChunk, 0, parts)
+	for i := 0; i < parts; i++ {
+		start := i * size
+		end := start + size
+		if end > len(payload) {
+			end = len(payload)
+		}
+		if start > len(payload) {
+			start = len(payload)
+		}
+		chunks = append(chunks, &transportpb.DNAChunk{
+			StewardId: stewardID, TenantId: "t1",
+			Data: payload[start:end], ChunkIndex: int32(i), TotalChunks: int32(parts),
+		})
+	}
+	return chunks
+}
+
+// TestDNAHandler_PersistsReassembledDNA (REQUIRED, #2616): a full DNA snapshot
+// streamed as chunks is reassembled and handed to the persister with its
+// attributes intact — proving the receiver no longer discards the DNA.
+func TestDNAHandler_PersistsReassembledDNA(t *testing.T) {
+	ca := newTestCA(t)
+	persister := &stubPersister{}
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), persister)
+
+	attrs := map[string]string{"hostname": "cfg-70-02", "os": "windows", "cpu_count": "8"}
+	ctx := peerContextWithCA(t, ca, "steward-persist")
+	stream := newTestDNAStream(ctx, dnaChunksFor(t, "steward-persist", attrs, 1)...)
+
+	require.NoError(t, h.HandleGRPC(stream))
+	require.NotNil(t, stream.resp)
+	assert.True(t, stream.resp.GetAccepted())
+
+	require.NotNil(t, persister.got, "the reassembled DNA must reach the persister, not be discarded")
+	assert.Equal(t, "steward-persist", persister.got.GetId())
+	assert.Equal(t, attrs, persister.got.GetAttributes())
+	assert.Equal(t, int32(len(attrs)), persister.got.GetAttributeCount())
+}
+
+// TestDNAHandler_MultiChunkReassembly (#2616): a snapshot split across multiple
+// chunks and delivered out of order reassembles correctly.
+func TestDNAHandler_MultiChunkReassembly(t *testing.T) {
+	ca := newTestCA(t)
+	persister := &stubPersister{}
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), persister)
+
+	attrs := map[string]string{"hostname": "cfg-ab-02", "os": "windows", "primary_mac": "00:15:5d:ea:a3:35", "memory_bytes": "17179869184"}
+	chunks := dnaChunksFor(t, "steward-multi", attrs, 3)
+	// Deliver out of order — the handler must sort by ChunkIndex.
+	chunks[0], chunks[2] = chunks[2], chunks[0]
+
+	ctx := peerContextWithCA(t, ca, "steward-multi")
+	require.NoError(t, h.HandleGRPC(newTestDNAStream(ctx, chunks...)))
+	require.NotNil(t, persister.got)
+	assert.Equal(t, attrs, persister.got.GetAttributes())
+}
+
+// TestDNAHandler_PersistError_FailsRPC (#2616): a persist failure surfaces as an
+// RPC error (steward retries), not a silent success.
+func TestDNAHandler_PersistError_FailsRPC(t *testing.T) {
+	ca := newTestCA(t)
+	persister := &stubPersister{err: errors.New("store down")}
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), persister)
+
+	ctx := peerContextWithCA(t, ca, "steward-err")
+	stream := newTestDNAStream(ctx, dnaChunksFor(t, "steward-err", map[string]string{"hostname": "h"}, 1)...)
+
+	err := h.HandleGRPC(stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist synced DNA")
+}
 
 // ---------------------------------------------------------------------------
 // Mock stream
@@ -151,7 +250,7 @@ func newRoundTripEnv(t *testing.T, stewardID string) *roundTripEnv {
 	)
 	queue := NewTenantQueue()
 	srv := &testTransportSrv{
-		dnaHandler:  NewDNAHandler(logging.NewNoopLogger(), queue),
+		dnaHandler:  NewDNAHandler(logging.NewNoopLogger(), queue, nil),
 		bulkHandler: NewBulkHandler(logging.NewNoopLogger(), queue),
 	}
 	transportpb.RegisterStewardTransportServer(grpcSrv, srv)
@@ -183,7 +282,7 @@ func newRoundTripEnv(t *testing.T, stewardID string) *roundTripEnv {
 // TestDNAHandler_MissingPeerCert verifies that a request with no mTLS peer
 // info in context is rejected with Unauthenticated.
 func TestDNAHandler_MissingPeerCert(t *testing.T) {
-	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue())
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil)
 	stream := newTestDNAStream(context.Background())
 
 	err := h.HandleGRPC(stream)
@@ -196,7 +295,7 @@ func TestDNAHandler_MissingPeerCert(t *testing.T) {
 // does not match the mTLS peer CN is rejected with PermissionDenied.
 func TestDNAHandler_StewardIDMismatch(t *testing.T) {
 	ca := newTestCA(t)
-	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue())
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil)
 
 	ctx := peerContextWithCA(t, ca, "steward-alice")
 	stream := newTestDNAStream(ctx, &transportpb.DNAChunk{
@@ -222,7 +321,7 @@ func TestDNAHandler_StewardIDMismatch(t *testing.T) {
 // passes validation and the handler sends an accepted response.
 func TestDNAHandler_MatchingStewardIDAccepted(t *testing.T) {
 	ca := newTestCA(t)
-	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue())
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil)
 
 	ctx := peerContextWithCA(t, ca, "steward-match")
 	stream := newTestDNAStream(ctx,
@@ -242,7 +341,7 @@ func TestDNAHandler_MatchingStewardIDAccepted(t *testing.T) {
 // accepted and returns a valid response.
 func TestDNAHandler_EmptyStream(t *testing.T) {
 	ca := newTestCA(t)
-	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue())
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil)
 
 	ctx := peerContextWithCA(t, ca, "steward-empty")
 	stream := newTestDNAStream(ctx) // zero chunks
@@ -258,7 +357,7 @@ func TestDNAHandler_EmptyStream(t *testing.T) {
 // HandleGRPC to return a wrapped error with the expected message.
 func TestDNAHandler_RecvError(t *testing.T) {
 	ca := newTestCA(t)
-	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue())
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil)
 
 	ctx := peerContextWithCA(t, ca, "steward-recv-err")
 	injectedErr := errors.New("simulated network failure")
@@ -276,7 +375,7 @@ func TestDNAHandler_RecvError(t *testing.T) {
 func TestDNAHandler_QueueFull_ReturnsResourceExhausted(t *testing.T) {
 	ca := newTestCA(t)
 	queue := NewTenantQueue()
-	h := NewDNAHandler(logging.NewNoopLogger(), queue)
+	h := NewDNAHandler(logging.NewNoopLogger(), queue, nil)
 
 	for i := 0; i < MaxConcurrentPerTenant; i++ {
 		require.NoError(t, queue.Acquire("tenant-full"))


### PR DESCRIPTION
## Summary

Fixes the controller-side DNA-sync **black hole** — the root cause of fleet DNA collapsing to near-empty for every reconnected steward (live-verified on cfg-lab 2026-07-12).

## Root cause

`DNAHandler.HandleGRPC` (the controller's data-plane `SyncDNA` receiver) received the `DNAChunk` stream, counted the chunks, logged "DNA sync received", **discarded them**, and returned `Accepted: true`. It never reassembled the DNA and never called the persist path. So the #2524 controller-initiated reconcile became an infinite no-op:

1. steward reconnects (launcher re-exec) → controller detects hash mismatch → sends `sync_dna`
2. steward streams its **full DNA** (*"Full DNA sync completed via data plane, attributes: 111"*)
3. controller **throws it away** → still a mismatch → re-fires `sync_dna` ~20s later → **infinite loop**, `cfg steward dna` stuck at 1 attribute.

(It looked fixed right after a push-upgrade only because the *initial registration publish* uses a different, working path — reconnect falls onto the broken data-plane path.)

## Fix

- Add a narrow `DNAPersister` interface (implemented by `*service.ControllerService.SyncDNA`, which stores durably + fires the #2524 hook) and inject it into `DNAHandler`; `server.go` wires `s.controllerService`.
- `HandleGRPC` now collects the chunks, **reassembles** them (concat `Data` in `ChunkIndex` order → `DNATransfer` JSON → attribute map, mirroring the steward's `dnaTransferToChunks`), builds a `common.DNA`, and **persists** it. `sync_dna` is always a full snapshot (`Delta=false`; deltas go via the control plane), so no merge is needed.
- A nil persister (tests) accepts without reassembly; production always wires one.

## Tests

- `TestDNAHandler_PersistsReassembledDNA` (REQUIRED) — a chunked snapshot is reassembled and reaches the persister with attributes intact.
- Out-of-order multi-chunk reassembly; persist-error propagation. Existing callers updated for the new signature.
- Whole-repo build + `features/controller/{transport,server,service}` tests green.

Live validation (loop stops, DNA repopulates on reconnect) to be confirmed by redeploying the controller to cfg-lab.

Fixes #2616

🤖 Generated with [Claude Code](https://claude.com/claude-code)