### PR TITLE
steward: live module DNA collection that survives reconnect and never clobbers (epic #2520)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -518,22 +518,17 @@ func runStewardInternal(ctx context.Context, regToken, controllerURL, configPath
 		// controller will pick up DNA on the next convergence-driven publish
 		// in publishConfigStatus. On success the DNA subsystem is marked healthy
 		// so the heartbeat transitions from degraded to healthy. (Issue #2034)
-		if currentDNA, dnaErr := dna.NewCollector(logger).Collect(runCtx); dnaErr == nil && currentDNA != nil {
-			subsysState.markHealthy("dna")
-			if pubErr := transportCl.PublishDNAUpdate(runCtx, currentDNA.Attributes, "", ""); pubErr != nil {
-				logger.Warn("Initial DNA publish failed; controller selectors may not find this steward until next config apply",
-					"error", pubErr)
-			} else {
-				logger.Info("Initial DNA snapshot published",
-					"attribute_count", len(currentDNA.Attributes))
-			}
-		} else if dnaErr != nil {
+		// Publish the FULL composite DNA (hardware + module). Using the composite
+		// collector — not a raw host-only dna.Collector — is essential: a host-only
+		// publish here runs after config apply and would delta-clobber the module
+		// DNA (cluster:*, vm:*) the config-apply publish just sent (#2520).
+		if pubErr := transportCl.PublishCurrentDNA(runCtx); pubErr != nil {
 			// DNA subsystem stays degraded; the refresh loop retries on each tick.
-			logger.Warn("DNA collection failed at startup; controller selectors may match no stewards until DNA is collected later",
-				"error", dnaErr)
+			logger.Warn("Initial DNA publish failed; controller selectors may match no stewards until the next convergence-driven publish",
+				"error", pubErr)
 		} else {
-			// nil error with nil DNA (empty collector result) — treat as healthy.
 			subsysState.markHealthy("dna")
+			logger.Info("Initial DNA snapshot published")
 		}
 
 		// Check for launcher-written upgrade flag files and emit lifecycle events.
@@ -1328,12 +1323,11 @@ func connectWithApprovedRegistration(
 
 	logger.Info("Configuration executor initialized", "tenant_id", reg.TenantID)
 
-	// Wire the executor as the module DNA source now that it exists (Issue #2435).
-	// The DNA adapter was constructed with nil; setting the executor here means
-	// the first DNA refresh tick after config sync will include module attributes.
-	if executor := transportClient.GetConfigExecutor(); executor != nil {
-		dnaAdapter.setModuleDNASource(executor)
-	}
+	// Wire the CLIENT (not the executor instance) as the module DNA source. The
+	// client delegates to its CURRENT c.configExecutor, so module DNA keeps flowing
+	// even though InitializeConfigExecutor replaces the executor on each
+	// connect/reconnect — a captured *Executor reference would go stale (#2520/#2435).
+	dnaAdapter.setModuleDNASource(transportClient)
 
 	return transportClient, nil
 }
@@ -1485,10 +1479,10 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 
 	logger.Info("Configuration executor initialized after reconnect", "tenant_id", logging.SanitizeLogValue(id.TenantID))
 
-	// Wire the executor as the module DNA source now that it exists (Issue #2435).
-	if executor := transportClient.GetConfigExecutor(); executor != nil {
-		dnaAdapterReconnect.setModuleDNASource(executor)
-	}
+	// Wire the CLIENT (not the executor instance) as the module DNA source — see the
+	// registration-path rationale above: InitializeConfigExecutor swaps the executor,
+	// so the adapter must delegate through the stable client (#2520/#2435).
+	dnaAdapterReconnect.setModuleDNASource(transportClient)
 
 	return transportClient, nil
 }

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -100,6 +100,12 @@ type TransportClient struct {
 	// Configuration executor (unified engine — same as standalone mode)
 	configExecutor *execution.Executor
 
+	// moduleDNAStore is the process-stable module-DNA snapshot shared across every
+	// executor this client builds. InitializeConfigExecutor replaces configExecutor
+	// on each connect/reconnect; a per-executor snapshot would be lost, so the store
+	// lives on the (stable) client and is injected into each executor (#2520).
+	moduleDNAStore *execution.ModuleDNASnapshot
+
 	// eventEmitter sends convergence observation events to the controller via LogStream.
 	// Initialised once by InitializeConfigExecutor; nil until then.
 	eventEmitter *EventEmitter
@@ -503,12 +509,22 @@ func (c *TransportClient) InitializeConfigExecutor(tenantID string) error {
 		}
 	}
 
+	// Ensure the shared module-DNA store exists so it survives executor re-init on
+	// reconnect (#2520). Created once, reused by every executor this client builds.
+	c.mu.Lock()
+	if c.moduleDNAStore == nil {
+		c.moduleDNAStore = execution.NewModuleDNASnapshot()
+	}
+	moduleDNAStore := c.moduleDNAStore
+	c.mu.Unlock()
+
 	execCfg := &execution.ExecutorConfig{
-		TenantID:     tenantID,
-		Logger:       c.logger,
-		SecretStore:  c.secretStore,
-		StewardID:    stewardID,
-		EventEmitter: emitter,
+		TenantID:          tenantID,
+		Logger:            c.logger,
+		SecretStore:       c.secretStore,
+		StewardID:         stewardID,
+		EventEmitter:      emitter,
+		ModuleDNASnapshot: moduleDNAStore,
 	}
 	executor, err := execution.NewExecutor(execCfg)
 	if err != nil {
@@ -1076,12 +1092,32 @@ func (c *TransportClient) syncConfigNow(ctx context.Context, commandID string, m
 		"status", report.Status)
 
 	// Publish DNA update carrying the config hash so the controller can verify
-	// delivery via heartbeats (Issue #1316).
-	c.dnaMu.RLock()
-	currentDNA := copyStringMap(c.lastPublishedDNA)
-	c.dnaMu.RUnlock()
+	// delivery via heartbeats (Issue #1316). A config apply IS a convergence, so
+	// refresh the FULL composite DNA (hardware facts + freshly-observed module
+	// state that ExecuteConfiguration just captured) rather than replaying the
+	// stale last-published host-only snapshot — this is how module/cluster DNA
+	// reaches the controller promptly instead of only on the 30m refresh tick
+	// (#2520 mechanism 1). Falls back to the cached snapshot if the composite
+	// collect is unavailable or empty.
+	var currentDNA map[string]string
+	c.mu.RLock()
+	collector := c.dnaCollector
+	c.mu.RUnlock()
+	if collector != nil {
+		if attrs, err := collector.CollectAttributes(ctx); err == nil && len(attrs) > 0 {
+			c.setCurrentDNAFromAttrs(attrs)
+			currentDNA = attrs
+		} else if err != nil {
+			c.logger.Info("Composite DNA collect after config apply failed; using cached snapshot", "error", err)
+		}
+	}
 	if currentDNA == nil {
-		currentDNA = make(map[string]string)
+		c.dnaMu.RLock()
+		currentDNA = copyStringMap(c.lastPublishedDNA)
+		c.dnaMu.RUnlock()
+		if currentDNA == nil {
+			currentDNA = make(map[string]string)
+		}
 	}
 	currentDNA["config_hash"] = configHash
 	if pubErr := c.PublishDNAUpdate(ctx, currentDNA, configHash, ""); pubErr != nil {
@@ -1561,6 +1597,30 @@ func (c *TransportClient) RefreshCurrentDNA(ctx context.Context) error {
 	return nil
 }
 
+// PublishCurrentDNA collects the FULL composite DNA (hardware facts + module
+// state) via the wired collector and publishes it. Every DNA publish must be
+// composite: PublishDNAUpdate delta-compresses against the last publish, so a
+// host-only publish would REMOVE previously-published module keys (cluster:*,
+// vm:*) — the clobber that made module DNA flicker in and out (#2520). Use this
+// for one-shot startup/selector publishes instead of a raw host-only collector.
+func (c *TransportClient) PublishCurrentDNA(ctx context.Context) error {
+	c.mu.RLock()
+	collector := c.dnaCollector
+	c.mu.RUnlock()
+	if collector == nil {
+		return nil
+	}
+	attrs, err := collector.CollectAttributes(ctx)
+	if err != nil {
+		return err
+	}
+	if len(attrs) == 0 {
+		return nil
+	}
+	c.setCurrentDNAFromAttrs(attrs)
+	return c.PublishDNAUpdate(ctx, attrs, "", "")
+}
+
 // StartDNARefreshLoop starts a background goroutine that re-collects system DNA
 // attributes on the configured interval and publishes delta updates to the
 // controller when at least one attribute value has changed.
@@ -1773,6 +1833,22 @@ func (c *TransportClient) GetConfigExecutor() *execution.Executor {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.configExecutor
+}
+
+// CollectModuleDNAAttributes delegates to the CURRENT config executor's module DNA
+// snapshot. Wiring the DNA collector adapter to the client (not a captured executor
+// instance) is deliberate: InitializeConfigExecutor replaces c.configExecutor on
+// every connect/reconnect, so a captured *Executor reference goes stale and module
+// DNA silently stops flowing (#2520). Delegating through the stable client always
+// reads the live executor. Returns nil before the executor exists.
+func (c *TransportClient) CollectModuleDNAAttributes(ctx context.Context) map[string]string {
+	c.mu.RLock()
+	executor := c.configExecutor
+	c.mu.RUnlock()
+	if executor == nil {
+		return nil
+	}
+	return executor.CollectModuleDNAAttributes(ctx)
 }
 
 // SetTenantID sets the tenant ID (used after HTTP registration).

--- a/features/steward/dna_attributes_test.go
+++ b/features/steward/dna_attributes_test.go
@@ -116,10 +116,13 @@ func TestSteward_CollectModuleDNAAttributes_FlattensChangeEvent(t *testing.T) {
 		}),
 	})
 
+	// Wait for the specific change-event key, not merely len>0: the steward's
+	// convergence loop now also seeds steady-state module DNA for managed
+	// resources (#2520), so the map is non-empty before this ChangeEvent lands.
 	var attrs map[string]string
 	require.Eventually(t, func() bool {
 		attrs = s.CollectModuleDNAAttributes(context.Background())
-		return len(attrs) > 0
+		return attrs["cluster:cfg-lab.member_nodes"] != ""
 	}, 2*time.Second, 10*time.Millisecond, "cached module attributes must appear after the ChangeEvent")
 
 	assert.Equal(t, "CFG-70-02,CFG-AB-02,CFG-C3-02", attrs["cluster:cfg-lab.member_nodes"],
@@ -174,10 +177,19 @@ func TestSteward_CollectModuleDNAAttributes_LastWriteWins(t *testing.T) {
 }
 
 // TestSteward_CollectModuleDNAAttributes_EvictsOnMonitorStop is the REQUIRED
-// TEST for #2423 AC5: a resource whose Monitor stops (module closes its
-// Changes channel / steward shutdown) is evicted from the cache — its keys
-// stop appearing in subsequent CollectModuleDNAAttributes calls, which is what
-// makes the key disappear from the next PublishDNAUpdate delta.
+// TEST for #2423 AC5, updated for the #2520 steady-state model: a resource seen
+// ONLY via the monitor change-event stream (never converged as a managed config
+// resource) is evicted when its Monitor stops — its change-event keys stop
+// appearing in subsequent CollectModuleDNAAttributes calls, which is what makes
+// the key disappear from the next PublishDNAUpdate delta.
+//
+// Note the contract change: a MANAGED resource's steady-state DNA (sourced from
+// the convergence Get, #2520) is NOT evicted on monitor stop — a config re-push
+// stops+restarts monitors transiently and blanking DNA each time was the churn
+// #2520 fixed. Managed-resource eviction is on config-removal (ExecuteConfiguration
+// prune), covered by TestExecuteConfiguration_PrunesRemovedResourceFromDNA. Here
+// "cluster:cfg-lab" is a monitor-only resource (no matching config resource), so
+// its keys DO evict on monitor stop.
 func TestSteward_CollectModuleDNAAttributes_EvictsOnMonitorStop(t *testing.T) {
 	s, mon := startMonitoredSteward(t)
 
@@ -189,15 +201,19 @@ func TestSteward_CollectModuleDNAAttributes_EvictsOnMonitorStop(t *testing.T) {
 		}),
 	})
 	require.Eventually(t, func() bool {
-		return len(s.CollectModuleDNAAttributes(context.Background())) > 0
-	}, 2*time.Second, 10*time.Millisecond, "attribute must be cached before the eviction check")
+		return s.CollectModuleDNAAttributes(context.Background())["cluster:cfg-lab.cno_owner_node"] != ""
+	}, 2*time.Second, 10*time.Millisecond, "monitor-only attribute must be cached before the eviction check")
 
 	mon.CloseChanges()
 
+	// The monitor-only resource's change-event keys must disappear. The steady-
+	// state DNA of the managed config resource may remain — eviction of managed
+	// resources is on config-removal, not monitor stop.
 	require.Eventually(t, func() bool {
-		return len(s.CollectModuleDNAAttributes(context.Background())) == 0
+		_, present := s.CollectModuleDNAAttributes(context.Background())["cluster:cfg-lab.cno_owner_node"]
+		return !present
 	}, 2*time.Second, 10*time.Millisecond,
-		"a stopped Monitor's resource must be evicted — the map passed to CollectAttributes no longer carries the key")
+		"a stopped monitor-only resource must be evicted from the change-event cache")
 }
 
 // TestSteward_CollectModuleDNAAttributes_NilDetailsSafe: an event with nil

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -73,6 +73,13 @@ type ExecutorConfig struct {
 	// a finite deadline to prevent a hung module from wedging the convergence loop
 	// (ADR-012 §7).
 	ModuleCallTimeoutSec int
+
+	// ModuleDNASnapshot is an optional shared module-DNA store (#2520). When set,
+	// this executor records observed module state into it and reads from it in
+	// CollectModuleDNAAttributes. The steward client passes ONE store into every
+	// executor it builds so module DNA survives executor re-init on reconnect. Nil
+	// gives the executor a private store (standalone / tests).
+	ModuleDNASnapshot *ModuleDNASnapshot
 }
 
 // Executor applies configurations using the unified Get→Compare→Set→Verify workflow.
@@ -102,6 +109,11 @@ type Executor struct {
 	// and verifyChanges. Derived from ModuleCallTimeoutSec at construction; defaults
 	// to 120 s when the config field is zero or negative (ADR-012 §7).
 	moduleCallTimeout time.Duration
+
+	// moduleDNA is the shared, process-stable module-DNA snapshot (#2520). Injected
+	// via ExecutorConfig.ModuleDNASnapshot so it survives executor re-init on
+	// reconnect; NewExecutor allocates a private one when none is supplied.
+	moduleDNA *ModuleDNASnapshot
 
 	// Monitor engine fields (Issue #2435). Protected by monitorMu except where noted.
 	monitorFields
@@ -145,6 +157,11 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 		callTimeout = 120 * time.Second
 	}
 
+	moduleDNA := cfg.ModuleDNASnapshot
+	if moduleDNA == nil {
+		moduleDNA = NewModuleDNASnapshot()
+	}
+
 	return &Executor{
 		factory:           f,
 		comparator:        comp,
@@ -155,6 +172,7 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 		driftMode:         cfg.DriftMode,
 		eventEmitter:      cfg.EventEmitter,
 		moduleCallTimeout: callTimeout,
+		moduleDNA:         moduleDNA,
 	}, nil
 }
 
@@ -209,6 +227,15 @@ func (e *Executor) ExecuteConfiguration(ctx context.Context, cfg config.StewardC
 			}
 		}
 	}
+
+	// Drop DNA snapshot entries for resources no longer in the config so a removed
+	// resource disappears from module DNA (#2520). Only the full pass knows the
+	// complete managed set, so prune here rather than in ExecuteResource.
+	keep := make(map[string]struct{}, len(cfg.Resources))
+	for _, r := range cfg.Resources {
+		keep[e.GetResourceID(r)] = struct{}{}
+	}
+	e.pruneModuleDNAState(keep)
 
 	report.EndTime = time.Now()
 
@@ -346,6 +373,12 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 		}
 		return result
 	}
+
+	// Capture the observed state for module DNA publication (#2520 mechanism 1).
+	// The periodic convergence loop AND monitor-triggered targeted reconciles both
+	// land here, so caching the Get result keeps module DNA live at steady state —
+	// not only when a change-event fires — with no extra module call.
+	e.cacheModuleDNAState(resourceID, currentState)
 
 	driftDetected, stateDiff := e.comparator.CompareStates(currentState, desiredState)
 	result.DriftDetected = driftDetected

--- a/features/steward/execution/monitor.go
+++ b/features/steward/execution/monitor.go
@@ -347,8 +347,93 @@ func (e *Executor) evictMonitorState(resourceIDs map[string]struct{}) {
 	e.monitorStateMu.Unlock()
 }
 
+// ModuleDNASnapshot is a process-stable store of each managed resource's last
+// observed state (AsMap), keyed by resourceID. It is shared across Executor
+// instances so module DNA survives executor re-initialization on reconnect
+// (#2520): InitializeConfigExecutor replaces the Executor on every connect, and a
+// per-Executor snapshot would be lost each time — the client owns ONE snapshot and
+// passes it into every Executor it builds. Safe for concurrent use.
+type ModuleDNASnapshot struct {
+	mu   sync.Mutex
+	snap map[string]map[string]interface{}
+}
+
+// NewModuleDNASnapshot returns an empty shared module-DNA store.
+func NewModuleDNASnapshot() *ModuleDNASnapshot {
+	return &ModuleDNASnapshot{snap: make(map[string]map[string]interface{})}
+}
+
+func (s *ModuleDNASnapshot) set(resourceID string, attrs map[string]interface{}) {
+	s.mu.Lock()
+	s.snap[resourceID] = attrs
+	s.mu.Unlock()
+}
+
+func (s *ModuleDNASnapshot) prune(keep map[string]struct{}) {
+	s.mu.Lock()
+	for id := range s.snap {
+		if _, ok := keep[id]; !ok {
+			delete(s.snap, id)
+		}
+	}
+	s.mu.Unlock()
+}
+
+// collect flattens every stored resource's fields into out under the DNA key
+// convention "<resourceID>.<field>".
+func (s *ModuleDNASnapshot) collect(out map[string]string) {
+	s.mu.Lock()
+	for resourceID, fields := range s.snap {
+		for field, v := range fields {
+			flattenDNAValue(resourceID+"."+field, v, out)
+		}
+	}
+	s.mu.Unlock()
+}
+
+// cacheModuleDNAState records a managed resource's observed state (AsMap) into the
+// shared module-DNA snapshot, keyed by resourceID. Called after each successful
+// convergence / targeted-reconcile Get (executor.ExecuteResource) so a STABLE
+// resource still contributes module DNA between change-events — the steady-state
+// source for #2520 mechanism 1. No extra module call: it reuses the Get the
+// Get→Compare→Set→Verify cycle already performs.
+func (e *Executor) cacheModuleDNAState(resourceID string, state modules.ConfigState) {
+	if resourceID == "" || state == nil || e.moduleDNA == nil {
+		return
+	}
+	snap := state.AsMap()
+	if snap == nil {
+		return
+	}
+	// Shallow-copy so a module mutating the map it returned cannot race the reader.
+	copied := make(map[string]interface{}, len(snap))
+	for k, v := range snap {
+		copied[k] = v
+	}
+	e.moduleDNA.set(resourceID, copied)
+}
+
+// pruneModuleDNAState drops shared-snapshot entries whose resourceID is not in
+// keep, so a resource removed from the config disappears from module DNA on the
+// next full convergence pass (ExecuteConfiguration). Targeted single-resource
+// reconciles never call this — only the full pass knows the complete resource set.
+func (e *Executor) pruneModuleDNAState(keep map[string]struct{}) {
+	if e.moduleDNA == nil {
+		return
+	}
+	e.moduleDNA.prune(keep)
+}
+
 // CollectModuleDNAAttributes returns a flattened, namespaced snapshot of every
-// actively-monitored module resource's latest observed state (Issue #2423).
+// managed module resource's latest observed state (Issue #2423, #2520).
+//
+// Two sources are unioned:
+//   - the shared moduleDNA snapshot: the convergence/targeted-reconcile Get result
+//     for every managed resource — the STEADY-STATE source, present even when
+//     nothing has changed and surviving executor re-init on reconnect.
+//   - monitorState: the monitor change-event cache — a fresher per-change overlay
+//     (e.g. cluster status carried on the event before the triggered reconcile's
+//     Get lands). On key collision the monitor value wins as the more recent.
 //
 // Key convention:
 //   - every key is "<resourceID>.<field>" with the resourceID verbatim
@@ -357,13 +442,18 @@ func (e *Executor) evictMonitorState(resourceIDs map[string]struct{}) {
 //   - any other value stringifies via fmt.Sprintf("%v", v)
 func (e *Executor) CollectModuleDNAAttributes(_ context.Context) map[string]string {
 	out := make(map[string]string)
+	// Steady-state snapshot first (covers all managed resources)...
+	if e.moduleDNA != nil {
+		e.moduleDNA.collect(out)
+	}
+	// ...then overlay fresher monitor change-event deltas.
 	e.monitorStateMu.Lock()
-	defer e.monitorStateMu.Unlock()
 	for resourceID, snap := range e.monitorState {
 		for field, v := range snap {
 			flattenDNAValue(resourceID+"."+field, v, out)
 		}
 	}
+	e.monitorStateMu.Unlock()
 	return out
 }
 

--- a/features/steward/execution/monitor_test.go
+++ b/features/steward/execution/monitor_test.go
@@ -144,6 +144,87 @@ func (m *noopModule) GetCallCount() int {
 	return m.getCalls
 }
 
+// observableModule is a real modules.Module (NOT a Monitor) whose Get returns a
+// fixed multi-field observed state that matches the desired `state` so no drift is
+// detected. It proves module DNA is captured from the convergence-loop Get alone —
+// no monitor engine, no change-events (#2520 mechanism 1 steady-state source).
+type observableModule struct{ state map[string]interface{} }
+
+func (m *observableModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	return execution.NewConfigState(m.state), nil
+}
+func (m *observableModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+// TestExecuteConfiguration_CapturesModuleDNAAtSteadyState is the REQUIRED test for
+// #2520 mechanism 1: a STABLE managed resource — no drift, no monitor, no
+// change-event — still contributes module DNA, sourced from the convergence Get.
+func TestExecuteConfiguration_CapturesModuleDNAAtSteadyState(t *testing.T) {
+	e := newMonitorExecutor(t)
+	execution.ExecutorFactory(e).RegisterModule("obs", &observableModule{
+		state: map[string]interface{}{
+			"state": "present",
+			"owner": "n1",
+			"nodes": []string{"n1", "n2"},
+		},
+	})
+
+	// Full convergence pass — no StartMonitors, no change-events.
+	report := e.ExecuteConfiguration(context.Background(),
+		stewardconfig.StewardConfig{Resources: singleResourceCfg("res1", "obs")})
+	require.Equal(t, 1, report.SuccessfulCount)
+
+	attrs := e.CollectModuleDNAAttributes(context.Background())
+	assert.Equal(t, "present", attrs["res1.state"],
+		"a stable resource's observed state must reach module DNA via the convergence Get")
+	assert.Equal(t, "n1", attrs["res1.owner"])
+	assert.Equal(t, "n1,n2", attrs["res1.nodes"])
+}
+
+// TestModuleDNASnapshot_SurvivesExecutorReinit is the REQUIRED test for the
+// reconnect-survival fix (#2520): the module DNA snapshot is shared across Executor
+// instances, so DNA converged by one executor is still readable after the client
+// re-initializes the executor (as happens on every reconnect). A per-executor
+// snapshot would be lost, silently blanking module DNA on the controller.
+func TestModuleDNASnapshot_SurvivesExecutorReinit(t *testing.T) {
+	shared := execution.NewModuleDNASnapshot()
+	mod := &observableModule{state: map[string]interface{}{"state": "present", "owner": "n1"}}
+
+	// Executor #1 (pre-reconnect) converges and populates the SHARED store.
+	e1 := newMonitorExecutorWithDNAStore(t, shared)
+	execution.ExecutorFactory(e1).RegisterModule("obs", mod)
+	e1.ExecuteConfiguration(context.Background(),
+		stewardconfig.StewardConfig{Resources: singleResourceCfg("res1", "obs")})
+	require.Equal(t, "n1", e1.CollectModuleDNAAttributes(context.Background())["res1.owner"])
+
+	// Executor #2 (post-reconnect, fresh instance) shares the SAME store and must
+	// see the DNA #1 converged — without re-running any convergence.
+	e2 := newMonitorExecutorWithDNAStore(t, shared)
+	assert.Equal(t, "n1", e2.CollectModuleDNAAttributes(context.Background())["res1.owner"],
+		"a re-initialized executor sharing the store must still surface previously-converged module DNA")
+}
+
+// TestExecuteConfiguration_PrunesRemovedResourceFromDNA verifies a resource dropped
+// from the config disappears from module DNA on the next full convergence pass.
+func TestExecuteConfiguration_PrunesRemovedResourceFromDNA(t *testing.T) {
+	e := newMonitorExecutor(t)
+	execution.ExecutorFactory(e).RegisterModule("obs", &observableModule{
+		state: map[string]interface{}{"state": "present", "owner": "n1"},
+	})
+
+	// First pass includes res1 → captured.
+	e.ExecuteConfiguration(context.Background(),
+		stewardconfig.StewardConfig{Resources: singleResourceCfg("res1", "obs")})
+	require.Equal(t, "n1", e.CollectModuleDNAAttributes(context.Background())["res1.owner"])
+
+	// Second pass with NO resources → res1 pruned.
+	e.ExecuteConfiguration(context.Background(),
+		stewardconfig.StewardConfig{Resources: nil})
+	_, present := e.CollectModuleDNAAttributes(context.Background())["res1.owner"]
+	assert.False(t, present, "a resource removed from config must be pruned from module DNA")
+}
+
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 // newMonitorExecutor creates a minimal Executor with an empty module factory.
@@ -158,6 +239,26 @@ func newMonitorExecutor(t *testing.T) *execution.Executor {
 	e, err := execution.NewExecutor(&execution.ExecutorConfig{
 		Logger:  logger,
 		Factory: f,
+	})
+	require.NoError(t, err)
+	return e
+}
+
+// newMonitorExecutorWithDNAStore builds an Executor wired to a caller-supplied
+// shared module-DNA snapshot, mirroring how the steward client injects one store
+// into every executor it builds (#2520).
+func newMonitorExecutorWithDNAStore(t *testing.T, store *execution.ModuleDNASnapshot) *execution.Executor {
+	t.Helper()
+	logger := logging.NewLogger("debug")
+	f := factory.New(nil, stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}, logger)
+	e, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:            logger,
+		Factory:           f,
+		ModuleDNASnapshot: store,
 	})
 	require.NoError(t, err)
 	return e


### PR DESCRIPTION
## Summary

Module DNA (`vm:*`, `cluster:*`) never reached the controller at steady state — a stable cluster/VM showed no module DNA, and `cfg steward modules` read "not available". Four root causes, all fixed:

1. **Source was change-events only.** `CollectModuleDNAAttributes` read the monitor change-event cache, which fills only on a change — and VM events carry no payload (`Details:nil`). Now each managed resource's observed state (`module.Get().AsMap()`) is captured during `ExecuteResource` (the Get the Get→Compare→Set→Verify cycle already performs — no extra module call), so a **stable** resource still contributes DNA. `ExecuteConfiguration` prunes resources dropped from config.

2. **Snapshot orphaned on reconnect.** `InitializeConfigExecutor` replaces `c.configExecutor` on every connect/reconnect (observed 3× at startup), so a per-executor snapshot was lost each time. The snapshot now lives in a shared `*ModuleDNASnapshot` the client owns and injects into every executor.

3. **Adapter captured a stale executor.** The DNA collector adapter held a specific `*Executor` reference that went stale after re-init. It now delegates through the stable `TransportClient`, which reads the **current** executor.

4. **Host-only publishes clobbered module DNA.** `PublishDNAUpdate` delta-compresses, so a host-only publish **removed** previously-published module keys (the flicker). The startup selector publish and the config-apply publish now both send the **full composite** DNA.

Realizes epic #2520 mechanism 1 (the convergence loop collects all module-managed DNA and reports changes).

## Changes

- `features/steward/execution/{executor,monitor}.go` — shared `ModuleDNASnapshot`, capture on convergence Get, prune, composite collect.
- `features/steward/client/client_transport.go` — client-owned shared store; `CollectModuleDNAAttributes` delegation; composite publish on config apply; `PublishCurrentDNA`.
- `cmd/steward/main.go` — wire the client (not a captured executor) as the DNA source; initial publish uses composite.

## Test results

`go test ./features/steward/execution/ ./features/steward/client/ ./cmd/steward/` → ok. New: `TestExecuteConfiguration_CapturesModuleDNAAtSteadyState`, `_PrunesRemovedResourceFromDNA`, `TestModuleDNASnapshot_SurvivesExecutorReinit`.

## Live validation

CFG-70-02: `cfg steward dna` is **stable** at 101 attributes including `cluster:cfg-lab.member_nodes=CFG-70-02,CFG-AB-02,CFG-C3-02`, `cno_owner_node=CFG-70-02`, and full `vm:*` state (`cpu_count`, `memory_mb`, `state`, `vhd_path`, `checkpoint_count`). No churn across repeated polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #2647