### PR TITLE
pipeline: acceptance reviewer catches advisory-mode CodeQL findings (Issue #2634)

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -113,10 +113,10 @@ All required CI checks must pass before reviewing code:
 
 GitHub Advanced Security (GHAS) — CodeQL, zizmor, dependency scanning, and secret scanning — reports findings both via the code-scanning alerts database and as inline PR review comments from `github-advanced-security[bot]`. Neither source appears in the CI status rollup, so Phase 2's check is not sufficient on its own.
 
-**Use the hardened helper** — do NOT query the code-scanning API or read PR comments directly. Its single source is the **`github-advanced-security` check-run annotations** on the PR head commit, filtered to checks whose `conclusion == failure`. This is the one surface that is simultaneously:
-- **New-in-PR only** — inherited develop alerts are not annotated on the PR's checks. (Querying `code-scanning/alerts?ref=refs/pull/<N>/merge` instead returns the union of develop's ~70 open alerts + the PR's new ones and would FAIL every PR. Do not do this.)
-- **Dismissal-respecting** — a human-dismissed alert flips its check to `success` and drops out, which is what preserves the human-sign-off model (below). Reading inline bot comments does NOT respect dismissal — anchored comments persist and cause false FAILs.
-- **Injection-safe** — only GitHub-generated `path`/`line`/`title` fields are read, never human-authored comment bodies.
+**Use the hardened helper** — do NOT query the code-scanning API or read PR comments directly. The helper runs two passes and both stay **new-in-PR only**, **dismissal-respecting**, and **injection-safe**:
+- **Pass 1** — **`github-advanced-security` check-run annotations** on the PR head commit, filtered to `conclusion == failure` (fail-on findings: zizmor, secret scanning, dependency review). Inherited develop alerts are not annotated on the PR's checks; a human-dismissed alert flips its check to `success` and drops out.
+- **Pass 2 (Issue #2634)** — **open** code-scanning alerts (`state=open`, so a human dismissal drops them) intersected with the lines the PR **adds**. This is required because **CodeQL runs advisory** (no `fail-on`): it concludes `success` even with findings, so Pass 1 never sees them — a `go/log-injection` alert merged unclassified through #2623 this way. The added-line intersection keeps it new-in-PR, so inherited alerts on untouched lines don't FP (this is why the raw `code-scanning/alerts?ref=refs/pull/<N>/merge` query is still forbidden — it returns develop's ~70 inherited alerts and would FAIL every PR).
+- Only GitHub-generated `path`/`line`/`rule` fields are read, never human-authored comment bodies.
 
 It returns one finding per line, `path:line:rule-or-title` (no raw markdown body):
 
@@ -133,7 +133,7 @@ It returns one finding per line, `path:line:rule-or-title` (no raw markdown body
 1. A commit removes the underlying issue (GHAS re-scans on push and drops the alert), or
 2. A **human** dismisses the alert in GitHub with a documented reason.
 
-So a genuine bug → route to fix (block). A finding you judge a false positive → **still block**, post your `likely-false-positive` analysis, and escalate to the founder for a dismissal decision — do not merge on the strength of your own FP call. Never "dismiss out of hand." `CodeQL` is a required check on `develop`, so an open finding also hard-blocks the merge queue independently of this review.
+So a genuine bug → route to fix (block). A finding you judge a false positive → **still block**, post your `likely-false-positive` analysis, and escalate to the founder for a dismissal decision — do not merge on the strength of your own FP call. Never "dismiss out of hand." `CodeQL` is a required check on `develop`, but it runs **advisory** (no `fail-on`): it concludes `success` with findings, so an open CodeQL finding does **not** hard-block the merge queue — **this review (Pass 2 above) is the only gate that catches it.** That is exactly why passing a PR without running this helper is unsafe.
 
 ## Phase 2.5: Code-Reference Extraction (BLOCKING)
 

--- a/scripts/pr-security-findings.sh
+++ b/scripts/pr-security-findings.sh
@@ -26,9 +26,15 @@
 #        (path/line/title), never human-authored comment bodies, so there is no
 #        prompt-injection surface.
 #
-# The `CodeQL` check is a REQUIRED check on `develop`, so an open finding hard-
-# blocks the merge queue independently of this helper. This helper is the
-# reviewer's advisory heads-up; the required check is the backstop.
+# The `CodeQL` check is a REQUIRED check on `develop`, but it runs in ADVISORY
+# mode (no `fail-on`), so it concludes `success` even when it reports findings —
+# the findings are NOT a merge-queue backstop and do NOT surface as a `failure`
+# check-run (Pass 1 is blind to them; #2623 merged a log-injection alert this
+# way). Pass 2 (Issue #2634) closes that: open code-scanning alerts intersected
+# with the lines the PR ADDS. state=open respects human dismissal; the
+# added-line intersection keeps it new-in-PR (inherited develop alerts on
+# untouched lines don't FP — the reason the raw `ref=.../merge` query was
+# rejected above).
 #
 # Output: one finding per line, `<path>:<line>:<rule-or-title>`. Empty stdout =
 # no PR-introduced GHAS findings = safe to PASS. Any output = blocking FAIL:
@@ -62,18 +68,67 @@ REPO="${CFGMS_REPO:-cfg-is/cfgms}"
 HEAD_SHA=$(gh pr view "${PR}" --repo "${REPO}" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
 [ -n "${HEAD_SHA}" ] || exit 0
 
-# For each failing github-advanced-security check on the head commit, emit its
-# annotations as `path:line:title`. Control characters (incl. any embedded
-# newlines/tabs in a title) are squashed to spaces so each finding stays on one
-# line; CR is stripped; results are de-duplicated.
-for crid in $(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
-    --jq '.check_runs[]
-          | select(.app.slug == "github-advanced-security" and .conclusion == "failure")
-          | .id' 2>/dev/null); do
-    gh api "repos/${REPO}/check-runs/${crid}/annotations" \
-        --jq '.[]
-              | "\(.path):\(.start_line):\(.title // "code-scanning")"' 2>/dev/null || true
-done | tr -d '\r' | tr '\000-\010\013-\037' ' ' | grep -v '^$' | sort -u | head -200 || true
+# Both passes emit `path:line:rule-or-title`; control chars are squashed to
+# spaces so each finding stays on one line; CR stripped; results de-duplicated.
+{
+    # Pass 1: failing github-advanced-security check annotations on the head
+    # commit (fail-on findings: zizmor, secret scanning, dependency review).
+    for crid in $(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
+        --jq '.check_runs[]
+              | select(.app.slug == "github-advanced-security" and .conclusion == "failure")
+              | .id' 2>/dev/null); do
+        gh api "repos/${REPO}/check-runs/${crid}/annotations" \
+            --jq '.[]
+                  | "\(.path):\(.start_line):\(.title // "code-scanning")"' 2>/dev/null || true
+    done
+
+    # Pass 2 (Issue #2634): open code-scanning alerts on lines the PR ADDS.
+    # Catches advisory-mode findings (CodeQL) that Pass 1 misses because their
+    # check concludes `success`. state=open respects human dismissal; the
+    # added-line intersection keeps it new-in-PR (no inherited-alert FP).
+    python3 - "${REPO}" "${PR}" <<'PYEOF' 2>/dev/null || true
+import json, re, subprocess, sys
+repo, pr = sys.argv[1], sys.argv[2]
+
+def gh_json(*args):
+    r = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+
+# Lines this PR ADDS, per file, from the unified-diff patch (new-file numbering).
+added = {}
+for f in gh_json("api", f"repos/{repo}/pulls/{pr}/files", "--paginate") or []:
+    path, patch = f.get("filename"), f.get("patch")
+    if not path or not patch:
+        continue
+    ln, s = None, added.setdefault(path, set())
+    for line in patch.split("\n"):
+        m = re.match(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@", line)
+        if m:
+            ln = int(m.group(1))
+            continue
+        if ln is None:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            s.add(ln); ln += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            pass  # deletion: no new-file line advance
+        else:
+            ln += 1  # context line
+
+# Open alerts whose location falls on an added line → new-in-PR finding.
+for a in gh_json("api", f"repos/{repo}/code-scanning/alerts?state=open&per_page=100", "--paginate") or []:
+    loc = ((a.get("most_recent_instance") or {}).get("location")) or {}
+    path, start = loc.get("path"), loc.get("start_line")
+    if path in added and start in added[path]:
+        rule = (a.get("rule") or {}).get("id") or "code-scanning"
+        print(f"{path}:{start}:{rule}")
+PYEOF
+} | tr -d '\r' | tr '\000-\010\013-\037' ' ' | grep -v '^$' | sort -u | head -200 || true
 
 # Always succeed: an empty result (grep filtering all lines -> exit 1 under
 # pipefail) is "no findings", not an error. The reviewer decides PASS/FAIL from

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -795,6 +795,13 @@ for arg in "$@"; do
         exit 0
     fi
 done
+# Pass 2 (Issue #2634): python fetches these WITHOUT --jq (parses raw JSON).
+for arg in "$@"; do
+    if [[ "$arg" == *"/pulls/"*"/files"* ]]; then printf '%s' "${FILES_JSON:-[]}"; exit 0; fi
+done
+for arg in "$@"; do
+    if [[ "$arg" == *"/code-scanning/alerts"* ]]; then printf '%s' "${ALERTS_JSON:-[]}"; exit 0; fi
+done
 exit 0
 MOCKEOF
     chmod +x "$tmp_dir/gh"
@@ -844,6 +851,32 @@ MOCKEOF
         log_pass "pr-security-findings.sh: no findings → empty output (PASS path)"
     else
         log_fail "pr-security-findings.sh: expected empty output for no findings, got: '$output'"
+    fi
+
+    # --- Pass 2 (Issue #2634): advisory code-scanning alert on an ADDED line is
+    #     emitted; an OPEN alert on an unchanged line (inherited) is NOT ---
+    # Patch adds new-file lines 255-258 (line 254 is a context line).
+    local FILES_ADD='[{"filename":"pkg/config/inheritance.go","patch":"@@ -250,1 +254,5 @@\n context254\n+line255\n+line256\n+line257\n+line258"}]'
+    # Two OPEN alerts: one on added line 258 (new-in-PR), one on context line 254 (inherited).
+    local ALERTS_MIX='[{"most_recent_instance":{"location":{"path":"pkg/config/inheritance.go","start_line":258}},"rule":{"id":"go/log-injection"}},{"most_recent_instance":{"location":{"path":"pkg/config/inheritance.go","start_line":254}},"rule":{"id":"go/log-injection"}}]'
+    output=$(HEAD_JSON="$HEAD" CHECK_RUNS_JSON="$CR_NONE" FILES_JSON="$FILES_ADD" ALERTS_JSON="$ALERTS_MIX" PATH="$tmp_dir:$PATH" bash "$script" 2623 2>/dev/null) || true
+    if echo "$output" | grep -q "pkg/config/inheritance.go:258:go/log-injection"; then
+        log_pass "pr-security-findings.sh: advisory CodeQL alert on an ADDED line is emitted (pass 2)"
+    else
+        log_fail "pr-security-findings.sh: expected added-line alert :258, got: '$output'"
+    fi
+    if echo "$output" | grep -q "pkg/config/inheritance.go:254"; then
+        log_fail "pr-security-findings.sh: inherited alert on unchanged line :254 must NOT be emitted, got: '$output'"
+    else
+        log_pass "pr-security-findings.sh: inherited alert on unchanged line NOT emitted (added-line intersection)"
+    fi
+
+    # --- Pass 2: with no alerts data, the extra passes stay silent (PASS) ---
+    output=$(HEAD_JSON="$HEAD" CHECK_RUNS_JSON="$CR_NONE" FILES_JSON="$FILES_ADD" PATH="$tmp_dir:$PATH" bash "$script" 2623 2>/dev/null) || true
+    if [[ -z "$output" ]]; then
+        log_pass "pr-security-findings.sh: added lines but no open alerts → empty (PASS path)"
+    else
+        log_fail "pr-security-findings.sh: expected empty output when no open alerts, got: '$output'"
     fi
 
     # --- Test: check-runs API error → exits 0, empty (not propagated) ---


### PR DESCRIPTION
## Summary
Closes the gap where the acceptance reviewer passed PRs carrying **advisory-mode CodeQL findings** — the hole that let a `go/log-injection` alert merge unclassified through **#2623**.

## Root cause
`pr-security-findings.sh` Pass 1 reads only `github-advanced-security` check-runs with `conclusion == failure`. CodeQL runs advisory here (`fail-on` is off), so it concludes **success** even when it reports findings — Pass 1 never sees them, and the helper even wrongly claimed an open CodeQL finding "hard-blocks the merge queue" (it doesn't).

## Fix
**Pass 2:** open code-scanning alerts (`state=open`, so a human dismissal drops them) intersected with the lines the PR **adds** (new-file diff numbering). The added-line intersection keeps it new-in-PR, so inherited develop alerts on untouched lines don't false-positive — which is why the previously-rejected `code-scanning/alerts?ref=refs/pull/<N>/merge` query is still forbidden. Only GitHub-generated `path`/`line`/`rule` fields are read.

`acceptance-reviewer.md` Phase 2.1 now documents both passes and corrects the "CodeQL hard-blocks the queue" claim — this review is the *only* gate for advisory findings.

## Validation
- **Live:** `pr-security-findings.sh 2623` now emits `pkg/config/inheritance.go:258:go/log-injection` (the line #2623 *added*) and correctly NOT the pre-existing `:241` (unchanged line); control PR #2611 stays empty.
- **Unit:** `scripts/test-scripts.sh` mocks the files + alerts APIs — asserts added-line alert emitted, unchanged-line (inherited) alert not, and empty-when-no-alerts. **211/211 pass.**

## Companion
**#2632** clears the standing `go/log-injection` FP alert backlog these now surface, so the gate starts from a clean baseline.

Fixes #2634

🤖 Generated with [Claude Code](https://claude.com/claude-code)