### PR TITLE
ci: fix integration-tests silently skipping on merge_group (Issue #2595)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -164,7 +164,12 @@ jobs:
     # golang image lacks but hosted runners ship (jq for the script tests).
     container: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.event_name == 'workflow_dispatch') && 'null' || '{"image":"golang:1.26.5-bookworm","options":"--user 1000:1000 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v /opt/ci-tools:/opt/ci-tools:ro"}') }}
     timeout-minutes: 25
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || github.ref == 'refs/heads/main'
+    # always() is required here: unit-tests is intentionally skipped on
+    # merge_group (PR-real design above), and GitHub's default implicit
+    # `needs` gate treats "skipped" as not-satisfied — without always(), this
+    # job would itself silently skip on merge_group despite its own event
+    # condition matching, recreating the exact bug this split was meant to fix.
+    if: always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || github.ref == 'refs/heads/main')
     needs: unit-tests
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## Summary

Follow-up to #2696, which just merged. That PR's merge_group CI run caught this live before I could land the fix in time — the merge queue auto-merged #2696 as soon as its required checks reported (a skipped check counts as passing), which happened before this fix commit could reach it.

`integration-tests` (test-suite.yml) is queue-real by #2696's design — it's supposed to run for real on `merge_group`. But it has `needs: unit-tests`, and `unit-tests` is *intentionally skipped* on `merge_group` (it's PR-real). GitHub's default implicit `needs` gate treats a skipped dependency as not-satisfied for any `if:` condition that doesn't explicitly reference `always()`/`success()`/`failure()`/`cancelled()` — so `integration-tests` was itself silently skipping on merge_group despite its own event condition matching, reproducing the exact silent-skip bug #2696 was written to fix, for a different underlying mechanical reason.

Confirmed live on PR #2696's own merge_group run before it merged: `unit-tests` → skipped (by design), `integration-tests` → skipped (this bug). The required check still reported "passing" (GitHub treats skip as satisfying required status checks), but `make test-production-critical` still never validated the merge commit — currently true on develop right now until this lands.

Fix: add `always() &&` to the job's `if:` condition, matching the pattern already used correctly in `cross-platform-build.yml`'s split `Build Gate` job.

## Test plan

- [x] `actionlint` clean
- [x] `make test` passes (211/0)
- [ ] Watching this PR's own merge_group run to confirm `integration-tests` now shows `success`, not `skipped`

Related to #2595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKyK8EREmXMbF6W13PGERE