### PR TITLE
ci: make trivy-scan blocking; slim security-deployment-gate (Issue #2606)

### DIFF
--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -66,11 +66,6 @@ jobs:
         # extraction. See docs/runbooks/trivy-rollback.md for rollback.
         sudo .github/scripts/install-trivy.sh 'v0.72.0' 'bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea'
 
-        # Install other security tools
-        make install-nancy
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
-        go install honnef.co/go/tools/cmd/staticcheck@2026.1
-        
         echo "✅ Security tools installed"
     
     - name: Run Security Gate Analysis
@@ -107,16 +102,10 @@ jobs:
           echo "✅ No critical/high vulnerabilities detected"
         fi
         
-        echo ""
-        echo "🛡️ Running Additional Security Scans..."
-        
-        # Run gosec for security patterns (non-blocking but reported)
-        if ! make security-gosec >/dev/null 2>&1; then
-          echo "⚠️  gosec detected security patterns (non-blocking)"
-        else
-          echo "✅ gosec security pattern scan passed"
-        fi
-        
+        # Advisory scans (nancy, gosec, staticcheck) are non-required contexts
+        # that run in security-scan.yml. They are not executed here so this
+        # gate remains focused on the single blocking Trivy vulnerability scan.
+
         # Check for emergency override
         if [ "${{ github.event.inputs.emergency_override }}" = "true" ] || [ -f "EMERGENCY_DEPLOYMENT" ]; then
           echo ""

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -96,6 +96,12 @@ jobs:
         path: sarif-results/
         retention-days: 30
 
+    - name: Fail on security findings
+      if: steps.scan.outputs.issues-found == 'true'
+      run: |
+        echo "❌ Trivy scan found CRITICAL/HIGH vulnerabilities — see scan output above"
+        exit 1
+
   nancy-scan:
     permissions:
       contents: read

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -24,8 +24,8 @@ The CFGMS security workflow integrates four complementary security scanning tool
 
 - **Purpose**: Scans filesystem for known vulnerabilities in dependencies and infrastructure
 - **Scope**: Critical/High CVEs, secrets, misconfigurations
-- **Blocking**: Yes (Critical/High vulnerabilities block deployment)
-- **SARIF Support**: Yes (GitHub Security tab integration)
+- **Blocking**: Yes — two enforcement points: (1) `trivy-scan` is a required PR/merge-queue context that exits 1 on findings; (2) `security-deployment-gate` in `production-gates.yml` also runs Trivy with `--exit-code 1`
+- **SARIF Support**: Yes (GitHub Security tab integration; uploaded with `if: always()` so findings land in the Security tab even when the job fails)
 
 ### 2. Nancy - Go Dependency Scanning
 
@@ -162,15 +162,16 @@ make test-with-security  # Runs: test + security-scan + summary
 
 **Security Gate Features**:
 
-- Critical/High vulnerability blocking
+- Critical/High vulnerability blocking via Trivy (`--exit-code 1`)
 - Emergency override mechanism
 - Comprehensive audit trail
-- Automated notifications
 - Integration with existing release gates
+
+**Scope**: `security-deployment-gate` runs only the blocking Trivy scan. Advisory tools (nancy, gosec, staticcheck) run as non-required contexts in `security-scan.yml` and are not executed here.
 
 **Gate Flow**:
 
-1. `security-deployment-gate` - Primary security validation
+1. `security-deployment-gate` - Primary security validation (Trivy only)
 2. `production-risk-assessment` - Risk analysis (requires security approval)
 
 ## Production Deployment Gates


### PR DESCRIPTION
## Summary

- **`security-scan.yml` `trivy-scan` job**: Added explicit `Fail on security findings` gate step that exits 1 when `steps.scan.outputs.issues-found == 'true'`, following the same pattern as `license-check.yml`. The `trivy-scan` required context now genuinely fails when CRITICAL/HIGH findings are present. SARIF upload and artifact steps retain `if: always()` so findings reach the Security tab even on failure.
- **`production-gates.yml` `security-deployment-gate` job**: Removed dead tool installs (`make install-nancy`, `go install gosec`, `go install staticcheck`) and the non-blocking gosec invocation (`make security-gosec`). Blocking Trivy scan, emergency-override logic, and audit-trail steps are retained unchanged. A comment documents that advisory tools run in `security-scan.yml`.
- **`docs/development/security-workflow-guide.md`**: Updated Trivy blocking description to name both enforcement points; updated production gate scope to reflect Trivy-only operation.

## Pre-flight evidence

`trivy fs . --scanners vuln,secret,misconfig --severity CRITICAL,HIGH --exit-code 1` exits **0** on current develop (zero findings across `go.mod`, `examples/security-fixes/go.mod`, `web/package-lock.json`, and all Dockerfiles). The newly-blocking `trivy-scan` check is green on merge.

## Specialist review results

| Lens | Verdict | Notes |
|------|---------|-------|
| Code quality (qa-code-reviewer) | ✅ PASS | No anti-patterns; YAML+docs changes only |
| Tests (qa-test-runner) | ✅ PASS | `make test-agent-complete` clean — all gates green |
| Security (security-engineer) | ✅ PASS | No blocking issues; security improvement confirmed |

## Test plan

- [ ] CI `trivy-scan` job passes (zero findings on develop)
- [ ] CI `security-deployment-gate` passes (Trivy clean; no longer installs/runs nancy/gosec/staticcheck)
- [ ] SARIF upload reachable in Security tab (upload-sarif step has `if: always()`)
- [ ] `make test-agent-complete` passes locally (confirmed by qa-test-runner)

Fixes #2606

🤖 Generated with [Claude Code](https://claude.ai/claude-code)