### PR TITLE
time: timezone + NTP/time-sync stdlib module (Issue #2476)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ STDLIB_MODULES := \
 	patch \
 	script \
 	service \
+	time \
 	user
 
 # Stdlib payload boundary check: all five sources of stdlib module names must agree.

--- a/build/darwin/build-pkg.sh
+++ b/build/darwin/build-pkg.sh
@@ -166,6 +166,7 @@ STDLIB_MODULES=(
     cfgms-module-patch
     cfgms-module-script
     cfgms-module-service
+    cfgms-module-time
     cfgms-module-user
 )
 MODULES_PAYLOAD_DIR="$PAYLOAD_DIR/usr/local/lib/cfgms/modules"

--- a/build/linux/install.sh
+++ b/build/linux/install.sh
@@ -151,6 +151,7 @@ STDLIB_MODULES=(
     cfgms-module-patch
     cfgms-module-script
     cfgms-module-service
+    cfgms-module-time
     cfgms-module-user
 )
 MODULES_INSTALL_DIR="${INSTALL_PREFIX}/usr/local/lib/cfgms/modules"

--- a/build/windows/cfgms-steward.wxs
+++ b/build/windows/cfgms-steward.wxs
@@ -103,6 +103,9 @@
           <Component Id="ModulePatch" Guid="*">
             <File Id="ModulePatchExe" Source="$(var.ModulesDir)\cfgms-module-patch.exe" Name="cfgms-module-patch.exe" KeyPath="yes" />
           </Component>
+          <Component Id="ModuleTime" Guid="*">
+            <File Id="ModuleTimeExe" Source="$(var.ModulesDir)\cfgms-module-time.exe" Name="cfgms-module-time.exe" KeyPath="yes" />
+          </Component>
           <Component Id="ModuleUser" Guid="*">
             <File Id="ModuleUserExe" Source="$(var.ModulesDir)\cfgms-module-user.exe" Name="cfgms-module-user.exe" KeyPath="yes" />
           </Component>
@@ -120,6 +123,7 @@
       <ComponentRef Id="ModuleScript" />
       <ComponentRef Id="ModuleFirewall" />
       <ComponentRef Id="ModulePatch" />
+      <ComponentRef Id="ModuleTime" />
       <ComponentRef Id="ModuleUser" />
     </Feature>
 

--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -213,7 +213,7 @@ Shipped in the steward installer, all `executors: [steward]` (closed set — see
 - `patch` - OS patch management (Windows Update COM API on Windows; `modules.ErrUnsupportedPlatform` fallback on Linux/macOS — real non-Windows backends are out of scope per ADR-016 PM Notes)
 - `user` - Local users & groups, membership, lock/disable state, password presence (observed only)
 - `cert_trust` - System trust store: install/trust CA & certs; keeps the CFGMS mTLS chain healthy fleet-wide
-- `time` - Timezone + NTP/time-sync — *planned (net-new)*
+- `time` - Timezone + NTP/time-sync configuration (`timezone`, `ntp_servers`, `ntp_sync_enabled`)
 - `hostname` - System/computer name & workgroup — *planned (net-new)*
 
 ### Extended steward modules (non-stdlib)

--- a/docs/modules/time.md
+++ b/docs/modules/time.md
@@ -1,0 +1,76 @@
+# time module
+
+Manages host timezone and NTP/time-sync configuration.
+
+## Rationale
+
+Time skew breaks Kerberos authentication, TLS certificate validation, and log
+correlation. Timezone and NTP configuration are therefore foundational
+properties of every managed host — correct time is a precondition for most
+other management operations. The `time` module declares authoritative ownership
+over the `time` DNA object kind (ADR-016 clause 5), ensuring no other module
+or manual change silently drifts the host clock configuration.
+
+## Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timezone` | string | IANA timezone identifier (e.g. `UTC`, `America/Chicago`) |
+| `ntp_servers` | list of strings | NTP server hostnames or IP addresses (sorted alphabetically) |
+| `ntp_sync_enabled` | bool | Whether automatic NTP synchronisation is enabled |
+
+`timezone` is required; `ntp_servers` may be empty; `ntp_sync_enabled` defaults
+to `false` when not specified.
+
+## Example DNA fragment
+
+```yaml
+timezone: America/Chicago
+ntp_servers:
+  - time1.example.com
+  - time2.example.com
+ntp_sync_enabled: true
+```
+
+## Platform behaviour
+
+### Linux
+
+- **Timezone**: stored in `/etc/timezone` (IANA name); runtime-applied via
+  `timedatectl set-timezone`. Assumes systemd-timesyncd as the time-sync daemon.
+- **NTP servers**: stored in `/etc/systemd/timesyncd.conf` under `[Time]\nNTP=`.
+- **NTP sync enabled**: tracked via a CFGMS-managed comment in the same config
+  file; runtime-applied via `timedatectl set-ntp`.
+- When timedatectl is unavailable (containers, CI without systemd), file writes
+  persist the desired state and take effect on next service start or boot.
+
+### Windows
+
+- **Timezone**: managed via `tzutil /s` (set) and `tzutil /g` (get).
+  Windows timezone identifiers use Windows format (e.g. `Eastern Standard Time`),
+  not IANA format. Pass the Windows identifier as the `timezone` field value.
+- **NTP servers**: managed via `w32tm /config /manualpeerlist`.
+- **NTP sync enabled**: managed via `w32tm /config /syncfromflags`.
+
+### macOS
+
+- **Timezone**: managed via `systemsetup -settimezone` / `-gettimezone`.
+- **NTP server**: managed via `systemsetup -setnetworktimeserver` /
+  `-getnetworktimeserver`. macOS supports only a single NTP server; if
+  `ntp_servers` contains multiple entries only the first (alphabetically) is
+  applied.
+- **NTP sync enabled**: managed via `systemsetup -setusingnetworktime` /
+  `-getusingnetworktime`.
+
+## Security notes
+
+- Requires root privileges on all platforms to write time configuration.
+- Shells out to `timedatectl`, `tzutil.exe`, `w32tm.exe`, and `systemsetup`
+  as declared in `module.yaml`'s `behavioral_envelope`.
+- No credentials or secrets are handled by this module.
+
+## Determinism
+
+`Get` always returns `ntp_servers` sorted alphabetically. `AsMap()` is
+byte-for-byte identical on repeated calls against unchanged state, satisfying
+ADR-016 clause 4.

--- a/features/modules/stdlib/time/cmd/main.go
+++ b/features/modules/stdlib/time/cmd/main.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// cfgms-module-time is the out-of-process gRPC binary for the time stdlib module.
+// It reads CFGMS_MODULE_SOCKET from the environment, registers the ModuleService
+// gRPC server, and handles SIGTERM for graceful shutdown.
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	"github.com/cfgis/cfgms/features/modules/adapter"
+	timemodule "github.com/cfgis/cfgms/features/modules/stdlib/time"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	socketPath := os.Getenv("CFGMS_MODULE_SOCKET")
+	if socketPath == "" {
+		log.Fatal("cfgms-module-time: CFGMS_MODULE_SOCKET environment variable is required")
+	}
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Fatalf("cfgms-module-time: failed to listen on %s: %v", socketPath, err) // #nosec G706 - socketPath is system-set (CFGMS_MODULE_SOCKET), not user input
+	}
+
+	srv := grpc.NewServer()
+	proto.RegisterModuleServiceServer(srv, adapter.New(timemodule.New(), "time", srv))
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		srv.GracefulStop()
+	}()
+
+	if err := srv.Serve(lis); err != nil {
+		log.Fatalf("cfgms-module-time: gRPC server exited with error: %v", err)
+	}
+}

--- a/features/modules/stdlib/time/executor.go
+++ b/features/modules/stdlib/time/executor.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package timemodule
+
+// timeState holds the observed current time configuration of the host.
+type timeState struct {
+	// Timezone is the IANA timezone identifier (e.g. "UTC", "America/Chicago").
+	Timezone string
+	// NTPServers is the list of NTP server addresses, always sorted for determinism.
+	NTPServers []string
+	// NTPSyncEnabled indicates whether automatic NTP synchronisation is configured.
+	NTPSyncEnabled bool
+}
+
+// timeExecutor is the platform-specific backend for host time configuration.
+// Each platform (Linux, Windows, macOS) provides its own implementation via
+// build tags. Unsupported platforms use the stub implementation that returns
+// ErrUnsupportedPlatform.
+type timeExecutor interface {
+	// getState returns the current timezone and NTP configuration of the host.
+	// NTPServers in the returned state are always sorted for determinism.
+	getState() (timeState, error)
+
+	// setState applies the desired timezone and NTP configuration. It is
+	// idempotent: calling setState when the host is already in the desired
+	// state is a no-op.
+	setState(desired timeState) error
+}

--- a/features/modules/stdlib/time/executor_darwin.go
+++ b/features/modules/stdlib/time/executor_darwin.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package timemodule
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// darwinExecutor manages host time configuration on macOS via the
+// systemsetup command-line tool.
+//
+// Timezone is managed via systemsetup -gettimezone / -settimezone.
+// NTP server is managed via systemsetup -getnetworktimeserver / -setnetworktimeserver.
+// NTP sync state is managed via systemsetup -getusingnetworktime / -setusingnetworktime.
+//
+// Note: macOS systemsetup only supports a single NTP server (not a list).
+// The module treats a single-element list as the canonical state; additional
+// servers beyond the first are ignored on Set and not returned on Get.
+type darwinExecutor struct{}
+
+func newExecutor() timeExecutor {
+	return &darwinExecutor{}
+}
+
+// getState returns the current timezone and NTP configuration from macOS.
+func (e *darwinExecutor) getState() (timeState, error) {
+	tz, err := e.getTimezone()
+	if err != nil {
+		return timeState{}, err
+	}
+
+	server, err := e.getNTPServer()
+	if err != nil {
+		return timeState{}, err
+	}
+
+	enabled, err := e.getNTPEnabled()
+	if err != nil {
+		return timeState{}, err
+	}
+
+	var servers []string
+	if server != "" {
+		servers = []string{server}
+	}
+	sort.Strings(servers)
+
+	return timeState{
+		Timezone:       tz,
+		NTPServers:     servers,
+		NTPSyncEnabled: enabled,
+	}, nil
+}
+
+// setState applies the desired timezone and NTP configuration via systemsetup.
+func (e *darwinExecutor) setState(desired timeState) error {
+	if out, err := exec.Command("systemsetup", "-settimezone", desired.Timezone).CombinedOutput(); err != nil { // #nosec G204 - timezone matches ianaTimezonePattern; no shell metacharacters
+		return fmt.Errorf("systemsetup -settimezone %s: %w (output: %s)", desired.Timezone, err, strings.TrimSpace(string(out)))
+	}
+
+	// macOS supports only a single NTP server; use the first if provided.
+	server := ""
+	if len(desired.NTPServers) > 0 {
+		servers := make([]string, len(desired.NTPServers))
+		copy(servers, desired.NTPServers)
+		sort.Strings(servers)
+		server = servers[0]
+	}
+	if server != "" {
+		if out, err := exec.Command("systemsetup", "-setnetworktimeserver", server).CombinedOutput(); err != nil { // #nosec G204 - server matches ntpServerPattern; no shell metacharacters
+			return fmt.Errorf("systemsetup -setnetworktimeserver %s: %w (output: %s)", server, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	ntpArg := "off"
+	if desired.NTPSyncEnabled {
+		ntpArg = "on"
+	}
+	if out, err := exec.Command("systemsetup", "-setusingnetworktime", ntpArg).CombinedOutput(); err != nil { // #nosec G204 - ntpArg is a controlled literal
+		return fmt.Errorf("systemsetup -setusingnetworktime %s: %w (output: %s)", ntpArg, err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
+}
+
+// getTimezone returns the current IANA timezone identifier.
+// Output format: "Time Zone: America/Chicago"
+func (e *darwinExecutor) getTimezone() (string, error) {
+	out, err := exec.Command("systemsetup", "-gettimezone").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("systemsetup -gettimezone: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	line := strings.TrimSpace(string(out))
+	// Strip "Time Zone: " prefix.
+	if idx := strings.Index(line, ":"); idx >= 0 {
+		return strings.TrimSpace(line[idx+1:]), nil
+	}
+	return line, nil
+}
+
+// getNTPServer returns the configured NTP server hostname.
+// Output format: "Network Time Server: time.apple.com"
+func (e *darwinExecutor) getNTPServer() (string, error) {
+	out, err := exec.Command("systemsetup", "-getnetworktimeserver").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("systemsetup -getnetworktimeserver: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	line := strings.TrimSpace(string(out))
+	if idx := strings.Index(line, ":"); idx >= 0 {
+		return strings.TrimSpace(line[idx+1:]), nil
+	}
+	return line, nil
+}
+
+// getNTPEnabled returns whether automatic network time synchronisation is on.
+// Output format: "Using Network Time: On" or "Using Network Time: Off"
+func (e *darwinExecutor) getNTPEnabled() (bool, error) {
+	out, err := exec.Command("systemsetup", "-getusingnetworktime").CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("systemsetup -getusingnetworktime: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	line := strings.ToLower(strings.TrimSpace(string(out)))
+	return strings.HasSuffix(line, "on"), nil
+}

--- a/features/modules/stdlib/time/executor_darwin_test.go
+++ b/features/modules/stdlib/time/executor_darwin_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package timemodule
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// systemsetupAvailable returns true when the systemsetup command is reachable.
+// macOS tests that interact with systemsetup require elevated privileges or
+// system access not present in all CI runners.
+func systemsetupAvailable() bool {
+	return exec.Command("systemsetup", "-gettimezone").Run() == nil
+}
+
+// TestDarwinExecutor_GetTimezone_Parsing verifies the colon-prefix stripping
+// logic used in getTimezone for the "Time Zone: America/Chicago" output format.
+func TestDarwinExecutor_GetTimezone_Parsing(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"Time Zone: America/Chicago", "America/Chicago"},
+		{"Time Zone: UTC", "UTC"},
+		{"Time Zone: Europe/London", "Europe/London"},
+		{"Time Zone: Pacific/Auckland", "Pacific/Auckland"},
+	}
+
+	for _, tc := range cases {
+		// Replicate the parsing contract from getTimezone.
+		got := ""
+		if idx := strings.Index(tc.raw, ":"); idx >= 0 {
+			got = strings.TrimSpace(tc.raw[idx+1:])
+		}
+		if got != tc.want {
+			t.Errorf("getTimezone parse(%q): got %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+// TestDarwinExecutor_GetNTPServer_Parsing verifies the colon-prefix stripping
+// logic used in getNTPServer for "Network Time Server: time.apple.com" output.
+func TestDarwinExecutor_GetNTPServer_Parsing(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"Network Time Server: time.apple.com", "time.apple.com"},
+		{"Network Time Server: pool.ntp.org", "pool.ntp.org"},
+		{"Network Time Server: ", ""},
+	}
+
+	for _, tc := range cases {
+		got := ""
+		if idx := strings.Index(tc.raw, ":"); idx >= 0 {
+			got = strings.TrimSpace(tc.raw[idx+1:])
+		}
+		if got != tc.want {
+			t.Errorf("getNTPServer parse(%q): got %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+// TestDarwinExecutor_GetNTPEnabled_Parsing verifies the suffix-detection logic
+// for the "Using Network Time: On" / "Using Network Time: Off" output format.
+func TestDarwinExecutor_GetNTPEnabled_Parsing(t *testing.T) {
+	cases := []struct {
+		raw     string
+		enabled bool
+	}{
+		{"Using Network Time: On", true},
+		{"Using Network Time: Off", false},
+		{"using network time: on", true},  // lowercase variant
+		{"using network time: off", false}, // lowercase variant
+		{"Using Network Time: ON", true},   // uppercase variant
+	}
+
+	for _, tc := range cases {
+		lower := strings.ToLower(strings.TrimSpace(tc.raw))
+		got := strings.HasSuffix(lower, "on")
+		if got != tc.enabled {
+			t.Errorf("getNTPEnabled parse(%q): got enabled=%v, want enabled=%v", tc.raw, got, tc.enabled)
+		}
+	}
+}
+
+// TestDarwinExecutor_GetState verifies the full getState round-trip on macOS
+// when systemsetup is available. Skipped when systemsetup is not accessible.
+func TestDarwinExecutor_GetState(t *testing.T) {
+	if !systemsetupAvailable() {
+		t.Skip("skipping: systemsetup not available or requires elevated privileges")
+	}
+
+	e := &darwinExecutor{}
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if state.Timezone == "" {
+		t.Error("getState() returned empty Timezone")
+	}
+	// NTPServers may be empty (valid when no NTP server is configured).
+	// NTPSyncEnabled is boolean — no assertion on the specific value.
+}

--- a/features/modules/stdlib/time/executor_linux.go
+++ b/features/modules/stdlib/time/executor_linux.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package timemodule
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// linuxExecutor manages host time configuration on Linux.
+//
+// Timezone is stored in /etc/timezone (IANA name, one line).
+// NTP server list and sync state are stored in /etc/systemd/timesyncd.conf;
+// this module assumes systemd-timesyncd as the time-sync daemon.
+//
+// File paths are configurable so tests can point at fixture files in a temp
+// directory (never mutating the CI host's real time configuration).
+//
+// setState shells out to timedatectl for runtime application; if timedatectl
+// is unavailable (no running systemd) the file writes still persist and take
+// effect on next boot or service start. Only genuine timedatectl failures on
+// systems where systemd IS running are returned as errors.
+type linuxExecutor struct {
+	timezoneFile    string // default: /etc/timezone
+	timesyncdConfig string // default: /etc/systemd/timesyncd.conf
+}
+
+func newExecutor() timeExecutor {
+	return &linuxExecutor{
+		timezoneFile:    "/etc/timezone",
+		timesyncdConfig: "/etc/systemd/timesyncd.conf",
+	}
+}
+
+// getState reads the current timezone and NTP configuration from disk.
+// All reads are file-based to support fixture-isolated testing without
+// requiring a running systemd instance.
+func (e *linuxExecutor) getState() (timeState, error) {
+	tz, err := e.readTimezone()
+	if err != nil {
+		return timeState{}, fmt.Errorf("read timezone: %w", err)
+	}
+
+	servers, enabled, err := e.readTimesyncd()
+	if err != nil {
+		return timeState{}, fmt.Errorf("read timesyncd config: %w", err)
+	}
+
+	sort.Strings(servers)
+	return timeState{
+		Timezone:       tz,
+		NTPServers:     servers,
+		NTPSyncEnabled: enabled,
+	}, nil
+}
+
+// setState writes the desired time configuration to disk and attempts to
+// apply it at runtime via timedatectl. File writes always succeed or return
+// an error. timedatectl failures are ignored when systemd is not running.
+func (e *linuxExecutor) setState(desired timeState) error {
+	if err := e.writeTimezone(desired.Timezone); err != nil {
+		return fmt.Errorf("write timezone: %w", err)
+	}
+
+	servers := make([]string, len(desired.NTPServers))
+	copy(servers, desired.NTPServers)
+	sort.Strings(servers)
+
+	if err := e.writeTimesyncd(servers, desired.NTPSyncEnabled); err != nil {
+		return fmt.Errorf("write timesyncd config: %w", err)
+	}
+
+	// Apply at runtime via timedatectl. Failures are silently ignored when
+	// systemd is not running (e.g. containers, CI environments). On systems
+	// where systemd IS the init, timedatectl failures are returned as errors.
+	if err := e.applyTimezone(desired.Timezone); err != nil {
+		return fmt.Errorf("timedatectl set-timezone: %w", err)
+	}
+	if err := e.applyNTPSync(desired.NTPSyncEnabled); err != nil {
+		return fmt.Errorf("timedatectl set-ntp: %w", err)
+	}
+
+	return nil
+}
+
+// readTimezone reads the IANA timezone name from timezoneFile.
+// Returns "UTC" when the file does not exist (system default before configuration).
+func (e *linuxExecutor) readTimezone() (string, error) {
+	data, err := os.ReadFile(e.timezoneFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "UTC", nil
+		}
+		return "", err
+	}
+	tz := strings.TrimSpace(string(data))
+	if tz == "" {
+		return "UTC", nil
+	}
+	return tz, nil
+}
+
+// writeTimezone writes the IANA timezone name to timezoneFile, creating the
+// file and any parent directories that do not exist.
+func (e *linuxExecutor) writeTimezone(timezone string) error {
+	if err := os.MkdirAll(filepath.Dir(e.timezoneFile), 0o755); err != nil { // #nosec G301 - /etc is world-traversable by convention
+		return err
+	}
+	return os.WriteFile(e.timezoneFile, []byte(timezone+"\n"), 0o644) // #nosec G306 - /etc/timezone is world-readable by convention
+}
+
+// ntpSyncEnabledMarker is the comment prefix written by this module in the
+// timesyncd config file to track the desired NTP sync enabled state.
+const ntpSyncEnabledMarker = "# cfgms:ntp_sync_enabled="
+
+// readTimesyncd parses /etc/systemd/timesyncd.conf (or the configured path)
+// for the NTP server list and the cfgms-managed sync-enabled state.
+// Returns empty servers and enabled=true when the file does not exist.
+func (e *linuxExecutor) readTimesyncd() (servers []string, enabled bool, err error) {
+	f, err := os.Open(e.timesyncdConfig)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	enabled = true // default if no cfgms marker found
+	inTimeSection := false
+	markerFound := false
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// cfgms-managed marker for NTP sync enabled state.
+		if strings.HasPrefix(trimmed, ntpSyncEnabledMarker) {
+			val := strings.TrimPrefix(trimmed, ntpSyncEnabledMarker)
+			enabled = strings.EqualFold(strings.TrimSpace(val), "true")
+			markerFound = true
+			continue
+		}
+
+		// Section header.
+		if strings.HasPrefix(trimmed, "[") {
+			inTimeSection = strings.EqualFold(trimmed, "[time]")
+			continue
+		}
+
+		// NTP= line inside [Time] section.
+		if inTimeSection && strings.HasPrefix(trimmed, "NTP=") {
+			val := strings.TrimPrefix(trimmed, "NTP=")
+			for _, s := range strings.Fields(val) {
+				if s != "" {
+					servers = append(servers, s)
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, false, err
+	}
+	if !markerFound {
+		// No cfgms marker: infer enabled from whether NTP servers are configured.
+		enabled = len(servers) > 0
+	}
+	return servers, enabled, nil
+}
+
+// writeTimesyncd writes the NTP server list and sync-enabled state to the
+// timesyncd config file. Parent directories are created if needed.
+func (e *linuxExecutor) writeTimesyncd(servers []string, enabled bool) error {
+	if err := os.MkdirAll(filepath.Dir(e.timesyncdConfig), 0o755); err != nil { // #nosec G301 - /etc/systemd is world-traversable by convention
+		return err
+	}
+
+	enabledVal := "true"
+	if !enabled {
+		enabledVal = "false"
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s%s\n", ntpSyncEnabledMarker, enabledVal)
+	sb.WriteString("[Time]\n")
+	sb.WriteString("NTP=")
+	sb.WriteString(strings.Join(servers, " "))
+	sb.WriteString("\n")
+	sb.WriteString("FallbackNTP=\n")
+
+	return os.WriteFile(e.timesyncdConfig, []byte(sb.String()), 0o644) // #nosec G306 - timesyncd.conf is world-readable by convention
+}
+
+// isTimedatectlUnavailable returns true when the error indicates that
+// timedatectl is either not installed or systemd is not running — both are
+// expected in containers and CI environments without a systemd init.
+func isTimedatectlUnavailable(err error, output string) bool {
+	// Binary not in PATH (exec error, not exit error).
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return true // exec.LookPath failed or similar — not a real failure
+	}
+	unavailableMarkers := []string{
+		"Failed to connect to bus",
+		"No such file or directory",
+		"Connection refused",
+		"Transport endpoint is not connected",
+		"System has not been booted with systemd",
+	}
+	for _, m := range unavailableMarkers {
+		if strings.Contains(output, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// applyTimezone calls timedatectl to apply the timezone change at runtime.
+// Returns nil when timedatectl is unavailable or systemd is not running;
+// file writes are the durable change in those cases.
+func (e *linuxExecutor) applyTimezone(timezone string) error {
+	out, err := exec.Command("timedatectl", "set-timezone", timezone).CombinedOutput() // #nosec G204 - timezone matches ianaTimezonePattern: no shell metacharacters
+	if err != nil {
+		output := strings.TrimSpace(string(out))
+		if isTimedatectlUnavailable(err, output) {
+			return nil
+		}
+		return fmt.Errorf("%w (output: %s)", err, output)
+	}
+	return nil
+}
+
+// applyNTPSync calls timedatectl to enable or disable NTP sync at runtime.
+// Returns nil when timedatectl is unavailable or systemd is not running;
+// file writes are the durable change in those cases.
+func (e *linuxExecutor) applyNTPSync(enabled bool) error {
+	arg := "false"
+	if enabled {
+		arg = "true"
+	}
+	out, err := exec.Command("timedatectl", "set-ntp", arg).CombinedOutput() // #nosec G204 - arg is a controlled literal
+	if err != nil {
+		output := strings.TrimSpace(string(out))
+		if isTimedatectlUnavailable(err, output) {
+			return nil
+		}
+		return fmt.Errorf("%w (output: %s)", err, output)
+	}
+	return nil
+}

--- a/features/modules/stdlib/time/executor_linux_test.go
+++ b/features/modules/stdlib/time/executor_linux_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package timemodule
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// newFixtureExecutor creates a linuxExecutor pointed at temp files inside
+// tmpDir. None of the CI host's real system files are touched.
+func newFixtureExecutor(t *testing.T) (*linuxExecutor, string) {
+	t.Helper()
+	dir := t.TempDir()
+	return &linuxExecutor{
+		timezoneFile:    filepath.Join(dir, "timezone"),
+		timesyncdConfig: filepath.Join(dir, "timesyncd.conf"),
+	}, dir
+}
+
+// TestLinuxExecutor_TimezoneRoundTrip verifies Get/Set round-trip for timezone
+// against fixture-isolated config paths (ADR-016 acceptance criterion).
+func TestLinuxExecutor_TimezoneRoundTrip(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+
+	desired := timeState{
+		Timezone:       "America/Chicago",
+		NTPServers:     []string{"time1.example.com", "time2.example.com"},
+		NTPSyncEnabled: true,
+	}
+
+	if err := e.setState(desired); err != nil {
+		// timedatectl may fail in CI (no systemd). Skip when the error is from
+		// timedatectl (not a file write problem); fatal when it's a genuine
+		// file write error since those indicate a broken test fixture.
+		if !isFileWriteError(err) {
+			t.Skipf("setState: timedatectl failed (expected in CI without systemd): %v", err)
+		}
+		t.Fatalf("setState file write failed: %v", err)
+	}
+
+	got, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if got.Timezone != desired.Timezone {
+		t.Errorf("Timezone: got %q, want %q", got.Timezone, desired.Timezone)
+	}
+}
+
+// TestLinuxExecutor_NTPServerListRoundTrip verifies Get/Set round-trip for
+// the NTP server list against fixture-isolated config paths.
+func TestLinuxExecutor_NTPServerListRoundTrip(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+
+	servers := []string{"time2.example.com", "time1.example.com", "time3.example.com"}
+	desired := timeState{
+		Timezone:       "UTC",
+		NTPServers:     servers,
+		NTPSyncEnabled: true,
+	}
+
+	if err := e.setState(desired); err != nil {
+		if !isFileWriteError(err) {
+			t.Skipf("setState: timedatectl failed (expected in CI without systemd): %v", err)
+		}
+		t.Fatalf("setState file write failed: %v", err)
+	}
+
+	got, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	wantServers := make([]string, len(servers))
+	copy(wantServers, servers)
+	sort.Strings(wantServers)
+
+	if len(got.NTPServers) != len(wantServers) {
+		t.Fatalf("NTPServers length: got %d, want %d — got=%v", len(got.NTPServers), len(wantServers), got.NTPServers)
+	}
+	for i := range wantServers {
+		if got.NTPServers[i] != wantServers[i] {
+			t.Errorf("NTPServers[%d]: got %q, want %q", i, got.NTPServers[i], wantServers[i])
+		}
+	}
+}
+
+// TestLinuxExecutor_NTPServersSorted verifies that getState always returns a
+// sorted NTP server list regardless of the order stored in the config file.
+func TestLinuxExecutor_NTPServersSorted(t *testing.T) {
+	e, dir := newFixtureExecutor(t)
+
+	// Write a timesyncd.conf with servers in reverse alphabetical order.
+	content := "# cfgms:ntp_sync_enabled=true\n[Time]\nNTP=z.pool.ntp.org a.pool.ntp.org m.pool.ntp.org\nFallbackNTP=\n"
+	if err := os.WriteFile(filepath.Join(dir, "timesyncd.conf"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "timezone"), []byte("UTC\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	// Verify the returned list is sorted.
+	for i := 1; i < len(got.NTPServers); i++ {
+		if got.NTPServers[i] < got.NTPServers[i-1] {
+			t.Errorf("NTPServers not sorted at index %d: %q < %q", i, got.NTPServers[i], got.NTPServers[i-1])
+		}
+	}
+}
+
+// TestLinuxExecutor_NTPSyncEnabledRoundTrip verifies that the NTP sync enabled
+// flag survives a Set → Get round-trip via the cfgms marker in timesyncd.conf.
+func TestLinuxExecutor_NTPSyncEnabledRoundTrip(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+
+	for _, wantEnabled := range []bool{true, false} {
+		desired := timeState{
+			Timezone:       "UTC",
+			NTPServers:     []string{"pool.ntp.org"},
+			NTPSyncEnabled: wantEnabled,
+		}
+
+		if err := e.setState(desired); err != nil {
+			if !isFileWriteError(err) {
+				t.Skipf("setState: timedatectl failed (expected in CI without systemd): %v", err)
+			}
+			t.Fatalf("setState file write failed: %v", err)
+		}
+
+		got, err := e.getState()
+		if err != nil {
+			t.Fatalf("getState() error after setState(enabled=%v): %v", wantEnabled, err)
+		}
+
+		if got.NTPSyncEnabled != wantEnabled {
+			t.Errorf("NTPSyncEnabled: got %v, want %v", got.NTPSyncEnabled, wantEnabled)
+		}
+	}
+}
+
+// TestLinuxExecutor_MissingFiles verifies getState returns sensible defaults
+// when the timezone and timesyncd config files do not exist.
+func TestLinuxExecutor_MissingFiles(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+	// Files don't exist — newFixtureExecutor only creates the dir, not files.
+
+	got, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() with missing files returned error: %v", err)
+	}
+
+	if got.Timezone == "" {
+		t.Error("getState() with missing timezone file must return a non-empty default timezone")
+	}
+}
+
+// TestLinuxExecutor_GetIsIdempotent verifies two consecutive getState calls
+// return identical results (ADR-016 clause 4 determinism contract).
+func TestLinuxExecutor_GetIsIdempotent(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+
+	desired := timeState{
+		Timezone:       "Europe/Berlin",
+		NTPServers:     []string{"ntp1.example.com", "ntp2.example.com"},
+		NTPSyncEnabled: true,
+	}
+
+	if err := e.setState(desired); err != nil {
+		if !isFileWriteError(err) {
+			t.Skipf("setState: timedatectl failed (expected in CI without systemd): %v", err)
+		}
+		t.Fatalf("setState file write failed: %v", err)
+	}
+
+	got1, err := e.getState()
+	if err != nil {
+		t.Fatalf("first getState() error: %v", err)
+	}
+	got2, err := e.getState()
+	if err != nil {
+		t.Fatalf("second getState() error: %v", err)
+	}
+
+	if got1.Timezone != got2.Timezone {
+		t.Errorf("Timezone not idempotent: %q vs %q", got1.Timezone, got2.Timezone)
+	}
+	if got1.NTPSyncEnabled != got2.NTPSyncEnabled {
+		t.Errorf("NTPSyncEnabled not idempotent: %v vs %v", got1.NTPSyncEnabled, got2.NTPSyncEnabled)
+	}
+	if len(got1.NTPServers) != len(got2.NTPServers) {
+		t.Errorf("NTPServers length not idempotent: %d vs %d", len(got1.NTPServers), len(got2.NTPServers))
+	}
+	for i := range got1.NTPServers {
+		if got1.NTPServers[i] != got2.NTPServers[i] {
+			t.Errorf("NTPServers[%d] not idempotent: %q vs %q", i, got1.NTPServers[i], got2.NTPServers[i])
+		}
+	}
+}
+
+// isFileWriteError returns true when the error originates from a file write
+// operation (i.e., a genuine failure unrelated to systemd unavailability).
+// Used to distinguish fixture-test-relevant failures from expected CI skips.
+func isFileWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// If the error message mentions timedatectl, it's a runtime-apply failure,
+	// not a file write failure.
+	return !strings.Contains(err.Error(), "timedatectl")
+}

--- a/features/modules/stdlib/time/executor_stub.go
+++ b/features/modules/stdlib/time/executor_stub.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !linux && !windows && !darwin
+
+package timemodule
+
+import "github.com/cfgis/cfgms/features/modules"
+
+// stubExecutor is used on platforms where time configuration is not supported.
+type stubExecutor struct{}
+
+func newExecutor() timeExecutor {
+	return &stubExecutor{}
+}
+
+func (e *stubExecutor) getState() (timeState, error) {
+	return timeState{}, modules.ErrUnsupportedPlatform
+}
+
+func (e *stubExecutor) setState(_ timeState) error {
+	return modules.ErrUnsupportedPlatform
+}

--- a/features/modules/stdlib/time/executor_windows.go
+++ b/features/modules/stdlib/time/executor_windows.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package timemodule
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// windowsExecutor manages host time configuration on Windows via tzutil.exe
+// and w32tm.exe.
+//
+// Timezone is managed via tzutil /s (set) and tzutil /g (get).
+// Note: Windows timezone identifiers use Windows format (e.g. "Eastern Standard Time"),
+// not IANA format. The module stores and returns Windows identifiers as-is.
+//
+// NTP servers are managed via w32tm /config /manualpeerlist.
+// NTP sync enabled/disabled is managed via w32tm /config /syncfromflags.
+type windowsExecutor struct{}
+
+func newExecutor() timeExecutor {
+	return &windowsExecutor{}
+}
+
+// getState returns the current timezone and NTP configuration from the Windows
+// Time Service.
+func (e *windowsExecutor) getState() (timeState, error) {
+	tz, err := e.getTimezone()
+	if err != nil {
+		return timeState{}, err
+	}
+
+	servers, enabled, err := e.getNTPConfig()
+	if err != nil {
+		return timeState{}, err
+	}
+
+	sort.Strings(servers)
+	return timeState{
+		Timezone:       tz,
+		NTPServers:     servers,
+		NTPSyncEnabled: enabled,
+	}, nil
+}
+
+// setState applies the desired timezone and NTP configuration via Windows tools.
+func (e *windowsExecutor) setState(desired timeState) error {
+	if out, err := exec.Command("tzutil", "/s", desired.Timezone).CombinedOutput(); err != nil { // #nosec G204 - timezone from Validate()
+		return fmt.Errorf("tzutil /s %s: %w (output: %s)", desired.Timezone, err, strings.TrimSpace(string(out)))
+	}
+
+	servers := make([]string, len(desired.NTPServers))
+	copy(servers, desired.NTPServers)
+	sort.Strings(servers)
+
+	peerList := strings.Join(servers, " ")
+	if peerList == "" {
+		peerList = "time.windows.com,0x9"
+	}
+
+	if out, err := exec.Command("w32tm", "/config", "/manualpeerlist:"+peerList, "/syncfromflags:manual", "/reliable:yes", "/update").CombinedOutput(); err != nil { // #nosec G204 - peer list from config
+		return fmt.Errorf("w32tm /config: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	if desired.NTPSyncEnabled {
+		if out, err := exec.Command("w32tm", "/config", "/syncfromflags:manual", "/update").CombinedOutput(); err != nil { // #nosec G204 - controlled literal
+			return fmt.Errorf("w32tm enable sync: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		}
+	} else {
+		if out, err := exec.Command("w32tm", "/config", "/syncfromflags:no", "/update").CombinedOutput(); err != nil { // #nosec G204 - controlled literal
+			return fmt.Errorf("w32tm disable sync: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	return nil
+}
+
+// getTimezone returns the current Windows timezone identifier via tzutil /g.
+func (e *windowsExecutor) getTimezone() (string, error) {
+	out, err := exec.Command("tzutil", "/g").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("tzutil /g: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// getNTPConfig returns the NTP peer list and sync-enabled state via w32tm.
+func (e *windowsExecutor) getNTPConfig() (servers []string, enabled bool, err error) {
+	out, runErr := exec.Command("w32tm", "/query", "/configuration").CombinedOutput()
+	if runErr != nil {
+		return nil, false, fmt.Errorf("w32tm /query /configuration: %w (output: %s)", runErr, strings.TrimSpace(string(out)))
+	}
+
+	output := string(out)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "NtpServer:") {
+			// Format: "NtpServer: server1,0x9 server2,0x9 (Local)"
+			val := strings.TrimPrefix(line, "NtpServer:")
+			// Remove trailing parenthetical annotation.
+			if idx := strings.Index(val, "("); idx >= 0 {
+				val = val[:idx]
+			}
+			for _, s := range strings.Fields(val) {
+				// Strip ,0x9 polling flags.
+				if comma := strings.Index(s, ","); comma >= 0 {
+					s = s[:comma]
+				}
+				if s != "" {
+					servers = append(servers, s)
+				}
+			}
+		}
+		if strings.HasPrefix(line, "Type:") {
+			val := strings.TrimSpace(strings.TrimPrefix(line, "Type:"))
+			// "NTP" or "NT5DS" means syncing; "NoSync" means disabled.
+			enabled = !strings.EqualFold(val, "NoSync")
+		}
+	}
+
+	return servers, enabled, nil
+}

--- a/features/modules/stdlib/time/executor_windows_test.go
+++ b/features/modules/stdlib/time/executor_windows_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package timemodule
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// w32tmAvailable returns true when the Windows Time Service is available.
+func w32tmAvailable() bool {
+	return exec.Command("w32tm", "/query", "/configuration").Run() == nil
+}
+
+// TestWindowsExecutor_GetNTPConfig_ServerParsing verifies the NtpServer line
+// parsing in getNTPConfig: it must strip trailing parenthetical annotations
+// and comma-delimited polling flags from each server token.
+func TestWindowsExecutor_GetNTPConfig_ServerParsing(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string
+		want    []string
+		enabled bool
+	}{
+		{
+			name:    "single server with polling flag",
+			line:    "NtpServer: time.windows.com,0x9 (Local)",
+			want:    []string{"time.windows.com"},
+			enabled: false, // type line absent → false default in this test
+		},
+		{
+			name:    "multiple servers with polling flags",
+			line:    "NtpServer: ntp1.example.com,0x9 ntp2.example.com,0x9 (Local)",
+			want:    []string{"ntp1.example.com", "ntp2.example.com"},
+			enabled: false,
+		},
+		{
+			name:    "server without polling flag",
+			line:    "NtpServer: pool.ntp.org (Local)",
+			want:    []string{"pool.ntp.org"},
+			enabled: false,
+		},
+		{
+			name:    "empty NtpServer",
+			line:    "NtpServer:  (Local)",
+			want:    nil,
+			enabled: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var servers []string
+
+			// Replicate the parsing contract from getNTPConfig.
+			ntpLine := strings.TrimSpace(tc.line)
+			if strings.HasPrefix(ntpLine, "NtpServer:") {
+				val := strings.TrimPrefix(ntpLine, "NtpServer:")
+				if idx := strings.Index(val, "("); idx >= 0 {
+					val = val[:idx]
+				}
+				for _, s := range strings.Fields(val) {
+					if comma := strings.Index(s, ","); comma >= 0 {
+						s = s[:comma]
+					}
+					if s != "" {
+						servers = append(servers, s)
+					}
+				}
+			}
+
+			if len(servers) != len(tc.want) {
+				t.Fatalf("server count: got %d (%v), want %d (%v)", len(servers), servers, len(tc.want), tc.want)
+			}
+			for i := range tc.want {
+				if servers[i] != tc.want[i] {
+					t.Errorf("server[%d]: got %q, want %q", i, servers[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestWindowsExecutor_GetNTPConfig_TypeParsing verifies the Type: line parsing
+// in getNTPConfig: "NTP" and "NT5DS" mean sync enabled; "NoSync" means disabled.
+func TestWindowsExecutor_GetNTPConfig_TypeParsing(t *testing.T) {
+	cases := []struct {
+		typeLine string
+		enabled  bool
+	}{
+		{"Type: NTP", true},
+		{"Type: NT5DS", true},
+		{"Type: NoSync", false},
+		{"Type: nosync", false}, // case-insensitive
+	}
+
+	for _, tc := range cases {
+		trimmed := strings.TrimSpace(tc.typeLine)
+		enabled := true
+		if strings.HasPrefix(trimmed, "Type:") {
+			val := strings.TrimSpace(strings.TrimPrefix(trimmed, "Type:"))
+			enabled = !strings.EqualFold(val, "NoSync")
+		}
+		if enabled != tc.enabled {
+			t.Errorf("Type parse(%q): got enabled=%v, want enabled=%v", tc.typeLine, enabled, tc.enabled)
+		}
+	}
+}
+
+// TestWindowsExecutor_GetState verifies the full getState round-trip on Windows
+// when w32tm and the Windows Time Service are available.
+func TestWindowsExecutor_GetState(t *testing.T) {
+	if !w32tmAvailable() {
+		t.Skip("skipping: w32tm not available or Windows Time Service is not running")
+	}
+
+	e := &windowsExecutor{}
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if state.Timezone == "" {
+		t.Error("getState() returned empty Timezone")
+	}
+	// NTPServers may be empty (valid when no peers are configured).
+	// NTPSyncEnabled is boolean — no assertion on the specific value.
+}

--- a/features/modules/stdlib/time/module.go
+++ b/features/modules/stdlib/time/module.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package timemodule implements the CFGMS stdlib time module.
+//
+// The package name is timemodule (not time) to avoid shadowing Go's standard
+// library time package, which this module also imports for duration handling.
+//
+// The module manages host timezone and NTP/time-sync configuration via the
+// platform executor. The resource ID is system-scoped (one time configuration
+// per host); any non-empty resource ID is accepted and refers to the single
+// system-wide configuration.
+package timemodule
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ianaTimezonePattern matches valid IANA timezone identifiers.
+// Accepted: "UTC", "America/Chicago", "Etc/GMT+5", "Pacific/Auckland".
+// Rejected: empty strings, strings with newlines or control characters,
+// strings starting with '-' (which could be mistaken for command flags).
+var ianaTimezonePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_+\-/]*$`)
+
+// ntpServerPattern matches valid NTP server hostnames or IPv4/IPv6 addresses.
+// Accepts dotted names, hostnames, and numeric addresses. Rejects leading '-',
+// newlines, spaces, and other shell-special characters.
+var ntpServerPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:\-\[\]]*$`)
+
+// TimeConfig represents the desired or observed time configuration of the host.
+type TimeConfig struct {
+	// Timezone is the IANA timezone identifier (e.g. "UTC", "America/Chicago").
+	Timezone string `yaml:"timezone"`
+	// NTPServers is the list of NTP server hostnames or IP addresses.
+	// Returned sorted alphabetically by Get for determinism (ADR-016 clause 4).
+	NTPServers []string `yaml:"ntp_servers"`
+	// NTPSyncEnabled indicates whether automatic NTP synchronisation is enabled.
+	NTPSyncEnabled bool `yaml:"ntp_sync_enabled"`
+}
+
+// AsMap returns the configuration as a map for field-by-field comparison.
+// NTPServers is sorted to ensure deterministic output (ADR-016 clause 4).
+func (c *TimeConfig) AsMap() map[string]interface{} {
+	servers := make([]string, len(c.NTPServers))
+	copy(servers, c.NTPServers)
+	sort.Strings(servers)
+	return map[string]interface{}{
+		"timezone":         c.Timezone,
+		"ntp_servers":      servers,
+		"ntp_sync_enabled": c.NTPSyncEnabled,
+	}
+}
+
+// ToYAML serializes the configuration to YAML.
+func (c *TimeConfig) ToYAML() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// FromYAML deserializes YAML data into the configuration.
+func (c *TimeConfig) FromYAML(data []byte) error {
+	return yaml.Unmarshal(data, c)
+}
+
+// Validate checks that the configuration is valid before applying it.
+func (c *TimeConfig) Validate() error {
+	if c.Timezone == "" {
+		return fmt.Errorf("%w: timezone is required (IANA identifier, e.g. \"UTC\" or \"America/Chicago\")", modules.ErrInvalidInput)
+	}
+	if !ianaTimezonePattern.MatchString(c.Timezone) {
+		return fmt.Errorf("%w: timezone %q is not a valid IANA identifier", modules.ErrInvalidInput, c.Timezone)
+	}
+	for _, srv := range c.NTPServers {
+		if strings.ContainsAny(srv, "\n\r\t") || !ntpServerPattern.MatchString(srv) {
+			return fmt.Errorf("%w: NTP server %q contains invalid characters", modules.ErrInvalidInput, srv)
+		}
+	}
+	return nil
+}
+
+// GetManagedFields returns the list of fields this configuration manages.
+func (c *TimeConfig) GetManagedFields() []string {
+	return []string{"timezone", "ntp_servers", "ntp_sync_enabled"}
+}
+
+// timeModule implements modules.Module for host time configuration.
+type timeModule struct {
+	modules.DefaultLoggingSupport
+	executor timeExecutor
+}
+
+// New returns a new time module instance.
+func New() modules.Module {
+	return &timeModule{
+		executor: newExecutor(),
+	}
+}
+
+// Get returns the current time configuration of the host.
+// The resource ID is system-scoped; any non-empty value refers to the single
+// host-wide time configuration.
+func (m *timeModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
+	if resourceID == "" {
+		return nil, modules.ErrInvalidResourceID
+	}
+
+	logger := m.GetEffectiveLogger(logging.ForModule("time"))
+	tenantID := logging.ExtractTenantFromContext(ctx)
+
+	logger.InfoCtx(ctx, "Getting time configuration",
+		"operation", "time_get",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"tenant_id", tenantID,
+		"resource_type", "time")
+
+	state, err := m.executor.getState()
+	if err != nil {
+		logger.ErrorCtx(ctx, "Failed to get time configuration",
+			"operation", "time_get",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"error_code", "TIME_GET_FAILED",
+			"error_details", logging.SanitizeLogValue(err.Error()))
+		return nil, err
+	}
+
+	servers := make([]string, len(state.NTPServers))
+	copy(servers, state.NTPServers)
+	sort.Strings(servers)
+
+	config := &TimeConfig{
+		Timezone:       state.Timezone,
+		NTPServers:     servers,
+		NTPSyncEnabled: state.NTPSyncEnabled,
+	}
+
+	logger.InfoCtx(ctx, "Time configuration retrieved",
+		"operation", "time_get",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"timezone", logging.SanitizeLogValue(state.Timezone),
+		"ntp_server_count", len(servers),
+		"ntp_sync_enabled", state.NTPSyncEnabled,
+		"status", "completed")
+
+	return config, nil
+}
+
+// Set applies the desired time configuration to the host.
+// The resource ID is system-scoped; any non-empty value refers to the single
+// host-wide time configuration.
+func (m *timeModule) Set(ctx context.Context, resourceID string, config modules.ConfigState) error {
+	if resourceID == "" {
+		return modules.ErrInvalidResourceID
+	}
+	if config == nil {
+		return fmt.Errorf("%w: config must not be nil", modules.ErrInvalidInput)
+	}
+
+	tc, ok := config.(*TimeConfig)
+	if !ok {
+		return fmt.Errorf("%w: expected *TimeConfig, got %T", modules.ErrInvalidInput, config)
+	}
+
+	if err := tc.Validate(); err != nil {
+		return err
+	}
+
+	logger := m.GetEffectiveLogger(logging.ForModule("time"))
+	tenantID := logging.ExtractTenantFromContext(ctx)
+
+	logger.InfoCtx(ctx, "Setting time configuration",
+		"operation", "time_set",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"tenant_id", tenantID,
+		"timezone", logging.SanitizeLogValue(tc.Timezone),
+		"ntp_server_count", len(tc.NTPServers),
+		"ntp_sync_enabled", tc.NTPSyncEnabled,
+		"resource_type", "time")
+
+	servers := make([]string, len(tc.NTPServers))
+	copy(servers, tc.NTPServers)
+	sort.Strings(servers)
+
+	desired := timeState{
+		Timezone:       tc.Timezone,
+		NTPServers:     servers,
+		NTPSyncEnabled: tc.NTPSyncEnabled,
+	}
+
+	if err := m.executor.setState(desired); err != nil {
+		logger.ErrorCtx(ctx, "Failed to set time configuration",
+			"operation", "time_set",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"error_code", "TIME_SET_FAILED",
+			"error_details", logging.SanitizeLogValue(err.Error()))
+		return err
+	}
+
+	logger.InfoCtx(ctx, "Time configuration applied",
+		"operation", "time_set",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"timezone", logging.SanitizeLogValue(tc.Timezone),
+		"status", "completed")
+
+	return nil
+}

--- a/features/modules/stdlib/time/module.yaml
+++ b/features/modules/stdlib/time/module.yaml
@@ -1,0 +1,52 @@
+name: time
+version: 0.1.0
+description: >
+  Manages host timezone and NTP/time-sync configuration.
+  Provides idempotent Get/Set management of timezone (IANA identifier),
+  NTP server list, and NTP sync enabled flag via native OS configuration
+  (timedatectl/systemd-timesyncd on Linux, w32tm/tzutil on Windows,
+  systemsetup on macOS). Correct time configuration is foundational:
+  time skew breaks Kerberos authentication, TLS certificate validation,
+  and log correlation.
+
+publisher: cfgms
+
+# Supported execution environments
+executors:
+  - steward  # Local time configuration management on steward systems
+
+requirements:
+  os: [windows, linux, darwin]
+  arch: [amd64, arm64]
+  min_memory: "64MB"
+  min_disk: "1MB"
+
+interfaces:
+  - Get
+  - Set
+  - Test
+
+owns:
+  - kind: time  # authority over time:* objects this module manages
+
+security:
+  requires_root: true  # writing /etc/timezone, /etc/systemd/timesyncd.conf, and calling timedatectl require root
+  capabilities: []
+  ports: []
+
+behavioral_envelope:
+  shells_out_to:
+    - timedatectl  # Linux: runtime timezone and NTP apply
+    - tzutil.exe   # Windows: timezone management
+    - w32tm.exe    # Windows: NTP/Windows Time Service management
+    - systemsetup  # macOS: timezone and network time management
+  reads_paths:
+    - /etc/timezone                # Linux: current IANA timezone name
+    - /etc/systemd/timesyncd.conf  # Linux: NTP server list and sync configuration
+  writes_paths:
+    - /etc/timezone                # Linux: desired timezone identifier
+    - /etc/systemd/timesyncd.conf  # Linux: desired NTP server list and sync state
+
+documentation:
+  api: "docs/modules/time.md"
+  examples: "docs/modules/time.md"

--- a/features/modules/stdlib/time/module_test.go
+++ b/features/modules/stdlib/time/module_test.go
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package timemodule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/modules/conformance"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestTimeModule_New verifies the module constructor returns a non-nil Module.
+func TestTimeModule_New(t *testing.T) {
+	m := New()
+	if m == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+// TestTimeConfig_Validate covers valid and invalid configurations.
+func TestTimeConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  TimeConfig
+		wantErr bool
+	}{
+		{
+			name:    "UTC timezone is valid",
+			config:  TimeConfig{Timezone: "UTC"},
+			wantErr: false,
+		},
+		{
+			name:    "IANA timezone is valid",
+			config:  TimeConfig{Timezone: "America/Chicago", NTPSyncEnabled: true},
+			wantErr: false,
+		},
+		{
+			name:    "with NTP servers is valid",
+			config:  TimeConfig{Timezone: "Europe/London", NTPServers: []string{"pool.ntp.org"}, NTPSyncEnabled: true},
+			wantErr: false,
+		},
+		{
+			name:    "empty timezone is invalid",
+			config:  TimeConfig{Timezone: ""},
+			wantErr: true,
+		},
+		{
+			name:    "NTP disabled with no servers is valid",
+			config:  TimeConfig{Timezone: "UTC", NTPSyncEnabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "timezone with leading dash is invalid",
+			config:  TimeConfig{Timezone: "-invalidzone"},
+			wantErr: true,
+		},
+		{
+			name:    "timezone with newline injection is invalid",
+			config:  TimeConfig{Timezone: "UTC\nmalicious"},
+			wantErr: true,
+		},
+		{
+			name:    "NTP server with newline is invalid",
+			config:  TimeConfig{Timezone: "UTC", NTPServers: []string{"pool.ntp.org\nevil"}},
+			wantErr: true,
+		},
+		{
+			name:    "NTP server with leading dash is invalid",
+			config:  TimeConfig{Timezone: "UTC", NTPServers: []string{"-badserver"}},
+			wantErr: true,
+		},
+		{
+			name:    "Etc/GMT+5 timezone is valid",
+			config:  TimeConfig{Timezone: "Etc/GMT+5"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestTimeConfig_AsMap verifies AsMap returns the expected keys and values,
+// with NTPServers sorted for determinism.
+func TestTimeConfig_AsMap(t *testing.T) {
+	tests := []struct {
+		name   string
+		config TimeConfig
+		checks map[string]interface{}
+	}{
+		{
+			name: "basic config",
+			config: TimeConfig{
+				Timezone:       "UTC",
+				NTPServers:     []string{"pool.ntp.org"},
+				NTPSyncEnabled: true,
+			},
+			checks: map[string]interface{}{
+				"timezone":         "UTC",
+				"ntp_sync_enabled": true,
+			},
+		},
+		{
+			name: "servers are sorted",
+			config: TimeConfig{
+				Timezone:       "America/New_York",
+				NTPServers:     []string{"z.pool.ntp.org", "a.pool.ntp.org"},
+				NTPSyncEnabled: true,
+			},
+			checks: map[string]interface{}{
+				"timezone":         "America/New_York",
+				"ntp_sync_enabled": true,
+			},
+		},
+		{
+			name: "ntp disabled",
+			config: TimeConfig{
+				Timezone:       "UTC",
+				NTPSyncEnabled: false,
+			},
+			checks: map[string]interface{}{
+				"timezone":         "UTC",
+				"ntp_sync_enabled": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.config.AsMap()
+			for k, wantV := range tt.checks {
+				got, ok := m[k]
+				if !ok {
+					t.Errorf("AsMap() missing key %q", k)
+					continue
+				}
+				if got != wantV {
+					t.Errorf("AsMap()[%q] = %v, want %v", k, got, wantV)
+				}
+			}
+			// ntp_servers must always be present and be a sorted slice.
+			servers, ok := m["ntp_servers"]
+			if !ok {
+				t.Error("AsMap() missing key \"ntp_servers\"")
+			} else {
+				sl, ok := servers.([]string)
+				if !ok {
+					t.Errorf("AsMap()[\"ntp_servers\"] is %T, want []string", servers)
+				} else {
+					for i := 1; i < len(sl); i++ {
+						if sl[i] < sl[i-1] {
+							t.Errorf("AsMap()[\"ntp_servers\"] is not sorted: %v", sl)
+							break
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestTimeConfig_AsMap_ServerSortingIsDeterministic verifies that AsMap with
+// an unsorted input always returns sorted output.
+func TestTimeConfig_AsMap_ServerSortingIsDeterministic(t *testing.T) {
+	cfg := &TimeConfig{
+		Timezone:       "UTC",
+		NTPServers:     []string{"z.ntp.org", "a.ntp.org", "m.ntp.org"},
+		NTPSyncEnabled: true,
+	}
+	m1 := cfg.AsMap()
+	m2 := cfg.AsMap()
+
+	sl1 := m1["ntp_servers"].([]string)
+	sl2 := m2["ntp_servers"].([]string)
+
+	if len(sl1) != len(sl2) {
+		t.Fatalf("server list length differs: %d vs %d", len(sl1), len(sl2))
+	}
+	for i := range sl1 {
+		if sl1[i] != sl2[i] {
+			t.Errorf("server[%d] differs: %q vs %q", i, sl1[i], sl2[i])
+		}
+	}
+}
+
+// TestTimeConfig_YAMLRoundTrip verifies ToYAML and FromYAML are inverse operations.
+func TestTimeConfig_YAMLRoundTrip(t *testing.T) {
+	original := &TimeConfig{
+		Timezone:       "America/Chicago",
+		NTPServers:     []string{"time1.example.com", "time2.example.com"},
+		NTPSyncEnabled: true,
+	}
+
+	data, err := original.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error: %v", err)
+	}
+
+	decoded := &TimeConfig{}
+	if err := decoded.FromYAML(data); err != nil {
+		t.Fatalf("FromYAML() error: %v", err)
+	}
+
+	if decoded.Timezone != original.Timezone {
+		t.Errorf("Timezone: got %q, want %q", decoded.Timezone, original.Timezone)
+	}
+	if decoded.NTPSyncEnabled != original.NTPSyncEnabled {
+		t.Errorf("NTPSyncEnabled: got %v, want %v", decoded.NTPSyncEnabled, original.NTPSyncEnabled)
+	}
+	if len(decoded.NTPServers) != len(original.NTPServers) {
+		t.Errorf("NTPServers length: got %d, want %d", len(decoded.NTPServers), len(original.NTPServers))
+	}
+}
+
+// TestTimeConfig_GetManagedFields verifies the fields reported as managed.
+func TestTimeConfig_GetManagedFields(t *testing.T) {
+	config := &TimeConfig{Timezone: "UTC"}
+	fields := config.GetManagedFields()
+
+	required := map[string]bool{
+		"timezone":         false,
+		"ntp_servers":      false,
+		"ntp_sync_enabled": false,
+	}
+	for _, f := range fields {
+		required[f] = true
+	}
+	for field, found := range required {
+		if !found {
+			t.Errorf("GetManagedFields() missing required field %q", field)
+		}
+	}
+}
+
+// TestTimeModule_Get_EmptyResourceID verifies Get rejects an empty resource ID.
+func TestTimeModule_Get_EmptyResourceID(t *testing.T) {
+	m := New()
+	_, err := m.Get(context.Background(), "")
+	if err == nil {
+		t.Error("Get() with empty resource ID must return an error")
+	}
+}
+
+// TestTimeModule_Set_InvalidInputs verifies Set rejects empty resource IDs and nil configs.
+func TestTimeModule_Set_InvalidInputs(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	validConfig := &TimeConfig{Timezone: "UTC", NTPSyncEnabled: true}
+
+	if err := m.Set(ctx, "", validConfig); err == nil {
+		t.Error("Set() with empty resource ID must return an error")
+	}
+
+	if err := m.Set(ctx, "system", nil); err == nil {
+		t.Error("Set() with nil config must return an error")
+	}
+}
+
+// TestTimeModule_Set_InvalidTimezone verifies Set rejects configs with an empty timezone.
+func TestTimeModule_Set_InvalidTimezone(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	badConfig := &TimeConfig{Timezone: ""}
+	if err := m.Set(ctx, "system", badConfig); err == nil {
+		t.Error("Set() with empty timezone must return an error")
+	}
+}
+
+// TestTimeModule_Set_WrongConfigType verifies Set rejects configs of the wrong type.
+func TestTimeModule_Set_WrongConfigType(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	// wrongConfig implements modules.ConfigState but is not *TimeConfig.
+	wrongCfg := &wrongConfigType{}
+	if err := m.Set(ctx, "system", wrongCfg); err == nil {
+		t.Error("Set() with wrong config type must return an error")
+	}
+}
+
+// wrongConfigType is a stub that implements modules.ConfigState but is not *TimeConfig.
+type wrongConfigType struct{}
+
+func (w *wrongConfigType) AsMap() map[string]interface{}  { return nil }
+func (w *wrongConfigType) ToYAML() ([]byte, error)        { return nil, nil }
+func (w *wrongConfigType) FromYAML(_ []byte) error        { return nil }
+func (w *wrongConfigType) Validate() error                { return nil }
+func (w *wrongConfigType) GetManagedFields() []string     { return nil }
+
+// TestTimeModule_LoggingInjection verifies the module implements LoggingInjectable.
+func TestTimeModule_LoggingInjection(t *testing.T) {
+	m := New()
+
+	injectable, ok := m.(modules.LoggingInjectable)
+	if !ok {
+		t.Fatal("New() must return a value implementing modules.LoggingInjectable")
+	}
+
+	_, injected := injectable.GetLogger()
+	if injected {
+		t.Error("GetLogger() must return injected=false before SetLogger is called")
+	}
+
+	testLogger := logging.ForModule("time-test")
+	if err := injectable.SetLogger(testLogger); err != nil {
+		t.Fatalf("SetLogger() returned unexpected error: %v", err)
+	}
+
+	got, injected := injectable.GetLogger()
+	if !injected {
+		t.Error("GetLogger() must return injected=true after SetLogger succeeds")
+	}
+	if got == nil {
+		t.Error("GetLogger() must return a non-nil logger after SetLogger")
+	}
+
+	if err := injectable.SetLogger(nil); err == nil {
+		t.Error("SetLogger(nil) must return an error")
+	}
+}
+
+// TestTimeModule_ConformanceDeterministicGet verifies that Get produces
+// byte-for-byte identical output on consecutive calls (ADR-016 clause 4).
+func TestTimeModule_ConformanceDeterministicGet(t *testing.T) {
+	m := New()
+	state, err := m.Get(context.Background(), "system")
+	if err != nil {
+		if errors.Is(err, modules.ErrUnsupportedPlatform) {
+			t.Skipf("skipping conformance test: Get unsupported on this platform: %v", err)
+		}
+		t.Fatalf("Get(\"system\") returned unexpected error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Get(\"system\") returned nil state with nil error")
+	}
+	conformance.AssertDeterministicGet(t, m, "system")
+}
+
+// TestTimeModule_ConformanceNoEphemeralFields verifies that TimeConfig returned
+// by Get() contains no banned ephemeral fields (ADR-016 clause 4).
+func TestTimeModule_ConformanceNoEphemeralFields(t *testing.T) {
+	m := New()
+	state, err := m.Get(context.Background(), "system")
+	if err != nil {
+		if errors.Is(err, modules.ErrUnsupportedPlatform) {
+			t.Skipf("skipping: Get unsupported on this platform: %v", err)
+		}
+		t.Fatalf("Get(\"system\") returned unexpected error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Get(\"system\") returned nil state with nil error")
+	}
+	conformance.AssertNoEphemeralFields(t, state, conformance.DefaultBannedEphemeralFields)
+}

--- a/features/steward/factory/factory.go
+++ b/features/steward/factory/factory.go
@@ -49,6 +49,7 @@ import (
 	package_module "github.com/cfgis/cfgms/features/modules/stdlib/package"
 	"github.com/cfgis/cfgms/features/modules/stdlib/patch"
 	"github.com/cfgis/cfgms/features/modules/stdlib/script"
+	time_module "github.com/cfgis/cfgms/features/modules/stdlib/time"
 	user_module "github.com/cfgis/cfgms/features/modules/stdlib/user"
 	"github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/discovery"
@@ -186,6 +187,7 @@ var builtinModuleConstructors = map[string]func() modules.Module{
 	"package":       func() modules.Module { return package_module.New() },
 	"patch":         func() modules.Module { return patch.New() },
 	"script":        func() modules.Module { return script.New() },
+	"time":          func() modules.Module { return time_module.New() },
 	"user":          func() modules.Module { return user_module.New() },
 }
 

--- a/features/steward/factory/factory_test.go
+++ b/features/steward/factory/factory_test.go
@@ -223,7 +223,7 @@ func TestGetModuleInfo(t *testing.T) {
 
 func TestAllBuiltinModulesLoad(t *testing.T) {
 	factory := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail}, logging.NewNoopLogger())
-	for _, name := range []string{"acme", "cert_trust", "directory", "file", "firewall", "github_runner", "hyperv", "package", "patch", "script", "user"} {
+	for _, name := range []string{"acme", "cert_trust", "directory", "file", "firewall", "github_runner", "hyperv", "package", "patch", "script", "time", "user"} {
 		mod, err := factory.LoadModule(name)
 		assert.NoError(t, err, "built-in module %q must load without error", name)
 		assert.NotNil(t, mod, "built-in module %q must not be nil", name)


### PR DESCRIPTION
## Summary

- Adds `features/modules/stdlib/time/` implementing the `time` stdlib module (IANA timezone + NTP/time-sync) across Linux, Windows, macOS, and a stub for unsupported platforms
- Registers in all five payload sources (Makefile, WXS, install.sh, build-pkg.sh, factory.go)
- Updates `docs/architecture/modules/README.md` and adds `docs/modules/time.md`

## Design notes

**Linux executor** uses configurable file paths (`timezoneFile`, `timesyncdConfig`) so tests point at temp dirs — the CI host's real timezone/NTP config is never touched. NTPSyncEnabled state is tracked via a `# cfgms:ntp_sync_enabled=` marker comment in timesyncd.conf; timedatectl is used for runtime apply and silently skipped when systemd is not running (containers, CI).

**Input validation**: `Validate()` enforces an IANA timezone identifier pattern (`^[A-Za-z][A-Za-z0-9_+\-/]*$`) and a hostname/IP pattern for each NTP server — rejecting leading dashes, newlines, and shell-special characters before they reach exec.Command or config file writes.

**Determinism**: NTPServers sorted alphabetically in `AsMap()` and before every setState call (ADR-016 clause 4). `conformance.AssertDeterministicGet` and `AssertNoEphemeralFields` pass on Linux.

## Test plan

- [ ] `go test ./features/modules/stdlib/time/... ./features/steward/factory/...` — all pass
- [ ] `make check-stdlib-payload-boundary` — 9 modules, all five sources agree
- [ ] `make check-stdlib-completeness` — ADR-016 clause 6 passes
- [ ] `make check-architecture` — no central provider violations
- [ ] `gosec ./features/modules/stdlib/time/...` — 0 issues
- [ ] Linux round-trip tests: `TestLinuxExecutor_TimezoneRoundTrip`, `TestLinuxExecutor_NTPServerListRoundTrip`, `TestLinuxExecutor_NTPSyncEnabledRoundTrip` — pass (timedatectl skipped in CI, file writes verified)
- [ ] Darwin parsing tests: `TestDarwinExecutor_GetTimezone_Parsing`, `TestDarwinExecutor_GetNTPEnabled_Parsing` — pass (no systemsetup needed)
- [ ] Windows parsing tests: `TestWindowsExecutor_GetNTPConfig_ServerParsing`, `TestWindowsExecutor_GetNTPConfig_TypeParsing` — pass (no w32tm needed)
- [ ] `TestAllBuiltinModulesLoad` — includes "time" entry

Fixes #2476

🤖 Generated with [Claude Code](https://claude.com/claude-code)