### PR TITLE
pipeline: preflight consumes merge-queue state — eviction escalation + one-shot rerun (Issue #2589)

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -493,12 +493,14 @@ issues that a rebase would clear. So PRs sit stuck even with all required
 checks green (DIRTY case) or with failures that aren't actually their
 fault (stale-base case).
 
-The preflight surfaces three actions in `review_recommendations`:
+The preflight surfaces these actions in `review_recommendations`:
 
 | Action | When | What to do |
 |---|---|---|
 | `rebase` | mergeStateStatus is DIRTY or (BEHIND with auto-merge armed) | Run `rebase-pr.sh`. The PR's branch needs to be current before any other action makes sense. |
 | `rebase_then_investigate` | CI red (any required check failed) | Run `rebase-pr.sh`. If `REBASE_OK`, wait one cycle for CI to re-run. If `REBASE_NOOP`, the branch was already current → the failure is real → diagnose + dispatch-fix. |
+| `rerun_failed_checks` | reviewed PASS, head CI red, PR out of the queue, failing run is attempt 1 (Issue #2589) | One-shot `./.claude/scripts/po-act.sh rerun <PR>` to clear a transient flake before enqueue. Budget is one rerun — if CI is still red next cycle the failing run is now attempt > 1 and the preflight routes to `investigate_queue_failures` instead. Do NOT rerun a PR already in the queue (the queue re-runs merge-group checks itself). |
+| `investigate_queue_failures` | reviewed PASS but the PR was evicted from the merge queue ≥ 2 times since its latest commit, OR its CI is still red after the one-shot rerun (Issue #2589) | The PR's merge-commit CI keeps failing (two evictions on the same head SHA ⇒ implicated; one can be innocent ALLGREEN-group fallout). Do NOT keep re-enqueuing. Same handling as `rebase_then_investigate`'s NOOP branch: `po-act.sh diagnose <PR>` then set status `Fix`. |
 | `investigate` (legacy) | rare; falls through if neither rebase nor red applies | Same handling as rebase_then_investigate's NOOP branch. |
 
 For each `rebase` or `rebase_then_investigate` recommendation, first acquire the

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -298,12 +298,19 @@ query {
         autoMergeRequest { enabledAt }
         author { login }
         labels(first: 20) { nodes { name } }
-        timelineItems(itemTypes: [LABELED_EVENT], first: 20) {
+        timelineItems(itemTypes: [LABELED_EVENT, ADDED_TO_MERGE_QUEUE_EVENT, REMOVED_FROM_MERGE_QUEUE_EVENT], first: 50) {
           nodes {
+            __typename
             ... on LabeledEvent {
               createdAt
               label { name }
               actor { login }
+            }
+            ... on AddedToMergeQueueEvent {
+              createdAt
+            }
+            ... on RemovedFromMergeQueueEvent {
+              createdAt
             }
           }
         }
@@ -1476,8 +1483,52 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
                 continue
 
             # Only reaches here when verdict == "pass" and no fix commit landed
-            # after the review (prior PASS is still valid). Flag as stuck if CI
-            # green + mergeable but not in queue and not already auto-merge-enabled.
+            # after the review (prior PASS is still valid).
+
+            # Issue #2589: queue-eviction escalation. A PR evicted from the merge
+            # queue >= 2 times since its latest commit is implicated — one
+            # eviction can be innocent ALLGREEN-group fallout, but two on the same
+            # head SHA means this PR's own merge-commit CI keeps failing. Do NOT
+            # keep silently re-enqueuing it forever; route to
+            # investigate_queue_failures so the cycle diagnoses and moves it to
+            # Fix (mirrors the rebase_then_investigate handling).
+            eviction_count = pr.get("eviction_count", 0)
+            if eviction_count >= 2 and not in_queue:
+                recs.append({
+                    "pr": pr["pr"],
+                    "story": pr["story_number"],
+                    "action": "investigate_queue_failures",
+                    "reason": f"reviewed PASS but evicted from the merge queue {eviction_count}x since the latest commit — merge-commit CI keeps failing; run `po-act.sh diagnose <PR>` + set status Fix instead of re-enqueuing",
+                })
+                continue
+
+            # Issue #2589: one-shot CI rerun for a transiently-red PASS PR. A
+            # PASS-verdict PR whose head CI went red while it sits OUT of the
+            # queue (a flake, or a superseded run) gets exactly one
+            # `gh run rerun --failed`. failed_run_attempt > 1 means the rerun
+            # already happened and CI is still red → not a flake; investigate
+            # instead of today's terminal skip. StatusContext legacy checks have
+            # no attempt and default to 1. (Budget is 1 to break the loop, not
+            # to mask flakes the de-flake stories must fix.)
+            if overall == "red" and not in_queue:
+                if pr.get("failed_run_attempt", 1) <= 1:
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "rerun_failed_checks",
+                        "reason": "reviewed PASS but head CI went red while out of the queue (attempt 1) — one-shot `po-act.sh rerun <PR>` to clear a transient flake before enqueueing",
+                    })
+                else:
+                    recs.append({
+                        "pr": pr["pr"],
+                        "story": pr["story_number"],
+                        "action": "investigate_queue_failures",
+                        "reason": "reviewed PASS but head CI is still red after a rerun (attempt > 1) — not a transient flake; run `po-act.sh diagnose <PR>` + set status Fix",
+                    })
+                continue
+
+            # Flag as stuck if CI green + mergeable but not in queue and not
+            # already auto-merge-enabled.
             if (
                 overall == "green"
                 and pr.get("mergeable") == "MERGEABLE"
@@ -1686,6 +1737,57 @@ def compute_fix_recommendations(fix_stories, pr_summaries, active_fix_pr_nums=No
     return recs
 
 
+def count_merge_queue_evictions(timeline_items, since_iso):
+    """Count RemovedFromMergeQueueEvent timeline items dated after since_iso.
+
+    since_iso is the PR's latest-commit ISO timestamp, so a fixed-and-repushed
+    PR starts a fresh eviction budget — evictions before the newest commit are
+    stale and don't count. timeline_items are the raw GraphQL nodes (each has a
+    __typename; RemovedFromMergeQueueEvent carries createdAt). ISO-8601 UTC
+    strings compare lexicographically. Manual dequeues (po-act.sh dequeue) are
+    indistinguishable from GitHub evictions in the timeline, so both count — the
+    escalation threshold of 2 tolerates one benign dequeue. (Issue #2589)
+    """
+    if not since_iso:
+        return 0
+    count = 0
+    for item in timeline_items or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("__typename") != "RemovedFromMergeQueueEvent":
+            continue
+        created = item.get("createdAt")
+        if created and created > since_iso:
+            count += 1
+    return count
+
+
+def _latest_failing_run_attempt(head_ref):
+    """Return the attempt number of the most recent failed workflow run on
+    head_ref, or 1 if none/unknown. Called only for a PASS PR whose head CI is
+    red and sits OUT of the queue (Issue #2589 rerun budget), so these two
+    scoped gh calls run at most once or twice per cycle. 1 == not yet rerun
+    (eligible for one `po-act.sh rerun`); > 1 == a rerun already ran (escalate
+    to investigate).
+    """
+    if not head_ref:
+        return 1
+    runs = gh("run", "list", "--branch", head_ref, "--limit", "20",
+              "--json", "databaseId,conclusion", check=False)
+    if not isinstance(runs, list):
+        return 1
+    failing = next(
+        (r for r in runs if isinstance(r, dict) and r.get("conclusion") == "failure"),
+        None,
+    )
+    if not failing or failing.get("databaseId") is None:
+        return 1
+    view = gh("run", "view", str(failing["databaseId"]), "--json", "attempt", check=False)
+    if isinstance(view, dict) and isinstance(view.get("attempt"), int) and view["attempt"] >= 1:
+        return view["attempt"]
+    return 1
+
+
 def _build_pr_summaries(prs):
     """Build pr_summaries from raw PR nodes (Phase 4 of the preflight cycle).
 
@@ -1754,6 +1856,15 @@ def _build_pr_summaries(prs):
             "mergeable": pr.get("mergeable"),
             "auto_merge_enabled": pr.get("autoMergeRequest") is not None,
             "ci_summary": ci_summary(pr.get("statusCheckRollup") or []),
+            # Issue #2589: merge-queue awareness.
+            # eviction_count is pure (timeline + latest commit); queue_state and
+            # failed_run_attempt are injected in main() (queue_state from the
+            # mergeQueue map, failed_run_attempt via a scoped run lookup for the
+            # rare red-CI PR) so this transform stays API-free and unit-testable.
+            "eviction_count": count_merge_queue_evictions(
+                pr.get("timeline_items", []), pr.get("latest_commit_date")),
+            "queue_state": None,
+            "failed_run_attempt": 1,
         })
     return summaries
 
@@ -2105,6 +2216,25 @@ def main():
 
     # Phase 4: PR summaries (includes author trust classification — Issue #1786).
     pr_summaries = _build_pr_summaries(prs)
+
+    # Issue #2589: inject merge-queue-derived fields _build_pr_summaries can't
+    # compute (it is API-free by design so it stays unit-testable).
+    #  - queue_state: the mergeQueue entry state for a queued PR, else None.
+    #  - failed_run_attempt: only for a PASS PR whose head CI is red AND is not
+    #    in the queue (the sole rerun-eligible shape) — a scoped lookup of the
+    #    failing run's attempt, so the recommender reruns once then escalates.
+    #    Bounded to those (0-2 per cycle); no broad extra round-trip.
+    queue_state_by_pr = {e["pr_number"]: e.get("state") for e in merge_queue}
+    for s in pr_summaries:
+        s["queue_state"] = queue_state_by_pr.get(s["pr"])
+        if (
+            s["pr"] not in queued_pr_numbers
+            and s.get("has_acceptance_review_comment")
+            and s.get("latest_review_verdict") == "pass"
+            and (s.get("ci_summary") or {}).get("overall") == "red"
+        ):
+            s["failed_run_attempt"] = _latest_failing_run_attempt(s.get("head_ref", ""))
+
     out["prs_open"] = pr_summaries
 
     # Surface external-author PRs as a top-priority cron section (AC7).

--- a/.claude/scripts/tests/test-preflight-external-pr.py
+++ b/.claude/scripts/tests/test-preflight-external-pr.py
@@ -29,7 +29,8 @@ def _load_preflight():
 
 def _make_raw_pr(number=999, head_ref="feature/story-999-agent", author_login="someuser",
                  is_draft=False, labels=None, timeline_items=None, comments=None,
-                 status_rollup=None, body="", mergeable="MERGEABLE", merge_state="CLEAN"):
+                 status_rollup=None, body="", mergeable="MERGEABLE", merge_state="CLEAN",
+                 latest_commit_date=None):
     """Build a minimal PR node as returned by gh_graphql_pipeline_overview (prs list)."""
     return {
         "number": number,
@@ -45,7 +46,7 @@ def _make_raw_pr(number=999, head_ref="feature/story-999-agent", author_login="s
         "timeline_items": timeline_items if timeline_items is not None else [],
         "comments": comments if comments is not None else [],
         "statusCheckRollup": status_rollup if status_rollup is not None else [],
-        "latest_commit_date": None,
+        "latest_commit_date": latest_commit_date,
     }
 
 
@@ -584,6 +585,113 @@ class TestWaitVerdictReviewRecommendations(unittest.TestCase):
         self.assertEqual(len(recs), 1)
         self.assertEqual(recs[0]["action"], "skip")
         self.assertIn("fail", recs[0]["reason"].lower())
+
+
+class TestMergeQueueStateRecommendations(unittest.TestCase):
+    """Issue #2589: preflight consumes merge-queue state — eviction escalation
+    (investigate_queue_failures) and one-shot CI rerun (rerun_failed_checks)."""
+
+    def setUp(self):
+        self.pf = _load_preflight()
+
+    def _make_summary(self, pr_num=101, story_num=42, ci_overall="green",
+                      eviction_count=0, failed_run_attempt=1, mergeable="MERGEABLE",
+                      merge_state="CLEAN"):
+        # A PASS-verdict, no-fix-landed PR shape — the block the #2589 branches
+        # live in. verdict='pass' + review comment present + latest_commit_date
+        # older than the (absent) review date so fix_landed_after_review is False.
+        return {
+            "pr": pr_num,
+            "story_number": story_num,
+            "author_login": "jrdnr",
+            "is_external": False,
+            "is_released": False,
+            "is_draft": False,
+            "wip_session_failed": False,
+            "has_acceptance_review_comment": True,
+            "latest_review_verdict": "pass",
+            "latest_review_comment_date": "2026-07-13T05:00:00Z",
+            "latest_commit_date": "2026-07-13T04:00:00Z",
+            "merge_state_status": merge_state,
+            "mergeable": mergeable,
+            "auto_merge_enabled": False,
+            "eviction_count": eviction_count,
+            "queue_state": None,
+            "failed_run_attempt": failed_run_attempt,
+            "ci_summary": {
+                "overall": ci_overall,
+                "pass": 4 if ci_overall == "green" else 0,
+                "pending": 0,
+                "fail": 1 if ci_overall == "red" else 0,
+                "skipped": 0,
+                "pending_checks": [],
+                "failed_checks": ["Cross-Platform Build Validation"] if ci_overall == "red" else [],
+            },
+        }
+
+    # --- count_merge_queue_evictions (pure timeline counting) ---
+    def test_eviction_count_after_commit_only(self):
+        tl = [
+            {"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2026-07-13T05:00:00Z"},
+            {"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2026-07-13T05:10:00Z"},
+            {"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2026-07-12T00:00:00Z"},  # stale (pre-commit)
+            {"__typename": "AddedToMergeQueueEvent", "createdAt": "2026-07-13T05:05:00Z"},
+            {"__typename": "LabeledEvent", "createdAt": "2026-07-13T05:20:00Z", "label": {"name": "x"}},
+        ]
+        self.assertEqual(self.pf.count_merge_queue_evictions(tl, "2026-07-13T04:00:00Z"), 2)
+
+    def test_eviction_count_zero_without_commit_date(self):
+        tl = [{"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2026-07-13T05:00:00Z"}]
+        self.assertEqual(self.pf.count_merge_queue_evictions(tl, None), 0)
+
+    def test_build_pr_summaries_populates_eviction_count(self):
+        raw = _make_raw_pr(
+            number=101, author_login="jrdnr",
+            latest_commit_date="2026-07-13T04:00:00Z",
+            timeline_items=[
+                {"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2026-07-13T05:00:00Z"},
+                {"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2026-07-13T05:10:00Z"},
+            ],
+        )
+        s = self.pf._build_pr_summaries([raw])[0]
+        self.assertEqual(s["eviction_count"], 2)
+        self.assertEqual(s["queue_state"], None)      # injected in main(), None by default
+        self.assertEqual(s["failed_run_attempt"], 1)  # default; main() overrides for red PRs
+
+    # --- eviction escalation (investigate_queue_failures) ---
+    def test_two_evictions_pass_not_in_queue_escalates(self):
+        recs = self.pf.compute_review_recommendations([self._make_summary(eviction_count=2)], set())
+        self.assertEqual(recs[0]["action"], "investigate_queue_failures")
+        self.assertIn("evicted", recs[0]["reason"].lower())
+
+    def test_one_eviction_green_still_enqueues(self):
+        """Regression: a single eviction is not enough to escalate — normal enqueue."""
+        recs = self.pf.compute_review_recommendations([self._make_summary(eviction_count=1)], set())
+        self.assertEqual(recs[0]["action"], "enqueue_merge")
+
+    def test_evicted_pr_currently_in_queue_not_escalated(self):
+        """A PR back in the queue (re-enqueued) must not be escalated — it's being processed."""
+        s = self._make_summary(eviction_count=3)
+        recs = self.pf.compute_review_recommendations([s], {s["pr"]})  # in queue
+        self.assertNotEqual(recs[0]["action"], "investigate_queue_failures")
+
+    # --- one-shot rerun (rerun_failed_checks) ---
+    def test_red_ci_attempt1_reruns(self):
+        recs = self.pf.compute_review_recommendations(
+            [self._make_summary(ci_overall="red", failed_run_attempt=1)], set())
+        self.assertEqual(recs[0]["action"], "rerun_failed_checks")
+
+    def test_red_ci_attempt2_investigates(self):
+        """After the one-shot rerun (attempt > 1) still red → not a flake, investigate (not skip)."""
+        recs = self.pf.compute_review_recommendations(
+            [self._make_summary(ci_overall="red", failed_run_attempt=2)], set())
+        self.assertEqual(recs[0]["action"], "investigate_queue_failures")
+
+    # --- zero-eviction green-path regression: recommendations unchanged ---
+    def test_zero_eviction_green_path_unchanged(self):
+        s = self._make_summary(eviction_count=0, ci_overall="green")
+        recs = self.pf.compute_review_recommendations([s], set())
+        self.assertEqual(recs[0]["action"], "enqueue_merge")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Makes the PO preflight merge-queue-aware, closing two silent loops it had ignored despite already fetching queue `state`.

## Changes
- **GraphQL:** the existing per-PR `timelineItems` query now also pulls `ADDED_TO_MERGE_QUEUE_EVENT` / `REMOVED_FROM_MERGE_QUEUE_EVENT` — **no new query** (AC5).
- **`eviction_count`** (pure, in `_build_pr_summaries`): count of `RemovedFromMergeQueue` events after the PR's latest commit, so a fixed-and-repushed PR starts a fresh budget.
- **`queue_state` + `failed_run_attempt`** injected in `main()` — `queue_state` from the mergeQueue map; `failed_run_attempt` via a scoped `gh run` lookup **only for a PASS PR with red head CI out of the queue** (0-2/cycle, the impl-note-sanctioned source), keeping `compute_review_recommendations` pure and fixture-testable.
- **`investigate_queue_failures`** — a PASS PR evicted ≥ 2× since its latest commit routes here instead of silent re-enqueue (one eviction can be innocent ALLGREEN-group fallout; two on the same head SHA is implicated → `po-act.sh diagnose` + Fix).
- **`rerun_failed_checks`** — a PASS PR with red head CI, out of the queue, failing run attempt 1 → one-shot `po-act.sh rerun`; attempt > 1 → `investigate_queue_failures` instead of the old terminal `skip`.
- **`po.md`** §4.1 action table documents both new actions + handling.

## Why now
This session hit exactly these gaps live: **#2597** sat evicted-and-re-enqueued repeatedly, and a MERGE-method auto-merge stall went undetected for cycles — precisely what queue-awareness surfaces.

## Validation
- **8 new unit tests** (eviction counting incl. pre-commit exclusion, escalation, one-shot rerun, attempt>1 investigate, in-queue-not-escalated, zero-eviction green-path regression) — full suite **53/53**.
- **Live preflight run clean** (new GraphQL event types valid, `degraded: false`) — the cron that depends on this won't break.
- `python3 -m py_compile` clean.

Fixes #2589

🤖 Generated with [Claude Code](https://claude.com/claude-code)