### PR TITLE
test: fix gofmt trailing blank line in factory_test.go

### DIFF
--- a/features/steward/factory/factory_test.go
+++ b/features/steward/factory/factory_test.go
@@ -345,4 +345,3 @@ func TestModuleFactory_Hyperv_DurableStoreUnavailable_FallsBack(t *testing.T) {
 	assert.Error(t, statErr,
 		"durable store root must not exist on the fallback path")
 }
-


### PR DESCRIPTION
Trailing blank line at EOF fails golangci-lint's gofmt check — pre-existing drift on develop, found while validating an unrelated story (#2495) in a Linux container harness where `make lint` runs the full pinned toolchain locally. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)