### PR TITLE
hostname: treat missing wmic.exe as ErrUnsupportedPlatform (Issue #2460)

### DIFF
--- a/features/modules/stdlib/hostname/executor_windows.go
+++ b/features/modules/stdlib/hostname/executor_windows.go
@@ -6,10 +6,13 @@
 package hostname
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/cfgis/cfgms/features/modules"
 )
 
 // windowsExecutor manages host identity configuration on Windows via
@@ -85,6 +88,9 @@ func (e *windowsExecutor) setState(desired hostnameState) error {
 func wmicGetWorkgroup(computerName string) (string, error) {
 	out, err := exec.Command("wmic", "computersystem", "get", "Workgroup", "/format:list").CombinedOutput() // #nosec G204 - no user-controlled values in arguments
 	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", fmt.Errorf("wmic.exe not present on this host: %w", modules.ErrUnsupportedPlatform)
+		}
 		return "", fmt.Errorf("wmic computersystem get Workgroup: %w (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 	for _, line := range strings.Split(string(out), "\n") {
@@ -114,6 +120,9 @@ func wmicSetWorkgroup(computerName, workgroup string) error {
 	out, err := exec.Command("wmic", "computersystem", "where", whereClause,
 		"call", "JoinDomainOrWorkgroup", fmt.Sprintf("WorkgroupName=%q", workgroup)).CombinedOutput() // #nosec G204 - workgroup validated by Validate()
 	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("wmic.exe not present on this host: %w", modules.ErrUnsupportedPlatform)
+		}
 		return fmt.Errorf("wmic JoinDomainOrWorkgroup: %w (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 	return nil


### PR DESCRIPTION
## Summary
- The whole merge queue has been stuck since PR #2694 merged (`7172b964`): `Native Build (Windows)` fails every `merge_group` run because the GitHub-hosted `windows-latest` image no longer ships `wmic.exe`, and `TestHostnameModule_ConformanceDeterministicGet`/`TestHostnameModule_ConformanceNoEphemeralFields` call the real `wmicGetWorkgroup` without a fake. Confirmed by inspecting the two failed `merge_group` runs for PR #2702 (both kicked from the queue at the `Build Gate` step, `exec: "wmic": executable file not found in %PATH%`).
- Those conformance tests already have a graceful skip for exactly this — `errors.Is(err, modules.ErrUnsupportedPlatform)` — the same sentinel every other stdlib module (`hyperv`, `firewall`, `cert_trust`, `time`, `user`, `service`) returns when a capability isn't available on the host. `wmicGetWorkgroup`/`wmicSetWorkgroup` just weren't mapping a missing binary to it.
- Fix: detect `exec.ErrNotFound` specifically in both wmic call sites and wrap it as `modules.ErrUnsupportedPlatform`. A real wmic query failure (bad output, permissions, etc.) still surfaces as a hard error — only the "binary isn't there" case is treated as unsupported-platform.
- No test changes needed — the existing skip logic in `module_test.go` now fires correctly once the sentinel is returned.

## Test plan
- [x] `GOOS=windows go build ./features/modules/stdlib/hostname/...` — compiles clean
- [x] `GOOS=windows go vet ./features/modules/stdlib/hostname/...` — clean
- [x] `GOOS=windows go test -c ./features/modules/stdlib/hostname` — compiles clean (can't execute Windows binaries on this host; will confirm live on the `merge_group` Windows runner)
- [x] `make test` — 211/211 passed
- [ ] Confirm `Native Build (Windows)` goes green on the next `merge_group` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)