### PR TITLE
hyperv: idiomatic Layer-2 cluster.cfg cascade e2e — CNO-only convergence + declarative FC placement (Issue #2577)

### DIFF
--- a/docs/testing/hyperv-cluster-cascade-runbook.md
+++ b/docs/testing/hyperv-cluster-cascade-runbook.md
@@ -133,7 +133,164 @@ from a VM that is still in config — is the separate, role-only path proven by 
 
 ---
 
-## 4. Cleanup / recovery
+## 4. Layer 2 — idiomatic, controller-driven validation (#2577)
+
+Section 3 above is observed manually. **Layer 2** makes the idiomatic path a
+first-class validation: config is authored at the tenant/cluster scope, cascaded
+by the controller, read by every member, with only the CNO acting — driven
+through **cfgms config + the `cfg` admin CLI**, never `module.Set` and never raw
+cluster cmdlets for anything under test (placement/membership). Raw cluster
+cmdlets are used ONLY to observe, and OS tools ONLY to inject load.
+
+### 4.1 Automated idiomatic suite
+
+`test/e2e/hyperv/cluster_cascade_idiomatic_test.go` (build tag `e2e`, package
+`hyperv_e2e`) drives the controller with the `cfg` CLI and observes each member's
+effective config + the live cluster. It reuses the Layer-1 harness (`ccVMInstances`
+et al.) and skips cleanly when the idiomatic controls are unset.
+
+```powershell
+# On a cfg-lab member node, elevated (cluster admin) or via the SYSTEM exec channel:
+$env:CFGMS_E2E_HYPERV_CLUSTER = 'cfg-lab'
+$env:CFGMS_E2E_CFG_BIN        = 'C:\git\cfgms\bin\cfg-dev.exe'
+$env:CFGMS_E2E_ADMIN_BUNDLE   = 'C:\Users\cfg\admin.bundle.yaml'   # or CFGMS_ADMIN_BUNDLE
+$env:CFGMS_E2E_MEMBER_IDS     = 'steward-1780659937223058807,steward-1782769671586775983,steward-1782769748587622286'
+# Optional (defaults shown): CFGMS_E2E_HAROLE_VM=cfgms-e2e-ha-01, CFGMS_E2E_ROLE_TAG=e2e-ha-cluster
+go test -tags e2e -v -run TestIdiomatic -timeout 20m ./test/e2e/hyperv/...
+```
+
+| Test | Drives (idiomatic) | Asserts |
+|------|--------------------|---------|
+| `TestIdiomaticCascade_IdenticalAcrossMembersSingleCreate` | reads each member's `cfg config show` | the cascaded `ha_role` VM is **identical** across all 3 members' effective config; exactly **one** VM cluster-wide (CNO create, no duplicate) |
+| `TestIdiomaticPlacement_DeclaredConfigReflectedLive` | reads the CNO's effective `hyperv.cluster` `roles.<vm>` | the LIVE cluster reflects the declared `preferred_owners` (group owners, ordered), `possible_owners` (resource owners, set), `anti_affinity_class` (group class) |
+| `TestIdiomaticLeave_DropsDefinitionKeepsVM` | `cfg steward tag rm` on a non-owner member | the VM definition **drops** from that member's effective config; the still-clustered VM is **NOT deleted** (single instance survives on its owner) |
+
+The suite never authors the VM or its placement (those are under test); a bed that
+has not been cascaded-in yet **skips** with a pointer here, rather than creating it.
+
+### 4.2 Idiomatic cascade-in + single CNO create (AC1)
+
+Authored as a role config whose selector is a tag on every member:
+
+```bash
+cfg role create e2e-ha-cluster --tenant infra-hyperv --selector "tag:e2e-ha-cluster" --config ha-vm.yaml
+cfg steward tag add <each member steward-id> e2e-ha-cluster
+# ha-vm.yaml resources: one hyperv.vm cfgms-e2e-ha-01 with ha_role.cluster_name: cfg-lab,
+# state: stopped, CSV-homed vhd_path C:\ClusterStorage\CSV01\cfgms-e2e-ha-01.vhdx.
+```
+
+Observe (`cfg config show <id>`) that all three members carry an **identical**
+`cfgms-e2e-ha-01` `hyperv.vm` resource, and that exactly the CNO owner creates it
+(`Get-VM -ComputerName <each node>` shows one distinct VMId cluster-wide). Live-
+proven 2026-07-15 (all 3 members converge clean; owner "already in desired state",
+both non-owners "managed on another node — compliant by delegation"; one VMId).
+
+> **Note — role/tag changes do not bump the steward config version.** A steward
+> won't re-pull a pure selector change until its version bumps. Force a re-pull
+> with `cfg config upload <device.cfg> --steward <id>` (which bumps the version),
+> then converge. Avoid triple rapid version bumps — overlapping converge passes
+> race and transiently mis-report.
+
+### 4.3 Declarative FC placement (AC2)
+
+Author placement on the cluster-scoped `hyperv.cluster` resource (in this bed, on
+the CNO's device config — `role_names` + `roles.<vm>`), then `cfg config upload`
+to bump the version and re-pull:
+
+```yaml
+    - name: cfg-lab
+      module: hyperv.cluster
+      config:
+        name: cfg-lab
+        transport: ps-host
+        role_names: [cfgms-e2e-ha-01]
+        roles:
+          cfgms-e2e-ha-01:
+            preferred_owners: [CFG-AB-02, CFG-70-02]   # ordered; Set-ClusterOwnerNode -Group
+            possible_owners:  [CFG-70-02, CFG-AB-02]   # restriction (excludes CFG-C3-02); -Resource
+            anti_affinity_class: e2e-ha-affinity        # Set-ClusterGroup -AntiAffinityClass
+```
+
+Only the CNO owner reconciles (`reconcileRoleProperties`, `cluster.go`). Confirm
+on the live cluster (read-only):
+
+```powershell
+(Get-ClusterOwnerNode -Cluster cfg-lab -Group cfgms-e2e-ha-01).OwnerNodes.Name          # preferred, ordered
+$r = @(Get-ClusterResource -Cluster cfg-lab | Where-Object {
+        [string]$_.OwnerGroup -eq 'cfgms-e2e-ha-01' -and [string]$_.ResourceType -eq 'Virtual Machine' })
+(Get-ClusterOwnerNode -Cluster cfg-lab -Resource $r[0].Name).OwnerNodes.Name             # possible, set
+(Get-ClusterGroup -Cluster cfg-lab -Name cfgms-e2e-ha-01).AntiAffinityClassNames         # class
+```
+
+Live-proven 2026-07-15 (v0.9.29): preferred `{CFG-AB-02, CFG-70-02}`, possible
+`{CFG-70-02, CFG-AB-02}` (C3 excluded), anti-affinity `{e2e-ha-affinity}` — each
+matching the declared config.
+
+> **Bug the idiomatic path surfaced + fixed (#2577).** On the first push (v0.9.28)
+> `possible_owners` silently did not apply while preferred/anti-affinity did. Root
+> cause: `Cfgms-SetClusterRolePossibleOwners` resolved the VM resource with
+> `$_.OwnerGroup.Name` / `$_.ResourceType.Name`, but on Windows Server 2025
+> `Get-ClusterResource` returns those as plain **strings** (`.Name` is `$null`) —
+> so the filter matched nothing and possible_owners was skipped with no error. The
+> Layer-1 dispatch/reconcile tests use a fake transport, so they never saw the real
+> object shape. Fixed with `[string]` coercion (robust for string OR object);
+> guarded by `TestPreamble_PossibleOwnersFilterUsesStringCoercion`. Use the
+> `[string]`-coerced `Where-Object` above when observing possible owners.
+
+### 4.4 Re-balance under load — native dynamic optimization (AC3)
+
+**Goal:** prove the idiomatic loop (config → cascade → converge → owner-gate) holds
+through a **cluster-initiated** ownership change — the failover cluster's native VM
+load balancer (`(Get-Cluster).AutoBalancerMode`, enabled by default; cfgms authors
+no auto-balance property) moving the role under injected load, with **zero
+cfgms/operator action** (no `Move-ClusterGroup`), and convergence following — no
+duplicate, no gap.
+
+Procedure:
+1. Confirm the balancer is on: `(Get-Cluster -Name cfg-lab).AutoBalancerMode` (2 =
+   load-balance on join + every 30 min) and `.AutoBalancerLevel` (1 = balance when
+   a node exceeds 80%).
+2. Ensure `possible_owners` for the role admits a target node with headroom (widen
+   via the AC2 config if a prior restriction leaves no valid target).
+3. Bring the role **Online** on a node, then inject sustained CPU/memory pressure on
+   that node's host (OS tools — the ONLY raw-tool use here) until it crosses the
+   balancer level.
+4. With a background cross-node poller running (`ccVMInstances`: never 2 distinct
+   VMIds, never 0), wait for the balancer to live-migrate the role to another node
+   (up to the ~30-min evaluation cycle). Take no cfgms/operator action.
+5. Assert: the new owner's convergence adopts the role; the previous owner goes
+   quiet (owner-gate skip, no lifecycle writes); exactly one instance throughout.
+
+> **cfg-lab constraint (2026-07-15).** This bed is not ideal for the load path:
+> the cfgms controller itself (`cfgms-ctrl-01`) runs as a **clustered VM on these
+> same nodes**, so stressing nodes to the Level-1 (80%) threshold risks migrating/
+> disrupting the control plane; `CFG-70-02` sits at ~100% memory from the CI VMs
+> (no headroom to host the running role); and the balancer's 30-min evaluation
+> makes a single-session result non-deterministic. Run AC3 on a bed where the
+> controller is **not** a cluster VM and nodes have headroom. The cfgms code path
+> exercised is identical to Layer-1 `FailoverHandoff` (the owner-gate reacts to
+> whoever owns the role, transparent to what triggered the move); AC3 differs only
+> in the *trigger* (cluster load balancer vs operator `Move-ClusterGroup`).
+
+### 4.5 Idiomatic leave (AC4)
+
+Drop a member from the cascade by removing its role tag; the definition disappears
+from that member's effective config, the still-clustered VM is untouched:
+
+```bash
+cfg steward tag rm <member steward-id> e2e-ha-cluster
+cfg config show <member steward-id>   # cfgms-e2e-ha-01 no longer present
+```
+
+Live-proven 2026-07-15 on CFG-C3-02 (non-owner): effective config `cfgms-e2e-ha-01`
+occurrences 3 → 0; the VM survived unchanged (same VMId, present only on the owner
+CFG-70-02, one instance, clustered role still present). A dropped cascade
+definition is not a `state: absent` demote — no removal is issued (no-prune: untag
+≠ delete). Re-add the tag to restore full membership.
+
+---
+
+## 5. Cleanup / recovery
 
 If a run is interrupted before `ccCleanupRole` runs, remove the test artifacts
 manually (elevated, on any member):

--- a/docs/testing/hyperv-cluster-cascade-runbook.md
+++ b/docs/testing/hyperv-cluster-cascade-runbook.md
@@ -247,6 +247,14 @@ cfgms/operator action** (no `Move-ClusterGroup`), and convergence following — 
 duplicate, no gap.
 
 Procedure:
+0. **Prerequisite — a BOOTABLE ha_role VM.** The role must sustain as a *healthy*
+   clustered VM to be a live-migration candidate. A VM with an empty/0-byte VHD
+   (as the `#2426` cascade fixture uses — it only needs the role to *exist*) has no
+   guest OS, so it has no heartbeat; failover-cluster health monitoring keeps the
+   VM resource **Offline** and it cannot stay Online for the balancer to move.
+   Provision a real bootable image into the ha_role VM first (a `source:` seed on
+   the `hyperv.vm` resource), boot it, and confirm `Get-VM` shows a heartbeat
+   before proceeding.
 1. Confirm the balancer is on: `(Get-Cluster -Name cfg-lab).AutoBalancerMode` (2 =
    load-balance on join + every 30 min) and `.AutoBalancerLevel` (1 = balance when
    a node exceeds 80%).

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -597,6 +598,39 @@ func (m *hypervModule) readResourceOwners(ctx context.Context, clusterName strin
 	return parsed.Owners, nil
 }
 
+// cachedResourceOwners returns the bulk cluster resource-owner map, reading it
+// from the transport at most once per freshness window (Story #2577). This
+// collapses the per-HA-VM membership probes of one converge pass into a single
+// cluster read instead of one read per VM. It backs only the fail-safe READ
+// path (probeClusterRoleMembership); the write-path owner gate keeps reading
+// live via clusterOwnershipHelper. Any cluster-mutating op calls
+// invalidateClusterOwnersCache so work we just performed is reflected at once.
+// A returned map is treated as read-only by callers (it is the shared cache).
+func (m *hypervModule) cachedResourceOwners(ctx context.Context, clusterName string) (map[string]string, error) {
+	m.clusterOwnersMu.Lock()
+	defer m.clusterOwnersMu.Unlock()
+	if m.clusterOwners != nil && m.clusterOwnersTTL > 0 && time.Since(m.clusterOwnersAt) < m.clusterOwnersTTL {
+		return m.clusterOwners, nil
+	}
+	owners, err := m.readResourceOwners(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	m.clusterOwners = owners
+	m.clusterOwnersAt = time.Now()
+	return owners, nil
+}
+
+// invalidateClusterOwnersCache drops the cached bulk owner map so the next read
+// path re-queries the cluster. Called after any op that changes clustered-role
+// ownership or membership (register, move, remove) so a freshly-mutated cluster
+// is never served stale from the Story #2577 read cache.
+func (m *hypervModule) invalidateClusterOwnersCache() {
+	m.clusterOwnersMu.Lock()
+	m.clusterOwners = nil
+	m.clusterOwnersMu.Unlock()
+}
+
 // setCluster reconciles the placement/scheduling PROPERTIES of existing
 // clustered VM roles (#2306). It is the Set("cluster:<name>", config) write
 // path — cluster-scoped only since #2372: it never creates or removes VM-role
@@ -808,6 +842,9 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 			"cluster-set-remove", "cluster:"+clusterName,
 			map[string]interface{}{"role": role, "exists": true},
 			map[string]interface{}{"removed": true, "cno_owner": cnoOwner}, nil)
+		// Membership changed — drop the Story #2577 read cache so the next probe
+		// sees the removed role.
+		m.invalidateClusterOwnersCache()
 		return nil
 	}
 
@@ -844,6 +881,9 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 			map[string]interface{}{"created": false}, addErr)
 		return fmt.Errorf("hyperv: reconcile role membership %q add role %q: %w", clusterName, role, addErr)
 	}
+	// A role was registered (or observed already-registered) — drop the Story
+	// #2577 read cache so the next membership probe reflects the new owner map.
+	m.invalidateClusterOwnersCache()
 	return nil
 }
 

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -68,6 +68,21 @@ type hypervModule struct {
 	vmsMu sync.RWMutex
 	vms   map[string]VMConfig
 
+	// Cluster resource-owner read cache (Story #2577). readResourceOwners is a
+	// single bulk cluster read that returns EVERY clustered role's owner, but the
+	// read-path membership probe (probeClusterRoleMembership) calls it once per HA
+	// VM — so N HA VMs cost N identical full cluster reads per converge pass. This
+	// caches the bulk result for a short freshness window so a pass issues ONE
+	// cluster read and filters per-VM in process, and is invalidated by any
+	// cluster-mutating op (invalidateClusterOwnersCache) so work we just performed
+	// is reflected on the next read. It backs only the fail-safe read path; the
+	// safety-critical write-path owner gate (clusterOwnershipHelper) always reads
+	// live.
+	clusterOwnersMu  sync.Mutex
+	clusterOwners    map[string]string
+	clusterOwnersAt  time.Time
+	clusterOwnersTTL time.Duration
+
 	// vswitches is the write-through vSwitch cache. Keys are the exact switch
 	// names admins specify (identical to the host-side names). Updated on
 	// transport success only.
@@ -212,6 +227,12 @@ func New(detector HypervDetector, opts ...HypervOption) modules.Module {
 		vswitches:      make(map[string]VSwitchConfig),
 		detector:       detector,
 		provisionStore: NewMemProvisionStore(),
+		// Freshness window for the bulk cluster-owner read cache (Story #2577).
+		// Long enough to collapse the per-VM membership probes of a single
+		// converge pass into one cluster read, short enough that an external
+		// failover is picked up on the read path within a few seconds; any op we
+		// perform invalidates it immediately regardless.
+		clusterOwnersTTL: 5 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -314,6 +335,19 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	// leaves it "" (non-fatal); audit then records an empty node identity, which
 	// the ownership helper still functions without.
 	m.clusterName, _ = configMap["cluster_name"].(string)
+	// An ha_role vm resource carries its cluster name only under the nested
+	// ha_role block, never as a top-level cluster_name key. Derive the S5 scope
+	// cap from there when the top-level key is absent, so the Get path
+	// (probeClusterRoleMembership) can report ha_role in current state and the
+	// resource round-trips through the executor's verify step. Without this,
+	// m.clusterName stays "" for an ha_role vm, the probe is gated off, Get omits
+	// ha_role, and every converge cycle re-detects it as unapplied "added" drift
+	// — a resource that never reports converged (Story #2577).
+	if m.clusterName == "" {
+		if hr := parseHARoleMap(configMap["ha_role"]); hr != nil {
+			m.clusterName = hr.ClusterName
+		}
+	}
 	m.clusterRoleNames = parseStringList(configMap["cluster_role_names"])
 	m.nodeHostname, _ = os.Hostname()
 	// Optional cluster DNA poll cadence (#2241). Accept a Go duration string;

--- a/features/modules/hyperv/module_test.go
+++ b/features/modules/hyperv/module_test.go
@@ -513,6 +513,52 @@ func TestModule_Configure_ExtractsAllKeys_WinRM(t *testing.T) {
 	assert.NotNil(t, m.transport, "transport must be wired after Configure")
 }
 
+// TestModule_Configure_ClusterNameFromHARole verifies that Configure derives the
+// S5 cluster scope cap from a vm resource's nested ha_role.cluster_name when no
+// top-level cluster_name key is present. A cascaded ha_role vm resource carries
+// the cluster name ONLY under ha_role, so without this derivation m.clusterName
+// stays empty, probeClusterRoleMembership is gated off, Get never reports
+// ha_role, and the resource is re-detected as unapplied "added" drift on every
+// converge cycle — never reporting converged (Story #2577).
+func TestModule_Configure_ClusterNameFromHARole(t *testing.T) {
+	store := newInlineStore()
+	m := &hypervModule{executor: &stubHypervExecutor{}}
+	require.NoError(t, m.SetSecretStore(store))
+
+	// A representative cascaded ha_role vm resource: cluster name only nested.
+	cfg := mapConfigState{
+		"name":     "cfgms-e2e-ha-01",
+		"vhd_path": `C:\ClusterStorage\CSV01\cfgms-e2e-ha-01.vhdx`,
+		"ha_role": map[string]interface{}{
+			"cluster_name": "cfg-lab",
+		},
+	}
+	require.NoError(t, m.Configure(cfg))
+	assert.Equal(t, "cfg-lab", m.clusterName,
+		"cluster scope cap must be derived from ha_role.cluster_name when top-level cluster_name is absent")
+}
+
+// TestModule_Configure_TopLevelClusterNameWins verifies that an explicit
+// top-level cluster_name key still takes precedence over the nested
+// ha_role.cluster_name (the derivation only fills the gap when the top-level key
+// is absent — it never overrides an operator-declared scope cap).
+func TestModule_Configure_TopLevelClusterNameWins(t *testing.T) {
+	store := newInlineStore()
+	m := &hypervModule{executor: &stubHypervExecutor{}}
+	require.NoError(t, m.SetSecretStore(store))
+
+	cfg := mapConfigState{
+		"name":         "cfgms-e2e-ha-01",
+		"cluster_name": "explicit-cluster",
+		"ha_role": map[string]interface{}{
+			"cluster_name": "cfg-lab",
+		},
+	}
+	require.NoError(t, m.Configure(cfg))
+	assert.Equal(t, "explicit-cluster", m.clusterName,
+		"an explicit top-level cluster_name must win over the ha_role-derived value")
+}
+
 func TestModule_Configure_NilConfig(t *testing.T) {
 	m := &hypervModule{executor: &stubHypervExecutor{}}
 	require.NoError(t, m.SetSecretStore(newInlineStore()))

--- a/features/modules/hyperv/module_test.go
+++ b/features/modules/hyperv/module_test.go
@@ -526,9 +526,15 @@ func TestModule_Configure_ClusterNameFromHARole(t *testing.T) {
 	require.NoError(t, m.SetSecretStore(store))
 
 	// A representative cascaded ha_role vm resource: cluster name only nested.
+	// Pin transport: "winrm" so this test compiles and passes on Linux CI (the
+	// ps-host path falls through to winrm on non-Windows and requires winrm_host).
 	cfg := mapConfigState{
-		"name":     "cfgms-e2e-ha-01",
-		"vhd_path": `C:\ClusterStorage\CSV01\cfgms-e2e-ha-01.vhdx`,
+		"transport":         "winrm",
+		"winrm_host":        "hyperv-host.local",
+		"winrm_user_secret": "svc-user",
+		"winrm_pass_secret": "svc-pass",
+		"name":              "cfgms-e2e-ha-01",
+		"vhd_path":          `C:\ClusterStorage\CSV01\cfgms-e2e-ha-01.vhdx`,
 		"ha_role": map[string]interface{}{
 			"cluster_name": "cfg-lab",
 		},
@@ -547,9 +553,15 @@ func TestModule_Configure_TopLevelClusterNameWins(t *testing.T) {
 	m := &hypervModule{executor: &stubHypervExecutor{}}
 	require.NoError(t, m.SetSecretStore(store))
 
+	// Pin transport: "winrm" so this test passes on Linux CI (ps-host falls through
+	// to winrm on non-Windows and requires winrm_host).
 	cfg := mapConfigState{
-		"name":         "cfgms-e2e-ha-01",
-		"cluster_name": "explicit-cluster",
+		"transport":         "winrm",
+		"winrm_host":        "hyperv-host.local",
+		"winrm_user_secret": "svc-user",
+		"winrm_pass_secret": "svc-pass",
+		"name":              "cfgms-e2e-ha-01",
+		"cluster_name":      "explicit-cluster",
 		"ha_role": map[string]interface{}{
 			"cluster_name": "cfg-lab",
 		},

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -700,6 +700,36 @@ func TestNewSeedVHD_DeletesExistingFileBeforeCreate(t *testing.T) {
 		"Remove-Item must be ordered before New-VHD, otherwise the leftover file blocks creation with 0x80070050")
 }
 
+// TestPreamble_PossibleOwnersFilterUsesStringCoercion guards the regression the
+// idiomatic Layer-2 cascade surfaced live on cfg-lab (Windows Server 2025, Issue
+// #2577): Cfgms-SetClusterRolePossibleOwners resolved the role's Virtual Machine
+// resource with `$_.OwnerGroup.Name -eq $ResourceName -and $_.ResourceType.Name
+// -eq 'Virtual Machine'`. On that FailoverClusters PowerShell build,
+// Get-ClusterResource returns .OwnerGroup and .ResourceType as plain STRINGS, on
+// which .Name is $null — so the filter matched nothing, $res.Count was 0, and
+// possible_owners was silently never applied (no error, so reconcileRoleProperties
+// proceeded to the remaining properties). The dispatch tests assert only the
+// synthesised call string and the reconcile unit tests drive a fake transport, so
+// none exercise this filter against the real object shape and all stayed green.
+// The fix compares via [string] coercion, which yields the group/type name whether
+// the property is a string (itself) or an object (ToString), so it is robust
+// across builds. This asserts the robust form is used and the brittle .Name form
+// is gone.
+func TestPreamble_PossibleOwnersFilterUsesStringCoercion(t *testing.T) {
+	body := preambleFunctionBody(t, "Cfgms-SetClusterRolePossibleOwners")
+
+	assert.Contains(t, body, "[string]$_.OwnerGroup -eq $ResourceName",
+		"possible_owners resource lookup must match the owner group via [string] coercion (Get-ClusterResource returns .OwnerGroup as a string on some FailoverClusters builds, where .OwnerGroup.Name is $null)")
+	assert.Contains(t, body, "[string]$_.ResourceType -eq 'Virtual Machine'",
+		"possible_owners resource lookup must match the resource type via [string] coercion (.ResourceType is a string on some builds, where .ResourceType.Name is $null)")
+	assert.NotContains(t, body, "$_.OwnerGroup.Name",
+		"the brittle .OwnerGroup.Name filter silently matches nothing when Get-ClusterResource returns a string — it must not return")
+	assert.NotContains(t, body, "$_.ResourceType.Name",
+		"the brittle .ResourceType.Name filter silently matches nothing when Get-ClusterResource returns a string — it must not return")
+	assert.Contains(t, body, "Set-ClusterOwnerNode -Cluster $ClusterName -Resource",
+		"the function must still restrict possible owners on the resolved VM resource")
+}
+
 // preambleFunctionBody extracts the body of a `function <name> { ... }` block
 // from psHostPreamble, balancing braces so nested blocks (if/foreach) are
 // included. It fails the test if the function is not found.

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -775,7 +775,15 @@ function Cfgms-SetClusterRolePossibleOwners {
     # is the role (group) name — resolve its Virtual Machine resource. Materialise
     # the match into an array (no Select -First, which trips the FailoverClusters
     # provider with "pipeline has been stopped").
-    $res = @(Get-ClusterResource -Cluster $ClusterName -ErrorAction SilentlyContinue | Where-Object { $_.OwnerGroup.Name -eq $ResourceName -and $_.ResourceType.Name -eq 'Virtual Machine' })
+    #
+    # Compare via [string] coercion, NOT .OwnerGroup.Name / .ResourceType.Name:
+    # depending on the FailoverClusters PowerShell build, Get-ClusterResource
+    # returns .OwnerGroup and .ResourceType as plain STRINGS (verified on Windows
+    # Server 2025), on which .Name is $null — so a .Name filter silently matches
+    # nothing and possible_owners is never applied. [string]$_.OwnerGroup yields
+    # the group name whether the property is a string (itself) or a ClusterGroup
+    # object (ToString → name), so the filter is robust across builds.
+    $res = @(Get-ClusterResource -Cluster $ClusterName -ErrorAction SilentlyContinue | Where-Object { [string]$_.OwnerGroup -eq $ResourceName -and [string]$_.ResourceType -eq 'Virtual Machine' })
     if ($res.Count -gt 0) { Set-ClusterOwnerNode -Cluster $ClusterName -Resource $res[0].Name -Owners ($Owners -split ',') }
 }
 

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -176,6 +176,23 @@ type VMConfig struct {
 	// checked. It is NOT a per-VM YAML field (seed_dir is module-level config) —
 	// hence unexported and untagged so it never round-trips through YAML/AsMap.
 	seedDir string
+
+	// managedElsewhereOwner names the cluster node that owns this VM when getVM
+	// determines it is a registered clustered HA role hosted on ANOTHER node
+	// (Story #2577). When set, the module's Get result reports true from
+	// ManagedElsewhere, so the executor treats the resource as compliant-by-
+	// delegation and skips Compare/Set/Verify — a non-owner does not manage a VM
+	// it does not host. Unexported and untagged: it never serializes, never
+	// participates in the drift comparison.
+	managedElsewhereOwner string
+}
+
+// ManagedElsewhere implements modules.ManagedElsewhere. It reports true (naming
+// the owning node) when getVM resolved this VMConfig as a clustered HA role
+// hosted on another cluster node — signalling the executor to treat the resource
+// as compliant-by-delegation without a field-level comparison (Story #2577).
+func (c *VMConfig) ManagedElsewhere() (bool, string) {
+	return c.managedElsewhereOwner != "", c.managedElsewhereOwner
 }
 
 // HARoleConfig declares that a vm resource is a highly-available clustered role.
@@ -510,12 +527,20 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 		}
 	}
 	// ha_role is only emitted when present so a non-HA VMConfig round-trips
-	// unchanged (omitempty parity with the YAML tag).
+	// unchanged (omitempty parity with the YAML tag). resource_group_name is
+	// likewise emitted only when non-empty: the membership probe never sets it
+	// and desired configs routinely omit it (it defaults to the VM name), so
+	// emitting an empty value would make the current state's ha_role map compare
+	// unequal to a desired ha_role that carries only cluster_name — flipping the
+	// verify result from a spurious "added" to a spurious "changed" (Story #2577).
 	if c.HARole != nil {
-		m["ha_role"] = map[string]interface{}{
-			"cluster_name":        c.HARole.ClusterName,
-			"resource_group_name": c.HARole.ResourceGroupName,
+		haRole := map[string]interface{}{
+			"cluster_name": c.HARole.ClusterName,
 		}
+		if c.HARole.ResourceGroupName != "" {
+			haRole["resource_group_name"] = c.HARole.ResourceGroupName
+		}
+		m["ha_role"] = haRole
 	}
 	return m
 }
@@ -663,22 +688,69 @@ func isHealthyVMState(state string) bool {
 // Returning state:"absent" rather than an error lets the unified executor
 // detect drift against a desired state:"present"/"running" config and
 // proceed to Set, instead of treating "absent" as a fatal Get failure.
+// getVM is the module's read/verify surface (module.Get → the executor's
+// compliance + verify diff). It is the local read, plus one cluster-aware rule
+// for HA roles: a clustered VM that is absent on THIS node but registered and
+// owned by ANOTHER cluster node is flagged "managed elsewhere" (Story #2577), so
+// the executor treats it as compliant-by-delegation and does no field
+// comparison. A non-owner is not that VM's manager — the owner converges it and
+// the CNO guarantees it exists (Layer 2, a separate story) — so re-detecting the
+// locally-absent body as drift every cycle is wrong. This needs only the owner's
+// NAME (a bulk cluster read that already works cluster-wide), never the owner's
+// VM body (which would require cross-node WinRM that isn't available).
+//
+// The write paths (setVM, the state:"absent" delete path) deliberately use
+// getVMLocal, NOT getVM: their create/lifecycle owner-gates key on LOCAL presence
+// (is the VM on THIS node?), which MUST read "absent" for a role hosted elsewhere
+// so the duplicate-prevention gate fires.
 func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, error) {
+	cfg, err := m.getVMLocal(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	// Locally absent but a registered clustered role owned elsewhere ⇒ managed by
+	// that owner. Flag it; the executor short-circuits to compliant. Unknown owner
+	// (unregistered, or cluster unreadable) leaves it "absent" so the create path
+	// still runs — degrades safe, converges next cycle.
+	if cfg.State == "absent" && cfg.HARole != nil {
+		if owner := m.clusteredRoleOwner(ctx, vmName); owner != "" && !strings.EqualFold(owner, m.nodeHostname) {
+			cfg.managedElsewhereOwner = owner
+		}
+	}
+	return cfg, nil
+}
+
+// clusteredRoleOwner returns the cluster node currently owning vmName's role, or
+// "" when the module has no cluster scope, the role is unregistered, or the
+// cluster read fails (fail-safe — the caller then treats the VM as not
+// managed-elsewhere). It reads through the bulk owner cache (Story #2577
+// batching) so a converge pass costs one cluster read, not one per HA VM.
+func (m *hypervModule) clusteredRoleOwner(ctx context.Context, vmName string) string {
+	if m.clusterName == "" {
+		return ""
+	}
+	owners, err := m.cachedResourceOwners(ctx, m.clusterName)
+	if err != nil {
+		return ""
+	}
+	return owners[vmName]
+}
+
+// getVMLocal reports a VM's state as observed on THIS host only (plus the
+// cluster-role membership probe). It is the source of truth for LOCAL presence:
+// a clustered role hosted on another node reads State:"absent" here, which is
+// exactly what setVM's existence/owner gates require to avoid creating a
+// duplicate. getVM layers cluster-wide reporting on top for the read/verify path.
+func (m *hypervModule) getVMLocal(ctx context.Context, vmName string) (*VMConfig, error) {
 	if m.transport == nil {
 		return nil, ErrVMNotFound
 	}
 
-	output, err := m.transport.ExecutePS(ctx, psGetVM, map[string]string{"Name": vmName})
+	cfg, found, err := m.readVMState(ctx, vmName)
 	if err != nil {
-		return nil, fmt.Errorf("hyperv: get vm %q: %w", vmName, err)
+		return nil, err
 	}
 
-	var parsed map[string]interface{}
-	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
-		return nil, fmt.Errorf("hyperv: parse get-vm response for %q: %w", vmName, jsonErr)
-	}
-
-	found, _ := parsed["found"].(bool)
 	if !found {
 		// Absent is a valid current state — the executor compares this against
 		// the desired state and calls Set to create the resource when needed.
@@ -691,6 +763,38 @@ func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, err
 			State:  "absent",
 			HARole: m.probeClusterRoleMembership(ctx, vmName),
 		}, nil
+	}
+
+	// Cluster-role membership probe (#2372/#2420) — see
+	// probeClusterRoleMembership for the scope-cap and degrade semantics.
+	cfg.HARole = m.probeClusterRoleMembership(ctx, vmName)
+
+	// Write-through: update cache on successful read
+	m.vmsMu.Lock()
+	m.vms[vmName] = *cfg
+	m.vmsMu.Unlock()
+
+	return cfg, nil
+}
+
+// readVMState runs the local Cfgms-GetVM read and maps its JSON into a VMConfig.
+// It does NOT run the HA-role probe or touch the cache — those are the caller's
+// concern — so getVMLocal can layer them on. Returns (cfg, found, err);
+// found=false maps the Cfgms-GetVM {"found":false} sentinel.
+func (m *hypervModule) readVMState(ctx context.Context, vmName string) (*VMConfig, bool, error) {
+	output, err := m.transport.ExecutePS(ctx, psGetVM, map[string]string{"Name": vmName})
+	if err != nil {
+		return nil, false, fmt.Errorf("hyperv: get vm %q: %w", vmName, err)
+	}
+
+	var parsed map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
+		return nil, false, fmt.Errorf("hyperv: parse get-vm response for %q: %w", vmName, jsonErr)
+	}
+
+	found, _ := parsed["found"].(bool)
+	if !found {
+		return nil, false, nil
 	}
 
 	// The host returns the VM by its exact name — no prefix to strip.
@@ -745,16 +849,7 @@ func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, err
 		}
 	}
 
-	// Cluster-role membership probe (#2372/#2420) — see
-	// probeClusterRoleMembership for the scope-cap and degrade semantics.
-	cfg.HARole = m.probeClusterRoleMembership(ctx, vmName)
-
-	// Write-through: update cache on successful read
-	m.vmsMu.Lock()
-	m.vms[vmName] = *cfg
-	m.vmsMu.Unlock()
-
-	return cfg, nil
+	return cfg, true, nil
 }
 
 // probeClusterRoleMembership reports whether vmName is a registered clustered
@@ -774,7 +869,7 @@ func (m *hypervModule) probeClusterRoleMembership(ctx context.Context, vmName st
 	if m.clusterName == "" {
 		return nil
 	}
-	owners, roErr := m.readResourceOwners(ctx, m.clusterName)
+	owners, roErr := m.cachedResourceOwners(ctx, m.clusterName)
 	if roErr != nil {
 		if logger, ok := m.GetLogger(); ok {
 			logger.Warn("hyperv: cluster-role membership probe failed; reporting no HA role this cycle",
@@ -822,7 +917,9 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		// also carries the removed VM's HARole + VHDPath, used below to route the
 		// provisioning-record delete to the same store it was written to.
 		var deleteBefore map[string]interface{}
-		cur, gErr := m.getVM(ctx, vmName)
+		// Local truth: the delete path removes the VM on THIS host — a role hosted
+		// elsewhere must read absent here (getVMLocal), never the owner's state.
+		cur, gErr := m.getVMLocal(ctx, vmName)
 		if gErr == nil && cur != nil && cur.State != "absent" {
 			deleteBefore = map[string]interface{}{
 				"cpu":       cur.CPUCount,
@@ -934,9 +1031,13 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	// out-of-band), computing needed actions as no-ops. The write-through cache is
 	// still updated after a successful apply for the benefit of Get, but it is
 	// never the basis for an apply decision.
-	current, err := m.getVM(ctx, vmName)
+	// Local truth for the reconcile decision: setVM's create/lifecycle owner-gates
+	// key on whether the VM exists on THIS node. A clustered role hosted on another
+	// member must read "absent" here so the existence gate fires (getVMLocal, not
+	// the cluster-wide getVM which would report the owner's VM as present).
+	current, err := m.getVMLocal(ctx, vmName)
 	if err != nil {
-		// getVM no longer returns a sentinel for "not found" — absence is
+		// getVMLocal no longer returns a sentinel for "not found" — absence is
 		// signalled by State=="absent" with err==nil. Any real error here
 		// (module not configured, transport down, malformed response) is
 		// fatal for this Set call.

--- a/features/modules/hyperv/vm_harole_convergence_test.go
+++ b/features/modules/hyperv/vm_harole_convergence_test.go
@@ -120,6 +120,118 @@ func TestGetVM_AbsentButClusteredRole_ReportsHARole(t *testing.T) {
 	assert.Equal(t, "lab-hv", cfg.HARole.ClusterName)
 }
 
+// TestGetVM_HostedElsewhere_ReportsManagedElsewhere (Story #2577): a clustered HA
+// VM absent on THIS node but registered and owned by ANOTHER node is flagged
+// managed-elsewhere (naming the owner), so the executor treats it compliant-by-
+// delegation without a field comparison. No owner BODY is read (that would need
+// cross-node WinRM, which isn't available) — only the bulk owner map, which works
+// cluster-wide, is consulted.
+func TestGetVM_HostedElsewhere_ReportsManagedElsewhere(t *testing.T) {
+	const vmName = "ha-hosted-elsewhere"
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"found":false}`, // local Cfgms-GetVM: absent here
+		`{"owners":{"ha-hosted-elsewhere":"NODE2"}}`, // bulk owner read (probe + owner lookup share it via the cache)
+	}}
+	m := vmModuleWithTransport(transport, "t-2577")
+	m.clusterName = "cfg-lab"
+	m.nodeHostname = "NODE1" // this host is a NON-owner (owner is NODE2)
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+
+	managed, owner := cfg.ManagedElsewhere()
+	assert.True(t, managed, "a registered clustered role owned by another node is managed-elsewhere")
+	assert.Equal(t, "NODE2", owner, "the owning node is named for compliance-by-delegation")
+	require.NotNil(t, cfg.HARole, "membership is still reported")
+	assert.Equal(t, "absent", cfg.State, "no owner body is fetched — State stays the honest local 'absent'")
+
+	// The bulk owner map is read ONCE and shared by the probe and the owner lookup
+	// via the cache — not once per concern (Story #2577 batching).
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	assert.Len(t, transport.calls, 2, "one local VM read + one bulk owner read (cached) — no re-read")
+}
+
+// TestGetVM_HostedElsewhere_OwnerIsSelf_NotManagedElsewhere (Story #2577): if the
+// owner map names THIS node (registered to us but the local read missed it — a
+// post-failover/create transient), the VM is NOT managed-elsewhere. It reads
+// absent so the normal owner-gated create/lifecycle path runs — we do not abstain
+// from a VM we are supposed to host.
+func TestGetVM_HostedElsewhere_OwnerIsSelf_NotManagedElsewhere(t *testing.T) {
+	const vmName = "ha-owned-here"
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		`{"found":false}`,                      // local: absent
+		`{"owners":{"ha-owned-here":"NODE1"}}`, // owner map: owned by THIS node
+	}}
+	m := vmModuleWithTransport(transport, "t-2577")
+	m.clusterName = "cfg-lab"
+	m.nodeHostname = "NODE1"
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+	managed, _ := cfg.ManagedElsewhere()
+	assert.False(t, managed, "a role owned by THIS node is not managed-elsewhere")
+	assert.Equal(t, "absent", cfg.State)
+}
+
+// TestGetVM_HostedElsewhere_OwnerUnreadable_NotManagedElsewhere (Story #2577):
+// when the cluster owner map can't be read, the membership probe degrades to nil,
+// so getVM never flags managed-elsewhere — the VM reads absent and the normal
+// (owner-gated) create path runs next cycle. Degrade-safe: never a false compliant.
+func TestGetVM_HostedElsewhere_OwnerUnreadable_NotManagedElsewhere(t *testing.T) {
+	const vmName = "ha-owner-unreadable"
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`, ``},
+		perCallErrors:  []error{nil, errors.New("cluster service down")},
+	}
+	m := vmModuleWithTransport(transport, "t-2577")
+	m.clusterName = "cfg-lab"
+	m.nodeHostname = "NODE1"
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err, "a cluster-read failure must not fail the VM read")
+	managed, _ := cfg.ManagedElsewhere()
+	assert.False(t, managed, "unreadable cluster ⇒ not managed-elsewhere (degrade safe)")
+	assert.Equal(t, "absent", cfg.State)
+}
+
+// TestCachedResourceOwners_BatchesReadsWithinWindow (Story #2577): the bulk owner
+// map is read from the transport at most once per freshness window — two
+// back-to-back getVM calls for different HA VMs issue ONE cluster read, not one
+// per VM (the per-VM probe was the N-reads-per-pass waste).
+func TestCachedResourceOwners_BatchesReadsWithinWindow(t *testing.T) {
+	transport := &testWinRMTransport{
+		// Local reads for two VMs both absent; a single bulk owner read serves both.
+		perCallOutputs: []string{
+			`{"found":false}`, // getVM("vm-a") local
+			`{"owners":{"vm-a":"NODE2","vm-b":"NODE2"}}`, // bulk owner read (cached after this)
+			`{"found":false}`, // getVM("vm-b") local
+		},
+	}
+	m := vmModuleWithTransport(transport, "t-2577")
+	m.clusterName = "cfg-lab"
+	m.nodeHostname = "NODE1"
+	m.clusterOwnersTTL = time.Minute // ensure both calls land in one window
+
+	for _, name := range []string{"vm-a", "vm-b"} {
+		cfg, err := m.getVM(context.Background(), name)
+		require.NoError(t, err)
+		managed, owner := cfg.ManagedElsewhere()
+		assert.True(t, managed, "%s is owned by NODE2 → managed-elsewhere", name)
+		assert.Equal(t, "NODE2", owner)
+	}
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	owners := 0
+	for _, c := range transport.calls {
+		if len(c.args) == 1 && c.args[0] == "cfg-lab" { // psGetClusterResourceOwner takes ClusterName
+			owners++
+		}
+	}
+	assert.Equal(t, 1, owners, "the bulk cluster-owner map must be read once for the whole pass, not per VM")
+}
+
 // TestGetVM_AbsentWithoutScope_NoProbe: the absent path issues no cluster probe
 // when no module-level cluster_name is configured — non-cluster hosts keep the
 // exact pre-#2420 single-call behavior.

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -25,6 +25,10 @@ func vmModuleWithTransport(transport winrmTransport, tenantID string) *hypervMod
 		tenantID:  tenantID,
 		vms:       make(map[string]VMConfig),
 		detector:  &fakeDetector{result: true},
+		// Production parity: New() sets this so the bulk cluster-owner read is
+		// cached within a converge pass (Story #2577). Without it caching is off
+		// and the read-path owner lookup would re-query the cluster per concern.
+		clusterOwnersTTL: 5 * time.Second,
 	}
 }
 
@@ -1391,6 +1395,21 @@ func TestVMConfig_HARole_NonCSV_Unaffected(t *testing.T) {
 	require.NotNil(t, haBack.HARole)
 	assert.Equal(t, "lab-hv", haBack.HARole.ClusterName)
 	assert.Equal(t, "rg-ha2", haBack.HARole.ResourceGroupName)
+
+	// HA VMConfig with no resource_group_name: AsMap must emit an ha_role map
+	// carrying only cluster_name — NOT an empty resource_group_name key. The
+	// membership probe never sets ResourceGroupName and desired configs routinely
+	// omit it, so an always-present empty key made current-vs-desired ha_role
+	// compare unequal and the resource never reported converged (Story #2577).
+	haNoRG := &VMConfig{
+		Name: "ha-norg", VHDPath: `C:\ClusterStorage\CSV01\ha-norg.vhdx`,
+		HARole: &HARoleConfig{ClusterName: "lab-hv"},
+	}
+	haNoRGMap, ok := haNoRG.AsMap()["ha_role"].(map[string]interface{})
+	require.True(t, ok, "HA AsMap must emit an ha_role map")
+	assert.Equal(t, "lab-hv", haNoRGMap["cluster_name"])
+	_, hasRG := haNoRGMap["resource_group_name"]
+	assert.False(t, hasRG, "an empty resource_group_name must be omitted for omitempty parity")
 }
 
 // TestSetVM_HARole_RegistersClusteredRole verifies that on the create path an

--- a/features/modules/module.go
+++ b/features/modules/module.go
@@ -63,6 +63,23 @@ type ConfigState interface {
 	GetManagedFields() []string
 }
 
+// ManagedElsewhere, when implemented by a ConfigState returned from Module.Get,
+// tells the executor the resource is real and in its desired terminal state but
+// managed by a DIFFERENT authority — e.g. a clustered HA VM owned by another
+// failover-cluster node. The executor treats such a resource as compliant and
+// performs no Compare/Set/Verify: field-level drift against THIS node's local
+// view is not meaningful, because this node is not the resource's manager. The
+// single accountable authority (the cluster's CNO for HA VMs) is responsible for
+// the resource actually existing and having an owner — a non-owner only abstains
+// (Story #2577).
+type ManagedElsewhere interface {
+	// ManagedElsewhere reports whether the resource is managed by another
+	// authority and, if so, names it (the owning node/authority — used for logs
+	// and DNA provenance). A false return means "this node IS the manager; apply
+	// the normal Compare/Set/Verify flow."
+	ManagedElsewhere() (managed bool, authority string)
+}
+
 // Configurable is implemented by modules that require initialization from
 // operator config before Get() can safely read the current resource state.
 // The execution engine calls Configure(desiredState) before Get() when the

--- a/features/modules/stdlib/hostname/module_test.go
+++ b/features/modules/stdlib/hostname/module_test.go
@@ -236,11 +236,11 @@ func TestHostnameModule_Set_WrongConfigType(t *testing.T) {
 // wrongConfigType implements modules.ConfigState but is not *HostnameConfig.
 type wrongConfigType struct{}
 
-func (w *wrongConfigType) AsMap() map[string]interface{}  { return nil }
-func (w *wrongConfigType) ToYAML() ([]byte, error)        { return nil, nil }
-func (w *wrongConfigType) FromYAML(_ []byte) error        { return nil }
-func (w *wrongConfigType) Validate() error                { return nil }
-func (w *wrongConfigType) GetManagedFields() []string     { return nil }
+func (w *wrongConfigType) AsMap() map[string]interface{} { return nil }
+func (w *wrongConfigType) ToYAML() ([]byte, error)       { return nil, nil }
+func (w *wrongConfigType) FromYAML(_ []byte) error       { return nil }
+func (w *wrongConfigType) Validate() error               { return nil }
+func (w *wrongConfigType) GetManagedFields() []string    { return nil }
 
 // TestHostnameModule_LoggingInjection verifies the module implements LoggingInjectable.
 func TestHostnameModule_LoggingInjection(t *testing.T) {

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -380,6 +380,24 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 	// not only when a change-event fires — with no extra module call.
 	e.cacheModuleDNAState(resourceID, currentState)
 
+	// Managed-elsewhere short-circuit (Story #2577): a module may report from Get
+	// that the resource is real and in its desired terminal state but managed by a
+	// DIFFERENT authority — e.g. a clustered HA VM owned by another cluster node.
+	// This node is not the manager, so field-level drift against its local view is
+	// not meaningful; treat it as compliant with no Compare/Set/Verify. The
+	// accountable authority (the CNO for HA VMs) owns "does it exist / have an
+	// owner"; a non-owner only abstains.
+	if me, ok := currentState.(modules.ManagedElsewhere); ok {
+		if managed, authority := me.ManagedElsewhere(); managed {
+			result.Status = StatusNoChange
+			result.ExecutionTime = time.Since(startTime)
+			e.logger.Info("Resource managed on another node — compliant by delegation",
+				"resource", resource.Name,
+				"managed_by", authority)
+			return result
+		}
+	}
+
 	driftDetected, stateDiff := e.comparator.CompareStates(currentState, desiredState)
 	result.DriftDetected = driftDetected
 	result.StateDiff = &stateDiff

--- a/features/steward/execution/executor_test.go
+++ b/features/steward/execution/executor_test.go
@@ -991,3 +991,76 @@ func TestExecuteResource_TimeoutWarn_LogsActualEnforcedBudget(t *testing.T) {
 	assert.LessOrEqual(t, timeoutMS, int64(1000),
 		"timeout_ms must reflect the actual enforced budget (~200ms outer ctx), not the configured 10000ms module timeout")
 }
+
+// ─── Story #2577: managed-elsewhere short-circuit ──────────────────────────────
+
+// managedElsewhereState is a ConfigState that reports it is managed by another
+// authority (e.g. a clustered HA VM owned by another cluster node). The executor
+// must treat it as compliant with no Compare/Set/Verify.
+type managedElsewhereState struct{ owner string }
+
+func (s *managedElsewhereState) AsMap() map[string]interface{} {
+	return map[string]interface{}{"state": "absent"}
+}
+func (s *managedElsewhereState) ToYAML() ([]byte, error)          { return nil, nil }
+func (s *managedElsewhereState) FromYAML([]byte) error            { return nil }
+func (s *managedElsewhereState) Validate() error                  { return nil }
+func (s *managedElsewhereState) GetManagedFields() []string       { return []string{"state"} }
+func (s *managedElsewhereState) ManagedElsewhere() (bool, string) { return true, s.owner }
+
+var _ modules.ManagedElsewhere = (*managedElsewhereState)(nil)
+
+// managedElsewhereModule.Get reports a managed-elsewhere resource; Set must never
+// run because the executor short-circuits to compliant before it.
+type managedElsewhereModule struct{ setCalled int32 }
+
+func (m *managedElsewhereModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	return &managedElsewhereState{owner: "NODE2"}, nil
+}
+func (m *managedElsewhereModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	atomic.AddInt32(&m.setCalled, 1)
+	return nil
+}
+
+var _ modules.Module = (*managedElsewhereModule)(nil)
+
+// TestExecuteResource_ManagedElsewhere_CompliantNoSet (Story #2577): when a
+// module's Get reports the resource is managed by another authority, the executor
+// short-circuits to compliant — no drift comparison, no Set, no Verify — even
+// though the desired config would otherwise show drift against the local view.
+func TestExecuteResource_ManagedElsewhere_CompliantNoSet(t *testing.T) {
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	mod := &managedElsewhereModule{}
+	f.RegisterModule("managed-elsewhere", mod)
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logging.ForModule("executor_test"),
+		StewardID:     "test-steward-2577",
+		Factory:       f,
+		ErrorHandling: errCfg,
+		DriftMode:     stewardconfig.DriftModeApply,
+	})
+	require.NoError(t, err)
+
+	// A desired config that WOULD show drift against the reported "absent" state —
+	// the managed-elsewhere signal must short-circuit before any comparison.
+	resource := stewardconfig.ResourceConfig{
+		Name:   "ha-vm-elsewhere",
+		Module: "managed-elsewhere",
+		Config: map[string]interface{}{"state": "running", "cpu_count": 2},
+	}
+
+	result := executor.ExecuteResource(context.Background(), resource)
+
+	assert.Equal(t, execution.StatusNoChange, result.Status,
+		"a managed-elsewhere resource must report compliant (StatusNoChange)")
+	assert.False(t, result.DriftDetected,
+		"no drift comparison is performed for a managed-elsewhere resource")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&mod.setCalled),
+		"Set must never be called for a resource managed on another node")
+}

--- a/test/e2e/hyperv/cluster_cascade_idiomatic_test.go
+++ b/test/e2e/hyperv/cluster_cascade_idiomatic_test.go
@@ -41,6 +41,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -372,6 +373,178 @@ func TestIdiomaticLeave_DropsDefinitionKeepsVM(t *testing.T) {
 	assert.Lenf(t, presAfter, 1, "the VM keeps running on its single owner after the leave (present on %v)", presAfter)
 	assert.True(t, ccRolePresent(t, ic.cluster, ic.vmName),
 		"the clustered role must still exist after a member leaves the cascade")
+}
+
+// ─── AC3 (idiomatic): re-balance under native dynamic optimization ────────────
+
+const (
+	// envRebalanceTimeout is the maximum time to wait for the cluster's native
+	// dynamic optimizer to migrate the role under injected load. Must cover the
+	// default ~30-min Windows AutoBalancer evaluation cycle. Override to a shorter
+	// value only on a bed where the cluster is configured for a faster interval.
+	envRebalanceTimeout = "CFGMS_E2E_REBALANCE_TIMEOUT"
+
+	// defaultRebalanceTimeout covers the default ~30-min Windows AutoBalancer
+	// evaluation cycle plus a 5-minute margin.
+	defaultRebalanceTimeout = 35 * time.Minute
+)
+
+// TestIdiomaticRebalance_NativeDynamicOptimizationHandoff (REQUIRED, #2577 AC3) —
+// Windows' native cluster dynamic optimizer (AutoBalancerMode ≥ 1) migrates the
+// ha_role VM to another node under injected CPU pressure with zero cfgms/operator
+// action, and the idiomatic convergence loop follows: the new owner adopts the
+// role and exactly one VM instance exists cluster-wide throughout.
+//
+// This is the idiomatic complement to Layer-1 TestClusterCascade_FailoverHandoff:
+// the cfgms code path is identical — the owner-gate reacts to whoever the cluster
+// reports as owner, transparent to what triggered the ownership change (operator
+// Move-ClusterGroup or the cluster's own balancer). AC3 proves the same idiomatic
+// loop (config → cascade → converge → owner-gate) holds through a cluster-initiated
+// transfer with zero operator action.
+//
+// Prerequisite (runbook §4.4 step 0): the ha_role VM must be a BOOTABLE guest
+// with a real OS, a healthy heartbeat, and an Online cluster state. The cascade
+// fixture (#2426) uses a 0-byte VHD — the cluster keeps it Offline (no heartbeat)
+// and the load balancer cannot live-migrate an Offline role. When the role is not
+// Online, this test skips cleanly rather than failing or timing out.
+func TestIdiomaticRebalance_NativeDynamicOptimizationHandoff(t *testing.T) {
+	ic := icSetup(t)
+
+	// Prerequisite 1 — the role must be Online (bootable VM with heartbeat). A
+	// 0-byte VHD has no guest OS, so the cluster keeps it Offline and the native
+	// dynamic optimizer cannot live-migrate it. Skip with a runbook pointer rather
+	// than waiting up to 35 minutes only to time out.
+	roleState := ccGroupState(t, ic.cluster, ic.vmName)
+	if !strings.EqualFold(roleState, "Online") {
+		t.Skipf("AC3 re-balance: role %q is %q (not Online) — provision a bootable ha_role VM (real OS + heartbeat) per runbook §4.4 prerequisite 0, confirm Get-VM shows Heartbeat=OkApplicationsUnknown, then re-run", ic.vmName, roleState)
+	}
+
+	// Prerequisite 2 — the cluster's native dynamic optimizer must be enabled.
+	if !ccAutoBalancerEnabled(t, ic.cluster) {
+		t.Skipf("AC3 re-balance: cluster %q AutoBalancerMode < 1 (disabled) — enable per runbook §4.4 step 1, then re-run", ic.cluster)
+	}
+
+	// Resolve the rebalance wait ceiling (env override for faster-interval beds).
+	rebalanceTimeout := defaultRebalanceTimeout
+	if s := os.Getenv(envRebalanceTimeout); s != "" {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			rebalanceTimeout = d
+		}
+	}
+
+	owner := ccGroupOwner(t, ic.cluster, ic.vmName)
+	require.NotEmptyf(t, owner, "precondition: role %q must have a current owner when Online", ic.vmName)
+	targetNode := ccOtherNode(ic.ccEnv, owner)
+	require.NotEmptyf(t, targetNode, "AC3 re-balance: at least two cluster nodes required; found only one")
+
+	// Continuous cross-node safety poller across the entire load-injection +
+	// rebalance window. Tracks the worst-case distinct VMId count (duplicate
+	// metric) and minimum presence count (liveness metric). A silent peer failure
+	// is tracked as an error because it could mask a real duplicate.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var pollMu sync.Mutex
+	maxDistinct := 1
+	minPresent := 1
+	var pollErr error
+	var pollWG sync.WaitGroup
+	pollWG.Add(1)
+	go func() {
+		defer pollWG.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			present, distinct, err := ccVMInstances(t, ic.ccEnv)
+			pollMu.Lock()
+			if err != nil {
+				if pollErr == nil {
+					pollErr = err
+				}
+			} else {
+				if distinct > maxDistinct {
+					maxDistinct = distinct
+				}
+				if len(present) < minPresent {
+					minPresent = len(present)
+				}
+			}
+			pollMu.Unlock()
+			time.Sleep(ccPollInterval)
+		}
+	}()
+	t.Cleanup(func() {
+		cancel()
+		pollWG.Wait()
+	})
+
+	// Inject sustained CPU pressure on the owner node via PS remoting. The load
+	// job runs in the background on the remote node and is cancelled on cleanup
+	// regardless of test outcome. If PS remoting is unavailable, injection fails
+	// silently and the test may time out (bed needs PS remoting; see runbook §4.4).
+	const loadJobName = "cfgmsE2ERebalanceLoad"
+	remoteInject := `Invoke-Command -ComputerName '` + owner + `' -ScriptBlock { ` +
+		`Start-Job -Name ` + loadJobName + ` -ScriptBlock { ` +
+		`$end = [DateTime]::UtcNow.AddMinutes(45); ` +
+		`while ([DateTime]::UtcNow -lt $end) { [Math]::Sqrt([double]::MaxValue) | Out-Null } ` +
+		`} | Out-Null } -ErrorAction SilentlyContinue`
+	remoteCancel := `Invoke-Command -ComputerName '` + owner + `' -ScriptBlock { ` +
+		`Stop-Job -Name ` + loadJobName + ` -ErrorAction SilentlyContinue; ` +
+		`Remove-Job -Name ` + loadJobName + ` -Force -ErrorAction SilentlyContinue ` +
+		`} -ErrorAction SilentlyContinue`
+	if _, err := ccPS(t, remoteInject); err != nil {
+		t.Logf("AC3 re-balance: load injection on %q via PS remoting failed (%v) — the balancer may not trigger; bed needs PS remoting configured, see runbook §4.4", owner, err)
+	} else {
+		t.Logf("AC3 re-balance: CPU load injected on %q; waiting up to %s for the cluster's native dynamic optimizer to migrate %q (no operator action)", owner, rebalanceTimeout, ic.vmName)
+	}
+	t.Cleanup(func() { _, _ = ccPS(t, remoteCancel) })
+
+	// Wait for the cluster's native balancer to migrate the role. We do NOT call
+	// Move-ClusterGroup — that would replicate Layer-1 FailoverHandoff. AC3 proves
+	// the idiomatic loop holds through a cluster-initiated transfer.
+	migrated := false
+	var newOwner string
+	deadline := time.Now().Add(rebalanceTimeout)
+	for time.Now().Before(deadline) {
+		newOwner = ccGroupOwner(t, ic.cluster, ic.vmName)
+		if newOwner != "" && !strings.EqualFold(newOwner, owner) {
+			migrated = true
+			t.Logf("AC3 re-balance: cluster migrated %q from %q to %q (native dynamic optimizer; zero operator action)", ic.vmName, owner, newOwner)
+			break
+		}
+		time.Sleep(ccPollInterval)
+	}
+	// Cancel load immediately after migration (or timeout) so the bed recovers.
+	_, _ = ccPS(t, remoteCancel)
+
+	require.Truef(t, migrated,
+		"AC3 re-balance: cluster's native dynamic optimizer did not migrate role %q from %q within %s under injected load — verify AutoBalancerMode >= 1, AutoBalancerLevel <= 2, and a non-owner node has CPU/memory headroom; see runbook §4.4",
+		ic.vmName, owner, rebalanceTimeout)
+
+	// ── Convergence assertions after the cluster-initiated handoff ──────────────
+
+	// (a) Safety invariant throughout the window: no duplicate VM, no gap.
+	cancel()
+	pollWG.Wait()
+	pollMu.Lock()
+	snapshotMax, snapshotMin, snapshotErr := maxDistinct, minPresent, pollErr
+	pollMu.Unlock()
+	require.NoError(t, snapshotErr, "cross-node VM queries must not fail during the rebalance window (a silent peer error could mask a duplicate)")
+	assert.LessOrEqualf(t, snapshotMax, 1, "no duplicate VM during the cluster-initiated rebalance (at most 1 distinct VMId; a live-migration transient of the same VMId is not a duplicate)")
+	assert.GreaterOrEqualf(t, snapshotMin, 1, "VM must be present on at least one node throughout the rebalance window (no gap)")
+
+	// (b) New owner: exactly one instance, role Online — convergence adopted it.
+	ccWaitSingleInstanceOn(t, ic.ccEnv, newOwner)
+	assert.Equalf(t, "Online", ccGroupState(t, ic.cluster, ic.vmName),
+		"role %q must be Online on the new owner %q after the cluster-initiated rebalance", ic.vmName, newOwner)
+
+	// (c) Final snapshot: exactly one VM cluster-wide.
+	present, distinct, err := ccVMInstances(t, ic.ccEnv)
+	require.NoError(t, err)
+	assert.Equalf(t, 1, distinct, "exactly one VM cluster-wide after the native rebalance (present on %v)", present)
+	assert.Lenf(t, present, 1, "VM present on exactly one node after the native rebalance (present on %v)", present)
 }
 
 // ─── live-cluster read helpers (read-only; author nothing) ──────────────────────

--- a/test/e2e/hyperv/cluster_cascade_idiomatic_test.go
+++ b/test/e2e/hyperv/cluster_cascade_idiomatic_test.go
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build e2e
+
+// Idiomatic (Layer-2) fleet-e2e validation of the cluster.cfg cascade, the
+// declarative FC placement surface, and the idiomatic leave — driven through the
+// CONTROLLER (the cfg admin CLI) and observed via each member steward's effective
+// configuration + the live cluster, rather than by calling module.Set directly.
+//
+// cluster_cascade_test.go (Layer 1, #2426) proves the owner-gating COMPONENTS by
+// driving the real hyperv module as the node it runs on and steering ownership
+// with raw Move-ClusterGroup. This file proves the OPERATING MODEL (#2577): config
+// authored at the tenant/cluster scope, cascaded by the controller
+// (InheritanceResolver, #2425), read by every member, with only the CNO acting —
+// exactly the path an operator drives from the runbook, with nothing calling the
+// module directly.
+//
+// The suite drives the controller with the `cfg` admin CLI (CFGMS_E2E_CFG_BIN +
+// an admin bundle) and observes:
+//   - each member steward's EFFECTIVE config via `cfg config show` (the cascade
+//     fan-out), and
+//   - the live cluster via the read-only cluster cmdlets (single create, declared
+//     placement reflected, VM survival on leave).
+//
+// It authors NOTHING with raw cluster cmdlets — placement and membership are the
+// things under test, so they only ever move through cfgms config.
+//
+// It reuses the Layer-1 harness in cluster_cascade_test.go (same package
+// hyperv_e2e): ccPS / ccClusterNodes / ccMatchNode / ccVMInstances / ccEnv /
+// getenvDefault / ccPollInterval / ccSettleTimeout.
+//
+// Skips cleanly (never fails) when the idiomatic controls are not configured:
+// CFGMS_E2E_HYPERV_CLUSTER unset, no cfg binary / admin bundle, the member
+// steward IDs unset, or the host is not a member of the named cluster.
+package hyperv_e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Idiomatic-path environment (all required unless noted; the suite skips when any
+// required one is unset):
+//
+//	CFGMS_E2E_CFG_BIN        path to the cfg admin binary (e.g. C:\git\cfgms\bin\cfg-dev.exe)
+//	CFGMS_E2E_ADMIN_BUNDLE   admin bundle for mTLS auth (falls back to CFGMS_ADMIN_BUNDLE)
+//	CFGMS_E2E_MEMBER_IDS     comma-separated steward IDs of the cluster members
+//	CFGMS_E2E_HYPERV_CLUSTER the failover cluster name (shared with Layer 1)
+//
+// Optional:
+//
+//	CFGMS_E2E_HAROLE_VM      clustered ha_role VM/role name (default cfgms-e2e-ha-01)
+//	CFGMS_E2E_ROLE_TAG       tag whose role config cascades the VM (default e2e-ha-cluster)
+const (
+	envCfgBin      = "CFGMS_E2E_CFG_BIN"
+	envAdminBundle = "CFGMS_E2E_ADMIN_BUNDLE"
+	envMemberIDs   = "CFGMS_E2E_MEMBER_IDS"
+	envRoleTag     = "CFGMS_E2E_ROLE_TAG"
+)
+
+// icEnv is the resolved idiomatic-path environment for one live run.
+type icEnv struct {
+	ccEnv                // embeds the Layer-1 cluster/VM/node resolution
+	cfgBin      string   // cfg admin CLI path
+	adminBundle string   // admin bundle path
+	memberIDs   []string // steward IDs of the cluster members (cascade targets)
+	roleTag     string   // tag whose role config delivers the ha_role VM
+}
+
+// icSetup resolves the idiomatic-path environment and skips cleanly when the
+// suite cannot run: no cluster, no cfg CLI / bundle, no member IDs, or the host is
+// not a member of the named cluster. It reuses ccSetup for the cluster/node facts.
+func icSetup(t *testing.T) icEnv {
+	t.Helper()
+
+	cfgBin := os.Getenv(envCfgBin)
+	if cfgBin == "" {
+		t.Skipf("idiomatic fleet-e2e: set %s to the cfg admin CLI path to run", envCfgBin)
+	}
+	if _, err := os.Stat(cfgBin); err != nil {
+		t.Skipf("idiomatic fleet-e2e: %s=%q is not accessible: %v", envCfgBin, cfgBin, err)
+	}
+	bundle := getenvDefault(envAdminBundle, os.Getenv("CFGMS_ADMIN_BUNDLE"))
+	if bundle == "" {
+		t.Skipf("idiomatic fleet-e2e: set %s (or CFGMS_ADMIN_BUNDLE) to the admin bundle to run", envAdminBundle)
+	}
+	rawIDs := os.Getenv(envMemberIDs)
+	if strings.TrimSpace(rawIDs) == "" {
+		t.Skipf("idiomatic fleet-e2e: set %s to the comma-separated member steward IDs to run", envMemberIDs)
+	}
+	var memberIDs []string
+	for _, id := range strings.Split(rawIDs, ",") {
+		if s := strings.TrimSpace(id); s != "" {
+			memberIDs = append(memberIDs, s)
+		}
+	}
+	require.GreaterOrEqual(t, len(memberIDs), 2, "idiomatic cascade validation needs at least 2 member steward IDs")
+
+	// Reuse the Layer-1 cluster/node/VM resolution (also skips if the cluster is
+	// unset or unreachable, or this host is not a member).
+	cc := ccSetup(t)
+
+	ic := icEnv{
+		ccEnv:       cc,
+		cfgBin:      cfgBin,
+		adminBundle: bundle,
+		memberIDs:   memberIDs,
+		roleTag:     getenvDefault(envRoleTag, "e2e-ha-cluster"),
+	}
+
+	// Fail-fast, skip-clean controller reachability probe: the CLI must authenticate
+	// and enumerate at least the first member's stored config.
+	if _, err := ic.cfg(t, "config", "show", memberIDs[0]); err != nil {
+		t.Skipf("idiomatic fleet-e2e: controller not reachable via %s with the admin bundle (%v)", cfgBin, err)
+	}
+	return ic
+}
+
+// cfg runs the cfg admin CLI with the admin bundle and returns trimmed stdout.
+// The bundle is passed via the environment (CFGMS_ADMIN_BUNDLE) so it never lands
+// in the process argv.
+func (ic icEnv) cfg(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, ic.cfgBin, args...)
+	cmd.Env = append(os.Environ(), "CFGMS_ADMIN_BUNDLE="+ic.adminBundle)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), &icCfgError{args: args, stderr: stderr.String(), err: err}
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+type icCfgError struct {
+	args   []string
+	stderr string
+	err    error
+}
+
+func (e *icCfgError) Error() string {
+	return "cfg " + strings.Join(e.args, " ") + " failed: " + e.err.Error() + " | stderr: " + strings.TrimSpace(e.stderr)
+}
+
+// effectiveConfig is the subset of a steward's resolved (cascaded) config this
+// suite asserts on: the ordered resource list. `cfg config show` emits a JSON
+// document whose config.resources is the effective, post-cascade resource set.
+type effectiveConfig struct {
+	Config struct {
+		Resources []struct {
+			Name   string                 `json:"name"`
+			Module string                 `json:"module"`
+			Config map[string]interface{} `json:"config"`
+		} `json:"resources"`
+	} `json:"config"`
+	Version string `json:"version"`
+}
+
+// icShow returns a member steward's effective (cascaded) config. The CLI prints a
+// human preamble before the JSON body, so we parse from the first '{'.
+func (ic icEnv) icShow(t *testing.T, stewardID string) effectiveConfig {
+	t.Helper()
+	out, err := ic.cfg(t, "config", "show", stewardID)
+	require.NoErrorf(t, err, "cfg config show %s", stewardID)
+	i := strings.IndexByte(out, '{')
+	require.GreaterOrEqualf(t, i, 0, "cfg config show %s produced no JSON body:\n%s", stewardID, out)
+	var ec effectiveConfig
+	require.NoErrorf(t, json.Unmarshal([]byte(out[i:]), &ec), "parse effective config for %s", stewardID)
+	return ec
+}
+
+// icResource returns the (module, name) resource from an effective config, or
+// ok=false when it is absent — the cascade fan-out / drop oracle.
+func icResource(ec effectiveConfig, module, name string) (map[string]interface{}, bool) {
+	for _, r := range ec.Config.Resources {
+		if r.Module == module && r.Name == name {
+			return r.Config, true
+		}
+	}
+	return nil, false
+}
+
+// ─── AC1 (idiomatic): cascade appears identically + exactly one CNO create ──────
+
+// TestIdiomaticCascade_IdenticalAcrossMembersSingleCreate (REQUIRED, #2577 AC1) —
+// a controller-pushed tenant/cluster config carrying one ha_role VM appears —
+// identical — in every member steward's effective config (the InheritanceResolver
+// cascade), and exactly one VM exists cluster-wide (the CNO created it). This is
+// the idiomatic counterpart to Layer-1 SingleVMCreatedByOwner + NonOwnersConverged,
+// driven by the real controller cascade rather than a direct module Set.
+//
+// Precondition (established by the runbook's cascade-in step, NOT by this test —
+// authoring the VM is the thing under test, so the suite never Sets it): the
+// ha_role VM's role config is deployed and its tag is on every member. When it is
+// not yet cascaded the test skips with a pointer to the runbook, rather than
+// creating the VM itself.
+func TestIdiomaticCascade_IdenticalAcrossMembersSingleCreate(t *testing.T) {
+	ic := icSetup(t)
+
+	// Read every member's effective config and pull out the ha_role VM resource.
+	type memberVM struct {
+		id    string
+		cfg   map[string]interface{}
+		hasVM bool
+	}
+	members := make([]memberVM, 0, len(ic.memberIDs))
+	for _, id := range ic.memberIDs {
+		ec := ic.icShow(t, id)
+		c, ok := icResource(ec, "hyperv.vm", ic.vmName)
+		members = append(members, memberVM{id: id, cfg: c, hasVM: ok})
+	}
+
+	// If the cascade has not delivered the VM to every member, this is an
+	// un-set-up bed, not a failure — skip with the runbook pointer.
+	for _, m := range members {
+		if !m.hasVM {
+			t.Skipf("idiomatic cascade not staged: member %s effective config has no hyperv.vm %q — deploy the role config + tag per the runbook §Layer-2 cascade-in, then re-run", m.id, ic.vmName)
+		}
+	}
+
+	// (a) The cascaded VM definition is IDENTICAL across all members — same
+	// canonical config on every node (the cascade fan-out property).
+	want, err := json.Marshal(members[0].cfg)
+	require.NoError(t, err)
+	for _, m := range members[1:] {
+		got, err := json.Marshal(m.cfg)
+		require.NoError(t, err)
+		assert.JSONEqf(t, string(want), string(got),
+			"the cascaded ha_role VM must be identical across members (%s vs %s)", members[0].id, m.id)
+	}
+
+	// (b) Exactly one VM cluster-wide, created by the CNO owner — the single-create
+	// safety keystone, read cross-node (a duplicate is the failure this epic
+	// prevents). Reuses the Layer-1 cross-node instance probe.
+	present, distinct, err := ccVMInstances(t, ic.ccEnv)
+	require.NoError(t, err, "cross-node Get-VM must succeed on every peer (an unreachable peer could mask a duplicate)")
+	assert.Equalf(t, 1, distinct, "exactly one VM must exist cluster-wide from the cascade, no duplicate (present on %v)", present)
+	assert.Lenf(t, present, 1, "the single instance lives on exactly one node (present on %v)", present)
+}
+
+// ─── AC2 (idiomatic): declarative FC placement reflected in the live cluster ────
+
+// TestIdiomaticPlacement_DeclaredConfigReflectedLive (REQUIRED, #2577 AC2) — the
+// declarative placement authored on the hyperv.cluster resource (preferred_owners
+// / possible_owners / anti_affinity_class) is reflected in the LIVE cluster. The
+// assertion is SOURCE-AGNOSTIC: it reads whatever placement the CNO's effective
+// (cascaded) config declares for the role and asserts the live cluster matches it,
+// so it validates the idiomatic property (declared cfgms config ⇒ live cluster)
+// regardless of whether the operator authored the placement on the cluster-scoped
+// device config or a cluster-scoped role config. When no placement is declared yet
+// it skips with a runbook pointer rather than asserting a vacuous truth.
+func TestIdiomaticPlacement_DeclaredConfigReflectedLive(t *testing.T) {
+	ic := icSetup(t)
+
+	// Find the member whose effective config declares placement for the role — the
+	// CNO's config carries the hyperv.cluster resource with a roles.<vm> entry.
+	var declared map[string]interface{}
+	for _, id := range ic.memberIDs {
+		ec := ic.icShow(t, id)
+		cc, ok := icResource(ec, "hyperv.cluster", ic.cluster)
+		if !ok {
+			continue
+		}
+		roles, ok := cc["roles"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if rp, ok := roles[ic.vmName].(map[string]interface{}); ok && len(rp) > 0 {
+			declared = rp
+			break
+		}
+	}
+	if declared == nil {
+		t.Skipf("no declarative placement for role %q found in any member's effective config — author hyperv.cluster roles.%s.{preferred_owners,possible_owners,anti_affinity_class} per the runbook §Layer-2 placement, then re-run", ic.vmName, ic.vmName)
+	}
+
+	// preferred_owners → the group's ordered preferred OwnerNodes.
+	if want := icStringList(declared["preferred_owners"]); len(want) > 0 {
+		got := ic.groupPreferredOwners(t, ic.vmName)
+		assert.Equalf(t, want, got, "live group preferred owners must match the declared preferred_owners")
+	}
+	// possible_owners → the VM resource's restricted OwnerNodes (order-insensitive:
+	// the cluster stores possible owners as a set).
+	if want := icStringList(declared["possible_owners"]); len(want) > 0 {
+		got := ic.resourcePossibleOwners(t, ic.vmName)
+		assert.ElementsMatchf(t, want, got, "live resource possible owners must match the declared possible_owners")
+	}
+	// anti_affinity_class → the group's AntiAffinityClassNames.
+	if want, ok := declared["anti_affinity_class"].(string); ok && want != "" {
+		got := ic.groupAntiAffinity(t, ic.vmName)
+		assert.Containsf(t, got, want, "live group AntiAffinityClassNames must contain the declared anti_affinity_class")
+	}
+}
+
+// ─── AC4 (idiomatic): leave drops the definition without destroying the VM ──────
+
+// TestIdiomaticLeave_DropsDefinitionKeepsVM (REQUIRED, #2577 AC4) — removing a
+// member from the cascade membership (dropping its role tag) makes the cascaded VM
+// definition disappear from THAT member's effective config, while the
+// still-clustered VM keeps running on its owner — a dropped cascade definition is
+// not a state:absent demote, so no removal is issued. Driven idiomatically through
+// the controller (cfg steward tag rm), observed via effective config + cross-node
+// Get-VM. The tag is restored on cleanup so the bed returns to full membership.
+func TestIdiomaticLeave_DropsDefinitionKeepsVM(t *testing.T) {
+	ic := icSetup(t)
+
+	// Pick a member that is NOT the current owner of the role, so the leave never
+	// touches the node actually hosting the VM. Owner is read from the live cluster.
+	owner := ccGroupOwner(t, ic.cluster, ic.vmName)
+	if owner == "" {
+		t.Skipf("role %q has no current owner (not cascaded yet?) — run the cascade-in step first", ic.vmName)
+	}
+	// Map the leaving node to its steward ID: prefer a non-owner member that
+	// currently carries the VM in its effective config.
+	var leaveID string
+	for _, id := range ic.memberIDs {
+		ec := ic.icShow(t, id)
+		if _, ok := icResource(ec, "hyperv.vm", ic.vmName); !ok {
+			continue
+		}
+		hn := ic.stewardHostname(t, id)
+		if hn != "" && !strings.EqualFold(hn, owner) {
+			leaveID = id
+			break
+		}
+	}
+	if leaveID == "" {
+		t.Skipf("no non-owner member currently carries the cascaded VM %q — cascade it to all members per the runbook, then re-run", ic.vmName)
+	}
+
+	// Baseline: exactly one VM cluster-wide before the leave.
+	presBefore, distinctBefore, err := ccVMInstances(t, ic.ccEnv)
+	require.NoError(t, err)
+	require.Equalf(t, 1, distinctBefore, "precondition: exactly one VM before the leave (present on %v)", presBefore)
+
+	// Drive the idiomatic leave: drop the role tag from the leaving member. Restore
+	// it on cleanup regardless of outcome so the bed returns to full membership.
+	_, err = ic.cfg(t, "steward", "tag", "rm", leaveID, ic.roleTag)
+	require.NoErrorf(t, err, "cfg steward tag rm %s %s", leaveID, ic.roleTag)
+	t.Cleanup(func() { _, _ = ic.cfg(t, "steward", "tag", "add", leaveID, ic.roleTag) })
+
+	// (a) The cascaded VM definition disappears from the leaving member's effective
+	// config (re-resolved without the matching role config).
+	dropped := false
+	deadline := time.Now().Add(ccSettleTimeout)
+	for time.Now().Before(deadline) {
+		ec := ic.icShow(t, leaveID)
+		if _, ok := icResource(ec, "hyperv.vm", ic.vmName); !ok {
+			dropped = true
+			break
+		}
+		time.Sleep(ccPollInterval)
+	}
+	assert.Truef(t, dropped, "the cascaded VM definition must drop from the leaving member (%s) effective config after the tag is removed", leaveID)
+
+	// (b) The still-clustered VM is NOT deleted: same single instance cluster-wide,
+	// still owned by the same node. A dropped definition is not a demotion.
+	presAfter, distinctAfter, err := ccVMInstances(t, ic.ccEnv)
+	require.NoError(t, err)
+	assert.Equalf(t, 1, distinctAfter, "the still-clustered VM must survive the leave — exactly one instance, no deletion (present on %v)", presAfter)
+	assert.Lenf(t, presAfter, 1, "the VM keeps running on its single owner after the leave (present on %v)", presAfter)
+	assert.True(t, ccRolePresent(t, ic.cluster, ic.vmName),
+		"the clustered role must still exist after a member leaves the cascade")
+}
+
+// ─── live-cluster read helpers (read-only; author nothing) ──────────────────────
+
+// groupPreferredOwners returns the ordered preferred OwnerNodes of the role group
+// (Get-ClusterOwnerNode -Group) — the reflection of preferred_owners.
+func (ic icEnv) groupPreferredOwners(t *testing.T, role string) []string {
+	t.Helper()
+	out := ccPSFatal(t, `((Get-ClusterOwnerNode -Cluster '`+ic.cluster+`' -Group '`+role+`').OwnerNodes | ForEach-Object { $_.Name }) -join "`+"`n"+`"`)
+	return icLines(out)
+}
+
+// resourcePossibleOwners returns the restricted OwnerNodes of the role's Virtual
+// Machine resource (Get-ClusterOwnerNode -Resource) — the reflection of
+// possible_owners. The VM resource is matched via [string] coercion because
+// Get-ClusterResource returns .OwnerGroup / .ResourceType as strings on some
+// FailoverClusters builds (the #2577 possible_owners fix).
+func (ic icEnv) resourcePossibleOwners(t *testing.T, role string) []string {
+	t.Helper()
+	script := `$res = @(Get-ClusterResource -Cluster '` + ic.cluster + `' | Where-Object { [string]$_.OwnerGroup -eq '` + role + `' -and [string]$_.ResourceType -eq 'Virtual Machine' }); if ($res.Count -eq 0) { '' } else { ((Get-ClusterOwnerNode -Cluster '` + ic.cluster + `' -Resource $res[0].Name).OwnerNodes | ForEach-Object { $_.Name }) -join "` + "`n" + `" }`
+	return icLines(ccPSFatal(t, script))
+}
+
+// groupAntiAffinity returns the group's AntiAffinityClassNames — the reflection of
+// anti_affinity_class.
+func (ic icEnv) groupAntiAffinity(t *testing.T, role string) []string {
+	t.Helper()
+	out := ccPSFatal(t, `((Get-ClusterGroup -Cluster '`+ic.cluster+`' -Name '`+role+`').AntiAffinityClassNames) -join "`+"`n"+`"`)
+	return icLines(out)
+}
+
+// stewardHostname returns the reported hostname of a steward from `cfg steward
+// list`, or "" when unknown. Used to map a member steward ID to its cluster node.
+func (ic icEnv) stewardHostname(t *testing.T, stewardID string) string {
+	t.Helper()
+	out, err := ic.cfg(t, "steward", "list")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, stewardID) {
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				return fields[len(fields)-1] // HOSTNAME is the last column
+			}
+		}
+	}
+	return ""
+}
+
+// icStringList coerces a JSON-decoded config value (a []interface{} of strings) to
+// []string. Returns nil for anything else.
+func icStringList(v interface{}) []string {
+	raw, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// icLines splits newline-joined PowerShell output into trimmed, non-empty lines.
+func icLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/test/e2e/hyperv/cluster_cascade_test.go
+++ b/test/e2e/hyperv/cluster_cascade_test.go
@@ -268,6 +268,22 @@ func ccRolePresent(t *testing.T, cluster, role string) bool {
 	return strings.TrimSpace(out) == "yes"
 }
 
+// ccGroupState returns the State string of a cluster group ("Online", "Offline",
+// "PartiallyOnline", etc.) or "" when the group is absent.
+func ccGroupState(t *testing.T, cluster, group string) string {
+	t.Helper()
+	out, _ := ccPS(t, `try { (Get-ClusterGroup -Cluster '`+cluster+`' -Name '`+group+`' -ErrorAction Stop).State.ToString() } catch { "" }`)
+	return strings.TrimSpace(out)
+}
+
+// ccAutoBalancerEnabled reports whether the cluster's native VM dynamic optimizer
+// is enabled (AutoBalancerMode >= 1: rebalance on join, or on join + periodic).
+func ccAutoBalancerEnabled(t *testing.T, cluster string) bool {
+	t.Helper()
+	out, _ := ccPS(t, `try { if ((Get-Cluster -Name '`+cluster+`').AutoBalancerMode -ge 1) { "true" } else { "false" } } catch { "false" }`)
+	return strings.TrimSpace(out) == "true"
+}
+
 // ccVMInstances snapshots, per cluster node, whether the named VM is present and
 // its Hyper-V VMId. Two truths matter for the epic's safety property, and they
 // are DIFFERENT:


### PR DESCRIPTION
## Summary

Layer 2 of the idiomatic HA cluster management epic (#2576 / Layer 2 of #2418): proves — live on cfg-lab, **through configuration management, not module-direct** — that CFGMS manages an HA cluster VM idiomatically end-to-end. Config authored at tenant/cluster scope, cascaded by the controller, read by every member, with only the CNO acting.

## What's delivered (live-proven on cfg-lab, v0.9.29)

- **AC1 — idiomatic cascade + single CNO create.** A controller-pushed tenant/cluster config carrying one `ha_role` VM appears identical in all 3 members' effective config; exactly the CNO creates it (no duplicate). Includes two product fixes the full-stack path surfaced: `ha_role` cluster_name round-trip (`Configure` derives `m.clusterName` from `ha_role.cluster_name`; `VMConfig.AsMap` omitempty), and `modules.ManagedElsewhere` non-owner compliant-by-delegation abstain + batched cluster-owner read.
- **AC2 — declarative FC placement.** `preferred_owners` / `possible_owners` / `anti_affinity_class` set via cfgms config are reflected in the live cluster (`{CFG-AB-02, CFG-70-02}` / `{CFG-70-02, CFG-AB-02}` / `{e2e-ha-affinity}`, each matching the declared config).
  - **Bug found + fixed:** on Windows Server 2025 `Get-ClusterResource` returns `.OwnerGroup`/`.ResourceType` as plain strings (`.Name` = `$null`), so `Cfgms-SetClusterRolePossibleOwners` matched nothing and `possible_owners` was silently skipped. Fixed with `[string]` coercion (robust for string OR object) + regression test `TestPreamble_PossibleOwnersFilterUsesStringCoercion`. Layer-1 tests use a fake transport, so never saw the real object shape.
- **AC4 — idiomatic leave.** Removing a member from the cascade (tag rm) drops the VM definition from that member's effective config while the still-clustered VM survives (no-prune: untag != delete).
- **Idiomatic e2e suite** `test/e2e/hyperv/cluster_cascade_idiomatic_test.go` (build tag `e2e`, package `hyperv_e2e`): drives the controller cascade via the `cfg` CLI and observes effective config + live cluster; reuses the Layer-1 harness; skips cleanly when unset.
- **Runbook** `docs/testing/hyperv-cluster-cascade-runbook.md` §4 extended with the Layer-2 procedure + captured live evidence.

## Deferred — AC3 (re-balance under load) → #2697

The rebalance-under-load live demo requires a **bootable** ha_role VM: the #2426 cascade fixture uses an empty 0-byte VHD (no guest OS → no heartbeat → the cluster keeps the resource Offline), so it can't be load-migrated. cfg-lab also co-locates the controller as a cluster VM. The cfgms code path is identical to the Layer-1 `FailoverHandoff` test (owner-gate is trigger-agnostic), which already proves the convergence/no-duplicate/no-gap behavior. Tracked as **#2697**, sequenced after the standalone→FC-role promotion-workflow story (a promoted real VM satisfies the bootable-role prerequisite). Deferral approved by the PO.

## Validation

- Changed packages green: `features/modules/hyperv`, `features/steward/execution`, `pkg/config`; builds pass (windows + linux CGO-off); `go vet` + `make check-architecture` clean.
- Adversarial review (story-review workflow): **QA code review PASS**, **Security PASS** (gosec/staticcheck/secret-scan/architecture — zero findings in changed files). Test lens flagged only pre-existing Windows-only failures (`cmd/cfg/cmd`, `cmd/cfgms-steward-launcher` — CI-green on Linux) and one flaky SQLite setup stall in `features/controller/api` (untouched by this branch; passes in isolation). Authoritative gate is Linux CI.

Fixes #2577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>