### PR TITLE
security: set HttpOnly on logout session-cookie deletion (Issue #2687)

### DIFF
--- a/features/controller/api/handlers_web_session.go
+++ b/features/controller/api/handlers_web_session.go
@@ -290,6 +290,7 @@ func (s *Server) handleWebLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 // clearWebSessionCookies expires both the session and CSRF cookies (Max-Age=0).
+// cfgms_session is HttpOnly (mirrors login-time design); cfgms_csrf is not (JS reads it).
 func clearWebSessionCookies(w http.ResponseWriter) {
 	for _, name := range []string{cookieWebSession, cookieCSRFSession} {
 		http.SetCookie(w, &http.Cookie{
@@ -298,6 +299,7 @@ func clearWebSessionCookies(w http.ResponseWriter) {
 			MaxAge:   -1, // serialised as Max-Age=0 → delete
 			Path:     "/",
 			Secure:   true,
+			HttpOnly: name == cookieWebSession,
 			SameSite: http.SameSiteStrictMode,
 		})
 	}

--- a/features/controller/api/handlers_web_session_test.go
+++ b/features/controller/api/handlers_web_session_test.go
@@ -343,6 +343,15 @@ func TestWebLogout_RevokesSessionAndClearsCookies(t *testing.T) {
 		}
 	}
 
+	// cfgms_session deletion cookie must carry HttpOnly (mirrors login-time design, clears CodeQL #1059).
+	if sess, ok := cookieMap[cookieWebSession]; ok {
+		assert.True(t, sess.HttpOnly, "cfgms_session deletion cookie must be HttpOnly")
+	}
+	// cfgms_csrf deletion cookie must NOT be HttpOnly (matches its login-time non-HttpOnly design).
+	if csrf, ok := cookieMap[cookieCSRFSession]; ok {
+		assert.False(t, csrf.HttpOnly, "cfgms_csrf deletion cookie must NOT be HttpOnly")
+	}
+
 	// Server-side session must be revoked — subsequent validation must fail.
 	srv.mu.RLock()
 	mgr := srv.webSessionManager

--- a/features/modules/stdlib/time/module_test.go
+++ b/features/modules/stdlib/time/module_test.go
@@ -292,11 +292,11 @@ func TestTimeModule_Set_WrongConfigType(t *testing.T) {
 // wrongConfigType is a stub that implements modules.ConfigState but is not *TimeConfig.
 type wrongConfigType struct{}
 
-func (w *wrongConfigType) AsMap() map[string]interface{}  { return nil }
-func (w *wrongConfigType) ToYAML() ([]byte, error)        { return nil, nil }
-func (w *wrongConfigType) FromYAML(_ []byte) error        { return nil }
-func (w *wrongConfigType) Validate() error                { return nil }
-func (w *wrongConfigType) GetManagedFields() []string     { return nil }
+func (w *wrongConfigType) AsMap() map[string]interface{} { return nil }
+func (w *wrongConfigType) ToYAML() ([]byte, error)       { return nil, nil }
+func (w *wrongConfigType) FromYAML(_ []byte) error       { return nil }
+func (w *wrongConfigType) Validate() error               { return nil }
+func (w *wrongConfigType) GetManagedFields() []string    { return nil }
 
 // TestTimeModule_LoggingInjection verifies the module implements LoggingInjectable.
 func TestTimeModule_LoggingInjection(t *testing.T) {


### PR DESCRIPTION
## Summary

- `clearWebSessionCookies` re-issued the `cfgms_session` cookie without `HttpOnly` on logout, despite the login-time cookie setting `HttpOnly: true`
- Fix: `HttpOnly: name == cookieWebSession` in the deletion loop — session cookie gets `HttpOnly`, CSRF cookie stays non-HttpOnly (JS reads it, by design)
- Clears CodeQL alert #1059 (`go/cookie-httponly-not-set`, CWE-1004, medium) on the next develop scan

Fixes #2687

## Files changed

- `features/controller/api/handlers_web_session.go` — one-line fix in `clearWebSessionCookies`
- `features/controller/api/handlers_web_session_test.go` — extend `TestWebLogout_RevokesSessionAndClearsCookies` to assert `HttpOnly` on the session deletion cookie and non-HttpOnly on the CSRF deletion cookie
- `features/modules/hyperv/provision_test.go` — add `require.Error` on unchecked `failProvision` return values (test quality fix from adversarial review)
- `features/modules/stdlib/time/module_test.go` — method alignment whitespace (cosmetic, from adversarial review)

## Specialist review results

| Reviewer | Round 1 | Round 2 |
|---|---|---|
| Code review | PASS | — |
| Test quality | FAIL (unchecked error returns in hyperv tests) | PASS |
| Security | PASS | — |

**Aggregate verdict: PASS** (`passed: true`, 1 fix round, 0 remaining findings)

## Test plan

- [x] `TestWebLogout_RevokesSessionAndClearsCookies` asserts `HttpOnly=true` on `cfgms_session` deletion cookie and `HttpOnly=false` on `cfgms_csrf` deletion cookie
- [x] Full `features/controller/api` package tests pass
- [x] `make test-agent-complete` passes (verified by story-review workflow)
- [ ] Alert #1059 clears on next develop CodeQL scan (`gh api repos/cfg-is/cfgms/code-scanning/alerts?state=open`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)