### PR TITLE
dna: surface persist rejections as gRPC errors instead of silent Accepted:true (Issue #2641)

### DIFF
--- a/features/controller/transport/dna_handler.go
+++ b/features/controller/transport/dna_handler.go
@@ -123,8 +123,12 @@ func (h *DNAHandler) HandleGRPC(stream grpc.ClientStreamingServer[transportpb.DN
 		return status.Errorf(codes.InvalidArgument, "failed to reassemble DNA: %v", rErr)
 	}
 
-	if _, pErr := h.persister.SyncDNA(ctx, dna); pErr != nil {
+	persistStatus, pErr := h.persister.SyncDNA(ctx, dna)
+	if pErr != nil {
 		return fmt.Errorf("failed to persist synced DNA for %s: %w", peerID, pErr)
+	}
+	if persistStatus != nil && persistStatus.Code != common.Status_OK {
+		return status.Errorf(codes.Unavailable, "DNA persist rejected: %s", persistStatus.Message)
 	}
 
 	h.logger.Info("DNA sync persisted", "peer_id", peerID, "attributes", dna.GetAttributeCount())

--- a/features/controller/transport/dna_handler_test.go
+++ b/features/controller/transport/dna_handler_test.go
@@ -19,6 +19,7 @@ import (
 
 	common "github.com/cfgis/cfgms/api/proto/common"
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/controller/service"
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	dptypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -119,6 +120,50 @@ func TestDNAHandler_PersistError_FailsRPC(t *testing.T) {
 	err := h.HandleGRPC(stream)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to persist synced DNA")
+}
+
+// TestDNAHandler_PersistStatusNotFound_FailsRPC (#2641): when the real
+// ControllerService rejects a sync for an unregistered steward it returns
+// Status_NOT_FOUND with a nil Go error. HandleGRPC must surface that as a gRPC
+// error so the steward retries rather than believing the sync succeeded.
+//
+// The persister is a real *service.ControllerService with no steward registered
+// for "steward-not-found", so SyncDNA takes its genuine not-found path — no stub.
+func TestDNAHandler_PersistStatusNotFound_FailsRPC(t *testing.T) {
+	ca := newTestCA(t)
+	svc := service.NewControllerService(logging.NewNoopLogger())
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), svc)
+
+	ctx := peerContextWithCA(t, ca, "steward-not-found")
+	stream := newTestDNAStream(ctx, dnaChunksFor(t, "steward-not-found", map[string]string{"hostname": "h", "os": "linux"}, 1)...)
+
+	err := h.HandleGRPC(stream)
+	require.Error(t, err)
+	assert.Nil(t, stream.resp, "Accepted response must not be sent when persist was rejected")
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+// TestDNAHandler_PersistStatusOK_Accepted (#2641): when the real
+// ControllerService accepts the sync (Status_OK), behavior is unchanged — the
+// steward is told Accepted: true.
+//
+// The persister is a real *service.ControllerService with "steward-ok"
+// registered, so SyncDNA takes its genuine happy path (in-memory update).
+func TestDNAHandler_PersistStatusOK_Accepted(t *testing.T) {
+	ca := newTestCA(t)
+	svc := service.NewControllerService(logging.NewNoopLogger())
+	require.NoError(t, svc.RegisterStewardWithAttributes(
+		"steward-ok", "t1", "", "active",
+		map[string]string{"hostname": "h", "os": "linux"},
+	))
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), svc)
+
+	ctx := peerContextWithCA(t, ca, "steward-ok")
+	stream := newTestDNAStream(ctx, dnaChunksFor(t, "steward-ok", map[string]string{"hostname": "h", "os": "linux"}, 1)...)
+
+	require.NoError(t, h.HandleGRPC(stream))
+	require.NotNil(t, stream.resp)
+	assert.True(t, stream.resp.GetAccepted())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `HandleGRPC` in `dna_handler.go` discarded the `*common.Status` returned by `SyncDNA`, checking only the Go error. A `Status_NOT_FOUND` result (steward absent from the in-memory registry, e.g. during controller restart warm-load race) was silently swallowed — the handler still sent `Accepted: true` to the steward, which had no reason to retry, losing the DNA permanently.
- **Fix:** Capture the returned `*common.Status` alongside the Go error; any non-OK `Status.Code` returns `codes.Unavailable` to the steward so it retries via its existing `clientSendDNA` error path.
- **Tests:** Two new integration tests drive a real `*service.ControllerService` (no stubs/mocks) through the transport layer to verify both the rejection and happy paths end-to-end.

Fixes #2641

## Specialist Review Results

| Reviewer | Round 1 | Round 2 |
|----------|---------|---------|
| Code Review | FAIL (stub approach rejected; upgraded to real components) | PASS |
| Test Quality | PASS | — |
| Security | PASS | — |

**Aggregate verdict: PASS** (`passed: true`, 1 fix round, 0 remaining findings)

## Test plan

- [ ] `TestDNAHandler_PersistStatusNotFound_FailsRPC` — unregistered steward → `SyncDNA` returns `Status_NOT_FOUND`/nil error → `HandleGRPC` returns `codes.Unavailable`, no `Accepted:true` sent
- [ ] `TestDNAHandler_PersistStatusOK_Accepted` — registered steward → `SyncDNA` returns `Status_OK` → `Accepted: true` returned (regression coverage)
- [ ] All existing `TestDNAHandler_*` tests continue to pass (11 total)
- [ ] `make test-agent-complete` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)