### PR TITLE
build: fix containerized e2e on Docker Desktop + add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Build-context exclusions for every image in this repo (all Dockerfiles use
+# `COPY . .` builders). Nothing here is read by any Dockerfile.
+# NOTE: web/dist is NOT excluded — the controller embeds it (web/embed.go).
+
+# VCS metadata (~140MB) — builds never run git against the repo
+.git
+
+# Claude Code agent state, incl. worktree checkouts (~400MB+)
+.claude
+
+# Frontend toolchain artifacts — images build Go only; node_modules exists
+# wherever the frontend CI lane or a local npm ci ran (~180MB, 14k files)
+web/node_modules
+web/coverage
+
+# Local test/build residue
+tmp/
+*.log
+coverage.out
+coverage.html

--- a/Dockerfile.test-runner
+++ b/Dockerfile.test-runner
@@ -18,6 +18,7 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     docker-ce-cli \
+    docker-buildx-plugin \
     docker-compose-plugin && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -1887,7 +1887,7 @@ test-e2e-ci:
 	@echo ""
 	@echo "📋 Step 2/3: Running tests in container with container-to-container networking..."
 	@docker build -t cfgms-test-runner -f Dockerfile.test-runner . >/dev/null 2>&1 && \
-	DOCKER_GID=$$(stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock) && \
+	DOCKER_GID=$$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --entrypoint stat cfgms-test-runner -c '%g' /var/run/docker.sock) && \
 	docker run --rm \
 		--user $$(id -u):$$(id -g) \
 		--network cfgms-test \


### PR DESCRIPTION
Two fixes that make the `test-e2e-ci` containerized lane work on macOS hosts (final items from today's local-validation sweep; CI behavior unchanged):

1. **Docker-socket GID**: the `--group-add` GID came from a host-side `stat` of `/var/run/docker.sock`, but inside Docker Desktop's VM the socket is `root:root 0660` (measured: `0:0 660`) while the host symlink is `user:staff` — every in-container docker call failed with `permission denied`. Now probed from inside the already-built `cfgms-test-runner` image, which is authoritative on both platforms (Linux bind mounts preserve the host GID, so native-Linux behavior is identical).

2. **.dockerignore (new)**: all Dockerfiles use `COPY . .` builders, so builds shipped `.git` (140MB), `.claude` worktrees (417MB), and `web/node_modules` when present (177MB / 13.8k files) as context. Over the Docker Desktop bind mount this pushed in-container compose builds past the 300s test deadline. `web/dist` remains included — the controller embeds it (`web/embed.go`). CI builds get faster too.

## Verification
- In-container socket-group probe returns `0` on Docker Desktop (was staff/20 from host stat)
- `cfgms-test-runner` build context transfer: <1s (was the dominant cost)
- Full `make test-complete` validation running on the #2495 story branch carrying these commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)