### PR TITLE
web: add saved views and asset-DNA drawer to fleet overview (Issue #2498)

### DIFF
--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -229,8 +229,13 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			// A known-good version that fast-exits coinciding with a
 			// context cancel is an environmental fault (e.g. WMI race on
 			// boot), not an upgrade failure. Return clean shutdown rather
-			// than rolling back or looping on a cancelled context.
+			// than rolling back or looping on a cancelled context. Log the
+			// suppression decision first: without it, an operator inspecting
+			// why the launcher exited on a proven binary sees nothing, and
+			// the rollback-suppression guarantee for known-good versions
+			// (Issue #2033) is indistinguishable from a silent crash.
 			if isKnownGood {
+				_, _ = fmt.Fprintf(s.Stderr, "launcher: version %q is known-good — fast exit (ran %s) coincided with shutdown; rollback suppressed, exiting cleanly\n", current, ranFor)
 				return nil
 			}
 			// Fall through to the rollback logic below — this looks

--- a/features/modules/stdlib/time/executor_darwin_test.go
+++ b/features/modules/stdlib/time/executor_darwin_test.go
@@ -75,7 +75,7 @@ func TestDarwinExecutor_GetNTPEnabled_Parsing(t *testing.T) {
 	}{
 		{"Using Network Time: On", true},
 		{"Using Network Time: Off", false},
-		{"using network time: on", true},  // lowercase variant
+		{"using network time: on", true},   // lowercase variant
 		{"using network time: off", false}, // lowercase variant
 		{"Using Network Time: ON", true},   // uppercase variant
 	}

--- a/web/README.md
+++ b/web/README.md
@@ -195,7 +195,8 @@ search box doubles as its live filter).
 [`src/fleet/FleetOverview.tsx`](src/fleet/FleetOverview.tsx) renders the
 steward table inside the app shell. Canonical design:
 [`docs/design/mockups/fleet-overview.html`](../docs/design/mockups/fleet-overview.html).
-Saved views and the row drill-in asset-DNA drawer are Story #2498.
+Story #2498 adds saved views and the row drill-in asset-DNA drawer (both
+below).
 
 ### Data flow
 
@@ -248,7 +249,73 @@ Ring, Model, Serial, MAC. Missing values render an em-dash placeholder.
 
 Column selection persists in `localStorage` under `cfgms.fleet.columns`
 (allowlisted in the A7.2 source scan; values read back are validated as
-untrusted input). Full named saved views are #2498.
+untrusted input).
+
+### Saved views (Story #2498)
+
+[`src/fleet/SavedViews.tsx`](src/fleet/SavedViews.tsx) — the toolbar's
+"View:" panel (mockup `pop-views`). A saved view captures the current
+**filter text, sort (column + direction), visible column set, and page
+size** under a technician-chosen name; applying one restores exactly those
+four fields. Tenant scope is session chrome (per the mockup) and is never
+captured or restored. Save, apply, rename, and delete all happen in the
+panel; the built-in **All stewards** entry restores the defaults.
+
+**Storage format.** Views persist in `localStorage` under the literal key
+`cfgms.fleet.views` (allowlisted in the A7.2 source scan), keyed per
+principal *inside* the stored record so the storage key itself stays
+literal:
+
+```json
+{
+  "<username>": [
+    {
+      "name": "acme servers",
+      "config": {
+        "filter": "acme",
+        "sort": { "key": "name", "direction": -1 },
+        "columns": ["name", "company", "os", "health", "seen"],
+        "pageSize": 100
+      }
+    }
+  ]
+}
+```
+
+Everything read back is **untrusted input** (security A10.2): the record,
+each view, and every config field are shape- and type-validated
+(`sort.key` and `columns` against the column registry, `pageSize` against
+the fixed page-size set, length caps on names and filter text). A view
+that fails validation is dropped; valid siblings survive. At most 50 views
+per principal. There is no server-side persistence endpoint in this epic —
+sharing/roaming views across browsers is future work.
+
+### Asset-DNA drawer (Story #2498)
+
+[`src/fleet/DnaDrawer.tsx`](src/fleet/DnaDrawer.tsx) — clicking (or
+Enter/Space on) a fleet row opens the right-hand drawer (mockup `.det`)
+for that steward. Escape or a scrim click closes it, matching the shell
+overlay conventions.
+
+**Data flow.** The drawer fetches `GET /api/v1/stewards/{id}/dna` through
+the #2495 client and validates the `{ data: DNAInfo }` envelope
+(`parseDNAInfo`) as untrusted wire data. A **fixed client-side allowlist**
+maps known attribute keys into the mockup's designed groups (Identity,
+Network, System, Session & agent); every attribute the steward reports
+beyond the allowlist renders under **Other attributes**, so new steward
+DNA appears without UI changes. Group headings and row labels come only
+from that allowlist, never from data, and steward-supplied keys and values
+reach the DOM as text nodes only (security A10.1). A raw-JSON `<details>`
+view shows the full parsed payload.
+
+**Redaction tolerance.** The endpoint may 404 (cross-tenant requests 404
+rather than 403, no DNA reported yet) and the controller denylists
+sensitive attribute keys — the drawer renders its error state with a retry
+affordance for failed fetches and simply renders whatever attribute set
+comes back, never a blank panel.
+
+Deep-linking the drawer (steward ID in the route) is deferred until the
+app has a router; the seam is marked in `FleetOverview.tsx`.
 
 ### Health mapping
 
@@ -276,7 +343,9 @@ source scans), `src/shell/*.test.tsx` (tenant-scope prefix matching,
 drawer/scrim/Escape behavior, user-menu logout dispatch), and
 `src/fleet/*.test.*` (pagination contract, live filter, sort, column
 picker + persistence, health/staleness mapping, loading/error/empty
-states, hostile-DNA text-node rendering). Setup (jest-dom
+states, hostile-DNA text-node rendering, saved-view round-trip +
+untrusted-config validation, DNA drawer fetch/grouping/error states +
+hostile attribute keys/values). Setup (jest-dom
 matchers, RTL cleanup, in-memory Storage for the A7.2 assertions):
 [`src/test/setup.ts`](src/test/setup.ts).
 

--- a/web/src/fleet/DnaDrawer.test.tsx
+++ b/web/src/fleet/DnaDrawer.test.tsx
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Asset-DNA drawer suite (Story #2498): fetch/render of grouped attributes,
+ * the "Other attributes" overflow group, loading and error states (incl.
+ * 404-redaction tolerance — the endpoint 404s cross-tenant and for
+ * denylisted attributes), Escape/scrim close, and the hostile-DNA
+ * guarantees: attribute KEYS and VALUES render as escaped text only, and
+ * group headings come from the fixed client-side allowlist, never from
+ * data (security A10.1).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import DnaDrawer, { DNA_GROUP_HEADINGS, parseDNAInfo } from './DnaDrawer.tsx'
+import type { Steward } from './columns.ts'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const steward: Steward = {
+  id: 'stw-001',
+  status: 'active',
+  last_seen: new Date().toISOString(),
+  version: 'v0.42',
+  dna: {
+    hostname: 'web-ingest-04',
+    os: 'linux',
+    architecture: 'amd64',
+    attributes: {},
+  },
+}
+
+function mockDNA(attributes: Record<string, string>, extra: Record<string, unknown> = {}) {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        data: {
+          hostname: 'web-ingest-04',
+          os: 'Ubuntu 24.04',
+          architecture: 'amd64',
+          config_hash: 'abc123',
+          collected_at: '2026-07-14T10:00:00Z',
+          attributes,
+          ...extra,
+        },
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  )
+}
+
+function renderDrawer(onClose = vi.fn()) {
+  render(<DnaDrawer steward={steward} nowMs={Date.now()} onClose={onClose} />)
+  return onClose
+}
+
+describe('parseDNAInfo (untrusted wire data)', () => {
+  it('rejects non-object payloads', () => {
+    expect(() => parseDNAInfo(null)).toThrow()
+    expect(() => parseDNAInfo('str')).toThrow()
+    expect(() => parseDNAInfo(42)).toThrow()
+  })
+
+  it('drops non-string attribute values and tolerates a missing attribute map', () => {
+    const parsed = parseDNAInfo({
+      hostname: 'h',
+      attributes: { good: 'v', bad: 7, worse: { nested: true } },
+    })
+    expect(parsed.attributes).toEqual({ good: 'v' })
+    expect(parseDNAInfo({ hostname: 'h' }).attributes).toEqual({})
+  })
+
+  it('coerces missing top-level fields to empty strings', () => {
+    const parsed = parseDNAInfo({})
+    expect(parsed.hostname).toBe('')
+    expect(parsed.os).toBe('')
+    expect(parsed.collectedAt).toBe('')
+  })
+})
+
+describe('drawer fetch and grouped rendering', () => {
+  it('fetches the steward DNA endpoint and renders known attributes in their designed groups', async () => {
+    mockDNA({
+      primary_ip: '10.20.4.14',
+      tenant: 'root/acme-corp',
+      current_user: 'svc_deploy',
+    })
+    renderDrawer()
+
+    expect(await screen.findByText('10.20.4.14')).toBeTruthy()
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toBe('/api/v1/stewards/stw-001/dna')
+
+    // Known attributes appear under their fixed group headings.
+    expect(screen.getByText('Network')).toBeTruthy()
+    expect(screen.getByText('IP address')).toBeTruthy()
+    expect(screen.getByText('Identity')).toBeTruthy()
+    expect(screen.getByText('root/acme-corp')).toBeTruthy()
+    expect(screen.getByText('Session & agent')).toBeTruthy()
+    expect(screen.getByText('svc_deploy')).toBeTruthy()
+  })
+
+  it('lists unrecognized attributes under the Other attributes group', async () => {
+    mockDNA({ some_novel_key: 'novel-value' })
+    renderDrawer()
+
+    expect(await screen.findByText('Other attributes')).toBeTruthy()
+    expect(screen.getByText('some_novel_key')).toBeTruthy()
+    expect(screen.getByText('novel-value')).toBeTruthy()
+  })
+
+  it('shows a loading state before the response arrives', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderDrawer()
+    expect(screen.getByTestId('dna-loading')).toBeTruthy()
+  })
+
+  it('tolerates a redacted/empty attribute set — top-level fields still render, never a blank panel', async () => {
+    mockDNA({})
+    renderDrawer()
+    expect(await screen.findByText('Ubuntu 24.04')).toBeTruthy()
+    expect(screen.getByText('web-ingest-04', { selector: '.v' })).toBeTruthy()
+    expect(screen.queryByText('Other attributes')).toBeNull()
+  })
+})
+
+describe('drawer error states', () => {
+  it('renders the error state on 404 (cross-tenant / DNA not found), never a blank panel', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'DNA not found', code: 'DNA_NOT_FOUND' }), {
+        status: 404,
+      }),
+    )
+    renderDrawer()
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('404')
+  })
+
+  it('renders the error state on network failure and retry refetches', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+    mockDNA({ primary_ip: '10.0.0.1' })
+    renderDrawer()
+
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(await screen.findByText('10.0.0.1')).toBeTruthy()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('drawer close behavior (shell overlay conventions)', () => {
+  it('closes on Escape', async () => {
+    mockDNA({})
+    const onClose = renderDrawer()
+    await screen.findByText('Ubuntu 24.04')
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes on scrim click', async () => {
+    mockDNA({})
+    const onClose = renderDrawer()
+    await screen.findByText('Ubuntu 24.04')
+    fireEvent.click(screen.getByTestId('dna-scrim'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('hostile DNA rendering (security A10.1)', () => {
+  const hostileKey = '<img src=x onerror="window.__pwned_key=1">'
+  const hostileValue = '<script>window.__pwned_val=1</script><b>bold</b>'
+
+  it('renders hostile attribute KEYS and VALUES as escaped text in Other attributes', async () => {
+    mockDNA({ [hostileKey]: hostileValue })
+    const { container } = render(
+      <DnaDrawer steward={steward} nowMs={Date.now()} onClose={vi.fn()} />,
+    )
+
+    expect(await screen.findByText('Other attributes')).toBeTruthy()
+    // The hostile strings are present as literal TEXT...
+    expect(screen.getByText(hostileKey)).toBeTruthy()
+    expect(screen.getByText(hostileValue)).toBeTruthy()
+    // ...and never became live markup.
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('b')).toBeNull()
+    expect(
+      (window as unknown as Record<string, unknown>).__pwned_key,
+    ).toBeUndefined()
+    expect(
+      (window as unknown as Record<string, unknown>).__pwned_val,
+    ).toBeUndefined()
+  })
+
+  it('group headings come only from the fixed client-side allowlist, never from data', async () => {
+    mockDNA({
+      'Injected heading': 'x',
+      '<h1>evil</h1>': 'y',
+      primary_ip: '10.0.0.1',
+    })
+    const { container } = render(
+      <DnaDrawer steward={steward} nowMs={Date.now()} onClose={vi.fn()} />,
+    )
+    await screen.findByText('Other attributes')
+
+    const headings = [...container.querySelectorAll('.grp .lbl')].map(
+      (el) => el.textContent,
+    )
+    expect(headings.length).toBeGreaterThan(0)
+    for (const heading of headings) {
+      expect(DNA_GROUP_HEADINGS).toContain(heading)
+    }
+  })
+})

--- a/web/src/fleet/DnaDrawer.tsx
+++ b/web/src/fleet/DnaDrawer.tsx
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Asset-DNA drawer (Story #2498) — mockup `.det`. Row drill-in for one
+ * steward: fetches GET /api/v1/stewards/{id}/dna via the #2495 client and
+ * renders the full attribute map as grouped key-value rows, machine values
+ * in mono. Escape and scrim click close it (shell overlay conventions).
+ *
+ * Grouping: a FIXED client-side allowlist maps known attribute keys into
+ * the mockup's designed groups; every attribute the steward reports that
+ * isn't in the allowlist lands under "Other attributes", so new DNA appears
+ * without UI changes. Group headings and row labels come ONLY from that
+ * allowlist — never from data (security A10.1). Steward-supplied keys and
+ * values are UNTRUSTED and cross into the DOM as JSX text nodes only; do
+ * not introduce dangerouslySetInnerHTML here.
+ *
+ * The endpoint may 404 (cross-tenant, no DNA yet, denylist redaction) or
+ * fail — those render the drawer's error state, never a blank panel.
+ *
+ * Deep-link seam: the app has no router yet; when one lands, the selected
+ * steward ID belongs in the route so the drawer is linkable.
+ */
+import { useEffect, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+import { deriveHealth } from './health.ts'
+import type { Steward } from './columns.ts'
+
+export interface StewardDNAInfo {
+  hostname: string
+  os: string
+  architecture: string
+  configHash: string
+  collectedAt: string
+  attributes: Record<string, string>
+}
+
+/** Validate the DNA payload (untrusted wire data). Throws on non-objects. */
+export function parseDNAInfo(data: unknown): StewardDNAInfo {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('unexpected response shape')
+  }
+  const record = data as Record<string, unknown>
+  const str = (value: unknown): string => (typeof value === 'string' ? value : '')
+  let attributes: Record<string, string> = {}
+  if (typeof record.attributes === 'object' && record.attributes !== null) {
+    attributes = Object.fromEntries(
+      Object.entries(record.attributes).filter(
+        (entry): entry is [string, string] => typeof entry[1] === 'string',
+      ),
+    )
+  }
+  return {
+    hostname: str(record.hostname),
+    os: str(record.os),
+    architecture: str(record.architecture),
+    configHash: str(record.config_hash),
+    collectedAt: str(record.collected_at),
+    attributes,
+  }
+}
+
+interface RowSpec {
+  /** Fixed display label — never derived from data. */
+  label: string
+  value: (dna: StewardDNAInfo) => string
+}
+
+interface GroupSpec {
+  heading: string
+  rows: RowSpec[]
+}
+
+/* Entry scan instead of computed member access: attribute maps are
+ * steward-supplied (untrusted), so no dynamic-key indexing into them
+ * (same idiom as columns.ts). */
+const attr =
+  (...keys: string[]) =>
+  (dna: StewardDNAInfo): string => {
+    for (const key of keys) {
+      const value = Object.entries(dna.attributes).find(([k]) => k === key)?.[1]
+      if (value) return value
+    }
+    return ''
+  }
+
+/*
+ * The fixed grouping allowlist (mockup drawer groups). Attribute keys named
+ * here render under their designed group; everything else overflows into
+ * "Other attributes".
+ */
+const DNA_GROUPS: readonly GroupSpec[] = [
+  {
+    heading: 'Identity',
+    rows: [
+      { label: 'Hostname', value: (dna) => dna.hostname },
+      { label: 'Company / tenant', value: attr('tenant') },
+      { label: 'Ring', value: attr('deployment_ring') },
+      { label: 'Machine ID', value: attr('machine_id', 'system_uuid', 'hardware_uuid') },
+    ],
+  },
+  {
+    heading: 'Network',
+    rows: [
+      { label: 'IP address', value: attr('primary_ip') },
+      { label: 'MAC', value: attr('primary_mac') },
+      { label: 'IP addresses', value: attr('ip_addresses') },
+      { label: 'Default gateway', value: attr('default_gateway') },
+      { label: 'DNS servers', value: attr('dns_servers', 'dns_nameservers') },
+      { label: 'DNS domain', value: attr('dns_domain', 'domain_name') },
+    ],
+  },
+  {
+    heading: 'System',
+    rows: [
+      { label: 'OS / platform', value: (dna) => dna.os || attr('os_pretty_name')(dna) },
+      { label: 'Architecture', value: (dna) => dna.architecture || attr('arch')(dna) },
+      { label: 'Kernel', value: attr('kernel_version') },
+      { label: 'Model', value: attr('system_model', 'hardware_model') },
+      { label: 'Manufacturer', value: attr('system_manufacturer') },
+      { label: 'Serial', value: attr('system_serial_number', 'motherboard_serial') },
+      { label: 'CPU', value: attr('cpu_model', 'cpu_name') },
+      { label: 'CPU cores', value: attr('cpu_cores', 'cpu_count') },
+      { label: 'Memory', value: attr('memory_total_human', 'memory_total_gb') },
+      { label: 'Uptime', value: attr('system_uptime') },
+    ],
+  },
+  {
+    heading: 'Session & agent',
+    rows: [
+      { label: 'Last logged-in user', value: attr('current_user') },
+      { label: 'Logged-in users', value: attr('logged_in_users') },
+      { label: 'Agent version', value: attr('steward.version') },
+      { label: 'Config hash', value: (dna) => dna.configHash },
+      { label: 'Collected', value: (dna) => dna.collectedAt },
+    ],
+  },
+]
+
+const OTHER_HEADING = 'Other attributes'
+
+/** Every heading the drawer can render — the A10.1 test asserts against this. */
+export const DNA_GROUP_HEADINGS: readonly string[] = [
+  ...DNA_GROUPS.map((group) => group.heading),
+  OTHER_HEADING,
+]
+
+/* Attribute keys consumed by the designed groups (including fallbacks) —
+ * anything the steward reports beyond these overflows to Other attributes. */
+const GROUPED_ATTR_KEYS = new Set<string>([
+  'tenant',
+  'deployment_ring',
+  'machine_id',
+  'system_uuid',
+  'hardware_uuid',
+  'primary_ip',
+  'primary_mac',
+  'ip_addresses',
+  'default_gateway',
+  'dns_servers',
+  'dns_nameservers',
+  'dns_domain',
+  'domain_name',
+  'os_pretty_name',
+  'arch',
+  'kernel_version',
+  'system_model',
+  'hardware_model',
+  'system_manufacturer',
+  'system_serial_number',
+  'motherboard_serial',
+  'cpu_model',
+  'cpu_name',
+  'cpu_cores',
+  'cpu_count',
+  'memory_total_human',
+  'memory_total_gb',
+  'system_uptime',
+  'current_user',
+  'logged_in_users',
+  'steward.version',
+])
+
+interface FetchOutcome {
+  /** Which (steward, attempt) request this outcome answers. */
+  key: string
+  dna?: StewardDNAInfo
+  error?: string
+}
+
+function KVRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="kv">
+      <span className="k">{label}</span>
+      <span className="v mono2">{value}</span>
+    </div>
+  )
+}
+
+export default function DnaDrawer({
+  steward,
+  nowMs,
+  onClose,
+}: {
+  steward: Steward
+  nowMs: number
+  onClose: () => void
+}) {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+  const key = `${steward.id}:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    const path = `/api/v1/stewards/${encodeURIComponent(steward.id)}/dna`
+    apiFetch(path)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`GET ${path} — ${response.status}`)
+        }
+        const body: unknown = await response.json()
+        const dna = parseDNAInfo((body as Record<string, unknown> | null)?.data)
+        if (!cancelled) setOutcome({ key, dna })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : `GET ${path} — request failed`,
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, steward.id])
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  const current = outcome?.key === key ? outcome : null
+  const dna = current?.dna
+  const health = deriveHealth(steward.status, steward.last_seen, nowMs)
+  const name = steward.dna?.hostname || steward.id
+
+  const otherAttrs =
+    dna === undefined
+      ? []
+      : Object.entries(dna.attributes)
+          .filter(([attrKey]) => !GROUPED_ATTR_KEYS.has(attrKey))
+          .sort(([a], [b]) => a.localeCompare(b))
+
+  return (
+    <>
+      <div className="scrim det-scrim" data-testid="dna-scrim" onClick={onClose} />
+      <aside className="det" role="dialog" aria-label={`Device DNA: ${name}`}>
+        <div className="dh">
+          <span className={`pill ${health.tone}`}>
+            <span className="dot" />
+            {health.label}
+          </span>
+          <span className="nm">{name}</span>
+          <button
+            type="button"
+            className="icobtn x"
+            aria-label="Close details"
+            onClick={onClose}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M6 6l12 12M18 6L6 18"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="db">
+          {current === null ? (
+            <div data-testid="dna-loading" aria-label="Loading device DNA">
+              {Array.from({ length: 8 }, (_, i) => (
+                <div className="kv" key={i}>
+                  <span className="skel" style={{ width: '30%' }} />
+                  <span className="skel" style={{ width: '45%' }} />
+                </div>
+              ))}
+            </div>
+          ) : current.error !== undefined ? (
+            <div className="notice err" role="alert">
+              <div className="ic">!</div>
+              <h3>Couldn&apos;t load device DNA</h3>
+              <p>
+                The DNA for this steward isn&apos;t available — it may not have
+                reported yet, or you may not have access to it.
+              </p>
+              <span className="mono2 detail">{current.error}</span>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => setAttempt((n) => n + 1)}
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            dna !== undefined && (
+              <>
+                {DNA_GROUPS.map((group) => {
+                  const rows = group.rows
+                    .map((row) => ({ label: row.label, value: row.value(dna) }))
+                    .filter((row) => row.value !== '')
+                  if (rows.length === 0) return null
+                  return (
+                    <div key={group.heading}>
+                      <div className="grp">
+                        <div className="lbl">{group.heading}</div>
+                      </div>
+                      {rows.map((row) => (
+                        <KVRow key={row.label} label={row.label} value={row.value} />
+                      ))}
+                      <div className="gsep" />
+                    </div>
+                  )
+                })}
+                {otherAttrs.length > 0 && (
+                  <div>
+                    <div className="grp">
+                      <div className="lbl">{OTHER_HEADING}</div>
+                    </div>
+                    {otherAttrs.map(([attrKey, value]) => (
+                      <KVRow key={attrKey} label={attrKey} value={value} />
+                    ))}
+                    <div className="gsep" />
+                  </div>
+                )}
+                <details className="raw">
+                  <summary>View all DNA (raw)</summary>
+                  <pre>{JSON.stringify(dna, null, 2)}</pre>
+                </details>
+              </>
+            )
+          )}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/web/src/fleet/FleetOverview.css
+++ b/web/src/fleet/FleetOverview.css
@@ -6,6 +6,8 @@
  * (docs/design/web-ui-design-tokens.css). Mono carries machine data;
  * tabular-nums on numerics; semantic state tokens color the Health pill.
  * Below 720px the table folds into the mockup's two-column card layout.
+ * Story #2498 adds the saved-views panel and the asset-DNA drawer (mockup
+ * `pop-views` and `.det`).
  */
 
 .ptool {
@@ -355,4 +357,226 @@ table.tbl {
     padding: 0;
     cursor: default;
   }
+}
+
+/* Rows are drill-in targets (Story #2498). */
+.tbl tbody tr.sel {
+  cursor: pointer;
+}
+.tbl tbody tr.sel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* Saved views (mockup `pop-views`). */
+.viewpicker {
+  position: relative;
+}
+.vbtn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 11px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.vbtn .viewname {
+  color: var(--accent);
+}
+.viewpop {
+  left: 0;
+  top: 40px;
+  min-width: 230px;
+}
+/* Popover rows double as buttons here — keep the .pop .row look. */
+.viewpop button.row {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  width: 100%;
+}
+.viewpop .viewrow {
+  padding: 2px 4px 2px 0;
+  gap: 2px;
+}
+.viewpop .viewapply {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  color: inherit;
+  flex: 1;
+  min-width: 0;
+  padding: 6px 5px 6px 9px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.viewpop .viewact {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-faint);
+  border-radius: var(--radius-sm);
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  flex: none;
+}
+.viewpop .viewact:hover {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+.viewform {
+  display: flex;
+  gap: 6px;
+  padding: 6px 8px 8px;
+}
+.viewform input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: var(--bg-sunk);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: var(--text-sm);
+  padding: 6px 8px;
+}
+.viewform button {
+  appearance: none;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.viewform button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Asset-DNA drawer (mockup `.det`). The shell scrim is inert by default;
+ * the drawer's own scrim is always live while mounted. */
+.det-scrim {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 44;
+}
+.det {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 400px;
+  max-width: 92%;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+  z-index: 45;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow);
+  animation: det-in 0.24s ease;
+}
+@keyframes det-in {
+  from {
+    transform: translateX(103%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .det {
+    animation: none;
+  }
+}
+.det .dh {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 15px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.det .dh .nm {
+  font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.det .dh .x {
+  margin-left: auto;
+}
+.det .db {
+  flex: 1;
+  overflow: auto;
+  padding: 6px 0 20px;
+}
+.det .grp {
+  padding: 12px 16px 4px;
+}
+.det .grp .lbl {
+  margin-bottom: 2px;
+}
+.det .kv {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 6px 16px;
+  font-size: 12.5px;
+  align-items: baseline;
+}
+.det .kv .k {
+  color: var(--text-secondary);
+  flex: none;
+}
+.det .kv .v {
+  text-align: right;
+  word-break: break-word;
+}
+.det .gsep {
+  height: 1px;
+  background: var(--border);
+  margin: 8px 16px;
+}
+.det .raw {
+  margin: 10px 16px 0;
+}
+.det .raw summary {
+  font-size: var(--text-sm);
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+}
+.det .raw pre {
+  margin: 8px 0 0;
+  padding: 12px;
+  background: var(--bg-sunk);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.55;
+}
+.det .kv .skel {
+  height: 12px;
 }

--- a/web/src/fleet/FleetOverview.test.tsx
+++ b/web/src/fleet/FleetOverview.test.tsx
@@ -17,6 +17,7 @@ import {
   waitFor,
   within,
 } from '@testing-library/react'
+import { AuthProvider } from '../auth/AuthContext.tsx'
 import {
   TenantScopeProvider,
   useTenantScope,
@@ -91,9 +92,11 @@ function mockFleet(stewards: Steward[]) {
 
 function renderFleet(search = '') {
   return render(
-    <TenantScopeProvider rootPath="root">
-      <FleetOverview search={search} />
-    </TenantScopeProvider>,
+    <AuthProvider>
+      <TenantScopeProvider rootPath="root">
+        <FleetOverview search={search} onSearchChange={() => {}} />
+      </TenantScopeProvider>
+    </AuthProvider>,
   )
 }
 
@@ -177,9 +180,11 @@ describe('live filter', () => {
     expect(dataRows()).toHaveLength(3)
 
     rerender(
-      <TenantScopeProvider rootPath="root">
-        <FleetOverview search="web-ingest" />
-      </TenantScopeProvider>,
+      <AuthProvider>
+        <TenantScopeProvider rootPath="root">
+          <FleetOverview search="web-ingest" onSearchChange={() => {}} />
+        </TenantScopeProvider>
+      </AuthProvider>,
     )
     expect(dataRows()).toHaveLength(1)
     expect(screen.getByText('web-ingest-04')).toBeInTheDocument()
@@ -192,9 +197,11 @@ describe('live filter', () => {
     await screen.findByRole('table')
     // Agent version is not a default column but is part of the haystack.
     rerender(
-      <TenantScopeProvider rootPath="root">
-        <FleetOverview search="v0.42" />
-      </TenantScopeProvider>,
+      <AuthProvider>
+        <TenantScopeProvider rootPath="root">
+          <FleetOverview search="v0.42" onSearchChange={() => {}} />
+        </TenantScopeProvider>
+      </AuthProvider>,
     )
     expect(dataRows()).toHaveLength(3)
   })
@@ -399,7 +406,7 @@ describe('tenant scope', () => {
           narrow-scope
         </button>
         <span data-testid="observed">{observedPaths.join(',')}</span>
-        <FleetOverview search="" />
+        <FleetOverview search="" onSearchChange={() => {}} />
       </div>
     )
   }
@@ -414,9 +421,11 @@ describe('tenant scope', () => {
   it('registers observed tenant paths and narrows displayed rows to the scope', async () => {
     mockFleet(fleet)
     render(
-      <TenantScopeProvider rootPath="root">
-        <ScopeHarness />
-      </TenantScopeProvider>,
+      <AuthProvider>
+        <TenantScopeProvider rootPath="root">
+          <ScopeHarness />
+        </TenantScopeProvider>
+      </AuthProvider>,
     )
     await screen.findByRole('table')
 
@@ -439,14 +448,16 @@ describe('tenant scope', () => {
           <button type="button" onClick={() => setScope('root/msp-a')}>
             narrow-scope
           </button>
-          <FleetOverview search="" />
+          <FleetOverview search="" onSearchChange={() => {}} />
         </div>
       )
     }
     render(
-      <TenantScopeProvider rootPath="root">
-        <NarrowToEmpty />
-      </TenantScopeProvider>,
+      <AuthProvider>
+        <TenantScopeProvider rootPath="root">
+          <NarrowToEmpty />
+        </TenantScopeProvider>
+      </AuthProvider>,
     )
     await screen.findByRole('table')
     fireEvent.click(screen.getByRole('button', { name: 'narrow-scope' }))

--- a/web/src/fleet/FleetOverview.tsx
+++ b/web/src/fleet/FleetOverview.tsx
@@ -9,11 +9,14 @@
  * filter and sort operate on the displayed page's rows, not the whole fleet.
  *
  * The live-filter input is the shell's global search box (#2496 chrome);
- * its value arrives via the `search` prop. Tenant scope (#2496 context) is
- * a display convenience narrowing displayed rows — server-side tenant
- * scoping on the API is the only enforcement (security A8.1).
+ * its value arrives via the `search` prop and saved views restore it via
+ * `onSearchChange`. Tenant scope (#2496 context) is a display convenience
+ * narrowing displayed rows — server-side tenant scoping on the API is the
+ * only enforcement (security A8.1); it is session chrome, never captured
+ * by a saved view.
  *
- * Saved views and the row drill-in asset-DNA drawer land in Story #2498.
+ * Story #2498 adds saved views (SavedViews.tsx) and the row drill-in
+ * asset-DNA drawer (DnaDrawer.tsx).
  */
 import { useMemo, useState } from 'react'
 import { isScopeMatch, useTenantScope } from '../shell/TenantScopeContext.tsx'
@@ -27,13 +30,16 @@ import {
 } from './columns.ts'
 import { deriveHealth, formatLastSeen, parseLastSeen } from './health.ts'
 import ColumnPicker from './ColumnPicker.tsx'
+import DnaDrawer from './DnaDrawer.tsx'
 import FleetTable, { type SortState } from './FleetTable.tsx'
 import { ErrorNotice, FleetEmpty, LoadingRows, NoMatch } from './FleetStates.tsx'
+import SavedViews, {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZES,
+  type ViewConfig,
+} from './SavedViews.tsx'
 import { useStewards } from './useStewards.ts'
 import './FleetOverview.css'
-
-const PAGE_SIZES = [25, 50, 100, 250] as const
-const DEFAULT_PAGE_SIZE = 50
 
 const formatCount = new Intl.NumberFormat('en-US')
 
@@ -74,7 +80,13 @@ function matchesFilter(steward: Steward, needle: string, nowMs: number): boolean
   return haystack.includes(needle)
 }
 
-export default function FleetOverview({ search }: { search: string }) {
+export default function FleetOverview({
+  search,
+  onSearchChange,
+}: {
+  search: string
+  onSearchChange: (value: string) => void
+}) {
   const { scope, rootPath } = useTenantScope()
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE)
   const [pageIndex, setPageIndex] = useState(0)
@@ -82,6 +94,9 @@ export default function FleetOverview({ search }: { search: string }) {
   const [visible, setVisible] = useState<ReadonlySet<ColumnKey>>(
     () => new Set(loadColumnPrefs() ?? DEFAULT_VISIBLE),
   )
+  // Row drill-in (deep-link seam: when a router lands, this belongs in the
+  // route so a drawer is linkable by steward ID).
+  const [selected, setSelected] = useState<Steward | null>(null)
 
   const { page, loading, error, fetchedAtMs, retry } = useStewards(
     pageSize,
@@ -144,6 +159,29 @@ export default function FleetOverview({ search }: { search: string }) {
     setPageIndex(0)
   }
 
+  /* The saved-view contract: exactly filter text, sort, visible column set,
+   * and page size — tenant scope is deliberately absent. */
+  const currentConfig = useMemo<ViewConfig>(
+    () => ({
+      filter: search,
+      sort:
+        sort === null
+          ? null
+          : { key: sort.key as ColumnKey, direction: sort.direction },
+      columns: COLUMNS.filter((c) => visible.has(c.key)).map((c) => c.key),
+      pageSize,
+    }),
+    [search, sort, visible, pageSize],
+  )
+
+  function applyView(config: ViewConfig) {
+    onSearchChange(config.filter)
+    setSort(config.sort)
+    setVisible(new Set(config.columns))
+    setPageSize(config.pageSize)
+    setPageIndex(0)
+  }
+
   const columns = COLUMNS.filter((column) => visible.has(column.key))
   const total = page?.total ?? 0
   const pages = Math.max(1, Math.ceil(total / pageSize))
@@ -165,6 +203,7 @@ export default function FleetOverview({ search }: { search: string }) {
       </div>
       <section className="panel">
         <div className="ptool">
+          <SavedViews current={currentConfig} onApply={applyView} />
           <ColumnPicker visible={visible} onToggle={onToggleColumn} />
           <span className="cnt" data-testid="fleet-count">
             {page === null ? '' : countText}
@@ -186,6 +225,15 @@ export default function FleetOverview({ search }: { search: string }) {
             sort={sort}
             onSort={onSort}
             nowMs={nowMs}
+            onRowSelect={setSelected}
+          />
+        )}
+
+        {selected !== null && (
+          <DnaDrawer
+            steward={selected}
+            nowMs={nowMs}
+            onClose={() => setSelected(null)}
           />
         )}
 

--- a/web/src/fleet/FleetTable.tsx
+++ b/web/src/fleet/FleetTable.tsx
@@ -9,8 +9,8 @@
  * text interpolation — text nodes only, never markup. Do not introduce
  * dangerouslySetInnerHTML here.
  *
- * Row drill-in (asset-DNA drawer) is Story #2498; it will attach through an
- * onRowSelect seam on this component.
+ * Row drill-in (Story #2498): rows are selectable via click or Enter/Space;
+ * the parent opens the asset-DNA drawer for the selected steward.
  */
 import { deriveHealth, formatLastSeen } from './health.ts'
 import type { ColumnDef, Steward } from './columns.ts'
@@ -67,12 +67,14 @@ export default function FleetTable({
   sort,
   onSort,
   nowMs,
+  onRowSelect,
 }: {
   stewards: Steward[]
   columns: ColumnDef[]
   sort: SortState | null
   onSort: (key: string) => void
   nowMs: number
+  onRowSelect?: (steward: Steward) => void
 }) {
   return (
     <table className="tbl">
@@ -105,7 +107,21 @@ export default function FleetTable({
       </thead>
       <tbody>
         {stewards.map((steward) => (
-          <tr key={steward.id}>
+          <tr
+            key={steward.id}
+            className={onRowSelect ? 'sel' : undefined}
+            tabIndex={onRowSelect ? 0 : undefined}
+            onClick={onRowSelect && (() => onRowSelect(steward))}
+            onKeyDown={
+              onRowSelect &&
+              ((event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  onRowSelect(steward)
+                }
+              })
+            }
+          >
             {columns.map((column) => (
               <Cell
                 key={column.key}

--- a/web/src/fleet/SavedViews.test.tsx
+++ b/web/src/fleet/SavedViews.test.tsx
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Saved views suite (Story #2498): save/apply/rename/delete round-trip with
+ * localStorage persistence, exact view-state restoration (filter, sort,
+ * column set, page size — NOT tenant scope), per-principal keying, and
+ * validation of configs read back from localStorage as untrusted input
+ * (security A10.2).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useEffect, useState } from 'react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import { AuthProvider, useAuth } from '../auth/AuthContext.tsx'
+import {
+  TenantScopeProvider,
+  useTenantScope,
+} from '../shell/TenantScopeContext.tsx'
+import FleetOverview from './FleetOverview.tsx'
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_SAVED_VIEWS,
+  loadViews,
+  saveViews,
+  type SavedView,
+  type ViewConfig,
+} from './SavedViews.tsx'
+import type { Steward } from './columns.ts'
+
+const STORAGE_KEY = 'cfgms.fleet.views'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+  localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function makeSteward(id: string, hostname: string): Steward {
+  return {
+    id,
+    status: 'active',
+    last_seen: new Date().toISOString(),
+    version: 'v0.42',
+    dna: {
+      hostname,
+      os: 'linux',
+      architecture: 'amd64',
+      // In-scope tenant so narrowing the scope in the harness never empties
+      // the table (the restoration test asserts against column headers).
+      attributes: { tenant: 'root/msp-a' },
+    },
+  }
+}
+
+const FLEET = [
+  makeSteward('s1', 'acme-web-01'),
+  makeSteward('s2', 'globex-db-01'),
+]
+
+/** Serve login endpoints plus a steward page for the FleetOverview harness. */
+function mockBackend() {
+  fetchMock.mockImplementation((input, init) => {
+    const url = new URL(String(input), 'https://controller.test')
+    if (url.pathname === '/api/v1/web/csrf') {
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }
+    if (url.pathname === '/api/v1/web/login') {
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }
+    if (url.pathname.endsWith('/dna')) {
+      const body = {
+        data: {
+          hostname: 'acme-web-01',
+          os: 'linux',
+          architecture: 'amd64',
+          attributes: {},
+        },
+      }
+      return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
+    }
+    if (url.pathname === '/api/v1/stewards') {
+      const limit = Number(url.searchParams.get('limit'))
+      const offset = Number(url.searchParams.get('offset'))
+      const body = {
+        data: {
+          stewards: FLEET.slice(offset, offset + limit),
+          total: FLEET.length,
+          limit,
+          offset,
+        },
+      }
+      return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
+    }
+    void init
+    return Promise.resolve(new Response('{}', { status: 404 }))
+  })
+}
+
+/*
+ * Harness playing AppShell's role: owns the search state (the shell's global
+ * search box) and exposes the tenant scope so tests can prove it is neither
+ * captured nor restored by views. Signs in through the real AuthProvider so
+ * views key off the actual principal.
+ */
+function Harness({ user }: { user: string }) {
+  const { status, login } = useAuth()
+  useEffect(() => {
+    if (status === 'signedOut') void login(user, 'pw')
+  }, [status, login, user])
+  if (status !== 'signedIn') return null
+  return (
+    <TenantScopeProvider rootPath="root">
+      <HarnessBody />
+    </TenantScopeProvider>
+  )
+}
+
+function HarnessBody() {
+  const [search, setSearch] = useState('')
+  const { scope, setScope } = useTenantScope()
+  return (
+    <>
+      <input
+        aria-label="Global filter"
+        value={search}
+        onChange={(event) => setSearch(event.target.value)}
+      />
+      <span data-testid="scope-probe">{scope}</span>
+      <button type="button" onClick={() => setScope('root/msp-a')}>
+        narrow scope
+      </button>
+      <FleetOverview search={search} onSearchChange={setSearch} />
+    </>
+  )
+}
+
+function renderHarness(user = 'alice') {
+  mockBackend()
+  return render(
+    <AuthProvider>
+      <Harness user={user} />
+    </AuthProvider>,
+  )
+}
+
+async function openViewsMenu() {
+  // Idempotent: saving leaves the panel open; a second toggle would close it.
+  if (screen.queryByRole('group', { name: 'Saved views' }) === null) {
+    fireEvent.click(await screen.findByRole('button', { name: /^View:/ }))
+  }
+}
+
+async function saveCurrentViewAs(name: string) {
+  await openViewsMenu()
+  fireEvent.click(screen.getByText('Save current view…'))
+  fireEvent.change(screen.getByLabelText('View name'), {
+    target: { value: name },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+}
+
+const validConfig: ViewConfig = {
+  filter: 'acme',
+  sort: { key: 'name', direction: -1 },
+  columns: ['name', 'os', 'health'],
+  pageSize: 100,
+}
+
+describe('localStorage round-trip and per-principal keying (pure functions)', () => {
+  it('save/load round-trips a view for its principal only', () => {
+    const view: SavedView = { name: 'Servers', config: validConfig }
+    saveViews('alice', [view])
+    expect(loadViews('alice')).toEqual([view])
+    expect(loadViews('bob')).toEqual([])
+  })
+
+  it('saving for one principal preserves the other principals in the record', () => {
+    saveViews('alice', [{ name: 'A', config: validConfig }])
+    saveViews('bob', [{ name: 'B', config: validConfig }])
+    expect(loadViews('alice').map((v) => v.name)).toEqual(['A'])
+    expect(loadViews('bob').map((v) => v.name)).toEqual(['B'])
+  })
+
+  it('caps the number of stored views per principal', () => {
+    const views = Array.from({ length: MAX_SAVED_VIEWS + 10 }, (_, i) => ({
+      name: `v${i}`,
+      config: validConfig,
+    }))
+    saveViews('alice', views)
+    expect(loadViews('alice').length).toBe(MAX_SAVED_VIEWS)
+  })
+})
+
+describe('untrusted localStorage validation (security A10.2)', () => {
+  function seed(raw: string) {
+    localStorage.setItem(STORAGE_KEY, raw)
+  }
+
+  it('falls back to empty on malformed JSON or a non-record top level', () => {
+    seed('{not json')
+    expect(loadViews('alice')).toEqual([])
+    seed('[1,2,3]')
+    expect(loadViews('alice')).toEqual([])
+    seed('"string"')
+    expect(loadViews('alice')).toEqual([])
+  })
+
+  it('drops views that fail shape or type validation, keeping valid siblings', () => {
+    const good = { name: 'Good', config: validConfig }
+    const cases: unknown[] = [
+      'not an object',
+      { name: 42, config: validConfig },
+      { name: '', config: validConfig },
+      { name: 'x'.repeat(200), config: validConfig },
+      { name: 'NoConfig' },
+      { name: 'BadFilter', config: { ...validConfig, filter: 7 } },
+      { name: 'BadSortKey', config: { ...validConfig, sort: { key: 'evil', direction: 1 } } },
+      { name: 'BadSortDir', config: { ...validConfig, sort: { key: 'name', direction: 0 } } },
+      { name: 'BadColumns', config: { ...validConfig, columns: ['name', 'not-a-column'] } },
+      { name: 'ColumnsNotArray', config: { ...validConfig, columns: 'name' } },
+      { name: 'BadPageSize', config: { ...validConfig, pageSize: 9999 } },
+      good,
+    ]
+    seed(JSON.stringify({ alice: cases }))
+    expect(loadViews('alice')).toEqual([good])
+  })
+
+  it('a principal entry that is not an array yields no views', () => {
+    seed(JSON.stringify({ alice: { sneaky: true } }))
+    expect(loadViews('alice')).toEqual([])
+  })
+})
+
+describe('saved views in the fleet overview', () => {
+  it('saves the current configuration, applies it exactly, and does not capture tenant scope', async () => {
+    renderHarness()
+    await screen.findByRole('table')
+
+    // Build a non-default view state: filter, sort desc, extra column, page size.
+    fireEvent.change(screen.getByLabelText('Global filter'), {
+      target: { value: 'acme' },
+    })
+    const nameHeader = () => screen.getByRole('columnheader', { name: /^Name/ })
+    fireEvent.click(nameHeader())
+    fireEvent.click(nameHeader()) // descending
+    fireEvent.click(screen.getByRole('button', { name: 'Columns' }))
+    fireEvent.click(screen.getByLabelText('OS / platform'))
+    fireEvent.keyDown(document, { key: 'Escape' })
+    fireEvent.change(screen.getByLabelText('Stewards per page'), {
+      target: { value: '100' },
+    })
+    // Narrow the tenant scope — this must NOT be captured by the view.
+    fireEvent.click(screen.getByRole('button', { name: 'narrow scope' }))
+
+    await saveCurrentViewAs('My view')
+
+    // The stored config captures exactly the four view fields — no scope.
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<
+      string,
+      { name: string; config: Record<string, unknown> }[]
+    >
+    const aliceViews = stored.alice ?? []
+    expect(aliceViews.map((v) => v.name)).toEqual(['My view'])
+    expect(Object.keys(aliceViews[0]?.config ?? {}).sort()).toEqual([
+      'columns',
+      'filter',
+      'pageSize',
+      'sort',
+    ])
+
+    // Reset everything via the built-in default view. The page-size change
+    // refetches, so wait for the pager to return.
+    await openViewsMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'All stewards' }))
+    expect((screen.getByLabelText('Global filter') as HTMLInputElement).value).toBe('')
+    expect(
+      ((await screen.findByLabelText('Stewards per page')) as HTMLSelectElement)
+        .value,
+    ).toBe(String(DEFAULT_PAGE_SIZE))
+    expect(screen.queryByRole('columnheader', { name: /^OS/ })).toBeNull()
+
+    // Apply the saved view: all four fields restore exactly.
+    await openViewsMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'My view' }))
+    expect((screen.getByLabelText('Global filter') as HTMLInputElement).value).toBe(
+      'acme',
+    )
+    expect(
+      ((await screen.findByLabelText('Stewards per page')) as HTMLSelectElement)
+        .value,
+    ).toBe('100')
+    expect(screen.getByRole('columnheader', { name: /^OS/ })).toBeTruthy()
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole('columnheader', { name: /^Name/ })
+          .getAttribute('aria-sort'),
+      ).toBe('descending'),
+    )
+    // Tenant scope was untouched by the apply.
+    expect(screen.getByTestId('scope-probe').textContent).toBe('root/msp-a')
+  })
+
+  it('views survive reload (fresh mount reads them back from localStorage)', async () => {
+    const first = renderHarness()
+    await screen.findByRole('table')
+    await saveCurrentViewAs('Persisted')
+    first.unmount()
+
+    renderHarness()
+    await screen.findByRole('table')
+    await openViewsMenu()
+    expect(screen.getByRole('button', { name: 'Persisted' })).toBeTruthy()
+  })
+
+  it('is keyed per principal — another user does not see the views', async () => {
+    const first = renderHarness('alice')
+    await screen.findByRole('table')
+    await saveCurrentViewAs('Alice only')
+    first.unmount()
+
+    renderHarness('bob')
+    await screen.findByRole('table')
+    await openViewsMenu()
+    expect(screen.queryByRole('button', { name: 'Alice only' })).toBeNull()
+  })
+
+  it('renames a view and the rename persists', async () => {
+    renderHarness()
+    await screen.findByRole('table')
+    await saveCurrentViewAs('Old name')
+
+    await openViewsMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Old name' }))
+    fireEvent.change(screen.getByLabelText('View name'), {
+      target: { value: 'New name' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(loadViews('alice').map((v) => v.name)).toEqual(['New name'])
+    await openViewsMenu()
+    expect(screen.getByRole('button', { name: 'New name' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Old name' })).toBeNull()
+  })
+
+  it('deletes a view and the deletion persists', async () => {
+    renderHarness()
+    await screen.findByRole('table')
+    await saveCurrentViewAs('Doomed')
+
+    await openViewsMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Doomed' }))
+    expect(loadViews('alice')).toEqual([])
+    expect(screen.queryByRole('button', { name: 'Doomed' })).toBeNull()
+  })
+
+  it('the views menu closes on Escape (shell overlay conventions)', async () => {
+    renderHarness()
+    await screen.findByRole('table')
+    await openViewsMenu()
+    expect(screen.getByText('Save current view…')).toBeTruthy()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.queryByText('Save current view…')).toBeNull(),
+    )
+  })
+})
+
+describe('row drill-in wiring', () => {
+  it('clicking a fleet row opens the asset-DNA drawer for that steward', async () => {
+    renderHarness()
+    const table = await screen.findByRole('table')
+    fetchMock.mockClear()
+
+    fireEvent.click(within(table).getByText('acme-web-01'))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeTruthy()
+    const dnaCall = fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .find((url) => url.includes('/dna'))
+    expect(dnaCall).toBe('/api/v1/stewards/s1/dna')
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+})

--- a/web/src/fleet/SavedViews.tsx
+++ b/web/src/fleet/SavedViews.tsx
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Saved fleet views (Story #2498) — mockup `pop-views`. A view captures the
+ * current fleet configuration (filter text, sort, visible column set, page
+ * size) under a technician-chosen name; applying one restores that state
+ * exactly. Tenant scope is session chrome (mockup), never captured.
+ *
+ * Views persist in localStorage under the literal key 'cfgms.fleet.views'
+ * (registered in Login.test.tsx STORAGE_ALLOWLIST) as a record keyed per
+ * principal: { [username]: SavedView[] }. There is no server-side
+ * persistence endpoint in this epic — sharing/roaming is future work.
+ * Everything read back from localStorage is UNTRUSTED input and is
+ * shape- and type-validated before use (security A10.2); a view that fails
+ * validation is dropped, valid siblings survive.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '../auth/AuthContext.tsx'
+import { COLUMNS, DEFAULT_VISIBLE, type ColumnKey } from './columns.ts'
+
+export const PAGE_SIZES = [25, 50, 100, 250] as const
+export const DEFAULT_PAGE_SIZE = 50
+export const MAX_SAVED_VIEWS = 50
+
+const MAX_NAME_LEN = 80
+const MAX_FILTER_LEN = 512
+
+export interface ViewSort {
+  key: ColumnKey
+  direction: 1 | -1
+}
+
+export interface ViewConfig {
+  filter: string
+  sort: ViewSort | null
+  columns: ColumnKey[]
+  pageSize: number
+}
+
+export interface SavedView {
+  name: string
+  config: ViewConfig
+}
+
+export const DEFAULT_CONFIG: ViewConfig = {
+  filter: '',
+  sort: null,
+  columns: [...DEFAULT_VISIBLE],
+  pageSize: DEFAULT_PAGE_SIZE,
+}
+
+const VALID_COLUMN_KEYS = new Set<string>(COLUMNS.map((c) => c.key))
+
+/** Canonical column order (registry order) so config comparison is stable. */
+export function canonicalColumns(keys: Iterable<ColumnKey>): ColumnKey[] {
+  const wanted = new Set<ColumnKey>(keys)
+  wanted.add('name')
+  return COLUMNS.filter((c) => wanted.has(c.key)).map((c) => c.key)
+}
+
+export function sameConfig(a: ViewConfig, b: ViewConfig): boolean {
+  return (
+    a.filter === b.filter &&
+    a.pageSize === b.pageSize &&
+    (a.sort === null
+      ? b.sort === null
+      : b.sort !== null &&
+        a.sort.key === b.sort.key &&
+        a.sort.direction === b.sort.direction) &&
+    canonicalColumns(a.columns).join() === canonicalColumns(b.columns).join()
+  )
+}
+
+function parseSort(value: unknown): ViewSort | null | undefined {
+  if (value === null) return null
+  if (typeof value !== 'object') return undefined
+  const record = value as Record<string, unknown>
+  if (typeof record.key !== 'string' || !VALID_COLUMN_KEYS.has(record.key)) {
+    return undefined
+  }
+  if (record.direction !== 1 && record.direction !== -1) return undefined
+  return { key: record.key as ColumnKey, direction: record.direction }
+}
+
+/** Validate one stored view; null when anything about it is off-shape. */
+function parseView(value: unknown): SavedView | null {
+  if (typeof value !== 'object' || value === null) return null
+  const record = value as Record<string, unknown>
+  const { name, config } = record
+  if (typeof name !== 'string' || name === '' || name.length > MAX_NAME_LEN) {
+    return null
+  }
+  if (typeof config !== 'object' || config === null) return null
+  const c = config as Record<string, unknown>
+  if (typeof c.filter !== 'string' || c.filter.length > MAX_FILTER_LEN) {
+    return null
+  }
+  const sort = parseSort(c.sort)
+  if (sort === undefined) return null
+  if (
+    !Array.isArray(c.columns) ||
+    !c.columns.every(
+      (k): k is ColumnKey => typeof k === 'string' && VALID_COLUMN_KEYS.has(k),
+    )
+  ) {
+    return null
+  }
+  if (
+    typeof c.pageSize !== 'number' ||
+    !PAGE_SIZES.some((size) => size === c.pageSize)
+  ) {
+    return null
+  }
+  return {
+    name,
+    config: {
+      filter: c.filter,
+      sort,
+      columns: canonicalColumns(c.columns),
+      pageSize: c.pageSize,
+    },
+  }
+}
+
+/**
+ * Parse the whole stored record ({ [principal]: SavedView[] }) from raw
+ * localStorage text. Untrusted input: anything off-shape degrades to the
+ * empty record / empty list, never a crash.
+ */
+export function parseSavedViews(raw: string | null): Record<string, SavedView[]> {
+  if (raw === null) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {}
+  }
+  const entries: [string, SavedView[]][] = []
+  for (const [principal, entry] of Object.entries(parsed)) {
+    if (!Array.isArray(entry)) continue
+    const views: SavedView[] = []
+    for (const candidate of entry) {
+      const view = parseView(candidate)
+      if (view !== null && !views.some((v) => v.name === view.name)) {
+        views.push(view)
+      }
+      if (views.length >= MAX_SAVED_VIEWS) break
+    }
+    entries.push([principal, views])
+  }
+  return Object.fromEntries(entries)
+}
+
+export function loadViews(principal: string): SavedView[] {
+  const record = parseSavedViews(localStorage.getItem('cfgms.fleet.views'))
+  return Object.entries(record).find(([key]) => key === principal)?.[1] ?? []
+}
+
+/** Persist one principal's views, preserving every other principal's. */
+export function saveViews(principal: string, views: SavedView[]): void {
+  const record = parseSavedViews(localStorage.getItem('cfgms.fleet.views'))
+  const next = Object.fromEntries([
+    ...Object.entries(record).filter(([key]) => key !== principal),
+    [principal, views.slice(0, MAX_SAVED_VIEWS)],
+  ])
+  localStorage.setItem('cfgms.fleet.views', JSON.stringify(next))
+}
+
+type Editing =
+  | { kind: 'save' }
+  | { kind: 'rename'; name: string }
+  | null
+
+export default function SavedViews({
+  current,
+  onApply,
+}: {
+  current: ViewConfig
+  onApply: (config: ViewConfig) => void
+}) {
+  const { principal } = useAuth()
+  const username = principal?.username ?? ''
+  const [open, setOpen] = useState(false)
+  // Loaded once per mount: a principal change always goes through the
+  // signedOut/expired auth states, which unmount the shell (RequireAuth
+  // swaps to the login screen), so this state can never go stale.
+  const [views, setViews] = useState<SavedView[]>(() => loadViews(username))
+  const [editing, setEditing] = useState<Editing>(null)
+  const [draftName, setDraftName] = useState('')
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    function onPointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onPointerDown)
+    }
+  }, [open])
+
+  function persist(next: SavedView[]) {
+    setViews(next)
+    saveViews(username, next)
+  }
+
+  function submitName() {
+    const name = draftName.trim().slice(0, MAX_NAME_LEN)
+    if (name === '' || editing === null) return
+    if (editing.kind === 'save') {
+      const next = views.filter((v) => v.name !== name)
+      next.push({ name, config: { ...current, columns: canonicalColumns(current.columns) } })
+      persist(next)
+    } else {
+      const next = views
+        .filter((v) => v.name !== name || v.name === editing.name)
+        .map((v) => (v.name === editing.name ? { ...v, name } : v))
+      persist(next)
+    }
+    setEditing(null)
+    setDraftName('')
+  }
+
+  function applyView(config: ViewConfig) {
+    onApply({ ...config, columns: [...config.columns], sort: config.sort && { ...config.sort } })
+    setOpen(false)
+  }
+
+  const activeName =
+    views.find((v) => sameConfig(v.config, current))?.name ??
+    (sameConfig(current, DEFAULT_CONFIG) ? 'All stewards' : 'Custom')
+
+  return (
+    <div className="viewpicker" ref={rootRef}>
+      <button
+        type="button"
+        className="vbtn"
+        aria-expanded={open}
+        onClick={() => {
+          setEditing(null)
+          setOpen((was) => !was)
+        }}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M4 6h16M7 12h10M10 18h4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+        </svg>
+        View: <span className="viewname">{activeName}</span>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M8 10l4 4 4-4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      {open && (
+        <div className="pop open viewpop" role="group" aria-label="Saved views">
+          <h4>Saved views</h4>
+          <button
+            type="button"
+            className={`row${activeName === 'All stewards' ? ' cur' : ''}`}
+            onClick={() => applyView(DEFAULT_CONFIG)}
+          >
+            All stewards
+          </button>
+          {views.map((view) => (
+            <div
+              className={`row viewrow${view.name === activeName ? ' cur' : ''}`}
+              key={view.name}
+            >
+              <button
+                type="button"
+                className="viewapply"
+                onClick={() => applyView(view.config)}
+              >
+                {view.name}
+              </button>
+              <button
+                type="button"
+                className="viewact"
+                aria-label={`Rename ${view.name}`}
+                onClick={() => {
+                  setEditing({ kind: 'rename', name: view.name })
+                  setDraftName(view.name)
+                }}
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M4 20l1-4L16 5l3 3L8 19l-4 1z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                className="viewact"
+                aria-label={`Delete ${view.name}`}
+                onClick={() => persist(views.filter((v) => v.name !== view.name))}
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                </svg>
+              </button>
+            </div>
+          ))}
+          <div className="sep" />
+          {editing === null ? (
+            <button
+              type="button"
+              className="row"
+              onClick={() => {
+                setEditing({ kind: 'save' })
+                setDraftName('')
+              }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+              </svg>
+              Save current view…
+            </button>
+          ) : (
+            <form
+              className="viewform"
+              onSubmit={(event) => {
+                event.preventDefault()
+                submitName()
+              }}
+            >
+              <input
+                aria-label="View name"
+                autoFocus
+                maxLength={MAX_NAME_LEN}
+                placeholder="View name"
+                value={draftName}
+                onChange={(event) => setDraftName(event.target.value)}
+              />
+              <button type="submit" disabled={draftName.trim() === ''}>
+                Save
+              </button>
+            </form>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/Login.test.tsx
+++ b/web/src/pages/Login.test.tsx
@@ -185,6 +185,12 @@ describe('forbidden references in source (security A7.1 / A7.2)', () => {
     // technician shows; a display preference, not auth data. Values read
     // back are shape-validated as untrusted input (columns.ts).
     { path: 'fleet/columns.ts', key: 'cfgms.fleet.columns' },
+    // Saved fleet views (Story #2498) — named view configurations (filter,
+    // sort, columns, page size), keyed per principal INSIDE the stored
+    // record (the storage key itself stays literal). Display preference,
+    // not auth data. Values read back are shape- and type-validated as
+    // untrusted input (SavedViews.tsx, security A10.2).
+    { path: 'fleet/SavedViews.tsx', key: 'cfgms.fleet.views' },
   ]
 
   it('no non-test source file uses localStorage/sessionStorage outside the explicit allowlist', () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -112,7 +112,7 @@ export default function AppShell() {
           </div>
 
           <div className="content">
-            <FleetOverview search={search} />
+            <FleetOverview search={search} onSearchChange={setSearch} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Completes the Web UI Foundation epic's fleet-overview surface (#2344): technicians can now save and recall named view configurations (filter text, sort, visible column set, page size) and click any steward row to open an asset-DNA drawer showing the full attribute map from `GET /api/v1/stewards/{id}/dna`. Read-only throughout; no Go API changes (the two small Go diffs are carried develop-gate fixes, see below).

## Changes

- **`SavedViews.tsx`** (new) — mockup `pop-views` panel: save/apply/rename/delete named views, built-in "All stewards" default, inline save form. A view captures exactly filter + sort + column set + page size; tenant scope is session chrome and is never captured. Persisted in `localStorage` under the allowlisted literal key `cfgms.fleet.views`, keyed per principal inside the record; everything read back is validated as untrusted input — invalid views dropped, valid siblings kept, 50-view cap (security A10.2)
- **`DnaDrawer.tsx`** (new) — mockup `.det` drawer: fetches steward DNA via the #2495 cookie/CSRF client, renders known attributes in a fixed grouping allowlist (Identity / Network / System / Session & agent) and every unrecognized attribute under "Other attributes" so new steward DNA appears without UI changes. Group headings/labels come only from the fixed allowlist, never from data; hostile attribute keys and values render as JSX text nodes only (security A10.1). Loading skeleton, error state with retry (tolerates 404/redaction — cross-tenant requests 404, controller denylists sensitive keys), Escape/scrim close, raw-JSON details view. Deep-link seam marked for when a router lands
- **`FleetTable.tsx`** — `onRowSelect` seam: rows selectable by click or Enter/Space with focus outline
- **`FleetOverview.tsx` / `AppShell.tsx`** — view capture/apply wiring; new `onSearchChange` prop so applying a view restores the shell's global search box
- **`Login.test.tsx`** — `cfgms.fleet.views` added to the A7.2 storage allowlist (literal-key rule)
- **`web/README.md`** — saved-view storage format + DNA drawer data flow (incl. redaction tolerance)
- **Carried develop-gate fixes** (commit 6b371291, per the #2692 precedent): launcher now logs the #2033 known-good rollback-suppression decision instead of exiting silently (root cause of the flaky `TestSupervise_KnownGood_FastExitRestartsInPlace`; no behavior change, verified `-count=3 -race`), and a one-space gofmt fix in `executor_darwin_test.go` (#2688 leftover that fails `make lint` on macOS hosts only)

## Security (A10.1 / A10.2 / threat model)

Steward DNA keys AND values are untrusted (stewards run on possibly-compromised hosts): text-node-only rendering regression-tested with hostile `<img onerror>` keys and `<script>` values; heading-allowlist asserted against rendered DOM. Saved-view configs from localStorage are shape- and type-validated field by field (`sort.key`/`columns` against the column registry, `pageSize` against the fixed set, length caps). `steward.id` is `encodeURIComponent`-wrapped in the fetch path. Security reviewer: **PASS — no findings** (gosec/Trivy/staticcheck/secret scan/check-architecture all clean).

## Test results

- Web suite: 98 → **124 tests passing** (26 new: drawer fetch/grouped render/error + redaction tolerance, hostile key/value inertness, heading allowlist, save/apply/rename/delete round-trip + reload persistence, exact view-state restoration incl. scope-not-captured, per-principal keying, untrusted-localStorage validation matrix)
- Frontend lane: vitest, eslint (security rules at error), tsc, vite build, `npm audit` (0 vulns) — all green
- Container validation (pinned toolchain): `test-commit`, `test-fast`, `test-production-critical` — all passed; `build-cross-validate` 5/5 platforms on host
- Adversarial review team: acceptance **PASS**, QA code review **PASS**, security **PASS**; the QA test lens surfaced the two develop-side gate issues above (launcher test flake + macOS-only gofmt), both fixed in the carried commit, with a fully green `make test-quality` (unit+race, lint, license headers, production-critical, cross-platform, Docker integration) verified with those fixes applied

## Design review

Light + dark captures of the real running app (login flow against a mock of the controller session/stewards/DNA API): saved-views panel, inline save form, applied-view restoration (filter/columns/sort/page-size), DNA drawer top and Other-attributes/raw-JSON bottom. Founder manually reviewed the captures and approved (2026-07-15; recorded on the issue AC). Deviations from the mockup confirmed in that review: rename/delete affordances on view rows (mockup shows apply-only rows), inline save form instead of an unspecified flow, no drawer action footer (actions out of scope), drawer groups keyed to real steward attribute keys with overflow group.

Fixes #2498

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
