### PR TITLE
hyperv: assert failProvision returns its cause in provision tests (errcheck)

### DIFF
--- a/features/modules/hyperv/provision_test.go
+++ b/features/modules/hyperv/provision_test.go
@@ -366,7 +366,9 @@ func TestFailProvision_RecordsFailedFrom(t *testing.T) {
 
 	// Re-fail the already-failed record → FailedFrom must NOT be clobbered to
 	// "failed"; the earliest failure phase (creating) is preserved.
-	m.failProvision(ctx, cfg, "vm-fail", rec, errors.New("second failure"))
+	// failProvision returns the original cause for the caller to propagate.
+	secondFailure := errors.New("second failure")
+	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-fail", rec, secondFailure), secondFailure)
 	assert.Equal(t, ProvisionStateFailed, rec.State)
 	assert.Equal(t, ProvisionStateCreating, rec.FailedFrom,
 		"a re-fail must keep the earliest failure phase, not overwrite it with failed")
@@ -383,7 +385,9 @@ func TestAdvanceProvision_ClearsStaleFailedFrom(t *testing.T) {
 	rec, err := m.loadOrInitProvision(ctx, cfg, "vm-retry")
 	require.NoError(t, err)
 	require.NoError(t, m.advanceProvision(ctx, cfg, "vm-retry", rec, ProvisionStateCreating))
-	m.failProvision(ctx, cfg, "vm-retry", rec, errors.New("seed failed"))
+	// failProvision returns the original cause for the caller to propagate.
+	seedFailure := errors.New("seed failed")
+	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-retry", rec, seedFailure), seedFailure)
 	require.Equal(t, ProvisionStateCreating, rec.FailedFrom)
 
 	// A retry advances the record forward again → the stale failure phase clears.


### PR DESCRIPTION
## What

Two `m.failProvision(...)` calls in `features/modules/hyperv/provision_test.go` (added by #2674) discard the function's error return. golangci-lint errcheck flags both, which fails `make test-commit` locally on develop:

```
provision_test.go:369:17: Error return value of `m.failProvision` is not checked (errcheck)
provision_test.go:386:17: Error return value of `m.failProvision` is not checked (errcheck)
```

`failProvision` returns the original cause for the caller to propagate, so the tests now assert exactly that contract with `require.ErrorIs(...)` instead of ignoring the return.

## Verification

Run in the pinned-toolchain validation container:

- `golangci-lint run features/modules/hyperv/...` → 0 issues
- `go test ./features/modules/hyperv/ -count=1` → ok

## Why a standalone PR

Found while validating web story #2497 (web-only branch); this pre-existing lint failure blocks the `make test-commit` gate for any branch off current develop, so it lands separately rather than riding an unrelated story PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)