### PR TITLE
ci: split heavy CI suites between pull_request and merge_group (Issue #2595)

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -15,6 +15,12 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Never cancel an in-flight merge_group run — only PR pushes cancel their own
+# workflow's prior run (#2595).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   GO_VERSION: '1.26.5'
 
@@ -22,12 +28,17 @@ permissions: {}
 
 jobs:
   # Fast cross-compilation check (single runner, all platforms)
+  # PR-REAL (#2595): fast single-runner compile check across all targets — cheap
+  # and deterministic on the diff. Native per-platform builds and Docker
+  # integration tests are queue-only (below); this job alone backs the PR-time
+  # Build Gate stub.
   cross-compile-check:
     name: Cross-Platform Compilation Check
     permissions:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
@@ -86,6 +97,10 @@ jobs:
             platform: Windows
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    # QUEUE-REAL (#2595): the 3-platform native build+test matrix is the
+    # fleet's most expensive suite — validated once against the merge commit
+    # rather than paying for it twice per PR.
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
@@ -140,12 +155,14 @@ jobs:
         retention-days: 5
 
   # Integration tests with Docker infrastructure (Linux only)
+  # QUEUE-REAL (#2595): Docker-heavy, validated once against the merge commit.
   integration-tests:
     name: Integration Tests (Docker)
     permissions:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
@@ -223,31 +240,65 @@ jobs:
       if: always()
       run: make test-integration-cleanup
 
-  # Integration gate - all platforms must succeed
+  # PR-time stub for the `Build Gate` required context (#2595). Real per-PR
+  # signal comes from cross-compile-check (fast compile validation); native
+  # multi-platform builds and Docker integration tests are queue-only (below) —
+  # running the fleet's most expensive suite twice per PR bought no additional
+  # coverage once the queue re-validates the merge commit.
+  build-gate-pr-stub:
+    name: Build Gate
+    permissions: {}
+    needs: [cross-compile-check]
+    runs-on: ubuntu-latest
+    if: always() && github.event_name == 'pull_request'
+    steps:
+    - name: Check PR-time Build Results
+      run: |
+        echo "## Build Gate Results (PR)" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        cross_compile="${{ needs.cross-compile-check.result }}"
+
+        echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+        echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+        echo "| Cross-Compile Check | $cross_compile |" >> $GITHUB_STEP_SUMMARY
+        echo "| Native Builds + Docker Integration | deferred to merge queue |" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        if [[ "$cross_compile" == "success" ]]; then
+          echo "### BUILD GATE PASSED (PR stub)" >> $GITHUB_STEP_SUMMARY
+          echo "Cross-compilation validated. Native builds and Docker integration tests run for real in the merge queue (#2595)." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "### BUILD GATE FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "Cross-compilation check failed." >> $GITHUB_STEP_SUMMARY
+          exit 1
+        fi
+
+  # QUEUE-REAL (#2595): the authoritative Build Gate — native multi-platform
+  # builds and Docker integration tests validate the actual merge commit here,
+  # not on every PR push. Mutually exclusive with the PR stub above by event.
   build-gate:
     name: Build Gate
     permissions: {}
-    needs: [cross-compile-check, native-builds, integration-tests]
+    needs: [native-builds, integration-tests]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     steps:
     - name: Check Build Results
       run: |
         echo "## Build Gate Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        cross_compile="${{ needs.cross-compile-check.result }}"
         native="${{ needs.native-builds.result }}"
         integration="${{ needs.integration-tests.result }}"
 
         echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
         echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-        echo "| Cross-Compile Check | $cross_compile |" >> $GITHUB_STEP_SUMMARY
         echo "| Native Builds | $native |" >> $GITHUB_STEP_SUMMARY
         echo "| Integration Tests | $integration |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        if [[ "$cross_compile" == "success" && "$native" == "success" && "$integration" == "success" ]]; then
+        if [[ "$native" == "success" && "$integration" == "success" ]]; then
           echo "### BUILD GATE PASSED" >> $GITHUB_STEP_SUMMARY
           echo "All platforms build and test successfully." >> $GITHUB_STEP_SUMMARY
         else

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -263,18 +263,6 @@ jobs:
           echo "   Skipping controller integration tests (no code changes)"
           echo "   No controller test validation required for docs-only changes"
 
-  fleet-e2e-tests:
-    name: fleet-e2e-tests
-    permissions: {}
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    steps:
-      - name: Docs-only fleet E2E validation
-        run: |
-          echo "✅ Documentation-only PR detected"
-          echo "   Skipping fleet E2E tests (no code changes)"
-          echo "   No fleet test validation required for docs-only changes"
-
   # QUEUE-REAL context (#2595): the real trivy-scan runs in the merge queue
   # (security-scan.yml). This stub only covers docs-only PRs; it must NOT fire on
   # merge_group. (Code PRs are covered by security-scan.yml's trivy-scan-pr-stub.)

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -28,6 +28,12 @@ on:
         required: false
         type: string
 
+# Never cancel an in-flight merge_group run — only PR pushes cancel their own
+# workflow's prior run (#2595).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:
@@ -408,11 +414,17 @@ jobs:
   #         fi
 
   #   # Cross-platform integration testing
+  # QUEUE-REAL (#2595): Docker-heavy controller integration suite (Buildx +
+  # image build) validated once against the merge commit rather than paying
+  # for it twice per PR. The `Controller Integration Tests (Linux)` required
+  # context is posted on PRs by the lightweight PR-stub job below (code PRs)
+  # and by documentation.yml (docs-only PRs).
   integration-tests-controller:
     name: Controller Integration Tests (Linux)
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
@@ -499,10 +511,27 @@ jobs:
       run: |
         docker compose -f docker-compose.test.yml down -v || true
 
+  # PR-time stub for the `Controller Integration Tests (Linux)` required context
+  # (#2595). The real suite runs in the merge queue (job above); this posts the
+  # required check green on code PRs.
+  integration-tests-controller-pr-stub:
+    name: Controller Integration Tests (Linux)
+    permissions: {}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: PR-time stub (real integration tests run in the merge queue)
+        run: |
+          echo "Controller Integration Tests (Linux): real Docker-based suite runs in the merge queue (merge_group) per #2595."
+          echo "This PR-time stub posts the required context; the authoritative run validates the merge commit."
+
+  # QUEUE-REAL (#2595): not a required context, but a 3-platform matrix — moved
+  # off pull_request so it isn't paid for twice per PR.
   integration-tests-steward:
     name: Steward Integration Tests
     permissions:
       contents: read
+    if: github.event_name == 'merge_group' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -564,12 +593,15 @@ jobs:
           go test -v -timeout=5m ./features/terminal/... -run "TestUnixShells"
         fi
 
+  # QUEUE-REAL (#2595): not a required context; depends on the real
+  # integration-tests-controller run, so matches its event condition.
   comprehensive-e2e-tests:
     name: Comprehensive E2E Testing
     permissions:
       contents: read
     runs-on: ubuntu-latest
     needs: [integration-tests-controller]
+    if: github.event_name == 'merge_group' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,6 +29,12 @@ on:
         - full
         - remediation-report
 
+# Never cancel an in-flight merge_group run — only PR pushes cancel their own
+# workflow's prior run (#2595).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   GO_VERSION: '1.26.5'
 
@@ -120,11 +126,15 @@ jobs:
         echo "❌ Trivy scan found CRITICAL/HIGH vulnerabilities — see scan output above"
         exit 1
 
+  # PR-REAL (#2595): advisory, non-required static analysis — fast, cheap, and
+  # deterministic on the diff. Developer/agent feedback matters more here than
+  # re-validating an unchanged dependency graph against the merge commit.
   nancy-scan:
     permissions:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     outputs:
       status: ${{ steps.scan.outputs.status }}
       issues-found: ${{ steps.scan.outputs.issues-found }}
@@ -164,11 +174,13 @@ jobs:
           echo "issues-found=true" >> $GITHUB_OUTPUT
         fi
 
+  # PR-REAL (#2595): advisory, non-required — see nancy-scan comment above.
   gosec-scan:
     permissions:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     outputs:
       status: ${{ steps.scan.outputs.status }}
       issues-found: ${{ steps.scan.outputs.issues-found }}
@@ -241,11 +253,13 @@ jobs:
         path: sarif-results/
         retention-days: 30
 
+  # PR-REAL (#2595): advisory, non-required — see nancy-scan comment above.
   staticcheck-scan:
     permissions:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     outputs:
       status: ${{ steps.scan.outputs.status }}
       issues-found: ${{ steps.scan.outputs.issues-found }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,6 +29,12 @@ on:
         - all
         - full
 
+# Never cancel an in-flight merge_group run — only PR pushes cancel their own
+# workflow's prior run (#2595).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   GO_VERSION: '1.26.5'
 
@@ -40,9 +46,15 @@ jobs:
   # 193–433s under merge-queue burst; hosted exec ~15% faster (511s vs 610s).
   # Moving unit-tests to hosted frees self-hosted pool capacity for
   # integration-tests where self-hosted exec is 2–3.5× faster than hosted.
+  # PR-REAL (#2595): unit tests are fast, cheap, and deterministic on the diff
+  # itself — real per-PR feedback matters more than re-validating against the
+  # merge commit. The merge queue gets a lightweight stub (below); docs-only
+  # PRs/queue entries are covered by documentation.yml's own stub instead (this
+  # workflow is paths-ignored for docs).
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -101,7 +113,30 @@ jobs:
         path: resource-samples-unit-tests.txt
         retention-days: 30
 
-  # Integration tests - runs on PRs to develop/main, workflow_dispatch, or push to main
+  # PR-time stub for the `unit-tests` required context on merge_group entries
+  # (code PRs). The real per-PR run above already validated this diff for real;
+  # this just posts the required context without re-running the fast suite a
+  # second time per queue entry.
+  unit-tests-mq-stub:
+    name: unit-tests
+    permissions: {}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group'
+    steps:
+      - name: Merge-queue stub (real run already validated this diff on the PR)
+        run: |
+          echo "unit-tests: already validated for real on the source PR (#2595)."
+          echo "This merge-queue stub posts the required context without paying for the fast suite twice."
+
+  # Integration tests - QUEUE-REAL (#2595): the real `make test-production-critical`
+  # run is queue-only (merge_group) and on push to main/workflow_dispatch — NOT on
+  # pull_request. This also fixes a live bug: the prior condition never matched
+  # `merge_group`, so the required `integration-tests` context was silently
+  # skipping (and passing) on every merge-queue entry — production-critical tests
+  # were never actually validated against a real merge commit. The PR-time stub
+  # (below) posts the required context on code PRs; docs-only PRs/queue entries
+  # are covered by documentation.yml's own stub instead (this workflow is
+  # paths-ignored for docs).
   #
   # runs-on routing (#2337, epic #565): fork-gated self-hosted routing — internal
   # events (push, merge_group, non-fork pull_request) run on the CFGMS-managed
@@ -129,7 +164,7 @@ jobs:
     # golang image lacks but hosted runners ship (jq for the script tests).
     container: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.event_name == 'workflow_dispatch') && 'null' || '{"image":"golang:1.26.5-bookworm","options":"--user 1000:1000 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v /opt/ci-tools:/opt/ci-tools:ro"}') }}
     timeout-minutes: 25
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || github.ref == 'refs/heads/main'
     needs: unit-tests
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -192,6 +227,20 @@ jobs:
         name: resource-samples-integration-tests
         path: resource-samples-integration-tests.txt
         retention-days: 30
+
+  # PR-time stub for the `integration-tests` required context (#2595). The real
+  # run is queue-only (job above) — it validates `make test-production-critical`
+  # against the merge commit rather than paying for it twice per PR.
+  integration-tests-pr-stub:
+    name: integration-tests
+    permissions: {}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: PR-time stub (real run happens in the merge queue)
+        run: |
+          echo "integration-tests: real production-critical suite runs in the merge queue (merge_group) per #2595."
+          echo "This PR-time stub posts the required context; the authoritative run validates the merge commit."
 
   # Cross-feature integration tests - chunked for efficiency
   cross-feature-tests:
@@ -355,8 +404,10 @@ jobs:
         
         if [[ "${{ needs.integration-tests.result }}" == "success" ]]; then
           echo "✅ **Integration Tests**: Passed" >> $GITHUB_STEP_SUMMARY
+        elif [[ "${{ needs.integration-tests.result }}" == "skipped" ]]; then
+          echo "⏭️ **Integration Tests**: Deferred to merge queue (#2595)" >> $GITHUB_STEP_SUMMARY
         else
-          echo "❌ **Integration Tests**: Failed or Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "❌ **Integration Tests**: Failed" >> $GITHUB_STEP_SUMMARY
         fi
         
         echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Founder-held story #2595 (marked \`founder-held\` / Founder Validation Hold — silent-failure risk that can only be caught watching real PRs/merge-group entries). Implemented directly in an inline founder session per the story's own execution model.

- Each of `test-suite.yml`, `production-gates.yml`, `cross-platform-build.yml`, `security-scan.yml` now runs its heavy jobs on exactly one of `pull_request` or `merge_group`, with an in-file rationale comment, following the `fleet-e2e.yml` precedent and the `security-deployment-gate`/`trivy-scan` split already landed via #2606.
  - PR-real (fast/cheap/deterministic on the diff): `unit-tests`, `cross-compile-check`, advisory static analysis (`nancy-scan`, `gosec-scan`, `staticcheck-scan`)
  - Queue-real (Docker/multi-platform-heavy, validates the actual merge commit): `integration-tests` (test-suite.yml), `native-builds`, `integration-tests` (Docker, cross-platform-build.yml), `Controller Integration Tests (Linux)`
  - Each queue-real required check gets a PR-time stub posting the same context name (mirroring the existing `security-deployment-gate-pr-stub`/`trivy-scan-pr-stub` pattern)
- **Fixes a live bug found while implementing this**: `test-suite.yml`'s `integration-tests` job had an `if:` condition that never matched `merge_group` — the required `integration-tests` context was silently skipping (and therefore passing) on every merge-queue entry. `make test-production-critical` was never actually validated against a real merge commit until this PR.
- `Build Gate` is split into a PR-time stub (gated on `cross-compile-check` only) and the queue-real aggregator (gated on `native-builds` + `integration-tests`), since its dependencies now run on different events.
- All four workflows get a `concurrency` group keyed so `merge_group` runs are never cancelled by a superseding PR push.
- Deletes `documentation.yml`'s stale `fleet-e2e-tests` stub — verified via the GitHub API that `fleet-e2e-tests` isn't a required check on the develop/main/release rulesets.

## Deferred (explicit follow-up, not silently folded in)

The story's 2026-07-12 scope addendum also asks to add `fleet-e2e-tests` to the develop ruleset's required checks. That needs its own new PR-time stub in `fleet-e2e.yml` first (or every code PR gets a permanently-"Expected" check and the queue stalls) — and doing so would override this story's own original "Out of Scope: do not change fleet-e2e.yml" line. Holding that as a separate explicit decision with the founder rather than bundling it into this PR.

## Test plan

- [x] `actionlint` clean on all 5 edited workflow files
- [x] `make test` passes (211/0)
- [ ] Real PR (this one) shows every required check reporting to completion — watching live
- [ ] Real merge-group entry (once this PR is approved and enqueued) shows every required check reporting to completion — watching live
- [ ] Security Engineer review
- [ ] Before/after job-count-per-queue-entry and wall-clock queue time, measured under real merge-group load, posted as a PR comment

Fixes #2595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKyK8EREmXMbF6W13PGERE