### PR TITLE
test: keep v020 audit-integration script above 1ms so AverageDuration is measurable

### DIFF
--- a/test/integration/v020_basic_test.go
+++ b/test/integration/v020_basic_test.go
@@ -26,8 +26,12 @@ func TestV020BasicIntegration(t *testing.T) {
 		require.NotNil(t, module)
 
 		// Test script configuration
+		// The sleep keeps the execution above 1ms: durations are recorded at
+		// millisecond granularity, and a bare echo can complete in <1ms on a
+		// fast Linux container, which would round AverageDuration down to 0
+		// and fail the metrics assertion below.
 		scriptConfig := &script.ScriptConfig{
-			Content:       "echo 'CFGMS v0.2.0 integration test successful'",
+			Content:       "echo 'CFGMS v0.2.0 integration test successful'; sleep 0.05",
 			Shell:         script.ShellBash,
 			Timeout:       30 * time.Second,
 			SigningPolicy: script.SigningPolicyNone,


### PR DESCRIPTION
## What

`TestV020BasicIntegration/Script_Module_with_Audit_Integration` asserts `metrics.AverageDuration > 0`. Durations are recorded at millisecond granularity (`duration_ms`), and a bare `echo` completes in under 1ms in a fast Linux container, so the recorded duration rounds to 0 and the test fails:

```
Error: "0" is not greater than "0"
```

The test script now runs `sleep 0.05` after the echo, keeping execution measurably above 1ms in any environment. The assertion keeps its meaning (a real duration was recorded); no product code changes.

## Verification

In the pinned-toolchain validation container: `go test ./test/integration/ -run TestV020BasicIntegration -count=3` → 3/3 pass (failed every run before the change).

## Why a standalone PR

Found while validating web story #2497 (web-only branch): this environment-sensitive failure blocks `make test-production-critical` locally on any branch off develop, so it lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)