### PR TITLE
api/cli: steward tag admin REST + cfg steward tag verb (Issue #2545)

### DIFF
--- a/cmd/cfg/cmd/steward_tag.go
+++ b/cmd/cfg/cmd/steward_tag.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	stewardTagURL         string
+	stewardTagAPIKey      string
+	stewardTagTLSCACert   string
+	stewardTagTLSInsecure bool
+)
+
+// stewardTagCmd is the parent command for cfg steward tag subcommands.
+var stewardTagCmd = &cobra.Command{
+	Use:   "tag",
+	Short: "Manage tags on a steward",
+	Long: `Add, remove, and list operator-assigned tags on a steward.
+
+Tags are controller-owned metadata used by tag: selectors to target stewards
+in role configs and cfg steward commands.
+
+Tag format: lowercase alphanumeric, optionally separated by hyphens (1-64 chars).
+Examples: prod, web-server, github-runner.
+
+Sub-commands: add, rm, ls`,
+}
+
+// stewardTagAddCmd implements cfg steward tag add <id> <tag>...
+var stewardTagAddCmd = &cobra.Command{
+	Use:   "add <steward-id> <tag> [tag...]",
+	Short: "Add tags to a steward",
+	Long: `Add one or more tags to a steward.
+
+Adding a tag that already exists is a no-op (idempotent).
+
+Examples:
+  cfg steward tag add steward-abc123 prod web-server \
+    --url https://controller.example.com --api-key mykey`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: runStewardTagAdd,
+}
+
+// stewardTagRmCmd implements cfg steward tag rm <id> <tag>...
+var stewardTagRmCmd = &cobra.Command{
+	Use:   "rm <steward-id> <tag> [tag...]",
+	Short: "Remove tags from a steward",
+	Long: `Remove one or more tags from a steward.
+
+Removing a tag that does not exist is a no-op (idempotent).
+
+Examples:
+  cfg steward tag rm steward-abc123 debug \
+    --url https://controller.example.com --api-key mykey`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: runStewardTagRm,
+}
+
+// stewardTagLsCmd implements cfg steward tag ls <id>
+var stewardTagLsCmd = &cobra.Command{
+	Use:   "ls <steward-id>",
+	Short: "List tags on a steward",
+	Long: `List all operator-assigned tags on a steward.
+
+Examples:
+  cfg steward tag ls steward-abc123 \
+    --url https://controller.example.com --api-key mykey`,
+	Args: cobra.ExactArgs(1),
+	RunE: runStewardTagLs,
+}
+
+func init() {
+	for _, cmd := range []*cobra.Command{stewardTagAddCmd, stewardTagRmCmd, stewardTagLsCmd} {
+		cmd.Flags().StringVar(&stewardTagURL, "url", "", "Controller API URL (env: CFGMS_API_URL)")
+		cmd.Flags().StringVar(&stewardTagAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
+		cmd.Flags().StringVar(&stewardTagTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+		cmd.Flags().BoolVar(&stewardTagTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+	}
+
+	stewardTagCmd.AddCommand(stewardTagAddCmd)
+	stewardTagCmd.AddCommand(stewardTagRmCmd)
+	stewardTagCmd.AddCommand(stewardTagLsCmd)
+	stewardCmd.AddCommand(stewardTagCmd)
+}
+
+// getStewardTagClient returns an API client for steward tag commands.
+func getStewardTagClient() (*APIClient, error) {
+	apiURL := strings.TrimSuffix(stewardTagURL, "/")
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveSessionOrBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	apiKey := stewardTagAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := stewardTagTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := stewardTagTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
+}
+
+func runStewardTagAdd(cmd *cobra.Command, args []string) error {
+	stewardID := url.PathEscape(args[0])
+	tags := args[1:]
+
+	payload, err := json.Marshal(map[string]interface{}{"tags": tags})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	client, err := getStewardTagClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodPost,
+		"/api/v1/stewards/"+stewardID+"/tags", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return fmt.Errorf("steward %q not found", args[0])
+	case http.StatusForbidden:
+		return fmt.Errorf("insufficient permissions to tag steward %q", args[0])
+	case http.StatusBadRequest:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("invalid tag: %s", string(body))
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("add failed (%s): %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data struct {
+			Tags []string `json:"tags"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Tags on %s: %s\n", args[0], strings.Join(apiResp.Data.Tags, ", "))
+	return nil
+}
+
+func runStewardTagRm(cmd *cobra.Command, args []string) error {
+	stewardID := url.PathEscape(args[0])
+	tags := args[1:]
+
+	payload, err := json.Marshal(map[string]interface{}{"tags": tags})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	client, err := getStewardTagClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodDelete,
+		"/api/v1/stewards/"+stewardID+"/tags", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return fmt.Errorf("steward %q not found", args[0])
+	case http.StatusForbidden:
+		return fmt.Errorf("insufficient permissions to manage tags on steward %q", args[0])
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("remove failed (%s): %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data struct {
+			Tags []string `json:"tags"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	remaining := apiResp.Data.Tags
+	if len(remaining) == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No tags remain on %s.\n", args[0])
+	} else {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Tags on %s: %s\n", args[0], strings.Join(remaining, ", "))
+	}
+	return nil
+}
+
+func runStewardTagLs(cmd *cobra.Command, args []string) error {
+	stewardID := url.PathEscape(args[0])
+
+	client, err := getStewardTagClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/stewards/"+stewardID+"/tags")
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return fmt.Errorf("steward %q not found", args[0])
+	case http.StatusForbidden:
+		return fmt.Errorf("insufficient permissions to list tags on steward %q", args[0])
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("list failed (%s): %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data struct {
+			Tags []string `json:"tags"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	tags := apiResp.Data.Tags
+	if len(tags) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No tags.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "TAG")
+	_, _ = fmt.Fprintln(w, "---")
+	for _, tag := range tags {
+		_, _ = fmt.Fprintln(w, tag)
+	}
+	return w.Flush()
+}

--- a/cmd/cfg/cmd/steward_tag_test.go
+++ b/cmd/cfg/cmd/steward_tag_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setStewardTagFlags wires the module-level flags for a test run and returns a cleanup func.
+func setStewardTagFlags(serverURL, apiKey string) func() {
+	origURL := stewardTagURL
+	origKey := stewardTagAPIKey
+	origInsecure := stewardTagTLSInsecure
+	stewardTagURL = serverURL
+	stewardTagAPIKey = apiKey
+	stewardTagTLSInsecure = true
+	return func() {
+		stewardTagURL = origURL
+		stewardTagAPIKey = origKey
+		stewardTagTLSInsecure = origInsecure
+	}
+}
+
+// tagsAPIResponse mirrors the REST response envelope for tag endpoints.
+type tagsAPIResponse struct {
+	Data struct {
+		Tags []string `json:"tags"`
+	} `json:"data"`
+}
+
+// TestStewardTagAddCmd_HappyPath verifies that runStewardTagAdd sends the correct
+// POST body and prints the resulting tag list.
+func TestStewardTagAddCmd_HappyPath(t *testing.T) {
+	var capturedBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/steward-abc/tags"), "path: %s", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsAPIResponse{Data: struct {
+			Tags []string `json:"tags"`
+		}{Tags: []string{"prod", "web"}}})
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	var out bytes.Buffer
+	stewardTagAddCmd.SetOut(&out)
+	err := runStewardTagAdd(stewardTagAddCmd, []string{"steward-abc", "prod", "web"})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "prod")
+	assert.Contains(t, out.String(), "web")
+
+	// Verify the request body contained the tags slice.
+	tagsRaw, ok := capturedBody["tags"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, tagsRaw, 2)
+}
+
+// TestStewardTagAddCmd_NotFound verifies a 404 returns a descriptive error.
+func TestStewardTagAddCmd_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	err := runStewardTagAdd(stewardTagAddCmd, []string{"no-such", "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestStewardTagAddCmd_Forbidden verifies a 403 returns a descriptive error.
+func TestStewardTagAddCmd_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	err := runStewardTagAdd(stewardTagAddCmd, []string{"other-tenant-steward", "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient permissions")
+}
+
+// TestStewardTagRmCmd_HappyPath verifies that runStewardTagRm sends the correct
+// DELETE body and prints the remaining tag list.
+func TestStewardTagRmCmd_HappyPath(t *testing.T) {
+	var capturedBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/steward-abc/tags"), "path: %s", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsAPIResponse{Data: struct {
+			Tags []string `json:"tags"`
+		}{Tags: []string{"prod"}}})
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	var out bytes.Buffer
+	stewardTagRmCmd.SetOut(&out)
+	err := runStewardTagRm(stewardTagRmCmd, []string{"steward-abc", "web"})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "prod")
+
+	tagsRaw, ok := capturedBody["tags"].([]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "web", tagsRaw[0])
+}
+
+// TestStewardTagRmCmd_AllRemoved verifies the "no tags remain" message when empty.
+func TestStewardTagRmCmd_AllRemoved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsAPIResponse{Data: struct {
+			Tags []string `json:"tags"`
+		}{Tags: []string{}}})
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	var out bytes.Buffer
+	stewardTagRmCmd.SetOut(&out)
+	err := runStewardTagRm(stewardTagRmCmd, []string{"steward-abc", "prod"})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "No tags remain")
+}
+
+// TestStewardTagRmCmd_NotFound verifies a 404 returns a descriptive error.
+func TestStewardTagRmCmd_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	err := runStewardTagRm(stewardTagRmCmd, []string{"no-such", "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestStewardTagLsCmd_HappyPath verifies that runStewardTagLs prints a table of tags.
+func TestStewardTagLsCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/steward-abc/tags"), "path: %s", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsAPIResponse{Data: struct {
+			Tags []string `json:"tags"`
+		}{Tags: []string{"prod", "web"}}})
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	var out bytes.Buffer
+	stewardTagLsCmd.SetOut(&out)
+	err := runStewardTagLs(stewardTagLsCmd, []string{"steward-abc"})
+	require.NoError(t, err)
+	output := out.String()
+	assert.Contains(t, output, "prod")
+	assert.Contains(t, output, "web")
+}
+
+// TestStewardTagLsCmd_Empty verifies the "no tags" message when no tags are set.
+func TestStewardTagLsCmd_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tagsAPIResponse{Data: struct {
+			Tags []string `json:"tags"`
+		}{Tags: []string{}}})
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	var out bytes.Buffer
+	stewardTagLsCmd.SetOut(&out)
+	err := runStewardTagLs(stewardTagLsCmd, []string{"steward-abc"})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "No tags")
+}
+
+// TestStewardTagLsCmd_NotFound verifies a 404 returns a descriptive error.
+func TestStewardTagLsCmd_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	err := runStewardTagLs(stewardTagLsCmd, []string{"no-such"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestStewardTagRmCmd_Forbidden verifies a 403 returns a descriptive error.
+func TestStewardTagRmCmd_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	err := runStewardTagRm(stewardTagRmCmd, []string{"other-tenant-steward", "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient permissions")
+}
+
+// TestStewardTagLsCmd_ServerError verifies that an unexpected server error is reported.
+func TestStewardTagLsCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	cleanup := setStewardTagFlags(srv.URL, "test-key")
+	defer cleanup()
+
+	err := runStewardTagLs(stewardTagLsCmd, []string{"steward-abc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list failed")
+}

--- a/docs/development/commands-reference.md
+++ b/docs/development/commands-reference.md
@@ -684,3 +684,75 @@ Deleted role config "github-runners"
 ```
 
 **Flags:** `--url`, `--api-key`, `--tls-ca-cert`, `--tls-insecure` (same as above).
+
+## cfg steward tag — Steward Tag Management (Issue #2545)
+
+Tags are operator-assigned metadata on a steward used by `tag:` selectors in role configs
+and fleet commands. Tags are controller-owned: they survive controller restarts and are
+never overwritten by the steward's DNA report cycle.
+
+**Tag format:** lowercase alphanumeric, optionally separated by hyphens (1–64 chars).
+Examples: `prod`, `web-server`, `github-runner`.
+
+**Required permissions:** `steward:tag:read` (GET), `steward:tag:write` (POST, DELETE).
+
+### cfg steward tag add
+
+Add one or more tags to a steward. Adding a tag that already exists is a no-op (idempotent).
+
+```bash
+cfg steward tag add <steward-id> <tag> [tag...] --url=https://controller.example.com --api-key=mykey
+```
+
+Example:
+
+```bash
+cfg steward tag add steward-abc123 prod web-server \
+  --url https://controller.example.com --api-key mykey
+```
+
+Output on success:
+
+```
+Tags on steward-abc123: prod, web-server
+```
+
+### cfg steward tag rm
+
+Remove one or more tags from a steward. Removing a tag that does not exist is a no-op (idempotent).
+
+```bash
+cfg steward tag rm <steward-id> <tag> [tag...] --url=https://controller.example.com --api-key=mykey
+```
+
+Output on success:
+
+```
+Tags on steward-abc123: prod
+```
+
+### cfg steward tag ls
+
+List all operator-assigned tags on a steward.
+
+```bash
+cfg steward tag ls <steward-id> --url=https://controller.example.com --api-key=mykey
+```
+
+Example output:
+
+```
+TAG
+---
+prod
+web-server
+```
+
+**Flags (all sub-commands):**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--url` | — | Controller API URL (env: CFGMS_API_URL) |
+| `--api-key` | — | API key for authentication (env: CFGMS_API_KEY) |
+| `--tls-ca-cert` | — | Path to CA certificate (env: CFGMS_TLS_CA_CERT) |
+| `--tls-insecure` | false | Skip TLS verification (env: CFGMS_TLS_INSECURE) |

--- a/features/controller/api/handlers_tags.go
+++ b/features/controller/api/handlers_tags.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/controller/tagstore"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// tagsRequest is the JSON body for POST and DELETE /api/v1/stewards/{id}/tags.
+type tagsRequest struct {
+	Tags []string `json:"tags"`
+}
+
+// tagsResponse is the JSON data envelope for tag endpoints.
+type tagsResponse struct {
+	Tags []string `json:"tags"`
+}
+
+// handleListStewardTags handles GET /api/v1/stewards/{id}/tags.
+// Returns the current tag list for the steward.
+func (s *Server) handleListStewardTags(w http.ResponseWriter, r *http.Request) {
+	stewardID, ok := s.resolveStewardForTags(w, r)
+	if !ok {
+		return
+	}
+
+	s.mu.RLock()
+	ts := s.tagStore
+	s.mu.RUnlock()
+	if ts == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "tag store not available", "TAG_STORE_UNAVAILABLE")
+		return
+	}
+
+	tags, err := ts.Get(r.Context(), stewardID)
+	if err != nil {
+		s.logger.Error("Failed to get tags",
+			"steward_id", logging.SanitizeLogValue(stewardID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read tags", "INTERNAL_ERROR")
+		return
+	}
+
+	if tags == nil {
+		tags = []string{}
+	}
+	s.writeSuccessResponse(w, tagsResponse{Tags: tags})
+}
+
+// handleAddStewardTags handles POST /api/v1/stewards/{id}/tags.
+// Merges the provided tags into the steward's existing tag set (idempotent).
+func (s *Server) handleAddStewardTags(w http.ResponseWriter, r *http.Request) {
+	stewardID, ok := s.resolveStewardForTags(w, r)
+	if !ok {
+		return
+	}
+
+	s.mu.RLock()
+	ts := s.tagStore
+	s.mu.RUnlock()
+	if ts == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "tag store not available", "TAG_STORE_UNAVAILABLE")
+		return
+	}
+
+	var req tagsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_BODY")
+		return
+	}
+
+	current, err := ts.Get(r.Context(), stewardID)
+	if err != nil {
+		s.logger.Error("Failed to read current tags",
+			"steward_id", logging.SanitizeLogValue(stewardID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read tags", "INTERNAL_ERROR")
+		return
+	}
+
+	merged := mergeTags(current, req.Tags)
+	if err := ts.Set(r.Context(), stewardID, merged); err != nil {
+		if errors.Is(err, tagstore.ErrInvalidTag) {
+			s.writeErrorResponse(w, http.StatusBadRequest, err.Error(), "INVALID_TAG")
+			return
+		}
+		s.logger.Error("Failed to set tags",
+			"steward_id", logging.SanitizeLogValue(stewardID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to set tags", "INTERNAL_ERROR")
+		return
+	}
+
+	s.logger.Info("Tags added",
+		"steward_id", logging.SanitizeLogValue(stewardID),
+		"count", len(merged))
+	s.writeSuccessResponse(w, tagsResponse{Tags: merged})
+}
+
+// handleDeleteStewardTags handles DELETE /api/v1/stewards/{id}/tags.
+// Removes the provided tags from the steward's tag set (idempotent).
+func (s *Server) handleDeleteStewardTags(w http.ResponseWriter, r *http.Request) {
+	stewardID, ok := s.resolveStewardForTags(w, r)
+	if !ok {
+		return
+	}
+
+	s.mu.RLock()
+	ts := s.tagStore
+	s.mu.RUnlock()
+	if ts == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "tag store not available", "TAG_STORE_UNAVAILABLE")
+		return
+	}
+
+	var req tagsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_BODY")
+		return
+	}
+
+	current, err := ts.Get(r.Context(), stewardID)
+	if err != nil {
+		s.logger.Error("Failed to read current tags",
+			"steward_id", logging.SanitizeLogValue(stewardID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read tags", "INTERNAL_ERROR")
+		return
+	}
+
+	remaining := removeTags(current, req.Tags)
+	if err := ts.Set(r.Context(), stewardID, remaining); err != nil {
+		s.logger.Error("Failed to set tags after removal",
+			"steward_id", logging.SanitizeLogValue(stewardID),
+			"error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to set tags", "INTERNAL_ERROR")
+		return
+	}
+
+	s.logger.Info("Tags removed",
+		"steward_id", logging.SanitizeLogValue(stewardID),
+		"removed", len(req.Tags),
+		"remaining", len(remaining))
+	s.writeSuccessResponse(w, tagsResponse{Tags: remaining})
+}
+
+// resolveStewardForTags validates the steward ID, looks up the steward, and enforces
+// tenant scoping. On any error it writes the response and returns false.
+func (s *Server) resolveStewardForTags(w http.ResponseWriter, r *http.Request) (string, bool) {
+	vars := mux.Vars(r)
+	stewardID := vars["id"]
+
+	if !identifierRegex.MatchString(stewardID) {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid steward ID format", "INVALID_STEWARD_ID")
+		return "", false
+	}
+
+	stewardInfo, exists := s.controllerService.GetStewardInfo(stewardID)
+	if !exists {
+		s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+		return "", false
+	}
+
+	// Enforce tenant scoping: a scoped caller may only operate on stewards in its
+	// own subtree. mTLS admin principals (empty TenantID) have global access.
+	// Returns 403 (not 404) to match the handleConfigPush cross-tenant guard pattern
+	// and the explicit requirement in issue #2545 AC.
+	callerTenantID := s.callerTenantID(r)
+	if callerTenantID != "" {
+		inSubtree := stewardInfo.TenantID == callerTenantID ||
+			strings.HasPrefix(stewardInfo.TenantID, callerTenantID+"/")
+		if !inSubtree {
+			s.writeErrorResponse(w, http.StatusForbidden,
+				"caller may only manage tags for stewards in its own tenant subtree",
+				"FORBIDDEN")
+			return "", false
+		}
+	}
+
+	return stewardID, true
+}
+
+// callerTenantID returns the authenticated caller's tenant ID.
+// mTLS admin certs have global scope (empty TenantID); API-key callers have a tenant scope.
+func (s *Server) callerTenantID(r *http.Request) string {
+	if p := s.extractAdminPrincipal(r); p != nil {
+		return p.TenantID
+	}
+	tid, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	return tid
+}
+
+// mergeTags returns the sorted union of current and incoming, deduplicated.
+func mergeTags(current, incoming []string) []string {
+	seen := make(map[string]struct{}, len(current)+len(incoming))
+	for _, t := range current {
+		seen[t] = struct{}{}
+	}
+	for _, t := range incoming {
+		seen[t] = struct{}{}
+	}
+	merged := make([]string, 0, len(seen))
+	for t := range seen {
+		merged = append(merged, t)
+	}
+	sort.Strings(merged)
+	return merged
+}
+
+// removeTags returns a copy of current with all tags in toRemove filtered out.
+func removeTags(current, toRemove []string) []string {
+	remove := make(map[string]struct{}, len(toRemove))
+	for _, t := range toRemove {
+		remove[t] = struct{}{}
+	}
+	result := make([]string, 0, len(current))
+	for _, t := range current {
+		if _, skip := remove[t]; !skip {
+			result = append(result, t)
+		}
+	}
+	return result
+}

--- a/features/controller/api/handlers_tags.go
+++ b/features/controller/api/handlers_tags.go
@@ -46,7 +46,7 @@ func (s *Server) handleListStewardTags(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Error("Failed to get tags",
 			"steward_id", logging.SanitizeLogValue(stewardID),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read tags", "INTERNAL_ERROR")
 		return
 	}
@@ -79,24 +79,18 @@ func (s *Server) handleAddStewardTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	current, err := ts.Get(r.Context(), stewardID)
+	incoming := req.Tags
+	merged, err := ts.Update(r.Context(), stewardID, func(current []string) ([]string, error) {
+		return mergeTags(current, incoming), nil
+	})
 	if err != nil {
-		s.logger.Error("Failed to read current tags",
-			"steward_id", logging.SanitizeLogValue(stewardID),
-			"error", err)
-		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read tags", "INTERNAL_ERROR")
-		return
-	}
-
-	merged := mergeTags(current, req.Tags)
-	if err := ts.Set(r.Context(), stewardID, merged); err != nil {
 		if errors.Is(err, tagstore.ErrInvalidTag) {
 			s.writeErrorResponse(w, http.StatusBadRequest, err.Error(), "INVALID_TAG")
 			return
 		}
 		s.logger.Error("Failed to set tags",
 			"steward_id", logging.SanitizeLogValue(stewardID),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to set tags", "INTERNAL_ERROR")
 		return
 	}
@@ -129,27 +123,21 @@ func (s *Server) handleDeleteStewardTags(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	current, err := ts.Get(r.Context(), stewardID)
+	toRemove := req.Tags
+	remaining, err := ts.Update(r.Context(), stewardID, func(current []string) ([]string, error) {
+		return removeTags(current, toRemove), nil
+	})
 	if err != nil {
-		s.logger.Error("Failed to read current tags",
-			"steward_id", logging.SanitizeLogValue(stewardID),
-			"error", err)
-		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read tags", "INTERNAL_ERROR")
-		return
-	}
-
-	remaining := removeTags(current, req.Tags)
-	if err := ts.Set(r.Context(), stewardID, remaining); err != nil {
 		s.logger.Error("Failed to set tags after removal",
 			"steward_id", logging.SanitizeLogValue(stewardID),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to set tags", "INTERNAL_ERROR")
 		return
 	}
 
 	s.logger.Info("Tags removed",
 		"steward_id", logging.SanitizeLogValue(stewardID),
-		"removed", len(req.Tags),
+		"removed", len(toRemove),
 		"remaining", len(remaining))
 	s.writeSuccessResponse(w, tagsResponse{Tags: remaining})
 }

--- a/features/controller/api/handlers_tags_test.go
+++ b/features/controller/api/handlers_tags_test.go
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/tagstore"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// setupTagServer creates a test server wired with a tag store and a pre-registered steward.
+func setupTagServer(t *testing.T) *Server {
+	t.Helper()
+	server := setupTestServer(t)
+	dsn := filepath.Join(t.TempDir(), "tags.db")
+	ts, err := tagstore.NewFromDSN(dsn, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NoError(t, ts.Initialize(context.Background()))
+	t.Cleanup(func() { _ = ts.Close() })
+	server.SetTagStore(ts)
+	return server
+}
+
+// addTagTestSteward registers a steward with the given ID and tenantID in the controller service.
+func addTagTestSteward(t *testing.T, server *Server, stewardID, tenantID string) {
+	t.Helper()
+	require.NoError(t, server.controllerService.RegisterSteward(stewardID, tenantID, "addr", "active"))
+}
+
+// doTagRequest sends an HTTP request to the server router and returns the recorder.
+func doTagRequest(server *Server, method, path string, apiKey string, body interface{}) *httptest.ResponseRecorder {
+	var bodyReader *bytes.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		bodyReader = bytes.NewReader(b)
+	} else {
+		bodyReader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, bodyReader)
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// ---- handleListStewardTags ----
+
+func TestHandleListStewardTags_HappyPath(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:read"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-list-ok", "test-tenant")
+
+	// Pre-populate tags.
+	ts := server.tagStore
+	require.NoError(t, ts.Set(context.Background(), "s-list-ok", []string{"prod", "web"}))
+
+	rec := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-list-ok/tags", apiKey, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	tags, _ := data["tags"].([]interface{})
+	assert.Len(t, tags, 2)
+}
+
+func TestHandleListStewardTags_EmptyList(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:read"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-empty", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-empty/tags", apiKey, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	tags, _ := data["tags"].([]interface{})
+	assert.Empty(t, tags)
+}
+
+func TestHandleListStewardTags_UnknownSteward(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:read"}, "test-tenant", 5*time.Minute)
+
+	rec := doTagRequest(server, http.MethodGet, "/api/v1/stewards/no-such-steward/tags", apiKey, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleListStewardTags_Unauthenticated(t *testing.T) {
+	server := setupTagServer(t)
+	addTagTestSteward(t, server, "s-unauth", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-unauth/tags", "", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandleListStewardTags_CrossTenant(t *testing.T) {
+	server := setupTagServer(t)
+	// API key scoped to "other-tenant" tries to access a steward in "test-tenant".
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:read"}, "other-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-cross-read", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-cross-read/tags", apiKey, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// ---- handleAddStewardTags ----
+
+func TestHandleAddStewardTags_HappyPath(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-add-ok", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-add-ok/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod", "web"}})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	tags, _ := data["tags"].([]interface{})
+	assert.Len(t, tags, 2)
+}
+
+func TestHandleAddStewardTags_Idempotent(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-idem", "test-tenant")
+
+	// Add prod first.
+	rec1 := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-idem/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	// Add prod again + web → should have prod + web (no duplicate).
+	rec2 := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-idem/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod", "web"}})
+	require.Equal(t, http.StatusOK, rec2.Code, "body: %s", rec2.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	tags, _ := data["tags"].([]interface{})
+	assert.Len(t, tags, 2)
+}
+
+func TestHandleAddStewardTags_InvalidTag(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-badtag", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-badtag/tags", apiKey,
+		map[string]interface{}{"tags": []string{"UPPERCASE-INVALID"}})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleAddStewardTags_UnknownSteward(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/no-such/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleAddStewardTags_CrossTenant(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "other-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-cross-add", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-cross-add/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleAddStewardTags_Unauthenticated(t *testing.T) {
+	server := setupTagServer(t)
+	addTagTestSteward(t, server, "s-unauth-add", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-unauth-add/tags", "",
+		map[string]interface{}{"tags": []string{"prod"}})
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandleAddStewardTags_TagStoreNil(t *testing.T) {
+	server := setupTestServer(t) // no tag store wired
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-nostore", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-nostore/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// ---- handleDeleteStewardTags ----
+
+func TestHandleDeleteStewardTags_HappyPath(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write", "steward:tag:read"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-del-ok", "test-tenant")
+
+	// Seed tags.
+	ts := server.tagStore
+	require.NoError(t, ts.Set(context.Background(), "s-del-ok", []string{"prod", "web", "debug"}))
+
+	// Remove one tag.
+	rec := doTagRequest(server, http.MethodDelete, "/api/v1/stewards/s-del-ok/tags", apiKey,
+		map[string]interface{}{"tags": []string{"debug"}})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	tags, _ := data["tags"].([]interface{})
+	assert.Len(t, tags, 2)
+
+	// Verify via GET.
+	rec2 := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-del-ok/tags", apiKey, nil)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp2 APIResponse
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	data2, _ := resp2.Data.(map[string]interface{})
+	tags2, _ := data2["tags"].([]interface{})
+	assert.Len(t, tags2, 2)
+}
+
+func TestHandleDeleteStewardTags_RemoveNonexistent(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-del-noop", "test-tenant")
+
+	// Remove a tag that was never set — should succeed with empty list.
+	rec := doTagRequest(server, http.MethodDelete, "/api/v1/stewards/s-del-noop/tags", apiKey,
+		map[string]interface{}{"tags": []string{"ghost"}})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, _ := resp.Data.(map[string]interface{})
+	tags, _ := data["tags"].([]interface{})
+	assert.Empty(t, tags)
+}
+
+func TestHandleDeleteStewardTags_UnknownSteward(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+
+	rec := doTagRequest(server, http.MethodDelete, "/api/v1/stewards/no-such/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleDeleteStewardTags_CrossTenant(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "other-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-cross-del", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodDelete, "/api/v1/stewards/s-cross-del/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// ---- round-trip ----
+
+func TestStewardTagsRoundTrip(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write", "steward:tag:read"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-roundtrip", "test-tenant")
+
+	// Add tags.
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-roundtrip/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod", "web"}})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// List tags.
+	rec2 := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-roundtrip/tags", apiKey, nil)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	data, _ := resp.Data.(map[string]interface{})
+	tags, _ := data["tags"].([]interface{})
+	assert.Len(t, tags, 2)
+
+	// Remove one.
+	rec3 := doTagRequest(server, http.MethodDelete, "/api/v1/stewards/s-roundtrip/tags", apiKey,
+		map[string]interface{}{"tags": []string{"web"}})
+	require.Equal(t, http.StatusOK, rec3.Code)
+
+	// List again — only prod remains.
+	rec4 := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-roundtrip/tags", apiKey, nil)
+	require.Equal(t, http.StatusOK, rec4.Code)
+	var resp4 APIResponse
+	require.NoError(t, json.Unmarshal(rec4.Body.Bytes(), &resp4))
+	data4, _ := resp4.Data.(map[string]interface{})
+	tags4, _ := data4["tags"].([]interface{})
+	assert.Len(t, tags4, 1)
+	assert.Equal(t, "prod", tags4[0])
+}
+
+// TestHandleListStewardTags_NilStore verifies a 503 when the tag store is not wired.
+func TestHandleListStewardTags_NilStore(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:read"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-nostore-get", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-nostore-get/tags", apiKey, nil)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleDeleteStewardTags_NilStore verifies a 503 when the tag store is not wired.
+func TestHandleDeleteStewardTags_NilStore(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-nostore-del", "test-tenant")
+
+	rec := doTagRequest(server, http.MethodDelete, "/api/v1/stewards/s-nostore-del/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleAddStewardTags_SubtreeAccess verifies that a caller scoped to a parent tenant
+// can tag stewards in child tenants (subtree access).
+func TestHandleAddStewardTags_SubtreeAccess(t *testing.T) {
+	server := setupTagServer(t)
+	// API key scoped to "msp" can tag stewards in "msp/client-1".
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write"}, "msp", 5*time.Minute)
+	addTagTestSteward(t, server, "s-child", "msp/client-1")
+
+	rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-child/tags", apiKey,
+		map[string]interface{}{"tags": []string{"prod"}})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+}
+
+// TestHandleListStewardTags_InvalidStewardID verifies that a malformed steward ID is rejected.
+func TestHandleListStewardTags_InvalidStewardID(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:read"}, "test-tenant", 5*time.Minute)
+
+	// The mux route parameter {id} does not match slashes / dots, so the router
+	// returns 404 for paths it cannot match. The identifier validation test is
+	// exercised via the direct handler path below.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/s-list-ok/tags", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	ctx := req.Context()
+	ctx = withTenantID(ctx, "test-tenant")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	// Inject an invalid steward ID via the principal context as if it came from a bad mux var.
+	server.handleListStewardTags(w, withVars(req, map[string]string{"id": "bad..id"}))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// withTenantID injects a tenantID into the request context.
+func withTenantID(ctx context.Context, tenantID string) context.Context {
+	return context.WithValue(ctx, ctxkeys.TenantID, tenantID)
+}
+
+// ---- mergeTags unit tests ----
+
+func TestMergeTags_BasicUnion(t *testing.T) {
+	result := mergeTags([]string{"a", "b"}, []string{"b", "c"})
+	assert.Equal(t, []string{"a", "b", "c"}, result)
+}
+
+func TestMergeTags_EmptyCurrent(t *testing.T) {
+	result := mergeTags(nil, []string{"prod", "web"})
+	assert.Equal(t, []string{"prod", "web"}, result)
+}
+
+func TestMergeTags_EmptyIncoming(t *testing.T) {
+	result := mergeTags([]string{"prod"}, nil)
+	assert.Equal(t, []string{"prod"}, result)
+}
+
+func TestMergeTags_BothEmpty(t *testing.T) {
+	result := mergeTags(nil, nil)
+	assert.Empty(t, result)
+}
+
+func TestMergeTags_Sorted(t *testing.T) {
+	result := mergeTags([]string{"z"}, []string{"a", "m"})
+	assert.Equal(t, []string{"a", "m", "z"}, result)
+}
+
+// ---- removeTags unit tests ----
+
+func TestRemoveTags_Basic(t *testing.T) {
+	result := removeTags([]string{"prod", "web", "debug"}, []string{"debug"})
+	assert.Equal(t, []string{"prod", "web"}, result)
+}
+
+func TestRemoveTags_RemoveNonexistent(t *testing.T) {
+	result := removeTags([]string{"prod"}, []string{"ghost"})
+	assert.Equal(t, []string{"prod"}, result)
+}
+
+func TestRemoveTags_RemoveAll(t *testing.T) {
+	result := removeTags([]string{"prod", "web"}, []string{"prod", "web"})
+	assert.Empty(t, result)
+}
+
+func TestRemoveTags_EmptySource(t *testing.T) {
+	result := removeTags(nil, []string{"prod"})
+	assert.Empty(t, result)
+}

--- a/features/controller/api/handlers_tags_test.go
+++ b/features/controller/api/handlers_tags_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -424,4 +425,37 @@ func TestRemoveTags_RemoveAll(t *testing.T) {
 func TestRemoveTags_EmptySource(t *testing.T) {
 	result := removeTags(nil, []string{"prod"})
 	assert.Empty(t, result)
+}
+
+// TestHandleAddStewardTags_Concurrent verifies that concurrent POST requests for the
+// same steward accumulate all tag additions — no update is silently overwritten.
+func TestHandleAddStewardTags_Concurrent(t *testing.T) {
+	server := setupTagServer(t)
+	apiKey := NewEphemeralTestKey(t, server, []string{"steward:tag:write", "steward:tag:read"}, "test-tenant", 5*time.Minute)
+	addTagTestSteward(t, server, "s-concurrent", "test-tenant")
+
+	const goroutines = 10
+	tags := []string{"taga", "tagb", "tagc", "tagd", "tage", "tagf", "tagg", "tagh", "tagi", "tagj"}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		tag := tags[i]
+		go func() {
+			defer wg.Done()
+			rec := doTagRequest(server, http.MethodPost, "/api/v1/stewards/s-concurrent/tags", apiKey,
+				map[string]interface{}{"tags": []string{tag}})
+			assert.Equal(t, http.StatusOK, rec.Code, "tag %s: %s", tag, rec.Body.String())
+		}()
+	}
+	wg.Wait()
+
+	rec := doTagRequest(server, http.MethodGet, "/api/v1/stewards/s-concurrent/tags", apiKey, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	got, _ := data["tags"].([]interface{})
+	assert.Len(t, got, goroutines, "all %d concurrent tag additions must be preserved", goroutines)
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/push"
 	controllerrun "github.com/cfgis/cfgms/features/controller/run"
 	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/controller/tagstore"
 	"github.com/cfgis/cfgms/features/modules/stdlib/script"
 	"github.com/cfgis/cfgms/features/monitoring"
 	"github.com/cfgis/cfgms/features/rbac"
@@ -138,6 +139,7 @@ type Server struct {
 	cleanupDone                    chan struct{}                         // closed when cleanup goroutine exits
 	closeOnce                      sync.Once                             // idempotent Close
 	roleConfigStore                cfgconfig.ConfigStore                 // Issue #2543: role-config storage under role-policies namespace
+	tagStore                       *tagstore.Store                       // Issue #2545: steward tag store for tag: selector support
 }
 
 // SetDraining implements cluster.DrainHealthRegistrar. When draining is true,
@@ -506,6 +508,11 @@ func (s *Server) setupRouter() {
 	scripts.Handle("", s.requirePermission("script", "admin")(http.HandlerFunc(s.handleListScripts))).Methods("GET")
 	scripts.Handle("/{id}", s.requirePermission("script", "admin")(http.HandlerFunc(s.handleGetScriptLibraryItem))).Methods("GET")
 	scripts.Handle("/{id}/privilege", s.requirePermission("script", "admin")(http.HandlerFunc(s.handlePutScriptPrivilege))).Methods("PUT")
+
+	// Steward tag management endpoints (Issue #2545)
+	stewards.Handle("/{id}/tags", s.requirePermission("steward", "tag:read")(http.HandlerFunc(s.handleListStewardTags))).Methods("GET")
+	stewards.Handle("/{id}/tags", s.requirePermission("steward", "tag:write")(http.HandlerFunc(s.handleAddStewardTags))).Methods("POST")
+	stewards.Handle("/{id}/tags", s.requirePermission("steward", "tag:write")(http.HandlerFunc(s.handleDeleteStewardTags))).Methods("DELETE")
 
 	// Role config endpoints (Issue #2543)
 	roles := api.PathPrefix("/roles").Subrouter()
@@ -1031,6 +1038,14 @@ func (s *Server) SetRoleConfigStore(cs cfgconfig.ConfigStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.roleConfigStore = cs
+}
+
+// SetTagStore wires the tag store for steward tag management (Issue #2545).
+// Call this after New() returns but before Start() is called.
+func (s *Server) SetTagStore(ts *tagstore.Store) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tagStore = ts
 }
 
 // SetRegistry wires the active-steward connection registry so that

--- a/features/controller/tagstore/tagstore.go
+++ b/features/controller/tagstore/tagstore.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite" // Pure-Go SQLite driver (CGO-free)
@@ -36,6 +37,7 @@ var ErrInvalidTag = errors.New("invalid tag: must match ^[a-z0-9][a-z0-9-]{0,63}
 type Store struct {
 	db     *sql.DB
 	logger logging.Logger
+	mu     sync.Mutex // serialises read-modify-write updates; Get/Set remain lockless
 }
 
 // NewFromDSN opens a SQLite database at dsn and returns a Store.
@@ -116,6 +118,32 @@ func (s *Store) Get(ctx context.Context, stewardID string) ([]string, error) {
 		return nil, fmt.Errorf("tagstore: get tags for %s: %w", logging.SanitizeLogValue(stewardID), err)
 	}
 	return unmarshalTags(encoded)
+}
+
+// Update atomically reads the current tag list for stewardID, applies fn, and
+// writes the result back. The write is serialised against all other Update calls
+// on this Store so that concurrent POST/DELETE requests for the same steward
+// cannot silently overwrite each other's changes. fn receives the current tag list
+// (never nil) and returns the desired new list. If fn returns an error the store
+// is not modified. Returns the new tag list on success.
+func (s *Store) Update(ctx context.Context, stewardID string, fn func([]string) ([]string, error)) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, err := s.Get(ctx, stewardID)
+	if err != nil {
+		return nil, fmt.Errorf("tagstore: update read for %s: %w", logging.SanitizeLogValue(stewardID), err)
+	}
+
+	updated, err := fn(current)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.Set(ctx, stewardID, updated); err != nil {
+		return nil, err
+	}
+	return updated, nil
 }
 
 // Delete removes the tag entry for stewardID.

--- a/features/controller/tagstore/tagstore_test.go
+++ b/features/controller/tagstore/tagstore_test.go
@@ -4,7 +4,9 @@ package tagstore_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -214,6 +216,104 @@ func TestStore_DurabilityAcrossRestart(t *testing.T) {
 
 	// TagsFor must also return durable results.
 	assert.Equal(t, []string{"env-prod", "region-eu"}, store2.TagsFor("steward-persist"))
+}
+
+// ---- Update tests -----------------------------------------------------------
+
+func TestStore_Update_Basic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Set(ctx, "s1", []string{"prod"}))
+
+	result, err := store.Update(ctx, "s1", func(current []string) ([]string, error) {
+		return append(current, "web"), nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod", "web"}, result)
+
+	stored, err := store.Get(ctx, "s1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod", "web"}, stored)
+}
+
+func TestStore_Update_EmptyBaseline(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	result, err := store.Update(ctx, "new-steward", func(current []string) ([]string, error) {
+		assert.Empty(t, current, "fn must receive empty slice for unknown steward")
+		return []string{"prod"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod"}, result)
+}
+
+func TestStore_Update_FnError_DoesNotWrite(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Set(ctx, "s1", []string{"prod"}))
+
+	fnErr := errors.New("fn rejected update")
+	_, err := store.Update(ctx, "s1", func(_ []string) ([]string, error) {
+		return nil, fnErr
+	})
+	require.ErrorIs(t, err, fnErr)
+
+	// Original tags must be unchanged.
+	stored, err := store.Get(ctx, "s1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod"}, stored)
+}
+
+func TestStore_Update_InvalidTagRejected(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Set(ctx, "s1", []string{"prod"}))
+
+	_, err := store.Update(ctx, "s1", func(current []string) ([]string, error) {
+		return append(current, "INVALID-UPPERCASE"), nil
+	})
+	require.ErrorIs(t, err, tagstore.ErrInvalidTag)
+
+	stored, err := store.Get(ctx, "s1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod"}, stored, "store must not be modified on invalid tag")
+}
+
+// TestStore_Update_Concurrent verifies that concurrent updates are serialised and
+// no tag writes are lost (the read-modify-write race is absent).
+func TestStore_Update_Concurrent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	// Each goroutine appends a unique tag. After all complete, all tags must be present.
+	for i := range goroutines {
+		tag := "tag" + string(rune('a'+i)) // tag-a … tag-t (20 tags)
+		go func() {
+			defer wg.Done()
+			_, err := store.Update(ctx, "concurrent-steward", func(current []string) ([]string, error) {
+				for _, t := range current {
+					if t == tag {
+						return current, nil // already present
+					}
+				}
+				return append(current, tag), nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	tags, err := store.Get(ctx, "concurrent-steward")
+	require.NoError(t, err)
+	assert.Len(t, tags, goroutines, "all %d concurrent updates must be preserved", goroutines)
 }
 
 // TestStore_MultiSteward verifies that Set/Get/Delete are correctly scoped to steward IDs.


### PR DESCRIPTION
## Summary

- **REST endpoints** for operator-assigned steward tags: `GET/POST/DELETE /api/v1/stewards/{id}/tags` with `steward:tag:read`/`steward:tag:write` permission guards
- **CLI commands** `cfg steward tag add/rm/ls` wiring to those endpoints, with session/bundle/API-key auth resolution consistent with other cfg subcommands
- **Cross-tenant 403**, unknown steward 404, unauthenticated 401 enforced; tag charset validated by tagstore; all HTTP-sourced values sanitized via `logging.SanitizeLogValue()`

## Changes

| File | Change |
|------|--------|
| `features/controller/api/handlers_tags.go` | New — GET/POST/DELETE handlers + merge/remove helpers |
| `features/controller/api/handlers_tags_test.go` | New — handler + unit tests (HappyPath, 404, 403, 401, idempotent, cross-tenant, nil store, mergeTags/removeTags helpers) |
| `features/controller/api/server.go` | `tagStore` field + `SetTagStore()` setter + route registration |
| `cmd/cfg/cmd/steward_tag.go` | New — `cfg steward tag add/rm/ls` commands |
| `cmd/cfg/cmd/steward_tag_test.go` | New — CLI wiring tests via httptest |
| `docs/development/commands-reference.md` | `cfg steward tag` section added |

## Review results

- **Security:** PASS — no issues in changed files; gosec findings pre-existing and unrelated
- **QA:** PASS — all handler paths covered; mergeTags/removeTags unit tested; CLI forbidden/server-error cases covered
- **Test runner:** PASS — `make test-agent-complete` exits 0, all 5 platforms compile

## Test plan

- [x] `make test-agent-complete` passes (all pre-commit, fast, production-critical checks + cross-platform compilation)
- [x] Handler tests: HappyPath GET/POST/DELETE, EmptyList, UnknownSteward (404), Unauthenticated (401), CrossTenant (403), Idempotent add/rm, InvalidTag, TagStoreNil (503), SubtreeAccess, RoundTrip
- [x] Unit tests: mergeTags (union, empty variants, sorted), removeTags (basic, nonexistent, all, empty source)
- [x] CLI tests: add/rm/ls happy path, 404, 403, server error, AllRemoved message

Fixes #2545

🤖 Generated with [Claude Code](https://claude.com/claude-code)