### PR TITLE
examples: fix github_runner example cfgs for out-of-box convergence (Issue #2684)

### DIFF
--- a/examples/ci-runners/README.md
+++ b/examples/ci-runners/README.md
@@ -122,7 +122,14 @@ Before uploading, edit the cfg to set:
 - `config.version` — the pinned runner agent release.
 - `config.agent_url` — the download URL matching the version and OS/arch.
 - `config.agent_sha256` — the SHA-256 of the archive (lowercase hex, 64 chars).
-  Verify with `sha256sum` (Linux) or `Get-FileHash` (Windows).
+  Verify with `sha256sum` (Linux) or `Get-FileHash` (Windows). The example
+  files ship with the real SHA-256 for their pinned versions; update this when
+  bumping `config.version` or `config.agent_url`.
+- `config.owner` — the GitHub organization or user that owns the repository
+  (e.g. `your-org`). Together with `config.repo`, the module derives the OS
+  service name as `actions.runner.<owner>-<repo>.<hostname>` at convergence
+  time — no manual `service_name` entry is required.
+- `config.repo` — the repository name without owner prefix (e.g. `your-repo`).
 - `runner-docker-group` script — replace `<RUNNER_USER>` with the OS user
   the runner agent runs as.
 - `ci-tools-dir` script — replace `<JQ_VERSION>` and `<JQ_SHA256_64HEX>`

--- a/examples/ci-runners/linux-runner.cfg
+++ b/examples/ci-runners/linux-runner.cfg
@@ -107,10 +107,10 @@ resources:
         # Verify after download: sha256sum /opt/ci-tools/jq
         JQ_VERSION="<JQ_VERSION>"
         JQ_SHA256="<JQ_SHA256_64HEX>"
-        JQ_URL="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
+        JQ_URL="https://github.com/jqlang/jq/releases/download/jq-$JQ_VERSION/jq-linux-amd64"
 
-        curl -fsSL -o /tmp/jq-download "${JQ_URL}"
-        echo "${JQ_SHA256}  /tmp/jq-download" | sha256sum --check --strict
+        curl -fsSL -o /tmp/jq-download "$JQ_URL"
+        echo "$JQ_SHA256  /tmp/jq-download" | sha256sum --check --strict
         install -m 0755 /tmp/jq-download /opt/ci-tools/jq
         rm -f /tmp/jq-download
 
@@ -138,15 +138,19 @@ resources:
       agent_url: "https://github.com/actions/runner/releases/download/v2.335.1/actions-runner-linux-x64-2.335.1.tar.gz"
 
       # Expected SHA-256 of the archive (lowercase hex, 64 chars).
-      # CHANGE: Replace with the actual sha256sum of the archive.
+      # Source: github.com/actions/runner releases/tag/v2.335.1 release body.
       # Verify: sha256sum actions-runner-linux-x64-2.335.1.tar.gz
-      agent_sha256: "PLACEHOLDER_SHA256_64HEX"
+      agent_sha256: "4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf"
 
       # Absolute install directory on the runner VM.
       work_dir: "/opt/actions-runner"
 
-      # OS service name for the runner daemon.
-      service_name: "github-runner"
+      # GitHub organization and repository that own this runner. Used by the
+      # module to derive the OS service name as:
+      #   actions.runner.<owner>-<repo>.<hostname>
+      # CHANGE: Replace with your actual org/repo.
+      owner: "your-org"
+      repo: "your-repo"
 
       # Runner labels surfaced to GitHub Actions workflow selectors.
       # Workflows in this repo select on ["self-hosted","Linux","cfgms"]

--- a/examples/ci-runners/windows-runner.cfg
+++ b/examples/ci-runners/windows-runner.cfg
@@ -37,15 +37,19 @@ resources:
       agent_url: "https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-win-x64-2.319.1.zip"
 
       # Expected SHA-256 of the archive (lowercase hex, 64 chars).
-      # CHANGE: Replace with the actual sha256sum of the archive.
+      # Source: github.com/actions/runner releases/tag/v2.319.1 release body.
       # Verify: Get-FileHash actions-runner-win-x64-2.319.1.zip -Algorithm SHA256
-      agent_sha256: "PLACEHOLDER_SHA256_64HEX"
+      agent_sha256: "1c78c51d20b817fb639e0b0ab564cf0469d083ad543ca3d0d7a2cdad5723f3a7"
 
       # Absolute install directory on the runner VM (Windows path).
       work_dir: 'C:\actions-runner'
 
-      # Windows service name for the runner daemon.
-      service_name: "github-runner"
+      # GitHub organization and repository that own this runner. Used by the
+      # module to derive the OS service name as:
+      #   actions.runner.<owner>-<repo>.<hostname>
+      # CHANGE: Replace with your actual org/repo.
+      owner: "your-org"
+      repo: "your-repo"
 
       # Runner labels surfaced to GitHub Actions workflow selectors.
       labels:

--- a/features/modules/extended/github_runner/example_config_test.go
+++ b/features/modules/extended/github_runner/example_config_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package github_runner
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+)
+
+// TestExampleRunnerConfigs_ParseAndValidate verifies that both example runner
+// cfg files parse without error and that the github-runner resource's config
+// produces a RunnerConfig that passes Validate(). This guards against
+// placeholder values (e.g. PLACEHOLDER_SHA256_64HEX) and structural problems
+// (e.g. missing owner/repo fields) that would prevent convergence as shipped.
+func TestExampleRunnerConfigs_ParseAndValidate(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must succeed")
+
+	// features/modules/extended/github_runner → up 4 levels to repo root
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+
+	tests := []struct {
+		name         string
+		cfgFile      string
+		windowsPath  bool // true when work_dir is a Windows absolute path (C:\...)
+	}{
+		{
+			name:    "linux-runner",
+			cfgFile: "linux-runner.cfg",
+		},
+		{
+			name:        "windows-runner",
+			cfgFile:     "windows-runner.cfg",
+			windowsPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgPath := filepath.Join(repoRoot, "examples", "ci-runners", tt.cfgFile)
+
+			stewardCfg, err := stewardconfig.LoadConfiguration(cfgPath)
+			require.NoError(t, err, "%s must parse without error", tt.cfgFile)
+
+			// Locate the github-runner resource.
+			var resMap map[string]interface{}
+			for _, res := range stewardCfg.Resources {
+				if res.Name == "github-runner" {
+					resMap = res.Config
+					break
+				}
+			}
+			require.NotNil(t, resMap, "resource \"github-runner\" not found in %s", tt.cfgFile)
+
+			var rc RunnerConfig
+			require.NoError(t, rc.fromMap(resMap), "fromMap must succeed for %s", tt.cfgFile)
+
+			// filepath.IsAbs("C:\...") returns false on Linux/macOS; substitute a
+			// valid temp dir so cross-platform CI can validate the rest of the config.
+			if tt.windowsPath && runtime.GOOS != "windows" {
+				rc.WorkDir = t.TempDir()
+			}
+
+			require.NoError(t, rc.Validate(), "%s github-runner config must pass Validate()", tt.name)
+		})
+	}
+}

--- a/features/modules/extended/github_runner/example_config_test.go
+++ b/features/modules/extended/github_runner/example_config_test.go
@@ -26,9 +26,9 @@ func TestExampleRunnerConfigs_ParseAndValidate(t *testing.T) {
 	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
 
 	tests := []struct {
-		name         string
-		cfgFile      string
-		windowsPath  bool // true when work_dir is a Windows absolute path (C:\...)
+		name        string
+		cfgFile     string
+		windowsPath bool // true when work_dir is a Windows absolute path (C:\...)
 	}{
 		{
 			name:    "linux-runner",

--- a/features/modules/extended/github_runner/example_config_test.go
+++ b/features/modules/extended/github_runner/example_config_test.go
@@ -28,11 +28,13 @@ func TestExampleRunnerConfigs_ParseAndValidate(t *testing.T) {
 	tests := []struct {
 		name        string
 		cfgFile     string
+		linuxPath   bool // true when work_dir is a Linux absolute path (/opt/...)
 		windowsPath bool // true when work_dir is a Windows absolute path (C:\...)
 	}{
 		{
-			name:    "linux-runner",
-			cfgFile: "linux-runner.cfg",
+			name:      "linux-runner",
+			cfgFile:   "linux-runner.cfg",
+			linuxPath: true,
 		},
 		{
 			name:        "windows-runner",
@@ -64,6 +66,11 @@ func TestExampleRunnerConfigs_ParseAndValidate(t *testing.T) {
 			// filepath.IsAbs("C:\...") returns false on Linux/macOS; substitute a
 			// valid temp dir so cross-platform CI can validate the rest of the config.
 			if tt.windowsPath && runtime.GOOS != "windows" {
+				rc.WorkDir = t.TempDir()
+			}
+			// filepath.IsAbs("/opt/...") returns false on Windows; substitute a
+			// valid temp dir so cross-platform CI can validate the rest of the config.
+			if tt.linuxPath && runtime.GOOS == "windows" {
 				rc.WorkDir = t.TempDir()
 			}
 

--- a/features/modules/hyperv/provision_test.go
+++ b/features/modules/hyperv/provision_test.go
@@ -368,7 +368,8 @@ func TestFailProvision_RecordsFailedFrom(t *testing.T) {
 	// "failed"; the earliest failure phase (creating) is preserved.
 	// failProvision returns the original cause for the caller to propagate.
 	secondFailure := errors.New("second failure")
-	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-fail", rec, secondFailure), secondFailure)
+	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-fail", rec, secondFailure), secondFailure,
+		"failProvision returns the original cause on a re-fail")
 	assert.Equal(t, ProvisionStateFailed, rec.State)
 	assert.Equal(t, ProvisionStateCreating, rec.FailedFrom,
 		"a re-fail must keep the earliest failure phase, not overwrite it with failed")
@@ -387,7 +388,8 @@ func TestAdvanceProvision_ClearsStaleFailedFrom(t *testing.T) {
 	require.NoError(t, m.advanceProvision(ctx, cfg, "vm-retry", rec, ProvisionStateCreating))
 	// failProvision returns the original cause for the caller to propagate.
 	seedFailure := errors.New("seed failed")
-	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-retry", rec, seedFailure), seedFailure)
+	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-retry", rec, seedFailure), seedFailure,
+		"failProvision returns the original cause")
 	require.Equal(t, ProvisionStateCreating, rec.FailedFrom)
 
 	// A retry advances the record forward again → the stale failure phase clears.

--- a/features/modules/stdlib/time/module_test.go
+++ b/features/modules/stdlib/time/module_test.go
@@ -292,11 +292,11 @@ func TestTimeModule_Set_WrongConfigType(t *testing.T) {
 // wrongConfigType is a stub that implements modules.ConfigState but is not *TimeConfig.
 type wrongConfigType struct{}
 
-func (w *wrongConfigType) AsMap() map[string]interface{}  { return nil }
-func (w *wrongConfigType) ToYAML() ([]byte, error)        { return nil, nil }
-func (w *wrongConfigType) FromYAML(_ []byte) error        { return nil }
-func (w *wrongConfigType) Validate() error                { return nil }
-func (w *wrongConfigType) GetManagedFields() []string     { return nil }
+func (w *wrongConfigType) AsMap() map[string]interface{} { return nil }
+func (w *wrongConfigType) ToYAML() ([]byte, error)       { return nil, nil }
+func (w *wrongConfigType) FromYAML(_ []byte) error       { return nil }
+func (w *wrongConfigType) Validate() error               { return nil }
+func (w *wrongConfigType) GetManagedFields() []string    { return nil }
 
 // TestTimeModule_LoggingInjection verifies the module implements LoggingInjectable.
 func TestTimeModule_LoggingInjection(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug 1 (SHA-256):** Replaced `PLACEHOLDER_SHA256_64HEX` in both example cfg files with the real, verified SHA-256 from the official GitHub Actions runner release pages (v2.335.1 linux-x64, v2.319.1 win-x64). `RunnerConfig.Validate()` requires a 64-char hex string, so the placeholder caused immediate validation failure.
- **Bug 2 (service_name):** Removed the static `service_name: "github-runner"` from both files and replaced it with `owner`/`repo` placeholder fields. `RunnerConfig.ResolveServiceName` already derives the correct `actions.runner.<owner>-<repo>.<hostname>` service name — this just wires it up in the examples.
- **Latent fix (bash syntax):** The `ci-tools-dir` script in `linux-runner.cfg` used `${JQ_VERSION}` etc. as bash variable references, which CFGMS's config loader treats as env-var expansion targets. Changed to `$VAR` (no braces) — equivalent bash, avoids the CFGMS `${...}` conflict.
- **Test:** Added `features/modules/extended/github_runner/example_config_test.go` that loads both cfg files via `config.LoadConfiguration`, locates the `github-runner` resource, and asserts `Validate()` passes without error.
- **README:** Updated "Runner cfg placeholders" section to reflect dropped `service_name` and new `config.owner`/`config.repo` fields.

## Specialist Review Results

- **Code review:** PASS — 0 findings
- **QA:** PASS — all tests pass; no mocks, no t.Skip, no empty assertions
- **Security:** PASS — no secrets committed, SHA-256 values from official source, cross-platform substitution is safe

## Test plan

- [x] `go test ./features/modules/extended/github_runner/...` passes (all existing + new test)
- [x] `TestExampleRunnerConfigs_ParseAndValidate/linux-runner` — LoadConfiguration + fromMap + Validate passes
- [x] `TestExampleRunnerConfigs_ParseAndValidate/windows-runner` — LoadConfiguration + fromMap + Validate passes (with temp dir for work_dir on Linux CI)
- [ ] `make test-complete` runs via CI

Fixes #2684

🤖 Generated with [Claude Code](https://claude.com/claude-code)