### PR TITLE
hyperv: selector-driven role cascade delivers a Hyper-V vswitch by tag + fix dead role-cascade REST (Issue #2548)

### DIFF
--- a/cmd/cfg/cmd/role.go
+++ b/cmd/cfg/cmd/role.go
@@ -33,10 +33,25 @@ var (
 	roleTLSCACert   string
 	roleTLSInsecure bool
 
+	// roleTenant targets a specific tenant. Role configs are stored per tenant, so
+	// a global/root admin must name the tenant explicitly; a tenant-scoped caller
+	// is pinned to its own tenant and this flag is ignored (Issue #2548).
+	roleTenant string
+
 	// create flags
 	roleSelector   string
 	roleConfigFile string
 )
+
+// roleTenantQuery returns the "?tenant=<id>" query suffix when --tenant is set,
+// or "" otherwise. Used by every role sub-command so a root admin can target a
+// tenant (the controller pins tenant-scoped callers to their own tenant).
+func roleTenantQuery() string {
+	if roleTenant == "" {
+		return ""
+	}
+	return "?tenant=" + url.QueryEscape(roleTenant)
+}
 
 // roleCmd is the parent command: cfg role ...
 var roleCmd = &cobra.Command{
@@ -112,6 +127,7 @@ func init() {
 		cmd.Flags().StringVar(&roleAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
 		cmd.Flags().StringVar(&roleTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
 		cmd.Flags().BoolVar(&roleTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+		cmd.Flags().StringVar(&roleTenant, "tenant", "", "Target tenant ID (required for a global admin; ignored for a tenant-scoped caller)")
 	}
 
 	roleCreateCmd.Flags().StringVar(&roleSelector, "selector", "", "Selector expression (required)")
@@ -195,7 +211,7 @@ func runRoleCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/roles", bytes.NewReader(body))
+	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/roles"+roleTenantQuery(), bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -223,7 +239,7 @@ func runRoleLs(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	resp, err := client.Get(context.Background(), "/api/v1/roles")
+	resp, err := client.Get(context.Background(), "/api/v1/roles"+roleTenantQuery())
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -263,7 +279,7 @@ func runRoleShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	resp, err := client.Get(context.Background(), "/api/v1/roles/"+name)
+	resp, err := client.Get(context.Background(), "/api/v1/roles/"+name+roleTenantQuery())
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -306,7 +322,7 @@ func runRoleDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	resp, err := client.doRequest(context.Background(), http.MethodDelete, "/api/v1/roles/"+name, nil)
+	resp, err := client.doRequest(context.Background(), http.MethodDelete, "/api/v1/roles/"+name+roleTenantQuery(), nil)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}

--- a/docs/deployment/hyperv-host-role.md
+++ b/docs/deployment/hyperv-host-role.md
@@ -1,0 +1,121 @@
+# Targeting Hyper-V hosts by tag — the `hyperv-host` role
+
+**Issue #2548 · epic #2537 (selector-driven role-config cascade — Path B)**
+
+This runbook shows how to deliver a Hyper-V configuration to a *class* of hosts
+by tag, with **no per-steward upload**. You author one role config, select it
+with `runtime_os == windows AND tag hyperv-host`, and every steward that matches
+inherits the config through the controller's `InheritanceResolver` cascade
+(#2546). Tag a host and the resource appears in its effective config; untag it
+and the resource is removed.
+
+The worked example delivers a NIC-independent **internal virtual switch**
+(`cfgms-role-net`) — uniform across every node, non-destructive, and idempotent.
+
+## Prerequisites
+
+- A controller running a build that includes the tag admin REST (#2545), the
+  selector-driven role adapter (#2546), and the role-config REST surface (#2543).
+- An admin credential: an admin bundle (`--bundle` / `CFGMS_ADMIN_BUNDLE`) or a
+  session (`cfg connect`).
+- The role config fragment: [`examples/roles/hyperv-host.cfg`](../../examples/roles/hyperv-host.cfg).
+- The tenant that owns the target stewards (below, `infra-hyperv`). A **global
+  admin must name the tenant** with `--tenant` — role configs are stored per
+  tenant. A tenant-scoped admin is pinned to its own tenant and omits `--tenant`.
+
+## 1. Author the role config
+
+The fragment file carries only the config to inject; the selector is supplied at
+author time.
+
+```bash
+cfg role create hyperv-host \
+  --tenant infra-hyperv \
+  --selector "os:windows tag:hyperv-host" \
+  --config examples/roles/hyperv-host.cfg
+
+cfg role ls   --tenant infra-hyperv          # hyperv-host listed
+cfg role show hyperv-host --tenant infra-hyperv   # inspect selector + fragment
+```
+
+The fragment is a single `hyperv.vswitch` resource of `switch_type: internal`,
+`state: present`. An internal switch has no host-NIC dependency, so the identical
+fragment is valid on every matched node.
+
+## 2. Tag a host — the resource appears in its effective config
+
+```bash
+STEWARD=<steward-id>     # e.g. the cfg-lab node's steward id
+
+cfg steward tag add "$STEWARD" hyperv-host
+cfg steward tag ls  "$STEWARD"           # hyperv-host
+
+# The injected resource now shows in the resolved config, sourced from the role
+# (NOT a per-steward upload):
+cfg config show "$STEWARD" | grep -A3 cfgms-role-net
+```
+
+The selector is `os:windows tag:hyperv-host`, so a host only inherits the role
+when **both** hold: its DNA reports `os == windows` **and** it carries the
+`hyperv-host` tag. Tag a Linux host and nothing is injected.
+
+## 3. The host converges the switch
+
+The tagged host applies the injected resource on its **next config-refresh /
+convergence cycle**, after which the switch exists on the host:
+
+```bash
+cfg steward exec "id:$STEWARD" \
+  --shell powershell \
+  --command 'Get-VMSwitch -Name cfgms-role-net | Format-List Name,SwitchType'
+# → Name: cfgms-role-net   SwitchType: Internal
+```
+
+> **Timing (important):** a tag change updates the *resolved* config immediately
+> (step 2), but the steward converges against the **last config version it was
+> handed** and only pulls a fresh config when that **version bumps**. A tag or
+> role change does **not** currently bump the steward's config version, so a
+> freshly-tagged host keeps converging its cached config and will not pick up the
+> role resource until the version next changes — e.g. any `cfg config upload` to
+> that steward (even re-uploading its unchanged device config), which forces a
+> re-pull whose fresh resolve now includes the injected resource. A steward
+> restart / reconnect alone is **not** sufficient (it re-applies the same cached
+> version). Prompt tag-driven convergence — bumping the effective version and/or
+> pushing on a role/tag change — is the DNA-currency concern tracked by epic
+> #2520; this story's scope is the cascade *delivery*, which is immediate and
+> correct. Verified live on cfg-lab 2026-07-15: tagging CFG-70-02 then bumping its
+> config version converged `cfgms-role-net` (internal) on the host.
+
+## 4. Untag — the resource leaves the resolved config
+
+```bash
+cfg steward tag rm "$STEWARD" hyperv-host
+
+# Removed from the resolved config immediately (the cascade no longer injects it):
+cfg config show "$STEWARD" | grep -c cfgms-role-net    # → 0
+```
+
+> **The physical switch is NOT auto-deleted on untag.** CFGMS convergence manages
+> *declared* resources and does **not** prune resources that merely disappear from
+> a config — removing a line never destroys infrastructure. So after untag the
+> steward simply stops managing `cfgms-role-net`; the switch remains on the host
+> until it is explicitly removed (e.g. `Remove-VMSwitch`, or a config that
+> declares it `state: absent`). The story chose an internal switch precisely so
+> that this lingering resource strands nothing (no attached VMs). Making a
+> role-removal actively tear the resource down is a separate behavior change
+> (undeclared-resource pruning) with fleet-wide safety implications — out of scope
+> here.
+
+## Removing the role entirely
+
+```bash
+cfg role delete hyperv-host --tenant infra-hyperv
+```
+
+## Why an internal switch
+
+The role fragment is uniform across every matched node by design, so it must not
+depend on any per-host detail. An **external** switch binds a specific physical
+NIC (`net_adapter_name`) that differs per node and would strand VMs when removed;
+an **internal** switch has neither constraint. Per-host field-level overrides
+(shared role + per-host tweaks) are a separate follow-up — see #2548 Non-Goals.

--- a/examples/roles/hyperv-host.cfg
+++ b/examples/roles/hyperv-host.cfg
@@ -1,0 +1,31 @@
+# hyperv-host role — config fragment (Issue #2548, epic #2537)
+#
+# This file is the StewardConfig *fragment* for the "hyperv-host" role. It is
+# injected — unchanged — into the effective config of every steward the role
+# selector matches, with NO per-steward upload (selector-driven role cascade,
+# #2546). Author it into the controller with:
+#
+#   cfg role create hyperv-host \
+#     --selector "os:windows tag:hyperv-host" \
+#     --config examples/roles/hyperv-host.cfg
+#
+# The selector (runtime_os == windows AND the operator tag `hyperv-host`) is
+# supplied at author time via --selector; this file carries only the fragment.
+# Target a class of hosts by tagging them — no config edit, no re-upload:
+#
+#   cfg steward tag add <steward-id> hyperv-host    # role resource appears
+#   cfg steward tag rm  <steward-id> hyperv-host    # role resource removed
+#
+# Design: the resource is a NIC-independent INTERNAL virtual switch. Because an
+# internal switch has no NetAdapter dependency, the identical fragment is valid
+# on every tagged node regardless of its physical adapters, and creation is
+# non-destructive and idempotent — no running VM is stranded when the tag is
+# removed and the switch converges away. (An external switch would bind a
+# specific host NIC and could not be uniform across nodes; that is out of scope
+# here — see #2548 Non-Goals.)
+resources:
+  - name: "cfgms-role-net"
+    module: "hyperv.vswitch"
+    config:
+      switch_type: "internal"
+      state: "present"

--- a/features/controller/api/handlers_roles.go
+++ b/features/controller/api/handlers_roles.go
@@ -58,6 +58,25 @@ func roleTenantFromRequest(r *http.Request, principal *Principal) string {
 	return ctxTenant
 }
 
+// resolveRoleTenant resolves the target tenant for a role request, or writes a
+// 400 TENANT_REQUIRED and returns ok=false when none can be determined (a global
+// admin that omitted ?tenant=). Every role operation — create, get, list, delete
+// — needs a concrete tenant: role configs are stored per tenant, and an empty
+// tenant reaching the store is not harmless. On the default flatfile backend a
+// get/delete with an empty tenant 500s (the key validator rejects it, so it never
+// surfaces as a clean not-found), and a list with an empty tenant filter omits
+// the tenant predicate entirely and returns roles across ALL tenants. Guarding
+// here keeps all four handlers consistent and closes that cross-tenant list.
+func (s *Server) resolveRoleTenant(w http.ResponseWriter, r *http.Request, principal *Principal) (string, bool) {
+	tenantID := roleTenantFromRequest(r, principal)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"tenant is required: a global admin must pass ?tenant=<id> (role configs are stored per tenant)", "TENANT_REQUIRED")
+		return "", false
+	}
+	return tenantID, true
+}
+
 // handleCreateRoleConfig implements POST /api/v1/roles.
 func (s *Server) handleCreateRoleConfig(w http.ResponseWriter, r *http.Request) {
 	if s.roleConfigStore == nil {
@@ -70,10 +89,8 @@ func (s *Server) handleCreateRoleConfig(w http.ResponseWriter, r *http.Request) 
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	tenantID := roleTenantFromRequest(r, principal)
-	if tenantID == "" {
-		s.writeErrorResponse(w, http.StatusBadRequest,
-			"tenant is required: a global admin must pass ?tenant=<id> (role configs are stored per tenant)", "TENANT_REQUIRED")
+	tenantID, ok := s.resolveRoleTenant(w, r, principal)
+	if !ok {
 		return
 	}
 
@@ -151,7 +168,10 @@ func (s *Server) handleGetRoleConfig(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	tenantID := roleTenantFromRequest(r, principal)
+	tenantID, ok := s.resolveRoleTenant(w, r, principal)
+	if !ok {
+		return
+	}
 
 	name := mux.Vars(r)["name"]
 	if name == "" {
@@ -196,7 +216,10 @@ func (s *Server) handleListRoleConfigs(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	tenantID := roleTenantFromRequest(r, principal)
+	tenantID, ok := s.resolveRoleTenant(w, r, principal)
+	if !ok {
+		return
+	}
 
 	entries, err := s.roleConfigStore.ListConfigs(r.Context(), &cfgconfig.ConfigFilter{
 		TenantID:  tenantID,
@@ -233,7 +256,10 @@ func (s *Server) handleDeleteRoleConfig(w http.ResponseWriter, r *http.Request) 
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	tenantID := roleTenantFromRequest(r, principal)
+	tenantID, ok := s.resolveRoleTenant(w, r, principal)
+	if !ok {
+		return
+	}
 
 	name := mux.Vars(r)["name"]
 	if name == "" {

--- a/features/controller/api/handlers_roles.go
+++ b/features/controller/api/handlers_roles.go
@@ -38,6 +38,26 @@ type createRoleConfigRequest struct {
 	Fragment stewardtypes.StewardConfig `json:"fragment"`
 }
 
+// roleTenantFromRequest resolves the target tenant for a role-config request.
+// Role configs are stored per tenant (the selector-driven resolver lists
+// role-policies under each steward's own tenant), so every role operation needs a
+// concrete tenant. A tenant-scoped caller is always pinned to its own tenant
+// (the auth middleware sets ctxkeys.TenantID from the authenticated principal). A
+// root/global admin — whose principal carries no tenant — selects the target
+// tenant explicitly via the ?tenant= query parameter; without it there is no way
+// to author into a named tenant and every store call fails "tenant ID is
+// required" (Issue #2548).
+func roleTenantFromRequest(r *http.Request, principal *Principal) string {
+	if principal.TenantID != "" {
+		return principal.TenantID
+	}
+	if q := strings.TrimSpace(r.URL.Query().Get("tenant")); q != "" {
+		return q
+	}
+	ctxTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	return ctxTenant
+}
+
 // handleCreateRoleConfig implements POST /api/v1/roles.
 func (s *Server) handleCreateRoleConfig(w http.ResponseWriter, r *http.Request) {
 	if s.roleConfigStore == nil {
@@ -45,19 +65,15 @@ func (s *Server) handleCreateRoleConfig(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
 	principal, ok := r.Context().Value(principalContextKey).(*Principal)
 	if !ok || principal == nil {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-
-	// Tenant scoping: a scoped caller may only author roles within their own tenant.
-	if principal.TenantID != "" && tenantID == "" {
-		tenantID = principal.TenantID
-	}
-	if principal.TenantID != "" && tenantID != principal.TenantID {
-		s.writeErrorResponse(w, http.StatusForbidden, "caller may only author roles within their own tenant", "FORBIDDEN")
+	tenantID := roleTenantFromRequest(r, principal)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"tenant is required: a global admin must pass ?tenant=<id> (role configs are stored per tenant)", "TENANT_REQUIRED")
 		return
 	}
 
@@ -130,15 +146,12 @@ func (s *Server) handleGetRoleConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
 	principal, ok := r.Context().Value(principalContextKey).(*Principal)
 	if !ok || principal == nil {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	if principal.TenantID != "" && tenantID == "" {
-		tenantID = principal.TenantID
-	}
+	tenantID := roleTenantFromRequest(r, principal)
 
 	name := mux.Vars(r)["name"]
 	if name == "" {
@@ -178,15 +191,12 @@ func (s *Server) handleListRoleConfigs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
 	principal, ok := r.Context().Value(principalContextKey).(*Principal)
 	if !ok || principal == nil {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	if principal.TenantID != "" && tenantID == "" {
-		tenantID = principal.TenantID
-	}
+	tenantID := roleTenantFromRequest(r, principal)
 
 	entries, err := s.roleConfigStore.ListConfigs(r.Context(), &cfgconfig.ConfigFilter{
 		TenantID:  tenantID,
@@ -218,19 +228,12 @@ func (s *Server) handleDeleteRoleConfig(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
 	principal, ok := r.Context().Value(principalContextKey).(*Principal)
 	if !ok || principal == nil {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	if principal.TenantID != "" && tenantID == "" {
-		tenantID = principal.TenantID
-	}
-	if principal.TenantID != "" && tenantID != principal.TenantID {
-		s.writeErrorResponse(w, http.StatusForbidden, "caller may only delete roles within their own tenant", "FORBIDDEN")
-		return
-	}
+	tenantID := roleTenantFromRequest(r, principal)
 
 	name := mux.Vars(r)["name"]
 	if name == "" {

--- a/features/controller/api/handlers_roles_test.go
+++ b/features/controller/api/handlers_roles_test.go
@@ -386,4 +386,25 @@ func TestHandleRoleConfig_RootAdminTenantTargeting(t *testing.T) {
 	require.Equal(t, http.StatusOK, recOther.Code)
 	assert.NotContains(t, recOther.Body.String(), "hyperv-host",
 		"role must not leak across tenants")
+
+	// A root admin omitting ?tenant= must be rejected 400 on GET/LIST/DELETE too —
+	// NOT reach the store with an empty tenant (which 500s on get/delete and, worse,
+	// lists across ALL tenants on the default flatfile backend).
+	recListNoTenant := list("/api/v1/roles")
+	assert.Equal(t, http.StatusBadRequest, recListNoTenant.Code,
+		"root admin LIST without ?tenant= must be 400, not a cross-tenant listing; body: %s", recListNoTenant.Body.String())
+
+	getNoTenant := withRoot(httptest.NewRequest(http.MethodGet, "/api/v1/roles/hyperv-host", nil))
+	getNoTenant = mux.SetURLVars(getNoTenant, map[string]string{"name": "hyperv-host"})
+	recGet := httptest.NewRecorder()
+	server.handleGetRoleConfig(recGet, getNoTenant)
+	assert.Equal(t, http.StatusBadRequest, recGet.Code,
+		"root admin GET without ?tenant= must be 400, not 500; body: %s", recGet.Body.String())
+
+	delNoTenant := withRoot(httptest.NewRequest(http.MethodDelete, "/api/v1/roles/hyperv-host", nil))
+	delNoTenant = mux.SetURLVars(delNoTenant, map[string]string{"name": "hyperv-host"})
+	recDel := httptest.NewRecorder()
+	server.handleDeleteRoleConfig(recDel, delNoTenant)
+	assert.Equal(t, http.StatusBadRequest, recDel.Code,
+		"root admin DELETE without ?tenant= must be 400, not 500; body: %s", recDel.Body.String())
 }

--- a/features/controller/api/handlers_roles_test.go
+++ b/features/controller/api/handlers_roles_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -227,9 +228,14 @@ func TestHandleRoleConfig_TenantScoping(t *testing.T) {
 	server.handleCreateRoleConfig(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code, "seed tenant-b role: %s", rec.Body.String())
 
-	// tenant-a caller tries to delete tenant-b's role — must get 403.
-	// The middleware sets tenantID from the API key; tenant-a key can't access tenant-b.
-	// Here we exercise cross-tenant enforcement by injecting a tenant-a principal trying to act on tenant-b context.
+	// A tenant-a caller cannot reach tenant-b's role. A tenant-scoped caller is
+	// PINNED to its own tenant (#2548): roleTenantFromRequest ignores any request-
+	// supplied tenant and uses the principal's tenant, so this delete operates in
+	// tenant-a — where tenant-b-role does not exist — and returns 404. Even with a
+	// mismatching tenant context injected (which the middleware never produces —
+	// it sets the context tenant FROM the principal), the caller can neither act
+	// on nor learn of another tenant's role. This is stronger isolation than the
+	// prior 403: it discloses nothing about tenant-b's contents.
 	ctxA := context.WithValue(context.Background(), principalContextKey, &Principal{
 		ID:       "caller-a",
 		TenantID: "tenant-a",
@@ -237,10 +243,12 @@ func TestHandleRoleConfig_TenantScoping(t *testing.T) {
 	ctxA = context.WithValue(ctxA, ctxkeys.TenantID, "tenant-b")
 
 	req2 := httptest.NewRequest(http.MethodDelete, "/api/v1/roles/tenant-b-role", nil)
-	req2 = req2.WithContext(ctxA)
+	// Direct handler call: set the {name} path var the router would normally supply.
+	req2 = mux.SetURLVars(req2.WithContext(ctxA), map[string]string{"name": "tenant-b-role"})
 	rec2 := httptest.NewRecorder()
 	server.handleDeleteRoleConfig(rec2, req2)
-	assert.Equal(t, http.StatusForbidden, rec2.Code)
+	assert.Equal(t, http.StatusNotFound, rec2.Code,
+		"scoped caller is pinned to its own tenant; tenant-b-role is not found there")
 
 	// GET via tenant-a API key returns 404 (not 200) because tenant-a has no roles.
 	req3 := httptest.NewRequest(http.MethodGet, "/api/v1/roles/tenant-b-role", nil)
@@ -325,4 +333,57 @@ func TestHandleCreateRoleConfig_WithFragment(t *testing.T) {
 	logging, ok := steward["logging"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "debug", fmt.Sprintf("%v", logging["level"]))
+}
+
+// TestHandleRoleConfig_RootAdminTenantTargeting is the regression guard for the
+// #2548 authoring fix: role configs are stored per tenant, so a global/root admin
+// (empty principal tenant) must select the target tenant via ?tenant=. Without it
+// the store call fails "tenant ID is required"; the handler must reject that as a
+// 400 up front, and honor ?tenant= (with cross-tenant isolation) when present.
+func TestHandleRoleConfig_RootAdminTenantTargeting(t *testing.T) {
+	server := setupRoleConfigServer(t)
+	// A root/global admin (as minted by the mTLS admin bundle) carries no tenant.
+	// The API-key auth path cannot represent this (it requires a tenant), so drive
+	// the handlers directly with a root Principal in context — the tenant-
+	// resolution logic under test lives in the handler, not the middleware.
+	rootPrincipal := &Principal{ID: "root-admin"}
+	withRoot := func(req *http.Request) *http.Request {
+		return req.WithContext(context.WithValue(req.Context(), principalContextKey, rootPrincipal))
+	}
+
+	post := func(url string) *httptest.ResponseRecorder {
+		req := withRoot(httptest.NewRequest(http.MethodPost, url,
+			bytes.NewReader(validRolePayload("hyperv-host", "os:windows tag:hyperv-host"))))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		server.handleCreateRoleConfig(rec, req)
+		return rec
+	}
+	list := func(url string) *httptest.ResponseRecorder {
+		req := withRoot(httptest.NewRequest(http.MethodGet, url, nil))
+		rec := httptest.NewRecorder()
+		server.handleListRoleConfigs(rec, req)
+		return rec
+	}
+
+	// Without ?tenant= → 400 (a root admin cannot author into an empty tenant).
+	recNoTenant := post("/api/v1/roles")
+	require.Equal(t, http.StatusBadRequest, recNoTenant.Code,
+		"root admin without ?tenant= must be rejected; body: %s", recNoTenant.Body.String())
+
+	// With ?tenant=infra-x → 201, stored under that tenant.
+	recCreate := post("/api/v1/roles?tenant=infra-x")
+	require.Equal(t, http.StatusCreated, recCreate.Code,
+		"root admin with ?tenant= must succeed; body: %s", recCreate.Body.String())
+
+	// Listing the same tenant returns it; a different tenant does not (isolation).
+	recSame := list("/api/v1/roles?tenant=infra-x")
+	require.Equal(t, http.StatusOK, recSame.Code)
+	assert.Contains(t, recSame.Body.String(), "hyperv-host",
+		"role must be listed under the tenant it was authored in")
+
+	recOther := list("/api/v1/roles?tenant=other-tenant")
+	require.Equal(t, http.StatusOK, recOther.Code)
+	assert.NotContains(t, recOther.Body.String(), "hyperv-host",
+		"role must not leak across tenants")
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -1048,6 +1048,24 @@ func (s *Server) SetTagStore(ts *tagstore.Store) {
 	s.tagStore = ts
 }
 
+// TagStore returns the wired tag store, or nil when unwired. Exposed so
+// controller startup wiring can be regression-tested (the tag REST endpoints
+// 503 when this is nil — Issue #2545/#2548).
+func (s *Server) TagStore() *tagstore.Store {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tagStore
+}
+
+// RoleConfigStore returns the wired role-config store, or nil when unwired.
+// Exposed so controller startup wiring can be regression-tested (the role REST
+// endpoints 503 when this is nil — Issue #2543/#2548).
+func (s *Server) RoleConfigStore() cfgconfig.ConfigStore {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.roleConfigStore
+}
+
 // SetRegistry wires the active-steward connection registry so that
 // GET /api/v1/stewards/{id} can report connection_state and active_sessions
 // (Issue #1323). Call this after New() returns but before Start() is called.

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -1044,6 +1044,29 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 
 	logger.Info("HTTP API server initialized successfully")
 
+	// Issue #2545: Wire the durable tag store into the HTTP API server too. The
+	// service layer was wired above (line ~371) so the selector engine / role
+	// adapter can read tags, but the REST admin endpoints (`/api/v1/stewards/
+	// {id}/tags`, handlers_tags.go) read the API server's OWN tagStore field —
+	// without this call it stays nil and every tag REST request returns 503
+	// TAG_STORE_UNAVAILABLE even though tags resolve fine internally. Nil when
+	// SQLite is unconfigured (SetTagStore is a no-op on nil; endpoints degrade to
+	// 503 by design in that case).
+	if tagStoreInstance != nil {
+		httpServer.SetTagStore(tagStoreInstance)
+	}
+
+	// Issue #2543: Wire the role-config store into the HTTP API server. Same
+	// wiring gap as the tag store above — the role-config REST endpoints
+	// (`/api/v1/roles`, handlers_roles.go) read the API server's roleConfigStore
+	// field, which is otherwise nil, so every author/list/delete returns 503
+	// "Role config store not available". The canonical store is the controller's
+	// config store under the role-policies namespace (the same store the
+	// selector-driven role adapter reads via GetConfigStore, config_service_v2.go).
+	if cs := storageManager.GetConfigStore(); cs != nil {
+		httpServer.SetRoleConfigStore(cs)
+	}
+
 	// Issue #2098: Wire registration-refresh stores into the HTTP API server so the
 	// challenge/complete endpoints and the admin approve/reject/policy endpoints are
 	// operational. GetStewardStore is always non-nil for the OSS composite (flatfile

--- a/features/controller/server/tag_role_store_wiring_test.go
+++ b/features/controller/server/tag_role_store_wiring_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestServer_New_WiresTagAndRoleConfigStoresIntoAPIServer is the regression guard
+// for Issue #2548: the durable tag store (#2545) and role-config store (#2543)
+// were initialized in New() and wired into the *service* layer, but never wired
+// into the HTTP API server — so every `/api/v1/stewards/{id}/tags` and
+// `/api/v1/roles` request returned 503 (TAG_STORE_UNAVAILABLE /
+// "Role config store not available") in production even though the stores existed
+// and the feature's unit tests (which call SetTagStore/SetRoleConfigStore
+// directly) passed. This asserts New() wires BOTH stores into the API server the
+// REST handlers actually read from.
+func TestServer_New_WiresTagAndRoleConfigStoresIntoAPIServer(t *testing.T) {
+	logger := logging.NewNoopLogger()
+
+	tempDir := t.TempDir()
+	certDir := tempDir + "/ca"
+
+	// Create the CA up front so EnableCertManagement startup succeeds.
+	_, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: certDir,
+		CAConfig: &cert.CAConfig{
+			Organization: "Store Wiring Test",
+			Country:      "US",
+			ValidityDays: 3650,
+			StoragePath:  certDir,
+		},
+		LoadExistingCA: false,
+	})
+	require.NoError(t, err, "failed to create test CA")
+
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		CertPath:   certDir,
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: true,
+			CAPath:               certDir,
+			Server: &config.ServerCertificateConfig{
+				CommonName:   "store-wiring-controller",
+				Organization: "Store Wiring Test",
+			},
+		},
+		Transport: &config.TransportConfig{
+			ListenAddr:     "127.0.0.1:0",
+			UseCertManager: true,
+			MaxConnections: 10,
+		},
+		// createTestStorageConfig sets SQLitePath, which initializeTagStore
+		// requires — without it the tag store is deliberately nil and this test
+		// would not distinguish "unconfigured" from "unwired".
+		Storage: createTestStorageConfig(tempDir, "store-wiring"),
+	}
+
+	srv, err := New(cfg, logger)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	require.NotNil(t, srv.httpServer, "API server must be initialized")
+
+	// Both stores must be wired into the API server the REST handlers read.
+	assert.NotNil(t, srv.httpServer.TagStore(),
+		"tag store must be wired into the API server (else /stewards/{id}/tags 503s)")
+	assert.NotNil(t, srv.httpServer.RoleConfigStore(),
+		"role-config store must be wired into the API server (else /roles 503s)")
+}

--- a/test/e2e/hyperv/role_cascade_test.go
+++ b/test/e2e/hyperv/role_cascade_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build e2e
+
+// Fleet-e2e live validation of the selector-driven role-config cascade delivering
+// a Hyper-V virtual switch by tag (#2548, epic #2537). This drives the REAL
+// controller cascade end-to-end — it does NOT call the hyperv module's Set
+// directly. It authors a role config on the controller, tags a steward, and
+// observes the injected resource appear in (and disappear from) that steward's
+// controller-RESOLVED effective config, exactly as an operator does from the
+// runbook (docs/deployment/hyperv-host-role.md).
+//
+// Observation goes through the `cfg` CLI against the live controller (admin
+// bundle), so the test exercises the tag REST (#2545), the role-config REST
+// (#2543), and the selector-driven injection (#2546) as a black box — the same
+// surface whose production wiring gaps this story fixed.
+//
+// The suite is excluded from CI and `make test-complete` by the e2e build tag,
+// and skips cleanly unless CFGMS_E2E_ROLE_CASCADE and the required inputs are set.
+//
+// Inputs (env):
+//
+//	CFGMS_E2E_ROLE_CASCADE   set to "1" to enable this suite
+//	CFGMS_E2E_CFG_BIN        path to a cfg binary built from develop (has `role`/`tag` verbs)
+//	CFGMS_ADMIN_BUNDLE       admin bundle for controller auth (read by cfg itself)
+//	CFGMS_E2E_STEWARD_ID     a windows-DNA steward to tag (e.g. a cfg-lab node)
+//	CFGMS_E2E_ROLE_TENANT    the tenant that owns the steward (e.g. infra-hyperv)
+package hyperv_e2e
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	envRoleCascade = "CFGMS_E2E_ROLE_CASCADE"
+	envCfgBin      = "CFGMS_E2E_CFG_BIN"
+	envStewardID   = "CFGMS_E2E_STEWARD_ID"
+	envRoleTenant  = "CFGMS_E2E_ROLE_TENANT"
+
+	roleName   = "hyperv-host-e2e"
+	roleTag    = "hyperv-host-e2e"
+	switchName = "cfgms-role-net-e2e"
+)
+
+// TestRoleCascade_DeliversVSwitchByTag proves the selector-driven cascade injects
+// the internal vswitch resource into a steward's resolved config when it is tagged
+// (matching os:windows tag:<tag>), and removes it on untag — no per-steward upload.
+func TestRoleCascade_DeliversVSwitchByTag(t *testing.T) {
+	if os.Getenv(envRoleCascade) != "1" {
+		t.Skipf("set %s=1 to run the live role-cascade e2e", envRoleCascade)
+	}
+	cfgBin := mustEnv(t, envCfgBin)
+	stewardID := mustEnv(t, envStewardID)
+	tenant := mustEnv(t, envRoleTenant)
+
+	// Fragment: a uniform internal vswitch, written to a temp file for `role create`.
+	fragment := "resources:\n" +
+		"  - name: \"" + switchName + "\"\n" +
+		"    module: \"hyperv.vswitch\"\n" +
+		"    config:\n" +
+		"      switch_type: \"internal\"\n" +
+		"      state: \"present\"\n"
+	fragFile := writeTemp(t, "role-fragment-*.cfg", fragment)
+
+	cfg := func(args ...string) string {
+		t.Helper()
+		out, err := exec.Command(cfgBin, args...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("cfg %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+
+	// Author the role and guarantee cleanup (idempotent — ignore delete errors).
+	cfg("role", "create", roleName, "--tenant", tenant,
+		"--selector", "os:windows tag:"+roleTag, "--config", fragFile)
+	t.Cleanup(func() {
+		_ = exec.Command(cfgBin, "steward", "tag", "rm", stewardID, roleTag).Run()
+		_ = exec.Command(cfgBin, "role", "delete", roleName, "--tenant", tenant).Run()
+	})
+
+	// Baseline: untagged steward's resolved config must NOT carry the switch.
+	if strings.Contains(cfg("config", "show", stewardID), switchName) {
+		t.Fatalf("baseline: %s already present in resolved config before tagging", switchName)
+	}
+
+	// Tag → the resolved config now carries the role-injected switch (no upload).
+	cfg("steward", "tag", "add", stewardID, roleTag)
+	if !strings.Contains(cfg("config", "show", stewardID), switchName) {
+		t.Fatalf("after tag: expected %s injected into resolved config, not found", switchName)
+	}
+
+	// Untag → the switch leaves the resolved config on the next resolve.
+	cfg("steward", "tag", "rm", stewardID, roleTag)
+	if strings.Contains(cfg("config", "show", stewardID), switchName) {
+		t.Fatalf("after untag: %s still present in resolved config", switchName)
+	}
+}
+
+func mustEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Skipf("%s not set; skipping live role-cascade e2e", key)
+	}
+	return v
+}
+
+func writeTemp(t *testing.T, pattern, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), pattern)
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	_ = f.Close()
+	return f.Name()
+}


### PR DESCRIPTION
## Summary

Story #2548 (epic #2537): prove — live on cfg-lab — that selector-driven role-config targeting delivers a **Hyper-V** config to a class of hosts **by tag, with no per-steward upload**. In doing so, the live proof surfaced that the entire role-cascade REST surface (epic #2537) was **dead-on-arrival in production**; this PR fixes that too.

## Production bugs found + fixed (the cascade was never functional)

The deployed controller predated #2545/#2546 (merged 2026-07-13). After redeploying current `develop`, three real gaps surfaced — all live-verified on cfg-lab:

1. **Tag store never wired into the HTTP API server** (#2545) — every `/api/v1/stewards/{id}/tags` returned 503. The store was initialized and wired into the *service* layer, but not the API server the REST handlers read.
2. **Role-config store never wired into the HTTP API server** (#2543) — same gap; every `/api/v1/roles` returned 503.
3. **No root-admin tenant targeting** — role configs are per-tenant, but the handler bound the tenant to the caller's principal, and the mTLS admin bundle is a tenant-less root admin, so `cfg role create` failed "tenant ID is required" with no way to name a tenant.

Both wiring gaps passed their unit tests (which call the setters directly) — the defect lived in `server.New()`. Added `TestServer_New_WiresTagAndRoleConfigStoresIntoAPIServer` (builds the controller via `New()`, asserts both stores are wired) as the regression that was missing.

## Changes

- **`server.go`**: wire tag + role-config stores into the API server (mirrors the approval-hook late-wiring idiom; nil-safe). `api.Server` gains `TagStore()`/`RoleConfigStore()` accessors for the regression test.
- **`handlers_roles.go` + `cmd/cfg/cmd/role.go`**: `roleTenantFromRequest` — scoped callers pinned to their own tenant, root admin selects via `?tenant=`; `resolveRoleTenant` returns **400 TENANT_REQUIRED** uniformly across create/get/list/delete when unresolvable (an empty tenant otherwise 500s on get/delete and silently lists **across all tenants**). New `--tenant` CLI flag. Tenant isolation is now *stronger* than the prior 403 (pinned → 404, no cross-tenant existence disclosure).
- **`examples/roles/hyperv-host.cfg`** — role fragment (uniform internal vswitch, `os:windows tag:hyperv-host`).
- **`docs/deployment/hyperv-host-role.md`** — operator runbook.
- **`test/e2e/hyperv/role_cascade_test.go`** — env-gated (`//go:build e2e`) validation driving the real controller cascade via the `cfg` CLI.

## Live proof (cfg-lab, CFG-70-02, 2026-07-15)

- Authored `hyperv-host` role → tagged the node → **`cfgms-role-net` injected into its resolved config, sourced from the role, no upload** (AC1/AC2, `cfg config show`).
- Config-version bump → **internal switch physically converged on the host** (`Get-VMSwitch`: SwitchType `Internal`, config v87 modules 3) (AC3).
- Untag → **removed from resolved config** (AC4 resolved side).

## Two honest limitations (⚠️ founder sign-off)

Both are documented in the runbook and (I believe) legitimately out of this story's scope:

1. **Convergence is not prompt on tag change.** The steward converges against its last config *version*; a tag/role change updates the resolved config but does **not bump the version**, so the host converges only after the version next changes (any `cfg config upload`). This is the DNA-currency concern epic **#2520** owns — the story body explicitly says *"do not block on it."*
2. **AC4 "switch converges away" is not literally delivered.** Untag removes the resource from the resolved config, but CFGMS does **not prune undeclared resources** (a deliberate safety property — removing a line never destroys infra), so the physical switch persists until explicitly removed. The story chose an internal switch precisely so this strands nothing.

## Adversarial review (pre-PR, self-dispatch on the Windows host)

- **Acceptance**: PASS — all code deliverables real; AC4 physical-removal flagged for the explicit sign-off above.
- **Security**: PASS, 0 blocking — tenant isolation sound and *hardened*; 2 LOW notes (one addressed below; the other: role-write endpoints don't require the mTLS-only tier that RBAC roles do — a #2543 design consideration, not a regression here).
- **QA**: PASS after one fix round — caught that the empty-tenant guard was only on `create` (get/delete 500'd, list went cross-tenant); fixed + re-verified.

## Validation

Native Windows: `features/controller/api` + `features/controller/server` green (incl. both regression tests); `cmd/cfg` role tests green; `gofmt`/`go vet` clean; `make check-architecture` pass; `GOOS=windows go build ./...` pass. Lint/secret-scan/Docker-inclusive gates deferred to CI.

Fixes #2548

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
