### PR TITLE
steward/controller: report hostname at registration (Issue #2640)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1063,6 +1063,12 @@ func registerAndConnect(ctx context.Context, token, controllerURL string, trustS
 			regReq.IdentityKeyPub = base64.StdEncoding.EncodeToString([]byte(pub))
 		}
 	}
+	// Seed hostname and OS so the controller is not identity-blind before first DNA sync
+	// (Issue #2640). Mirrors features/steward/dna/dna.go:227 without importing that package.
+	if hostname, err := os.Hostname(); err == nil {
+		regReq.Hostname = hostname
+	}
+	regReq.OS = runtime.GOOS
 
 	regResp, pendingResp, err := httpClient.Register(regCtx, regReq)
 	if err != nil {

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -30,6 +30,12 @@ type RegistrationRequest struct {
 	DeviceID           string `json:"device_id,omitempty"`            // 64-char lowercase hex SHA-256 of Ed25519 public key
 	IdentityKeyPub     string `json:"identity_key_pub,omitempty"`     // base64-encoded Ed25519 public key (32 bytes)
 	KeyProtectionLevel string `json:"key_protection_level,omitempty"` // "file" or "tpm"
+
+	// Best-effort identity hints seeded into initial DNA so the controller is not
+	// blind to connected stewards before their first DNA sync (Issue #2640).
+	// Registration succeeds even when these fields are absent.
+	Hostname string `json:"hostname,omitempty"`
+	OS       string `json:"os,omitempty"`
 }
 
 // RegistrationResponse represents the steward registration response for an approved registration.
@@ -540,6 +546,19 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	stewardID := fmt.Sprintf("steward-%d", time.Now().UnixNano())
 
+	// Build initial DNA attributes from best-effort identity hints (Issue #2640).
+	// Hostname and OS are optional; registration succeeds when absent.
+	var initialAttrs map[string]string
+	if req.Hostname != "" || req.OS != "" {
+		initialAttrs = make(map[string]string)
+		if req.Hostname != "" {
+			initialAttrs["hostname"] = req.Hostname
+		}
+		if req.OS != "" {
+			initialAttrs["os"] = req.OS
+		}
+	}
+
 	// Perennial tokens survive registration; log the use for auditability.
 	s.logger.Info("Token used for registration",
 		"token_prefix", logging.RedactedID(req.Token),
@@ -609,7 +628,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 					http.Error(w, "Server misconfiguration: transport address not configured", http.StatusInternalServerError)
 					return
 				}
-				if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, quarantineTransportAddr, "quarantined"); err != nil {
+				if err := s.controllerService.RegisterStewardWithAttributes(stewardID, token.TenantID, quarantineTransportAddr, "quarantined", initialAttrs); err != nil {
 					s.logger.Error("Failed to register quarantined steward in controller service",
 						"steward_id", stewardID, "error", err)
 				}
@@ -756,7 +775,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		"steward_id", stewardID,
 		"validity_days", validityDays)
 
-	if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, resp.TransportAddress, "registered"); err != nil {
+	if err := s.controllerService.RegisterStewardWithAttributes(stewardID, token.TenantID, resp.TransportAddress, "registered", initialAttrs); err != nil {
 		s.logger.Error("Failed to register steward in controller service",
 			"steward_id", stewardID, "error", err)
 	}

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -1235,12 +1235,14 @@ func TestHandleRegister_ApprovePath_TransportAddressError(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "transport address not configured")
 }
 
-// newHandleRegisterServerWithStewardStore creates a server wired with a testStewardStore
-// for device identity persistence tests.
-func newHandleRegisterServerWithStewardStore(t *testing.T, tokenStore registration.Store, certMgr *cert.Manager) (*Server, *testStewardStore) {
+// newHandleRegisterServerWithStewardStore creates a server wired with a real
+// SQLite-backed StewardStore (from the OSS composite storage manager) for device
+// identity persistence tests. No fakes — CFGMS mandates real component testing.
+func newHandleRegisterServerWithStewardStore(t *testing.T, tokenStore registration.Store, certMgr *cert.Manager) (*Server, business.StewardStore) {
 	t.Helper()
 	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
-	ss := newTestStewardStore()
+	ss := pkgtesting.SetupTestStorage(t).GetStewardStore()
+	require.NotNil(t, ss, "test storage must provide a StewardStore")
 	server.SetStewardStore(ss)
 	return server, ss
 }
@@ -1574,4 +1576,76 @@ func TestProvisionedVMRegistration_IPTrustGate(t *testing.T) {
 		assert.Equal(t, "hv-vms", resp.Group,
 			"auto-admission response must include the token's fleet group")
 	})
+}
+
+// TestHandleRegister_HostnameSeededBeforeDNASync verifies that a hostname sent at
+// registration is visible in GetStewardInfo immediately after the registration
+// completes — before any SyncDNA call (Issue #2640, AC #1).
+func TestHandleRegister_HostnameSeededBeforeDNASync(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	certMgr := newTestCertManager(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
+	server.SetApprovalHook(&AlwaysApproveHook{})
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_hostname_seed",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	deviceID := "c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3"
+
+	rec := postRegisterWithBody(server, RegistrationRequest{
+		Token:          "cfgms_reg_hostname_seed",
+		DeviceID:       deviceID,
+		IdentityKeyPub: base64.StdEncoding.EncodeToString([]byte(pub)),
+		Hostname:       "worker-node-42",
+		OS:             "linux",
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "registration with hostname must succeed")
+
+	var resp RegistrationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.StewardID)
+
+	// No SyncDNA has been called — hostname must be visible solely from registration.
+	info, ok := server.controllerService.GetStewardInfo(resp.StewardID)
+	require.True(t, ok, "registered steward must be present in controller service")
+	require.NotNil(t, info.DNA)
+	assert.Equal(t, "worker-node-42", info.DNA.Attributes["hostname"],
+		"hostname must be visible in DNA immediately after registration, before any SyncDNA")
+	assert.Equal(t, "linux", info.DNA.Attributes["os"],
+		"os must be visible in DNA immediately after registration, before any SyncDNA")
+}
+
+// TestHandleRegister_EmptyHostnameStillRegisters verifies that a registration with no
+// hostname field still succeeds (hostname is optional — Issue #2640, AC #2).
+func TestHandleRegister_EmptyHostnameStillRegisters(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	certMgr := newTestCertManager(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
+	server.SetApprovalHook(&AlwaysApproveHook{})
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_no_hostname",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_no_hostname")
+	assert.Equal(t, http.StatusOK, rec.Code, "registration without hostname must still succeed")
+
+	var resp RegistrationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.StewardID)
+
+	info, ok := server.controllerService.GetStewardInfo(resp.StewardID)
+	require.True(t, ok)
+	require.NotNil(t, info.DNA)
+	assert.Empty(t, info.DNA.Attributes["hostname"],
+		"no hostname attribute should be set when none was sent at registration")
 }

--- a/features/controller/service/controller_service.go
+++ b/features/controller/service/controller_service.go
@@ -748,7 +748,20 @@ func (s *ControllerService) lookupDurableTenant(stewardID string) (tenantID stri
 // device_count: 0). Persisting here lets the next startup warm-load the steward
 // before it reconnects, so GET /api/v1/stewards/{id} keeps returning it.
 func (s *ControllerService) RegisterSteward(stewardID, tenantID, transportAddr, status string) error {
+	return s.RegisterStewardWithAttributes(stewardID, tenantID, transportAddr, status, nil)
+}
+
+// RegisterStewardWithAttributes is like RegisterSteward but seeds initial DNA attributes
+// (e.g. hostname, os) so the controller is not identity-blind before the first DNA sync
+// (Issue #2640). Pass nil initialAttrs to get identical behaviour to RegisterSteward.
+func (s *ControllerService) RegisterStewardWithAttributes(stewardID, tenantID, transportAddr, status string, initialAttrs map[string]string) error {
 	dna := &common.DNA{Id: stewardID}
+	if len(initialAttrs) > 0 {
+		dna.Attributes = make(map[string]string, len(initialAttrs))
+		for k, v := range initialAttrs {
+			dna.Attributes[k] = v
+		}
+	}
 
 	s.mu.Lock()
 	s.stewards[stewardID] = &StewardInfo{

--- a/features/controller/service/controller_service_test.go
+++ b/features/controller/service/controller_service_test.go
@@ -552,6 +552,36 @@ func TestRegisterSteward_FieldsPopulated(t *testing.T) {
 	assert.True(t, !info.LastHeartbeat.After(after))
 }
 
+// TestRegisterStewardWithAttributes_SetsInitialDNA verifies that hostname and OS
+// provided at registration are visible in GetStewardInfo immediately — before any
+// SyncDNA call — closing the identity-blind window (Issue #2640).
+func TestRegisterStewardWithAttributes_SetsInitialDNA(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+
+	initialAttrs := map[string]string{"hostname": "worker-01", "os": "linux"}
+	require.NoError(t, svc.RegisterStewardWithAttributes("s-attrs", "tenant-a", "addr-1", "registered", initialAttrs))
+
+	info, ok := svc.GetStewardInfo("s-attrs")
+	require.True(t, ok)
+	require.NotNil(t, info.DNA)
+	assert.Equal(t, "worker-01", info.DNA.Attributes["hostname"], "hostname must be visible before SyncDNA")
+	assert.Equal(t, "linux", info.DNA.Attributes["os"], "os must be visible before SyncDNA")
+}
+
+// TestRegisterStewardWithAttributes_NilAttrsIsIdenticalToRegisterSteward proves the
+// existing callers are unaffected: nil initialAttrs yields the same result as the
+// original RegisterSteward (DNA with only the steward ID, no attributes).
+func TestRegisterStewardWithAttributes_NilAttrsIsIdenticalToRegisterSteward(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+
+	require.NoError(t, svc.RegisterStewardWithAttributes("s-nil", "tenant-a", "addr-1", "registered", nil))
+
+	info, ok := svc.GetStewardInfo("s-nil")
+	require.True(t, ok)
+	require.NotNil(t, info.DNA)
+	assert.Empty(t, info.DNA.Attributes, "nil initialAttrs must not set any DNA attributes")
+}
+
 // --- Issue #2008: registry repopulation on cert-reuse reconnect / restart ---
 
 // TestEnsureSteward_AddsAbsentStewardWithDurableTenant proves the PRIMARY fix:

--- a/features/steward/registration/client_http.go
+++ b/features/steward/registration/client_http.go
@@ -25,6 +25,11 @@ type RegistrationRequest struct {
 	Token          string `json:"token"`
 	DeviceID       string `json:"device_id,omitempty"`        // 64-char hex SHA-256 of Ed25519 public key (Issue #2094)
 	IdentityKeyPub string `json:"identity_key_pub,omitempty"` // base64-encoded Ed25519 public key (Issue #2094)
+
+	// Best-effort identity hints seeded into initial DNA so the controller is not
+	// blind to connected stewards before their first DNA sync (Issue #2640).
+	Hostname string `json:"hostname,omitempty"`
+	OS       string `json:"os,omitempty"`
 }
 
 // RegistrationResponse represents the response from the controller for an approved registration.


### PR DESCRIPTION
## Summary

- Adds `Hostname` and `OS` optional fields to `RegistrationRequest` (both steward-side in `features/steward/registration/client_http.go` and controller-side in `features/controller/api/handlers_registration.go`)
- Steward populates these at registration via `os.Hostname()` / `runtime.GOOS` (mirroring `dna.go:227`, no new package dependency)
- Controller seeds them into `DNA.Attributes["hostname"]` / `["os"]` via new `RegisterStewardWithAttributes` method before the first DNA sync
- All existing `RegisterSteward` callers are unaffected (additive, nil-safe)

Fixes #2640

## Specialist Review Results

**Code Review**: PASS (round 2 — pre-existing fake `testStewardStore` replaced with real SQLite store via `pkgtesting.SetupTestStorage`)

**Test Quality**: PASS — 2 new handler tests + 2 service unit tests; real components throughout

**Security**: PASS — new fields are best-effort, not logged in changed code, require a valid registration token, and are later overwritten by the real DNA sync; no blocking findings

## Test plan

- [ ] `TestHandleRegister_HostnameSeededBeforeDNASync` — hostname+OS visible in `GetStewardInfo` before any `SyncDNA`
- [ ] `TestHandleRegister_EmptyHostnameStillRegisters` — absent hostname field does not break registration
- [ ] `TestRegisterStewardWithAttributes_SetsInitialDNA` — DNA attributes set at registration
- [ ] `TestRegisterStewardWithAttributes_NilAttrsIsIdenticalToRegisterSteward` — nil attrs ≡ existing `RegisterSteward`
- [ ] All CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)