### PR TITLE
config: role-config injection in InheritanceResolver (Issue #2546)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -168,14 +168,14 @@ The controller decides which steward gets which cfg based on:
 - **Tenant hierarchy** — cfgs inherit through the recursive tenant hierarchy (e.g., MSP → Client → Group → Device). Child tenants can override parent settings at any depth ✓ implemented (`InheritanceResolver.ResolveConfiguration()`)
 - **Cluster membership** — a steward that belongs to one or more clusters (Hyper-V, SQL, etc.) receives an additional `cluster-policies/<clusterName>` config layer inserted after Group-level and before Device-level in the merge order ✓ implemented (`InheritanceResolver` cluster-policies cascade, Issue #2425)
 - **Effective cfg** — the controller resolves inheritance and produces the effective cfg for each steward, merging all applicable layers ✓ implemented (`GetEffectiveConfiguration()`)
-- **Tag-based targeting** — stewards can carry arbitrary tags (e.g., `ring=canary`, `role=web-server`, `region=us-east`); a cfg targets stewards by tag expression — tags exist on steward records (fleet query supports tag filtering for device lists), but tag-based cfg distribution fanout is not yet implemented; the current fanout sends to all active stewards
-- **DNA-attribute matching** — a cfg can target stewards whose DNA attributes match a predicate (e.g., `os=linux`, `cpu_arch=arm64`) — desired state; not currently implemented in cfg distribution
+- **Tag-based targeting** — stewards can carry arbitrary tags (e.g., `ring=canary`, `role=web-server`, `region=us-east`); a cfg targets stewards by tag expression via role configs ✓ implemented (`roleConfigAdapter` in config_service_v2.go injects matching role fragments into `InheritanceResolver`, Issue #2546)
+- **DNA-attribute matching** — a cfg can target stewards whose DNA attributes match a predicate (e.g., `os=linux`, `cpu_arch=arm64`) via role config selectors ✓ implemented (same role-policies cascade, Issue #2546)
 
 **Deployment rings:** see the Deployment Rings section below for the v1 mechanism. Operator-tagged phased rollouts using separate cfgs are still supported alongside rings.
 
-### Cluster-Policies Cascade
+### Cluster-Policies and Role-Policies Cascade
 
-Stewards that are members of a named cluster (Hyper-V failover cluster, SQL AG, etc.) receive an additional configuration layer sourced from `cluster-policies/<clusterName>`. This layer is applied by `InheritanceResolver.ResolveConfiguration()` after the tenant hierarchy and before device-level config.
+Stewards receive additional configuration layers beyond the tenant hierarchy: cluster membership adds a `cluster-policies/<clusterName>` layer, and matching role configs add a `role-policies/<roleName>` layer. Both are applied by `InheritanceResolver.ResolveConfiguration()` after the tenant hierarchy and before device-level config.
 
 **Merge priority order (lowest → highest):**
 
@@ -185,9 +185,10 @@ Stewards that are members of a named cluster (Hyper-V failover cluster, SQL AG, 
 | Client | `client-policies/<tenantID>` | Tenant hierarchy |
 | Group | `group-policies/<tenantID>-groups` | Tenant hierarchy |
 | **Cluster** | **`cluster-policies/<clusterName>`** | **Cluster membership (DNA attributes)** |
+| **Role** | **`role-policies/<roleName>`** | **Selector match (DNA + controller tags)** |
 | Device | `stewards/<stewardID>` | Device-level override |
 
-A device-level resource of the same name always wins over a cluster-policy resource. A cluster-policy resource overrides group-level defaults for the same name.
+A device-level resource always wins. A role resource overrides cluster-policies for the same resource name. A cluster resource overrides group-level defaults.
 
 **Sourcing cluster membership:** the cluster registry is derived from steward DNA attributes published by the steward's `DNARefreshLoop` ticker (default 30 min). A steward that carries `cluster:<clusterName>.*` DNA attributes is recorded as a member of that cluster. Membership is **eventually consistent**: a steward joining or leaving a cluster can take up to one refresh interval before `ResolveConfiguration` reflects the change.
 
@@ -195,9 +196,9 @@ A device-level resource of the same name always wins over a cluster-policy resou
 
 **No-op for non-clustered stewards:** when a steward has no cluster membership, the cluster-policies step is skipped entirely. The `EffectiveConfiguration` output is byte-identical to before this cascade level was introduced, verified by regression tests.
 
-### Role-Policies Namespace (Issue #2543)
+### Role-Policies Namespace (Issues #2543, #2546)
 
-The `role-policies` ConfigStore namespace stores **role configs**: named objects that couple a selector expression with a `StewardConfig` fragment. During config resolution (S4) the resolver evaluates all role configs for the tenant, selects those whose selector matches the target steward, and merges the fragments into the effective config. Authoring is handled by the `/api/v1/roles` REST endpoint and the `cfg role` CLI verb.
+The `role-policies` ConfigStore namespace stores **role configs**: named objects that couple a selector expression with a `StewardConfig` fragment. During config resolution the resolver evaluates all role configs for the tenant, selects those whose selector matches the target steward's DNA + controller-stored tags, and merges the fragments into the effective config after cluster-policies and before device config. Authoring is handled by the `/api/v1/roles` REST endpoint and the `cfg role` CLI verb.
 
 **Role config object shape:**
 
@@ -224,7 +225,7 @@ ConfigKey{TenantID: "<tenant>", Namespace: "role-policies", Name: "<roleName>"}
 
 **Authoring:** `POST /api/v1/roles` (requires `role:write`), `GET /api/v1/roles` / `GET /api/v1/roles/{name}` (requires `role:read`), `DELETE /api/v1/roles/{name}` (requires `role:write`). Cross-tenant authoring is rejected with 403. See `cfg role --help` for CLI usage.
 
-**Resolution:** role configs do not affect the config-resolution pipeline until S4 is implemented. The storage and REST surface are authoritative for authoring only.
+**Resolution:** `InheritanceResolver.ResolveConfiguration()` applies matching role fragments between cluster-policies and device-level config (Issue #2546). The `roleConfigAdapter` in `config_service_v2.go` lists all `role-policies` entries for the tenant, parses each selector via `pkg/fleet/selector.Parse`, and returns the matching fragments sorted alphabetically by name. Multiple matching roles merge in that order; later names override earlier ones for the same resource. A role-provider error is non-fatal: resolution continues without role fragments and a WARN is emitted.
 
 ## Deployment Rings
 

--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/config"
 	controllerrouter "github.com/cfgis/cfgms/pkg/configrouting/providers/controller"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -86,6 +88,143 @@ func (a *clusterRegistryAdapter) MemberClusters(stewardID string) []string {
 	return reg.MemberClusters(stewardID)
 }
 
+// storedRoleConfig is the JSON shape written by handlers_roles.go (features/controller/api).
+// Duplicated here without importing the api package to break the service→api→service cycle.
+type storedRoleConfig struct {
+	Name     string                     `json:"name"`
+	Selector string                     `json:"selector"`
+	Fragment stewardtypes.StewardConfig `json:"fragment"`
+}
+
+// singleStewardProvider is a fleet.StewardProvider wrapping exactly one StewardData.
+// Used by roleConfigAdapter to check filter matches via the canonical fleet.MemoryQuery
+// (which calls the unexported matchesFilter) — one matcher, two consumers (Issue #2546).
+type singleStewardProvider struct{ s fleet.StewardData }
+
+func (p *singleStewardProvider) GetAllStewards() []fleet.StewardData {
+	return []fleet.StewardData{p.s}
+}
+
+// roleConfigAdapter adapts the controller's config store and steward state to the
+// roleConfigProvider interface expected by pkg/config.InheritanceResolver.
+// It lists all role-policies for the steward's tenant, parses each selector, and
+// returns the fragments whose selector matches the steward's current DNA + tags.
+type roleConfigAdapter struct {
+	controllerSvc *ControllerService
+	configStore   cfgconfig.ConfigStore
+	logger        logging.Logger
+}
+
+// MatchingRoleFragments returns the role config fragments whose selectors match
+// stewardID's current DNA + controller-stored tags, sorted alphabetically by role name.
+// DNA currency: os/arch/runtime_os are eventually-consistent (steward-reported, refreshed
+// on DNARefreshLoop; default 30 min); tags are always-current (controller store, updated
+// on each tag admin call). Dynamic-attribute correctness is tracked by epic #2520 — do
+// not block on it.
+func (a *roleConfigAdapter) MatchingRoleFragments(ctx context.Context, stewardID string) ([]config.RoleFragment, error) {
+	info, exists := a.controllerSvc.GetStewardInfo(stewardID)
+	if !exists {
+		return nil, nil
+	}
+
+	// Build DNA attrs map; merge in controller-stored tags so tag: selector terms work.
+	attrs := make(map[string]string)
+	if info.DNA != nil {
+		for k, v := range info.DNA.Attributes {
+			attrs[k] = v
+		}
+	}
+	if ts := a.controllerSvc.TagStore(); ts != nil {
+		attrs = mergeTagsIntoAttrs(attrs, ts.TagsFor(stewardID))
+	}
+
+	entries, err := a.configStore.ListConfigs(ctx, &cfgconfig.ConfigFilter{
+		TenantID:  info.TenantID,
+		Namespace: "role-policies",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("role adapter: list role-policies for tenant %s: %w",
+			logging.SanitizeLogValue(info.TenantID), err)
+	}
+
+	stewardData := fleet.StewardData{
+		ID:            stewardID,
+		TenantID:      info.TenantID,
+		DNAAttributes: attrs,
+	}
+	q := fleet.NewMemoryQuery(&singleStewardProvider{s: stewardData})
+
+	var matched []config.RoleFragment
+	for _, entry := range entries {
+		var rc storedRoleConfig
+		if err := json.Unmarshal(entry.Data, &rc); err != nil {
+			a.logger.Warn("role adapter: skipping malformed role config entry",
+				"name", logging.SanitizeLogValue(entry.Key.Name),
+				"error", err)
+			continue
+		}
+		filter, _, err := selector.Parse(rc.Selector)
+		if err != nil {
+			a.logger.Warn("role adapter: skipping role config with unparseable selector",
+				"name", logging.SanitizeLogValue(rc.Name),
+				"error", err)
+			continue
+		}
+		count, _ := q.Count(ctx, filter)
+		if count > 0 {
+			matched = append(matched, config.RoleFragment{
+				Name:   rc.Name,
+				Config: rc.Fragment,
+			})
+		}
+	}
+
+	// Sort alphabetically by role name for deterministic merge order; later name
+	// overrides earlier for the same resource name (same upsert semantics as other layers).
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].Name < matched[j].Name
+	})
+
+	return matched, nil
+}
+
+// mergeTagsIntoAttrs returns a copy of attrs with ctrlTags merged into the "tags" key.
+// DNA-reported tags come first; controller-stored tags follow; duplicates are dropped.
+// Never mutates the input map — attrs may alias info.DNA.Attributes (shared, cached ref).
+func mergeTagsIntoAttrs(attrs map[string]string, ctrlTags []string) map[string]string {
+	if len(ctrlTags) == 0 {
+		return attrs
+	}
+	merged := make(map[string]string, len(attrs)+1)
+	for k, v := range attrs {
+		merged[k] = v
+	}
+	seen := make(map[string]struct{})
+	var all []string
+	for _, t := range strings.Split(merged["tags"], ",") {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; !dup {
+			seen[t] = struct{}{}
+			all = append(all, t)
+		}
+	}
+	for _, t := range ctrlTags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; !dup {
+			seen[t] = struct{}{}
+			all = append(all, t)
+		}
+	}
+	merged["tags"] = strings.Join(all, ",")
+	return merged
+}
+
 // FanoutCallback is invoked inside SetConfiguration after a successful ConfigStore write.
 // tenantID matches the authenticated tenant that issued the write; cfgID is the steward
 // config identifier. The callback must not block — hand off expensive work to a goroutine.
@@ -121,11 +260,16 @@ func NewConfigurationServiceV2(logger logging.Logger, storageManager *interfaces
 
 	var ir *config.InheritanceResolver
 	if controllerSvc != nil {
-		ir = config.NewInheritanceResolverWithClusters(
+		ir = config.NewInheritanceResolverWithRoles(
 			router,
 			storageManager.GetClientTenantStore(),
 			storageManager.GetTenantStore(),
 			&clusterRegistryAdapter{controllerSvc: controllerSvc},
+			&roleConfigAdapter{
+				controllerSvc: controllerSvc,
+				configStore:   storageManager.GetConfigStore(),
+				logger:        logger,
+			},
 		)
 	} else {
 		ir = config.NewInheritanceResolver(router, storageManager.GetClientTenantStore(), storageManager.GetTenantStore())

--- a/features/controller/service/config_service_v2_test.go
+++ b/features/controller/service/config_service_v2_test.go
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	controllerpb "github.com/cfgis/cfgms/api/proto/controller"
+	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
+	"github.com/cfgis/cfgms/features/controller/tagstore"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// newTestTagStore creates a real SQLite tag store for service-level tests.
+func newTestTagStore(t *testing.T) *tagstore.Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "tags.db")
+	store, err := tagstore.NewFromDSN("file:"+dbPath, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NoError(t, store.Initialize(context.Background()))
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// storeRoleConfig writes a role config JSON entry into the config store under role-policies.
+func storeRoleConfig(t *testing.T, cs cfgconfig.ConfigStore, tenantID, name, selectorExpr string, frag stewardtypes.StewardConfig) {
+	t.Helper()
+	rc := storedRoleConfig{
+		Name:     name,
+		Selector: selectorExpr,
+		Fragment: frag,
+	}
+	data, err := json.Marshal(rc)
+	require.NoError(t, err)
+	checksum := fmt.Sprintf("%x", sha256.Sum256(data))
+	now := time.Now().UTC()
+	require.NoError(t, cs.StoreConfig(context.Background(), &cfgconfig.ConfigEntry{
+		Key:       &cfgconfig.ConfigKey{TenantID: tenantID, Namespace: "role-policies", Name: name},
+		Data:      data,
+		Format:    cfgconfig.ConfigFormatJSON,
+		Checksum:  checksum,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}))
+}
+
+// TestGetConfiguration_TaggedStewardReceivesRoleResource is the REQUIRED TEST from AC:
+// a steward tagged github-runner whose DNA os=windows resolves a role config with selector
+// "os:windows tag:github-runner"; its github_runner resource appears in the effective config.
+// A non-matching steward does not receive it.
+func TestGetConfiguration_TaggedStewardReceivesRoleResource(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+	ts := newTestTagStore(t)
+
+	// Seed a single-tenant hierarchy so InheritanceResolver can walk it.
+	require.NoError(t, sm.GetTenantStore().CreateTenant(ctx,
+		&business.TenantData{ID: "tenant-a", Name: "Tenant A", Status: business.TenantStatusActive}))
+
+	// Set up a ControllerService with the tag store wired in.
+	controllerSvc := NewControllerService(logger)
+	controllerSvc.SetTagStore(ts)
+
+	// Register two stewards: steward-win (windows, tagged) and steward-linux (linux, no tag).
+	// Tenant ID is carried via context (set by auth middleware in production).
+	tenantCtx := context.WithValue(ctx, ctxkeys.TenantID, "tenant-a")
+
+	winDNA := &commonpb.DNA{
+		Id:         "steward-win",
+		Attributes: map[string]string{"os": "windows", "arch": "amd64"},
+	}
+	linuxDNA := &commonpb.DNA{
+		Id:         "steward-linux",
+		Attributes: map[string]string{"os": "linux", "arch": "amd64"},
+	}
+
+	respWin, err := controllerSvc.AcceptRegistration(tenantCtx, &controllerpb.RegisterRequest{
+		InitialDna: winDNA,
+	})
+	require.NoError(t, err)
+	winID := respWin.StewardId
+
+	respLinux, err := controllerSvc.AcceptRegistration(tenantCtx, &controllerpb.RegisterRequest{
+		InitialDna: linuxDNA,
+	})
+	require.NoError(t, err)
+	linuxID := respLinux.StewardId
+
+	// Tag winID with "github-runner"; leave linuxID untagged.
+	require.NoError(t, ts.Set(ctx, winID, []string{"github-runner"}))
+
+	// Store the role config targeting "os:windows tag:github-runner".
+	storeRoleConfig(t, sm.GetConfigStore(), "tenant-a", "github-runner-role",
+		"os:windows tag:github-runner",
+		stewardtypes.StewardConfig{
+			Resources: []stewardtypes.ResourceConfig{
+				{Name: "github-runner-resource", Module: "github_runner",
+					Config: map[string]interface{}{"runner": "true"}},
+			},
+		},
+	)
+
+	// Store device-level configs so GetConfiguration finds sources at each level.
+	svc := NewConfigurationServiceV2(logger, sm, controllerSvc)
+	require.NoError(t, svc.SetConfiguration(ctx, "tenant-a", winID, &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{ID: winID, Mode: stewardtypes.ModeController},
+		Modules: map[string]string{"github_runner": "github_runner"},
+	}))
+	require.NoError(t, svc.SetConfiguration(ctx, "tenant-a", linuxID, &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{ID: linuxID, Mode: stewardtypes.ModeController},
+	}))
+
+	// winID: GetConfiguration must include the role's github_runner resource.
+	cfgRespWin, err := svc.GetConfiguration(ctx, &controllerpb.ConfigRequest{StewardId: winID})
+	require.NoError(t, err)
+	require.Equal(t, "OK", cfgRespWin.Status.Code.String(), "steward-win config must succeed")
+
+	winCfg, err := stewardtypes.FromProto(cfgRespWin.Config.Config)
+	require.NoError(t, err)
+
+	winResourceNames := make(map[string]bool)
+	for _, r := range winCfg.Resources {
+		winResourceNames[r.Name] = true
+	}
+	assert.True(t, winResourceNames["github-runner-resource"],
+		"github_runner resource must appear in windows steward effective config (selector matches)")
+
+	// linuxID: GetConfiguration must NOT include the role's resource (selector mismatch).
+	cfgRespLinux, err := svc.GetConfiguration(ctx, &controllerpb.ConfigRequest{StewardId: linuxID})
+	require.NoError(t, err)
+	require.Equal(t, "OK", cfgRespLinux.Status.Code.String(), "steward-linux config must succeed")
+
+	linuxCfg, err := stewardtypes.FromProto(cfgRespLinux.Config.Config)
+	require.NoError(t, err)
+
+	for _, r := range linuxCfg.Resources {
+		assert.NotEqual(t, "github-runner-resource", r.Name,
+			"github_runner resource must NOT appear in linux steward effective config (selector mismatch)")
+	}
+}
+
+// TestGetConfiguration_UntaggingRemovesRoleResource verifies that removing a tag causes
+// the role's resources to be absent on the next GetConfiguration call.
+func TestGetConfiguration_UntaggingRemovesRoleResource(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+	ts := newTestTagStore(t)
+
+	require.NoError(t, sm.GetTenantStore().CreateTenant(ctx,
+		&business.TenantData{ID: "tenant-b", Name: "Tenant B", Status: business.TenantStatusActive}))
+
+	controllerSvc := NewControllerService(logger)
+	controllerSvc.SetTagStore(ts)
+
+	tenantCtxB := context.WithValue(ctx, ctxkeys.TenantID, "tenant-b")
+	regResp, err := controllerSvc.AcceptRegistration(tenantCtxB, &controllerpb.RegisterRequest{
+		InitialDna: &commonpb.DNA{
+			Id:         "steward-tag-test",
+			Attributes: map[string]string{"os": "linux"},
+		},
+	})
+	require.NoError(t, err)
+	stewardID := regResp.StewardId
+
+	require.NoError(t, ts.Set(ctx, stewardID, []string{"web-server"}))
+
+	storeRoleConfig(t, sm.GetConfigStore(), "tenant-b", "web-role", "tag:web-server",
+		stewardtypes.StewardConfig{
+			Resources: []stewardtypes.ResourceConfig{
+				{Name: "web-resource", Module: "file"},
+			},
+		},
+	)
+
+	svc := NewConfigurationServiceV2(logger, sm, controllerSvc)
+	require.NoError(t, svc.SetConfiguration(ctx, "tenant-b", stewardID, &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{ID: stewardID, Mode: stewardtypes.ModeController},
+		Modules: map[string]string{"file": "file"},
+	}))
+
+	// Tagged: role resource must appear.
+	respTagged, err := svc.GetConfiguration(ctx, &controllerpb.ConfigRequest{StewardId: stewardID})
+	require.NoError(t, err)
+	cfgTagged, err := stewardtypes.FromProto(respTagged.Config.Config)
+	require.NoError(t, err)
+
+	taggedNames := make(map[string]bool)
+	for _, r := range cfgTagged.Resources {
+		taggedNames[r.Name] = true
+	}
+	assert.True(t, taggedNames["web-resource"], "web-resource must appear when steward is tagged web-server")
+
+	// Untag: clear the tag list; next resolve must not include the role resource.
+	require.NoError(t, ts.Set(ctx, stewardID, []string{}))
+
+	respUntagged, err := svc.GetConfiguration(ctx, &controllerpb.ConfigRequest{StewardId: stewardID})
+	require.NoError(t, err)
+	cfgUntagged, err := stewardtypes.FromProto(respUntagged.Config.Config)
+	require.NoError(t, err)
+
+	for _, r := range cfgUntagged.Resources {
+		assert.NotEqual(t, "web-resource", r.Name,
+			"web-resource must be absent after untagging the steward")
+	}
+}
+
+// findResource returns the resource with the given name from resources, failing the test
+// if it is absent.
+func findResource(t *testing.T, resources []stewardtypes.ResourceConfig, name string) stewardtypes.ResourceConfig {
+	t.Helper()
+	for _, r := range resources {
+		if r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("resource %q not found in effective config", name)
+	return stewardtypes.ResourceConfig{}
+}
+
+// TestGetConfiguration_RolePrecedence_DeviceBeatsRoleBeatsCluster verifies the cascade
+// precedence for a single resource name shared across cluster-policies, role-policies and
+// device level: device beats role, role beats cluster. Exercised end-to-end through the
+// real roleConfigAdapter + clusterRegistryAdapter wired by NewConfigurationServiceV2
+// (Issue #2546 — no test stubs; real components only).
+func TestGetConfiguration_RolePrecedence_DeviceBeatsRoleBeatsCluster(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+	ts := newTestTagStore(t)
+
+	require.NoError(t, sm.GetTenantStore().CreateTenant(ctx,
+		&business.TenantData{ID: "tenant-c", Name: "Tenant C", Status: business.TenantStatusActive}))
+
+	controllerSvc := NewControllerService(logger)
+	controllerSvc.SetTagStore(ts)
+
+	tenantCtx := context.WithValue(ctx, ctxkeys.TenantID, "tenant-c")
+
+	// Both stewards are members of cluster "my-cluster" (via a cluster:my-cluster.* DNA key)
+	// and tagged "shared-role" so the role selector matches.
+	regDev, err := controllerSvc.AcceptRegistration(tenantCtx, &controllerpb.RegisterRequest{
+		InitialDna: &commonpb.DNA{
+			Id:         "steward-dev",
+			Attributes: map[string]string{"os": "linux", "cluster:my-cluster.member": "1"},
+		},
+	})
+	require.NoError(t, err)
+	devID := regDev.StewardId
+
+	regNoDev, err := controllerSvc.AcceptRegistration(tenantCtx, &controllerpb.RegisterRequest{
+		InitialDna: &commonpb.DNA{
+			Id:         "steward-nodev",
+			Attributes: map[string]string{"os": "linux", "cluster:my-cluster.member": "1"},
+		},
+	})
+	require.NoError(t, err)
+	noDevID := regNoDev.StewardId
+
+	require.NoError(t, ts.Set(ctx, devID, []string{"shared-role"}))
+	require.NoError(t, ts.Set(ctx, noDevID, []string{"shared-role"}))
+
+	// Cluster-policies sets shared=cluster.
+	require.NoError(t, sm.GetConfigStore().StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{TenantID: "tenant-c", Namespace: "cluster-policies", Name: "my-cluster"},
+		Data: marshalStewardConfigYAML(t, stewardtypes.StewardConfig{
+			Resources: []stewardtypes.ResourceConfig{
+				{Name: "shared", Module: "file", Config: map[string]interface{}{"value": "cluster"}},
+			},
+		}),
+		Format: cfgconfig.ConfigFormatYAML,
+	}))
+
+	// Role-policies sets shared=role, matched via tag:shared-role.
+	storeRoleConfig(t, sm.GetConfigStore(), "tenant-c", "shared-role", "tag:shared-role",
+		stewardtypes.StewardConfig{
+			Resources: []stewardtypes.ResourceConfig{
+				{Name: "shared", Module: "file", Config: map[string]interface{}{"value": "role"}},
+			},
+		},
+	)
+
+	svc := NewConfigurationServiceV2(logger, sm, controllerSvc)
+
+	// steward-dev: device-level sets shared=device → device must win over role and cluster.
+	require.NoError(t, svc.SetConfiguration(ctx, "tenant-c", devID, &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{ID: devID, Mode: stewardtypes.ModeController},
+		Modules: map[string]string{"file": "file"},
+		Resources: []stewardtypes.ResourceConfig{
+			{Name: "shared", Module: "file", Config: map[string]interface{}{"value": "device"}},
+		},
+	}))
+	// steward-nodev: no device-level "shared" resource.
+	require.NoError(t, svc.SetConfiguration(ctx, "tenant-c", noDevID, &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{ID: noDevID, Mode: stewardtypes.ModeController},
+	}))
+
+	effDev, err := svc.GetEffectiveConfiguration(ctx, "tenant-c", devID)
+	require.NoError(t, err)
+	sharedDev := findResource(t, effDev.Config.Resources, "shared")
+	assert.Equal(t, "device", sharedDev.Config["value"],
+		"device-level must win over both role and cluster for the same resource name")
+
+	effNoDev, err := svc.GetEffectiveConfiguration(ctx, "tenant-c", noDevID)
+	require.NoError(t, err)
+	sharedNoDev := findResource(t, effNoDev.Config.Resources, "shared")
+	assert.Equal(t, "role", sharedNoDev.Config["value"],
+		"role-level must win over cluster-policies when no device config is present")
+}
+
+// TestGetConfiguration_MalformedRoleConfig_IsNonFatal verifies that a malformed role-policies
+// entry is skipped by the real roleConfigAdapter without failing resolution: a valid sibling
+// role still applies and device-level config still appears. This is the real-component
+// equivalent of the resolver's "role provider hiccup is non-fatal" contract (Issue #2546).
+func TestGetConfiguration_MalformedRoleConfig_IsNonFatal(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+	ts := newTestTagStore(t)
+
+	require.NoError(t, sm.GetTenantStore().CreateTenant(ctx,
+		&business.TenantData{ID: "tenant-d", Name: "Tenant D", Status: business.TenantStatusActive}))
+
+	controllerSvc := NewControllerService(logger)
+	controllerSvc.SetTagStore(ts)
+
+	tenantCtx := context.WithValue(ctx, ctxkeys.TenantID, "tenant-d")
+	reg, err := controllerSvc.AcceptRegistration(tenantCtx, &controllerpb.RegisterRequest{
+		InitialDna: &commonpb.DNA{Id: "steward-d", Attributes: map[string]string{"os": "linux"}},
+	})
+	require.NoError(t, err)
+	stewardID := reg.StewardId
+	require.NoError(t, ts.Set(ctx, stewardID, []string{"good-role"}))
+
+	// Malformed role-policies entry: not valid JSON. The adapter must skip it (logged warn),
+	// not fail resolution.
+	require.NoError(t, sm.GetConfigStore().StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key:    &cfgconfig.ConfigKey{TenantID: "tenant-d", Namespace: "role-policies", Name: "broken-role"},
+		Data:   []byte("{{{not valid json"),
+		Format: cfgconfig.ConfigFormatJSON,
+	}))
+
+	// Valid sibling role config matching the steward's tag.
+	storeRoleConfig(t, sm.GetConfigStore(), "tenant-d", "good-role", "tag:good-role",
+		stewardtypes.StewardConfig{
+			Resources: []stewardtypes.ResourceConfig{
+				{Name: "good-resource", Module: "file"},
+			},
+		},
+	)
+
+	svc := NewConfigurationServiceV2(logger, sm, controllerSvc)
+	require.NoError(t, svc.SetConfiguration(ctx, "tenant-d", stewardID, &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{ID: stewardID, Mode: stewardtypes.ModeController},
+		Modules: map[string]string{"file": "file"},
+		Resources: []stewardtypes.ResourceConfig{
+			{Name: "device-resource", Module: "file", Config: map[string]interface{}{"path": "/tmp/x"}},
+		},
+	}))
+
+	eff, err := svc.GetEffectiveConfiguration(ctx, "tenant-d", stewardID)
+	require.NoError(t, err, "malformed role config must not fail resolution")
+
+	names := make(map[string]bool)
+	for _, r := range eff.Config.Resources {
+		names[r.Name] = true
+	}
+	assert.True(t, names["device-resource"],
+		"device-level resource must appear despite malformed role config")
+	assert.True(t, names["good-resource"],
+		"valid sibling role resource must still apply despite the malformed sibling")
+}

--- a/pkg/config/inheritance.go
+++ b/pkg/config/inheritance.go
@@ -41,6 +41,27 @@ type clusterMembership interface {
 	MemberClusters(stewardID string) []string
 }
 
+// RoleFragment pairs a role's name with its StewardConfig fragment for merge ordering.
+// Returned by roleConfigProvider.MatchingRoleFragments, sorted alphabetically by Name
+// so that multiple matching roles produce a deterministic merge order.
+type RoleFragment struct {
+	Name   string
+	Config stewardconfig.StewardConfig
+}
+
+// roleConfigProvider is the minimal interface InheritanceResolver requires to fetch
+// role config fragments that match a steward's DNA + tags. Defined locally (same
+// pattern as clusterMembership) to avoid importing features/controller/fleet into
+// pkg/config, which would create a circular dependency. The concrete
+// *roleConfigAdapter in features/controller/service satisfies this by duck-typing.
+type roleConfigProvider interface {
+	// MatchingRoleFragments returns the role config fragments whose selectors match
+	// stewardID, sorted alphabetically by role name. Returns nil, nil when no roles
+	// match. A non-nil error is non-fatal to the caller — the resolver logs and
+	// skips the role layer entirely rather than failing resolution.
+	MatchingRoleFragments(ctx context.Context, stewardID string) ([]RoleFragment, error)
+}
+
 // cfgStoreAsRouter wraps a plain ConfigStore to satisfy configSourceRouter.
 // SnapshotSources always returns ConfigSourceTypeController for backward compatibility
 // (used by NewInheritanceResolverWithStorageManager which has no router available).
@@ -61,8 +82,9 @@ type InheritanceResolver struct {
 	configStore       configSourceRouter
 	clientTenantStore business.ClientTenantStore
 	tenantStore       business.TenantStore
-	clusterRegistry   clusterMembership // optional; nil means no cluster-policies cascade
-	logger            logging.Logger    // never nil after construction; see log()
+	clusterRegistry   clusterMembership  // optional; nil means no cluster-policies cascade
+	roleProvider      roleConfigProvider // optional; nil means no role-policies cascade
+	logger            logging.Logger     // never nil after construction; see log()
 }
 
 // log returns the resolver's logger, defaulting to a NoopLogger when the resolver
@@ -122,6 +144,21 @@ func NewInheritanceResolverWithClusters(configStore configSourceRouter, clientTe
 		clientTenantStore: clientTenantStore,
 		tenantStore:       tenantStore,
 		clusterRegistry:   registry,
+		logger:            logging.NewLogger("info"),
+	}
+}
+
+// NewInheritanceResolverWithRoles creates an InheritanceResolver with both a cluster
+// membership provider and a role config provider wired in. Pass nil for either to
+// disable that cascade layer. Role fragments are applied after cluster-policies and
+// before device-level config (precedence order: cluster < role < device).
+func NewInheritanceResolverWithRoles(configStore configSourceRouter, clientTenantStore business.ClientTenantStore, tenantStore business.TenantStore, registry clusterMembership, roles roleConfigProvider) *InheritanceResolver {
+	return &InheritanceResolver{
+		configStore:       configStore,
+		clientTenantStore: clientTenantStore,
+		tenantStore:       tenantStore,
+		clusterRegistry:   registry,
+		roleProvider:      roles,
 		logger:            logging.NewLogger("info"),
 	}
 }
@@ -205,6 +242,25 @@ func (ir *InheritanceResolver) ResolveConfiguration(ctx context.Context, tenantI
 					"tenant_id", tenantID,
 					"cluster", clusterName,
 					"error", err.Error())
+			}
+		}
+	}
+
+	// Apply role-policies after cluster-policies and before device config.
+	// Each role whose selector matches this steward contributes a config fragment.
+	// Fragments are applied in alphabetical role-name order so multiple matching
+	// roles produce a deterministic merge (later name overrides earlier for the same
+	// resource). A provider hiccup must not fail resolution — log and treat as no roles.
+	if ir.roleProvider != nil {
+		fragments, err := ir.roleProvider.MatchingRoleFragments(ctx, stewardID)
+		if err != nil {
+			ir.log().WarnCtx(ctx, "skipping role-policies; treating as no roles",
+				"steward_id", stewardID,
+				"tenant_id", tenantID,
+				"error", err.Error())
+		} else {
+			for _, frag := range fragments {
+				ir.applyRoleFragment(effective, tenantID, frag)
 			}
 		}
 	}
@@ -314,6 +370,19 @@ func (ir *InheritanceResolver) applyClusterConfiguration(ctx context.Context, ef
 
 	ir.applyConfigurationWithSource(effective, &clusterConfig, inheritSrc)
 	return nil
+}
+
+// applyRoleFragment merges a single role config fragment into effective. The
+// InheritanceSource level (LevelGroup+2) places role fragments between
+// cluster-policies (LevelGroup+1) and device-level (LevelDevice) in source metadata.
+func (ir *InheritanceResolver) applyRoleFragment(effective *EffectiveConfiguration, tenantID string, frag RoleFragment) {
+	inheritSrc := &InheritanceSource{
+		Level:      int(LevelGroup) + 2, // between cluster-policies and device in merge order
+		TenantID:   tenantID,
+		ConfigName: frag.Name,
+		Source:     fmt.Sprintf("Role (role-policies/%s)", frag.Name),
+	}
+	ir.applyConfigurationWithSource(effective, &frag.Config, inheritSrc)
 }
 
 // applyDeviceConfiguration applies device-specific configuration


### PR DESCRIPTION
## Summary

- Adds a **role-policies cascade** layer to `InheritanceResolver` sitting between cluster-policies and device config in the merge precedence chain
- `roleConfigAdapter` in `features/controller/service` wires the canonical `fleet.MemoryQuery` + `selector.Parse` path — no second matcher implementation
- Controller-stored tags are merged into DNA attributes before selector evaluation so `tag:` terms always reflect current tag state; `os:`/`arch:` terms are eventually-consistent (steward-reported, default 30 min refresh)

## Changed files

| File | Change |
|------|--------|
| `pkg/config/inheritance.go` | `RoleFragment` type, `roleConfigProvider` interface, `NewInheritanceResolverWithRoles` constructor, role cascade block in `ResolveConfiguration`, `applyRoleFragment` helper |
| `features/controller/service/config_service_v2.go` | `roleConfigAdapter` implementing the new interface; `storedRoleConfig` local mirror to avoid service→api import cycle; `mergeTagsIntoAttrs`; wiring in `NewConfigurationServiceV2` |
| `features/controller/service/config_service_v2_test.go` | Real-component integration tests: tagged steward receives role resource, untagging removes it, device > role > cluster precedence, malformed role entry is non-fatal |
| `docs/architecture/controller-operating-model.md` | Merge priority table updated to include Role layer; Role-Policies Namespace section updated to show S4 implemented |

## Test plan

- [x] `TestGetConfiguration_TaggedStewardReceivesRoleResource` — steward with matching DNA + tag gets role resource; non-matching steward does not
- [x] `TestGetConfiguration_UntaggingRemovesRoleResource` — removing tag causes role resource to disappear on next resolve
- [x] `TestGetConfiguration_RolePrecedence_DeviceBeatsRoleBeatsCluster` — device config overrides role; role overrides cluster-policies
- [x] `TestGetConfiguration_MalformedRoleConfig_IsNonFatal` — malformed role-policies entry is skipped; resolution succeeds with remaining valid entries
- [x] `make test-agent-complete` — all CI gates pass (unit, integration, build, security)
- [x] Story-review workflow passed: 2 review rounds, 1 fix round (gofmt + stub→real-component test migration), 0 remaining findings

Fixes #2546

🤖 Generated with [Claude Code](https://claude.com/claude-code)