### PR TITLE
dna: manifest-driven DNA required-field guard (Issue #2642)

### DIFF
--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -118,12 +118,15 @@ the snapshot fails the write-integrity guard. Omitting `required_fields` from an
 required-field constraint. The full declaration contract and configuration-type
 resolution rules are defined in [ADR-020](../decisions/020-dna-required-field-declaration.md).
 
-**Current status (follow-on implementation pending):** Until the manifest-driven
-loader story lands, the operative required-field table is the hand-coded map in
-`features/controller/service/dna_integrity.go` (seeded by issue #2617 with
-`full-os-device → {hostname, os}`). Adding `required_fields` to a `module.yaml` today
-documents intent; it does not yet drive the guard. When the loader is built, the
-manifest entries become the authoritative source and the hand-coded table is retired.
+**Implementation (issue #2642):** The manifest-driven loader is now active. On
+controller startup the guard builds its required-field table by reading every
+`module.yaml` embedded in the controller binary
+(`features/modules.StdlibManifests`). All steward-kind modules' `required_fields`
+are unioned into the `full-os-device` configuration type (ADR-020 Path A).
+Adding `required_fields` to a stdlib `module.yaml` therefore changes what the
+guard enforces with no change to `dna_integrity.go`. The hand-coded Go literal
+from issue #2617 has been retired; the module manifests are now the authoritative
+source.
 
 ### `Get` canonical fragment contract (ADR-016 clause 4)
 

--- a/features/controller/service/dna_integrity.go
+++ b/features/controller/service/dna_integrity.go
@@ -3,21 +3,102 @@
 package service
 
 import (
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+
 	common "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/modules"
 )
 
 // configType identifies the configuration type of a managed device.
-// The per-type required-field table is seeded here for full-OS devices;
-// #2618 will extend it for additional device kinds without rewriting the guard.
 type configType string
 
 const configTypeFullOSDevice configType = "full-os-device"
 
-// dnaRequiredFields maps each configuration type to the Attributes keys that
-// must be present and non-empty for a valid DNA snapshot.
-// Seed: only full-os-device (all current stewards). #2618 adds further entries.
-var dnaRequiredFields = map[configType][]string{
-	configTypeFullOSDevice: {"hostname", "os"},
+// dnaRequiredFields is the active required-field table built from the embedded
+// stdlib module manifests at package init. All steward-kind modules' required_fields
+// are unioned into configTypeFullOSDevice per ADR-020 Path A (steward-hosted entities
+// inferred from active module set). Tests may pass a custom table to
+// checkDNAIntegrityWithTable to probe different declaration states.
+var dnaRequiredFields map[configType][]string
+
+func init() {
+	var err error
+	dnaRequiredFields, err = buildRequiredFieldsFromManifestFS(modules.StdlibManifests, "stdlib")
+	if err != nil {
+		// StdlibManifests is compiled in — this path should not be reached in
+		// practice. An empty table (conservative default: unknown contracts cannot
+		// be violated) keeps the guard from falsely rejecting snapshots.
+		dnaRequiredFields = map[configType][]string{}
+	}
+}
+
+// buildRequiredFieldsFromManifests reads all module.yaml files rooted at dir
+// and returns the required-field table. Steward-kind modules contribute their
+// required_fields to configTypeFullOSDevice (ADR-020 Path A). The result is the
+// union of all declared fields; duplicates are eliminated.
+//
+// This function is used by tests to build tables from test-fixture manifests.
+// Production code uses buildRequiredFieldsFromManifestFS with the embedded FS.
+func buildRequiredFieldsFromManifests(dir string) (map[configType][]string, error) {
+	return buildRequiredFieldsFromManifestFS(os.DirFS(dir), ".")
+}
+
+// buildRequiredFieldsFromManifestFS is the canonical loader: walks fsys under
+// root, parses every module.yaml, and unions required_fields from all steward
+// modules into configTypeFullOSDevice.
+func buildRequiredFieldsFromManifestFS(fsys fs.FS, root string) (map[configType][]string, error) {
+	seen := map[configType]map[string]struct{}{}
+	table := map[configType][]string{}
+
+	err := fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "module.yaml" {
+			return nil
+		}
+
+		f, openErr := fsys.Open(path)
+		if openErr != nil {
+			return fmt.Errorf("open %s: %w", path, openErr)
+		}
+		defer func() { _ = f.Close() }()
+
+		meta, parseErr := modules.ParseModuleMetadata(f)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+
+		if meta.Kind != "steward" {
+			return nil
+		}
+
+		ct := configTypeFullOSDevice
+		if _, ok := seen[ct]; !ok {
+			seen[ct] = map[string]struct{}{}
+		}
+		for _, own := range meta.Owns {
+			for _, field := range own.RequiredFields {
+				if _, dup := seen[ct][field]; !dup {
+					seen[ct][field] = struct{}{}
+					table[ct] = append(table[ct], field)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort each slice for deterministic ordering in tests and logs.
+	for ct := range table {
+		sort.Strings(table[ct])
+	}
+	return table, nil
 }
 
 // dnaIntegrityResult is the outcome of a DNA integrity check.
@@ -27,18 +108,25 @@ type dnaIntegrityResult struct {
 }
 
 // checkDNAIntegrity returns whether the DNA snapshot satisfies the required-field
-// contract for the given configuration type. A nil DNA, or any required Attributes
-// key that is absent or empty, fails the check and lists the offending fields.
+// contract for the given configuration type. The required-set is read from the
+// package-level dnaRequiredFields table, which is built from the embedded stdlib
+// module manifests at init time (ADR-020).
 //
-// The check is table-driven: to seed the required set for a new device kind,
-// add an entry to dnaRequiredFields (see #2618). An unregistered config type
-// passes by default (conservative: unknown contracts cannot be violated).
+// Call sites in AcceptRegistration and SyncDNA are unchanged from #2617.
 func checkDNAIntegrity(dna *common.DNA, ct configType) dnaIntegrityResult {
+	return checkDNAIntegrityWithTable(dna, ct, dnaRequiredFields)
+}
+
+// checkDNAIntegrityWithTable is the table-parameterised implementation. Tests
+// call this directly with a table built from test-fixture manifests to prove
+// that the required-set drives the guard without any code change to guard logic.
+func checkDNAIntegrityWithTable(dna *common.DNA, ct configType, table map[configType][]string) dnaIntegrityResult {
 	if dna == nil {
 		return dnaIntegrityResult{missingFields: []string{"(nil DNA)"}}
 	}
-	required, ok := dnaRequiredFields[ct]
+	required, ok := table[ct]
 	if !ok {
+		// Conservative default: unknown config types have no declared contract.
 		return dnaIntegrityResult{valid: true}
 	}
 	var missing []string

--- a/features/controller/service/dna_integrity_test.go
+++ b/features/controller/service/dna_integrity_test.go
@@ -4,6 +4,8 @@ package service
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -412,4 +414,225 @@ func TestAcceptRegistration_RejectsNilInitialDNA(t *testing.T) {
 	info, ok := svc.GetStewardInfo(resp.StewardId)
 	require.True(t, ok)
 	assert.Nil(t, info.DNA)
+}
+
+// --- Manifest-driven required-field loader tests (ADR-020 / Issue #2642) ---
+
+// writeManifest creates a module.yaml in dir/moduleName/module.yaml with the
+// given YAML content and returns the path to the file.
+func writeManifest(t *testing.T, dir, moduleName, content string) string {
+	t.Helper()
+	modDir := filepath.Join(dir, moduleName)
+	require.NoError(t, os.MkdirAll(modDir, 0750))
+	path := filepath.Join(modDir, "module.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+// TestBuildRequiredFields_FullOSDevice proves that buildRequiredFieldsFromManifests
+// reads required_fields from a steward module's owns: entries and maps them to
+// the full-os-device config type (ADR-020 Path A). This satisfies AC1: the
+// guard's required-set table is built from module.yaml declarations, not a
+// hardcoded Go literal.
+func TestBuildRequiredFields_FullOSDevice(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "identity", `
+name: identity
+version: 0.1.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: device
+    required_fields:
+      - hostname
+      - os
+`)
+
+	table, err := buildRequiredFieldsFromManifests(dir)
+	require.NoError(t, err)
+
+	fields, ok := table[configTypeFullOSDevice]
+	require.True(t, ok, "full-os-device must be present in the built table")
+	assert.Contains(t, fields, "hostname")
+	assert.Contains(t, fields, "os")
+
+	// Confirm the guard rejects a DNA missing hostname.
+	dnaNoHostname := &commonpb.DNA{
+		Id:         "dev-manifest-1",
+		Attributes: map[string]string{"os": "linux"},
+	}
+	result := checkDNAIntegrityWithTable(dnaNoHostname, configTypeFullOSDevice, table)
+	assert.False(t, result.valid)
+	assert.Contains(t, result.missingFields, "hostname")
+
+	// Confirm the guard accepts a DNA with both fields.
+	dnaFull := &commonpb.DNA{
+		Id:         "dev-manifest-2",
+		Attributes: map[string]string{"hostname": "myhost", "os": "linux"},
+	}
+	result = checkDNAIntegrityWithTable(dnaFull, configTypeFullOSDevice, table)
+	assert.True(t, result.valid)
+	assert.Empty(t, result.missingFields)
+}
+
+// TestBuildRequiredFields_UnionAcrossModules proves that required_fields from
+// multiple steward modules are unioned into a single full-os-device contract.
+func TestBuildRequiredFields_UnionAcrossModules(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "mod-a", `
+name: mod-a
+version: 0.1.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: resource-a
+    required_fields:
+      - hostname
+      - os
+`)
+	writeManifest(t, dir, "mod-b", `
+name: mod-b
+version: 0.1.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: resource-b
+    required_fields:
+      - hostname
+      - region
+`)
+
+	table, err := buildRequiredFieldsFromManifests(dir)
+	require.NoError(t, err)
+
+	fields := table[configTypeFullOSDevice]
+	assert.Contains(t, fields, "hostname", "hostname should appear in union (declared by both modules)")
+	assert.Contains(t, fields, "os")
+	assert.Contains(t, fields, "region")
+
+	// hostname must appear only once (deduplication)
+	count := 0
+	for _, f := range fields {
+		if f == "hostname" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "hostname must appear exactly once after deduplication")
+}
+
+// TestBuildRequiredFields_NonStewardModulesSkipped proves that outpost and
+// workflow (controller) modules do not contribute to the full-os-device table.
+func TestBuildRequiredFields_NonStewardModulesSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "outpost-mod", `
+name: outpost-mod
+version: 0.1.0
+publisher: cfgms
+executors:
+  - outpost
+owns:
+  - kind: printer
+    required_fields:
+      - printer_ip
+`)
+
+	table, err := buildRequiredFieldsFromManifests(dir)
+	require.NoError(t, err)
+
+	fields := table[configTypeFullOSDevice]
+	assert.NotContains(t, fields, "printer_ip", "outpost module fields must not appear in full-os-device table")
+}
+
+// TestDNAIntegrityDrivenByManifestDeclaration proves that adding a required_fields
+// entry to an existing module.yaml changes what the guard rejects — zero changes
+// to dna_integrity.go's guard logic required. This satisfies AC2.
+func TestDNAIntegrityDrivenByManifestDeclaration(t *testing.T) {
+	dir := t.TempDir()
+
+	// Step 1: module declares hostname and os as required.
+	manifestPath := writeManifest(t, dir, "steward-mod", `
+name: steward-mod
+version: 0.1.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: resource
+    required_fields:
+      - hostname
+      - os
+`)
+
+	table, err := buildRequiredFieldsFromManifests(dir)
+	require.NoError(t, err)
+
+	dna := &commonpb.DNA{
+		Id:         "dev-ac2",
+		Attributes: map[string]string{"hostname": "myhost", "os": "linux"},
+	}
+	result := checkDNAIntegrityWithTable(dna, configTypeFullOSDevice, table)
+	assert.True(t, result.valid, "DNA with hostname+os must pass before adding new required field")
+
+	// Step 2: add region to the manifest's required_fields — no change to guard logic.
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`
+name: steward-mod
+version: 0.1.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: resource
+    required_fields:
+      - hostname
+      - os
+      - region
+`), 0600))
+
+	tableAfter, err := buildRequiredFieldsFromManifests(dir)
+	require.NoError(t, err)
+
+	// Guard now rejects DNA that lacks region — no guard logic was changed.
+	resultAfter := checkDNAIntegrityWithTable(dna, configTypeFullOSDevice, tableAfter)
+	assert.False(t, resultAfter.valid, "guard must reject DNA missing region after manifest update")
+	assert.Contains(t, resultAfter.missingFields, "region")
+
+	// DNA with the new field passes.
+	dnaFull := &commonpb.DNA{
+		Id: "dev-ac2-full",
+		Attributes: map[string]string{
+			"hostname": "myhost",
+			"os":       "linux",
+			"region":   "us-east-1",
+		},
+	}
+	resultFull := checkDNAIntegrityWithTable(dnaFull, configTypeFullOSDevice, tableAfter)
+	assert.True(t, resultFull.valid)
+}
+
+// TestBuildRequiredFields_StdlibManifests proves that the real embedded stdlib
+// manifests yield the full-os-device → {hostname, os} contract that the
+// #2617 guard seeded, confirming the manifest declarations are consistent
+// with the guard's expected behavior (AC1 against the live manifests).
+func TestBuildRequiredFields_StdlibManifests(t *testing.T) {
+	// dnaRequiredFields is populated from StdlibManifests by the package init.
+	fields, ok := dnaRequiredFields[configTypeFullOSDevice]
+	require.True(t, ok, "full-os-device entry must exist in the stdlib-manifest-driven table")
+	assert.Contains(t, fields, "hostname")
+	assert.Contains(t, fields, "os")
+
+	// Guard behaves identically to the pre-manifest hardcoded seed.
+	validDNA := &commonpb.DNA{
+		Id:         "dev-stdlib-valid",
+		Attributes: map[string]string{"hostname": "myhost", "os": "linux"},
+	}
+	assert.True(t, checkDNAIntegrity(validDNA, configTypeFullOSDevice).valid)
+
+	emptyDNA := &commonpb.DNA{Id: "dev-stdlib-empty", Attributes: map[string]string{}}
+	result := checkDNAIntegrity(emptyDNA, configTypeFullOSDevice)
+	assert.False(t, result.valid)
+	assert.Contains(t, result.missingFields, "hostname")
+	assert.Contains(t, result.missingFields, "os")
 }

--- a/features/modules/metadata.go
+++ b/features/modules/metadata.go
@@ -19,6 +19,13 @@ import (
 type OwnershipDeclaration struct {
 	// Kind is the object-identity namespace (e.g. "service", "file", "package").
 	Kind string `yaml:"kind" json:"kind"`
+	// RequiredFields lists DNA Attributes keys that must be present and non-empty
+	// for every DNA snapshot from an entity where this module is active, per
+	// ADR-020. The controller unions RequiredFields across all active modules at
+	// DNA write time; a field absent or empty in the snapshot fails the
+	// write-integrity guard. Omitting RequiredFields is valid (no additional
+	// constraint beyond module ownership).
+	RequiredFields []string `yaml:"required_fields,omitempty" json:"required_fields,omitempty"`
 }
 
 // ModuleMetadata represents the complete metadata for a module
@@ -426,10 +433,16 @@ func (m *ModuleMetadata) Clone() *ModuleMetadata {
 		}
 	}
 
-	// Deep copy ownership declarations (OwnershipDeclaration contains only strings)
+	// Deep copy ownership declarations (each entry may carry a RequiredFields slice)
 	if m.Owns != nil {
 		clone.Owns = make([]OwnershipDeclaration, len(m.Owns))
-		copy(clone.Owns, m.Owns)
+		for i, o := range m.Owns {
+			clone.Owns[i] = OwnershipDeclaration{Kind: o.Kind}
+			if o.RequiredFields != nil {
+				clone.Owns[i].RequiredFields = make([]string, len(o.RequiredFields))
+				copy(clone.Owns[i].RequiredFields, o.RequiredFields)
+			}
+		}
 	}
 
 	return clone

--- a/features/modules/metadata_test.go
+++ b/features/modules/metadata_test.go
@@ -960,7 +960,10 @@ func TestModuleMetadata_Clone_Owns(t *testing.T) {
 		Publisher: "cfgms",
 		Executors: []string{"steward"},
 		Kind:      "steward",
-		Owns:      []OwnershipDeclaration{{Kind: "service"}, {Kind: "file"}},
+		Owns: []OwnershipDeclaration{
+			{Kind: "service", RequiredFields: []string{"hostname", "os"}},
+			{Kind: "file"},
+		},
 	}
 
 	clone := original.Clone()
@@ -972,12 +975,104 @@ func TestModuleMetadata_Clone_Owns(t *testing.T) {
 		if clone.Owns[i].Kind != want.Kind {
 			t.Errorf("Clone Owns[%d].Kind = %q, want %q", i, clone.Owns[i].Kind, want.Kind)
 		}
+		if len(clone.Owns[i].RequiredFields) != len(want.RequiredFields) {
+			t.Errorf("Clone Owns[%d].RequiredFields length = %d, want %d", i, len(clone.Owns[i].RequiredFields), len(want.RequiredFields))
+		}
 	}
 
-	// Verify deep copy — mutating clone must not affect original
+	// Verify deep copy — mutating clone's Kind and RequiredFields must not affect original.
 	clone.Owns[0].Kind = "mutated"
 	if original.Owns[0].Kind == "mutated" {
-		t.Error("Mutating clone Owns[0] affected original")
+		t.Error("Mutating clone Owns[0].Kind affected original")
+	}
+	clone.Owns[0].RequiredFields[0] = "mutated-field"
+	if original.Owns[0].RequiredFields[0] == "mutated-field" {
+		t.Error("Mutating clone Owns[0].RequiredFields affected original")
+	}
+}
+
+// TestParseModuleMetadata_RequiredFields verifies that required_fields within
+// owns: entries is parsed correctly and that omitting it is backward-compatible.
+func TestParseModuleMetadata_RequiredFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		yaml           string
+		wantOwns       []OwnershipDeclaration
+	}{
+		{
+			name: "owns with required_fields",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: service
+    required_fields:
+      - hostname
+      - os`,
+			wantOwns: []OwnershipDeclaration{
+				{Kind: "service", RequiredFields: []string{"hostname", "os"}},
+			},
+		},
+		{
+			name: "owns without required_fields — backward compatible",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: service`,
+			wantOwns: []OwnershipDeclaration{
+				{Kind: "service", RequiredFields: nil},
+			},
+		},
+		{
+			name: "mixed — one entry with required_fields, one without",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+owns:
+  - kind: service
+    required_fields:
+      - hostname
+  - kind: file`,
+			wantOwns: []OwnershipDeclaration{
+				{Kind: "service", RequiredFields: []string{"hostname"}},
+				{Kind: "file", RequiredFields: nil},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := strings.NewReader(tt.yaml)
+			metadata, err := ParseModuleMetadata(reader)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			if len(metadata.Owns) != len(tt.wantOwns) {
+				t.Fatalf("Owns length = %d, want %d", len(metadata.Owns), len(tt.wantOwns))
+			}
+			for i, want := range tt.wantOwns {
+				got := metadata.Owns[i]
+				if got.Kind != want.Kind {
+					t.Errorf("Owns[%d].Kind = %q, want %q", i, got.Kind, want.Kind)
+				}
+				if len(got.RequiredFields) != len(want.RequiredFields) {
+					t.Errorf("Owns[%d].RequiredFields = %v, want %v", i, got.RequiredFields, want.RequiredFields)
+					continue
+				}
+				for j, wf := range want.RequiredFields {
+					if got.RequiredFields[j] != wf {
+						t.Errorf("Owns[%d].RequiredFields[%d] = %q, want %q", i, j, got.RequiredFields[j], wf)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/features/modules/stdlib/file/module.yaml
+++ b/features/modules/stdlib/file/module.yaml
@@ -26,6 +26,9 @@ interfaces:
 
 owns:
   - kind: file  # authority over file:* objects this module manages
+    required_fields:
+      - hostname  # device identity — required in every full-os-device DNA snapshot
+      - os        # device identity — required in every full-os-device DNA snapshot
 
 security:
   requires_root: false

--- a/features/modules/stdlib/firewall/module.yaml
+++ b/features/modules/stdlib/firewall/module.yaml
@@ -20,6 +20,9 @@ interfaces:
 
 owns:
   - kind: firewall  # authority over firewall:* objects this module manages
+    required_fields:
+      - hostname  # device identity — required in every full-os-device DNA snapshot
+      - os        # device identity — required in every full-os-device DNA snapshot
 
 security:
   requires_root: true

--- a/features/modules/stdlib/package/module.yaml
+++ b/features/modules/stdlib/package/module.yaml
@@ -22,6 +22,9 @@ interfaces:
 
 owns:
   - kind: package  # authority over package:* objects this module manages
+    required_fields:
+      - hostname  # device identity — required in every full-os-device DNA snapshot
+      - os        # device identity — required in every full-os-device DNA snapshot
 
 security:
   requires_root: true

--- a/features/modules/stdlib/patch/module.yaml
+++ b/features/modules/stdlib/patch/module.yaml
@@ -25,6 +25,9 @@ interfaces:
 
 owns:
   - kind: patch  # authority over patch:* objects this module manages
+    required_fields:
+      - hostname  # device identity — required in every full-os-device DNA snapshot
+      - os        # device identity — required in every full-os-device DNA snapshot
 
 security:
   requires_root: true  # installing patches requires elevated privileges

--- a/features/modules/stdlib/script/module.yaml
+++ b/features/modules/stdlib/script/module.yaml
@@ -24,6 +24,9 @@ interfaces:
 
 owns:
   - kind: script  # authority over script:* objects this module manages
+    required_fields:
+      - hostname  # device identity — required in every full-os-device DNA snapshot
+      - os        # device identity — required in every full-os-device DNA snapshot
 
 security:
   requires_root: false

--- a/features/modules/stdlib/service/module.yaml
+++ b/features/modules/stdlib/service/module.yaml
@@ -25,6 +25,9 @@ interfaces:
 
 owns:
   - kind: service  # authority over service:* objects this module manages
+    required_fields:
+      - hostname  # device identity — required in every full-os-device DNA snapshot
+      - os        # device identity — required in every full-os-device DNA snapshot
 
 security:
   requires_root: true  # start/stop/enable/disable require elevated privileges

--- a/features/modules/stdlib_manifests.go
+++ b/features/modules/stdlib_manifests.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package modules
+
+import "embed"
+
+// StdlibManifests contains the embedded module.yaml files for all stdlib modules.
+// The controller's DNA integrity guard reads required_fields declarations from
+// these manifests to build its per-configuration-type required-field table
+// (ADR-020, implemented by issue #2642).
+//
+//go:embed stdlib/*/module.yaml
+var StdlibManifests embed.FS


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `full-os-device → {hostname, os}` Go literal in `dna_integrity.go` with a manifest-driven loader (`buildRequiredFieldsFromManifestFS`) that reads `required_fields` from embedded stdlib `module.yaml` files at package init time
- Adds `RequiredFields []string` to `OwnershipDeclaration` in `features/modules/metadata.go` per ADR-020 declaration schema
- Updates all six `owns:`-carrying stdlib modules (`file`, `firewall`, `package`, `patch`, `script`, `service`) to declare `required_fields: [hostname, os]`
- Embeds the stdlib manifests as `StdlibManifests embed.FS` so the controller binary is self-contained
- Adds `checkDNAIntegrityWithTable` for table-parameterised testing; all #2617 call sites in `AcceptRegistration`/`SyncDNA` are unchanged

## Acceptance criteria status

- [x] **AC1**: `buildRequiredFieldsFromManifests` on test fixtures yields `full-os-device → {hostname, os}`; `TestBuildRequiredFields_FullOSDevice` and `TestBuildRequiredFields_StdlibManifests` prove this
- [x] **AC2**: `TestDNAIntegrityDrivenByManifestDeclaration` proves adding a field to a fixture manifest changes guard rejection with zero guard logic changes
- [x] **AC3**: Six stdlib modules each carry `required_fields: [hostname, os]`
- [x] All existing `TestCheckDNAIntegrity_*`, `TestSyncDNA_*`, and `TestAcceptRegistration_*` tests pass unchanged
- [x] `docs/architecture/modules/README.md` updated — loader is now active

## Specialist review results

- **Code Review**: PASS
- **QA / Test Runner**: PASS
- **Security**: PASS

Fixes #2642

🤖 Generated with [Claude Code](https://claude.com/claude-code)