### PR TITLE
ci: security gates queue-real with PR stubs (Issue #2595 phase 1)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -210,11 +210,16 @@ jobs:
           echo "   Skipping code unit tests (no code changes)"
           echo "   Documentation validation is sufficient for merge"
 
+  # QUEUE-REAL context (#2595): the real security-deployment-gate scan runs in the
+  # merge queue (production-gates.yml). This stub only covers docs-only PRs, where
+  # that workflow is paths-ignored. It must NOT fire on merge_group — the real job
+  # is the sole queue poster there. (Code PRs are covered by production-gates.yml's
+  # security-deployment-gate-pr-stub.)
   security-deployment-gate:
     name: security-deployment-gate
     permissions: {}
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     steps:
       - name: Docs-only security validation
         run: |
@@ -270,11 +275,14 @@ jobs:
           echo "   Skipping fleet E2E tests (no code changes)"
           echo "   No fleet test validation required for docs-only changes"
 
+  # QUEUE-REAL context (#2595): the real trivy-scan runs in the merge queue
+  # (security-scan.yml). This stub only covers docs-only PRs; it must NOT fire on
+  # merge_group. (Code PRs are covered by security-scan.yml's trivy-scan-pr-stub.)
   trivy-scan:
     name: trivy-scan
     permissions: {}
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     steps:
       - name: Docs-only Trivy validation
         run: |

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -31,14 +31,36 @@ on:
 permissions: {}
 
 jobs:
+  # PR-time stub for the `security-deployment-gate` required context (#2595).
+  # The real scan runs in the merge queue (security-deployment-gate job below);
+  # this posts the required check green on code PRs so branch protection is
+  # satisfied without double-scanning every push. Docs-only PRs are covered by
+  # documentation.yml's stub instead (this workflow is paths-ignored for docs).
+  # Same check-name as the real job; the two are mutually exclusive by event.
+  security-deployment-gate-pr-stub:
+    name: security-deployment-gate
+    permissions: {}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: PR-time stub (real scan runs in the merge queue)
+        run: |
+          echo "security-deployment-gate: real vulnerability scan runs in the merge queue (merge_group) per #2595."
+          echo "This PR-time stub posts the required context; the authoritative scan runs against the merge commit."
+
   # Security Gate - Critical Vulnerability Blocking (Story #99)
-  # NOTE: Runs on PRs and push to main only (skips post-merge to develop to avoid redundancy)
+  # QUEUE-REAL (#2595): the real vulnerability scan runs in the merge queue
+  # (merge_group) and on push to main — NOT on pull_request. The queue must scan
+  # the actual merge commit (zero-trust posture), and this is the dedup half of
+  # the #2595 split. The `security-deployment-gate` required context is posted on
+  # PRs by the lightweight `security-deployment-gate-pr-stub` job below (code PRs)
+  # and by documentation.yml (docs-only PRs).
   security-deployment-gate:
     permissions:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'merge_group' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     outputs:
       security-status: ${{ steps.security-gate.outputs.security-status }}
       deployment-allowed: ${{ steps.security-gate.outputs.deployment-allowed }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,13 +35,31 @@ env:
 permissions: {}
 
 jobs:
+  # PR-time stub for the `trivy-scan` required context (#2595).
+  # QUEUE-REAL: the real Trivy scan runs in the merge queue (merge_group) and on
+  # push to main — see the trivy-scan job below. This posts the required check
+  # green on code PRs; docs-only PRs are covered by documentation.yml's stub.
+  # Same check-name as the real job; mutually exclusive by event.
+  trivy-scan-pr-stub:
+    name: trivy-scan
+    permissions: {}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: PR-time stub (real scan runs in the merge queue)
+        run: |
+          echo "trivy-scan: real image/dependency scan runs in the merge queue (merge_group) per #2595."
+          echo "This PR-time stub posts the required context; the authoritative scan runs against the merge commit."
+
   # Parallel security scanning jobs for optimal performance
+  # QUEUE-REAL (#2595): runs in the merge queue and on main, not on pull_request.
   trivy-scan:
     permissions:
       contents: read
       security-events: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name == 'merge_group' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     outputs:
       status: ${{ steps.scan.outputs.status }}
       issues-found: ${{ steps.scan.outputs.issues-found }}


### PR DESCRIPTION
## Phase 1 of #2595 — security contexts go queue-real

Splits the two **security** required contexts to run their real scan **only in the merge queue** (the dedup + zero-trust-posture half of #2595). Tests/build (PR-real) and concurrency groups are later phases on separate PRs.

### Changes
- **`production-gates.yml`** — `security-deployment-gate` heavy job now `merge_group`/main only (was PR+queue). This closes the confirmed gap where the queue accepted a docs-stub instead of scanning the **actual merge commit**. Added `security-deployment-gate-pr-stub` (same check-name, `pull_request`) so code PRs still post the required context green.
- **`security-scan.yml`** — `trivy-scan` heavy job → `merge_group`/main only; added `trivy-scan-pr-stub`.
- **`documentation.yml`** — the `security-deployment-gate` and `trivy-scan` docs-stubs restricted to `pull_request` (they no longer duplicate the real job in the queue).

### Coherence (one poster per event)
| Context | code PR | docs-only PR | merge queue |
|---|---|---|---|
| `security-deployment-gate` | co-located PR stub | documentation.yml stub | **real scan** |
| `trivy-scan` | co-located PR stub | documentation.yml stub | **real scan** |

### Verification
Founder-observed on this live PR: every required context reports on the PR (none stuck "Expected"), and on enqueue the two security contexts run their **real** scan in the merge group. **This PR is not auto-merged** — it lands only after the queue behavior is confirmed by hand.

Refs #2595 (partial — phase 1 of a multi-PR story)

🤖 Generated with [Claude Code](https://claude.com/claude-code)