### PR TITLE
modules: hostname stdlib module - system name and workgroup (Issue #2460)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ STDLIB_MODULES := \
 	cert_trust \
 	file \
 	firewall \
+	hostname \
 	package \
 	patch \
 	script \

--- a/build/darwin/build-pkg.sh
+++ b/build/darwin/build-pkg.sh
@@ -162,6 +162,7 @@ STDLIB_MODULES=(
     cfgms-module-cert_trust
     cfgms-module-file
     cfgms-module-firewall
+    cfgms-module-hostname
     cfgms-module-package
     cfgms-module-patch
     cfgms-module-script

--- a/build/linux/install.sh
+++ b/build/linux/install.sh
@@ -147,6 +147,7 @@ STDLIB_MODULES=(
     cfgms-module-cert_trust
     cfgms-module-file
     cfgms-module-firewall
+    cfgms-module-hostname
     cfgms-module-package
     cfgms-module-patch
     cfgms-module-script

--- a/build/windows/cfgms-steward.wxs
+++ b/build/windows/cfgms-steward.wxs
@@ -100,6 +100,9 @@
           <Component Id="ModuleFirewall" Guid="*">
             <File Id="ModuleFirewallExe" Source="$(var.ModulesDir)\cfgms-module-firewall.exe" Name="cfgms-module-firewall.exe" KeyPath="yes" />
           </Component>
+          <Component Id="ModuleHostname" Guid="*">
+            <File Id="ModuleHostnameExe" Source="$(var.ModulesDir)\cfgms-module-hostname.exe" Name="cfgms-module-hostname.exe" KeyPath="yes" />
+          </Component>
           <Component Id="ModulePatch" Guid="*">
             <File Id="ModulePatchExe" Source="$(var.ModulesDir)\cfgms-module-patch.exe" Name="cfgms-module-patch.exe" KeyPath="yes" />
           </Component>
@@ -122,6 +125,7 @@
       <ComponentRef Id="ModulePackage" />
       <ComponentRef Id="ModuleScript" />
       <ComponentRef Id="ModuleFirewall" />
+      <ComponentRef Id="ModuleHostname" />
       <ComponentRef Id="ModulePatch" />
       <ComponentRef Id="ModuleTime" />
       <ComponentRef Id="ModuleUser" />

--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -214,7 +214,7 @@ Shipped in the steward installer, all `executors: [steward]` (closed set — see
 - `user` - Local users & groups, membership, lock/disable state, password presence (observed only)
 - `cert_trust` - System trust store: install/trust CA & certs; keeps the CFGMS mTLS chain healthy fleet-wide
 - `time` - Timezone + NTP/time-sync configuration (`timezone`, `ntp_servers`, `ntp_sync_enabled`)
-- `hostname` - System/computer name & workgroup — *planned (net-new)*
+- `hostname` - System/computer name & workgroup
 
 ### Extended steward modules (non-stdlib)
 

--- a/docs/modules/hostname.md
+++ b/docs/modules/hostname.md
@@ -1,0 +1,96 @@
+# hostname module
+
+Manages the host system name (computer name) and Windows workgroup.
+
+## Rationale
+
+The system hostname is a foundational host identity property: it appears in
+certificate SANs, DNS records, log metadata, and service-discovery registrations.
+Unmanaged drift — a rename from a manual `hostnamectl` call, an OS image clone
+with a shared name, or a workgroup mismatch — cascades into authentication
+failures, certificate validation errors, and monitoring gaps.
+
+The `hostname` module declares authoritative ownership over the `hostname` DNA
+object kind (ADR-016 clause 5). It is a **declare-once identity** module per
+ADR-016 clause 1: the desired hostname is set once and held, not
+continuously re-derived. Repeated `Set` calls with the same desired hostname
+are idempotent no-ops and never trigger a rename or reboot.
+
+## Fields
+
+| Field | Type | Platforms | Description |
+|-------|------|-----------|-------------|
+| `hostname` | string | All | System/computer name (RFC 1123 label: alphanumeric + hyphens, no leading/trailing hyphen, max 253 chars) |
+| `workgroup` | string | Windows only | NetBIOS workgroup name (alphanumeric, hyphen, underscore; max 15 chars). Absent on Linux and macOS fragments. |
+
+`hostname` is required. `workgroup` is optional on Windows and absent on all
+other platforms.
+
+## Example DNA fragment
+
+### Linux / macOS
+
+```yaml
+hostname: webserver-01
+```
+
+### Windows
+
+```yaml
+hostname: WEBSERVER01
+workgroup: CORP
+```
+
+## Platform behaviour
+
+### Linux
+
+- **Read**: current hostname is read from `/etc/hostname`. If the file does not
+  exist, `os.Hostname()` is used as a fallback (unmanaged hosts still report a
+  value).
+- **Write**: desired hostname is written to `/etc/hostname` (durable) and applied
+  to the running kernel via `syscall.Sethostname` (runtime, no reboot required).
+- **Workgroup**: not applicable; absent from the DNA fragment.
+
+### macOS
+
+- **Read**: `scutil --get HostName` returns the current BSD hostname.
+- **Write**: `scutil --set HostName <name>` and `scutil --set ComputerName <name>`
+  are both called to keep all macOS naming layers consistent.
+- **Workgroup**: not applicable; absent from the DNA fragment.
+- Requires admin privileges.
+
+### Windows
+
+- **Read hostname**: `os.Hostname()` (in-process).
+- **Read workgroup**: `wmic computersystem get Workgroup /format:list`.
+- **Write hostname**: `netdom renamecomputer <current> /newname:<new> /reboot:0 /force`.
+  The `/reboot:0` flag suppresses the automatic reboot; the rename takes effect
+  on the next manual reboot scheduled by the operator.
+- **Write workgroup**: `wmic computersystem where name=<name> call JoinDomainOrWorkgroup`.
+- Requires administrator privileges.
+
+## Security notes
+
+- Requires root/admin privileges on all platforms.
+- Input is validated against RFC 1123 (hostname) and NetBIOS (workgroup) patterns
+  before any system call or shell-out; no shell metacharacters pass through.
+- Shells out to `scutil` (macOS), `wmic.exe` and `netdom.exe` (Windows) as
+  declared in `module.yaml`'s `behavioral_envelope`. On Linux all operations
+  are in-process (no shell-out).
+- No credentials or secrets are handled by this module.
+
+## Idempotency
+
+`Set` checks the current hostname against the desired hostname before writing.
+If they match, the function returns immediately without calling any system APIs.
+This is especially important for declare-once identity: an accidental repeated
+apply must not trigger a rename churn or, on Windows, an unintended reboot
+notification.
+
+## Determinism
+
+`Get` always returns the same fields for the same unchanged host state.
+`AsMap()` is byte-for-byte identical on repeated calls (ADR-016 clause 4).
+The `workgroup` field is absent (not an empty string) on non-Windows platforms,
+preventing a spurious cross-platform field-presence difference.

--- a/features/modules/stdlib/hostname/cmd/main.go
+++ b/features/modules/stdlib/hostname/cmd/main.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// cfgms-module-hostname is the out-of-process gRPC binary for the hostname stdlib module.
+// It reads CFGMS_MODULE_SOCKET from the environment, registers the ModuleService
+// gRPC server, and handles SIGTERM for graceful shutdown.
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	"github.com/cfgis/cfgms/features/modules/adapter"
+	hostname "github.com/cfgis/cfgms/features/modules/stdlib/hostname"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	socketPath := os.Getenv("CFGMS_MODULE_SOCKET")
+	if socketPath == "" {
+		log.Fatal("cfgms-module-hostname: CFGMS_MODULE_SOCKET environment variable is required")
+	}
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Fatalf("cfgms-module-hostname: failed to listen on %s: %v", socketPath, err) // #nosec G706 - socketPath is system-set (CFGMS_MODULE_SOCKET), not user input
+	}
+
+	srv := grpc.NewServer()
+	proto.RegisterModuleServiceServer(srv, adapter.New(hostname.New(), "hostname", srv))
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		srv.GracefulStop()
+	}()
+
+	if err := srv.Serve(lis); err != nil {
+		log.Fatalf("cfgms-module-hostname: gRPC server exited with error: %v", err)
+	}
+}

--- a/features/modules/stdlib/hostname/executor.go
+++ b/features/modules/stdlib/hostname/executor.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package hostname
+
+// hostnameState holds the observed current identity configuration of the host.
+type hostnameState struct {
+	// Hostname is the system/computer name of the host.
+	Hostname string
+	// Workgroup is the Windows workgroup name. Empty on Linux and macOS.
+	Workgroup string
+}
+
+// hostnameExecutor is the platform-specific backend for host identity configuration.
+// Each platform (Linux, Windows, macOS) provides its own implementation via
+// build tags. Unsupported platforms use the stub implementation that returns
+// ErrUnsupportedPlatform.
+type hostnameExecutor interface {
+	// getState returns the current hostname (and workgroup on Windows) of the host.
+	getState() (hostnameState, error)
+
+	// setState applies the desired hostname (and workgroup on Windows). It is
+	// idempotent: calling setState when the host is already in the desired
+	// state is a no-op.
+	setState(desired hostnameState) error
+}

--- a/features/modules/stdlib/hostname/executor_darwin.go
+++ b/features/modules/stdlib/hostname/executor_darwin.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package hostname
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// darwinExecutor manages host identity configuration on macOS via the
+// scutil command-line tool.
+//
+// ComputerName (friendly display name) and HostName (BSD/kernel hostname) are
+// both managed. getHostNameFn returns HostName as the canonical value;
+// setHostNamesFn writes both so the machine name is consistent in all macOS
+// naming layers.
+//
+// Workgroup is a Windows-only concept; it is never read or written on macOS.
+//
+// getHostNameFn and setHostNamesFn are injected as function values so that
+// tests can substitute fixtures without requiring a real macOS host or
+// elevated privileges. The production defaults call scutil, which is declared
+// in module.yaml behavioral_envelope as a shelling-out dependency (preferred
+// over in-process APIs on macOS because Apple's System Configuration framework
+// is not available without CGO).
+type darwinExecutor struct {
+	getHostNameFn  func() (string, error)
+	setHostNamesFn func(name string) error
+}
+
+func newExecutor() hostnameExecutor {
+	return &darwinExecutor{
+		getHostNameFn:  scutilGetHostName,
+		setHostNamesFn: scutilSetHostNames,
+	}
+}
+
+// getState returns the current hostname from macOS via the injected getHostNameFn.
+func (e *darwinExecutor) getState() (hostnameState, error) {
+	h, err := e.getHostNameFn()
+	if err != nil {
+		return hostnameState{}, err
+	}
+	return hostnameState{Hostname: h}, nil
+}
+
+// setState sets the hostname via the injected setHostNamesFn.
+func (e *darwinExecutor) setState(desired hostnameState) error {
+	return e.setHostNamesFn(desired.Hostname)
+}
+
+// scutilGetHostName returns the current BSD hostname via scutil --get HostName.
+func scutilGetHostName() (string, error) {
+	out, err := exec.Command("scutil", "--get", "HostName").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("scutil --get HostName: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// scutilSetHostNames sets both ComputerName and HostName via scutil to keep
+// all macOS naming layers consistent.
+func scutilSetHostNames(name string) error {
+	if out, err := exec.Command("scutil", "--set", "ComputerName", name).CombinedOutput(); err != nil { // #nosec G204 - name matches hostnamePattern; no shell metacharacters
+		return fmt.Errorf("scutil --set ComputerName: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	if out, err := exec.Command("scutil", "--set", "HostName", name).CombinedOutput(); err != nil { // #nosec G204 - name matches hostnamePattern; no shell metacharacters
+		return fmt.Errorf("scutil --set HostName: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/features/modules/stdlib/hostname/executor_darwin_test.go
+++ b/features/modules/stdlib/hostname/executor_darwin_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package hostname
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// scutilAvailable returns true when the scutil command is reachable on this runner.
+func scutilAvailable() bool {
+	return exec.Command("scutil", "--get", "HostName").Run() == nil
+}
+
+// newDarwinFixtureExecutor creates a darwinExecutor with injectable functions
+// pointed at fixture values. Tests never call real scutil commands or require
+// macOS admin privileges.
+func newDarwinFixtureExecutor(initialHostname string) (*darwinExecutor, *string) {
+	current := initialHostname
+	e := &darwinExecutor{
+		getHostNameFn:  func() (string, error) { return current, nil },
+		setHostNamesFn: func(name string) error { current = name; return nil },
+	}
+	return e, &current
+}
+
+// TestDarwinExecutor_HostnameRoundTrip verifies Set→Get round-trip using
+// fixture-injected functions. Real scutil is never called.
+func TestDarwinExecutor_HostnameRoundTrip(t *testing.T) {
+	e, current := newDarwinFixtureExecutor("initial-host")
+
+	if err := e.setState(hostnameState{Hostname: "new-host"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	if *current != "new-host" {
+		t.Errorf("setHostNamesFn captured %q, want %q", *current, "new-host")
+	}
+
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() after setState error: %v", err)
+	}
+
+	if state.Hostname != "new-host" {
+		t.Errorf("Hostname: got %q, want %q", state.Hostname, "new-host")
+	}
+}
+
+// TestDarwinExecutor_WorkgroupAbsent verifies that getState never returns a
+// non-empty Workgroup on macOS (Workgroup is Windows-only).
+func TestDarwinExecutor_WorkgroupAbsent(t *testing.T) {
+	e, _ := newDarwinFixtureExecutor("mac-host")
+
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if state.Workgroup != "" {
+		t.Errorf("getState() on macOS must not return a workgroup; got %q", state.Workgroup)
+	}
+}
+
+// TestDarwinExecutor_GetIsIdempotent verifies two consecutive getState calls
+// return identical results (ADR-016 clause 4 determinism contract).
+func TestDarwinExecutor_GetIsIdempotent(t *testing.T) {
+	e, _ := newDarwinFixtureExecutor("idempotent-host")
+
+	got1, err := e.getState()
+	if err != nil {
+		t.Fatalf("first getState() error: %v", err)
+	}
+	got2, err := e.getState()
+	if err != nil {
+		t.Fatalf("second getState() error: %v", err)
+	}
+
+	if got1.Hostname != got2.Hostname {
+		t.Errorf("Hostname not idempotent: %q vs %q", got1.Hostname, got2.Hostname)
+	}
+}
+
+// TestDarwinExecutor_GetState_Integration verifies the full getState round-trip
+// on macOS when scutil is available. Skipped when scutil is not accessible or
+// requires elevated privileges not present on the runner.
+func TestDarwinExecutor_GetState_Integration(t *testing.T) {
+	if !scutilAvailable() {
+		t.Skip("skipping: scutil not available or requires elevated privileges")
+	}
+
+	e := &darwinExecutor{
+		getHostNameFn:  scutilGetHostName,
+		setHostNamesFn: scutilSetHostNames,
+	}
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if state.Hostname == "" {
+		t.Error("getState() returned empty Hostname")
+	}
+}

--- a/features/modules/stdlib/hostname/executor_linux.go
+++ b/features/modules/stdlib/hostname/executor_linux.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package hostname
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// linuxExecutor manages host identity configuration on Linux.
+//
+// The current hostname is read from /etc/hostname (the durable config file).
+// When /etc/hostname does not exist, os.Hostname() is used as a fallback so
+// that hosts that have never been managed by this module still report a value.
+//
+// setState writes the desired hostname to /etc/hostname for persistence and
+// calls the injected setHostname function (defaults to syscall.Sethostname)
+// for runtime application without requiring a reboot.
+//
+// Both hostnameFile and setHostname are configurable so tests can substitute
+// fixture paths and no-op functions, never mutating the CI runner's actual
+// hostname or kernel state.
+//
+// Workgroup is a Windows-only concept; it is never read or written on Linux.
+type linuxExecutor struct {
+	hostnameFile string // default: /etc/hostname
+	setHostname  func(name string) error
+}
+
+func newExecutor() hostnameExecutor {
+	return &linuxExecutor{
+		hostnameFile: "/etc/hostname",
+		setHostname:  sysSetHostname,
+	}
+}
+
+// sysSetHostname applies the hostname to the running kernel via syscall.Sethostname.
+func sysSetHostname(name string) error {
+	return syscall.Sethostname([]byte(name))
+}
+
+// getState reads the current hostname from /etc/hostname.
+// Falls back to os.Hostname() when the file does not exist so that unmanaged
+// hosts still return a meaningful value.
+func (e *linuxExecutor) getState() (hostnameState, error) {
+	data, err := os.ReadFile(e.hostnameFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// File absent — read the runtime hostname from the kernel.
+			h, herr := os.Hostname()
+			if herr != nil {
+				return hostnameState{}, fmt.Errorf("os.Hostname: %w", herr)
+			}
+			return hostnameState{Hostname: strings.TrimSpace(h)}, nil
+		}
+		return hostnameState{}, fmt.Errorf("read /etc/hostname: %w", err)
+	}
+	return hostnameState{Hostname: strings.TrimSpace(string(data))}, nil
+}
+
+// setState writes the desired hostname to /etc/hostname for persistence and
+// applies it at runtime via the injected setHostname function.
+// Parent directories are created if needed (handles missing /etc on bare containers).
+func (e *linuxExecutor) setState(desired hostnameState) error {
+	if err := os.MkdirAll(filepath.Dir(e.hostnameFile), 0o755); err != nil { // #nosec G301 - /etc is world-traversable by convention
+		return fmt.Errorf("create hostname file parent: %w", err)
+	}
+	if err := os.WriteFile(e.hostnameFile, []byte(desired.Hostname+"\n"), 0o644); err != nil { // #nosec G306 - /etc/hostname is world-readable by convention
+		return fmt.Errorf("write /etc/hostname: %w", err)
+	}
+	if err := e.setHostname(desired.Hostname); err != nil {
+		return fmt.Errorf("syscall Sethostname: %w", err)
+	}
+	return nil
+}

--- a/features/modules/stdlib/hostname/executor_linux_test.go
+++ b/features/modules/stdlib/hostname/executor_linux_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package hostname
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newFixtureExecutor creates a linuxExecutor with:
+//   - hostnameFile pointing at a temp file (never /etc/hostname)
+//   - setHostname wired to a no-op that captures the value written
+//
+// Tests can manipulate the temp file and captured value directly, without
+// requiring root or touching the CI runner's actual kernel hostname.
+func newFixtureExecutor(t *testing.T) (*linuxExecutor, *string) {
+	t.Helper()
+	dir := t.TempDir()
+	var captured string
+	e := &linuxExecutor{
+		hostnameFile: filepath.Join(dir, "hostname"),
+		setHostname:  func(name string) error { captured = name; return nil },
+	}
+	return e, &captured
+}
+
+// TestLinuxExecutor_GetDefaultsWhenFileAbsent verifies getState returns a
+// non-empty hostname (from os.Hostname fallback) when /etc/hostname is missing.
+func TestLinuxExecutor_GetDefaultsWhenFileAbsent(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+	// hostnameFile does not exist yet; getState must fall back to os.Hostname.
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() with missing file returned error: %v", err)
+	}
+	if state.Hostname == "" {
+		t.Error("getState() with missing file must return a non-empty hostname")
+	}
+}
+
+// TestLinuxExecutor_HostnameRoundTrip verifies Set→Get round-trip via fixture
+// paths. The injected no-op setHostname never calls syscall.Sethostname, so
+// the CI runner's kernel hostname is never modified.
+func TestLinuxExecutor_HostnameRoundTrip(t *testing.T) {
+	e, captured := newFixtureExecutor(t)
+
+	desired := hostnameState{Hostname: "fixture-host"}
+
+	if err := e.setState(desired); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	// The injected setHostname should have been called with the desired name.
+	if *captured != "fixture-host" {
+		t.Errorf("setHostname was called with %q, want %q", *captured, "fixture-host")
+	}
+
+	got, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() after setState error: %v", err)
+	}
+
+	if got.Hostname != desired.Hostname {
+		t.Errorf("Hostname: got %q, want %q", got.Hostname, desired.Hostname)
+	}
+}
+
+// TestLinuxExecutor_WorkgroupAbsent verifies that getState never returns a
+// non-empty Workgroup on Linux (Workgroup is Windows-only).
+func TestLinuxExecutor_WorkgroupAbsent(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+
+	if err := e.setState(hostnameState{Hostname: "linux-host"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if state.Workgroup != "" {
+		t.Errorf("getState() on Linux must not return a workgroup; got %q", state.Workgroup)
+	}
+}
+
+// TestLinuxExecutor_HostnameFileContent verifies that setState writes the
+// hostname to hostnameFile with a trailing newline (POSIX line-ending convention).
+func TestLinuxExecutor_HostnameFileContent(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+
+	if err := e.setState(hostnameState{Hostname: "test-node"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	data, err := os.ReadFile(e.hostnameFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", e.hostnameFile, err)
+	}
+
+	want := "test-node\n"
+	if string(data) != want {
+		t.Errorf("hostnameFile content = %q, want %q", string(data), want)
+	}
+}
+
+// TestLinuxExecutor_GetIsIdempotent verifies two consecutive getState calls
+// return identical results (ADR-016 clause 4 determinism contract).
+func TestLinuxExecutor_GetIsIdempotent(t *testing.T) {
+	e, _ := newFixtureExecutor(t)
+
+	if err := e.setState(hostnameState{Hostname: "idempotent-host"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	got1, err := e.getState()
+	if err != nil {
+		t.Fatalf("first getState() error: %v", err)
+	}
+	got2, err := e.getState()
+	if err != nil {
+		t.Fatalf("second getState() error: %v", err)
+	}
+
+	if got1.Hostname != got2.Hostname {
+		t.Errorf("Hostname not idempotent: %q vs %q", got1.Hostname, got2.Hostname)
+	}
+}
+
+// TestLinuxExecutor_SetIsIdempotentNoOp verifies that the hostnameModule's
+// Set method skips the write when the host is already in the desired state —
+// the injected setHostname is not called a second time (ADR-016 clause 1,
+// declare-once identity semantics).
+func TestLinuxExecutor_SetIsIdempotentNoOp(t *testing.T) {
+	dir := t.TempDir()
+	callCount := 0
+	e := &linuxExecutor{
+		hostnameFile: filepath.Join(dir, "hostname"),
+		setHostname:  func(_ string) error { callCount++; return nil },
+	}
+
+	m := &hostnameModule{executor: e}
+	ctx := context.Background()
+
+	cfg := &HostnameConfig{Hostname: "stable-host"}
+
+	// First Set: the file doesn't exist yet so getState falls back to os.Hostname
+	// (which is NOT "stable-host"), causing setState to execute.
+	if err := m.Set(ctx, "system", cfg); err != nil {
+		t.Fatalf("first Set() error: %v", err)
+	}
+	afterFirst := callCount
+
+	// Second Set: the file now contains "stable-host" so getState returns the
+	// same value as desired; the module must return early without calling setState.
+	if err := m.Set(ctx, "system", cfg); err != nil {
+		t.Fatalf("second Set() error: %v", err)
+	}
+
+	if callCount != afterFirst {
+		t.Errorf("setHostname called %d additional time(s) on idempotent Set; want 0", callCount-afterFirst)
+	}
+}

--- a/features/modules/stdlib/hostname/executor_stub.go
+++ b/features/modules/stdlib/hostname/executor_stub.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !linux && !windows && !darwin
+
+package hostname
+
+import "github.com/cfgis/cfgms/features/modules"
+
+// stubExecutor is used on platforms where hostname configuration is not supported.
+type stubExecutor struct{}
+
+func newExecutor() hostnameExecutor {
+	return &stubExecutor{}
+}
+
+func (e *stubExecutor) getState() (hostnameState, error) {
+	return hostnameState{}, modules.ErrUnsupportedPlatform
+}
+
+func (e *stubExecutor) setState(_ hostnameState) error {
+	return modules.ErrUnsupportedPlatform
+}

--- a/features/modules/stdlib/hostname/executor_windows.go
+++ b/features/modules/stdlib/hostname/executor_windows.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package hostname
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// windowsExecutor manages host identity configuration on Windows via
+// os.Hostname (read), wmic.exe (workgroup read/set), and netdom.exe (rename).
+//
+// Both getHostname and getWorkgroup are injected as function values so that
+// tests can substitute fixture functions without touching the real host's
+// identity or requiring elevated privileges on the CI runner.
+//
+// wmic.exe and netdom.exe are declared in module.yaml behavioral_envelope as
+// shelling-out dependencies (preferred over native COM/WMI calls to avoid a
+// CGO dependency for out-of-process modules).
+type windowsExecutor struct {
+	getHostname  func() (string, error)
+	getWorkgroup func(computerName string) (string, error)
+	setHostname  func(currentName, newName string) error
+	setWorkgroup func(computerName, workgroup string) error
+}
+
+func newExecutor() hostnameExecutor {
+	return &windowsExecutor{
+		getHostname:  os.Hostname,
+		getWorkgroup: wmicGetWorkgroup,
+		setHostname:  netdomRename,
+		setWorkgroup: wmicSetWorkgroup,
+	}
+}
+
+// getState returns the current hostname and workgroup from Windows.
+func (e *windowsExecutor) getState() (hostnameState, error) {
+	hostname, err := e.getHostname()
+	if err != nil {
+		return hostnameState{}, fmt.Errorf("get hostname: %w", err)
+	}
+	hostname = strings.TrimSpace(hostname)
+
+	workgroup, err := e.getWorkgroup(hostname)
+	if err != nil {
+		return hostnameState{}, fmt.Errorf("get workgroup: %w", err)
+	}
+
+	return hostnameState{
+		Hostname:  hostname,
+		Workgroup: workgroup,
+	}, nil
+}
+
+// setState applies the desired hostname and workgroup on Windows.
+// Each change is applied only when the desired value differs from the current.
+func (e *windowsExecutor) setState(desired hostnameState) error {
+	current, err := e.getState()
+	if err != nil {
+		return fmt.Errorf("get current state: %w", err)
+	}
+
+	if current.Hostname != desired.Hostname {
+		if err := e.setHostname(current.Hostname, desired.Hostname); err != nil {
+			return fmt.Errorf("rename computer: %w", err)
+		}
+	}
+
+	if desired.Workgroup != "" && current.Workgroup != desired.Workgroup {
+		if err := e.setWorkgroup(desired.Hostname, desired.Workgroup); err != nil {
+			return fmt.Errorf("set workgroup: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// wmicGetWorkgroup reads the current workgroup via wmic computersystem.
+// Output format: "Workgroup=WORKGROUPNAME" (one line after /format:list).
+func wmicGetWorkgroup(computerName string) (string, error) {
+	out, err := exec.Command("wmic", "computersystem", "get", "Workgroup", "/format:list").CombinedOutput() // #nosec G204 - no user-controlled values in arguments
+	if err != nil {
+		return "", fmt.Errorf("wmic computersystem get Workgroup: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToUpper(line), "WORKGROUP=") {
+			return strings.TrimSpace(line[len("WORKGROUP="):]), nil
+		}
+	}
+	return "", nil
+}
+
+// netdomRename renames the computer via netdom.exe.
+// /reboot:0 suppresses the automatic reboot — the rename takes effect on
+// the next manual reboot scheduled by the operator.
+func netdomRename(currentName, newName string) error {
+	out, err := exec.Command("netdom", "renamecomputer", currentName, "/newname:"+newName, "/reboot:0", "/force").CombinedOutput() // #nosec G204 - names validated by Validate()
+	if err != nil {
+		return fmt.Errorf("netdom renamecomputer: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// wmicSetWorkgroup joins the computer to the specified workgroup via wmic.
+func wmicSetWorkgroup(computerName, workgroup string) error {
+	// wmic computersystem where name=... call JoinDomainOrWorkgroup WorkgroupName=...
+	whereClause := fmt.Sprintf(`name="%s"`, computerName) // #nosec G204 - computerName validated by Validate()
+	out, err := exec.Command("wmic", "computersystem", "where", whereClause,
+		"call", "JoinDomainOrWorkgroup", fmt.Sprintf("WorkgroupName=%q", workgroup)).CombinedOutput() // #nosec G204 - workgroup validated by Validate()
+	if err != nil {
+		return fmt.Errorf("wmic JoinDomainOrWorkgroup: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/features/modules/stdlib/hostname/executor_windows_test.go
+++ b/features/modules/stdlib/hostname/executor_windows_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package hostname
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// newWindowsFixtureExecutor creates a windowsExecutor with all four injectable
+// functions pointing at fixture values. Tests never call real wmic/netdom or
+// require Windows admin privileges.
+func newWindowsFixtureExecutor(initialHostname, initialWorkgroup string) (*windowsExecutor, *hostnameState) {
+	state := &hostnameState{Hostname: initialHostname, Workgroup: initialWorkgroup}
+	e := &windowsExecutor{
+		getHostname:  func() (string, error) { return state.Hostname, nil },
+		getWorkgroup: func(_ string) (string, error) { return state.Workgroup, nil },
+		setHostname:  func(_, newName string) error { state.Hostname = newName; return nil },
+		setWorkgroup: func(_, wg string) error { state.Workgroup = wg; return nil },
+	}
+	return e, state
+}
+
+// TestWindowsExecutor_HostnameRoundTrip verifies Set→Get round-trip using
+// fixture-injected functions. Real wmic/netdom are never called.
+func TestWindowsExecutor_HostnameRoundTrip(t *testing.T) {
+	e, state := newWindowsFixtureExecutor("old-host", "WORKGROUP")
+
+	if err := e.setState(hostnameState{Hostname: "new-host", Workgroup: "WORKGROUP"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	if state.Hostname != "new-host" {
+		t.Errorf("Hostname after setState: got %q, want %q", state.Hostname, "new-host")
+	}
+
+	got, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() after setState error: %v", err)
+	}
+
+	if got.Hostname != "new-host" {
+		t.Errorf("getState().Hostname: got %q, want %q", got.Hostname, "new-host")
+	}
+}
+
+// TestWindowsExecutor_WorkgroupRoundTrip verifies Set→Get round-trip for the
+// workgroup field using fixture-injected functions.
+func TestWindowsExecutor_WorkgroupRoundTrip(t *testing.T) {
+	e, state := newWindowsFixtureExecutor("myhost", "OLDGROUP")
+
+	if err := e.setState(hostnameState{Hostname: "myhost", Workgroup: "NEWGROUP"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	if state.Workgroup != "NEWGROUP" {
+		t.Errorf("Workgroup after setState: got %q, want %q", state.Workgroup, "NEWGROUP")
+	}
+
+	got, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if got.Workgroup != "NEWGROUP" {
+		t.Errorf("getState().Workgroup: got %q, want %q", got.Workgroup, "NEWGROUP")
+	}
+}
+
+// TestWindowsExecutor_HostnameUnchangedWhenSame verifies that setHostname is
+// not called when the current hostname already matches the desired value.
+func TestWindowsExecutor_HostnameUnchangedWhenSame(t *testing.T) {
+	renameCalls := 0
+	e := &windowsExecutor{
+		getHostname:  func() (string, error) { return "same-host", nil },
+		getWorkgroup: func(_ string) (string, error) { return "WORKGROUP", nil },
+		setHostname:  func(_, _ string) error { renameCalls++; return nil },
+		setWorkgroup: func(_, _ string) error { return nil },
+	}
+
+	if err := e.setState(hostnameState{Hostname: "same-host", Workgroup: "WORKGROUP"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	if renameCalls != 0 {
+		t.Errorf("setHostname called %d time(s) when hostname was already correct; want 0", renameCalls)
+	}
+}
+
+// TestWindowsExecutor_WorkgroupUnchangedWhenSame verifies that setWorkgroup is
+// not called when the current workgroup already matches the desired value.
+func TestWindowsExecutor_WorkgroupUnchangedWhenSame(t *testing.T) {
+	workgroupCalls := 0
+	e := &windowsExecutor{
+		getHostname:  func() (string, error) { return "myhost", nil },
+		getWorkgroup: func(_ string) (string, error) { return "SAME", nil },
+		setHostname:  func(_, _ string) error { return nil },
+		setWorkgroup: func(_, _ string) error { workgroupCalls++; return nil },
+	}
+
+	if err := e.setState(hostnameState{Hostname: "myhost", Workgroup: "SAME"}); err != nil {
+		t.Fatalf("setState() error: %v", err)
+	}
+
+	if workgroupCalls != 0 {
+		t.Errorf("setWorkgroup called %d time(s) when workgroup was already correct; want 0", workgroupCalls)
+	}
+}
+
+// TestWindowsExecutor_GetIsIdempotent verifies two consecutive getState calls
+// return identical results (ADR-016 clause 4 determinism contract).
+func TestWindowsExecutor_GetIsIdempotent(t *testing.T) {
+	e, _ := newWindowsFixtureExecutor("stable-host", "CORP")
+
+	got1, err := e.getState()
+	if err != nil {
+		t.Fatalf("first getState() error: %v", err)
+	}
+	got2, err := e.getState()
+	if err != nil {
+		t.Fatalf("second getState() error: %v", err)
+	}
+
+	if got1.Hostname != got2.Hostname {
+		t.Errorf("Hostname not idempotent: %q vs %q", got1.Hostname, got2.Hostname)
+	}
+	if got1.Workgroup != got2.Workgroup {
+		t.Errorf("Workgroup not idempotent: %q vs %q", got1.Workgroup, got2.Workgroup)
+	}
+}
+
+// TestWindowsExecutor_WmicWorkgroupParsing verifies that the wmic output
+// parsing correctly extracts the workgroup name from "Workgroup=GROUPNAME"
+// lines (case-insensitive, trims surrounding whitespace and CRLF endings).
+func TestWindowsExecutor_WmicWorkgroupParsing(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "standard workgroup",
+			output: "\r\nWorkgroup=WORKGROUP\r\n",
+			want:   "WORKGROUP",
+		},
+		{
+			name:   "custom workgroup",
+			output: "Workgroup=CORP\r\n",
+			want:   "CORP",
+		},
+		{
+			name:   "empty workgroup",
+			output: "Workgroup=\r\n",
+			want:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Replicate the parsing logic from wmicGetWorkgroup.
+			var got string
+			for _, line := range strings.Split(strings.ReplaceAll(tc.output, "\r\n", "\n"), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(strings.ToUpper(trimmed), "WORKGROUP=") {
+					got = strings.TrimSpace(trimmed[len("WORKGROUP="):])
+					break
+				}
+			}
+			if got != tc.want {
+				t.Errorf("wmicGetWorkgroup parse(%q): got %q, want %q", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+// wmicAvailable returns true when wmic.exe is reachable on this runner.
+func wmicAvailable() bool {
+	return exec.Command("wmic", "computersystem", "get", "Workgroup", "/format:list").Run() == nil
+}
+
+// TestWindowsExecutor_GetState_Integration verifies the full getState round-trip
+// on Windows when wmic.exe is available. Skipped when wmic is absent.
+func TestWindowsExecutor_GetState_Integration(t *testing.T) {
+	if !wmicAvailable() {
+		t.Skip("skipping: wmic not available on this runner")
+	}
+
+	e := &windowsExecutor{
+		getHostname:  os.Hostname,
+		getWorkgroup: wmicGetWorkgroup,
+		setHostname:  netdomRename,
+		setWorkgroup: wmicSetWorkgroup,
+	}
+	state, err := e.getState()
+	if err != nil {
+		t.Fatalf("getState() error: %v", err)
+	}
+
+	if state.Hostname == "" {
+		t.Error("getState() returned empty Hostname")
+	}
+}

--- a/features/modules/stdlib/hostname/module.go
+++ b/features/modules/stdlib/hostname/module.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package hostname implements the CFGMS stdlib hostname module.
+//
+// The module manages the host system name (computer name) and Windows workgroup
+// via the platform executor. The resource ID is system-scoped (one hostname
+// configuration per host); any non-empty resource ID is accepted and refers to
+// the single host-wide identity.
+//
+// This is a declare-once identity module per ADR-016 clause 1: the desired
+// hostname is set once and held, not continuously re-derived. Repeated Set
+// calls with the same desired hostname are idempotent no-ops.
+package hostname
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// hostnamePattern matches valid hostname labels per RFC 952 / RFC 1123.
+// Accepts alphanumeric labels and hyphens; rejects leading/trailing hyphens,
+// empty strings, and control characters.
+var hostnamePattern = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`)
+
+// workgroupPattern matches valid Windows workgroup names (NetBIOS name rules).
+// Accepts alphanumeric characters, hyphens, and underscores; max 15 characters.
+var workgroupPattern = regexp.MustCompile(`^[A-Za-z0-9_\-]{1,15}$`)
+
+// HostnameConfig represents the desired or observed hostname configuration.
+type HostnameConfig struct {
+	// Hostname is the system/computer name of the host.
+	Hostname string `yaml:"hostname"`
+	// Workgroup is the Windows workgroup name. Omitted on Linux and macOS.
+	Workgroup string `yaml:"workgroup,omitempty"`
+}
+
+// AsMap returns the configuration as a map for field-by-field comparison.
+// Workgroup is omitted when empty so that Linux and macOS fragments do not
+// carry a spurious absent-vs-empty distinction (ADR-016 clause 4).
+func (c *HostnameConfig) AsMap() map[string]interface{} {
+	m := map[string]interface{}{
+		"hostname": c.Hostname,
+	}
+	if c.Workgroup != "" {
+		m["workgroup"] = c.Workgroup
+	}
+	return m
+}
+
+// ToYAML serializes the configuration to YAML.
+func (c *HostnameConfig) ToYAML() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// FromYAML deserializes YAML data into the configuration.
+func (c *HostnameConfig) FromYAML(data []byte) error {
+	return yaml.Unmarshal(data, c)
+}
+
+// Validate checks that the configuration is valid before applying it.
+func (c *HostnameConfig) Validate() error {
+	if c.Hostname == "" {
+		return fmt.Errorf("%w: hostname is required", modules.ErrInvalidInput)
+	}
+	if len(c.Hostname) > 253 {
+		return fmt.Errorf("%w: hostname exceeds 253-character limit", modules.ErrInvalidInput)
+	}
+	if !hostnamePattern.MatchString(c.Hostname) {
+		return fmt.Errorf("%w: hostname %q is not a valid host label (RFC 1123: alphanumeric and hyphens, no leading/trailing hyphen)", modules.ErrInvalidInput, c.Hostname)
+	}
+	if c.Workgroup != "" && !workgroupPattern.MatchString(c.Workgroup) {
+		return fmt.Errorf("%w: workgroup %q is not a valid NetBIOS name (alphanumeric, hyphen, underscore; max 15 chars)", modules.ErrInvalidInput, c.Workgroup)
+	}
+	return nil
+}
+
+// GetManagedFields returns the list of fields this configuration manages.
+func (c *HostnameConfig) GetManagedFields() []string {
+	return []string{"hostname", "workgroup"}
+}
+
+// hostnameModule implements modules.Module for host identity configuration.
+type hostnameModule struct {
+	modules.DefaultLoggingSupport
+	executor hostnameExecutor
+}
+
+// New returns a new hostname module instance.
+func New() modules.Module {
+	return &hostnameModule{
+		executor: newExecutor(),
+	}
+}
+
+// Get returns the current hostname configuration of the host.
+// The resource ID is system-scoped; any non-empty value refers to the single
+// host-wide identity configuration.
+func (m *hostnameModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
+	if resourceID == "" {
+		return nil, modules.ErrInvalidResourceID
+	}
+
+	logger := m.GetEffectiveLogger(logging.ForModule("hostname"))
+	tenantID := logging.ExtractTenantFromContext(ctx)
+
+	logger.InfoCtx(ctx, "Getting hostname configuration",
+		"operation", "hostname_get",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"tenant_id", tenantID,
+		"resource_type", "hostname")
+
+	state, err := m.executor.getState()
+	if err != nil {
+		logger.ErrorCtx(ctx, "Failed to get hostname configuration",
+			"operation", "hostname_get",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"error_code", "HOSTNAME_GET_FAILED",
+			"error_details", logging.SanitizeLogValue(err.Error()))
+		return nil, err
+	}
+
+	config := &HostnameConfig{
+		Hostname:  state.Hostname,
+		Workgroup: state.Workgroup,
+	}
+
+	logger.InfoCtx(ctx, "Hostname configuration retrieved",
+		"operation", "hostname_get",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"status", "completed")
+
+	return config, nil
+}
+
+// Set applies the desired hostname configuration to the host.
+// Repeated calls with the same desired configuration are idempotent no-ops —
+// important for declare-once identity semantics (ADR-016 clause 1).
+func (m *hostnameModule) Set(ctx context.Context, resourceID string, config modules.ConfigState) error {
+	if resourceID == "" {
+		return modules.ErrInvalidResourceID
+	}
+	if config == nil {
+		return fmt.Errorf("%w: config must not be nil", modules.ErrInvalidInput)
+	}
+
+	hc, ok := config.(*HostnameConfig)
+	if !ok {
+		return fmt.Errorf("%w: expected *HostnameConfig, got %T", modules.ErrInvalidInput, config)
+	}
+
+	if err := hc.Validate(); err != nil {
+		return err
+	}
+
+	logger := m.GetEffectiveLogger(logging.ForModule("hostname"))
+	tenantID := logging.ExtractTenantFromContext(ctx)
+
+	logger.InfoCtx(ctx, "Setting hostname configuration",
+		"operation", "hostname_set",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"tenant_id", tenantID,
+		"resource_type", "hostname")
+
+	// Idempotency: skip the write if the host is already in the desired state.
+	// This is especially important for declare-once identity modules — repeated
+	// applies must not trigger reboots or rename churn (ADR-016 clause 1).
+	current, err := m.executor.getState()
+	if err == nil && current.Hostname == hc.Hostname && current.Workgroup == hc.Workgroup {
+		logger.InfoCtx(ctx, "Hostname already matches desired state; no-op",
+			"operation", "hostname_set",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"status", "no-op")
+		return nil
+	}
+
+	desired := hostnameState{
+		Hostname:  hc.Hostname,
+		Workgroup: hc.Workgroup,
+	}
+
+	if err := m.executor.setState(desired); err != nil {
+		logger.ErrorCtx(ctx, "Failed to set hostname configuration",
+			"operation", "hostname_set",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"error_code", "HOSTNAME_SET_FAILED",
+			"error_details", logging.SanitizeLogValue(err.Error()))
+		return err
+	}
+
+	logger.InfoCtx(ctx, "Hostname configuration applied",
+		"operation", "hostname_set",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"status", "completed")
+
+	return nil
+}

--- a/features/modules/stdlib/hostname/module.yaml
+++ b/features/modules/stdlib/hostname/module.yaml
@@ -1,0 +1,48 @@
+name: hostname
+version: 0.1.0
+description: >
+  Manages the host system name (computer name) and workgroup (Windows-only).
+  Provides idempotent Get/Set management of the host identity: reading and
+  writing the machine name via in-process OS APIs on Linux (os.Hostname /
+  syscall.Sethostname + /etc/hostname), scutil on macOS, and wmic/netdom on
+  Windows. Workgroup is a Windows-only field; it is absent on Linux and macOS
+  fragments. This is a declare-once identity module per ADR-016 clause 1 —
+  the desired hostname is set once and held, not continuously re-derived.
+
+publisher: cfgms
+
+# Supported execution environments
+executors:
+  - steward  # Local system-name management on steward systems
+
+requirements:
+  os: [windows, linux, darwin]
+  arch: [amd64, arm64]
+  min_memory: "32MB"
+  min_disk: "1MB"
+
+interfaces:
+  - Get
+  - Set
+
+owns:
+  - kind: hostname  # authority over hostname:* objects this module manages
+
+security:
+  requires_root: true  # writing /etc/hostname and syscall.Sethostname require root on Linux; scutil requires admin on macOS; wmic/netdom require admin on Windows
+  capabilities: []
+  ports: []
+
+behavioral_envelope:
+  shells_out_to:
+    - scutil        # macOS: computer name and hostname management
+    - wmic.exe      # Windows: workgroup read (computersystem get Workgroup) and set
+    - netdom.exe    # Windows: hostname rename (renamecomputer)
+  reads_paths:
+    - /etc/hostname  # Linux: current hostname (one-line FQDN or short name)
+  writes_paths:
+    - /etc/hostname  # Linux: desired hostname (written before runtime syscall apply)
+
+documentation:
+  api: "docs/modules/hostname.md"
+  examples: "docs/modules/hostname.md"

--- a/features/modules/stdlib/hostname/module_test.go
+++ b/features/modules/stdlib/hostname/module_test.go
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hostname
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/modules/conformance"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestHostnameModule_New verifies the module constructor returns a non-nil Module.
+func TestHostnameModule_New(t *testing.T) {
+	m := New()
+	if m == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+// TestHostnameConfig_Validate covers valid and invalid configurations.
+func TestHostnameConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  HostnameConfig
+		wantErr bool
+	}{
+		{
+			name:    "simple hostname is valid",
+			config:  HostnameConfig{Hostname: "myhost"},
+			wantErr: false,
+		},
+		{
+			name:    "hostname with hyphen is valid",
+			config:  HostnameConfig{Hostname: "my-host"},
+			wantErr: false,
+		},
+		{
+			name:    "hostname with digits is valid",
+			config:  HostnameConfig{Hostname: "host01"},
+			wantErr: false,
+		},
+		{
+			name:    "empty hostname is invalid",
+			config:  HostnameConfig{Hostname: ""},
+			wantErr: true,
+		},
+		{
+			name:    "hostname with leading hyphen is invalid",
+			config:  HostnameConfig{Hostname: "-badhost"},
+			wantErr: true,
+		},
+		{
+			name:    "hostname with trailing hyphen is invalid",
+			config:  HostnameConfig{Hostname: "badhost-"},
+			wantErr: true,
+		},
+		{
+			name:    "hostname with space is invalid",
+			config:  HostnameConfig{Hostname: "bad host"},
+			wantErr: true,
+		},
+		{
+			name:    "hostname with newline injection is invalid",
+			config:  HostnameConfig{Hostname: "host\nevil"},
+			wantErr: true,
+		},
+		{
+			name:    "valid hostname with workgroup is valid",
+			config:  HostnameConfig{Hostname: "myhost", Workgroup: "WORKGROUP"},
+			wantErr: false,
+		},
+		{
+			name:    "workgroup with special chars is invalid",
+			config:  HostnameConfig{Hostname: "myhost", Workgroup: "WORK GROUP"},
+			wantErr: true,
+		},
+		{
+			name:    "workgroup too long is invalid",
+			config:  HostnameConfig{Hostname: "myhost", Workgroup: "TOOLONGWORKGROUP"},
+			wantErr: true,
+		},
+		{
+			name:    "workgroup with hyphen and underscore is valid",
+			config:  HostnameConfig{Hostname: "myhost", Workgroup: "MY_WG-1"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestHostnameConfig_AsMap verifies AsMap returns expected keys and values.
+func TestHostnameConfig_AsMap(t *testing.T) {
+	t.Run("hostname only (no workgroup)", func(t *testing.T) {
+		cfg := &HostnameConfig{Hostname: "myhost"}
+		m := cfg.AsMap()
+
+		got, ok := m["hostname"]
+		if !ok {
+			t.Error("AsMap() missing key \"hostname\"")
+		} else if got != "myhost" {
+			t.Errorf("AsMap()[\"hostname\"] = %v, want \"myhost\"", got)
+		}
+
+		if _, ok := m["workgroup"]; ok {
+			t.Error("AsMap() must not include \"workgroup\" when empty (Linux/macOS fragment)")
+		}
+	})
+
+	t.Run("hostname with workgroup (Windows fragment)", func(t *testing.T) {
+		cfg := &HostnameConfig{Hostname: "myhost", Workgroup: "WORKGROUP"}
+		m := cfg.AsMap()
+
+		if got := m["hostname"]; got != "myhost" {
+			t.Errorf("AsMap()[\"hostname\"] = %v, want \"myhost\"", got)
+		}
+		if got := m["workgroup"]; got != "WORKGROUP" {
+			t.Errorf("AsMap()[\"workgroup\"] = %v, want \"WORKGROUP\"", got)
+		}
+	})
+}
+
+// TestHostnameConfig_AsMap_WorkgroupAbsentWhenEmpty verifies the key is
+// completely absent (not an empty string) when workgroup is unset — this
+// prevents a spurious cross-platform field-presence difference in DNA
+// fragments (ADR-016 clause 4).
+func TestHostnameConfig_AsMap_WorkgroupAbsentWhenEmpty(t *testing.T) {
+	cfg := &HostnameConfig{Hostname: "server01", Workgroup: ""}
+	m := cfg.AsMap()
+	if _, ok := m["workgroup"]; ok {
+		t.Error("AsMap() must not include workgroup key when Workgroup is empty")
+	}
+}
+
+// TestHostnameConfig_YAMLRoundTrip verifies ToYAML and FromYAML are inverse operations.
+func TestHostnameConfig_YAMLRoundTrip(t *testing.T) {
+	original := &HostnameConfig{
+		Hostname:  "webserver-01",
+		Workgroup: "CORP",
+	}
+
+	data, err := original.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error: %v", err)
+	}
+
+	decoded := &HostnameConfig{}
+	if err := decoded.FromYAML(data); err != nil {
+		t.Fatalf("FromYAML() error: %v", err)
+	}
+
+	if decoded.Hostname != original.Hostname {
+		t.Errorf("Hostname: got %q, want %q", decoded.Hostname, original.Hostname)
+	}
+	if decoded.Workgroup != original.Workgroup {
+		t.Errorf("Workgroup: got %q, want %q", decoded.Workgroup, original.Workgroup)
+	}
+}
+
+// TestHostnameConfig_GetManagedFields verifies the fields reported as managed.
+func TestHostnameConfig_GetManagedFields(t *testing.T) {
+	config := &HostnameConfig{Hostname: "myhost"}
+	fields := config.GetManagedFields()
+
+	required := map[string]bool{
+		"hostname":  false,
+		"workgroup": false,
+	}
+	for _, f := range fields {
+		required[f] = true
+	}
+	for field, found := range required {
+		if !found {
+			t.Errorf("GetManagedFields() missing required field %q", field)
+		}
+	}
+}
+
+// TestHostnameModule_Get_EmptyResourceID verifies Get rejects an empty resource ID.
+func TestHostnameModule_Get_EmptyResourceID(t *testing.T) {
+	m := New()
+	_, err := m.Get(context.Background(), "")
+	if err == nil {
+		t.Error("Get() with empty resource ID must return an error")
+	}
+}
+
+// TestHostnameModule_Set_InvalidInputs verifies Set rejects empty resource IDs and nil configs.
+func TestHostnameModule_Set_InvalidInputs(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	validConfig := &HostnameConfig{Hostname: "myhost"}
+
+	if err := m.Set(ctx, "", validConfig); err == nil {
+		t.Error("Set() with empty resource ID must return an error")
+	}
+
+	if err := m.Set(ctx, "system", nil); err == nil {
+		t.Error("Set() with nil config must return an error")
+	}
+}
+
+// TestHostnameModule_Set_InvalidHostname verifies Set rejects configs with an empty hostname.
+func TestHostnameModule_Set_InvalidHostname(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	badConfig := &HostnameConfig{Hostname: ""}
+	if err := m.Set(ctx, "system", badConfig); err == nil {
+		t.Error("Set() with empty hostname must return an error")
+	}
+}
+
+// TestHostnameModule_Set_WrongConfigType verifies Set rejects configs of the wrong type.
+func TestHostnameModule_Set_WrongConfigType(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	wrongCfg := &wrongConfigType{}
+	if err := m.Set(ctx, "system", wrongCfg); err == nil {
+		t.Error("Set() with wrong config type must return an error")
+	}
+}
+
+// wrongConfigType implements modules.ConfigState but is not *HostnameConfig.
+type wrongConfigType struct{}
+
+func (w *wrongConfigType) AsMap() map[string]interface{}  { return nil }
+func (w *wrongConfigType) ToYAML() ([]byte, error)        { return nil, nil }
+func (w *wrongConfigType) FromYAML(_ []byte) error        { return nil }
+func (w *wrongConfigType) Validate() error                { return nil }
+func (w *wrongConfigType) GetManagedFields() []string     { return nil }
+
+// TestHostnameModule_LoggingInjection verifies the module implements LoggingInjectable.
+func TestHostnameModule_LoggingInjection(t *testing.T) {
+	m := New()
+
+	injectable, ok := m.(modules.LoggingInjectable)
+	if !ok {
+		t.Fatal("New() must return a value implementing modules.LoggingInjectable")
+	}
+
+	_, injected := injectable.GetLogger()
+	if injected {
+		t.Error("GetLogger() must return injected=false before SetLogger is called")
+	}
+
+	testLogger := logging.ForModule("hostname-test")
+	if err := injectable.SetLogger(testLogger); err != nil {
+		t.Fatalf("SetLogger() returned unexpected error: %v", err)
+	}
+
+	got, injected := injectable.GetLogger()
+	if !injected {
+		t.Error("GetLogger() must return injected=true after SetLogger succeeds")
+	}
+	if got == nil {
+		t.Error("GetLogger() must return a non-nil logger after SetLogger")
+	}
+
+	if err := injectable.SetLogger(nil); err == nil {
+		t.Error("SetLogger(nil) must return an error")
+	}
+}
+
+// TestHostnameModule_ConformanceDeterministicGet verifies that Get produces
+// byte-for-byte identical output on consecutive calls (ADR-016 clause 4).
+func TestHostnameModule_ConformanceDeterministicGet(t *testing.T) {
+	m := New()
+	state, err := m.Get(context.Background(), "system")
+	if err != nil {
+		if errors.Is(err, modules.ErrUnsupportedPlatform) {
+			t.Skipf("skipping conformance test: Get unsupported on this platform: %v", err)
+		}
+		t.Fatalf("Get(\"system\") returned unexpected error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Get(\"system\") returned nil state with nil error")
+	}
+	conformance.AssertDeterministicGet(t, m, "system")
+}
+
+// TestHostnameModule_ConformanceNoEphemeralFields verifies that HostnameConfig
+// returned by Get() contains no banned ephemeral fields (ADR-016 clause 4).
+func TestHostnameModule_ConformanceNoEphemeralFields(t *testing.T) {
+	m := New()
+	state, err := m.Get(context.Background(), "system")
+	if err != nil {
+		if errors.Is(err, modules.ErrUnsupportedPlatform) {
+			t.Skipf("skipping: Get unsupported on this platform: %v", err)
+		}
+		t.Fatalf("Get(\"system\") returned unexpected error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Get(\"system\") returned nil state with nil error")
+	}
+	conformance.AssertNoEphemeralFields(t, state, conformance.DefaultBannedEphemeralFields)
+}

--- a/features/steward/factory/factory.go
+++ b/features/steward/factory/factory.go
@@ -46,6 +46,7 @@ import (
 	cert_trust_module "github.com/cfgis/cfgms/features/modules/stdlib/cert_trust"
 	"github.com/cfgis/cfgms/features/modules/stdlib/file"
 	"github.com/cfgis/cfgms/features/modules/stdlib/firewall"
+	hostname_module "github.com/cfgis/cfgms/features/modules/stdlib/hostname"
 	package_module "github.com/cfgis/cfgms/features/modules/stdlib/package"
 	"github.com/cfgis/cfgms/features/modules/stdlib/patch"
 	"github.com/cfgis/cfgms/features/modules/stdlib/script"
@@ -184,6 +185,7 @@ var builtinModuleConstructors = map[string]func() modules.Module{
 	"file":          func() modules.Module { return file.New() },
 	"firewall":      func() modules.Module { return firewall.New() },
 	"github_runner": func() modules.Module { return github_runner_module.New() },
+	"hostname":      func() modules.Module { return hostname_module.New() },
 	"package":       func() modules.Module { return package_module.New() },
 	"patch":         func() modules.Module { return patch.New() },
 	"script":        func() modules.Module { return script.New() },

--- a/features/steward/factory/factory_test.go
+++ b/features/steward/factory/factory_test.go
@@ -223,7 +223,7 @@ func TestGetModuleInfo(t *testing.T) {
 
 func TestAllBuiltinModulesLoad(t *testing.T) {
 	factory := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail}, logging.NewNoopLogger())
-	for _, name := range []string{"acme", "cert_trust", "directory", "file", "firewall", "github_runner", "hyperv", "package", "patch", "script", "time", "user"} {
+	for _, name := range []string{"acme", "cert_trust", "directory", "file", "firewall", "github_runner", "hostname", "hyperv", "package", "patch", "script", "time", "user"} {
 		mod, err := factory.LoadModule(name)
 		assert.NoError(t, err, "built-in module %q must load without error", name)
 		assert.NotNil(t, mod, "built-in module %q must not be nil", name)


### PR DESCRIPTION
Fixes #2477

Agent session failed with exit code 1. Review container logs for details.