### PR TITLE
ci: wire stdlib completeness gate into unit-tests CI job (Issue #2700)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,7 +31,7 @@ Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to 
 **Triggers**: Pull Requests to main/develop, Merge Group, push to main, Manual dispatch
 
 **Jobs**:
-- `unit-tests` — `make test` with `CFGMS_TEST_INTEGRATION=0`; every PR; emits the `unit-tests` required context
+- `unit-tests` — `make check-stdlib-completeness` (ADR-016 clause 6 gate) then `make test` with `CFGMS_TEST_INTEGRATION=0`; every PR; emits the `unit-tests` required context
 - `integration-tests` — `make test-production-critical` on self-hosted Linux (hermetic container); needs `unit-tests`; emits the `integration-tests` required context
 - `cross-feature-tests` / `production-readiness` / `synthetic-monitoring` — workflow_dispatch `all`/`full` level only
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -77,6 +77,9 @@ jobs:
     - name: Install dependencies
       run: go mod download
 
+    - name: Stdlib completeness gate (ADR-016 clause 6)
+      run: make check-stdlib-completeness
+
     - name: Start Linux resource sampler (self-hosted only, best-effort)
       if: github.event_name != 'workflow_dispatch' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
       continue-on-error: true

--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -176,7 +176,7 @@ Everything else — however useful — is an `extended` module, built as a stand
 
 ### Stdlib membership is enforced by the build
 
-Adding or removing a module from stdlib requires **five coordinated changes**, each enforced by `make check-stdlib-payload-boundary` (wired into `make test-commit`):
+Adding or removing a module from stdlib requires **five coordinated changes**, each enforced by `make check-stdlib-payload-boundary` (wired into `make test-commit` and enforced in CI via the `unit-tests` job):
 
 1. `features/modules/stdlib/<name>/` — the module directory
 2. `Makefile` `STDLIB_MODULES` variable — drives compilation
@@ -188,7 +188,7 @@ The build fails if any of the five disagree. New entries in `.wxs`, `install.sh`
 
 ### Stdlib completeness is enforced by the build (ADR-016 clause 6)
 
-In addition to the payload boundary, `make check-stdlib-completeness` (also wired into `make test-commit`, via `check-stdlib-payload-boundary` as a prerequisite) asserts that every module under `stdlib/` is fully compliant:
+In addition to the payload boundary, `make check-stdlib-completeness` (also wired into `make test-commit`, via `check-stdlib-payload-boundary` as a prerequisite, and enforced in CI via the `unit-tests` job) asserts that every module under `stdlib/` is fully compliant:
 
 | Check | What is verified |
 |-------|-----------------|

--- a/features/modules/stdlib/hostname/module_test.go
+++ b/features/modules/stdlib/hostname/module_test.go
@@ -236,11 +236,11 @@ func TestHostnameModule_Set_WrongConfigType(t *testing.T) {
 // wrongConfigType implements modules.ConfigState but is not *HostnameConfig.
 type wrongConfigType struct{}
 
-func (w *wrongConfigType) AsMap() map[string]interface{}  { return nil }
-func (w *wrongConfigType) ToYAML() ([]byte, error)        { return nil, nil }
-func (w *wrongConfigType) FromYAML(_ []byte) error        { return nil }
-func (w *wrongConfigType) Validate() error                { return nil }
-func (w *wrongConfigType) GetManagedFields() []string     { return nil }
+func (w *wrongConfigType) AsMap() map[string]interface{} { return nil }
+func (w *wrongConfigType) ToYAML() ([]byte, error)       { return nil, nil }
+func (w *wrongConfigType) FromYAML(_ []byte) error       { return nil }
+func (w *wrongConfigType) Validate() error               { return nil }
+func (w *wrongConfigType) GetManagedFields() []string    { return nil }
 
 // TestHostnameModule_LoggingInjection verifies the module implements LoggingInjectable.
 func TestHostnameModule_LoggingInjection(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a `Stdlib completeness gate (ADR-016 clause 6)` step to the `unit-tests` job in `.github/workflows/test-suite.yml`, after `Install dependencies` and before `Run Fast Unit Tests`
- Updates `.github/workflows/README.md` to mention the new step in the `unit-tests` job description
- Updates `docs/architecture/modules/README.md` to note CI enforcement alongside the existing local `make test-commit` reference

Fixes #2700

## Gap being closed

`make check-stdlib-completeness` previously only ran via the local pre-commit hook and `make test-commit`/`make test-complete`. External-contributor fork PRs never triggered it; developers bypassing hooks with `--no-verify` could merge a clause-6 violation undetected. The gate now runs on every PR via CI.

## AC#2 — Violation demo (captured locally, not shipped)

Temporarily deleted `features/modules/stdlib/hostname/cmd/main.go` and ran `make check-stdlib-completeness`:

```
🔍 Checking stdlib payload boundary (ADR-016 clause 3)...
✅ All five stdlib payload sources agree: cert_trust, file, firewall, hostname, package, patch, script, service, time, user

🔍 Checking stdlib module completeness (ADR-016 clause 6)...

❌ STDLIB COMPLETENESS VIOLATIONS (1 total)
========================================================

  ❌ [hostname] check-3: cmd/main.go not found (bundle entry point missing)

See ADR-016 clause 6 and docs/architecture/modules/README.md for requirements.
make: *** [Makefile:163: check-stdlib-completeness] Error 1
```

Exit code: non-zero (2). File restored before commit — merged state passes `make test-complete` cleanly.

## Specialist review results

- **Code Review (QA)**: PASS — no test quality issues; CI-only YAML + doc changes
- **Security Review**: PASS — static `make check-stdlib-completeness` command, no untrusted interpolation; gitleaks clean
- **Test Runner**: PASS (after 1 fix round — gofmt alignment in `features/modules/stdlib/hostname/module_test.go` corrected by developer agent)

## Test plan

- [ ] Confirm `git grep -rln "check-stdlib\|stdlib-completeness\|stdlib-payload-boundary" -- '.github/'` returns `.github/workflows/test-suite.yml`
- [ ] Confirm `make check-stdlib-completeness` exits 0 on clean tree
- [ ] Confirm CI `unit-tests` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)