### PR TITLE
web: implement authenticated app shell chrome (nav, tenant switcher, search, alerts, user menu)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ __pycache__/
 # Build cache
 /.cache/
 
+# Personal local-validation harness (not part of the product)
+/Dockerfile.validate
+
 # Git storage provider test artifacts (tenant data written to repo root by tests)
 # These are created when git-storage tests use repo-relative paths instead of t.TempDir()
 /2026/

--- a/web/README.md
+++ b/web/README.md
@@ -149,8 +149,47 @@ The app authenticates against the controller's web session endpoints
 - **Route guard.** `RequireAuth` renders the login screen
   ([`src/pages/Login.tsx`](src/pages/Login.tsx), canonical design:
   [`docs/design/mockups/login.html`](../docs/design/mockups/login.html))
-  for any unauthenticated visit; the authenticated placeholder it protects
-  is replaced by the app shell in #2496.
+  for any unauthenticated visit; the authenticated screen it protects is
+  the app shell (#2496).
+
+## App shell architecture (Story #2496)
+
+Every authenticated screen mounts inside [`src/shell/AppShell.tsx`](src/shell/AppShell.tsx)
+— the persistent chrome fixed by
+[`docs/design/mockups/fleet-overview.html`](../docs/design/mockups/fleet-overview.html)
+(lines ~102-266): sidebar navigation, a top app bar (tenant-scope switcher,
+global search, alert center, user menu), and the responsive drawer/scrim
+behavior below 1024px. `App.tsx` renders `AppShell` as the sole child of
+`RequireAuth`; later epics mount their views into `AppShell`'s `.content`
+area (fleet overview, #2497, is the first occupant — this story ships that
+area as an empty-state placeholder).
+
+- **Tenant-scope context — a display convenience, not a security boundary
+  (security A8.1).** [`src/shell/TenantScopeContext.tsx`](src/shell/TenantScopeContext.tsx)
+  holds the currently selected scope and the set of paths observed so far
+  (seeded with the principal's own root path; later views call
+  `registerObservedPath` as they see more of the tenant tree — there is no
+  list-tenants API). `isScopeMatch` mirrors the server's path-separator-aware
+  ancestor check in `handlers_stewards.go` (`tenant-a` must never match
+  `tenant-abc`). **Server-side tenant scoping on every API call is the only
+  real enforcement** — this context only decides what a technician sees in
+  the switcher and gives views a shared scope to filter by.
+- **Global search / alert center are chrome only.** No search or alerting
+  backend exists yet; `GlobalSearch` is a controlled input a later view can
+  wire up, and `AlertCenter` renders its designed empty state rather than
+  fabricated sample data.
+- **User menu.** Shows the signed-in principal from `AuthContext` and hosts
+  logout via the #2495 auth actions, plus the design-system theme toggle
+  (auto/light/dark via `:root[data-theme]`). Theme choice persists in
+  `localStorage` under `cfgms.theme` — a display preference, not auth data,
+  so it's explicitly allowlisted in the A7.2 source scan
+  ([`src/pages/Login.test.tsx`](src/pages/Login.test.tsx)
+  `STORAGE_ALLOWLIST`) rather than exempt from it: any new storage key
+  anywhere in `web/` must be added to that allowlist by exact `(file, key)`
+  match or the scan fails, and a non-literal key always fails closed.
+- **Responsive drawer.** Below 1024px the sidebar becomes an off-canvas
+  drawer opened by the hamburger button; a scrim covers the content and
+  Escape or a scrim click closes it, matching the mockup harness.
 
 ## Testing
 
@@ -161,8 +200,10 @@ pre-session flow, 401 interception),
 [`src/auth/AuthContext.test.tsx`](src/auth/AuthContext.test.tsx) (state
 transitions, web-storage assertions), and
 [`src/pages/Login.test.tsx`](src/pages/Login.test.tsx) (mockup states,
-source scans). Setup (jest-dom matchers, RTL cleanup, in-memory Storage
-for the A7.2 assertions): [`src/test/setup.ts`](src/test/setup.ts).
+source scans), and `src/shell/*.test.tsx` (tenant-scope prefix matching,
+drawer/scrim/Escape behavior, user-menu logout dispatch). Setup (jest-dom
+matchers, RTL cleanup, in-memory Storage for the A7.2 assertions):
+[`src/test/setup.ts`](src/test/setup.ts).
 
 ## License
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -26,10 +26,10 @@ describe('App', () => {
   it('guards the authenticated screen: unauthenticated visit renders the login screen', () => {
     render(<App />)
     expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
-    expect(screen.queryByText(/signed in as/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument()
   })
 
-  it('full flow: login lands on the authenticated placeholder; sign-out returns to signin', async () => {
+  it('full flow: login lands on the app shell; sign-out returns to signin', async () => {
     fetchMock.mockImplementation((input) => {
       const url = String(input)
       if (url.endsWith('/api/v1/web/csrf')) {
@@ -48,12 +48,12 @@ describe('App', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
-    await waitFor(() =>
-      expect(screen.getByText(/signed in as/i)).toBeInTheDocument(),
-    )
-    expect(screen.getByText('admin@msp-a')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('navigation')).toBeInTheDocument())
 
-    fireEvent.click(screen.getByRole('button', { name: /sign out/i }))
+    fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    expect(screen.getByText('admin@msp-a')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('menuitem', { name: /sign out/i }))
+
     await waitFor(() =>
       expect(
         screen.getByRole('button', { name: /sign in/i }),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,48 +2,34 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * App root (Story #2495): auth provider + route guard around a minimal
- * authenticated placeholder. The real app-shell chrome (nav, tenant
- * switcher, search, alerts, user menu) is Story #2496 and replaces
- * AuthedHome.
+ * App root: auth provider + route guard around the authenticated app
+ * shell (Story #2496).
  */
 import { useEffect } from 'react'
 import { apiFetch } from './api/client.ts'
-import { AuthProvider, RequireAuth, useAuth } from './auth/AuthContext.tsx'
+import { AuthProvider, RequireAuth } from './auth/AuthContext.tsx'
+import AppShell from './shell/AppShell.tsx'
 
-function AuthedHome() {
-  const { principal, logout } = useAuth()
-
+function AuthedApp() {
   // Lightweight authenticated probe (story #2495 note): session presence is
   // inferred from API responses, never from reading cookies. A 401 here is
   // handled centrally — the app drops to the login screen ("session
   // expired"). The response body is irrelevant.
   useEffect(() => {
     void apiFetch('/api/v1/stewards?page_size=1').catch(() => {
-      // Network errors are not session expiry; the next real data call
-      // (app shell, #2496) owns user-visible error handling.
+      // Network errors are not session expiry; the fleet view (#2497) owns
+      // user-visible error handling for its own data call.
     })
   }, [])
 
-  return (
-    <main className="authed-home">
-      <h1>CFGMS</h1>
-      <p>
-        Signed in as <code>{principal?.username}</code>. App shell lands in
-        Story #2496.
-      </p>
-      <button type="button" onClick={() => void logout()}>
-        Sign out
-      </button>
-    </main>
-  )
+  return <AppShell />
 }
 
 function App() {
   return (
     <AuthProvider>
       <RequireAuth>
-        <AuthedHome />
+        <AuthedApp />
       </RequireAuth>
     </AuthProvider>
   )

--- a/web/src/pages/Login.test.tsx
+++ b/web/src/pages/Login.test.tsx
@@ -176,7 +176,12 @@ describe('forbidden references in source (security A7.1 / A7.2)', () => {
   //
   // NEVER add an auth/session/principal/credential key here — that data
   // must stay in-memory only (React context), per A7.2.
-  const STORAGE_ALLOWLIST: ReadonlyArray<{ path: string; key: string }> = []
+  const STORAGE_ALLOWLIST: ReadonlyArray<{ path: string; key: string }> = [
+    // Theme preference (Story #2496) — a UI display preference, not auth
+    // data; persists across reloads so the sidebar/topbar don't reset to
+    // "auto" every visit.
+    { path: 'shell/UserMenu.tsx', key: 'cfgms.theme' },
+  ]
 
   it('no non-test source file uses localStorage/sessionStorage outside the explicit allowlist', () => {
     const offenders: string[] = []
@@ -200,11 +205,12 @@ describe('forbidden references in source (security A7.1 / A7.2)', () => {
     expect(offenders).toEqual([])
   })
 
-  // Proves the allowlist mechanism is live: an unauthorized literal key is
-  // rejected, a non-literal (computed) key is rejected, and — once a real
-  // entry exists — an allowlisted key is accepted. Uses synthetic source
-  // text so the test doesn't depend on any real file's current content.
-  it('the storage allowlist rejects unauthorized and non-literal keys', () => {
+  // Proves the allowlist mechanism is live: an allowlisted literal key is
+  // accepted, an unauthorized literal key is rejected, and a non-literal
+  // (computed) key is rejected even if its runtime value would be fine.
+  // Uses synthetic source text so the test doesn't depend on any real
+  // file's current content.
+  it('the storage allowlist accepts only the exact allowlisted key', () => {
     const check = (path: string, content: string) => {
       const anyCallPattern = /(localStorage|sessionStorage)\.(setItem|getItem|removeItem)\(/g
       const literalCallPattern =
@@ -220,9 +226,14 @@ describe('forbidden references in source (security A7.1 / A7.2)', () => {
       }
       return 'ok'
     }
-    expect(check('shell/UserMenu.tsx', "localStorage.setItem('cfgms.theme', mode)")).toBe(
-      'unauthorized', // no allowlist entry exists yet — every new key must be added deliberately
+    // The real, currently-allowlisted entry (Story #2496 theme toggle).
+    expect(check('shell/UserMenu.tsx', "localStorage.setItem('cfgms.theme', mode)")).toBe('ok')
+    // A different key on the same file is not automatically allowed.
+    expect(check('shell/UserMenu.tsx', "localStorage.setItem('cfgms.session_hint', mode)")).toBe(
+      'unauthorized',
     )
+    // A computed key is rejected even though it can't be inspected — fails
+    // closed rather than trusting the call site.
     expect(check('shell/UserMenu.tsx', 'localStorage.setItem(dynamicKey, mode)')).toBe('non-literal')
   })
 })

--- a/web/src/shell/AlertCenter.test.tsx
+++ b/web/src/shell/AlertCenter.test.tsx
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { describe, expect, it } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import AlertCenter from './AlertCenter.tsx'
+
+describe('AlertCenter', () => {
+  it('renders a bell button with no badge when there are no alerts', () => {
+    render(<AlertCenter />)
+    const button = screen.getByRole('button', { name: /notifications/i })
+    expect(button).toBeInTheDocument()
+    expect(screen.queryByTestId('alert-badge')).not.toBeInTheDocument()
+  })
+
+  it('opens a popover showing the designed empty state', () => {
+    render(<AlertCenter />)
+    fireEvent.click(screen.getByRole('button', { name: /notifications/i }))
+    expect(screen.getByText(/no notifications/i)).toBeInTheDocument()
+  })
+
+  it('closes on Escape', () => {
+    render(<AlertCenter />)
+    fireEvent.click(screen.getByRole('button', { name: /notifications/i }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/shell/AlertCenter.tsx
+++ b/web/src/shell/AlertCenter.tsx
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Alert / notification center (Story #2496) —
+ * mockups/fleet-overview.html `#pop-notif`. There is no alerting backend
+ * (story Out of Scope), so this renders its designed EMPTY state rather
+ * than fabricated sample alerts; a later epic wires a real feed in.
+ */
+import { useEffect, useRef, useState } from 'react'
+
+export default function AlertCenter() {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const alertCount = 0
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    function onClickAway(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onClickAway)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onClickAway)
+    }
+  }, [open])
+
+  return (
+    <div className="alertcenter-root" ref={rootRef}>
+      <button
+        type="button"
+        className="icobtn"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Notifications"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path
+            d="M6 9a6 6 0 1112 0c0 5 2 6 2 6H4s2-1 2-6z"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinejoin="round"
+          />
+          <path d="M10 20a2 2 0 004 0" stroke="currentColor" strokeWidth="1.6" />
+        </svg>
+        {alertCount > 0 && (
+          <span className="badge" data-testid="alert-badge">
+            {alertCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="pop right open" role="menu">
+          <h4>Notifications</h4>
+          <div className="notice empty">
+            <p>No notifications.</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/shell/AppShell.css
+++ b/web/src/shell/AppShell.css
@@ -1,0 +1,405 @@
+/* SPDX-License-Identifier: AGPL-3.0-only */
+/* Copyright 2026 Jordan Ritz */
+
+/*
+ * App shell chrome (Story #2496) — every value is a token var() from
+ * docs/design/web-ui-design-tokens.css. Layout mirrors
+ * docs/design/mockups/fleet-overview.html lines ~102-266 (the shell around
+ * the fleet content, not the fleet table itself — that's Story #2497).
+ *
+ * The mockup's --accent-weak (a muted accent-tinted background for the
+ * active nav item) has no direct token; --tint-blue is the closest existing
+ * neutral/accent-adjacent tint and is used in its place rather than forking
+ * a new color value.
+ */
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 35;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+body.drawer .scrim {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.icobtn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  border-radius: var(--radius);
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  position: relative;
+  flex: none;
+}
+.icobtn:hover {
+  color: var(--text-primary);
+}
+
+.shell {
+  display: grid;
+  grid-template-columns: 1fr;
+  min-height: 100dvh;
+  position: relative;
+}
+
+.side {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 250px;
+  z-index: 40;
+  transform: translateX(-105%);
+  transition: transform 0.22s ease;
+}
+body.drawer .side {
+  transform: translateX(0);
+}
+
+.side .logo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-4) var(--space-3);
+}
+.side .logo .l {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+.side .logo b {
+  font-size: var(--text-md);
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+.side .logo i {
+  font-style: normal;
+  font-size: var(--text-xs);
+  color: var(--text-faint);
+  letter-spacing: 0.05em;
+}
+
+nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px var(--space-3);
+}
+nav a {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: var(--text-base);
+  cursor: pointer;
+}
+nav a.active {
+  background: var(--tint-blue);
+  color: var(--accent);
+  font-weight: 600;
+}
+nav a.soon {
+  opacity: 0.5;
+}
+nav a.soon .tag {
+  margin-left: auto;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.appbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border);
+}
+.ham {
+  display: none;
+}
+
+.scope {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 7px 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  white-space: nowrap;
+}
+.scope-lbl {
+  color: var(--text-faint);
+}
+.scope-path {
+  color: var(--text-secondary);
+}
+.scope-path b {
+  color: var(--text-primary);
+}
+.scope-root {
+  position: relative;
+}
+
+.searchbox {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  max-width: 440px;
+}
+.searchbox svg {
+  color: var(--text-faint);
+  flex: none;
+}
+.searchbox input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--text-base);
+  padding: 9px 0;
+  outline: none;
+}
+.searchbox input::placeholder {
+  color: var(--text-faint);
+}
+
+.abspacer {
+  flex: 1;
+}
+
+.alertcenter-root,
+.usermenu-root {
+  position: relative;
+}
+
+.badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: var(--radius-pill);
+  background: var(--state-crit);
+  color: #fff;
+  font-size: 9.5px;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+}
+
+.uav {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-ink);
+  display: grid;
+  place-items: center;
+  font-size: var(--text-sm);
+  font-weight: 700;
+  cursor: pointer;
+  flex: none;
+  border: 0;
+  appearance: none;
+}
+
+.pop {
+  position: absolute;
+  z-index: 60;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: 6px;
+  min-width: 230px;
+  top: 44px;
+  left: 0;
+}
+.pop.right {
+  left: auto;
+  right: 0;
+}
+.pop h4 {
+  margin: 2px 8px 6px;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.pop .row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 8px 9px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  cursor: pointer;
+  color: var(--text-primary);
+}
+.pop .row:hover {
+  background: var(--bg-elevated);
+}
+.pop .row.cur {
+  background: var(--tint-blue);
+  color: var(--accent);
+  font-weight: 600;
+}
+.pop .sep {
+  height: 1px;
+  background: var(--border);
+  margin: 5px 4px;
+}
+
+.miniseg {
+  display: flex;
+  gap: 3px;
+  margin: 2px 8px 6px;
+}
+.miniseg button {
+  flex: 1;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  border-radius: 6px;
+  padding: 5px;
+  cursor: pointer;
+}
+.miniseg button.on {
+  background: var(--accent);
+  color: var(--accent-ink);
+  border-color: var(--accent);
+}
+
+.content {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.htitle h1 {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.htitle p {
+  margin: 3px 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+}
+
+.panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.notice {
+  padding: 38px var(--space-5);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+}
+.notice h3 {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 700;
+}
+.notice p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+  max-width: 340px;
+}
+
+@media (min-width: 1024px) {
+  .shell {
+    grid-template-columns: 250px 1fr;
+  }
+  .side {
+    position: static;
+    transform: none;
+  }
+  body.drawer .scrim {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .ham,
+  .drawer-close {
+    display: none;
+  }
+  .content {
+    padding: var(--space-5) var(--space-6);
+  }
+}
+@media (max-width: 1023px) {
+  .ham {
+    display: grid;
+  }
+}
+@media (max-width: 719px) {
+  .appbar {
+    flex-wrap: wrap;
+    row-gap: 10px;
+  }
+  .searchbox {
+    order: 6;
+    flex-basis: 100%;
+    max-width: none;
+  }
+  .searchbox input {
+    padding: 11px 0;
+    font-size: var(--text-lg);
+  }
+}

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import AppShell from './AppShell.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  document.body.className = ''
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function renderShell() {
+  return render(
+    <AuthProvider>
+      <AppShell />
+    </AuthProvider>,
+  )
+}
+
+describe('AppShell', () => {
+  it('renders sidebar navigation with Fleet active and other items marked soon', () => {
+    renderShell()
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /fleet/i })).toBeInTheDocument()
+    expect(screen.getAllByText(/soon/i).length).toBeGreaterThan(0)
+  })
+
+  it('renders the content area empty-state placeholder (no fleet table in this story)', () => {
+    renderShell()
+    expect(screen.getByText(/fleet overview lands in story #2497/i)).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders the tenant switcher, search, alert center, and user menu', () => {
+    renderShell()
+    expect(screen.getByRole('button', { name: /root/i })).toBeInTheDocument()
+    expect(screen.getByRole('searchbox')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /account menu/i })).toBeInTheDocument()
+  })
+
+  it('opens the mobile drawer via the hamburger button and shows a scrim', () => {
+    renderShell()
+    const hamburger = screen.getByRole('button', { name: /open navigation/i })
+    fireEvent.click(hamburger)
+    expect(document.body.classList.contains('drawer')).toBe(true)
+  })
+
+  it('closes the drawer on Escape', () => {
+    renderShell()
+    fireEvent.click(screen.getByRole('button', { name: /open navigation/i }))
+    expect(document.body.classList.contains('drawer')).toBe(true)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(document.body.classList.contains('drawer')).toBe(false)
+  })
+
+  it('closes the drawer when the scrim is clicked', () => {
+    renderShell()
+    fireEvent.click(screen.getByRole('button', { name: /open navigation/i }))
+    fireEvent.click(screen.getByTestId('shell-scrim'))
+    expect(document.body.classList.contains('drawer')).toBe(false)
+  })
+})

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * App shell (Story #2496) — mockups/fleet-overview.html lines ~102-266.
+ * The persistent chrome every authenticated screen mounts into: sidebar +
+ * top bar at desktop width, hamburger + off-canvas drawer + scrim below
+ * 1024px, Escape closes overlays. Fleet overview (#2497) is the first real
+ * occupant of `.content` — this story renders its empty-state placeholder.
+ */
+import { useEffect, useState } from 'react'
+import { TenantScopeProvider } from './TenantScopeContext.tsx'
+import TenantSwitcher from './TenantSwitcher.tsx'
+import GlobalSearch from './GlobalSearch.tsx'
+import AlertCenter from './AlertCenter.tsx'
+import UserMenu from './UserMenu.tsx'
+import './AppShell.css'
+
+const NAV_ITEMS = [
+  { label: 'Fleet', active: true, soon: false },
+  { label: 'Modules', active: false, soon: true },
+  { label: 'Config', active: false, soon: true },
+  { label: 'Audit', active: false, soon: true },
+] as const
+
+export default function AppShell() {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    document.body.classList.toggle('drawer', drawerOpen)
+    return () => document.body.classList.remove('drawer')
+  }, [drawerOpen])
+
+  useEffect(() => {
+    if (!drawerOpen) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setDrawerOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [drawerOpen])
+
+  return (
+    <TenantScopeProvider rootPath="root">
+      <div
+        className="scrim"
+        data-testid="shell-scrim"
+        onClick={() => setDrawerOpen(false)}
+      />
+      <div className="shell">
+        <aside className="side">
+          <div className="logo">
+            <div className="l">
+              <b>CFGMS</b>
+              <i>controller</i>
+            </div>
+            <button
+              type="button"
+              className="icobtn drawer-close"
+              aria-label="Close navigation"
+              onClick={() => setDrawerOpen(false)}
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M6 6l12 12M18 6L6 18"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          </div>
+          <nav>
+            {NAV_ITEMS.map((item) => (
+              <a
+                key={item.label}
+                role="link"
+                tabIndex={0}
+                className={`${item.active ? 'active' : ''}${item.soon ? ' soon' : ''}`}
+              >
+                {item.label}
+                {item.soon && <span className="tag">soon</span>}
+              </a>
+            ))}
+          </nav>
+        </aside>
+
+        <div className="main">
+          <div className="appbar">
+            <button
+              type="button"
+              className="icobtn ham"
+              aria-label="Open navigation"
+              onClick={() => setDrawerOpen(true)}
+            >
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M4 7h16M4 12h16M4 17h16"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+            <TenantSwitcher />
+            <GlobalSearch value={search} onChange={setSearch} />
+            <div className="abspacer" />
+            <AlertCenter />
+            <UserMenu />
+          </div>
+
+          <div className="content">
+            <div className="htitle">
+              <h1>Fleet</h1>
+              <p>Stewards enrolled to this controller, with the device DNA you choose.</p>
+            </div>
+            <section className="panel">
+              <div className="notice empty">
+                <h3>Fleet overview lands in Story #2497</h3>
+                <p>This screen will list enrolled stewards once that story ships.</p>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </TenantScopeProvider>
+  )
+}

--- a/web/src/shell/GlobalSearch.test.tsx
+++ b/web/src/shell/GlobalSearch.test.tsx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import GlobalSearch from './GlobalSearch.tsx'
+
+describe('GlobalSearch', () => {
+  it('renders a search input with the mockup placeholder copy', () => {
+    render(<GlobalSearch value="" onChange={() => {}} />)
+    expect(
+      screen.getByPlaceholderText(/filter stewards by name, user, ip, company/i),
+    ).toBeInTheDocument()
+  })
+
+  it('is a controlled input that reports changes without calling any API', () => {
+    const onChange = vi.fn()
+    render(<GlobalSearch value="" onChange={onChange} />)
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'acme' } })
+    expect(onChange).toHaveBeenCalledWith('acme')
+  })
+
+  it('reflects the controlled value prop', () => {
+    render(<GlobalSearch value="acme" onChange={() => {}} />)
+    expect(screen.getByRole('searchbox')).toHaveValue('acme')
+  })
+})

--- a/web/src/shell/GlobalSearch.test.tsx
+++ b/web/src/shell/GlobalSearch.test.tsx
@@ -13,11 +13,18 @@ describe('GlobalSearch', () => {
     ).toBeInTheDocument()
   })
 
-  it('is a controlled input that reports changes without calling any API', () => {
+  it('is a controlled input that reports changes via onChange only', () => {
     const onChange = vi.fn()
-    render(<GlobalSearch value="" onChange={onChange} />)
-    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'acme' } })
-    expect(onChange).toHaveBeenCalledWith('acme')
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    try {
+      render(<GlobalSearch value="" onChange={onChange} />)
+      fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'acme' } })
+      expect(onChange).toHaveBeenCalledWith('acme')
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it('reflects the controlled value prop', () => {

--- a/web/src/shell/GlobalSearch.tsx
+++ b/web/src/shell/GlobalSearch.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Global search (Story #2496) — mockups/fleet-overview.html `.searchbox`.
+ * Chrome only: a controlled input scoping to whatever view mounts under
+ * the shell (fleet overview, #2497) filters client-side. No search
+ * backend call is introduced here.
+ */
+export default function GlobalSearch({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="searchbox">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="1.7" />
+        <path d="M20 20l-3-3" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+      </svg>
+      <input
+        role="searchbox"
+        type="text"
+        placeholder="Filter stewards by name, user, IP, company…"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  )
+}

--- a/web/src/shell/TenantScopeContext.test.tsx
+++ b/web/src/shell/TenantScopeContext.test.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { describe, expect, it } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import {
+  TenantScopeProvider,
+  useTenantScope,
+  isScopeMatch,
+} from './TenantScopeContext.tsx'
+
+describe('isScopeMatch (path-separator-aware prefix matching)', () => {
+  it('matches a path against itself', () => {
+    expect(isScopeMatch('root/msp-a', 'root/msp-a')).toBe(true)
+  })
+
+  it('matches a true descendant (separator boundary respected)', () => {
+    expect(isScopeMatch('root/msp-a/client-1', 'root/msp-a')).toBe(true)
+  })
+
+  it('does not match a sibling with a shared string prefix', () => {
+    // The exact boundary case named in the story: "tenant-a" must not match "tenant-abc".
+    expect(isScopeMatch('tenant-abc', 'tenant-a')).toBe(false)
+  })
+
+  it('does not match an unrelated path', () => {
+    expect(isScopeMatch('root/msp-b', 'root/msp-a')).toBe(false)
+  })
+
+  it('does not match an ancestor against a descendant scope', () => {
+    expect(isScopeMatch('root', 'root/msp-a')).toBe(false)
+  })
+})
+
+function Probe() {
+  const { scope, observedPaths, setScope, registerObservedPath } = useTenantScope()
+  return (
+    <div>
+      <span data-testid="scope">{scope}</span>
+      <span data-testid="paths">{observedPaths.join(',')}</span>
+      <button type="button" onClick={() => setScope('root/msp-a/client-1')}>
+        select
+      </button>
+      <button type="button" onClick={() => registerObservedPath('root/msp-a/client-1')}>
+        observe
+      </button>
+      <button type="button" onClick={() => registerObservedPath('root/msp-a')}>
+        observe-dup
+      </button>
+    </div>
+  )
+}
+
+describe('TenantScopeProvider', () => {
+  it('initializes scope to the provided root path', () => {
+    render(
+      <TenantScopeProvider rootPath="root/msp-a">
+        <Probe />
+      </TenantScopeProvider>,
+    )
+    expect(screen.getByTestId('scope').textContent).toBe('root/msp-a')
+    expect(screen.getByTestId('paths').textContent).toBe('root/msp-a')
+  })
+
+  it('registers newly observed descendant paths exactly once', () => {
+    render(
+      <TenantScopeProvider rootPath="root/msp-a">
+        <Probe />
+      </TenantScopeProvider>,
+    )
+    act(() => screen.getByText('observe').click())
+    act(() => screen.getByText('observe-dup').click())
+    act(() => screen.getByText('observe').click())
+    expect(screen.getByTestId('paths').textContent).toBe('root/msp-a,root/msp-a/client-1')
+  })
+
+  it('updates the selected scope via setScope', () => {
+    render(
+      <TenantScopeProvider rootPath="root/msp-a">
+        <Probe />
+      </TenantScopeProvider>,
+    )
+    act(() => screen.getByText('select').click())
+    expect(screen.getByTestId('scope').textContent).toBe('root/msp-a/client-1')
+  })
+
+  it('throws when useTenantScope is used outside the provider', () => {
+    function Bare() {
+      useTenantScope()
+      return null
+    }
+    expect(() => render(<Bare />)).toThrow(/TenantScopeProvider/)
+  })
+})

--- a/web/src/shell/TenantScopeContext.tsx
+++ b/web/src/shell/TenantScopeContext.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Tenant scope (Story #2496) — a DISPLAY CONVENIENCE, not a security
+ * boundary (security A8.1). Server-side tenant scoping on every API call
+ * is the only enforcement; this context only decides what a technician
+ * sees in the switcher and gives later views (fleet overview, #2497) a
+ * shared "current scope" to filter by.
+ *
+ * There is no list-tenants API (see story Out of Scope) — selectable scopes
+ * are the principal's own root path plus whatever descendant paths a later
+ * view has actually observed in its data (registerObservedPath), matching
+ * CLAUDE.md's recursive root/msp-a/client-1 path model.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export type TenantPath = string
+
+/**
+ * Path-separator-aware prefix match, mirroring the server-side ancestor
+ * check in handlers_stewards.go: candidate equals scope, or candidate is a
+ * descendant of scope at a "/" boundary — "tenant-a" must never match
+ * "tenant-abc".
+ */
+export function isScopeMatch(candidate: TenantPath, scope: TenantPath): boolean {
+  return candidate === scope || candidate.startsWith(`${scope}/`)
+}
+
+export interface TenantScopeValue {
+  /** The currently selected scope. */
+  scope: TenantPath
+  /** Selectable scopes: the principal's root path + observed descendants. */
+  observedPaths: TenantPath[]
+  setScope: (path: TenantPath) => void
+  /** Later views (e.g. fleet overview) report paths they've actually seen. */
+  registerObservedPath: (path: TenantPath) => void
+}
+
+const TenantScopeContext = createContext<TenantScopeValue | null>(null)
+
+export function TenantScopeProvider({
+  rootPath,
+  children,
+}: {
+  rootPath: TenantPath
+  children: ReactNode
+}) {
+  const [scope, setScope] = useState<TenantPath>(rootPath)
+  const [observedPaths, setObservedPaths] = useState<TenantPath[]>([rootPath])
+
+  const registerObservedPath = useCallback((path: TenantPath) => {
+    setObservedPaths((prev) => (prev.includes(path) ? prev : [...prev, path]))
+  }, [])
+
+  const value = useMemo(
+    () => ({ scope, observedPaths, setScope, registerObservedPath }),
+    [scope, observedPaths, registerObservedPath],
+  )
+
+  return (
+    <TenantScopeContext.Provider value={value}>{children}</TenantScopeContext.Provider>
+  )
+}
+
+export function useTenantScope(): TenantScopeValue {
+  const value = useContext(TenantScopeContext)
+  if (value === null) {
+    throw new Error('useTenantScope must be used within a TenantScopeProvider')
+  }
+  return value
+}

--- a/web/src/shell/TenantSwitcher.test.tsx
+++ b/web/src/shell/TenantSwitcher.test.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { describe, expect, it } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TenantScopeProvider, useTenantScope } from './TenantScopeContext.tsx'
+import TenantSwitcher from './TenantSwitcher.tsx'
+
+function Harness() {
+  const { registerObservedPath } = useTenantScope()
+  registerObservedPath('root/msp-a/client-1')
+  return <TenantSwitcher />
+}
+
+describe('TenantSwitcher', () => {
+  it('shows the current scope path', () => {
+    render(
+      <TenantScopeProvider rootPath="root/msp-a">
+        <TenantSwitcher />
+      </TenantScopeProvider>,
+    )
+    expect(screen.getByRole('button', { name: /root\/msp-a/ })).toBeInTheDocument()
+  })
+
+  it('opens a menu listing observed scopes and selects one', () => {
+    render(
+      <TenantScopeProvider rootPath="root/msp-a">
+        <Harness />
+      </TenantScopeProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /root\/msp-a/ }))
+    const option = screen.getByRole('menuitem', { name: /root\/msp-a\/client-1/ })
+    fireEvent.click(option)
+    expect(screen.getByRole('button', { name: /root\/msp-a\/client-1/ })).toBeInTheDocument()
+  })
+
+  it('closes the menu on Escape', () => {
+    render(
+      <TenantScopeProvider rootPath="root/msp-a">
+        <TenantSwitcher />
+      </TenantScopeProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /root\/msp-a/ }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/shell/TenantSwitcher.test.tsx
+++ b/web/src/shell/TenantSwitcher.test.tsx
@@ -2,13 +2,16 @@
 // Copyright 2026 Jordan Ritz
 
 import { describe, expect, it } from 'vitest'
+import { useEffect } from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { TenantScopeProvider, useTenantScope } from './TenantScopeContext.tsx'
 import TenantSwitcher from './TenantSwitcher.tsx'
 
 function Harness() {
   const { registerObservedPath } = useTenantScope()
-  registerObservedPath('root/msp-a/client-1')
+  useEffect(() => {
+    registerObservedPath('root/msp-a/client-1')
+  }, [registerObservedPath])
   return <TenantSwitcher />
 }
 

--- a/web/src/shell/TenantSwitcher.tsx
+++ b/web/src/shell/TenantSwitcher.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Tenant-scope switcher (Story #2496) — mockups/fleet-overview.html
+ * `.scope` button + `#pop-tenant` popover. A display convenience; the
+ * selected scope publishes via TenantScopeContext for views to filter by.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { useTenantScope } from './TenantScopeContext.tsx'
+
+export default function TenantSwitcher() {
+  const { scope, observedPaths, setScope } = useTenantScope()
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    function onClickAway(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onClickAway)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onClickAway)
+    }
+  }, [open])
+
+  const segments = scope.split('/')
+  const leaf = segments[segments.length - 1]
+  const ancestry = segments.slice(0, -1).join('/')
+
+  return (
+    <div className="scope-root" ref={rootRef}>
+      <button
+        type="button"
+        className="scope"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="scope-lbl">scope</span>
+        <span className="scope-path mono">
+          {ancestry ? `${ancestry}/` : ''}
+          <b>{leaf}</b>
+        </span>
+      </button>
+      {open && (
+        <div className="pop open" role="menu">
+          <h4>Switch scope</h4>
+          {observedPaths.map((path) => (
+            <div
+              key={path}
+              role="menuitem"
+              tabIndex={0}
+              className={`row${path === scope ? ' cur' : ''}`}
+              onClick={() => {
+                setScope(path)
+                setOpen(false)
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  setScope(path)
+                  setOpen(false)
+                }
+              }}
+            >
+              <span className="mono">{path}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/shell/UserMenu.test.tsx
+++ b/web/src/shell/UserMenu.test.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import UserMenu from './UserMenu.tsx'
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(status === 204 ? null : JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  document.documentElement.removeAttribute('data-theme')
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+async function signIn() {
+  fetchMock.mockResolvedValueOnce(jsonResponse(200))
+  fetchMock.mockResolvedValueOnce(jsonResponse(200))
+  render(
+    <AuthProvider>
+      <UserMenu />
+    </AuthProvider>,
+  )
+}
+
+describe('UserMenu', () => {
+  it('shows initials derived from the signed-in principal', async () => {
+    // AuthProvider starts signedOut with no principal; render directly with
+    // a signed-in principal by driving login through the provider's probe
+    // is unnecessary here — UserMenu only needs a principal to render, so
+    // exercise it via the real provider's login flow.
+    await signIn()
+    // Not signed in yet in this render path (no login form here) — assert
+    // the menu renders without a principal gracefully (avatar shows '?').
+    expect(screen.getByRole('button', { name: /account menu/i })).toBeInTheDocument()
+  })
+
+  it('opens the menu and dispatches logout on click', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(204))
+    render(
+      <AuthProvider>
+        <UserMenu />
+      </AuthProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    const signOut = screen.getByRole('menuitem', { name: /sign out/i })
+    fireEvent.click(signOut)
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/web/logout',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('toggles the theme attribute on the document root', () => {
+    render(
+      <AuthProvider>
+        <UserMenu />
+      </AuthProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^dark$/i }))
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    fireEvent.click(screen.getByRole('button', { name: /^light$/i }))
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+    fireEvent.click(screen.getByRole('button', { name: /^auto$/i }))
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('persists the theme choice to localStorage under the allowlisted key', () => {
+    render(
+      <AuthProvider>
+        <UserMenu />
+      </AuthProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^dark$/i }))
+    expect(localStorage.getItem('cfgms.theme')).toBe('dark')
+  })
+
+  it('restores the persisted theme choice on mount', () => {
+    localStorage.setItem('cfgms.theme', 'dark')
+    render(
+      <AuthProvider>
+        <UserMenu />
+      </AuthProvider>,
+    )
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+
+  it('ignores a corrupt stored theme value and falls back to auto', () => {
+    localStorage.setItem('cfgms.theme', 'not-a-real-theme')
+    render(
+      <AuthProvider>
+        <UserMenu />
+      </AuthProvider>,
+    )
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('closes on Escape', () => {
+    render(
+      <AuthProvider>
+        <UserMenu />
+      </AuthProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' })
+    })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/shell/UserMenu.test.tsx
+++ b/web/src/shell/UserMenu.test.tsx
@@ -3,7 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { AuthProvider } from '../auth/AuthContext.tsx'
+import { AuthProvider, useAuth } from '../auth/AuthContext.tsx'
 import UserMenu from './UserMenu.tsx'
 
 function jsonResponse(status: number, body: unknown = {}): Response {
@@ -27,26 +27,61 @@ afterEach(() => {
   localStorage.clear()
 })
 
-async function signIn() {
-  fetchMock.mockResolvedValueOnce(jsonResponse(200))
-  fetchMock.mockResolvedValueOnce(jsonResponse(200))
+// Drives a real sign-in through AuthProvider.login() — UserMenu has no
+// login form of its own, so a principal only exists once something calls
+// the provider's login() (same mechanism App.tsx's Login screen uses).
+function SignedInHarness({ username }: { username: string }) {
+  const { login } = useAuth()
+  return (
+    <>
+      <button type="button" onClick={() => void login(username, 'pw-pw-pw-pw')}>
+        drive-login
+      </button>
+      <UserMenu />
+    </>
+  )
+}
+
+async function signIn(username: string) {
+  fetchMock.mockResolvedValue(jsonResponse(200))
   render(
     <AuthProvider>
-      <UserMenu />
+      <SignedInHarness username={username} />
     </AuthProvider>,
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'drive-login' }))
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/web/login',
+      expect.objectContaining({ method: 'POST' }),
+    ),
   )
 }
 
 describe('UserMenu', () => {
   it('shows initials derived from the signed-in principal', async () => {
-    // AuthProvider starts signedOut with no principal; render directly with
-    // a signed-in principal by driving login through the provider's probe
-    // is unnecessary here — UserMenu only needs a principal to render, so
-    // exercise it via the real provider's login flow.
-    await signIn()
-    // Not signed in yet in this render path (no login form here) — assert
-    // the menu renders without a principal gracefully (avatar shows '?').
-    expect(screen.getByRole('button', { name: /account menu/i })).toBeInTheDocument()
+    await signIn('admin@msp-a')
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /account menu/i })).toHaveTextContent('AD'),
+    )
+    fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    expect(screen.getByText('admin@msp-a')).toBeInTheDocument()
+  })
+
+  it('derives initials from a two-part local address (dot-separated)', async () => {
+    await signIn('jane.doe@msp-a')
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /account menu/i })).toHaveTextContent('JD'),
+    )
+  })
+
+  it('shows the fallback avatar when no principal is signed in', () => {
+    render(
+      <AuthProvider>
+        <UserMenu />
+      </AuthProvider>,
+    )
+    expect(screen.getByRole('button', { name: /account menu/i })).toHaveTextContent('?')
   })
 
   it('opens the menu and dispatches logout on click', async () => {

--- a/web/src/shell/UserMenu.tsx
+++ b/web/src/shell/UserMenu.tsx
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * User menu (Story #2496) — mockups/fleet-overview.html `#pop-user`.
+ * Shows the signed-in principal (via #2495 auth context) and hosts logout,
+ * plus the design-system theme toggle (auto/light/dark via
+ * :root[data-theme]). Theme choice persists in localStorage — a display
+ * preference, not auth data, so it's explicitly allowlisted in the A7.2
+ * source scan (Login.test.tsx STORAGE_ALLOWLIST) rather than exempt from
+ * it. The scan requires the key to be a plain string literal at each call
+ * site (not a shared constant) so both the automated check and a human
+ * reviewer can see the exact key without following indirection — write
+ * 'cfgms.theme' inline every time, never factor it into a variable.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '../auth/AuthContext.tsx'
+
+type ThemeMode = 'auto' | 'light' | 'dark'
+
+function loadThemeMode(): ThemeMode {
+  const stored = localStorage.getItem('cfgms.theme')
+  return stored === 'light' || stored === 'dark' || stored === 'auto' ? stored : 'auto'
+}
+
+function applyTheme(mode: ThemeMode) {
+  if (mode === 'auto') {
+    document.documentElement.removeAttribute('data-theme')
+  } else {
+    document.documentElement.setAttribute('data-theme', mode)
+  }
+}
+
+function initials(username: string | undefined): string {
+  if (!username) return '?'
+  const local = username.split('@')[0] ?? username
+  const parts = local.split(/[._-]/).filter(Boolean)
+  const text = parts.length >= 2 ? `${parts[0]?.[0] ?? ''}${parts[1]?.[0] ?? ''}` : local.slice(0, 2)
+  return text.toUpperCase()
+}
+
+export default function UserMenu() {
+  const { principal, logout } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [themeMode, setThemeMode] = useState<ThemeMode>(loadThemeMode)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    applyTheme(themeMode)
+    localStorage.setItem('cfgms.theme', themeMode)
+  }, [themeMode])
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    function onClickAway(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onClickAway)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onClickAway)
+    }
+  }, [open])
+
+  return (
+    <div className="usermenu-root" ref={rootRef}>
+      <button
+        type="button"
+        className="uav"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Account menu"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {initials(principal?.username)}
+      </button>
+      {open && (
+        <div className="pop right open" role="menu">
+          <div className="row" style={{ cursor: 'default' }}>
+            <div className="uav" style={{ width: 30, height: 30, fontSize: 11 }}>
+              {initials(principal?.username)}
+            </div>
+            <div>{principal?.username ?? 'Not signed in'}</div>
+          </div>
+          <div className="sep" />
+          <h4>Theme</h4>
+          <div className="miniseg">
+            {(['light', 'auto', 'dark'] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                className={themeMode === mode ? 'on' : ''}
+                onClick={() => setThemeMode(mode)}
+              >
+                {mode.slice(0, 1).toUpperCase() + mode.slice(1)}
+              </button>
+            ))}
+          </div>
+          <div className="sep" />
+          <div
+            role="menuitem"
+            tabIndex={0}
+            className="row"
+            style={{ color: 'var(--state-crit)' }}
+            onClick={() => void logout()}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') void logout()
+            }}
+          >
+            Sign out
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Implements the persistent authenticated app shell (Story #2496) that every later web-UI epic mounts into — sidebar navigation, tenant-scope switcher, global search, alert center, and user menu (identity + logout + theme toggle), per `docs/design/mockups/fleet-overview.html`.

Fixes #2496

## Components (`web/src/shell/`)

- `AppShell.tsx` — sidebar/topbar/drawer grid; desktop sidebar, mobile hamburger + off-canvas drawer + scrim, Escape closes overlays
- `TenantScopeContext.tsx` — client-side tenant scope (path-separator-aware prefix matching, `tenant-a` never matches `tenant-abc`); a **display convenience, not a security boundary** (A8.1) — server-side scoping is the only real enforcement
- `TenantSwitcher.tsx`, `GlobalSearch.tsx`, `AlertCenter.tsx` — chrome per mockup, designed empty/placeholder states, no new backend calls
- `UserMenu.tsx` — signed-in identity, logout (#2495 flow), theme toggle (auto/light/dark via `:root[data-theme]`, persisted under the A7.2-allowlisted `cfgms.theme` key)

`App.tsx` now renders `AppShell` as the sole child of `RequireAuth`, replacing the Story #2495 placeholder. Fleet overview (#2497) is the first real occupant of `.content`; this story ships its empty-state placeholder.

## Verification

- `npx vitest run` — 63/63 pass, including the required coverage: tenant-scope prefix matching (incl. the `tenant-a`/`tenant-abc` boundary case), drawer open/close/Escape, user-menu logout dispatch
- `make test-complete` run natively on macOS with ThreatLocker in enforcing mode (not bypass) — unit tests, lint, security-precommit, check-architecture, security-scan (gosec/trivy/nancy/staticcheck), cross-platform compile (5 platforms), and Docker integration tests all pass clean. `test-e2e-fast` hit a transient Docker Desktop VM network drop unrelated to this change or to ThreatLocker (documented local-only gap; CI validates e2e authoritatively on Linux).
- One incidental fix: pre-existing `gofmt` violation in `features/steward/factory/factory_test.go`, unrelated to this story, required to pass the blocking lint gate.
- Design reviewed live: light/dark, desktop/mobile, and drawer-open states were captured against the real running app (real login flow, not a static mock) and reviewed/approved by the founder on 2026-07-15 — see review-method comment on this PR. No screenshots are attached to this PR (see that comment for why).

## Docs

`web/README.md` "App shell architecture" section covers route layout, the tenant-scope context contract, and the A8.1 security-boundary caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
