### PR TITLE
build: serialize test-e2e-fast suites to fix shared-container race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1940,16 +1940,16 @@ test-e2e-fast:
 	@echo ""
 	@echo "⚡ FAST E2E VALIDATION"
 	@echo "======================"
-	@echo "Running 2 core test suites in parallel:"
+	@echo "Running 2 core test suites sequentially:"
 	@echo "  1️⃣  Transport integration tests"
 	@echo "  2️⃣  Controller E2E tests"
 	@echo ""
-	@echo "⏱️  Expected runtime: ~3-5 minutes"
+	@echo "⏱️  Expected runtime: ~5-8 minutes"
 	@echo "⚠️  Excludes long-running performance/scale tests (use test-e2e-parallel for full validation)"
 	@echo ""
 	@$(MAKE) test-transport-setup
 	@echo ""
-	@$(MAKE) -j2 test-e2e-transport test-e2e-controller || { \
+	@$(MAKE) test-e2e-transport test-e2e-controller || { \
 		echo ""; \
 		echo "❌ One or more E2E test suites failed"; \
 		$(MAKE) test-transport-cleanup; \

--- a/Makefile
+++ b/Makefile
@@ -1886,7 +1886,7 @@ test-e2e-ci:
 	@echo ""
 	@echo "📋 Step 2/3: Running tests in container with container-to-container networking..."
 	@docker build -t cfgms-test-runner -f Dockerfile.test-runner . >/dev/null 2>&1 && \
-	DOCKER_GID=$$(stat -c '%g' /var/run/docker.sock) && \
+	DOCKER_GID=$$(stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock) && \
 	docker run --rm \
 		--user $$(id -u):$$(id -g) \
 		--network cfgms-test \


### PR DESCRIPTION
## What

`make test-e2e-fast` ran `test-e2e-transport` and `test-e2e-controller` with `-j2`. Both suites use the same `cfgms-test` compose project: the transport suite's container-recreate window races `TestController`'s `IsInfrastructureRunning()` check, and both then attempt to create `cfgms-timescaledb-test` — reproduced twice consecutively on macOS as `Conflict: container name already in use` (`docker_helper.go` no-ops only when all three containers are already up).

Serializing the two suites removes the race. CI is unaffected — it runs these suites as separate jobs and never invokes `test-e2e-fast`; the cost is a few extra minutes in local `make test-complete` runs.

Follow-up to the local-validation fixes merged in #2569.

## Verification

- Race reproduced twice with `-j2` (runs ~30 min apart, identical failure)
- Sequential run passes the e2e phase (full `make test-complete` validation in progress on the #2495 story branch, which carries this commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)