### PR TITLE
user: simplify darwin group-list append (staticcheck S1011)

### DIFF
--- a/features/modules/stdlib/user/executor_darwin.go
+++ b/features/modules/stdlib/user/executor_darwin.go
@@ -43,9 +43,7 @@ func (e *darwinExecutor) getState(username string) (userState, error) {
 	// Resolve group names via id -Gn (all groups, space-separated).
 	groupOut, err := exec.Command("id", "-Gn", username).CombinedOutput() // #nosec G204 - username validated by caller
 	if err == nil {
-		for _, g := range strings.Fields(strings.TrimSpace(string(groupOut))) {
-			state.Groups = append(state.Groups, g)
-		}
+		state.Groups = append(state.Groups, strings.Fields(strings.TrimSpace(string(groupOut)))...)
 		sort.Strings(state.Groups)
 	}
 


### PR DESCRIPTION
One-line staticcheck S1011 fix in `executor_darwin.go`: replace the element-wise append loop with a spread append. Only visible when linting on macOS — CI's Linux lint never compiles Darwin-tagged files, which is a known gap (same class as the `rotation_unix.go` fix in #2569).

Verified: `golangci-lint run` reports 0 issues on macOS; `go test ./features/modules/stdlib/user/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)