### PR TITLE
ci: add GHA layer caching to test-runner and fleet e2e builds (Issue #2594)

### DIFF
--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -47,5 +47,10 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Run fleet E2E tests
+        env:
+          COMPOSE_BAKE: "1"
         run: make test-e2e-fleet

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -417,6 +417,20 @@ jobs:
         make test-transport-setup
         echo "✅ Docker infrastructure ready"
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Build test runner image
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: .
+        file: ./Dockerfile.test-runner
+        push: false
+        load: true
+        tags: cfgms-test-runner
+        cache-from: type=gha,scope=cfgms-test-runner
+        cache-to: type=gha,mode=max,scope=cfgms-test-runner
+
     - name: Run Controller Integration Tests
       env:
         CFGMS_TEST_INTEGRATION: "1"
@@ -428,9 +442,6 @@ jobs:
         set -a
         source .env.test
         set +a
-
-        # Build test runner for container-to-container networking (enables UDP/QUIC)
-        docker build -t cfgms-test-runner -f Dockerfile.test-runner .
 
         # Get Docker socket group to grant non-root user access
         DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -673,6 +673,11 @@ services:
     build:
       context: .
       dockerfile: cmd/controller/Dockerfile
+      x-bake:
+        cache-from:
+          - type=gha,scope=cfgms-fleet-controller
+        cache-to:
+          - type=gha,mode=max,scope=cfgms-fleet-controller
     ports:
       - "4437:4433/udp"   # gRPC-over-QUIC transport
       - "8090:9080"       # HTTP API
@@ -734,6 +739,11 @@ services:
       dockerfile: cmd/steward/Dockerfile.debian
       args:
         STEWARD_CONTROLLER_URL: "https://fleet-controller:9080"
+      x-bake:
+        cache-from:
+          - type=gha,scope=cfgms-fleet-steward-debian
+        cache-to:
+          - type=gha,mode=max,scope=cfgms-fleet-steward-debian
     environment:
       CFGMS_REGISTRATION_TOKEN: "dockertest_fleet_child_a"
       CFGMS_LOG_LEVEL: "debug"
@@ -767,6 +777,11 @@ services:
       dockerfile: cmd/steward/Dockerfile.debian
       args:
         STEWARD_CONTROLLER_URL: "https://fleet-controller:9080"
+      x-bake:
+        cache-from:
+          - type=gha,scope=cfgms-fleet-steward-debian
+        cache-to:
+          - type=gha,mode=max,scope=cfgms-fleet-steward-debian
     environment:
       CFGMS_REGISTRATION_TOKEN: "dockertest_fleet_child_b"
       CFGMS_LOG_LEVEL: "debug"

--- a/pkg/logging/providers/file/rotation_unix.go
+++ b/pkg/logging/providers/file/rotation_unix.go
@@ -24,7 +24,7 @@ func (p *FileProvider) calculateDiskUsage() (float64, error) {
 	// int64 on Linux but uint32 on Darwin — go through int64 so the guard
 	// compiles and lints cleanly on both (a direct `stat.Bsize < 0` is
 	// statically false on Darwin and staticcheck SA4003 rejects it there).
-	bsize := int64(stat.Bsize)
+	bsize := int64(stat.Bsize) //nolint:unconvert // no-op on linux; required on darwin where Bsize is uint32
 	if bsize <= 0 {
 		return 0, fmt.Errorf("invalid block size: %d", bsize)
 	}


### PR DESCRIPTION
## Summary

- **`production-gates.yml`**: Replace plain `docker build` for `Dockerfile.test-runner` with `docker/setup-buildx-action` + `docker/build-push-action` (SHA-pinned, matching the existing pattern in `docker-security.yml`). GHA layer cache wired via `cache-from/cache-to: type=gha,scope=cfgms-test-runner` — no more from-scratch base image pull on every merge-group run.
- **`fleet-e2e.yml`**: Add `docker/setup-buildx-action` and set `COMPOSE_BAKE=1` on the `make test-e2e-fleet` step. With bake mode active, Docker Compose delegates builds to `docker buildx bake`, which reads the `x-bake` cache config from the compose file and uses GHA cache.
- **`docker-compose.test.yml`**: Add `x-bake` `cache-from`/`cache-to` blocks to the three fleet profile services (`fleet-controller`, `fleet-steward-1`, `fleet-steward-2`) with distinct `scope=` keys (`cfgms-fleet-controller`, `cfgms-fleet-steward-debian`) to prevent cache eviction across image types.
- **`rotation_unix.go`**: Fix a pre-existing `unconvert` lint warning found during adversarial review — the `// nolint:unconvert` directive was on the line above the cast; golangci-lint requires same-line placement.

## Reviewer results (story-review workflow — 3 rounds, 2 fix cycles)

| Lens | Result | Notes |
|------|--------|-------|
| Code review (qa-code-reviewer) | ✅ PASS | 0 findings — CI YAML changes are correct, pattern matches docker-security.yml reference |
| Security (security-engineer) | ✅ PASS | 1 informational warning: GHA cache carries a general cache-poisoning surface, but blast radius is limited to test-only images never pushed to a registry; actions are SHA-pinned. Non-blocking. |
| Tests (qa-test-runner) | ✅ PASS (round 3) | Round 1: GitHub API eventual-consistency flake in test-scripts.sh. Round 2: pre-existing unconvert lint issue in rotation_unix.go. Both fixed; round 3 all 211 script tests + 160 Go packages pass, golangci-lint clean. |

## Test plan

- [ ] Merge to develop via queue; observe `integration-tests-controller` and `fleet-e2e-tests` run
- [ ] On second merge-group run after the first (cache is warm): confirm reduced build time for "Build test runner image" step and explicit GHA cache-hit log lines from buildx for fleet images
- [ ] Post before/after wall-clock measurements as PR comment per #2501/#2584 pattern

Fixes #2594