### PR TITLE
ci: triage zizmor findings to zero, scan develop pushes, and make zizmor blocking (Issue #2607)

### DIFF
--- a/.github/actions/sign-scripts/action.yml
+++ b/.github/actions/sign-scripts/action.yml
@@ -156,7 +156,7 @@ runs:
         $cfgBin = Join-Path $env:RUNNER_TEMP 'cfg.exe'
         Write-Host "Downloading cfg from $url"
         Invoke-WebRequest -Uri $url -OutFile $cfgBin -UseBasicParsing
-        # zizmor: ignore[dangerous-environment-file]
+        # zizmor: ignore[github-env]
         # RUNNER_TEMP is a GitHub Actions runner-provided environment variable; it is
         # not influenced by repository content or pull-request authors. Writing it to
         # GITHUB_PATH adds the runner's temp directory to PATH so that the cfg binary

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,6 +81,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -34,6 +34,8 @@ env:
   IMAGE_PREFIX: cfg-is/cfgms
   TRIVY_VERSION: 'v0.72.0'
 
+permissions: {}
+
 jobs:
   # Scan Controller Docker Image
   scan-controller:
@@ -52,6 +54,7 @@ jobs:
         persist-credentials: false
 
     - name: Install Trivy (cached)
+      # zizmor: ignore[unpinned-tools] — TRIVY_VERSION is pinned to a specific clean release (v0.72.0, post-CVE-2026-33634); the action itself is SHA-pinned
       uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1 — pinned to SHA per CVE-2026-33634
       with:
         version: ${{ env.TRIVY_VERSION }}
@@ -141,6 +144,7 @@ jobs:
         persist-credentials: false
 
     - name: Install Trivy (cached)
+      # zizmor: ignore[unpinned-tools] — TRIVY_VERSION is pinned to a specific clean release (v0.72.0, post-CVE-2026-33634); the action itself is SHA-pinned
       uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1 — pinned to SHA per CVE-2026-33634
       with:
         version: ${{ env.TRIVY_VERSION }}
@@ -219,6 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [scan-controller, scan-steward]
     if: always()
+    permissions: {}
     steps:
     - name: Generate Summary
       run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Validate CLAUDE.md Structure
         run: |
@@ -118,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Validate Roadmap Format
         run: |

--- a/.github/workflows/label-decommission-gate.yml
+++ b/.github/workflows/label-decommission-gate.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions: {}
+
 jobs:
   no-pipeline-labels:
     name: No pipeline/agent label references in executable code
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -70,30 +70,33 @@ jobs:
     
     - name: Run Security Gate Analysis
       id: security-gate
+      env:
+        EMERGENCY_OVERRIDE: ${{ github.event.inputs.emergency_override }}
+        OVERRIDE_REASON: ${{ github.event.inputs.override_reason }}
       run: |
         echo "🚪 PRODUCTION SECURITY DEPLOYMENT GATE"
         echo "======================================"
         echo ""
-        
+
         # Initialize variables
         critical_vulns=0
         high_vulns=0
         security_issues_found=false
         deployment_blocked=false
         override_required=false
-        
+
         # Check for critical vulnerabilities with Trivy
         echo "🔍 Scanning for Critical/High Vulnerabilities..."
         trivy fs . --severity CRITICAL,HIGH --exit-code 1 --format table > /tmp/trivy-critical.txt 2>&1
         trivy_exit_code=$?
-        
+
         if [ $trivy_exit_code -ne 0 ]; then
           echo "❌ CRITICAL/HIGH vulnerabilities detected in dependencies"
           critical_vulns=$(trivy fs . --severity CRITICAL --format json --quiet | jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' 2>/dev/null || echo "0")
           high_vulns=$(trivy fs . --severity HIGH --format json --quiet | jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' 2>/dev/null || echo "0")
           security_issues_found=true
           deployment_blocked=true
-          
+
           echo "  Critical vulnerabilities: $critical_vulns"
           echo "  High vulnerabilities: $high_vulns"
           echo ""
@@ -101,19 +104,19 @@ jobs:
         else
           echo "✅ No critical/high vulnerabilities detected"
         fi
-        
+
         # Advisory scans (nancy, gosec, staticcheck) are non-required contexts
         # that run in security-scan.yml. They are not executed here so this
         # gate remains focused on the single blocking Trivy vulnerability scan.
 
         # Check for emergency override
-        if [ "${{ github.event.inputs.emergency_override }}" = "true" ] || [ -f "EMERGENCY_DEPLOYMENT" ]; then
+        if [ "$EMERGENCY_OVERRIDE" = "true" ] || [ -f "EMERGENCY_DEPLOYMENT" ]; then
           echo ""
           echo "🚨 EMERGENCY OVERRIDE DETECTED"
           echo "============================="
           if [ "$deployment_blocked" = "true" ]; then
             echo "⚠️  Security issues present but emergency override authorized"
-            echo "   Override reason: ${{ github.event.inputs.override_reason || 'Manual emergency file present' }}"
+            echo "   Override reason: ${OVERRIDE_REASON:-Manual emergency file present}"
             deployment_blocked=false
             override_required=true
           fi
@@ -153,45 +156,50 @@ jobs:
     
     - name: Generate Security Audit Trail
       if: always()
+      env:
+        SECURITY_STATUS: ${{ steps.security-gate.outputs.security-status }}
+        DEPLOYMENT_ALLOWED: ${{ steps.security-gate.outputs.deployment-allowed }}
+        OVERRIDE_REQUIRED: ${{ steps.security-gate.outputs.override-required }}
+        OVERRIDE_REASON: ${{ github.event.inputs.override_reason }}
       run: |
         echo "📝 SECURITY AUDIT TRAIL"
         echo "======================"
         echo ""
         echo "Deployment Details:"
         echo "- Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-        echo "- Branch: ${{ github.ref }}"
-        echo "- Commit: ${{ github.sha }}"
-        echo "- Actor: ${{ github.actor }}"
-        echo "- Event: ${{ github.event_name }}"
+        echo "- Branch: $GITHUB_REF"
+        echo "- Commit: $GITHUB_SHA"
+        echo "- Actor: $GITHUB_ACTOR"
+        echo "- Event: $GITHUB_EVENT_NAME"
         echo ""
         echo "Security Gate Results:"
-        echo "- Security Status: ${{ steps.security-gate.outputs.security-status }}"
-        echo "- Deployment Allowed: ${{ steps.security-gate.outputs.deployment-allowed }}"
-        echo "- Override Used: ${{ steps.security-gate.outputs.override-required }}"
+        echo "- Security Status: $SECURITY_STATUS"
+        echo "- Deployment Allowed: $DEPLOYMENT_ALLOWED"
+        echo "- Override Used: $OVERRIDE_REQUIRED"
         echo ""
-        if [ "${{ steps.security-gate.outputs.override-required }}" = "true" ]; then
+        if [ "$OVERRIDE_REQUIRED" = "true" ]; then
           echo "Override Details:"
-          echo "- Reason: ${{ github.event.inputs.override_reason || 'Emergency file override' }}"
-          echo "- Authorized by: ${{ github.actor }}"
+          echo "- Reason: ${OVERRIDE_REASON:-Emergency file override}"
+          echo "- Authorized by: $GITHUB_ACTOR"
           echo "- Approval required: YES (manual review needed)"
         fi
-        
+
         # Save audit trail
         mkdir -p audit-logs
         cat > audit-logs/deployment-security-audit.json << EOF
         {
           "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
           "deployment": {
-            "branch": "${{ github.ref }}",
-            "commit": "${{ github.sha }}",
-            "actor": "${{ github.actor }}",
-            "event": "${{ github.event_name }}"
+            "branch": "$GITHUB_REF",
+            "commit": "$GITHUB_SHA",
+            "actor": "$GITHUB_ACTOR",
+            "event": "$GITHUB_EVENT_NAME"
           },
           "security_gate": {
-            "status": "${{ steps.security-gate.outputs.security-status }}",
-            "deployment_allowed": ${{ steps.security-gate.outputs.deployment-allowed }},
-            "override_used": ${{ steps.security-gate.outputs.override-required }},
-            "override_reason": "${{ github.event.inputs.override_reason || 'N/A' }}"
+            "status": "$SECURITY_STATUS",
+            "deployment_allowed": $DEPLOYMENT_ALLOWED,
+            "override_used": $OVERRIDE_REQUIRED,
+            "override_reason": "${OVERRIDE_REASON:-N/A}"
           }
         }
         EOF

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -294,22 +294,31 @@ jobs:
 
     - name: Security Summary
       id: summary
+      env:
+        TRIVY_STATUS: ${{ needs.trivy-scan.outputs.status }}
+        NANCY_STATUS: ${{ needs.nancy-scan.outputs.status }}
+        GOSEC_STATUS: ${{ needs.gosec-scan.outputs.status }}
+        STATICCHECK_STATUS: ${{ needs.staticcheck-scan.outputs.status }}
+        TRIVY_ISSUES: ${{ needs.trivy-scan.outputs.issues-found }}
+        NANCY_ISSUES: ${{ needs.nancy-scan.outputs.issues-found }}
+        GOSEC_ISSUES: ${{ needs.gosec-scan.outputs.issues-found }}
+        STATICCHECK_ISSUES: ${{ needs.staticcheck-scan.outputs.issues-found }}
       run: |
         echo "📊 Parallel Security Scan Summary"
         echo "================================="
         echo ""
         echo "Individual Tool Results:"
-        echo "  • Trivy: ${{ needs.trivy-scan.outputs.status }}"
-        echo "  • Nancy: ${{ needs.nancy-scan.outputs.status }}"
-        echo "  • gosec: ${{ needs.gosec-scan.outputs.status }}"
-        echo "  • staticcheck: ${{ needs.staticcheck-scan.outputs.status }}"
+        echo "  • Trivy: $TRIVY_STATUS"
+        echo "  • Nancy: $NANCY_STATUS"
+        echo "  • gosec: $GOSEC_STATUS"
+        echo "  • staticcheck: $STATICCHECK_STATUS"
         echo ""
-        
+
         # Determine if any issues were found
-        if [ "${{ needs.trivy-scan.outputs.issues-found }}" = "true" ] || \
-           [ "${{ needs.nancy-scan.outputs.issues-found }}" = "true" ] || \
-           [ "${{ needs.gosec-scan.outputs.issues-found }}" = "true" ] || \
-           [ "${{ needs.staticcheck-scan.outputs.issues-found }}" = "true" ]; then
+        if [ "$TRIVY_ISSUES" = "true" ] || \
+           [ "$NANCY_ISSUES" = "true" ] || \
+           [ "$GOSEC_ISSUES" = "true" ] || \
+           [ "$STATICCHECK_ISSUES" = "true" ]; then
           echo "issues-found=true" >> $GITHUB_OUTPUT
           echo "❌ Security issues detected across tools"
         else
@@ -367,18 +376,24 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
     - name: Production Deployment Decision
+      env:
+        TRIVY_STATUS: ${{ needs.security-validation.outputs.trivy-status }}
+        NANCY_STATUS: ${{ needs.security-validation.outputs.nancy-status }}
+        GOSEC_STATUS: ${{ needs.security-validation.outputs.gosec-status }}
+        STATICCHECK_STATUS: ${{ needs.security-validation.outputs.staticcheck-status }}
+        ISSUES_FOUND: ${{ needs.security-validation.outputs.issues-found }}
       run: |
         echo "🚪 PRODUCTION DEPLOYMENT GATE"
         echo "============================"
         echo ""
         echo "Security Scan Results:"
-        echo "  • Trivy: ${{ needs.security-validation.outputs.trivy-status }}"
-        echo "  • Nancy: ${{ needs.security-validation.outputs.nancy-status }}"
-        echo "  • gosec: ${{ needs.security-validation.outputs.gosec-status }}"
-        echo "  • staticcheck: ${{ needs.security-validation.outputs.staticcheck-status }}"
+        echo "  • Trivy: $TRIVY_STATUS"
+        echo "  • Nancy: $NANCY_STATUS"
+        echo "  • gosec: $GOSEC_STATUS"
+        echo "  • staticcheck: $STATICCHECK_STATUS"
         echo ""
-        
-        if [ "${{ needs.security-validation.outputs.issues-found }}" = "true" ]; then
+
+        if [ "$ISSUES_FOUND" = "true" ]; then
           echo "❌ PRODUCTION DEPLOYMENT BLOCKED"
           echo "   Critical security issues must be resolved before deployment"
           echo ""
@@ -401,19 +416,25 @@ jobs:
     if: always()
     steps:
     - name: Security Scan Summary
+      env:
+        TRIVY_DISPLAY: ${{ needs.security-validation.outputs.trivy-status == 'passed' && '✅ Passed' || '❌ Failed' }}
+        NANCY_DISPLAY: ${{ needs.security-validation.outputs.nancy-status == 'passed' && '✅ Passed' || '❌ Failed' }}
+        GOSEC_DISPLAY: ${{ needs.security-validation.outputs.gosec-status == 'passed' && '✅ Passed' || '❌ Failed' }}
+        STATICCHECK_DISPLAY: ${{ needs.security-validation.outputs.staticcheck-status == 'passed' && '✅ Passed' || '❌ Failed' }}
+        ISSUES_FOUND: ${{ needs.security-validation.outputs.issues-found }}
       run: |
         echo "## Security Scan Summary 🛡️" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Scan Results" >> $GITHUB_STEP_SUMMARY
         echo "| Tool | Status |" >> $GITHUB_STEP_SUMMARY
         echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-        echo "| Trivy | ${{ needs.security-validation.outputs.trivy-status == 'passed' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Nancy | ${{ needs.security-validation.outputs.nancy-status == 'passed' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| gosec | ${{ needs.security-validation.outputs.gosec-status == 'passed' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| staticcheck | ${{ needs.security-validation.outputs.staticcheck-status == 'passed' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| Trivy | $TRIVY_DISPLAY |" >> $GITHUB_STEP_SUMMARY
+        echo "| Nancy | $NANCY_DISPLAY |" >> $GITHUB_STEP_SUMMARY
+        echo "| gosec | $GOSEC_DISPLAY |" >> $GITHUB_STEP_SUMMARY
+        echo "| staticcheck | $STATICCHECK_DISPLAY |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        
-        if [ "${{ needs.security-validation.outputs.issues-found }}" = "true" ]; then
+
+        if [ "$ISSUES_FOUND" = "true" ]; then
           echo "### 🤖 Automated Remediation" >> $GITHUB_STEP_SUMMARY
           echo "Security issues detected! Use Claude Code for automated fixes:" >> $GITHUB_STEP_SUMMARY
           echo "1. Download the \`security-scan-results\` artifact" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Deliberate-finding demonstration (AC5 — reverted next commit)
-        run: echo "PR title is ${{ github.event.pull_request.title }}"
-
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Deliberate-finding demonstration (AC5 — reverted next commit)
+        run: echo "PR title is ${{ github.event.pull_request.title }}"
+
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main, develop ]
   merge_group:
+  push:
+    branches: [ develop ]
+    paths: [ '.github/**' ]
   workflow_dispatch:
 
 permissions: {}
@@ -23,7 +26,6 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
-        continue-on-error: true
         with:
           upload: always
         env:


### PR DESCRIPTION
## Summary

- **Remove `continue-on-error: true`** from `zizmor.yml` — the zizmor check now blocks PRs on findings instead of reporting advisory-only
- **Add `push: branches: [develop] paths: ['.github/**']`** to `zizmor.yml` — default-branch analyses materialize as GitHub Security tab SARIF alerts when workflow files change on develop
- **Fix template injection** in `production-gates.yml` (2 steps) and `security-scan.yml` (3 steps): `\${{ github.event.inputs.* }}` and `\${{ needs.*.outputs.* }}` values moved into `env:` blocks and referenced via shell variables, eliminating injection sinks in `run:` scripts
- **Add `persist-credentials: false`** to checkouts in `codeql-analysis.yml`, `documentation.yml`, `license-check.yml` — prevents GITHUB_TOKEN from leaking into git credentials store
- **Add default-deny `permissions: {}`** at workflow level in `docker-security.yml` and `label-decommission-gate.yml`, with job-level grants preserved
- **Suppress `unpinned-tools`** in `docker-security.yml` Trivy install steps with inline justification comment
- **Update suppress comment rule name** in `sign-scripts/action.yml` from `dangerous-environment-file` → `github-env` (zizmor v0.5.x rename)

## Specialist Review Results

**Security Engineer:** PASS — all changes strictly improve security posture; no injection sinks introduced; no hardcoded secrets; no central-provider violations; remaining `\${{ matrix.* }}` refs are workflow-defined enums (not user-controllable).

**QA Code Reviewer:** PASS — no mocks, no `t.Skip()` abuse, no empty assertions (YAML-only changes). Three pre-existing warnings noted in unrelated CI jobs (pre-existing, out of scope for this story).

**QA Test Runner:** PASS — `make test-agent-complete` passed; all platforms compile (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64).

## AC5 Gate-Blocks Demonstration

To satisfy AC5, two commits were added to this PR:

1. **Deliberate finding (commit `b17382db`)** — added `run: echo "PR title is \${{ github.event.pull_request.title }}"` to `zizmor.yml`, an unquoted `pull_request.title` expression in a `run:` block. Zizmor flagged this as `template-injection` (error level), uploading a SARIF result that caused the required `zizmor` check to **fail**: https://github.com/cfg-is/cfgms/runs/86907673406

2. **Revert (commit `d0cc7a56`)** — removed the deliberate step. Zizmor found zero unsuppressed findings; the required `zizmor` check **passed**: https://github.com/cfg-is/cfgms/runs/86908392718

The gate blocks: findings → red check; zero findings → green check.

## Test Plan

- [x] `make test-agent-complete` — all pre-commit checks, fast tests, production-critical tests, cross-platform builds pass
- [x] Security scan (`make security-scan`) — Trivy, Nancy, gosec, staticcheck all pass
- [x] Architecture check (`make check-architecture`) — no central-provider violations
- [x] All 9 changed files are YAML-only (no Go source changes)
- [x] CI: `zizmor` check runs on this PR and passes with zero findings (see AC5 green run above)
- [ ] CI: After merge to develop, push trigger fires zizmor on `.github/**` changes and uploads SARIF to Security tab

Fixes #2607

🤖 Generated with [Claude Code](https://claude.com/claude-code)