### PR TITLE
web: implement fleet-overview table with live filter, sort, DNA columns, pagination (Issue #2497)

### DIFF
--- a/features/modules/hyperv/provision_test.go
+++ b/features/modules/hyperv/provision_test.go
@@ -366,7 +366,9 @@ func TestFailProvision_RecordsFailedFrom(t *testing.T) {
 
 	// Re-fail the already-failed record → FailedFrom must NOT be clobbered to
 	// "failed"; the earliest failure phase (creating) is preserved.
-	m.failProvision(ctx, cfg, "vm-fail", rec, errors.New("second failure"))
+	// failProvision returns the original cause for the caller to propagate.
+	secondFailure := errors.New("second failure")
+	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-fail", rec, secondFailure), secondFailure)
 	assert.Equal(t, ProvisionStateFailed, rec.State)
 	assert.Equal(t, ProvisionStateCreating, rec.FailedFrom,
 		"a re-fail must keep the earliest failure phase, not overwrite it with failed")
@@ -383,7 +385,9 @@ func TestAdvanceProvision_ClearsStaleFailedFrom(t *testing.T) {
 	rec, err := m.loadOrInitProvision(ctx, cfg, "vm-retry")
 	require.NoError(t, err)
 	require.NoError(t, m.advanceProvision(ctx, cfg, "vm-retry", rec, ProvisionStateCreating))
-	m.failProvision(ctx, cfg, "vm-retry", rec, errors.New("seed failed"))
+	// failProvision returns the original cause for the caller to propagate.
+	seedFailure := errors.New("seed failed")
+	require.ErrorIs(t, m.failProvision(ctx, cfg, "vm-retry", rec, seedFailure), seedFailure)
 	require.Equal(t, ProvisionStateCreating, rec.FailedFrom)
 
 	// A retry advances the record forward again → the stale failure phase clears.

--- a/test/integration/v020_basic_test.go
+++ b/test/integration/v020_basic_test.go
@@ -26,8 +26,12 @@ func TestV020BasicIntegration(t *testing.T) {
 		require.NotNil(t, module)
 
 		// Test script configuration
+		// The sleep keeps the execution above 1ms: durations are recorded at
+		// millisecond granularity, and a bare echo can complete in <1ms on a
+		// fast Linux container, which would round AverageDuration down to 0
+		// and fail the metrics assertion below.
 		scriptConfig := &script.ScriptConfig{
-			Content:       "echo 'CFGMS v0.2.0 integration test successful'",
+			Content:       "echo 'CFGMS v0.2.0 integration test successful'; sleep 0.05",
 			Shell:         script.ShellBash,
 			Timeout:       30 * time.Second,
 			SigningPolicy: script.SigningPolicyNone,

--- a/web/README.md
+++ b/web/README.md
@@ -4,9 +4,8 @@
 # CFGMS Web UI
 
 React + TypeScript + Vite application for the controller-served web UI
-(Epic #2344). This is the toolchain scaffold (Story #2488): a buildable,
-lintable, testable app with a minimal placeholder screen. The login screen
-(#2495) and app shell (#2496) land in later stories.
+(Epic #2344): toolchain scaffold (#2488), login screen (#2495), app shell
+(#2496), and the fleet overview (#2497).
 
 The JS/TS toolchain is fully contained in `web/` and does not participate in
 any Go build or test gate. CI runs the same scripts (`lint`, `typecheck`,
@@ -161,8 +160,8 @@ Every authenticated screen mounts inside [`src/shell/AppShell.tsx`](src/shell/Ap
 global search, alert center, user menu), and the responsive drawer/scrim
 behavior below 1024px. `App.tsx` renders `AppShell` as the sole child of
 `RequireAuth`; later epics mount their views into `AppShell`'s `.content`
-area (fleet overview, #2497, is the first occupant — this story ships that
-area as an empty-state placeholder).
+area (fleet overview, #2497, is the first occupant; the shell's global
+search box doubles as its live filter).
 
 - **Tenant-scope context — a display convenience, not a security boundary
   (security A8.1).** [`src/shell/TenantScopeContext.tsx`](src/shell/TenantScopeContext.tsx)
@@ -191,6 +190,79 @@ area as an empty-state placeholder).
   drawer opened by the hamburger button; a scrim covers the content and
   Escape or a scrim click closes it, matching the mockup harness.
 
+## Fleet overview (Story #2497)
+
+[`src/fleet/FleetOverview.tsx`](src/fleet/FleetOverview.tsx) renders the
+steward table inside the app shell. Canonical design:
+[`docs/design/mockups/fleet-overview.html`](../docs/design/mockups/fleet-overview.html).
+Saved views and the row drill-in asset-DNA drawer are Story #2498.
+
+### Data flow
+
+- **Endpoint:** `GET /api/v1/stewards?limit=<n>&offset=<n>` through the
+  #2495 client (`apiFetch` — cookie session, central 401 handling). The
+  response is the `{ data: { stewards, total, limit, offset } }` envelope
+  from Issue #2489: `total` is the post-filter, pre-slice fleet count and
+  page order is deterministic (steward-ID sort).
+- **Scale posture (48k+ stewards):** only the current server page is ever
+  held in memory; the full fleet is never fetched. The pager and the
+  toolbar count render the server `total`.
+- **Client-side semantics (fixed by the epic):** the live filter (the
+  shell's global search box) and column sort operate on the **displayed
+  page's rows** — the filter is not a fleet-wide query bar, and the server
+  provides only pagination + count (no sort/filter params). The pager's
+  "Showing X–Y of Z" always describes the server page window; the toolbar
+  count switches to "N of Z match" while a filter or narrowed scope is
+  active. The filter haystack covers every mapped DNA value (visible or
+  hidden columns) plus the derived health and check-in text.
+- **Tenant scope:** rows are narrowed by the #2496 scope context via
+  `isScopeMatch` when a scope below the principal's root is selected, and
+  tenant paths observed in page data are reported back through
+  `registerObservedPath`. Display convenience only — server-side tenant
+  scoping on the API call is the only enforcement (security A8.1).
+- **Untrusted data:** the response body is shape-validated
+  (`parseStewardPage`) before rendering, and every steward-supplied value
+  reaches the DOM as a text node only — never markup (security A9.1;
+  regression-tested with hostile DNA values).
+
+### DNA-attribute → column mapping
+
+Defined in [`src/fleet/columns.ts`](src/fleet/columns.ts). Default columns:
+Name, Company, Last user, IP, Health, Last check-in; opt-in: OS, Agent,
+Ring, Model, Serial, MAC. Missing values render an em-dash placeholder.
+
+| Column        | Source (payload field / `dna.attributes` key)                                           |
+|---------------|-----------------------------------------------------------------------------------------|
+| Name          | `dna.hostname`, fallback `id`                                                           |
+| Company       | `tenant` (tenant path; **not emitted by the controller yet** — renders `—` until it is) |
+| Last user     | `current_user`                                                                          |
+| IP            | `primary_ip`                                                                            |
+| Health        | derived from `status` + `last_seen` (see below)                                         |
+| Last check-in | `last_seen`, relative (`12s ago` … `3d ago`; `—` = never)                               |
+| OS            | `dna.os`, fallback `os_pretty_name`                                                     |
+| Agent         | `version`, fallback `steward.version`                                                   |
+| Ring          | `deployment_ring`                                                                       |
+| Model         | `system_model`, fallback `hardware_model`                                               |
+| Serial        | `system_serial_number`, fallback `motherboard_serial`                                   |
+| MAC           | `primary_mac`                                                                           |
+
+Column selection persists in `localStorage` under `cfgms.fleet.columns`
+(allowlisted in the A7.2 source scan; values read back are validated as
+untrusted input). Full named saved views are #2498.
+
+### Health mapping
+
+[`src/fleet/health.ts`](src/fleet/health.ts) folds lifecycle `status` and
+`last_seen` staleness into one cell, colored only by semantic state tokens:
+active/online + heartbeat ≤ 5 min → **Healthy** (ok); active/online but
+older (or never) → **Unreachable** (crit); `degraded` → **Degraded**
+(warn); `lost`/`offline` → **Unreachable** (crit); `revoked` → **Revoked**
+(crit); `registered`/`dormant`/`archived` → neutral; unknown statuses
+render neutral with the raw label as inert text. The 5-minute threshold is
+a display heuristic (the payload pins no heartbeat contract), anchored at
+fetch time; Go's zero time (`0001-01-01T00:00:00Z`) is treated as "never
+seen".
+
 ## Testing
 
 Vitest with jsdom and Testing Library. Suites:
@@ -200,8 +272,11 @@ pre-session flow, 401 interception),
 [`src/auth/AuthContext.test.tsx`](src/auth/AuthContext.test.tsx) (state
 transitions, web-storage assertions), and
 [`src/pages/Login.test.tsx`](src/pages/Login.test.tsx) (mockup states,
-source scans), and `src/shell/*.test.tsx` (tenant-scope prefix matching,
-drawer/scrim/Escape behavior, user-menu logout dispatch). Setup (jest-dom
+source scans), `src/shell/*.test.tsx` (tenant-scope prefix matching,
+drawer/scrim/Escape behavior, user-menu logout dispatch), and
+`src/fleet/*.test.*` (pagination contract, live filter, sort, column
+picker + persistence, health/staleness mapping, loading/error/empty
+states, hostile-DNA text-node rendering). Setup (jest-dom
 matchers, RTL cleanup, in-memory Storage for the A7.2 assertions):
 [`src/test/setup.ts`](src/test/setup.ts).
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -66,7 +66,7 @@ describe('App', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('probes the session after login; a 401 drops to the expired login screen', async () => {
+  it('a 401 on the fleet data call drops to the expired login screen', async () => {
     fetchMock.mockImplementation((input) => {
       const url = String(input)
       if (url.endsWith('/api/v1/web/csrf')) {
@@ -76,7 +76,8 @@ describe('App', () => {
       if (url.endsWith('/api/v1/web/login')) {
         return Promise.resolve(jsonResponse(200))
       }
-      // The authenticated probe — a dead session answers 401.
+      // The fleet view's steward-page fetch (#2497) doubles as the
+      // authenticated probe — a dead session answers 401.
       return Promise.resolve(jsonResponse(401))
     })
 
@@ -89,16 +90,16 @@ describe('App', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
-    // The probe fires on mount of the authenticated screen, 401s, and the
-    // guard drops back to the login screen in its expired state.
+    // The fleet data call fires on mount of the authenticated screen, 401s,
+    // and the guard drops back to the login screen in its expired state.
     await waitFor(() =>
       expect(
         screen.getByText(/session expired\. sign in again to continue\./i),
       ).toBeInTheDocument(),
     )
-    const probeCall = fetchMock.mock.calls.find((c) =>
+    const dataCall = fetchMock.mock.calls.find((c) =>
       String(c[0]).includes('/api/v1/stewards'),
     )
-    expect(probeCall).toBeDefined()
+    expect(dataCall).toBeDefined()
   })
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,32 +4,21 @@
 /*
  * App root: auth provider + route guard around the authenticated app
  * shell (Story #2496).
+ *
+ * Session presence is inferred from API responses, never from reading
+ * cookies (#2495). The fleet view's own data call (GET /api/v1/stewards,
+ * #2497) doubles as the authenticated probe — a 401 on it is handled
+ * centrally and drops the app to the login screen ("session expired"), so
+ * the shell no longer fires a separate probe request.
  */
-import { useEffect } from 'react'
-import { apiFetch } from './api/client.ts'
 import { AuthProvider, RequireAuth } from './auth/AuthContext.tsx'
 import AppShell from './shell/AppShell.tsx'
-
-function AuthedApp() {
-  // Lightweight authenticated probe (story #2495 note): session presence is
-  // inferred from API responses, never from reading cookies. A 401 here is
-  // handled centrally — the app drops to the login screen ("session
-  // expired"). The response body is irrelevant.
-  useEffect(() => {
-    void apiFetch('/api/v1/stewards?page_size=1').catch(() => {
-      // Network errors are not session expiry; the fleet view (#2497) owns
-      // user-visible error handling for its own data call.
-    })
-  }, [])
-
-  return <AppShell />
-}
 
 function App() {
   return (
     <AuthProvider>
       <RequireAuth>
-        <AuthedApp />
+        <AppShell />
       </RequireAuth>
     </AuthProvider>
   )

--- a/web/src/fleet/ColumnPicker.tsx
+++ b/web/src/fleet/ColumnPicker.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Device-DNA column picker (Story #2497) — mockup `pop-cols`. Defaults and
+ * opt-in columns are separated by a rule; Name is locked on. Popover follows
+ * the shell overlay conventions: Escape and outside-click close it.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { COLUMNS, type ColumnKey } from './columns.ts'
+
+export default function ColumnPicker({
+  visible,
+  onToggle,
+}: {
+  visible: ReadonlySet<ColumnKey>
+  onToggle: (key: ColumnKey) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    function onPointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onPointerDown)
+    }
+  }, [open])
+
+  const defaults = COLUMNS.filter((c) => c.defaultVisible)
+  const optIns = COLUMNS.filter((c) => !c.defaultVisible)
+
+  return (
+    <div className="colpicker" ref={rootRef}>
+      <button
+        type="button"
+        className="colbtn"
+        aria-expanded={open}
+        onClick={() => setOpen((was) => !was)}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M4 5h16v14H4zM10 5v14M16 5v14" stroke="currentColor" strokeWidth="1.6" />
+        </svg>
+        Columns
+      </button>
+      {open && (
+        <div className="pop open colpop" role="group" aria-label="Device DNA columns">
+          <h4>Device DNA columns</h4>
+          {defaults.map((column) => (
+            <label className={`ck${column.locked ? ' dis' : ''}`} key={column.key}>
+              <input
+                type="checkbox"
+                checked={visible.has(column.key)}
+                disabled={column.locked}
+                onChange={() => onToggle(column.key)}
+              />
+              {column.pickerLabel}
+            </label>
+          ))}
+          <div className="sep" />
+          {optIns.map((column) => (
+            <label className="ck" key={column.key}>
+              <input
+                type="checkbox"
+                checked={visible.has(column.key)}
+                onChange={() => onToggle(column.key)}
+              />
+              {column.pickerLabel}
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/fleet/FleetOverview.css
+++ b/web/src/fleet/FleetOverview.css
@@ -1,0 +1,358 @@
+/* SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright 2026 Jordan Ritz
+ *
+ * Fleet overview (Story #2497) — mockups/fleet-overview.html table, toolbar,
+ * pager, and data states, on the design tokens
+ * (docs/design/web-ui-design-tokens.css). Mono carries machine data;
+ * tabular-nums on numerics; semantic state tokens color the Health pill.
+ * Below 720px the table folds into the mockup's two-column card layout.
+ */
+
+.ptool {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 13px;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+  flex-wrap: wrap;
+}
+.colpicker {
+  position: relative;
+}
+.colbtn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 11px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.colpop {
+  left: 0;
+  top: 40px;
+  min-width: 210px;
+}
+.ck {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 9px;
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.ck:hover {
+  background: var(--bg-elevated);
+}
+.ck input {
+  accent-color: var(--accent);
+  width: 15px;
+  height: 15px;
+}
+.ck.dis {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.ptool .cnt {
+  margin-left: auto;
+  font-size: var(--text-sm);
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.pill .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+}
+.pill.ok {
+  background: var(--state-ok-bg);
+  color: var(--state-ok);
+}
+.pill.warn {
+  background: var(--state-warn-bg);
+  color: var(--state-warn);
+}
+.pill.crit {
+  background: var(--state-crit-bg);
+  color: var(--state-crit);
+}
+.pill.neutral {
+  background: var(--state-neutral-bg);
+  color: var(--state-neutral);
+}
+
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-base);
+}
+.tbl th {
+  text-align: left;
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  font-weight: 600;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+.tbl th .ar {
+  opacity: 0;
+  margin-left: 4px;
+  font-size: 9px;
+}
+.tbl th.sort .ar {
+  opacity: 1;
+  color: var(--accent);
+}
+.tbl td {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.tbl tbody tr:last-child td {
+  border-bottom: 0;
+}
+/* Row hover only where rows are real table rows — in the <720px card fold
+ * the per-cell background would paint a patchwork. */
+@media (hover: hover) and (min-width: 720px) {
+  .tbl tbody tr:hover td {
+    background: var(--bg-elevated);
+  }
+}
+.nm {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+.mut {
+  color: var(--text-secondary);
+  font-size: 12.5px;
+}
+.mono2 {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.seen {
+  color: var(--text-faint);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.pager {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  border-top: 1px solid var(--border);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+  font-variant-numeric: tabular-nums;
+}
+.pager .sz select {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 4px 6px;
+}
+.pager .pg {
+  display: flex;
+  gap: 3px;
+  margin-left: auto;
+}
+.pager .pg button {
+  appearance: none;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 7px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+.pager .pg button.on {
+  background: var(--accent);
+  color: var(--accent-ink);
+  border-color: var(--accent);
+}
+.pager .pg button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.skel {
+  background: linear-gradient(
+    90deg,
+    var(--bg-elevated) 25%,
+    var(--bg-sunk) 37%,
+    var(--bg-elevated) 63%
+  );
+  background-size: 400% 100%;
+  animation: fleet-shimmer 1.3s ease infinite;
+  border-radius: 6px;
+  height: 12px;
+}
+@keyframes fleet-shimmer {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .skel {
+    animation: none;
+  }
+}
+.skrow {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 0.8fr 0.8fr;
+  gap: 14px;
+  padding: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.skrow:last-child {
+  border-bottom: 0;
+}
+
+.notice .ic {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+}
+.notice.err .ic {
+  background: var(--state-crit-bg);
+  color: var(--state-crit);
+}
+.notice.empty .ic {
+  background: var(--bg-elevated);
+  color: var(--text-faint);
+}
+.notice .btn {
+  margin-top: 6px;
+  appearance: none;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font: inherit;
+  font-size: var(--text-base);
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+.notice.err .detail {
+  font-size: var(--text-sm);
+  color: var(--text-faint);
+}
+
+/* Phone layout: fold each row into the mockup's two-column card. Columns
+ * beyond the default six stay table-only (opt-in DNA reads best at width). */
+@media (max-width: 719px) {
+  .tbl thead {
+    display: none;
+  }
+  table.tbl,
+  .tbl tbody,
+  .tbl tr,
+  .tbl td {
+    display: block;
+    width: 100%;
+  }
+  .tbl tbody tr {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    display: grid;
+    grid-template-columns: 1fr 148px;
+    gap: 3px 10px;
+  }
+  .tbl td {
+    padding: 0;
+    border: 0;
+    white-space: normal;
+  }
+  /* Right column left-aligns to one gutter so status/time/IP scan cleanly. */
+  .tbl td.c-name {
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .tbl td.c-health {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: start;
+  }
+  .tbl td.c-company {
+    grid-column: 1;
+    grid-row: 2;
+  }
+  .tbl td.c-seen {
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: start;
+  }
+  .tbl td.c-user {
+    grid-column: 1;
+    grid-row: 3;
+  }
+  .tbl td.c-ip {
+    grid-column: 2;
+    grid-row: 3;
+    justify-self: start;
+  }
+  .tbl td.c-os,
+  .tbl td.c-agent,
+  .tbl td.c-serial,
+  .tbl td.c-model,
+  .tbl td.c-mac,
+  .tbl td.c-ring,
+  .tbl td.c-spacer {
+    display: none;
+  }
+}
+@media (min-width: 720px) {
+  /* Trailing spacer eats all slack so data columns hug their content. */
+  .tbl th.c-spacer,
+  .tbl td.c-spacer {
+    width: 100%;
+    padding: 0;
+    cursor: default;
+  }
+}

--- a/web/src/fleet/FleetOverview.test.tsx
+++ b/web/src/fleet/FleetOverview.test.tsx
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Fleet overview suite (Story #2497): pagination param generation + total
+ * rendering, live-filter narrowing, sort ordering, column add/remove +
+ * persistence, health mapping (incl. staleness), the loading/error/empty
+ * states, tenant-scope narrowing, and the hostile-DNA text-node guarantee
+ * (security A9.1).
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import {
+  TenantScopeProvider,
+  useTenantScope,
+} from '../shell/TenantScopeContext.tsx'
+import FleetOverview from './FleetOverview.tsx'
+import { STALE_AFTER_MS } from './health.ts'
+import type { Steward } from './columns.ts'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+interface StewardSpec {
+  id: string
+  hostname?: string
+  status?: string
+  lastSeenMsAgo?: number | null
+  attributes?: Record<string, string>
+  version?: string
+}
+
+function makeSteward(spec: StewardSpec): Steward {
+  const lastSeen =
+    spec.lastSeenMsAgo === null
+      ? '0001-01-01T00:00:00Z'
+      : new Date(Date.now() - (spec.lastSeenMsAgo ?? 10_000)).toISOString()
+  return {
+    id: spec.id,
+    status: spec.status ?? 'active',
+    last_seen: lastSeen,
+    version: spec.version ?? 'v0.42',
+    dna: {
+      hostname: spec.hostname ?? spec.id,
+      os: 'linux',
+      architecture: 'amd64',
+      attributes: spec.attributes ?? {},
+    },
+  }
+}
+
+/** Serve a fleet: each request slices [offset, offset+limit) of `stewards`. */
+function mockFleet(stewards: Steward[]) {
+  fetchMock.mockImplementation((input) => {
+    const url = new URL(String(input), 'https://controller.test')
+    const limit = Number(url.searchParams.get('limit'))
+    const offset = Number(url.searchParams.get('offset'))
+    const body = {
+      data: {
+        stewards: stewards.slice(offset, offset + limit),
+        total: stewards.length,
+        limit,
+        offset,
+      },
+      timestamp: new Date().toISOString(),
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+}
+
+function renderFleet(search = '') {
+  return render(
+    <TenantScopeProvider rootPath="root">
+      <FleetOverview search={search} />
+    </TenantScopeProvider>,
+  )
+}
+
+function dataRows(): HTMLElement[] {
+  return within(screen.getByRole('table')).getAllByRole('row').slice(1)
+}
+
+function firstCellText(row: HTMLElement): string | null {
+  return within(row).getAllByRole('cell')[0]?.textContent ?? null
+}
+
+describe('pagination', () => {
+  const fleet = Array.from({ length: 120 }, (_, i) =>
+    makeSteward({ id: `s${String(i + 1).padStart(3, '0')}` }),
+  )
+
+  it('requests limit/offset pages and renders the server total, never the full fleet', async () => {
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+
+    const firstUrl = String(fetchMock.mock.calls[0]?.[0])
+    expect(firstUrl).toContain('/api/v1/stewards?')
+    expect(firstUrl).toContain('limit=50')
+    expect(firstUrl).toContain('offset=0')
+
+    expect(screen.getByTestId('fleet-count').textContent).toBe('120 stewards')
+    expect(screen.getByTestId('fleet-pager').textContent).toContain(
+      'Showing 1–50 of 120 stewards',
+    )
+    // Only the page is rendered, not the fleet.
+    expect(dataRows()).toHaveLength(50)
+  })
+
+  it('next page requests the next server window', async () => {
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }))
+    await waitFor(() =>
+      expect(screen.getByTestId('fleet-pager').textContent).toContain(
+        'Showing 51–100 of 120 stewards',
+      ),
+    )
+    const lastUrl = String(fetchMock.mock.calls.at(-1)?.[0])
+    expect(lastUrl).toContain('limit=50')
+    expect(lastUrl).toContain('offset=50')
+  })
+
+  it('page-size change refetches from offset 0 with the new limit', async () => {
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+
+    fireEvent.change(screen.getByLabelText('Stewards per page'), {
+      target: { value: '25' },
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('fleet-pager').textContent).toContain(
+        'Showing 1–25 of 120 stewards',
+      ),
+    )
+    const lastUrl = String(fetchMock.mock.calls.at(-1)?.[0])
+    expect(lastUrl).toContain('limit=25')
+    expect(lastUrl).toContain('offset=0')
+  })
+})
+
+describe('live filter', () => {
+  const fleet = [
+    makeSteward({ id: 's1', hostname: 'web-ingest-04', attributes: { current_user: 'svc_deploy' } }),
+    makeSteward({ id: 's2', hostname: 'dc-01', attributes: { current_user: 'administrator' } }),
+    makeSteward({ id: 's3', hostname: 'kiosk-lobby', attributes: { current_user: 'kiosk' } }),
+  ]
+
+  it('narrows displayed rows as the search value changes and reports match count', async () => {
+    mockFleet(fleet)
+    const { rerender } = renderFleet()
+    await screen.findByRole('table')
+    expect(dataRows()).toHaveLength(3)
+
+    rerender(
+      <TenantScopeProvider rootPath="root">
+        <FleetOverview search="web-ingest" />
+      </TenantScopeProvider>,
+    )
+    expect(dataRows()).toHaveLength(1)
+    expect(screen.getByText('web-ingest-04')).toBeInTheDocument()
+    expect(screen.getByTestId('fleet-count').textContent).toBe('1 of 3 match')
+  })
+
+  it('matches values from hidden columns too (mockup behavior)', async () => {
+    mockFleet(fleet)
+    const { rerender } = renderFleet()
+    await screen.findByRole('table')
+    // Agent version is not a default column but is part of the haystack.
+    rerender(
+      <TenantScopeProvider rootPath="root">
+        <FleetOverview search="v0.42" />
+      </TenantScopeProvider>,
+    )
+    expect(dataRows()).toHaveLength(3)
+  })
+
+  it('shows the filter no-match empty state, distinct from no-stewards', async () => {
+    mockFleet(fleet)
+    renderFleet('no-such-host')
+    await screen.findByText('No stewards match your filter')
+    expect(screen.queryByText('No stewards enrolled yet')).not.toBeInTheDocument()
+  })
+})
+
+describe('sort', () => {
+  const fleet = [
+    makeSteward({ id: 's1', hostname: 'charlie' }),
+    makeSteward({ id: 's2', hostname: 'alpha' }),
+    makeSteward({ id: 's3', hostname: 'bravo' }),
+  ]
+
+  it('orders displayed rows by the clicked header and flips on re-click', async () => {
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+
+    const nameHeader = screen.getByRole('columnheader', { name: /name/i })
+    fireEvent.click(nameHeader)
+    let names = dataRows().map(firstCellText)
+    expect(names).toEqual(['alpha', 'bravo', 'charlie'])
+    expect(nameHeader).toHaveAttribute('aria-sort', 'ascending')
+
+    fireEvent.click(nameHeader)
+    names = dataRows().map(firstCellText)
+    expect(names).toEqual(['charlie', 'bravo', 'alpha'])
+    expect(nameHeader).toHaveAttribute('aria-sort', 'descending')
+  })
+
+  it('sorts Last check-in chronologically, not lexically', async () => {
+    mockFleet([
+      makeSteward({ id: 's1', hostname: 'old', lastSeenMsAgo: 2 * 3_600_000 }),
+      makeSteward({ id: 's2', hostname: 'newest', lastSeenMsAgo: 5_000 }),
+      makeSteward({ id: 's3', hostname: 'never', lastSeenMsAgo: null, status: 'registered' }),
+    ])
+    renderFleet()
+    await screen.findByRole('table')
+    fireEvent.click(screen.getByRole('columnheader', { name: /last check-in/i }))
+    const names = dataRows().map(firstCellText)
+    // Ascending: never-seen first, then oldest, then newest.
+    expect(names).toEqual(['never', 'old', 'newest'])
+  })
+})
+
+describe('columns', () => {
+  const fleet = [
+    makeSteward({
+      id: 's1',
+      hostname: 'host-a',
+      attributes: {
+        deployment_ring: 'canary',
+        system_serial_number: 'SER-77',
+        primary_mac: 'aa:bb:cc:dd:ee:ff',
+      },
+    }),
+  ]
+
+  it('shows the default column set with opt-ins hidden', async () => {
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+    for (const label of ['Name', 'Company', 'Last user', 'IP', 'Health', 'Last check-in']) {
+      expect(screen.getByRole('columnheader', { name: label })).toBeInTheDocument()
+    }
+    expect(screen.queryByRole('columnheader', { name: /ring/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: /serial/i })).not.toBeInTheDocument()
+  })
+
+  it('adds and removes columns via the picker; Name is locked on', async () => {
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Ring' }))
+    expect(screen.getByRole('columnheader', { name: /ring/i })).toBeInTheDocument()
+    expect(screen.getByText('canary')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Company' }))
+    expect(screen.queryByRole('columnheader', { name: /company/i })).not.toBeInTheDocument()
+
+    expect(screen.getByRole('checkbox', { name: 'Name' })).toBeDisabled()
+  })
+
+  it('persists the selection across a reload under the allowlisted key', async () => {
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Ring' }))
+
+    const stored = localStorage.getItem('cfgms.fleet.columns')
+    expect(stored).not.toBeNull()
+    expect(JSON.parse(stored as string)).toContain('ring')
+
+    cleanup()
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+    expect(screen.getByRole('columnheader', { name: /ring/i })).toBeInTheDocument()
+  })
+
+  it('ignores a corrupted stored selection (untrusted input) and falls back to defaults', async () => {
+    localStorage.setItem('cfgms.fleet.columns', '{"not":"an-array"')
+    mockFleet(fleet)
+    renderFleet()
+    await screen.findByRole('table')
+    expect(screen.getByRole('columnheader', { name: /company/i })).toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: /ring/i })).not.toBeInTheDocument()
+  })
+
+  it('renders an em-dash placeholder for missing DNA attributes', async () => {
+    mockFleet([makeSteward({ id: 's-bare', attributes: {} })])
+    renderFleet()
+    await screen.findByRole('table')
+    const [row] = dataRows()
+    if (row === undefined) throw new Error('expected a data row')
+    // Company, Last user, and IP are unset on this steward.
+    expect(within(row).getAllByText('—').length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('health column', () => {
+  it('maps Status + LastSeen staleness onto semantic pills', async () => {
+    mockFleet([
+      makeSteward({ id: 's1', hostname: 'fresh', status: 'active', lastSeenMsAgo: 10_000 }),
+      makeSteward({ id: 's2', hostname: 'stale', status: 'active', lastSeenMsAgo: STALE_AFTER_MS + 60_000 }),
+      makeSteward({ id: 's3', hostname: 'degraded', status: 'degraded' }),
+      makeSteward({ id: 's4', hostname: 'enrolled', status: 'registered', lastSeenMsAgo: null }),
+    ])
+    renderFleet()
+    await screen.findByRole('table')
+
+    expect(screen.getByText('Healthy')).toBeInTheDocument()
+    expect(screen.getByText('Unreachable')).toBeInTheDocument()
+    expect(screen.getByText('Degraded')).toBeInTheDocument()
+    expect(screen.getByText('Registered')).toBeInTheDocument()
+
+    expect(screen.getByText('Healthy').className).toContain('ok')
+    expect(screen.getByText('Unreachable').className).toContain('crit')
+    expect(screen.getByText('Degraded').className).toContain('warn')
+    expect(screen.getByText('Registered').className).toContain('neutral')
+  })
+})
+
+describe('data states', () => {
+  it('shows skeleton rows while the page is loading', () => {
+    fetchMock.mockImplementation(() => new Promise<Response>(() => {}))
+    renderFleet()
+    expect(screen.getByTestId('fleet-loading')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a failed request as the error state with a retry affordance', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 503, headers: { 'Content-Type': 'application/json' } }),
+    )
+    renderFleet()
+    await screen.findByRole('alert')
+    expect(screen.getByText(/couldn't reach the controller/i)).toBeInTheDocument()
+    expect(screen.getByText('GET /api/v1/stewards — 503')).toBeInTheDocument()
+
+    mockFleet([makeSteward({ id: 's1', hostname: 'back-online' })])
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    await screen.findByRole('table')
+    expect(screen.getByText('back-online')).toBeInTheDocument()
+  })
+
+  it('treats an unexpected response shape as an error, never renders garbage', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { wrong: true } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    renderFleet()
+    await screen.findByRole('alert')
+    expect(screen.getByText('unexpected response shape')).toBeInTheDocument()
+  })
+
+  it('shows the enrolled-empty state for a zero-steward fleet', async () => {
+    mockFleet([])
+    renderFleet()
+    await screen.findByText('No stewards enrolled yet')
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+})
+
+describe('tenant scope', () => {
+  function ScopeHarness() {
+    const { setScope, observedPaths } = useTenantScope()
+    return (
+      <div>
+        <button type="button" onClick={() => setScope('root/msp-a')}>
+          narrow-scope
+        </button>
+        <span data-testid="observed">{observedPaths.join(',')}</span>
+        <FleetOverview search="" />
+      </div>
+    )
+  }
+
+  const fleet = [
+    makeSteward({ id: 's1', hostname: 'in-scope', attributes: { tenant: 'root/msp-a' } }),
+    makeSteward({ id: 's2', hostname: 'descendant', attributes: { tenant: 'root/msp-a/client-1' } }),
+    makeSteward({ id: 's3', hostname: 'other-tenant', attributes: { tenant: 'root/msp-b' } }),
+    makeSteward({ id: 's4', hostname: 'no-tenant-data' }),
+  ]
+
+  it('registers observed tenant paths and narrows displayed rows to the scope', async () => {
+    mockFleet(fleet)
+    render(
+      <TenantScopeProvider rootPath="root">
+        <ScopeHarness />
+      </TenantScopeProvider>,
+    )
+    await screen.findByRole('table')
+
+    // Paths observed in the page data are offered to the switcher.
+    expect(screen.getByTestId('observed').textContent).toContain('root/msp-a')
+    expect(screen.getByTestId('observed').textContent).toContain('root/msp-b')
+
+    fireEvent.click(screen.getByRole('button', { name: 'narrow-scope' }))
+    const names = dataRows().map(firstCellText)
+    expect(names).toEqual(['in-scope', 'descendant'])
+    expect(screen.getByTestId('fleet-count').textContent).toBe('2 of 4 match')
+  })
+
+  it('shows the scope no-match state when the scope holds no rows on this page', async () => {
+    mockFleet([makeSteward({ id: 's3', hostname: 'other-tenant', attributes: { tenant: 'root/msp-b' } })])
+    function NarrowToEmpty() {
+      const { setScope } = useTenantScope()
+      return (
+        <div>
+          <button type="button" onClick={() => setScope('root/msp-a')}>
+            narrow-scope
+          </button>
+          <FleetOverview search="" />
+        </div>
+      )
+    }
+    render(
+      <TenantScopeProvider rootPath="root">
+        <NarrowToEmpty />
+      </TenantScopeProvider>,
+    )
+    await screen.findByRole('table')
+    fireEvent.click(screen.getByRole('button', { name: 'narrow-scope' }))
+    expect(screen.getByText('No stewards in this scope')).toBeInTheDocument()
+    expect(screen.queryByText(/match your filter/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('hostile steward values (security A9.1)', () => {
+  it('renders a hostile hostname as inert text, never as markup', async () => {
+    const hostile = '<img src=x onerror="document.title=\'pwned\'">'
+    mockFleet([
+      makeSteward({
+        id: 's-evil',
+        hostname: hostile,
+        attributes: {
+          current_user: '<script>document.title="pwned"</script>',
+          primary_ip: '"><svg onload=alert(1)>',
+        },
+      }),
+    ])
+    renderFleet()
+    await screen.findByRole('table')
+
+    // The literal strings are visible as text…
+    expect(screen.getByText(hostile)).toBeInTheDocument()
+    // …and no element was ever created from them.
+    expect(document.querySelector('img')).toBeNull()
+    expect(document.querySelector('script')).toBeNull()
+    expect(document.title).not.toBe('pwned')
+  })
+})

--- a/web/src/fleet/FleetOverview.tsx
+++ b/web/src/fleet/FleetOverview.tsx
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Fleet overview (Story #2497) — the first real occupant of the app shell's
+ * content area. Renders one server page of stewards (pagination + total are
+ * the server's, per the #2489 contract) with client-side live filter, column
+ * sort, and a selectable device-DNA column set — fixed epic semantics: the
+ * filter and sort operate on the displayed page's rows, not the whole fleet.
+ *
+ * The live-filter input is the shell's global search box (#2496 chrome);
+ * its value arrives via the `search` prop. Tenant scope (#2496 context) is
+ * a display convenience narrowing displayed rows — server-side tenant
+ * scoping on the API is the only enforcement (security A8.1).
+ *
+ * Saved views and the row drill-in asset-DNA drawer land in Story #2498.
+ */
+import { useMemo, useState } from 'react'
+import { isScopeMatch, useTenantScope } from '../shell/TenantScopeContext.tsx'
+import {
+  COLUMNS,
+  DEFAULT_VISIBLE,
+  loadColumnPrefs,
+  saveColumnPrefs,
+  type ColumnKey,
+  type Steward,
+} from './columns.ts'
+import { deriveHealth, formatLastSeen, parseLastSeen } from './health.ts'
+import ColumnPicker from './ColumnPicker.tsx'
+import FleetTable, { type SortState } from './FleetTable.tsx'
+import { ErrorNotice, FleetEmpty, LoadingRows, NoMatch } from './FleetStates.tsx'
+import { useStewards } from './useStewards.ts'
+import './FleetOverview.css'
+
+const PAGE_SIZES = [25, 50, 100, 250] as const
+const DEFAULT_PAGE_SIZE = 50
+
+const formatCount = new Intl.NumberFormat('en-US')
+
+/** Page-number strip: current ±1, first, last, with ellipsis gaps. */
+export function buildPageList(current: number, pages: number): (number | '…')[] {
+  const wanted = new Set<number>([1, current - 1, current, current + 1, pages])
+  const ordered = [...wanted]
+    .filter((n) => n >= 1 && n <= pages)
+    .sort((a, b) => a - b)
+  const result: (number | '…')[] = []
+  let previous = 0
+  for (const n of ordered) {
+    if (previous !== 0 && n - previous > 1) result.push('…')
+    result.push(n)
+    previous = n
+  }
+  return result
+}
+
+function sortValue(key: ColumnKey, steward: Steward, nowMs: number): string | number {
+  if (key === 'seen') return parseLastSeen(steward.last_seen) ?? Number.NEGATIVE_INFINITY
+  if (key === 'health') return deriveHealth(steward.status, steward.last_seen, nowMs).label
+  const column = COLUMNS.find((c) => c.key === key)
+  return column ? column.value(steward).toLowerCase() : ''
+}
+
+/* Filter haystack spans every mapped DNA value plus the derived health and
+ * check-in text, whether or not the column is currently shown (mockup
+ * behavior: hiding a column doesn't stop it matching). */
+function matchesFilter(steward: Steward, needle: string, nowMs: number): boolean {
+  const haystack = [
+    ...COLUMNS.map((column) => column.value(steward)),
+    deriveHealth(steward.status, steward.last_seen, nowMs).label,
+    formatLastSeen(steward.last_seen, nowMs),
+  ]
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(needle)
+}
+
+export default function FleetOverview({ search }: { search: string }) {
+  const { scope, rootPath } = useTenantScope()
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE)
+  const [pageIndex, setPageIndex] = useState(0)
+  const [sort, setSort] = useState<SortState | null>(null)
+  const [visible, setVisible] = useState<ReadonlySet<ColumnKey>>(
+    () => new Set(loadColumnPrefs() ?? DEFAULT_VISIBLE),
+  )
+
+  const { page, loading, error, fetchedAtMs, retry } = useStewards(
+    pageSize,
+    pageIndex * pageSize,
+  )
+
+  // Relative times and staleness anchor at fetch time — the moment the data
+  // was true — so the render itself stays pure.
+  const nowMs = fetchedAtMs
+  const needle = search.trim().toLowerCase()
+  const scoped = scope !== rootPath
+
+  const displayRows = useMemo(() => {
+    if (page === null) return []
+    let rows = page.stewards
+    if (scoped) {
+      rows = rows.filter((steward) => {
+        const tenantPath = steward.dna?.attributes?.['tenant']
+        return tenantPath !== undefined && isScopeMatch(tenantPath, scope)
+      })
+    }
+    if (needle !== '') {
+      rows = rows.filter((steward) => matchesFilter(steward, needle, nowMs))
+    }
+    if (sort !== null) {
+      const key = sort.key as ColumnKey
+      rows = [...rows].sort((a, b) => {
+        const av = sortValue(key, a, nowMs)
+        const bv = sortValue(key, b, nowMs)
+        if (typeof av === 'number' && typeof bv === 'number') {
+          return (av - bv) * sort.direction
+        }
+        return String(av).localeCompare(String(bv)) * sort.direction
+      })
+    }
+    return rows
+  }, [page, scoped, scope, needle, sort, nowMs])
+
+  function onSort(key: string) {
+    setSort((was) =>
+      was?.key === key
+        ? { key, direction: was.direction === 1 ? -1 : 1 }
+        : { key, direction: 1 },
+    )
+  }
+
+  function onToggleColumn(key: ColumnKey) {
+    setVisible((was) => {
+      const next = new Set(was)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      next.add('name')
+      saveColumnPrefs([...next])
+      return next
+    })
+  }
+
+  function onPageSize(next: number) {
+    setPageSize(next)
+    setPageIndex(0)
+  }
+
+  const columns = COLUMNS.filter((column) => visible.has(column.key))
+  const total = page?.total ?? 0
+  const pages = Math.max(1, Math.ceil(total / pageSize))
+  const current = pageIndex + 1
+  const narrowed = needle !== '' || scoped
+  const pageRowCount = page?.stewards.length ?? 0
+  const from = total === 0 ? 0 : pageIndex * pageSize + 1
+  const to = pageIndex * pageSize + pageRowCount
+
+  const countText = narrowed
+    ? `${formatCount.format(displayRows.length)} of ${formatCount.format(total)} match`
+    : `${formatCount.format(total)} stewards`
+
+  return (
+    <>
+      <div className="htitle">
+        <h1>Fleet</h1>
+        <p>Stewards enrolled to this controller, with the device DNA you choose.</p>
+      </div>
+      <section className="panel">
+        <div className="ptool">
+          <ColumnPicker visible={visible} onToggle={onToggleColumn} />
+          <span className="cnt" data-testid="fleet-count">
+            {page === null ? '' : countText}
+          </span>
+        </div>
+
+        {loading ? (
+          <LoadingRows />
+        ) : error !== null ? (
+          <ErrorNotice detail={error} onRetry={retry} />
+        ) : page === null || total === 0 ? (
+          <FleetEmpty />
+        ) : displayRows.length === 0 ? (
+          <NoMatch scopeOnly={needle === ''} />
+        ) : (
+          <FleetTable
+            stewards={displayRows}
+            columns={columns}
+            sort={sort}
+            onSort={onSort}
+            nowMs={nowMs}
+          />
+        )}
+
+        {page !== null && error === null && total > 0 && (
+          <div className="pager" data-testid="fleet-pager">
+            <span>
+              Showing <b>{formatCount.format(from)}</b>–<b>{formatCount.format(to)}</b> of{' '}
+              <b>{formatCount.format(total)}</b> stewards
+            </span>
+            <label className="sz">
+              <select
+                aria-label="Stewards per page"
+                value={pageSize}
+                onChange={(event) => onPageSize(Number(event.target.value))}
+              >
+                {PAGE_SIZES.map((size) => (
+                  <option key={size} value={size}>
+                    {size} / page
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="pg">
+              <button
+                type="button"
+                aria-label="Previous page"
+                disabled={current <= 1}
+                onClick={() => setPageIndex((i) => Math.max(0, i - 1))}
+              >
+                ‹
+              </button>
+              {buildPageList(current, pages).map((entry, index) =>
+                entry === '…' ? (
+                  <button type="button" key={`gap-${index}`} disabled>
+                    …
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    key={entry}
+                    className={entry === current ? 'on' : ''}
+                    aria-current={entry === current ? 'page' : undefined}
+                    onClick={() => setPageIndex(entry - 1)}
+                  >
+                    {formatCount.format(entry)}
+                  </button>
+                ),
+              )}
+              <button
+                type="button"
+                aria-label="Next page"
+                disabled={current >= pages}
+                onClick={() => setPageIndex((i) => Math.min(pages - 1, i + 1))}
+              >
+                ›
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+    </>
+  )
+}

--- a/web/src/fleet/FleetStates.tsx
+++ b/web/src/fleet/FleetStates.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Fleet view data states (Story #2497) — mockup preview states: skeleton
+ * rows while loading, an error notice with a retry affordance, and two
+ * distinguishable empty states ("no stewards enrolled" vs "nothing matched
+ * the filter/scope").
+ */
+
+export function LoadingRows() {
+  return (
+    <div data-testid="fleet-loading" aria-label="Loading stewards">
+      {Array.from({ length: 6 }, (_, i) => (
+        <div className="skrow" key={i}>
+          <span className="skel" style={{ width: '75%' }} />
+          <span className="skel" style={{ width: '60%' }} />
+          <span className="skel" style={{ width: '70%' }} />
+          <span className="skel" style={{ width: '50%' }} />
+          <span className="skel" style={{ width: '55%' }} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ErrorNotice({
+  detail,
+  onRetry,
+}: {
+  detail: string
+  onRetry: () => void
+}) {
+  return (
+    <div className="notice err" role="alert">
+      <div className="ic">!</div>
+      <h3>Couldn&apos;t reach the controller</h3>
+      <p>The fleet list request failed. Check your connection and try again.</p>
+      <span className="mono detail">{detail}</span>
+      <button type="button" className="btn" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  )
+}
+
+/** The fleet itself is empty — no steward has ever enrolled. */
+export function FleetEmpty() {
+  return (
+    <div className="notice empty">
+      <div className="ic">◍</div>
+      <h3>No stewards enrolled yet</h3>
+      <p>
+        Once you install a steward and it registers with this controller,
+        it&apos;ll appear here with live health.
+      </p>
+    </div>
+  )
+}
+
+/** Stewards exist, but the live filter or tenant scope matched none. */
+export function NoMatch({ scopeOnly }: { scopeOnly: boolean }) {
+  return (
+    <div className="notice empty">
+      <div className="ic">◍</div>
+      {scopeOnly ? (
+        <>
+          <h3>No stewards in this scope</h3>
+          <p>The selected tenant scope contains no stewards on this page.</p>
+        </>
+      ) : (
+        <>
+          <h3>No stewards match your filter</h3>
+          <p>Nothing on this page matches the current search. Clear the filter to see all rows.</p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/fleet/FleetTable.tsx
+++ b/web/src/fleet/FleetTable.tsx
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Fleet table (Story #2497) — mockup `table.tbl`. Sortable headers, mono
+ * machine data, semantic Health pill, em-dash for missing DNA attributes.
+ *
+ * Security A9.1: every steward-supplied value lands in the DOM through JSX
+ * text interpolation — text nodes only, never markup. Do not introduce
+ * dangerouslySetInnerHTML here.
+ *
+ * Row drill-in (asset-DNA drawer) is Story #2498; it will attach through an
+ * onRowSelect seam on this component.
+ */
+import { deriveHealth, formatLastSeen } from './health.ts'
+import type { ColumnDef, Steward } from './columns.ts'
+
+export interface SortState {
+  key: string
+  direction: 1 | -1
+}
+
+const CELL_CLASS: Record<string, string> = {
+  name: 'nm',
+  muted: 'mut',
+  mono: 'mono2',
+}
+
+function Cell({
+  column,
+  steward,
+  nowMs,
+}: {
+  column: ColumnDef
+  steward: Steward
+  nowMs: number
+}) {
+  if (column.kind === 'health') {
+    const health = deriveHealth(steward.status, steward.last_seen, nowMs)
+    return (
+      <td className={`c-${column.key}`}>
+        <span className={`pill ${health.tone}`}>
+          <span className="dot" />
+          {health.label}
+        </span>
+      </td>
+    )
+  }
+  if (column.kind === 'seen') {
+    return (
+      <td className={`c-${column.key}`}>
+        <span className="seen">{formatLastSeen(steward.last_seen, nowMs)}</span>
+      </td>
+    )
+  }
+  const value = column.value(steward)
+  return (
+    <td className={`c-${column.key}`}>
+      <span className={CELL_CLASS[column.kind]}>{value || '—'}</span>
+    </td>
+  )
+}
+
+export default function FleetTable({
+  stewards,
+  columns,
+  sort,
+  onSort,
+  nowMs,
+}: {
+  stewards: Steward[]
+  columns: ColumnDef[]
+  sort: SortState | null
+  onSort: (key: string) => void
+  nowMs: number
+}) {
+  return (
+    <table className="tbl">
+      <thead>
+        <tr>
+          {columns.map((column) => {
+            const active = sort?.key === column.key
+            return (
+              <th
+                key={column.key}
+                className={`c-${column.key}${active ? ' sort' : ''}`}
+                aria-sort={
+                  active
+                    ? sort.direction > 0
+                      ? 'ascending'
+                      : 'descending'
+                    : undefined
+                }
+                onClick={() => onSort(column.key)}
+              >
+                {column.label}
+                <span className="ar" aria-hidden="true">
+                  {active && sort.direction < 0 ? '▲' : '▼'}
+                </span>
+              </th>
+            )
+          })}
+          <th className="c-spacer" aria-hidden="true" />
+        </tr>
+      </thead>
+      <tbody>
+        {stewards.map((steward) => (
+          <tr key={steward.id}>
+            {columns.map((column) => (
+              <Cell
+                key={column.key}
+                column={column}
+                steward={steward}
+                nowMs={nowMs}
+              />
+            ))}
+            <td className="c-spacer" />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/web/src/fleet/columns.ts
+++ b/web/src/fleet/columns.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Device-DNA column registry for the fleet view (Story #2497).
+ *
+ * Column → attribute mapping is pinned here and documented in web/README.md.
+ * Steward-supplied values are UNTRUSTED (threat model: stewards run on hosts
+ * that may be compromised) — every value crosses into the DOM as a text node
+ * only; nothing in this module or its consumers renders steward data as
+ * markup (security A9.1).
+ *
+ * Column selection persists in localStorage under the literal key
+ * 'cfgms.fleet.columns' — a UI display preference, not auth data; the key is
+ * registered in the storage allowlist (Login.test.tsx STORAGE_ALLOWLIST) and
+ * written inline at each call site per that scan's literal-key rule. Values
+ * read back are untrusted input and are shape-validated before use.
+ */
+
+export interface StewardDNA {
+  hostname?: string
+  os?: string
+  architecture?: string
+  attributes?: Record<string, string>
+}
+
+/* GET /api/v1/stewards page-item payload (features/controller/api/types.go). */
+export interface Steward {
+  id: string
+  status?: string
+  last_seen?: string
+  version?: string
+  dna?: StewardDNA | null
+}
+
+export interface StewardPage {
+  stewards: Steward[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export type ColumnKey =
+  | 'name'
+  | 'company'
+  | 'user'
+  | 'ip'
+  | 'os'
+  | 'agent'
+  | 'serial'
+  | 'model'
+  | 'mac'
+  | 'ring'
+  | 'health'
+  | 'seen'
+
+/* Cell typography per the design system: mono carries machine data. */
+export type CellKind = 'name' | 'muted' | 'mono' | 'health' | 'seen'
+
+export interface ColumnDef {
+  key: ColumnKey
+  /** Table header text. */
+  label: string
+  /** Column-picker checkbox text (mockup wording). */
+  pickerLabel: string
+  defaultVisible: boolean
+  /** Name anchors every row and cannot be hidden. */
+  locked?: boolean
+  kind: CellKind
+  /** Raw display/filter value; '' renders as an em-dash placeholder. */
+  value: (s: Steward) => string
+}
+
+function attr(s: Steward, key: string): string {
+  const attributes = s.dna?.attributes
+  if (attributes === undefined) return ''
+  // Entry scan instead of computed member access: attribute maps are
+  // steward-supplied (untrusted), so no dynamic-key indexing into them.
+  return Object.entries(attributes).find(([k]) => k === key)?.[1] ?? ''
+}
+
+/*
+ * Header order matches the mockup table. `health` and `seen` derive from
+ * status/last_seen via health.ts; their value() here is the filter haystack
+ * contribution only.
+ */
+export const COLUMNS: readonly ColumnDef[] = [
+  {
+    key: 'name',
+    label: 'Name',
+    pickerLabel: 'Name',
+    defaultVisible: true,
+    locked: true,
+    kind: 'name',
+    value: (s) => s.dna?.hostname || s.id,
+  },
+  {
+    key: 'company',
+    label: 'Company',
+    pickerLabel: 'Company',
+    defaultVisible: true,
+    kind: 'muted',
+    // Tenant path attribute; the controller does not emit it yet, so this
+    // renders the em-dash placeholder until it does (see web/README.md).
+    value: (s) => attr(s, 'tenant'),
+  },
+  {
+    key: 'user',
+    label: 'Last user',
+    pickerLabel: 'Last logged-in user',
+    defaultVisible: true,
+    kind: 'mono',
+    value: (s) => attr(s, 'current_user'),
+  },
+  {
+    key: 'ip',
+    label: 'IP',
+    pickerLabel: 'IP address',
+    defaultVisible: true,
+    kind: 'mono',
+    value: (s) => attr(s, 'primary_ip'),
+  },
+  {
+    key: 'os',
+    label: 'OS',
+    pickerLabel: 'OS / platform',
+    defaultVisible: false,
+    kind: 'muted',
+    value: (s) => s.dna?.os || attr(s, 'os_pretty_name'),
+  },
+  {
+    key: 'agent',
+    label: 'Agent',
+    pickerLabel: 'Agent version',
+    defaultVisible: false,
+    kind: 'mono',
+    value: (s) => s.version || attr(s, 'steward.version'),
+  },
+  {
+    key: 'serial',
+    label: 'Serial',
+    pickerLabel: 'Serial',
+    defaultVisible: false,
+    kind: 'mono',
+    value: (s) => attr(s, 'system_serial_number') || attr(s, 'motherboard_serial'),
+  },
+  {
+    key: 'model',
+    label: 'Model',
+    pickerLabel: 'Model',
+    defaultVisible: false,
+    kind: 'muted',
+    value: (s) => attr(s, 'system_model') || attr(s, 'hardware_model'),
+  },
+  {
+    key: 'mac',
+    label: 'MAC',
+    pickerLabel: 'MAC address',
+    defaultVisible: false,
+    kind: 'mono',
+    value: (s) => attr(s, 'primary_mac'),
+  },
+  {
+    key: 'ring',
+    label: 'Ring',
+    pickerLabel: 'Ring',
+    defaultVisible: false,
+    kind: 'mono',
+    value: (s) => attr(s, 'deployment_ring'),
+  },
+  {
+    key: 'health',
+    label: 'Health',
+    pickerLabel: 'Health',
+    defaultVisible: true,
+    kind: 'health',
+    value: (s) => s.status ?? '',
+  },
+  {
+    key: 'seen',
+    label: 'Last check-in',
+    pickerLabel: 'Last check-in',
+    defaultVisible: true,
+    kind: 'seen',
+    value: (s) => s.last_seen ?? '',
+  },
+] as const
+
+export const DEFAULT_VISIBLE: readonly ColumnKey[] = COLUMNS.filter(
+  (c) => c.defaultVisible,
+).map((c) => c.key)
+
+const VALID_KEYS = new Set<string>(COLUMNS.map((c) => c.key))
+
+/*
+ * Load the persisted column selection. Returns null (caller falls back to
+ * defaults) when nothing is stored or the stored value fails validation —
+ * localStorage contents are untrusted input, never assumed well-formed.
+ */
+export function loadColumnPrefs(): ColumnKey[] | null {
+  const raw = localStorage.getItem('cfgms.fleet.columns')
+  if (raw === null) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!Array.isArray(parsed)) return null
+  const keys = parsed.filter(
+    (k): k is ColumnKey => typeof k === 'string' && VALID_KEYS.has(k),
+  )
+  if (keys.length === 0) return null
+  return [...new Set<ColumnKey>(['name', ...keys])]
+}
+
+export function saveColumnPrefs(keys: readonly ColumnKey[]): void {
+  localStorage.setItem('cfgms.fleet.columns', JSON.stringify(keys))
+}

--- a/web/src/fleet/health.test.ts
+++ b/web/src/fleet/health.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { describe, expect, it } from 'vitest'
+import {
+  STALE_AFTER_MS,
+  deriveHealth,
+  formatLastSeen,
+  parseLastSeen,
+} from './health.ts'
+
+const NOW = Date.UTC(2026, 6, 15, 12, 0, 0)
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString()
+
+describe('deriveHealth', () => {
+  it('maps a fresh active steward to Healthy/ok', () => {
+    expect(deriveHealth('active', iso(30_000), NOW)).toEqual({
+      label: 'Healthy',
+      tone: 'ok',
+    })
+  })
+
+  it('maps an active steward with a stale heartbeat to Unreachable/crit', () => {
+    expect(deriveHealth('active', iso(STALE_AFTER_MS + 60_000), NOW)).toEqual({
+      label: 'Unreachable',
+      tone: 'crit',
+    })
+  })
+
+  it('treats exactly-at-threshold as still fresh, one ms past as stale', () => {
+    expect(deriveHealth('active', iso(STALE_AFTER_MS), NOW).tone).toBe('ok')
+    expect(deriveHealth('active', iso(STALE_AFTER_MS + 1), NOW).tone).toBe('crit')
+  })
+
+  it('maps an active steward that has never checked in to Unreachable', () => {
+    expect(deriveHealth('active', '0001-01-01T00:00:00Z', NOW).tone).toBe('crit')
+    expect(deriveHealth('active', undefined, NOW).tone).toBe('crit')
+  })
+
+  it('maps lifecycle states independently of staleness', () => {
+    expect(deriveHealth('degraded', iso(0), NOW)).toEqual({
+      label: 'Degraded',
+      tone: 'warn',
+    })
+    expect(deriveHealth('lost', iso(0), NOW).label).toBe('Unreachable')
+    expect(deriveHealth('offline', iso(0), NOW).tone).toBe('crit')
+    expect(deriveHealth('revoked', iso(0), NOW).tone).toBe('crit')
+    expect(deriveHealth('registered', undefined, NOW)).toEqual({
+      label: 'Registered',
+      tone: 'neutral',
+    })
+    expect(deriveHealth('dormant', iso(0), NOW).tone).toBe('neutral')
+    expect(deriveHealth('archived', iso(0), NOW).tone).toBe('neutral')
+  })
+
+  it('is case-insensitive on status', () => {
+    expect(deriveHealth('Active', iso(0), NOW).label).toBe('Healthy')
+    expect(deriveHealth('ONLINE', iso(0), NOW).label).toBe('Healthy')
+  })
+
+  it('renders unknown statuses as neutral with the raw label', () => {
+    expect(deriveHealth('quarantined', iso(0), NOW)).toEqual({
+      label: 'quarantined',
+      tone: 'neutral',
+    })
+    expect(deriveHealth(undefined, iso(0), NOW)).toEqual({
+      label: 'Unknown',
+      tone: 'neutral',
+    })
+  })
+})
+
+describe('parseLastSeen', () => {
+  it('rejects the Go zero time, garbage, and empty values as never-seen', () => {
+    expect(parseLastSeen('0001-01-01T00:00:00Z')).toBeNull()
+    expect(parseLastSeen('not-a-date')).toBeNull()
+    expect(parseLastSeen(undefined)).toBeNull()
+    expect(parseLastSeen('')).toBeNull()
+  })
+
+  it('parses a real timestamp', () => {
+    expect(parseLastSeen(new Date(NOW).toISOString())).toBe(NOW)
+  })
+})
+
+describe('formatLastSeen', () => {
+  it('renders an em-dash for never-seen', () => {
+    expect(formatLastSeen('0001-01-01T00:00:00Z', NOW)).toBe('—')
+    expect(formatLastSeen(undefined, NOW)).toBe('—')
+  })
+
+  it('buckets seconds, minutes, hours, and days', () => {
+    expect(formatLastSeen(iso(12_000), NOW)).toBe('12s ago')
+    expect(formatLastSeen(iso(3 * 60_000), NOW)).toBe('3m ago')
+    expect(formatLastSeen(iso(5 * 3_600_000), NOW)).toBe('5h ago')
+    expect(formatLastSeen(iso(2 * 86_400_000), NOW)).toBe('2d ago')
+  })
+
+  it('clamps clock skew (future last_seen) to 0s ago', () => {
+    expect(formatLastSeen(iso(-30_000), NOW)).toBe('0s ago')
+  })
+})

--- a/web/src/fleet/health.ts
+++ b/web/src/fleet/health.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Health derivation for the fleet view (Story #2497).
+ *
+ * The API payload carries a lifecycle `status` (business.StewardStatus:
+ * registered/active/lost/dormant/archived/revoked — plus online/offline on
+ * the filtered fleet-query path) and a `last_seen` heartbeat timestamp. The
+ * Health column folds both into one signal: an "active" steward whose
+ * heartbeat has gone stale is presented as Unreachable, because a healthy
+ * label next to a 20-minute-old check-in would be a lie.
+ *
+ * Colors carry meaning only (design-system pillar 2): each tone maps to a
+ * semantic state token (--state-ok/-warn/-crit/-neutral), never a decorative
+ * color.
+ */
+
+export type HealthTone = 'ok' | 'warn' | 'crit' | 'neutral'
+
+export interface Health {
+  label: string
+  tone: HealthTone
+}
+
+/*
+ * Heartbeat age beyond which an otherwise-active steward is presented as
+ * Unreachable. The payload pins no heartbeat contract, so this is a display
+ * threshold, not protocol truth; 5 minutes matches the reference mockup's
+ * semantics (a 6-minute-old check-in renders critical).
+ */
+export const STALE_AFTER_MS = 5 * 60_000
+
+/*
+ * Timestamps earlier than this are treated as "never seen". Go's zero
+ * time.Time serializes as 0001-01-01T00:00:00Z (a registered-but-never-
+ * connected steward), which must not render as "seen 700,000 days ago".
+ */
+const MIN_VALID_MS = Date.UTC(2000, 0, 1)
+
+/** Parse a last-seen timestamp; null means never seen (or unparseable). */
+export function parseLastSeen(lastSeen: string | undefined): number | null {
+  if (!lastSeen) return null
+  const ms = Date.parse(lastSeen)
+  if (Number.isNaN(ms) || ms < MIN_VALID_MS) return null
+  return ms
+}
+
+/** Fold lifecycle status + heartbeat staleness into the Health cell value. */
+export function deriveHealth(
+  status: string | undefined,
+  lastSeen: string | undefined,
+  nowMs: number,
+): Health {
+  const normalized = (status ?? '').trim().toLowerCase()
+  switch (normalized) {
+    case 'active':
+    case 'online':
+    case 'connected':
+    case 'healthy': {
+      const seen = parseLastSeen(lastSeen)
+      const fresh = seen !== null && nowMs - seen <= STALE_AFTER_MS
+      return fresh
+        ? { label: 'Healthy', tone: 'ok' }
+        : { label: 'Unreachable', tone: 'crit' }
+    }
+    case 'degraded':
+      return { label: 'Degraded', tone: 'warn' }
+    case 'lost':
+    case 'offline':
+    case 'unhealthy':
+      return { label: 'Unreachable', tone: 'crit' }
+    case 'revoked':
+      return { label: 'Revoked', tone: 'crit' }
+    case 'registered':
+      return { label: 'Registered', tone: 'neutral' }
+    case 'dormant':
+      return { label: 'Dormant', tone: 'neutral' }
+    case 'archived':
+      return { label: 'Archived', tone: 'neutral' }
+    default:
+      // Unknown lifecycle states render as inert text, never a guessed tone.
+      return { label: status?.trim() ? status.trim() : 'Unknown', tone: 'neutral' }
+  }
+}
+
+/** Relative check-in age for the Last check-in column; em-dash when never. */
+export function formatLastSeen(
+  lastSeen: string | undefined,
+  nowMs: number,
+): string {
+  const seen = parseLastSeen(lastSeen)
+  if (seen === null) return '—'
+  const diff = Math.max(0, nowMs - seen)
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
+}

--- a/web/src/fleet/useStewards.ts
+++ b/web/src/fleet/useStewards.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Fleet data hook (Story #2497): one server page of stewards from
+ * GET /api/v1/stewards?limit&offset via the #2495 cookie/CSRF client.
+ *
+ * Scale posture: only the current page is ever held in memory; the fleet
+ * count comes from the server `total` (post-filter, pre-slice — the #2489
+ * contract), so the view works unchanged at 48k+ stewards. A 401 is handled
+ * centrally by apiFetch (session expired → login screen); everything else
+ * surfaces here as the view's error state.
+ *
+ * Tenant scope (#2496): observed tenant paths are reported to the scope
+ * context so the switcher can offer them. The response body is untrusted
+ * wire data — parseStewardPage validates shape before anything renders.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+import { useTenantScope } from '../shell/TenantScopeContext.tsx'
+import type { Steward, StewardPage } from './columns.ts'
+
+export interface UseStewardsResult {
+  page: StewardPage | null
+  loading: boolean
+  /** User-presentable failure line, e.g. "GET /api/v1/stewards — 503". */
+  error: string | null
+  /** Wall-clock stamp of when the page arrived; anchors relative times. */
+  fetchedAtMs: number
+  retry: () => void
+}
+
+function parseSteward(value: unknown): Steward | null {
+  if (typeof value !== 'object' || value === null) return null
+  const record = value as Record<string, unknown>
+  if (typeof record.id !== 'string' || record.id === '') return null
+  const steward: Steward = { id: record.id }
+  if (typeof record.status === 'string') steward.status = record.status
+  if (typeof record.last_seen === 'string') steward.last_seen = record.last_seen
+  if (typeof record.version === 'string') steward.version = record.version
+  if (typeof record.dna === 'object' && record.dna !== null) {
+    const dna = record.dna as Record<string, unknown>
+    let attributes: Record<string, string> = {}
+    if (typeof dna.attributes === 'object' && dna.attributes !== null) {
+      attributes = Object.fromEntries(
+        Object.entries(dna.attributes).filter(
+          (entry): entry is [string, string] => typeof entry[1] === 'string',
+        ),
+      )
+    }
+    steward.dna = {
+      hostname: typeof dna.hostname === 'string' ? dna.hostname : undefined,
+      os: typeof dna.os === 'string' ? dna.os : undefined,
+      architecture:
+        typeof dna.architecture === 'string' ? dna.architecture : undefined,
+      attributes,
+    }
+  }
+  return steward
+}
+
+/** Validate the paginated envelope (untrusted wire data). */
+export function parseStewardPage(data: unknown): StewardPage {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('unexpected response shape')
+  }
+  const record = data as Record<string, unknown>
+  if (
+    !Array.isArray(record.stewards) ||
+    typeof record.total !== 'number' ||
+    typeof record.limit !== 'number' ||
+    typeof record.offset !== 'number'
+  ) {
+    throw new Error('unexpected response shape')
+  }
+  const stewards: Steward[] = []
+  for (const entry of record.stewards) {
+    const steward = parseSteward(entry)
+    if (steward !== null) stewards.push(steward)
+  }
+  return {
+    stewards,
+    total: record.total,
+    limit: record.limit,
+    offset: record.offset,
+  }
+}
+
+interface FetchOutcome {
+  /** Which (limit, offset, attempt) request this outcome answers. */
+  key: string
+  page?: StewardPage
+  error?: string
+  fetchedAtMs: number
+}
+
+export function useStewards(limit: number, offset: number): UseStewardsResult {
+  const { registerObservedPath } = useTenantScope()
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+
+  // Loading is derived, not set: the view is loading whenever the latest
+  // outcome doesn't answer the current request key.
+  const key = `${limit}:${offset}:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    })
+    apiFetch(`/api/v1/stewards?${params.toString()}`)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`GET /api/v1/stewards — ${response.status}`)
+        }
+        const body: unknown = await response.json()
+        const parsed = parseStewardPage(
+          (body as Record<string, unknown> | null)?.data,
+        )
+        if (cancelled) return
+        for (const steward of parsed.stewards) {
+          const tenantPath = steward.dna?.attributes?.['tenant']
+          if (tenantPath) registerObservedPath(tenantPath)
+        }
+        setOutcome({ key, page: parsed, fetchedAtMs: Date.now() })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/stewards — request failed',
+          fetchedAtMs: Date.now(),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, limit, offset, registerObservedPath])
+
+  const current = outcome?.key === key ? outcome : null
+  return {
+    page: current?.page ?? null,
+    loading: current === null,
+    error: current?.error ?? null,
+    fetchedAtMs: current?.fetchedAtMs ?? 0,
+    retry,
+  }
+}

--- a/web/src/pages/Login.test.tsx
+++ b/web/src/pages/Login.test.tsx
@@ -181,6 +181,10 @@ describe('forbidden references in source (security A7.1 / A7.2)', () => {
     // data; persists across reloads so the sidebar/topbar don't reset to
     // "auto" every visit.
     { path: 'shell/UserMenu.tsx', key: 'cfgms.theme' },
+    // Fleet column selection (Story #2497) — which device-DNA columns the
+    // technician shows; a display preference, not auth data. Values read
+    // back are shape-validated as untrusted input (columns.ts).
+    { path: 'fleet/columns.ts', key: 'cfgms.fleet.columns' },
   ]
 
   it('no non-test source file uses localStorage/sessionStorage outside the explicit allowlist', () => {

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -11,6 +11,17 @@ const fetchMock = vi.fn<typeof fetch>()
 beforeEach(() => {
   vi.stubGlobal('fetch', fetchMock)
   fetchMock.mockReset()
+  // The fleet view (#2497) fetches its steward page on mount; shell tests
+  // serve it an empty page so the chrome renders over a quiet content area.
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        data: { stewards: [], total: 0, limit: 50, offset: 0 },
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  )
   document.body.className = ''
 })
 
@@ -34,10 +45,15 @@ describe('AppShell', () => {
     expect(screen.getAllByText(/soon/i).length).toBeGreaterThan(0)
   })
 
-  it('renders the content area empty-state placeholder (no fleet table in this story)', () => {
+  it('mounts the fleet overview (#2497) in the content area', async () => {
     renderShell()
-    expect(screen.getByText(/fleet overview lands in story #2497/i)).toBeInTheDocument()
-    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Fleet', level: 1 }),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByText(/no stewards enrolled yet/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /columns/i })).toBeInTheDocument()
   })
 
   it('renders the tenant switcher, search, alert center, and user menu', () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -5,10 +5,11 @@
  * App shell (Story #2496) — mockups/fleet-overview.html lines ~102-266.
  * The persistent chrome every authenticated screen mounts into: sidebar +
  * top bar at desktop width, hamburger + off-canvas drawer + scrim below
- * 1024px, Escape closes overlays. Fleet overview (#2497) is the first real
- * occupant of `.content` — this story renders its empty-state placeholder.
+ * 1024px, Escape closes overlays. Fleet overview (#2497) occupies
+ * `.content`; the global search box is its live filter.
  */
 import { useEffect, useState } from 'react'
+import FleetOverview from '../fleet/FleetOverview.tsx'
 import { TenantScopeProvider } from './TenantScopeContext.tsx'
 import TenantSwitcher from './TenantSwitcher.tsx'
 import GlobalSearch from './GlobalSearch.tsx'
@@ -111,16 +112,7 @@ export default function AppShell() {
           </div>
 
           <div className="content">
-            <div className="htitle">
-              <h1>Fleet</h1>
-              <p>Stewards enrolled to this controller, with the device DNA you choose.</p>
-            </div>
-            <section className="panel">
-              <div className="notice empty">
-                <h3>Fleet overview lands in Story #2497</h3>
-                <p>This screen will list enrolled stewards once that story ships.</p>
-              </div>
-            </section>
+            <FleetOverview search={search} />
           </div>
         </div>
       </div>

--- a/web/src/shell/TenantScopeContext.tsx
+++ b/web/src/shell/TenantScopeContext.tsx
@@ -37,6 +37,8 @@ export function isScopeMatch(candidate: TenantPath, scope: TenantPath): boolean 
 export interface TenantScopeValue {
   /** The currently selected scope. */
   scope: TenantPath
+  /** The principal's root path — scope === rootPath means "not narrowed". */
+  rootPath: TenantPath
   /** Selectable scopes: the principal's root path + observed descendants. */
   observedPaths: TenantPath[]
   setScope: (path: TenantPath) => void
@@ -61,8 +63,8 @@ export function TenantScopeProvider({
   }, [])
 
   const value = useMemo(
-    () => ({ scope, observedPaths, setScope, registerObservedPath }),
-    [scope, observedPaths, registerObservedPath],
+    () => ({ scope, rootPath, observedPaths, setScope, registerObservedPath }),
+    [scope, rootPath, observedPaths, registerObservedPath],
   )
 
   return (


### PR DESCRIPTION
## Summary

Fleet overview (`web/src/fleet/`) — the first real occupant of the app shell's content area. Renders one server page of stewards from `GET /api/v1/stewards?limit&offset` (the #2489 envelope: server `total`, stable ID order) with client-side live filter and column sort over the displayed page's rows (fixed epic semantics), a selectable device-DNA column set, scale-aware pagination written for 48k+ stewards, and first-class loading / error / empty states.

## Changes

- **`FleetOverview.tsx`** — page assembly: server-driven pager (true fleet total, page-size select, numbered strip), live filter fed by the shell's global search box (#2496 chrome), client-side sort, tenant-scope narrowing via the #2496 context (display convenience; server-side scoping is the only enforcement — security A8.1)
- **`columns.ts`** — DNA-attribute → column registry with verified real attribute keys (`current_user`, `primary_ip`, `deployment_ring`, `system_serial_number`, `system_model`, `primary_mac`); defaults Name/Company/Last user/IP/Health/Last check-in, opt-in OS/Agent/Ring/Model/Serial/MAC; selection persists under allowlisted `cfgms.fleet.columns`, read back as validated untrusted input; missing attributes render an em-dash
- **`health.ts`** — Status + LastSeen staleness → semantic Health pill (active but >5 min stale ⇒ Unreachable; Go zero time ⇒ never seen); unknown statuses render neutral as inert text
- **`useStewards.ts`** — data hook via the #2495 cookie/CSRF client; response shape-validated before render; observed tenant paths reported to the scope switcher; the fleet fetch doubles as the session probe (separate probe in `App.tsx` removed)
- **`FleetTable.tsx` / `ColumnPicker.tsx` / `FleetStates.tsx` / `FleetOverview.css`** — mockup-faithful table (aria-sort, mono machine data, tabular-nums, <720px card fold), picker popover with shell overlay conventions, skeleton/error-with-retry/dual empty states, all on the design tokens
- **`web/README.md`** — fleet data flow, full column→attribute mapping table, health mapping, storage key
- Carries two pre-existing develop gate fixes found during validation, also filed standalone: #2689 (hyperv errcheck) and #2690 (v020 sub-ms duration flake) — their diffs collapse out of this PR once those merge

## Security (A9.1 / threat model)

Steward-supplied values are untrusted: every value reaches the DOM as a JSX text node only — regression-tested with hostile hostname/user/IP payloads (no element creation, literal text rendered). Security reviewer: PASS — no findings (scans: check-architecture, security-precommit, Trivy).

## Test results

- Web suite: 61 → **98 tests passing** (pagination params + total, filter narrowing incl. hidden-column haystack, sort incl. chronological check-in, column add/remove + persistence + corrupted-storage fallback, health staleness mapping, loading/error/empty ×2, scope narrowing + observed-path registration, XSS inertness)
- Frontend lane: vitest, eslint (security rules at error), tsc, `npm audit`, vite build — all green
- `make test-quality` (QA runner): unit (race), lint, license headers, production-critical, cross-platform compile (5/5), Docker integration — all passed
- Adversarial review team (acceptance + QA test + QA code + security): **passed round 1, zero findings**

## Design review

Founder reviewed and approved captures of the real running app (2026-07-15): light/dark × ready/filter/sort/column-picker/loading/error/empty + mobile, taken through a genuine login flow against a mock of the controller session API. Deviations from the mockup confirmed in review: no stat tiles (needs an aggregate endpoint — full-fleet fetch forbidden), Views button lands with #2498, Company renders em-dash until the controller emits a tenant-path attribute, row drill-in is #2498.

Fixes #2497

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)