### PR TITLE
dex: prove in-steward Go ETW consume path feasible — consumer PoC + feasibility report (Issue #2571)

### DIFF
--- a/features/steward/dex/CONSUME_FEASIBILITY.md
+++ b/features/steward/dex/CONSUME_FEASIBILITY.md
@@ -215,10 +215,49 @@ signing surface that (b) would add). cgo is a **build-time** consideration
 (CGO_ENABLED=1 for the DEX build target); the PoC keeps it fully isolated behind
 the `dexconsume` tag so the current CGO_ENABLED=0 steward build is unaffected.
 
+## Memory-safe variant — Rust, PROVEN in-process (live)
+
+The C spike answers "is it feasible"; it does **not** mean C is the right production
+language. The irreducibly-unsafe part of raw ETW consumption is exactly one thing —
+the OS hands the callback a raw `EVENT_RECORD*` valid only for that call, and
+*something* must dereference it. Everything else (the ring, indices, counters,
+string handling — where the C variant's one review bug lived) can be memory-safe.
+
+To prove that, the **same architecture was re-implemented in Rust**
+(`features/steward/dex/rust/`, a `staticlib` exporting the identical `cfgms_*` C
+ABI, linked into the same Go wrapper via cgo under the `dexrust` build tag). The
+unsafe surface is reduced to two marked spots: the shared static ring (`UnsafeCell`
++ `unsafe impl Sync`) and the single raw `EVENT_RECORD` deref. windows-sys provides
+the exact ETW struct layouts, so field offsets are correct by construction.
+
+**Live SYSTEM run (CFG-70-02, 20 s), Rust callback:**
+
+| Metric | C variant | **Rust variant** |
+|--------|-----------|------------------|
+| Events consumed | 47,426 (12 s) / 6,094,835 (10 min) | **52,877 (20 s)** |
+| Ring drops / ETW-lost | 0 / 0 | **0 / 0** |
+| Runtime crash | none | **none** (`process_trace_status=0`) |
+| CPU (1-core) | 0.39–0.487 % | **0.469 %** |
+| Attribution | works (shared Go drain) | **works** (65 PIDs, same Go code) |
+| TDH decode | proven | not ported (orthogonal; Rust PoC skips it) |
+
+Same crash-safe in-process consumption, comparable overhead, in a memory-safe
+language. The Rust variant also passes the identical SPSC-ring unit tests
+(`go test -tags "dexconsume dexrust"`). Cost: a Rust GNU toolchain at build time
+and the windows-sys static-lib link (documented in `rust/build.sh` +
+`consume_rust_link_windows.go`).
+
 ## Recommended consume architecture
 
-1. **In-process, non-reentrant C callback → C ring → Go drain** (candidate (c)).
-   Proven stable and cheap. This is the load-bearing recommendation.
+1. **In-process, non-reentrant native callback → ring → Go drain** (candidate (c)).
+   Proven stable and cheap in **both C and Rust** — the mechanism is the load-bearing
+   recommendation; the native language is an orthogonal call.
+   - **For production, prefer Rust over C** (in-process staticlib via cgo, or an
+     out-of-process Rust helper if the steward must stay pure Go): the unsafe
+     surface shrinks to ~2 lines, and the exact class of bug the C review caught
+     (an out-of-bounds read in the TDH string decode) is a compile-time
+     non-starter in safe Rust. Adopting either is a real toolchain / signing-pipeline
+     decision for a Go-first codebase, so it is called out here, not assumed.
 2. **Decode selectively, off the hot path.** TDH per-event is expensive; the hot
    callback should stay header-only (+ raw payload copy where a signal needs it),
    and decode only the specific events a configured signal consumes.

--- a/features/steward/dex/CONSUME_FEASIBILITY.md
+++ b/features/steward/dex/CONSUME_FEASIBILITY.md
@@ -1,0 +1,248 @@
+# DEX In-Process ETW Consume Feasibility — Measured Results (#2571)
+
+Feasibility deliverable for the Windows in-steward Go DEX collection agent. This
+closes the load-bearing gap left open by #2540 (`SPIKE_RESULTS.md`): #2517/#2540
+proved provider **reachability + enablement overhead** only and shipped with **no
+consumer**, because the in-process Go `ProcessTrace` consumer crashed the Go
+runtime (`acquireSudog` / `cgocallbackg` corruption). This spike proves the
+**consume path and everything the agent depends on downstream of it** — with real
+runs in the steward's `LocalSystem` (SYSTEM) context, not desk research.
+
+This is a **throwaway PoC** (build tag `dexconsume`, cgo; never compiled into the
+production steward). It does **not** build the DEX engine, define a schema, or
+persist anything. The collection track stays gated on the storage-shape ADR +
+ADR-017 Amendment 1.
+
+## Bottom line — GO (in-steward Go DEX consumption is feasible)
+
+An in-steward Go process **can** consume, decode, and attribute a high-rate ETW
+stream in its own SYSTEM service context, stably, well within the 1.0% CPU budget.
+The #2517 runtime crash is **avoided by construction** with a non-reentrant C
+callback. The one hard limit is unchanged from #2540 and is a Windows platform
+fact, not an agent limitation: **UI/app-hang ("employee experience") signals do
+not emit in the steward's service session (0)** and require a separate per-session
+acquisition path.
+
+| # | Load-bearing part | Verdict |
+|---|-------------------|---------|
+| 1 | High-rate in-process consumption, stable | **PROVEN** |
+| 2 | Event decode in Go (TDH / manifest schema) | **PROVEN** |
+| 3 | Per-process / entity attribution | **PROVEN** |
+| 4 | Real overhead at volume vs 1.0% budget | **PROVEN** (within budget) |
+| 5 | Sustained ≥10-min stability | **PROVEN** _(see run 2)_ |
+| 6 | Session-0 UX-signal reachability | **BLOCKED** — needs a per-session component |
+
+## The crux and the architecture decision
+
+#2517 found that a real-time `ProcessTrace` consumer with a
+`windows.NewCallback`-wrapped Go callback corrupts the Go runtime under load:
+every ETW event fires the callback on an OS thread ETW owns, and the native→Go
+transition (`cgocallbackg`) mutates per-P runtime state that collides with the
+scheduler. Restricting the callback body to atomic ops does not help — the crash
+is in the *entry path*, not the body.
+
+Four candidate architectures were considered (story §"Load-bearing parts", part 1):
+
+- **(a) Event-Log-first (`EvtSubscribe`)** — proven in-process by the hyperv
+  Monitor (#2114), but only exists for signals that have an Event Log *channel*.
+  The high-rate kernel providers (Kernel-Disk, Kernel-PerfInfo, Kernel-File) are
+  raw-ETW-only, so (a) cannot cover part 1's requirement.
+- **(b) Out-of-process native consumer** piping to Go — works, but adds an IPC
+  boundary and a second signed binary to deploy.
+- **(c) In-process Go with a non-reentrant C callback** — the EventRecordCallback
+  is a pure C function that copies each event into a C ring buffer and never calls
+  back into Go; a Go goroutine drains the ring. The hot path is C→C only, so
+  `cgocallbackg` is never taken.
+- **(d) Buffered `.etl`-file mode** parsed periodically — higher latency; still
+  needs a `ProcessTrace` callback to read the file (same crash unless the callback
+  is C).
+
+**Chosen: (c).** It keeps everything in one signed binary, needs no IPC, and is
+the minimal change that makes the crash structurally impossible. Implementation:
+`consume_etw_windows.c` (single-producer/single-consumer ring + the C callback +
+`OpenTrace`/`ProcessTrace` runner + bounded TDH decode) and `consume_windows.go`
+(cgo wrapper: session start, drain, attribution, overhead, ETW lost-event query).
+
+## Run context (proof of real runs)
+
+Executed **in the steward's own `LocalSystem` service context** via the signed
+inline-exec admin channel (`cfg steward exec`) to the CFG-70-02 steward — the
+faithful deployment context, which holds the ETW `StartTrace` privilege.
+
+| Field | Value |
+|-------|-------|
+| Host | **CFG-70-02** |
+| Executing identity | **NT AUTHORITY\SYSTEM** (steward `LocalSystem` service context) |
+| Windows session | **0** (service session — no interactive desktop) |
+| OS | Microsoft Windows Server 2025 Datacenter Evaluation, build 26100 |
+| Steward | `steward-1780659937223058807`, tenant `infra-hyperv` |
+| Binary | `go test -c -tags dexconsume` PoC, run as SYSTEM |
+| Providers | Win32k, Kernel-Disk, Kernel-PerfInfo, DNS-Client, **Kernel-File** (high-rate stress) |
+
+**Why this is a real privileged run:** run **non-elevated** the same binary reports
+`session_start_err: StartTraceW: Access is denied. (code 5)` and consumes nothing;
+run in the steward SYSTEM context it starts the session and consumes tens of
+thousands of events. That flip is only possible under genuine `StartTrace`
+privilege.
+
+## Part 1 — High-rate in-process consumption, stable — PROVEN
+
+**Run 1 (12 s window, all 5 providers, live SYSTEM):**
+
+| Metric | Value |
+|--------|-------|
+| Events observed by the C callback (`total_seen`) | **47,426** |
+| Events drained by Go (`total_drained`) | **47,426** |
+| Ring-full drops (`dropped_ring`) | **0** |
+| ETW kernel lost events (`etw_events_lost`) | **0** |
+| ETW real-time buffers lost | **0** |
+| Throughput | **≈3,950 events/s** |
+| Runtime crash | **none** (`crashed: false`, process returned cleanly) |
+
+The consumer stayed up for the full window under real host load, drained every
+event the callback enqueued, and lost nothing — with the exact `ProcessTrace`
+real-time consumer that crashed the runtime in #2517, now made safe by the C
+callback. **The #2517 crash is resolved (avoided by construction).**
+
+## Part 2 — Event decode in Go (TDH / manifest schema) — PROVEN
+
+The C callback TDH-decodes a bounded sample of target-provider events into named
+fields (`TdhGetEventInformation` → `TdhGetProperty` per top-level property). Real
+decoded fields from run 1 (`decode_sample`), meaning extracted, not just counts:
+
+- **DNS-Client** event 1001: `Interface=vEthernet (HVSwitch_1G); TotalServerCount=2; Index=1; DynamicAddress=1; AddressLength=16`
+- **Kernel-File** event 15 (Read): `ByteOffset=2698805248; IOSize=4096; IssuingThreadId=2552; FileObject=…; FileKey=…`
+- **Kernel-File** event 10 (Create): `FileKey=…; FileName=\Device\HarddiskVolume3\Windows\System32\ualapi.dll`
+- **Kernel-File** event 24 (OperationEnd): `ExtraInformation=4096; Status=0`
+
+Manifest/MOF schema decode works from the live `EVENT_RECORD` during the callback.
+Note: TDH decode is comparatively expensive (`TdhGetEventInformation` builds a
+`TRACE_EVENT_INFO` per event), so a production agent should decode **selectively**
+(only the events a signal needs), not every event on the hot path — see
+recommendation below. The bounded-sample design here reflects that.
+
+## Part 3 — Per-process / entity attribution — PROVEN
+
+Every event carries `EVENT_HEADER.ProcessId`; the Go drain side resolves PID →
+full image path via `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` +
+`QueryFullProcessImageName`, cached per PID. Run 1 attributed **57 distinct PIDs**.
+Top attributed images (event counts):
+
+| PID | Image | Events |
+|-----|-------|--------|
+| 19072 | `C:\Program Files\PowerShell\7\pwsh.exe` | 24,522 |
+| 5948 | `…\wbem\WmiPrvSE.exe` | 5,998 |
+| 15012 | `C:\Python314\python.exe` | 4,544 |
+| 4 | System | 2,247 |
+| 17380 | `…\CFGMS\versions\v0.9.25\cfgms-steward.exe` | 1,459 |
+| 1080 | `…\System32\lsass.exe` | 410 |
+
+Attribution resolves the "who" for a DEX signal. Protected/exited PIDs resolve to
+an empty image (an expected, handled edge — e.g. PID 0/4 are labelled). User
+attribution (token → SID → account) is a straightforward extension of the same
+per-PID handle and is noted as low-risk; it was not required to prove the part.
+
+## Part 4 — Real overhead at volume vs the 1.0% budget — PROVEN (within budget)
+
+Overhead is `GetProcessTimes` (kernel+user) delta over the window, normalised to
+one logical core; working set via `GetProcessMemoryInfo`.
+
+| Run | Window | Throughput | CPU % (1-core) | Working set | Dropped / ETW-lost | Verdict |
+|-----|--------|-----------|----------------|-------------|--------------------|---------|
+| 1 | 12 s | ≈3,950 evt/s | **0.39 %** | ~10 MB¹ | 0 / 0 | within 1.0% budget |
+| 2 | **10 min** | **≈10,158 evt/s** | **0.487 %** | **~9–12 MB (flat)** | **0 / 0** | **within 1.0% budget** |
+
+This is the **real consume+decode-sample+attribute cost**, superseding #2540's
+enablement-only 0.00–0.05% figure. Run 2 sustained **10.1k events/s for 10 minutes**
+— 2.5× run 1's rate — at **0.487% of one core**, still comfortably under the 1.0%
+budget, with **zero dropped and zero ETW-lost events** (6,094,835 consumed, all
+drained). Working set held **flat at ~9–12 MB** the whole run (per the periodic
+samples), so consumption does not grow unbounded with volume.
+
+¹ Run 1 reported a transient 51 MB working-set reading at teardown; the 10-minute
+run's periodic sampling shows the steady-state working set is **~10 MB**, which is
+the reliable figure. Embedded in the already-running steward the marginal cost is
+smaller still.
+
+## Part 5 — Sustained ≥10-minute stability — PROVEN
+
+**Run 2 (600 s window, all 5 providers, launched detached in the steward SYSTEM
+context):**
+
+| Metric | Value |
+|--------|-------|
+| Duration | **600.0 s** |
+| Events consumed (`total_seen` == `total_drained`) | **6,094,835** |
+| Ring-full drops | **0** |
+| ETW kernel lost events / buffers lost | **0 / 0** |
+| Sustained throughput | **≈10,158 events/s** |
+| CPU | **0.487 %** of one core (within budget) |
+| Working set | **~9–12 MB, flat** across all 20 periodic samples |
+| Distinct PIDs attributed | **1,010** |
+| Runtime crash | **none** (`crashed: false`) |
+
+The 20 in-run working-set samples (one per 30 s) range **9.3–12.0 MB with no
+upward trend** — memory is bounded and actually settles *lower* in the back half
+as caches stabilise. Over 6 million events in 10 minutes were consumed with **zero
+loss** and **no crash**. Sustained stability under real high-rate load is proven.
+
+## Part 6 — Session-0 UX-signal reachability — BLOCKED (needs a per-session path)
+
+Win32k (app-hang / UI-responsiveness) was enabled in every run and emitted
+**0 events** (`per_provider` Win32k = 0), confirming #2540: the steward runs as a
+`LocalSystem` service in **session 0**, and the Win32k/DWM UI-responsiveness and
+app-hang signals are **desktop-session** signals that do not emit in a service
+session, regardless of privilege or of the (now-working) consumer. This is a
+Windows platform fact: the consumer is not the limitation — the events are not
+produced in session 0.
+
+**Determination:** the "employee experience" half of DEX (app-hang, UI
+responsiveness) **cannot be sourced from the steward's own service session** via
+either raw ETW or Event Log. It requires a **per-session component** (a per-user
+session agent, or a session-attached helper) — a distinct acquisition path from
+the in-steward collector this spike validates. Machine-health signals (disk,
+faults, file, DNS, WMI SMART/thermal) have no such limitation.
+
+## Cross-cutting — behavioral-envelope fit
+
+The chosen architecture fits the steward threat model (CLAUDE.md): the consumer is
+a declared ETW real-time session over in-box providers, no obfuscation, no
+in-memory tricks, no runtime code composition. The C callback is ordinary compiled
+code in the (signed) binary. A production consumer would compile this same
+C-callback path into the signed steward or a signed module binary — no
+out-of-process helper is required (candidate (c) avoids the second-binary +
+signing surface that (b) would add). cgo is a **build-time** consideration
+(CGO_ENABLED=1 for the DEX build target); the PoC keeps it fully isolated behind
+the `dexconsume` tag so the current CGO_ENABLED=0 steward build is unaffected.
+
+## Recommended consume architecture
+
+1. **In-process, non-reentrant C callback → C ring → Go drain** (candidate (c)).
+   Proven stable and cheap. This is the load-bearing recommendation.
+2. **Decode selectively, off the hot path.** TDH per-event is expensive; the hot
+   callback should stay header-only (+ raw payload copy where a signal needs it),
+   and decode only the specific events a configured signal consumes.
+3. **Attribute on the drain side** (PID → image/user), cached per PID.
+4. **Machine-health signals** (disk/fault/file/DNS/SMART/thermal) → this in-steward
+   collector. **UX signals** (app-hang/UI-responsiveness) → a separate per-session
+   component (Part 6); do not block the machine-health track on it.
+
+## Reproduction
+
+```bash
+# Build the throwaway consumer binary (Windows, cgo):
+CGO_ENABLED=1 go test -c -tags dexconsume -o dex-consume.test.exe ./features/steward/dex/
+
+# Run it in the steward SYSTEM context (holds StartTrace). Short window inline:
+cfg steward exec <steward-id> --shell pwsh --timeout 90s --command \
+  "$env:DEX_CONSUME_SEC='12'; Start-Process -FilePath 'C:\path\dex-consume.test.exe' \
+   -ArgumentList '-test.run','TestDexConsumeLive' -RedirectStandardOutput 'C:\path\out.txt' \
+   -Wait -NoNewWindow"
+# then read out.txt (JSON between <<<DEX_CONSUME_JSON>>> markers)
+
+# Long (10-min) window: launch DETACHED (no -Wait), read the file back after ~10 min
+# (the inline-exec job has a ~15-30s runtime cap; the detached child runs as SYSTEM).
+```
+
+Non-elevated the binary reports `StartTraceW: Access is denied. (code 5)` and
+consumes nothing (privilege-skip path) — it still builds and runs anywhere.

--- a/features/steward/dex/consume_etw_windows.c
+++ b/features/steward/dex/consume_etw_windows.c
@@ -153,8 +153,15 @@ static void tdh_decode_one(PEVENT_RECORD ev, int provider_idx) {
             case TDH_INTYPE_POINTER: decode_appendf("%s=%llu;", nameA, (unsigned long long)*(UINT64 *)buf); emitted++; break;
             case TDH_INTYPE_INT64:  decode_appendf("%s=%lld;", nameA, (long long)*(INT64 *)buf); emitted++; break;
             case TDH_INTYPE_UNICODESTRING: {
+                // Bound the wide-char scan to the property's own byte length: TDH does
+                // NOT guarantee a terminating NUL within propSize, so passing -1 would
+                // let WideCharToMultiByte read past buf[512]. Convert exactly the
+                // wchars the property holds, then NUL-terminate the output ourselves.
                 char sval[256];
-                if (WideCharToMultiByte(CP_UTF8, 0, (WCHAR *)buf, -1, sval, sizeof(sval), NULL, NULL) > 0) {
+                int wch = (int)(propSize / sizeof(WCHAR));
+                int w = WideCharToMultiByte(CP_UTF8, 0, (WCHAR *)buf, wch, sval, (int)sizeof(sval) - 1, NULL, NULL);
+                if (w > 0) {
+                    sval[w] = '\0';
                     decode_appendf("%s=%s;", nameA, sval); emitted++;
                 }
                 break;
@@ -173,31 +180,56 @@ static void tdh_decode_one(PEVENT_RECORD ev, int provider_idx) {
 
 // ─── the callback (pure C, never re-enters Go) ───────────────────────────────
 
-static void WINAPI cfgms_event_cb(PEVENT_RECORD ev) {
+// ring_push is the single producer-side enqueue: it counts the event and writes
+// it to the ring (or increments dropped_ring when full). Shared by the ETW
+// callback and the test hook so both exercise the identical SPSC write path.
+static void ring_push(uint64_t timestamp, uint32_t pid, uint32_t tid,
+                      uint16_t provider_idx, uint16_t event_id, uint8_t opcode) {
     __atomic_add_fetch(&g_total_seen, 1, __ATOMIC_RELAXED);
-
-    int decode_target = 0;
-    int pidx = provider_lookup(&ev->EventHeader.ProviderId, &decode_target);
 
     unsigned int head = __atomic_load_n(&g_head, __ATOMIC_RELAXED);
     unsigned int tail = __atomic_load_n(&g_tail, __ATOMIC_ACQUIRE);
     if ((head - tail) >= RING_CAP) {
         __atomic_add_fetch(&g_dropped_ring, 1, __ATOMIC_RELAXED);
-    } else {
-        CfgmsEvent *slot = &g_ring[head & RING_MASK];
-        slot->timestamp    = (uint64_t)ev->EventHeader.TimeStamp.QuadPart;
-        slot->pid          = ev->EventHeader.ProcessId;
-        slot->tid          = ev->EventHeader.ThreadId;
-        slot->provider_idx = (uint16_t)pidx;
-        slot->event_id     = ev->EventHeader.EventDescriptor.Id;
-        slot->opcode       = ev->EventHeader.EventDescriptor.Opcode;
-        __atomic_store_n(&g_head, head + 1, __ATOMIC_RELEASE);
+        return;
     }
+    CfgmsEvent *slot = &g_ring[head & RING_MASK];
+    slot->timestamp    = timestamp;
+    slot->pid          = pid;
+    slot->tid          = tid;
+    slot->provider_idx = provider_idx;
+    slot->event_id     = event_id;
+    slot->opcode       = opcode;
+    __atomic_store_n(&g_head, head + 1, __ATOMIC_RELEASE);
+}
+
+static void WINAPI cfgms_event_cb(PEVENT_RECORD ev) {
+    int decode_target = 0;
+    int pidx = provider_lookup(&ev->EventHeader.ProviderId, &decode_target);
+
+    ring_push((uint64_t)ev->EventHeader.TimeStamp.QuadPart,
+              ev->EventHeader.ProcessId, ev->EventHeader.ThreadId,
+              (uint16_t)pidx, ev->EventHeader.EventDescriptor.Id,
+              ev->EventHeader.EventDescriptor.Opcode);
 
     if (decode_target && g_decode_count < DECODE_CAP) {
         g_decode_count++;
         tdh_decode_one(ev, pidx);
     }
+}
+
+void cfgms_test_enqueue(unsigned int pid, unsigned short provider_idx, unsigned short event_id) {
+    ring_push(0, pid, 0, provider_idx, event_id, 0);
+}
+
+void cfgms_reset(void) {
+    __atomic_store_n(&g_head, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&g_tail, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&g_total_seen, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&g_dropped_ring, 0, __ATOMIC_RELAXED);
+    g_provider_count = 0;
+    g_decode_len = 0;
+    g_decode_count = 0;
 }
 
 // ─── run / stop ──────────────────────────────────────────────────────────────

--- a/features/steward/dex/consume_etw_windows.c
+++ b/features/steward/dex/consume_etw_windows.c
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows && dexconsume
+
+// consume_etw_windows.c — non-reentrant C-callback ETW consumer (#2571).
+// See consume_etw_windows.h for the architecture rationale.
+
+#include <windows.h>
+#include <evntrace.h>
+#include <evntcons.h>
+#include <tdh.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "consume_etw_windows.h"
+
+// mingw-w64's tdh.h declares the TDH functions and structs but not the
+// _TDH_IN_TYPE enum. These are stable, documented Windows values — define the
+// ones we decode, guarded so a future mingw that adds them does not conflict.
+#ifndef TDH_INTYPE_UNICODESTRING
+#define TDH_INTYPE_UNICODESTRING 1
+#define TDH_INTYPE_ANSISTRING    2
+#define TDH_INTYPE_INT8          3
+#define TDH_INTYPE_UINT8         4
+#define TDH_INTYPE_INT16         5
+#define TDH_INTYPE_UINT16        6
+#define TDH_INTYPE_INT32         7
+#define TDH_INTYPE_UINT32        8
+#define TDH_INTYPE_INT64         9
+#define TDH_INTYPE_UINT64        10
+#define TDH_INTYPE_POINTER       16
+#define TDH_INTYPE_HEXINT32      20
+#define TDH_INTYPE_HEXINT64      21
+#endif
+
+// ─── SPSC ring buffer ────────────────────────────────────────────────────────
+// One producer (the ProcessTrace callback thread) and one consumer (the Go drain
+// goroutine). Power-of-two capacity; head published with release, tail with
+// release, cross-reads with acquire.
+
+#define RING_CAP   (1u << 16)   // 65536 slots
+#define RING_MASK  (RING_CAP - 1u)
+
+static CfgmsEvent   g_ring[RING_CAP];
+static volatile unsigned int g_head = 0; // producer writes
+static volatile unsigned int g_tail = 0; // consumer writes
+
+static volatile long long g_total_seen   = 0;
+static volatile long long g_dropped_ring = 0;
+
+// ─── provider registry (for the callback's GUID -> idx stamp) ────────────────
+
+#define MAX_PROVIDERS 16
+typedef struct {
+    unsigned char guid[16];
+    int           idx;
+    int           decode_target;
+} ProviderEntry;
+static ProviderEntry g_providers[MAX_PROVIDERS];
+static int           g_provider_count = 0;
+
+void cfgms_register_provider(const unsigned char *guid16, int idx, int is_decode_target) {
+    if (g_provider_count >= MAX_PROVIDERS) return;
+    memcpy(g_providers[g_provider_count].guid, guid16, 16);
+    g_providers[g_provider_count].idx = idx;
+    g_providers[g_provider_count].decode_target = is_decode_target;
+    g_provider_count++;
+}
+
+static int provider_lookup(const GUID *g, int *decode_target) {
+    for (int i = 0; i < g_provider_count; i++) {
+        if (memcmp(&g_providers[i].guid[0], g, 16) == 0) {
+            if (decode_target) *decode_target = g_providers[i].decode_target;
+            return g_providers[i].idx;
+        }
+    }
+    if (decode_target) *decode_target = 0;
+    return 0xFFFF;
+}
+
+// ─── bounded TDH decode sample (Part 2 proof) ────────────────────────────────
+// The callback TDH-decodes only the first DECODE_CAP target-provider events into
+// a text buffer, so the hot path stays header-only. Read from Go after the run
+// (single-threaded producer, no concurrent reader during the run).
+
+#define DECODE_CAP      64
+#define DECODE_BUF_SIZE (64 * 1024)
+static char g_decode_buf[DECODE_BUF_SIZE];
+static int  g_decode_len   = 0;
+static int  g_decode_count = 0;
+
+static void decode_appendf(const char *fmt, ...) {
+    if (g_decode_len >= DECODE_BUF_SIZE - 1) return;
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(g_decode_buf + g_decode_len, DECODE_BUF_SIZE - g_decode_len, fmt, ap);
+    va_end(ap);
+    if (n > 0) g_decode_len += n;
+    if (g_decode_len > DECODE_BUF_SIZE - 1) g_decode_len = DECODE_BUF_SIZE - 1;
+}
+
+// tdh_decode_one enumerates the top-level properties of one event and appends
+// "Name=Value;" pairs for the common scalar/string in-types. Best-effort: an
+// unrecognised type is skipped. Never allocates unboundedly; caps per-event work.
+static void tdh_decode_one(PEVENT_RECORD ev, int provider_idx) {
+    DWORD infoSize = 0;
+    ULONG st = TdhGetEventInformation(ev, 0, NULL, NULL, &infoSize);
+    if (st != ERROR_INSUFFICIENT_BUFFER) return;
+    PTRACE_EVENT_INFO info = (PTRACE_EVENT_INFO)malloc(infoSize);
+    if (!info) return;
+    st = TdhGetEventInformation(ev, 0, NULL, info, &infoSize);
+    if (st != ERROR_SUCCESS) { free(info); return; }
+
+    decode_appendf("%d|%u|", provider_idx, (unsigned)ev->EventHeader.EventDescriptor.Id);
+
+    int emitted = 0;
+    ULONG count = info->TopLevelPropertyCount;
+    if (count > 12) count = 12; // bound per-event work
+    for (ULONG i = 0; i < count; i++) {
+        EVENT_PROPERTY_INFO *pi = &info->EventPropertyInfoArray[i];
+        // Skip structs and array-typed properties for the sample (scalars/strings only).
+        if (pi->Flags & (PropertyStruct | PropertyParamCount)) continue;
+
+        const WCHAR *nameW = (const WCHAR *)((PBYTE)info + pi->NameOffset);
+        char nameA[128];
+        int nn = WideCharToMultiByte(CP_UTF8, 0, nameW, -1, nameA, sizeof(nameA), NULL, NULL);
+        if (nn <= 0) continue;
+
+        PROPERTY_DATA_DESCRIPTOR pdd;
+        pdd.PropertyName = (ULONGLONG)(ULONG_PTR)nameW;
+        pdd.ArrayIndex   = 0;
+        pdd.Reserved     = 0;
+
+        DWORD propSize = 0;
+        if (TdhGetPropertySize(ev, 0, NULL, 1, &pdd, &propSize) != ERROR_SUCCESS) continue;
+        if (propSize == 0 || propSize > 512) continue;
+        BYTE buf[512];
+        if (TdhGetProperty(ev, 0, NULL, 1, &pdd, propSize, buf) != ERROR_SUCCESS) continue;
+
+        USHORT inType = pi->nonStructType.InType;
+        switch (inType) {
+            case TDH_INTYPE_UINT8:  decode_appendf("%s=%u;", nameA, (unsigned)*(UINT8 *)buf); emitted++; break;
+            case TDH_INTYPE_INT8:   decode_appendf("%s=%d;", nameA, (int)*(INT8 *)buf); emitted++; break;
+            case TDH_INTYPE_UINT16: decode_appendf("%s=%u;", nameA, (unsigned)*(UINT16 *)buf); emitted++; break;
+            case TDH_INTYPE_INT16:  decode_appendf("%s=%d;", nameA, (int)*(INT16 *)buf); emitted++; break;
+            case TDH_INTYPE_UINT32:
+            case TDH_INTYPE_HEXINT32: decode_appendf("%s=%lu;", nameA, (unsigned long)*(UINT32 *)buf); emitted++; break;
+            case TDH_INTYPE_INT32:  decode_appendf("%s=%ld;", nameA, (long)*(INT32 *)buf); emitted++; break;
+            case TDH_INTYPE_UINT64:
+            case TDH_INTYPE_HEXINT64:
+            case TDH_INTYPE_POINTER: decode_appendf("%s=%llu;", nameA, (unsigned long long)*(UINT64 *)buf); emitted++; break;
+            case TDH_INTYPE_INT64:  decode_appendf("%s=%lld;", nameA, (long long)*(INT64 *)buf); emitted++; break;
+            case TDH_INTYPE_UNICODESTRING: {
+                char sval[256];
+                if (WideCharToMultiByte(CP_UTF8, 0, (WCHAR *)buf, -1, sval, sizeof(sval), NULL, NULL) > 0) {
+                    decode_appendf("%s=%s;", nameA, sval); emitted++;
+                }
+                break;
+            }
+            case TDH_INTYPE_ANSISTRING:
+                decode_appendf("%s=%.200s;", nameA, (char *)buf); emitted++;
+                break;
+            default:
+                break; // unrecognised scalar type — skip for the sample
+        }
+        if (emitted >= 6) break; // enough named fields to prove decode
+    }
+    decode_appendf("\n");
+    free(info);
+}
+
+// ─── the callback (pure C, never re-enters Go) ───────────────────────────────
+
+static void WINAPI cfgms_event_cb(PEVENT_RECORD ev) {
+    __atomic_add_fetch(&g_total_seen, 1, __ATOMIC_RELAXED);
+
+    int decode_target = 0;
+    int pidx = provider_lookup(&ev->EventHeader.ProviderId, &decode_target);
+
+    unsigned int head = __atomic_load_n(&g_head, __ATOMIC_RELAXED);
+    unsigned int tail = __atomic_load_n(&g_tail, __ATOMIC_ACQUIRE);
+    if ((head - tail) >= RING_CAP) {
+        __atomic_add_fetch(&g_dropped_ring, 1, __ATOMIC_RELAXED);
+    } else {
+        CfgmsEvent *slot = &g_ring[head & RING_MASK];
+        slot->timestamp    = (uint64_t)ev->EventHeader.TimeStamp.QuadPart;
+        slot->pid          = ev->EventHeader.ProcessId;
+        slot->tid          = ev->EventHeader.ThreadId;
+        slot->provider_idx = (uint16_t)pidx;
+        slot->event_id     = ev->EventHeader.EventDescriptor.Id;
+        slot->opcode       = ev->EventHeader.EventDescriptor.Opcode;
+        __atomic_store_n(&g_head, head + 1, __ATOMIC_RELEASE);
+    }
+
+    if (decode_target && g_decode_count < DECODE_CAP) {
+        g_decode_count++;
+        tdh_decode_one(ev, pidx);
+    }
+}
+
+// ─── run / stop ──────────────────────────────────────────────────────────────
+
+static TRACEHANDLE g_trace = (TRACEHANDLE)INVALID_HANDLE_VALUE;
+
+unsigned long cfgms_run(const unsigned short *sessionNameW) {
+    EVENT_TRACE_LOGFILEW log;
+    ZeroMemory(&log, sizeof(log));
+    log.LoggerName          = (LPWSTR)sessionNameW;
+    log.ProcessTraceMode    = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD;
+    log.EventRecordCallback = cfgms_event_cb;
+
+    TRACEHANDLE h = OpenTraceW(&log);
+    if (h == (TRACEHANDLE)INVALID_HANDLE_VALUE) {
+        return GetLastError();
+    }
+    g_trace = h;
+
+    ULONG st = ProcessTrace(&h, 1, NULL, NULL);
+    return st;
+}
+
+void cfgms_stop(void) {
+    if (g_trace != (TRACEHANDLE)INVALID_HANDLE_VALUE) {
+        CloseTrace(g_trace);
+        g_trace = (TRACEHANDLE)INVALID_HANDLE_VALUE;
+    }
+}
+
+// ─── drain / counters / decode sample ────────────────────────────────────────
+
+int cfgms_drain(CfgmsEvent *out, int max) {
+    unsigned int tail = __atomic_load_n(&g_tail, __ATOMIC_RELAXED);
+    unsigned int head = __atomic_load_n(&g_head, __ATOMIC_ACQUIRE);
+    int n = 0;
+    while (tail != head && n < max) {
+        out[n] = g_ring[tail & RING_MASK];
+        tail++;
+        n++;
+    }
+    __atomic_store_n(&g_tail, tail, __ATOMIC_RELEASE);
+    return n;
+}
+
+unsigned long long cfgms_total_seen(void)   { return (unsigned long long)__atomic_load_n(&g_total_seen, __ATOMIC_RELAXED); }
+unsigned long long cfgms_dropped_ring(void) { return (unsigned long long)__atomic_load_n(&g_dropped_ring, __ATOMIC_RELAXED); }
+
+char *cfgms_decode_sample(void) {
+    if (g_decode_len == 0) return NULL;
+    char *out = (char *)malloc(g_decode_len + 1);
+    if (!out) return NULL;
+    memcpy(out, g_decode_buf, g_decode_len);
+    out[g_decode_len] = '\0';
+    return out;
+}
+
+void cfgms_free(char *p) { free(p); }

--- a/features/steward/dex/consume_etw_windows.c
+++ b/features/steward/dex/consume_etw_windows.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
 
-//go:build windows && dexconsume
+//go:build windows && dexconsume && !dexrust
 
 // consume_etw_windows.c — non-reentrant C-callback ETW consumer (#2571).
 // See consume_etw_windows.h for the architecture rationale.

--- a/features/steward/dex/consume_etw_windows.h
+++ b/features/steward/dex/consume_etw_windows.h
@@ -48,8 +48,18 @@ unsigned long cfgms_run(const unsigned short *sessionNameW);
 // cfgms_stop closes the trace so ProcessTrace returns. Safe to call once.
 void cfgms_stop(void);
 
+// cfgms_reset clears all whole-run C state (ring indices, counters, provider
+// registry, decode sample) so a process may run more than one consume window.
+// Call before registering providers for a fresh run.
+void cfgms_reset(void);
+
 // cfgms_drain pops up to max events from the ring into out; returns the count.
 int cfgms_drain(CfgmsEvent *out, int max);
+
+// cfgms_test_enqueue pushes one synthetic event through the exact producer path
+// the callback uses (ring write + total_seen / dropped_ring accounting), so the
+// SPSC ring + drain can be unit-tested without ETW privilege. Test-only.
+void cfgms_test_enqueue(unsigned int pid, unsigned short provider_idx, unsigned short event_id);
 
 // Counters (monotonic, whole-run):
 unsigned long long cfgms_total_seen(void);   // events the callback observed

--- a/features/steward/dex/consume_etw_windows.h
+++ b/features/steward/dex/consume_etw_windows.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// consume_etw_windows.h — C side of the DEX in-process ETW consumer PoC (#2571).
+//
+// This is the non-reentrant C-callback architecture (candidate (c) in the story):
+// the ETW EventRecordCallback is a pure C function that copies a compact,
+// fixed-size header record into a single-producer/single-consumer ring buffer and
+// NEVER calls back into Go. A Go goroutine drains the ring. Because the hot
+// callback path is C→C only, the native→Go transition (cgocallbackg) that
+// corrupts the Go runtime's sudog cache under high-rate ETW callbacks (#2517) is
+// never taken.
+//
+// Only compiled behind the `dexconsume` build tag (throwaway spike; never in the
+// production steward path).
+
+#ifndef CFGMS_DEX_CONSUME_H
+#define CFGMS_DEX_CONSUME_H
+
+#include <stdint.h>
+
+// CfgmsEvent is the compact per-event record the C callback copies into the ring.
+// Header-only: the hot path never decodes (decode is a bounded sample; see below),
+// so this stays cheap to produce at high rate. Attribution (pid -> image) happens
+// on the Go drain side.
+typedef struct CfgmsEvent {
+    uint64_t timestamp;    // EVENT_HEADER.TimeStamp (raw QPC/FILETIME units)
+    uint32_t pid;          // EVENT_HEADER.ProcessId
+    uint32_t tid;          // EVENT_HEADER.ThreadId
+    uint16_t provider_idx; // index registered via cfgms_register_provider (0xFFFF = unknown)
+    uint16_t event_id;     // EVENT_DESCRIPTOR.Id
+    uint8_t  opcode;       // EVENT_DESCRIPTOR.Opcode
+    uint8_t  _pad[3];
+} CfgmsEvent;
+
+// cfgms_register_provider maps a provider GUID (16 raw bytes, in windows.GUID
+// memory order) to a small index the callback stamps into each record. If
+// is_decode_target != 0, the callback also TDH-decodes a bounded sample of this
+// provider's events (Part 2 proof). Call before cfgms_run.
+void cfgms_register_provider(const unsigned char *guid16, int idx, int is_decode_target);
+
+// cfgms_run opens the named real-time session and runs ProcessTrace. It BLOCKS on
+// the calling thread (the Go caller runs it on a LockOSThread goroutine) until
+// cfgms_stop is called or the session ends. Returns the Win32 status from
+// ProcessTrace (ERROR_SUCCESS or ERROR_CANCELLED on a clean stop).
+unsigned long cfgms_run(const unsigned short *sessionNameW);
+
+// cfgms_stop closes the trace so ProcessTrace returns. Safe to call once.
+void cfgms_stop(void);
+
+// cfgms_drain pops up to max events from the ring into out; returns the count.
+int cfgms_drain(CfgmsEvent *out, int max);
+
+// Counters (monotonic, whole-run):
+unsigned long long cfgms_total_seen(void);   // events the callback observed
+unsigned long long cfgms_dropped_ring(void); // events dropped because the ring was full
+
+// cfgms_decode_sample returns a malloc'd, NUL-terminated UTF-8 string: one line
+// per TDH-decoded sample event, "provider_idx|event_id|Name=Value;Name=Value;...".
+// Proof that we extract structured named fields (not just a count). Free with
+// cfgms_free. Returns NULL if nothing was decoded.
+char *cfgms_decode_sample(void);
+void  cfgms_free(char *p);
+
+#endif // CFGMS_DEX_CONSUME_H

--- a/features/steward/dex/consume_live_windows_test.go
+++ b/features/steward/dex/consume_live_windows_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows && dexconsume
+
+// consume_live_windows_test.go — runnable entry for the DEX consume PoC (#2571).
+//
+// This is NOT an ordinary unit test: it is the spike's live runner, gated behind
+// the `dexconsume` build tag so it never compiles into normal builds or the
+// production steward. Build it into a standalone binary and run it in the steward
+// SYSTEM context (which holds the ETW StartTrace privilege):
+//
+//	CGO_ENABLED=1 go test -c -tags dexconsume -o dex-consume.test.exe ./features/steward/dex/
+//	# then, as SYSTEM via `cfg steward exec` (env selects the window/providers):
+//	dex-consume.test.exe -test.run TestDexConsumeLive -test.v
+//
+// Non-privileged it degrades cleanly: StartTrace is denied and the report carries
+// SessionStartErr, so the binary still builds and runs anywhere. Config is via
+// environment so it survives the detached Start-Process long-run path.
+package dex
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return def
+}
+
+func envList(key string) []string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestDexConsumeLive runs one consume window and prints the JSON report between
+// stable markers so a caller can extract it from mixed test-framework output.
+func TestDexConsumeLive(t *testing.T) {
+	dur := envDuration("DEX_CONSUME_SEC", 20*time.Second)
+	providers := envList("DEX_CONSUME_PROVIDERS")
+	session := "cfgms-dex-consume-" + strconv.Itoa(os.Getpid())
+
+	report := RunConsume(context.Background(), ConsumeConfig{
+		SessionName: session,
+		Duration:    dur,
+		Providers:   providers,
+	})
+
+	fmt.Println("<<<DEX_CONSUME_JSON>>>")
+	fmt.Println(MarshalReport(report))
+	fmt.Println("<<<END_DEX_CONSUME_JSON>>>")
+
+	if report.SessionStartErr != "" {
+		t.Logf("session did not start (expected when not privileged): %s", report.SessionStartErr)
+		return
+	}
+	t.Logf("consumed: total_seen=%d drained=%d dropped_ring=%d etw_lost=%d throughput/s=%.0f cpu%%=%.3f wsMB=%.1f",
+		report.TotalSeen, report.TotalDrained, report.DroppedRing, report.ETWEventsLost,
+		report.ThroughputPerSec, report.CPUPercent, report.WorkingSetMB)
+}

--- a/features/steward/dex/consume_ring_windows_test.go
+++ b/features/steward/dex/consume_ring_windows_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows && dexconsume
+
+// Non-live coverage of the SPSC ring buffer — the load-bearing concurrent core —
+// exercised through the same producer path the ETW callback uses (via the
+// ringTest* wrappers in consume_ringtest_windows.go), with no ETW privilege.
+package dex
+
+import "testing"
+
+// ringCap mirrors RING_CAP in consume_etw_windows.c.
+const ringCap = 1 << 16
+
+func TestRing_PushDrainFIFO(t *testing.T) {
+	ringTestReset()
+
+	const n = 1000
+	for i := 0; i < n; i++ {
+		ringTestEnqueue(uint32(1000+i), uint16(i%4), uint16(i))
+	}
+
+	got := ringTestDrain(4096)
+	if len(got) != n {
+		t.Fatalf("drained %d events, want %d", len(got), n)
+	}
+	// Events come out in FIFO order with the fields the producer wrote.
+	for i := 0; i < n; i++ {
+		if got[i].PID != uint32(1000+i) {
+			t.Fatalf("event %d: pid=%d, want %d (FIFO order broken)", i, got[i].PID, 1000+i)
+		}
+		if got[i].EventID != uint16(i) {
+			t.Fatalf("event %d: event_id=%d, want %d", i, got[i].EventID, i)
+		}
+		if got[i].ProviderIdx != uint16(i%4) {
+			t.Fatalf("event %d: provider_idx=%d, want %d", i, got[i].ProviderIdx, i%4)
+		}
+	}
+	if seen := ringTestTotalSeen(); seen != n {
+		t.Fatalf("total_seen=%d, want %d", seen, n)
+	}
+	if dropped := ringTestDroppedRing(); dropped != 0 {
+		t.Fatalf("dropped_ring=%d, want 0", dropped)
+	}
+	// A second drain on an empty ring returns nothing.
+	if got := ringTestDrain(4096); len(got) != 0 {
+		t.Fatalf("second drain returned %d, want 0", len(got))
+	}
+}
+
+func TestRing_DropsWhenFull(t *testing.T) {
+	ringTestReset()
+
+	const extra = 500
+	for i := 0; i < ringCap+extra; i++ {
+		ringTestEnqueue(uint32(i), 0, 0)
+	}
+	// Every event is seen; exactly the overflow beyond capacity is dropped.
+	if seen := ringTestTotalSeen(); seen != ringCap+extra {
+		t.Fatalf("total_seen=%d, want %d", seen, ringCap+extra)
+	}
+	if dropped := ringTestDroppedRing(); dropped != extra {
+		t.Fatalf("dropped_ring=%d, want %d", dropped, extra)
+	}
+	// The ring holds exactly its capacity for the consumer to drain.
+	if got := ringTestDrain(ringCap); len(got) != ringCap {
+		t.Fatalf("drained %d, want %d (full ring)", len(got), ringCap)
+	}
+}
+
+func TestRing_ResetClearsState(t *testing.T) {
+	ringTestReset()
+	for i := 0; i < 10; i++ {
+		ringTestEnqueue(uint32(i), 0, 0)
+	}
+	ringTestReset()
+	if seen := ringTestTotalSeen(); seen != 0 {
+		t.Fatalf("reset must zero total_seen: got %d", seen)
+	}
+	if got := ringTestDrain(16); len(got) != 0 {
+		t.Fatalf("reset must empty the ring: drained %d", len(got))
+	}
+}

--- a/features/steward/dex/consume_ringtest_windows.go
+++ b/features/steward/dex/consume_ringtest_windows.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows && dexconsume
+
+// Test-support wrappers around the C ring primitives. cgo cannot be used directly
+// in _test.go files, so these thin Go shims live in a regular (tagged) file and
+// are called from consume_ring_windows_test.go to exercise the SPSC ring + drain
+// without ETW privilege.
+package dex
+
+/*
+#include "consume_etw_windows.h"
+*/
+import "C"
+
+// ringEvent is the Go view of a drained CfgmsEvent, for test assertions.
+type ringEvent struct {
+	Timestamp   uint64
+	PID         uint32
+	TID         uint32
+	ProviderIdx uint16
+	EventID     uint16
+	Opcode      uint8
+}
+
+func ringTestReset()              { C.cfgms_reset() }
+func ringTestTotalSeen() uint64   { return uint64(C.cfgms_total_seen()) }
+func ringTestDroppedRing() uint64 { return uint64(C.cfgms_dropped_ring()) }
+
+func ringTestEnqueue(pid uint32, providerIdx, eventID uint16) {
+	C.cfgms_test_enqueue(C.uint(pid), C.ushort(providerIdx), C.ushort(eventID))
+}
+
+func ringTestDrain(max int) []ringEvent {
+	buf := make([]C.CfgmsEvent, max)
+	n := int(C.cfgms_drain(&buf[0], C.int(max)))
+	out := make([]ringEvent, n)
+	for i := 0; i < n; i++ {
+		out[i] = ringEvent{
+			Timestamp:   uint64(buf[i].timestamp),
+			PID:         uint32(buf[i].pid),
+			TID:         uint32(buf[i].tid),
+			ProviderIdx: uint16(buf[i].provider_idx),
+			EventID:     uint16(buf[i].event_id),
+			Opcode:      uint8(buf[i].opcode),
+		}
+	}
+	return out
+}

--- a/features/steward/dex/consume_rust_link_windows.go
+++ b/features/steward/dex/consume_rust_link_windows.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows && dexconsume && dexrust
+
+// consume_rust_link_windows.go — links the Rust variant of the ETW consumer
+// (features/steward/dex/rust/) instead of the C one, under the `dexrust` build
+// tag. The Rust staticlib exports the identical cfgms_* C ABI, so the Go wrapper
+// (consume_windows.go) is reused unchanged — only the native implementation and
+// its link flags differ. consume_etw_windows.c is excluded under this tag
+// (`//go:build ... && !dexrust`) so there is no duplicate-symbol clash.
+//
+// Build the staticlib first: (cd rust && cargo build --release), stage its .a
+// plus the windows-sys umbrella import lib into rust/link/, then
+//
+//	go test -c -tags "dexconsume dexrust" ./features/steward/dex/
+//
+// The libs Rust std needs come from `cargo rustc -- --print native-static-libs`.
+package dex
+
+// #cgo LDFLAGS: -L${SRCDIR}/rust/link -ldexetw -lwindows.0.52.0 -lntdll -luserenv -lws2_32 -ldbghelp
+import "C"

--- a/features/steward/dex/consume_windows.go
+++ b/features/steward/dex/consume_windows.go
@@ -160,6 +160,7 @@ type ConsumeReport struct {
 	WithinBudget     bool             `json:"within_budget"`
 	WorkingSetMB     float64          `json:"working_set_mb"`
 	MemSamples       []MemSample      `json:"mem_samples,omitempty"` // periodic trend (Part 5)
+	ProcessTraceStat uint32           `json:"process_trace_status"`  // ProcessTrace return (0=SUCCESS, 1223=CANCELLED on clean stop)
 	Crashed          bool             `json:"crashed"`               // always false if we returned (proof of no runtime crash)
 }
 
@@ -226,6 +227,11 @@ func RunConsume(ctx context.Context, cfg ConsumeConfig) ConsumeReport {
 		report.ProvidersEnabled = append(report.ProvidersEnabled, p.name)
 	}
 
+	// Clear any C-global state from a prior run in this process so a second
+	// RunConsume call starts clean (fresh ring indices, counters, provider
+	// registry, decode sample).
+	C.cfgms_reset()
+
 	// 1. Start the real-time session.
 	handle, err := startNamedTrace(cfg.SessionName, eventTraceRealTimeMode)
 	if err != nil {
@@ -267,12 +273,13 @@ func RunConsume(ctx context.Context, cfg ConsumeConfig) ConsumeReport {
 	copy((*[1 << 16]byte)(cName)[:len(nameUTF16)*2], (*[1 << 16]byte)(unsafe.Pointer(&nameUTF16[0]))[:len(nameUTF16)*2])
 
 	var producerWG sync.WaitGroup
+	var runStatus C.ulong
 	producerWG.Add(1)
 	go func() {
 		defer producerWG.Done()
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
-		C.cfgms_run((*C.ushort)(cName))
+		runStatus = C.cfgms_run((*C.ushort)(cName))
 	}()
 
 	// 4. Drain loop for the window (attribute + count).
@@ -340,7 +347,8 @@ drainLoop:
 	C.cfgms_stop()                              // CloseTrace → ProcessTrace returns
 	_ = stopNamedTrace(handle, cfg.SessionName) //nolint:errcheck // best-effort teardown
 	producerWG.Wait()
-	drain() // final sweep of anything left in the ring
+	report.ProcessTraceStat = uint32(runStatus) // safe: happens-after producerWG.Wait
+	drain()                                     // final sweep of anything left in the ring
 
 	cpuAfter, _ := processTimesNs()
 	wallElapsed := time.Since(wallBefore).Seconds()

--- a/features/steward/dex/consume_windows.go
+++ b/features/steward/dex/consume_windows.go
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows && dexconsume
+
+// consume_windows.go — Go side of the DEX in-process ETW consume feasibility PoC
+// (#2571). Drives the non-reentrant C-callback consumer (consume_etw_windows.c):
+// starts a real-time ETW session (reusing the collector's session/provider
+// helpers), runs C ProcessTrace on a locked-OS-thread goroutine, and drains the
+// C ring on a separate goroutine — counting, attributing (pid -> image), and
+// measuring real overhead at volume.
+//
+// Behind the `dexconsume` build tag: this is a throwaway spike that pulls in cgo,
+// so it is NEVER compiled into the production steward (CGO_ENABLED=0) path.
+
+package dex
+
+/*
+#cgo LDFLAGS: -ltdh -ladvapi32
+#include <stdlib.h>
+#include "consume_etw_windows.h"
+*/
+import "C"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// ─── psapi binding for working-set measurement ───────────────────────────────
+
+var (
+	modpsapi                 = windows.NewLazySystemDLL("psapi.dll")
+	procGetProcessMemoryInfo = modpsapi.NewProc("GetProcessMemoryInfo")
+)
+
+type processMemoryCounters struct {
+	CB                         uint32
+	PageFaultCount             uint32
+	PeakWorkingSetSize         uintptr
+	WorkingSetSize             uintptr
+	QuotaPeakPagedPoolUsage    uintptr
+	QuotaPagedPoolUsage        uintptr
+	QuotaPeakNonPagedPoolUsage uintptr
+	QuotaNonPagedPoolUsage     uintptr
+	PagefileUsage              uintptr
+	PeakPagefileUsage          uintptr
+}
+
+func workingSetBytes() uint64 {
+	handle, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(windows.GetCurrentProcessId()))
+	if err != nil {
+		return 0
+	}
+	defer windows.CloseHandle(handle)
+	var pmc processMemoryCounters
+	pmc.CB = uint32(unsafe.Sizeof(pmc))
+	ret, _, _ := procGetProcessMemoryInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&pmc)), uintptr(pmc.CB))
+	if ret == 0 {
+		return 0
+	}
+	return uint64(pmc.WorkingSetSize)
+}
+
+// ─── ControlTrace QUERY for ETW lost-event counts ────────────────────────────
+
+var procControlTraceW = modadvapi32.NewProc("ControlTraceW")
+
+const eventTraceControlQuery uint32 = 0
+
+// queryLostEvents reads the session's EventsLost + RealTimeBuffersLost via
+// ControlTraceW(QUERY). Must be called while the session still exists (before
+// StopTrace). Best-effort: returns (0,0) on error.
+func queryLostEvents(sessionName string) (eventsLost, rtBuffersLost uint32) {
+	nameUTF16, err := windows.UTF16FromString(sessionName)
+	if err != nil {
+		return 0, 0
+	}
+	nameBytes := len(nameUTF16) * 2
+	totalSize := uint32(unsafe.Sizeof(eventTraceProperties{}) + uintptr(nameBytes))
+	buf := make([]byte, totalSize)
+	props := (*eventTraceProperties)(unsafe.Pointer(&buf[0]))
+	props.Wnode.BufferSize = totalSize
+	props.Wnode.Flags = wnodeFlagTracedGUID
+	props.LoggerNameOffset = uint32(unsafe.Sizeof(eventTraceProperties{}))
+
+	ret, _, _ := procControlTraceW.Call(
+		0,
+		uintptr(unsafe.Pointer(&nameUTF16[0])),
+		uintptr(unsafe.Pointer(props)),
+		uintptr(eventTraceControlQuery),
+	)
+	if ret != 0 {
+		return 0, 0
+	}
+	return props.EventsLost, props.RealTimeBuffersLost
+}
+
+// ─── consume config + report ─────────────────────────────────────────────────
+
+// ConsumeConfig parameterises a single consume run.
+type ConsumeConfig struct {
+	SessionName  string
+	Duration     time.Duration
+	DrainEveryMS int      // drain cadence
+	Providers    []string // provider names to enable (must match etwProviders[].name); empty = all non-Win32k
+}
+
+// ProviderCount is a per-provider drained-event tally.
+type ProviderCount struct {
+	Provider string `json:"provider"`
+	Events   int    `json:"events"`
+}
+
+// AttributedProc is a pid -> image attribution sample entry.
+type AttributedProc struct {
+	PID   uint32 `json:"pid"`
+	Image string `json:"image"`
+	Count int    `json:"count"`
+}
+
+// MemSample is a point-in-time working-set + progress reading, sampled through
+// the run so a 10-minute stability window can show whether memory trends upward.
+type MemSample struct {
+	ElapsedSec   float64 `json:"elapsed_sec"`
+	WorkingSetMB float64 `json:"working_set_mb"`
+	Drained      uint64  `json:"drained"`
+	DroppedRing  uint64  `json:"dropped_ring"`
+}
+
+// ConsumeReport is the machine-readable result of a consume run — the evidence
+// backing the feasibility verdicts.
+type ConsumeReport struct {
+	Host             string           `json:"host"`
+	Timestamp        string           `json:"timestamp"`
+	DurationSec      float64          `json:"duration_sec"`
+	ProvidersEnabled []string         `json:"providers_enabled"`
+	SessionStartErr  string           `json:"session_start_err,omitempty"`
+	TotalSeen        uint64           `json:"total_seen"`         // events the C callback observed
+	TotalDrained     uint64           `json:"total_drained"`      // events Go pulled from the ring
+	DroppedRing      uint64           `json:"dropped_ring"`       // ring-full drops in the callback
+	ETWEventsLost    uint32           `json:"etw_events_lost"`    // kernel-side lost (buffers overrun)
+	ETWBuffersLost   uint32           `json:"etw_buffers_lost"`   // real-time buffers lost
+	ThroughputPerSec float64          `json:"throughput_per_sec"` // drained / duration
+	PerProvider      []ProviderCount  `json:"per_provider"`
+	DistinctPIDs     int              `json:"distinct_pids"`
+	Attribution      []AttributedProc `json:"attribution_sample"`
+	DecodeSample     []string         `json:"decode_sample"`
+	CPUPercent       float64          `json:"cpu_percent"`
+	BudgetPercent    float64          `json:"budget_percent"`
+	WithinBudget     bool             `json:"within_budget"`
+	WorkingSetMB     float64          `json:"working_set_mb"`
+	MemSamples       []MemSample      `json:"mem_samples,omitempty"` // periodic trend (Part 5)
+	Crashed          bool             `json:"crashed"`               // always false if we returned (proof of no runtime crash)
+}
+
+// ─── the consumer ────────────────────────────────────────────────────────────
+
+// consumeProviderSet is the provider set for the consume PoC: the four reachable
+// providers proven in #2540 plus Microsoft-Windows-Kernel-File, a very high-rate
+// provider used to stress the consumer (Part 1 / Part 4). Win32k stays in the set
+// for the session-0 reachability determination (Part 6) but emits nothing in
+// session 0.
+func consumeProviderSet() []etwProvider {
+	set := make([]etwProvider, 0, len(etwProviders)+1)
+	set = append(set, etwProviders...)
+	set = append(set, etwProvider{
+		// Kernel-File fires on nearly every file-system operation host-wide — the
+		// highest-rate readily-available manifest provider, ideal for a consume
+		// stress test. Reuses SignalDiskIO so it is flagged as a TDH decode target.
+		class:    SignalDiskIO,
+		name:     "Microsoft-Windows-Kernel-File",
+		guidStr:  "{edd08927-9cc4-4e65-b970-c2560fb5c289}",
+		matchAny: 0,
+	})
+	return set
+}
+
+// selectConsumeProviders returns the etwProvider entries whose name is in want
+// (or all of consumeProviderSet when want is empty). Order is preserved so the
+// registered idx is stable within a run.
+func selectConsumeProviders(want []string) []etwProvider {
+	all := consumeProviderSet()
+	if len(want) == 0 {
+		return all
+	}
+	set := make(map[string]bool, len(want))
+	for _, w := range want {
+		set[w] = true
+	}
+	out := make([]etwProvider, 0, len(want))
+	for _, p := range all {
+		if set[p.name] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// RunConsume executes one consume run and returns the evidence report. It never
+// panics out to the caller on a consume error; a failure to start the session is
+// reported in SessionStartErr with zeroed counts.
+func RunConsume(ctx context.Context, cfg ConsumeConfig) ConsumeReport {
+	if cfg.DrainEveryMS <= 0 {
+		cfg.DrainEveryMS = 20
+	}
+	host, _ := os.Hostname()
+	providers := selectConsumeProviders(cfg.Providers)
+
+	report := ConsumeReport{
+		Host:          host,
+		Timestamp:     time.Now().UTC().Format(time.RFC3339),
+		DurationSec:   cfg.Duration.Seconds(),
+		BudgetPercent: 1.0,
+	}
+	for _, p := range providers {
+		report.ProvidersEnabled = append(report.ProvidersEnabled, p.name)
+	}
+
+	// 1. Start the real-time session.
+	handle, err := startNamedTrace(cfg.SessionName, eventTraceRealTimeMode)
+	if err != nil {
+		report.SessionStartErr = err.Error()
+		return report
+	}
+
+	// 2. Register providers with the C callback and enable them on the session.
+	for idx, p := range providers {
+		guid, gerr := parseGUID(p.guidStr)
+		if gerr != nil {
+			continue
+		}
+		decodeTarget := 0
+		if p.class == SignalDiskIO || p.class == SignalNetwork {
+			decodeTarget = 1 // manifest/MOF providers that TDH-decode into named fields
+		}
+		C.cfgms_register_provider(
+			(*C.uchar)(unsafe.Pointer(&guid)),
+			C.int(idx),
+			C.int(decodeTarget),
+		)
+		procEnableTraceEx2.Call( //nolint:errcheck // best-effort; reachability proven in #2540
+			handle,
+			uintptr(unsafe.Pointer(&guid)),
+			1,
+			uintptr(traceLevelInformation),
+			uintptr(p.matchAny),
+			0, 0, 0,
+		)
+	}
+
+	// 3. Producer goroutine: C ProcessTrace blocks here for the whole run. The
+	// session name is copied into C memory so it outlives the blocking call
+	// regardless of Go GC.
+	nameUTF16, _ := windows.UTF16FromString(cfg.SessionName)
+	cName := C.malloc(C.size_t(len(nameUTF16) * 2))
+	defer C.free(cName)
+	copy((*[1 << 16]byte)(cName)[:len(nameUTF16)*2], (*[1 << 16]byte)(unsafe.Pointer(&nameUTF16[0]))[:len(nameUTF16)*2])
+
+	var producerWG sync.WaitGroup
+	producerWG.Add(1)
+	go func() {
+		defer producerWG.Done()
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		C.cfgms_run((*C.ushort)(cName))
+	}()
+
+	// 4. Drain loop for the window (attribute + count).
+	cpuBefore, _ := processTimesNs()
+	wallBefore := time.Now()
+
+	perProvider := make([]int, len(providers))
+	pidCounts := make(map[uint32]int)
+	imageCache := make(map[uint32]string)
+	var totalDrained uint64
+
+	const drainBatch = 4096
+	buf := make([]C.CfgmsEvent, drainBatch)
+
+	runCtx, cancel := context.WithTimeout(ctx, cfg.Duration)
+	defer cancel()
+	ticker := time.NewTicker(time.Duration(cfg.DrainEveryMS) * time.Millisecond)
+	defer ticker.Stop()
+	sampleTicker := time.NewTicker(30 * time.Second)
+	defer sampleTicker.Stop()
+
+	drain := func() {
+		for {
+			n := int(C.cfgms_drain(&buf[0], C.int(drainBatch)))
+			if n == 0 {
+				return
+			}
+			for i := 0; i < n; i++ {
+				ev := buf[i]
+				totalDrained++
+				if int(ev.provider_idx) < len(perProvider) {
+					perProvider[ev.provider_idx]++
+				}
+				pid := uint32(ev.pid)
+				pidCounts[pid]++
+				if _, ok := imageCache[pid]; !ok {
+					imageCache[pid] = imageForPID(pid)
+				}
+			}
+			if n < drainBatch {
+				return
+			}
+		}
+	}
+
+drainLoop:
+	for {
+		select {
+		case <-runCtx.Done():
+			break drainLoop
+		case <-ticker.C:
+			drain()
+		case <-sampleTicker.C:
+			report.MemSamples = append(report.MemSamples, MemSample{
+				ElapsedSec:   time.Since(wallBefore).Seconds(),
+				WorkingSetMB: float64(workingSetBytes()) / (1024 * 1024),
+				Drained:      totalDrained,
+				DroppedRing:  uint64(C.cfgms_dropped_ring()),
+			})
+		}
+	}
+
+	// 5. Read ETW lost counts BEFORE tearing the session down, then stop.
+	report.ETWEventsLost, report.ETWBuffersLost = queryLostEvents(cfg.SessionName)
+	C.cfgms_stop()                              // CloseTrace → ProcessTrace returns
+	_ = stopNamedTrace(handle, cfg.SessionName) //nolint:errcheck // best-effort teardown
+	producerWG.Wait()
+	drain() // final sweep of anything left in the ring
+
+	cpuAfter, _ := processTimesNs()
+	wallElapsed := time.Since(wallBefore).Seconds()
+
+	// 6. Overhead.
+	cpuNs := int64(cpuAfter) - int64(cpuBefore)
+	if wallElapsed > 0 {
+		report.CPUPercent = (float64(cpuNs) / (wallElapsed * float64(time.Second))) * 100.0
+		report.ThroughputPerSec = float64(totalDrained) / wallElapsed
+	}
+	report.WithinBudget = report.CPUPercent <= report.BudgetPercent
+	report.WorkingSetMB = float64(workingSetBytes()) / (1024 * 1024)
+	report.DurationSec = wallElapsed
+
+	// 7. Counters + per-provider + attribution + decode sample.
+	report.TotalSeen = uint64(C.cfgms_total_seen())
+	report.DroppedRing = uint64(C.cfgms_dropped_ring())
+	report.TotalDrained = totalDrained
+	for i, p := range providers {
+		report.PerProvider = append(report.PerProvider, ProviderCount{Provider: p.name, Events: perProvider[i]})
+	}
+	report.DistinctPIDs = len(pidCounts)
+	report.Attribution = topAttribution(pidCounts, imageCache, 15)
+	report.DecodeSample = readDecodeSample()
+
+	return report
+}
+
+// imageForPID resolves a PID to its full image path via
+// QueryFullProcessImageName. Returns "" when the process is gone or access is
+// denied (e.g. protected/system PIDs) — a real, expected attribution edge.
+func imageForPID(pid uint32) string {
+	if pid == 0 {
+		return "System Idle (pid 0)"
+	}
+	if pid == 4 {
+		return "System (pid 4)"
+	}
+	h, err := windows.OpenProcess(processQueryLimitedInformation, false, pid)
+	if err != nil {
+		return ""
+	}
+	defer windows.CloseHandle(h)
+	buf := make([]uint16, 1024)
+	size := uint32(len(buf))
+	if err := windows.QueryFullProcessImageName(h, 0, &buf[0], &size); err != nil {
+		return ""
+	}
+	return windows.UTF16ToString(buf[:size])
+}
+
+// topAttribution returns the top-n pids by event count with their resolved image.
+func topAttribution(counts map[uint32]int, images map[uint32]string, n int) []AttributedProc {
+	out := make([]AttributedProc, 0, len(counts))
+	for pid, c := range counts {
+		out = append(out, AttributedProc{PID: pid, Image: images[pid], Count: c})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+// readDecodeSample pulls the C-side TDH decode sample and splits it into lines.
+func readDecodeSample() []string {
+	cstr := C.cfgms_decode_sample()
+	if cstr == nil {
+		return nil
+	}
+	defer C.cfgms_free(cstr)
+	s := C.GoString(cstr)
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			if i > start {
+				lines = append(lines, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+// MarshalReport renders a ConsumeReport as indented JSON.
+func MarshalReport(r ConsumeReport) string {
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"marshal_error":%q}`, err.Error())
+	}
+	return string(b)
+}

--- a/features/steward/dex/consume_windows_test.go
+++ b/features/steward/dex/consume_windows_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows && dexconsume
+
+// Non-live unit tests for the consume PoC's pure Go logic (attribution ordering,
+// provider selection, decode-sample parsing, well-known PID labelling). These
+// need no ETW privilege, so they exercise the drain-side logic anywhere the
+// dexconsume tag is built. The end-to-end consume proof is TestDexConsumeLive,
+// which requires the SYSTEM StartTrace privilege.
+package dex
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSelectConsumeProviders(t *testing.T) {
+	// Empty want → the full set (4 collector providers + Kernel-File).
+	all := selectConsumeProviders(nil)
+	if len(all) != len(etwProviders)+1 {
+		t.Fatalf("empty selector must return the full consume set: got %d, want %d", len(all), len(etwProviders)+1)
+	}
+
+	// Explicit subset → only the named providers, order preserved.
+	got := selectConsumeProviders([]string{"Microsoft-Windows-Kernel-File", "Microsoft-Windows-DNS-Client"})
+	var names []string
+	for _, p := range got {
+		names = append(names, p.name)
+	}
+	// Order follows consumeProviderSet (DNS-Client precedes Kernel-File there).
+	want := []string{"Microsoft-Windows-DNS-Client", "Microsoft-Windows-Kernel-File"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("subset selection preserves set order: got %v, want %v", names, want)
+	}
+
+	// Unknown name → dropped, not an error.
+	if len(selectConsumeProviders([]string{"Not-A-Provider"})) != 0 {
+		t.Fatalf("unknown provider name must select nothing")
+	}
+}
+
+func TestTopAttribution(t *testing.T) {
+	counts := map[uint32]int{100: 5, 200: 50, 300: 1, 400: 20}
+	images := map[uint32]string{100: "a.exe", 200: "b.exe", 300: "c.exe", 400: "d.exe"}
+
+	top := topAttribution(counts, images, 2)
+	if len(top) != 2 {
+		t.Fatalf("n=2 must cap the result at 2: got %d", len(top))
+	}
+	// Descending by count: 200 (50) then 400 (20).
+	if top[0].PID != 200 || top[0].Count != 50 || top[0].Image != "b.exe" {
+		t.Fatalf("highest-count pid must sort first: got %+v", top[0])
+	}
+	if top[1].PID != 400 || top[1].Count != 20 {
+		t.Fatalf("second-highest must follow: got %+v", top[1])
+	}
+
+	// n larger than the map returns all entries.
+	if len(topAttribution(counts, images, 100)) != 4 {
+		t.Fatalf("n greater than map size must return all entries")
+	}
+}
+
+func TestImageForPID_WellKnown(t *testing.T) {
+	// PID 0 and 4 are labelled without a syscall (they cannot be OpenProcess'd).
+	if got := imageForPID(0); got != "System Idle (pid 0)" {
+		t.Fatalf("pid 0 label: got %q", got)
+	}
+	if got := imageForPID(4); got != "System (pid 4)" {
+		t.Fatalf("pid 4 label: got %q", got)
+	}
+}
+
+func TestReadDecodeSample_EmptyBeforeRun(t *testing.T) {
+	// With no consume run, the C decode buffer is empty and the reader returns nil
+	// rather than a spurious empty line.
+	if got := readDecodeSample(); got != nil {
+		t.Fatalf("decode sample must be nil before any run: got %v", got)
+	}
+}

--- a/features/steward/dex/rust/.gitignore
+++ b/features/steward/dex/rust/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts — regenerate with `cargo build --release` + the staging step in
+# consume_rust_link_windows.go. Never committed (multi-MB, toolchain-specific).
+/target/
+/link/
+/Cargo.lock

--- a/features/steward/dex/rust/Cargo.toml
+++ b/features/steward/dex/rust/Cargo.toml
@@ -1,0 +1,27 @@
+# Throwaway Rust variant of the DEX in-process ETW consumer (#2571) — proves the
+# same non-reentrant-callback architecture in a memory-safe language. Built as a
+# staticlib and linked into the Go PoC via cgo under the `dexrust` build tag.
+# Never part of the production steward build.
+[package]
+name = "dexetw"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "dexetw"
+crate-type = ["staticlib"]
+
+[dependencies]
+# windows-sys gives the exact ETW struct layouts (EVENT_RECORD/EVENT_HEADER),
+# so we never hand-guess field offsets — reading pid/timestamp/provider is correct
+# by construction. Only the raw pointer deref itself is `unsafe`.
+windows-sys = { version = "0.59", features = [
+    "Win32_System_Diagnostics_Etw",
+    "Win32_System_Time",
+    "Win32_Foundation",
+] }
+
+[profile.release]
+opt-level = 3
+panic = "abort"

--- a/features/steward/dex/rust/build.sh
+++ b/features/steward/dex/rust/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build the Rust ETW consumer staticlib (#2571) and stage it — plus the
+# windows-sys umbrella import lib it depends on — into rust/link/, where the cgo
+# `dexrust` build (consume_rust_link_windows.go) links them via -L${SRCDIR}/rust/link.
+#
+# Prereq: a Rust GNU toolchain (`rustup default stable-x86_64-pc-windows-gnu`) so
+# the .a links against the same mingw gcc cgo uses. Then, from the repo root:
+#   bash features/steward/dex/rust/build.sh
+#   go test -c -tags "dexconsume dexrust" ./features/steward/dex/
+#
+# The exact Rust-std native libs to pass in the cgo LDFLAGS come from:
+#   cargo rustc --release --lib -- --print native-static-libs
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cargo build --release
+mkdir -p link
+cp target/release/libdexetw.a link/
+
+# windows-sys 0.59 pulls its Win32 import symbols from a bundled umbrella lib in
+# the windows_x86_64_gnu crate. Locate it by glob so a patch-version bump still works.
+umbrella=$(find "${CARGO_HOME:-$HOME/.cargo}/registry/src" \
+    -path '*windows_x86_64_gnu*/lib/libwindows.0.52.0.a' 2>/dev/null | head -1)
+if [[ -z "${umbrella}" || ! -f "${umbrella}" ]]; then
+    echo "ERROR: could not find libwindows.0.52.0.a (windows_x86_64_gnu crate). If the" >&2
+    echo "windows-sys version changed, update the -lwindows.* flag in" >&2
+    echo "consume_rust_link_windows.go to match." >&2
+    exit 1
+fi
+cp "${umbrella}" link/
+
+echo "staged into rust/link/: $(ls link/)"

--- a/features/steward/dex/rust/src/lib.rs
+++ b/features/steward/dex/rust/src/lib.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Rust variant of the DEX in-process ETW consumer (#2571). Same architecture as
+// the C version (consume_etw_windows.c): a non-reentrant native callback copies a
+// compact header record into a single-producer/single-consumer ring and never
+// re-enters Go; a Go goroutine drains the ring via cgo. This proves the crash-safe
+// consume path is achievable in a MEMORY-SAFE language — the unsafe surface is
+// reduced to exactly two spots (marked `// UNSAFE:` below): the shared static ring
+// buffer, and the one raw `EVENT_RECORD` pointer deref the OS ABI forces. All the
+// bounds/index/counter logic is safe Rust.
+//
+// Exposes the identical C ABI (cfgms_* + CfgmsEvent layout) as the C version, so
+// the existing Go wrapper links it unchanged under the `dexrust` build tag.
+
+#![allow(non_snake_case)]
+
+use std::cell::UnsafeCell;
+use std::os::raw::{c_char, c_int};
+use std::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, Ordering};
+
+use windows_sys::core::GUID;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::System::Diagnostics::Etw::{
+    CloseTrace, OpenTraceW, ProcessTrace, EVENT_RECORD, EVENT_TRACE_LOGFILEW,
+    PROCESSTRACE_HANDLE, PROCESS_TRACE_MODE_EVENT_RECORD, PROCESS_TRACE_MODE_REAL_TIME,
+};
+
+const RING_CAP: u32 = 1 << 16;
+const RING_MASK: u32 = RING_CAP - 1;
+
+// Mirrors CfgmsEvent in consume_etw_windows.h exactly (repr(C)).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CfgmsEvent {
+    pub timestamp: u64,
+    pub pid: u32,
+    pub tid: u32,
+    pub provider_idx: u16,
+    pub event_id: u16,
+    pub opcode: u8,
+    pub _pad: [u8; 3],
+}
+
+const EMPTY_EVENT: CfgmsEvent = CfgmsEvent {
+    timestamp: 0,
+    pid: 0,
+    tid: 0,
+    provider_idx: 0,
+    event_id: 0,
+    opcode: 0,
+    _pad: [0; 3],
+};
+
+// ── SPSC ring ────────────────────────────────────────────────────────────────
+// UNSAFE #1: a process-global fixed ring shared between the ETW callback thread
+// (single producer) and the Go drain goroutine (single consumer). UnsafeCell +
+// an explicit `unsafe impl Sync` is the minimal interior-mutability escape; the
+// head/tail indices are atomics so the happens-before edges are enforced safely.
+struct Ring {
+    buf: UnsafeCell<[CfgmsEvent; RING_CAP as usize]>,
+}
+unsafe impl Sync for Ring {}
+
+static RING: Ring = Ring {
+    buf: UnsafeCell::new([EMPTY_EVENT; RING_CAP as usize]),
+};
+static HEAD: AtomicU32 = AtomicU32::new(0);
+static TAIL: AtomicU32 = AtomicU32::new(0);
+static TOTAL_SEEN: AtomicU64 = AtomicU64::new(0);
+static DROPPED_RING: AtomicU64 = AtomicU64::new(0);
+
+fn ring_push(ev: CfgmsEvent) {
+    TOTAL_SEEN.fetch_add(1, Ordering::Relaxed);
+    let head = HEAD.load(Ordering::Relaxed);
+    let tail = TAIL.load(Ordering::Acquire);
+    if head.wrapping_sub(tail) >= RING_CAP {
+        DROPPED_RING.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    // UNSAFE #1 (write): sole producer writes its slot before publishing `head`.
+    unsafe {
+        (*RING.buf.get())[(head & RING_MASK) as usize] = ev;
+    }
+    HEAD.store(head.wrapping_add(1), Ordering::Release);
+}
+
+// ── provider registry (GUID → idx stamp for the callback) ────────────────────
+const MAX_PROVIDERS: usize = 16;
+struct Providers {
+    guids: UnsafeCell<[[u8; 16]; MAX_PROVIDERS]>,
+    idxs: UnsafeCell<[u16; MAX_PROVIDERS]>,
+}
+unsafe impl Sync for Providers {}
+static PROVIDERS: Providers = Providers {
+    guids: UnsafeCell::new([[0u8; 16]; MAX_PROVIDERS]),
+    idxs: UnsafeCell::new([0u16; MAX_PROVIDERS]),
+};
+static PROVIDER_COUNT: AtomicU16 = AtomicU16::new(0);
+
+fn provider_lookup(guid: &GUID) -> u16 {
+    // GUID has the same 16-byte layout the C side registered (windows.GUID order).
+    let want = guid_bytes(guid);
+    let n = PROVIDER_COUNT.load(Ordering::Acquire) as usize;
+    // Registration completes (Go, single-threaded) before ProcessTrace starts, so
+    // this read side needs no locking.
+    let guids = unsafe { &*PROVIDERS.guids.get() };
+    let idxs = unsafe { &*PROVIDERS.idxs.get() };
+    for i in 0..n {
+        if guids[i] == want {
+            return idxs[i];
+        }
+    }
+    0xFFFF
+}
+
+fn guid_bytes(g: &GUID) -> [u8; 16] {
+    let mut b = [0u8; 16];
+    b[0..4].copy_from_slice(&g.data1.to_le_bytes());
+    b[4..6].copy_from_slice(&g.data2.to_le_bytes());
+    b[6..8].copy_from_slice(&g.data3.to_le_bytes());
+    b[8..16].copy_from_slice(&g.data4);
+    b
+}
+
+// ── the callback (native, never re-enters Go) ────────────────────────────────
+// UNSAFE #2: the OS hands us a raw EVENT_RECORD pointer valid only for this call.
+// Dereferencing it is the single irreducible unsafe op — everything after is safe.
+unsafe extern "system" fn cfgms_event_cb(ev: *mut EVENT_RECORD) {
+    if ev.is_null() {
+        return;
+    }
+    let h = &(*ev).EventHeader; // UNSAFE #2
+    let pidx = provider_lookup(&h.ProviderId);
+    ring_push(CfgmsEvent {
+        timestamp: h.TimeStamp as u64,
+        pid: h.ProcessId,
+        tid: h.ThreadId,
+        provider_idx: pidx,
+        event_id: h.EventDescriptor.Id,
+        opcode: h.EventDescriptor.Opcode,
+        _pad: [0; 3],
+    });
+}
+
+// ── trace handle ─────────────────────────────────────────────────────────────
+static G_TRACE: AtomicU64 = AtomicU64::new(u64::MAX); // INVALID_PROCESSTRACE_HANDLE
+
+// ── exported C ABI (matches consume_etw_windows.h) ───────────────────────────
+
+#[no_mangle]
+pub extern "C" fn cfgms_register_provider(guid16: *const u8, idx: c_int, _is_decode_target: c_int) {
+    if guid16.is_null() {
+        return;
+    }
+    let n = PROVIDER_COUNT.load(Ordering::Relaxed) as usize;
+    if n >= MAX_PROVIDERS {
+        return;
+    }
+    // Copy the 16 GUID bytes; registration is single-threaded (pre-run).
+    let src = unsafe { std::slice::from_raw_parts(guid16, 16) };
+    let guids = unsafe { &mut *PROVIDERS.guids.get() };
+    let idxs = unsafe { &mut *PROVIDERS.idxs.get() };
+    guids[n].copy_from_slice(src);
+    idxs[n] = idx as u16;
+    PROVIDER_COUNT.store((n + 1) as u16, Ordering::Release);
+}
+
+#[no_mangle]
+pub extern "C" fn cfgms_run(session_name_w: *const u16) -> u32 {
+    let mut log: EVENT_TRACE_LOGFILEW = unsafe { std::mem::zeroed() };
+    log.LoggerName = session_name_w as *mut u16;
+    log.Anonymous1.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD;
+    log.Anonymous2.EventRecordCallback = Some(cfgms_event_cb);
+
+    let h = unsafe { OpenTraceW(&mut log) }; // PROCESSTRACE_HANDLE { Value: u64 }
+    if h.Value == u64::MAX {
+        return unsafe { GetLastError() };
+    }
+    G_TRACE.store(h.Value, Ordering::SeqCst);
+    unsafe { ProcessTrace(&h, 1, std::ptr::null(), std::ptr::null()) }
+}
+
+#[no_mangle]
+pub extern "C" fn cfgms_stop() {
+    let v = G_TRACE.swap(u64::MAX, Ordering::SeqCst);
+    if v != u64::MAX {
+        unsafe { CloseTrace(PROCESSTRACE_HANDLE { Value: v }) };
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cfgms_reset() {
+    HEAD.store(0, Ordering::Relaxed);
+    TAIL.store(0, Ordering::Relaxed);
+    TOTAL_SEEN.store(0, Ordering::Relaxed);
+    DROPPED_RING.store(0, Ordering::Relaxed);
+    PROVIDER_COUNT.store(0, Ordering::Relaxed);
+}
+
+#[no_mangle]
+pub extern "C" fn cfgms_drain(out: *mut CfgmsEvent, max: c_int) -> c_int {
+    if out.is_null() || max <= 0 {
+        return 0;
+    }
+    let out = unsafe { std::slice::from_raw_parts_mut(out, max as usize) };
+    let mut tail = TAIL.load(Ordering::Relaxed);
+    let head = HEAD.load(Ordering::Acquire);
+    let buf = unsafe { &*RING.buf.get() };
+    let mut n = 0usize;
+    while tail != head && n < max as usize {
+        out[n] = buf[(tail & RING_MASK) as usize];
+        tail = tail.wrapping_add(1);
+        n += 1;
+    }
+    TAIL.store(tail, Ordering::Release);
+    n as c_int
+}
+
+#[no_mangle]
+pub extern "C" fn cfgms_total_seen() -> u64 {
+    TOTAL_SEEN.load(Ordering::Relaxed)
+}
+
+#[no_mangle]
+pub extern "C" fn cfgms_dropped_ring() -> u64 {
+    DROPPED_RING.load(Ordering::Relaxed)
+}
+
+// Decode is TDH-schema work identical to the C variant and orthogonal to the
+// crash-safe-consume question this Rust PoC proves; the Rust variant reports no
+// decode sample (Go handles the null).
+#[no_mangle]
+pub extern "C" fn cfgms_decode_sample() -> *mut c_char {
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn cfgms_free(_p: *mut c_char) {}
+
+#[no_mangle]
+pub extern "C" fn cfgms_test_enqueue(pid: u32, provider_idx: u16, event_id: u16) {
+    ring_push(CfgmsEvent {
+        timestamp: 0,
+        pid,
+        tid: 0,
+        provider_idx,
+        event_id,
+        opcode: 0,
+        _pad: [0; 3],
+    });
+}


### PR DESCRIPTION
Fixes #2571

## Summary

Feasibility spike (#2571) proving that an **in-steward Go agent can consume, decode, and attribute a high-rate ETW stream** in its own SYSTEM service context — the load-bearing question #2517/#2540 left open (their in-process Go `ProcessTrace` consumer crashed the Go runtime, so #2540 shipped with **no consumer** and measured enablement overhead only).

**Verdict: GO.** Backed by two real runs in the steward `LocalSystem` context on CFG-70-02.

## The crux and the fix

#2517 found that a `windows.NewCallback`-wrapped Go ETW callback corrupts the Go runtime (`acquireSudog` / `cgocallbackg`) — every event routes the ETW-owned thread back into Go. **Architecture chosen (candidate (c)):** the `EventRecordCallback` is a **pure C function** that copies a compact header record into a single-producer/single-consumer C ring buffer and **never re-enters Go**; a Go goroutine drains the ring, attributes (PID→image), and measures overhead. The hot path is C→C only, so `cgocallbackg` is never taken — the crash is structurally impossible.

## Load-bearing verdicts (all backed by live SYSTEM runs)

| # | Part | Verdict | Evidence |
|---|------|---------|----------|
| 1 | High-rate in-process consumption, stable | **PROVEN** | 10-min run: 6,094,835 events, 0 dropped, 0 ETW-lost, no crash |
| 2 | Event decode in Go (TDH) | **PROVEN** | Named fields from DNS-Client, Kernel-File (`FileName=\Device\…`) |
| 3 | Per-process attribution | **PROVEN** | 1,010 distinct PIDs → image paths |
| 4 | Overhead at volume vs 1.0% budget | **PROVEN** | 10,158 evt/s sustained at **0.487% CPU**, ~10 MB flat WS |
| 5 | Sustained ≥10-min stability | **PROVEN** | 600 s, 6M events, 0 loss, no memory trend (20 samples) |
| 6 | Session-0 UX-signal reachability | **BLOCKED** | Win32k emits 0 events in session 0 → needs a per-session component |

Full evidence, architecture rationale, and the recommended consume architecture are in **`features/steward/dex/CONSUME_FEASIBILITY.md`**.

## Changes (all under `features/steward/dex/`, all behind `//go:build windows && dexconsume`)

- `consume_etw_windows.c` / `.h` — SPSC ring, the pure-C `EventRecordCallback`, `OpenTrace`/`ProcessTrace` runner, bounded TDH decode sample, reset + test hook.
- `consume_windows.go` — cgo wrapper: real-time session start (reusing the collector's helpers), C `ProcessTrace` on a `LockOSThread` goroutine, drain + attribute + overhead + ETW lost-event query + periodic memory sampling.
- `consume_live_windows_test.go` — the runnable spike entry (`go test -c -tags dexconsume`, env-configured).
- `consume_windows_test.go` / `consume_ring_windows_test.go` / `consume_ringtest_windows.go` — non-live unit coverage of the drain-side logic **and the SPSC ring core** (FIFO order, drop-when-full accounting, reset).
- `CONSUME_FEASIBILITY.md` — the report.

## Scope guardrail (respected)

Throwaway PoC only. **cgo + the whole consumer are behind the `dexconsume` tag**, so the production steward (`CGO_ENABLED=0`, tag off) never compiles any of it — verified `CGO_ENABLED=0 go build ./...` and `GOOS=linux go build ./...` both green. No DEX schema, no persistence, no production `cfg`/control-plane/module surface. The collection track stays gated on the storage-shape ADR + ADR-017 Amendment 1.

## Validation

`go vet -tags dexconsume`, all tagged unit tests (ring + helpers), `CGO_ENABLED=0` production build, `GOOS=linux` cross-build, `gofmt`, and `make check-architecture` all pass locally. Adversarial review (acceptance + QA code review) run pre-PR: 1 blocking finding (a TDH unicode-decode OOB read) **fixed and re-verified live**; warnings (run-status capture, C-global reset, ring test coverage) addressed. Full `make test-complete` (lint/gosec/Docker) deferred to CI — this Windows self-dispatch host lacks those binaries.

Issue #2571

🤖 Generated with [Claude Code](https://claude.com/claude-code)