### PR TITLE
logging: split rotation_unix.go into linux/darwin variants (staticcheck)

### DIFF
--- a/pkg/logging/providers/file/rotation_darwin.go
+++ b/pkg/logging/providers/file/rotation_darwin.go
@@ -1,9 +1,9 @@
-//go:build !windows
-// +build !windows
+//go:build darwin
+// +build darwin
 
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// Package file - Platform-specific disk usage calculation for Unix-like systems
+// Package file - Platform-specific disk usage calculation for macOS
 
 package file
 
@@ -20,11 +20,8 @@ func (p *FileProvider) calculateDiskUsage() (float64, error) {
 		return 0, fmt.Errorf("failed to get filesystem stats: %w", err)
 	}
 
-	// Calculate usage percentage with bounds checking. Statfs_t.Bsize is
-	// int64 on Linux but uint32 on Darwin — go through int64 so the guard
-	// compiles and lints cleanly on both (a direct `stat.Bsize < 0` is
-	// statically false on Darwin and staticcheck SA4003 rejects it there).
-	bsize := int64(stat.Bsize) //nolint:unconvert // no-op on linux; required on darwin where Bsize is uint32
+	// Bsize is uint32 on Darwin; widen before the bounds check.
+	bsize := int64(stat.Bsize)
 	if bsize <= 0 {
 		return 0, fmt.Errorf("invalid block size: %d", bsize)
 	}

--- a/pkg/logging/providers/file/rotation_linux.go
+++ b/pkg/logging/providers/file/rotation_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+// +build linux
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package file - Platform-specific disk usage calculation for Linux
+
+package file
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// calculateDiskUsage calculates disk usage percentage for the log directory
+// This implementation uses syscall.Statfs which is available on Unix-like systems.
+func (p *FileProvider) calculateDiskUsage() (float64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(p.config.Directory, &stat); err != nil {
+		return 0, fmt.Errorf("failed to get filesystem stats: %w", err)
+	}
+
+	// Bsize is already int64 on Linux; bounds-check directly.
+	if stat.Bsize <= 0 {
+		return 0, fmt.Errorf("invalid block size: %d", stat.Bsize)
+	}
+	// #nosec G115 - Block size is validated above to be positive
+	blockSize := uint64(stat.Bsize)
+
+	totalBytes := stat.Blocks * blockSize
+	freeBytes := stat.Bavail * blockSize
+	usedBytes := totalBytes - freeBytes
+
+	if totalBytes == 0 {
+		return 0, nil
+	}
+
+	return float64(usedBytes) / float64(totalBytes) * 100.0, nil
+}


### PR DESCRIPTION
Found while validating an unrelated frontend story (#2495) in a Linux container harness with the CI-pinned golangci-lint version — separated out per that story's review (Go changes were out of its declared scope).

`syscall.Statfs_t.Bsize` is `int64` on Linux but `uint32` on Darwin. A single shared bounds-check on `stat.Bsize` either lints as a no-op conversion (`unconvert`) or a statically-false comparison (staticcheck `SA4003`) depending on which platform's Go toolchain lints it — CI only lints on Linux, so the Darwin failure mode was invisible there. Splitting into `rotation_linux.go` / `rotation_darwin.go` (matching the existing `rotation_windows.go` split) gives each platform its own type-correct check.

## Verification
- `go build` / `go test ./pkg/logging/providers/file/...` pass on macOS
- `GOOS=linux go build ./pkg/logging/...` cross-compiles clean
- `golangci-lint run ./pkg/logging/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)