### PR TITLE
controller: DNA write-integrity guard (Issue #2617)

### DIFF
--- a/features/controller/service/config_service_v2_test.go
+++ b/features/controller/service/config_service_v2_test.go
@@ -82,11 +82,11 @@ func TestGetConfiguration_TaggedStewardReceivesRoleResource(t *testing.T) {
 
 	winDNA := &commonpb.DNA{
 		Id:         "steward-win",
-		Attributes: map[string]string{"os": "windows", "arch": "amd64"},
+		Attributes: map[string]string{"os": "windows", "hostname": "win-host", "arch": "amd64"},
 	}
 	linuxDNA := &commonpb.DNA{
 		Id:         "steward-linux",
-		Attributes: map[string]string{"os": "linux", "arch": "amd64"},
+		Attributes: map[string]string{"os": "linux", "hostname": "linux-host", "arch": "amd64"},
 	}
 
 	respWin, err := controllerSvc.AcceptRegistration(tenantCtx, &controllerpb.RegisterRequest{

--- a/features/controller/service/controller_service.go
+++ b/features/controller/service/controller_service.go
@@ -176,6 +176,12 @@ func (s *ControllerService) StorageReady(ctx context.Context) error {
 
 // AcceptRegistration handles steward registration requests
 func (s *ControllerService) AcceptRegistration(ctx context.Context, req *controller.RegisterRequest) (*controller.RegisterResponse, error) {
+	// Treat nil InitialDna as an empty snapshot so callers that omit it get a
+	// clean integrity-rejection path rather than a nil-dereference panic.
+	if req.InitialDna == nil {
+		req.InitialDna = &common.DNA{}
+	}
+
 	// Extract tenant information from gRPC metadata
 	tenantID := s.extractTenantID(ctx)
 
@@ -230,13 +236,29 @@ func (s *ControllerService) AcceptRegistration(ctx context.Context, req *control
 		return nil, fmt.Errorf("registration failed: %w", err)
 	}
 
+	// Validate DNA integrity. A degenerate snapshot (empty or missing core
+	// identity fields) must not clobber good DNA, so we leave the DNA field nil
+	// on the StewardInfo and skip the durable write. The registration itself
+	// still succeeds structurally — the steward gets its ID and token.
+	dnaCheck := checkDNAIntegrity(req.InitialDna, configTypeFullOSDevice)
+	if !dnaCheck.valid {
+		s.logger.Warn("dna_integrity_rejected",
+			"steward_id", logging.SanitizeLogValue(stewardID),
+			"missing_fields", dnaCheck.missingFields)
+	}
+
+	var registrationDNA *common.DNA
+	if dnaCheck.valid {
+		registrationDNA = req.InitialDna
+	}
+
 	// Store/update steward information
 	s.mu.Lock()
 	s.stewards[stewardID] = &StewardInfo{
 		ID:            stewardID,
 		TenantID:      tenantID,
 		Version:       req.Version,
-		DNA:           req.InitialDna,
+		DNA:           registrationDNA,
 		LastHeartbeat: time.Now(),
 		Status:        "registered",
 		Metrics:       make(map[string]string),
@@ -244,8 +266,10 @@ func (s *ControllerService) AcceptRegistration(ctx context.Context, req *control
 	}
 	s.mu.Unlock()
 
-	// Persist initial DNA to durable storage
-	s.storeDNA(ctx, stewardID, tenantID, req.InitialDna, "registered")
+	// Persist initial DNA to durable storage only when the snapshot is valid.
+	if dnaCheck.valid {
+		s.storeDNA(ctx, stewardID, tenantID, req.InitialDna, "registered")
+	}
 
 	s.logger.Info("Steward registration completed",
 		"steward_id", stewardID,
@@ -320,6 +344,20 @@ func (s *ControllerService) SyncDNA(ctx context.Context, dna *common.DNA) (*comm
 		return &common.Status{
 			Code:    common.Status_NOT_FOUND,
 			Message: "Steward not found",
+		}, nil
+	}
+
+	// Validate DNA integrity before writing. A degenerate snapshot (empty or
+	// missing hostname/os) must not overwrite the prior last-known-good DNA;
+	// the snapshot is also not appended to history.
+	dnaCheck := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	if !dnaCheck.valid {
+		s.logger.Warn("dna_integrity_rejected",
+			"steward_id", logging.SanitizeLogValue(dna.Id),
+			"missing_fields", dnaCheck.missingFields)
+		return &common.Status{
+			Code:    common.Status_OK,
+			Message: "DNA rejected: degenerate snapshot (missing core identity fields)",
 		}, nil
 	}
 

--- a/features/controller/service/controller_service_test.go
+++ b/features/controller/service/controller_service_test.go
@@ -298,7 +298,7 @@ func TestStoreDNA_WriteOnSync(t *testing.T) {
 	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
 
 	// Register a steward
-	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux", "hostname": "dev-1-host"})
 	svc.mu.Lock()
 	svc.stewards["dev-1"] = &StewardInfo{
 		ID:       "dev-1",
@@ -1117,7 +1117,7 @@ func TestSetPostDNASyncHook_FiresAfterSyncDNA(t *testing.T) {
 
 	dna := &commonpb.DNA{
 		Id:         "steward-hook",
-		Attributes: map[string]string{"os": "linux", "arch": "amd64"},
+		Attributes: map[string]string{"os": "linux", "hostname": "hook-host", "arch": "amd64"},
 	}
 	status, err := svc.SyncDNA(ctx, dna)
 	require.NoError(t, err)
@@ -1169,7 +1169,7 @@ func TestSetPostDNASyncHook_HookReceivesDNACopy(t *testing.T) {
 	var hookDNA *commonpb.DNA
 	svc.SetPostDNASyncHook(func(_ string, dna *commonpb.DNA) { hookDNA = dna })
 
-	attrs := map[string]string{"version": "2.0", "platform": "linux"}
+	attrs := map[string]string{"version": "2.0", "platform": "linux", "hostname": "dnacopy-host", "os": "linux"}
 	dna := &commonpb.DNA{Id: "steward-dnacopy", Attributes: attrs}
 	_, err := svc.SyncDNA(ctx, dna)
 	require.NoError(t, err)

--- a/features/controller/service/dna_integrity.go
+++ b/features/controller/service/dna_integrity.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package service
+
+import (
+	common "github.com/cfgis/cfgms/api/proto/common"
+)
+
+// configType identifies the configuration type of a managed device.
+// The per-type required-field table is seeded here for full-OS devices;
+// #2618 will extend it for additional device kinds without rewriting the guard.
+type configType string
+
+const configTypeFullOSDevice configType = "full-os-device"
+
+// dnaRequiredFields maps each configuration type to the Attributes keys that
+// must be present and non-empty for a valid DNA snapshot.
+// Seed: only full-os-device (all current stewards). #2618 adds further entries.
+var dnaRequiredFields = map[configType][]string{
+	configTypeFullOSDevice: {"hostname", "os"},
+}
+
+// dnaIntegrityResult is the outcome of a DNA integrity check.
+type dnaIntegrityResult struct {
+	valid         bool
+	missingFields []string
+}
+
+// checkDNAIntegrity returns whether the DNA snapshot satisfies the required-field
+// contract for the given configuration type. A nil DNA, or any required Attributes
+// key that is absent or empty, fails the check and lists the offending fields.
+//
+// The check is table-driven: to seed the required set for a new device kind,
+// add an entry to dnaRequiredFields (see #2618). An unregistered config type
+// passes by default (conservative: unknown contracts cannot be violated).
+func checkDNAIntegrity(dna *common.DNA, ct configType) dnaIntegrityResult {
+	if dna == nil {
+		return dnaIntegrityResult{missingFields: []string{"(nil DNA)"}}
+	}
+	required, ok := dnaRequiredFields[ct]
+	if !ok {
+		return dnaIntegrityResult{valid: true}
+	}
+	var missing []string
+	for _, field := range required {
+		if dna.Attributes[field] == "" {
+			missing = append(missing, field)
+		}
+	}
+	if len(missing) > 0 {
+		return dnaIntegrityResult{missingFields: missing}
+	}
+	return dnaIntegrityResult{valid: true}
+}

--- a/features/controller/service/dna_integrity_test.go
+++ b/features/controller/service/dna_integrity_test.go
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	controllerpb "github.com/cfgis/cfgms/api/proto/controller"
+	fleetStorage "github.com/cfgis/cfgms/features/controller/fleet/storage"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// makeValidDNA returns a DNA snapshot that satisfies the full-os-device required set.
+func makeValidDNA(id string) *commonpb.DNA {
+	return &commonpb.DNA{
+		Id:              id,
+		SyncFingerprint: "fp-" + id,
+		Attributes: map[string]string{
+			"hostname": "host-" + id,
+			"os":       "linux",
+		},
+	}
+}
+
+// --- Unit tests for checkDNAIntegrity ---
+
+func TestCheckDNAIntegrity_NilDNA(t *testing.T) {
+	result := checkDNAIntegrity(nil, configTypeFullOSDevice)
+	assert.False(t, result.valid)
+	assert.NotEmpty(t, result.missingFields)
+}
+
+func TestCheckDNAIntegrity_EmptyAttributes(t *testing.T) {
+	dna := &commonpb.DNA{Id: "dev-1", Attributes: map[string]string{}}
+	result := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	assert.False(t, result.valid)
+	assert.Contains(t, result.missingFields, "hostname")
+	assert.Contains(t, result.missingFields, "os")
+}
+
+func TestCheckDNAIntegrity_MissingHostname(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id:         "dev-1",
+		Attributes: map[string]string{"os": "linux"},
+	}
+	result := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	assert.False(t, result.valid)
+	assert.Contains(t, result.missingFields, "hostname")
+	assert.NotContains(t, result.missingFields, "os")
+}
+
+func TestCheckDNAIntegrity_MissingOS(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id:         "dev-1",
+		Attributes: map[string]string{"hostname": "myhost"},
+	}
+	result := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	assert.False(t, result.valid)
+	assert.Contains(t, result.missingFields, "os")
+	assert.NotContains(t, result.missingFields, "hostname")
+}
+
+func TestCheckDNAIntegrity_EmptyHostnameValue(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id:         "dev-1",
+		Attributes: map[string]string{"hostname": "", "os": "linux"},
+	}
+	result := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	assert.False(t, result.valid)
+	assert.Contains(t, result.missingFields, "hostname")
+}
+
+func TestCheckDNAIntegrity_EmptyOSValue(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id:         "dev-1",
+		Attributes: map[string]string{"hostname": "myhost", "os": ""},
+	}
+	result := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	assert.False(t, result.valid)
+	assert.Contains(t, result.missingFields, "os")
+}
+
+func TestCheckDNAIntegrity_ValidCoreIdentity(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id:         "dev-1",
+		Attributes: map[string]string{"hostname": "myhost", "os": "linux"},
+	}
+	result := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	assert.True(t, result.valid)
+	assert.Empty(t, result.missingFields)
+}
+
+// Optional fields (vm_count legitimately absent) must not block a valid write.
+func TestCheckDNAIntegrity_ValidWithOptionalFieldsAbsent(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id: "dev-1",
+		Attributes: map[string]string{
+			"hostname": "myhost",
+			"os":       "windows",
+			// vm_count intentionally omitted
+		},
+	}
+	result := checkDNAIntegrity(dna, configTypeFullOSDevice)
+	assert.True(t, result.valid)
+	assert.Empty(t, result.missingFields)
+}
+
+// Unknown config type has no contract; conservative default is valid.
+func TestCheckDNAIntegrity_UnknownConfigType(t *testing.T) {
+	dna := &commonpb.DNA{Id: "dev-1", Attributes: map[string]string{}}
+	result := checkDNAIntegrity(dna, configType("unknown-type"))
+	assert.True(t, result.valid)
+}
+
+// --- Integration tests: SyncDNA write guard ---
+
+// TestSyncDNA_RejectsDegenerateDNA verifies that a degenerate snapshot (missing
+// hostname/os) is rejected: in-memory DNA and durable history stay at the prior
+// good snapshot.
+func TestSyncDNA_RejectsDegenerateDNA_PriorSnapshotUnchanged(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	log := &logCapture{}
+	svc := NewControllerServiceWithStorage(log, storage)
+	ctx := context.Background()
+
+	goodDNA := makeValidDNA("dev-1")
+	svc.mu.Lock()
+	svc.stewards["dev-1"] = &StewardInfo{
+		ID:       "dev-1",
+		TenantID: "tenant-a",
+		DNA:      goodDNA,
+		Status:   "active",
+		Metrics:  make(map[string]string),
+	}
+	svc.mu.Unlock()
+	require.NoError(t, storage.Store(ctx, "dev-1", goodDNA, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "active"}))
+
+	// Sync degenerate snapshot (missing hostname and os).
+	degenerateDNA := &commonpb.DNA{Id: "dev-1", Attributes: map[string]string{}}
+	_, err := svc.SyncDNA(ctx, degenerateDNA)
+	require.NoError(t, err)
+
+	// In-memory DNA must still be the good snapshot.
+	info, ok := svc.GetStewardInfo("dev-1")
+	require.True(t, ok)
+	assert.Equal(t, goodDNA.Attributes["hostname"], info.DNA.Attributes["hostname"])
+	assert.Equal(t, goodDNA.Attributes["os"], info.DNA.Attributes["os"])
+
+	// History must have exactly one entry — degenerate not appended.
+	history, err := storage.GetHistory(ctx, "dev-1", &fleetStorage.QueryOptions{IncludeData: true})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, history.TotalCount, "degenerate snapshot must not be appended to history")
+
+	// WARN log entry must have been emitted.
+	entry, found := log.findEntry("dna_integrity_rejected")
+	assert.True(t, found, "expected dna_integrity_rejected WARN log entry")
+	assert.Equal(t, "WARN", entry.level)
+}
+
+// TestSyncDNA_RejectsNilAttributesDNA verifies that a nil-attributes DNA
+// snapshot is also rejected by the SyncDNA path.
+func TestSyncDNA_RejectsNilAttributesDNA(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	ctx := context.Background()
+
+	goodDNA := makeValidDNA("dev-2")
+	svc.mu.Lock()
+	svc.stewards["dev-2"] = &StewardInfo{
+		ID:       "dev-2",
+		TenantID: "tenant-b",
+		DNA:      goodDNA,
+		Status:   "active",
+		Metrics:  make(map[string]string),
+	}
+	svc.mu.Unlock()
+	require.NoError(t, storage.Store(ctx, "dev-2", goodDNA, &fleetStorage.StoreOptions{TenantID: "tenant-b", Status: "active"}))
+
+	emptyDNA := &commonpb.DNA{Id: "dev-2"} // nil Attributes map
+	_, err := svc.SyncDNA(ctx, emptyDNA)
+	require.NoError(t, err)
+
+	info, ok := svc.GetStewardInfo("dev-2")
+	require.True(t, ok)
+	assert.NotNil(t, info.DNA)
+	assert.Equal(t, "host-dev-2", info.DNA.Attributes["hostname"])
+
+	history, err := storage.GetHistory(ctx, "dev-2", &fleetStorage.QueryOptions{IncludeData: true})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, history.TotalCount)
+}
+
+// TestSyncDNA_AcceptsValidDNA verifies a valid DNA snapshot persists and versions.
+func TestSyncDNA_AcceptsValidDNA(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	ctx := context.Background()
+
+	firstDNA := makeValidDNA("dev-3")
+	svc.mu.Lock()
+	svc.stewards["dev-3"] = &StewardInfo{
+		ID:       "dev-3",
+		TenantID: "tenant-c",
+		DNA:      firstDNA,
+		Status:   "active",
+		Metrics:  make(map[string]string),
+	}
+	svc.mu.Unlock()
+	require.NoError(t, storage.Store(ctx, "dev-3", firstDNA, &fleetStorage.StoreOptions{TenantID: "tenant-c", Status: "active"}))
+
+	secondDNA := &commonpb.DNA{
+		Id:         "dev-3",
+		Attributes: map[string]string{"hostname": "host-dev-3-renamed", "os": "linux"},
+	}
+	status, err := svc.SyncDNA(ctx, secondDNA)
+	require.NoError(t, err)
+	assert.Equal(t, commonpb.Status_OK, status.Code)
+
+	info, ok := svc.GetStewardInfo("dev-3")
+	require.True(t, ok)
+	assert.Equal(t, "host-dev-3-renamed", info.DNA.Attributes["hostname"])
+
+	history, err := storage.GetHistory(ctx, "dev-3", &fleetStorage.QueryOptions{IncludeData: true})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, history.TotalCount)
+}
+
+// TestSyncDNA_AcceptsValidDNA_OptionalFieldsAbsent verifies that absent optional
+// fields (vm_count etc.) do not trigger rejection.
+func TestSyncDNA_AcceptsValidDNA_OptionalFieldsAbsent(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+	ctx := context.Background()
+
+	svc.mu.Lock()
+	svc.stewards["dev-4"] = &StewardInfo{
+		ID:      "dev-4",
+		Status:  "active",
+		Metrics: make(map[string]string),
+	}
+	svc.mu.Unlock()
+
+	dna := &commonpb.DNA{
+		Id: "dev-4",
+		Attributes: map[string]string{
+			"hostname": "myhost",
+			"os":       "macos",
+			// vm_count absent — must not block
+		},
+	}
+	status, err := svc.SyncDNA(ctx, dna)
+	require.NoError(t, err)
+	assert.Equal(t, commonpb.Status_OK, status.Code)
+
+	info, ok := svc.GetStewardInfo("dev-4")
+	require.True(t, ok)
+	assert.Equal(t, "macos", info.DNA.Attributes["os"])
+}
+
+// TestSyncDNA_PostHookNotFiredOnRejection verifies that postDNASyncHook is not
+// invoked when a degenerate snapshot is rejected.
+func TestSyncDNA_PostHookNotFiredOnRejection(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+	ctx := context.Background()
+
+	goodDNA := makeValidDNA("dev-5")
+	svc.mu.Lock()
+	svc.stewards["dev-5"] = &StewardInfo{
+		ID:      "dev-5",
+		DNA:     goodDNA,
+		Status:  "active",
+		Metrics: make(map[string]string),
+	}
+	svc.mu.Unlock()
+
+	hookFired := false
+	svc.SetPostDNASyncHook(func(id string, dna *commonpb.DNA) {
+		hookFired = true
+	})
+
+	degenerateDNA := &commonpb.DNA{Id: "dev-5", Attributes: map[string]string{}}
+	_, err := svc.SyncDNA(ctx, degenerateDNA)
+	require.NoError(t, err)
+	assert.False(t, hookFired, "postDNASyncHook must not fire on degenerate rejection")
+}
+
+// TestSyncDNA_WarnLogContainsStewardIDAndMissingFields verifies the WARN log
+// entry names the steward id and the specific missing fields.
+func TestSyncDNA_WarnLogContainsStewardIDAndMissingFields(t *testing.T) {
+	log := &logCapture{}
+	svc := NewControllerService(log)
+	ctx := context.Background()
+
+	svc.mu.Lock()
+	svc.stewards["dev-6"] = &StewardInfo{
+		ID:      "dev-6",
+		DNA:     makeValidDNA("dev-6"),
+		Status:  "active",
+		Metrics: make(map[string]string),
+	}
+	svc.mu.Unlock()
+
+	// DNA missing only "os".
+	dna := &commonpb.DNA{
+		Id:         "dev-6",
+		Attributes: map[string]string{"hostname": "myhost"},
+	}
+	_, err := svc.SyncDNA(ctx, dna)
+	require.NoError(t, err)
+
+	entry, found := log.findEntry("dna_integrity_rejected")
+	require.True(t, found, "expected dna_integrity_rejected WARN log entry")
+
+	// steward_id field present.
+	_, hasStewardID := entry.fieldValue("steward_id")
+	assert.True(t, hasStewardID)
+
+	// missing_fields value is a []string containing "os".
+	val, ok := entry.fieldValue("missing_fields")
+	require.True(t, ok)
+	fields, isSlice := val.([]string)
+	require.True(t, isSlice, "missing_fields should be []string")
+	assert.Contains(t, fields, "os")
+	assert.NotContains(t, fields, "hostname")
+}
+
+// --- Integration tests: AcceptRegistration write guard ---
+
+// TestAcceptRegistration_RejectsDegenerateInitialDNA verifies that a registration
+// with a degenerate initial DNA still creates the StewardInfo entry (registration
+// structurally succeeds) but leaves the DNA field nil and stores no durable record.
+func TestAcceptRegistration_RejectsDegenerateInitialDNA(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	log := &logCapture{}
+	svc := NewControllerServiceWithStorage(log, storage)
+	ctx := context.Background()
+
+	req := &controllerpb.RegisterRequest{
+		Version:        "1.0.0",
+		InitialDna:     &commonpb.DNA{Id: "dna-bad", Attributes: map[string]string{}},
+		IsReconnection: false,
+	}
+	resp, err := svc.AcceptRegistration(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	stewardID := resp.StewardId
+
+	// StewardInfo created but DNA must be nil.
+	info, ok := svc.GetStewardInfo(stewardID)
+	require.True(t, ok, "steward entry should exist even when DNA rejected")
+	assert.Nil(t, info.DNA, "DNA must be nil when initial snapshot is degenerate")
+
+	// No durable DNA record stored.
+	_, err = storage.GetLatestByDeviceID(ctx, stewardID)
+	assert.Error(t, err, "no durable record should exist for degenerate initial DNA")
+
+	// WARN log emitted.
+	entry, found := log.findEntry("dna_integrity_rejected")
+	assert.True(t, found, "expected dna_integrity_rejected WARN log entry")
+	assert.Equal(t, "WARN", entry.level)
+}
+
+// TestAcceptRegistration_AcceptsValidInitialDNA verifies a registration with
+// valid initial DNA persists the record normally.
+func TestAcceptRegistration_AcceptsValidInitialDNA(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	ctx := context.Background()
+
+	req := &controllerpb.RegisterRequest{
+		Version:        "1.0.0",
+		InitialDna:     makeValidDNA("dna-good"),
+		IsReconnection: false,
+	}
+	resp, err := svc.AcceptRegistration(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	stewardID := resp.StewardId
+
+	info, ok := svc.GetStewardInfo(stewardID)
+	require.True(t, ok)
+	require.NotNil(t, info.DNA)
+	assert.Equal(t, "linux", info.DNA.Attributes["os"])
+
+	record, err := storage.GetLatestByDeviceID(ctx, stewardID)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+}
+
+// TestAcceptRegistration_RejectsNilInitialDNA verifies a nil InitialDna is
+// handled without panic; registration succeeds structurally, DNA is left nil.
+func TestAcceptRegistration_RejectsNilInitialDNA(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	ctx := context.Background()
+
+	req := &controllerpb.RegisterRequest{
+		Version:        "1.0.0",
+		InitialDna:     nil,
+		IsReconnection: false,
+	}
+	resp, err := svc.AcceptRegistration(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	info, ok := svc.GetStewardInfo(resp.StewardId)
+	require.True(t, ok)
+	assert.Nil(t, info.DNA)
+}


### PR DESCRIPTION
## Summary

- Adds a table-driven DNA write-integrity guard at both `AcceptRegistration` and `SyncDNA` that rejects snapshots missing `hostname` or `os` from `Attributes`
- Degenerate snapshots are logged with a WARN (steward_id + missing_fields) and never written to memory (`steward.DNA`) or durable storage (`dnaStorage.Store`)
- Adds nil `InitialDna` guard in `AcceptRegistration` to prevent panic on nil initial registration DNA
- New `dna_integrity.go` holds a `configType`-keyed required-field table seeded with `full-os-device → {hostname, os}`; #2618 extends the table without touching the guard logic

## Specialist Review Results

- **Security**: PASS — no central-provider violations, no hardcoded secrets, gosec clean, user-controlled steward IDs wrapped with `logging.SanitizeLogValue`, missing_fields logs only internal constants, generic rejection messages avoid information disclosure
- **QA**: PASS — 17 tests in new files, no mocks, no `t.Skip()`, no `time.Sleep` synchronization, all error paths covered; one pre-existing warning (TestGetStewardInfo_ConcurrentSyncDNA_NoRace lacks explicit assertions, out of scope for this story)
- **Test runner**: PASS — `make test-agent-complete` completed; all tests pass, cross-platform compilation (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) successful

## Test plan

- [ ] `make test` passes locally
- [ ] `go test ./features/controller/service/...` — 17 new tests cover nil DNA, nil Attributes, missing hostname, missing os, empty field values, unknown config type, SyncDNA rejection (prior snapshot unchanged, history count=1), AcceptRegistration rejection (StewardInfo.DNA=nil), valid DNA acceptance, post-hook not fired on rejection, structured WARN log fields
- [ ] Existing tests updated to include `hostname` in DNA attributes wherever `SyncDNA` or `AcceptRegistration` was called with `{"os": "linux"}` only

Fixes #2617

🤖 Generated with [Claude Code](https://claude.com/claude-code)