### PR TITLE
hyperv: re-arm monitor subsystem after Close so config re-push keeps module/cluster DNA alive

### DIFF
--- a/features/modules/hyperv/monitor_windows.go
+++ b/features/modules/hyperv/monitor_windows.go
@@ -347,7 +347,19 @@ func (m *hypervModule) Monitor(_ context.Context, resourceID string, _ modules.C
 	m.monMu.Lock()
 	defer m.monMu.Unlock()
 	if m.monClosed {
-		return fmt.Errorf("hyperv monitor: closed")
+		// Close() is terminal for the monitor subsystem, but the executor's
+		// monitor engine calls Close() merely to STOP monitors before restarting
+		// them on the next config push (client_transport.go StartMonitors →
+		// stopMonitorEngine → Close), reusing this cached module instance. A fresh
+		// Monitor() call therefore re-arms the subsystem: Close() already released
+		// the OS watchers, joined the cluster pollers, and nilled the changes
+		// channel, so clear the closed flag and stale interest and let the
+		// establishment paths below rebuild a clean subscription. Without this,
+		// every hyperv resource (VM and cluster) fails monitoring after the first
+		// config re-push and stops emitting module/cluster DNA.
+		m.monClosed = false
+		m.monInterest = nil
+		m.monClusterInterest = nil
 	}
 	if m.monChanges == nil {
 		m.monChanges = make(chan modules.ChangeEvent, monitorChannelDepth)

--- a/features/modules/hyperv/monitor_windows_test.go
+++ b/features/modules/hyperv/monitor_windows_test.go
@@ -248,6 +248,42 @@ func TestHypervMonitorCloseReleasesSubscription(t *testing.T) {
 	require.NoError(t, m.Close())
 }
 
+// TestHypervMonitorReArmsAfterClose pins the monitor-lifecycle contract the
+// executor's monitor engine depends on: StartMonitors stops the previous engine
+// (which calls module Close) and re-registers interest on EVERY config push,
+// reusing the SAME cached module instance. Close() is terminal for the
+// subscription, but a subsequent Monitor() must RE-ARM the subsystem — not
+// return "closed" — or every hyperv resource (VM and cluster) stops monitoring
+// after the first config re-push and stops emitting module/cluster DNA.
+//
+// Regression: live CFG-70-02 steward logged "Failed to start module monitor …
+// error=hyperv monitor: closed" for vm:* and cluster:* on the second config
+// push, so no cluster:* DNA ever flowed to the controller.
+func TestHypervMonitorReArmsAfterClose(t *testing.T) {
+	calls, teardowns := fakeEstablish(t)
+	m := newMonitorModule(t)
+
+	// First arm + stop, mirroring one StartMonitors→stopMonitorEngine cycle.
+	require.NoError(t, m.Monitor(context.Background(), "vm:x", nil))
+	require.NotZero(t, m.monSub, "subscription established on first arm")
+	require.NoError(t, m.Close())
+	require.True(t, m.monClosed, "Close marks the subsystem closed")
+	require.Equal(t, 1, *teardowns, "first subscription released on Close")
+
+	// Second config push: StartMonitors re-registers interest on the reused
+	// instance. This must succeed (re-arm), NOT return "hyperv monitor: closed".
+	require.NoError(t, m.Monitor(context.Background(), "vm:x", nil),
+		"Monitor must re-arm a closed subsystem, not error")
+	require.False(t, m.monClosed, "re-arm clears the closed flag")
+	require.NotNil(t, m.Changes(), "Changes() returns a fresh channel after re-arm")
+	require.Equal(t, 2, *calls, "re-arm re-establishes the host subscription")
+
+	// A cluster resource re-arms through the same path (routes to the cluster
+	// poller branch) without erroring.
+	require.NoError(t, m.Monitor(context.Background(), "cluster:cfg-lab", nil),
+		"cluster resource re-arms after Close on the same instance")
+}
+
 // changeTypeForEventID is the manifest-grounded core; assert the documented
 // mappings directly so a future edit that drops an ID is caught.
 func TestChangeTypeForEventID(t *testing.T) {


### PR DESCRIPTION
## Summary

The executor's monitor engine stops the previous engine — calling each module's `Close()` — and re-registers interest on **every** controller config push (`client_transport.go` `SyncConfiguration` → `StartMonitors` → `stopMonitorEngine` → `monitor.Close()`), reusing the **same cached module instance**. hyperv `Close()` set `monClosed = true` terminally, so the second-and-later config push returned `hyperv monitor: closed` from `Monitor()` for **every** hyperv resource (`vm:*` and `cluster:*`) — silently killing all module/cluster DNA emission after the first re-push (and leaving `cfg steward modules` "not available").

`Monitor()` now **re-arms** a closed subsystem: `Close()` already released the OS watchers, joined the cluster pollers, and nilled the changes channel, so a fresh `Monitor()` clears `monClosed` + stale interest and lets the establishment paths rebuild a clean subscription.

Part of epic #2520 (DNA sync). The dependent steady-state module-DNA source gap (module DNA is sourced from the change-event cache, not a live pull) is tracked separately under the same epic.

## Changes

- `features/modules/hyperv/monitor_windows.go` — `Monitor()` re-arms when `monClosed`.
- `features/modules/hyperv/monitor_windows_test.go` — `TestHypervMonitorReArmsAfterClose` (vm + cluster re-arm).

## Test results

`go test ./features/modules/hyperv/ -run 'TestHypervMonitorReArmsAfterClose|TestHypervMonitorClose' -count=1` → ok (native Windows build).

## Live validation

CFG-70-02 (v0.9.19): all resources converge `status=OK` with no `Failed to start module monitor` across repeated config pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #2646