### PR TITLE
workflow: fix cirunner-provision descriptor bugs (Issue #2708)

### DIFF
--- a/features/workflow/cirunner_provision_test.go
+++ b/features/workflow/cirunner_provision_test.go
@@ -52,13 +52,37 @@ func TestCIRunnerProvisionWorkflowDescriptor(t *testing.T) {
 	assert.Equal(t, "POST", httpStep.Method)
 	assert.Contains(t, httpStep.URL, "/api/v1/config/push")
 
-	// AC #5: the stage step references the register script by id + version
-	// (a named library script), NOT a per-standup generated script.
+	// AC #1 + AC #2: the stage step uses the real script module stage schema —
+	// nested stage:{id,version} block (ScriptConfig.Stage / scriptConfigFromMap),
+	// not flat script_id/script_version which scriptConfigFromMap never reads.
+	// id and version are derived from runner_os so they cannot drift from each
+	// other (Issue #2336 regression guard).
 	stageCfg := wf.Steps[1].Config
 	require.NotNil(t, stageCfg, "stage step must have config")
 	assert.Equal(t, "stage", stageCfg["action"])
-	assert.Contains(t, stageCfg, "script_id", "stage references a library script by id")
-	assert.Contains(t, stageCfg, "script_version", "stage references the script by version")
+
+	// Flat keys must be absent; the engine only decodes the nested stage block.
+	assert.NotContains(t, stageCfg, "script_id",
+		"flat script_id must not be present; use nested stage.id (scriptConfigFromMap schema)")
+	assert.NotContains(t, stageCfg, "script_version",
+		"flat script_version must not be present; use nested stage.version (scriptConfigFromMap schema)")
+
+	stageBlock, ok := stageCfg["stage"].(map[string]interface{})
+	require.True(t, ok, "stage config must carry a nested 'stage' block (ScriptConfig.Stage)")
+
+	stageID, _ := stageBlock["id"].(string)
+	assert.Contains(t, stageID, ".runner_os",
+		"stage.id must be derived from runner_os via template")
+
+	// AC #2: stage.version template must branch on runner_os, gating both
+	// version literals — linux 1.0.0 and windows 1.1.0 (--runasservice).
+	stageVersion, _ := stageBlock["version"].(string)
+	assert.Contains(t, stageVersion, "1.0.0",
+		"stage.version must include the linux version literal (1.0.0)")
+	assert.Contains(t, stageVersion, "1.1.0",
+		"stage.version must include the windows version literal (1.1.0)")
+	assert.Contains(t, stageVersion, "eq .runner_os",
+		"stage.version must branch on runner_os (eq .runner_os conditional)")
 
 	// The token is bound as a secret-store param, never a literal value.
 	bindings, ok := stageCfg["param_bindings"].([]interface{})
@@ -66,16 +90,32 @@ func TestCIRunnerProvisionWorkflowDescriptor(t *testing.T) {
 	assert.True(t, hasSecretBinding(bindings, "RUNNER_TOKEN"),
 		"RUNNER_TOKEN must be bound from the secret store")
 
-	// AC #4: the wait/poll step keys off the github_runner module's reported
-	// state (a while condition), NOT a fixed sleep.
+	// AC #3 + AC #4: the wait/poll step keys off the github_runner module's
+	// reported state via the real result-binding and DNA-response shape.
 	loop := wf.Steps[3].Loop
 	require.NotNil(t, loop, "while step must carry a loop block")
 	require.NotNil(t, loop.Condition, "the poll loop must have a state condition, not a fixed sleep")
 	assert.Contains(t, loop.Condition.Expression, "github_runner",
 		"the poll condition must key off the github_runner module's reported state")
+
+	// AC #4: condition must read DNAInfo.Attributes (flat map[string]string keyed
+	// by "<resourceID>.<field>", e.g. "github_runner.state") — not a nested
+	// modules object which does not exist on the DNA response.
+	assert.Contains(t, loop.Condition.Expression, ".attributes",
+		"condition must read DNAInfo.Attributes (flat map), not a nested modules object")
+	assert.Contains(t, loop.Condition.Expression, `"github_runner.state"`,
+		"condition must address the flattened DNA attribute key convention")
+	assert.NotContains(t, loop.Condition.Expression, ".modules",
+		"condition must not reference the nonexistent .modules field on DNAInfo (regression guard)")
+
 	require.Len(t, wf.Steps[3].Steps, 1, "the while body polls the steward DNA")
 	pollStep := wf.Steps[3].Steps[0]
 	assert.Equal(t, StepTypeHTTP, pollStep.Type)
+	// AC #3: poll step name must be hyphen-free so the engine's result binding
+	// (<step_name>_response_json) is accessible via Go text/template dot notation.
+	// Hyphens (U+002D) are rejected by the template field lexer.
+	assert.NotContains(t, pollStep.Name, "-",
+		"poll step name must not contain hyphens (template field lexer rejects U+002D)")
 	require.NotNil(t, pollStep.HTTP)
 	assert.Equal(t, "GET", pollStep.HTTP.Method)
 	assert.Contains(t, pollStep.HTTP.URL, "/dna", "the poll reads the steward DNA")

--- a/features/workflow/examples/cirunner-provision.yaml
+++ b/features/workflow/examples/cirunner-provision.yaml
@@ -25,15 +25,21 @@ timeout: 30m
 on_failure: stop
 
 variables:
+  # REQUIRED: replace with your GitHub organization name.
   github_owner: "your-org"
+  # REQUIRED: replace with your GitHub repository name.
   github_repo: "your-repo"
+  # REQUIRED: update to match github_owner/github_repo above.
   repo_url: "https://github.com/your-org/your-repo"
+  # REQUIRED: replace with the URL of your CFGMS controller instance.
   controller_url: "https://controller.example.com:8443"
+  # REQUIRED: replace with the enrolled steward ID of the CI host to provision.
   steward_id: "your-steward-id"
+  # Target OS for the runner: "linux" or "windows".
+  # stage-register-script derives the script id and version from this value —
+  # changing runner_os is the only change needed to target a different OS.
   runner_os: "linux"
   runner_labels: "self-hosted,linux,cfgms"
-  register_script_id: "register-github-runner-linux"
-  register_script_version: "1.0.0"
   # Secret-store key the staging step binds to the RUNNER_TOKEN script param.
   runner_token_secret_key: "cfgms/cirunner/registration-token"
 
@@ -55,17 +61,25 @@ steps:
         backoff_multiplier: 2.0
 
   # 2. Stage the stable per-OS register script from the library and bind the
-  #    just-minted token as a SECRET param (from: secret-store). The script is
-  #    referenced by id + version — NOT generated per standup. The token value
-  #    is resolved at execution time and injected as CFGMS_SECRET_RUNNER_TOKEN;
-  #    it is never written here.
+  #    just-minted token as a SECRET param (from: secret-store). The script id
+  #    and version are derived from runner_os at render time — changing runner_os
+  #    is the only operator action needed to target a different OS. Linux uses
+  #    1.0.0; Windows requires 1.1.0 (adds --runasservice; the linux script does
+  #    not). Avoids the silent mismatch when id/version were independent
+  #    variables that could drift from runner_os (Issue #2336 regression guard).
+  #
+  #    stage.id and stage.version are nested under the "stage:" key per the
+  #    ScriptConfig schema (scriptConfigFromMap in script/config.go) — top-level
+  #    script_id/script_version keys are never decoded by that path.
+  #    param_bindings stays top-level (ParamBindings field on ScriptConfig).
   - name: stage-register-script
     type: task
     module: script
     config:
       action: stage
-      script_id: "{{ .register_script_id }}"
-      script_version: "{{ .register_script_version }}"
+      stage:
+        id: "register-github-runner-{{ .runner_os }}"
+        version: '{{ if eq .runner_os "windows" }}1.1.0{{ else }}1.0.0{{ end }}'
       param_bindings:
         - name: RUNNER_TOKEN
           from: secret-store
@@ -100,6 +114,16 @@ steps:
   #    each iteration is an HTTP GET of the steward DNA, and the loop continues
   #    WHILE the module is not yet enrolled+running. Bounded by max_iterations
   #    and the workflow timeout — never a fixed sleep.
+  #
+  #    The poll step name is underscore-separated (poll_steward_dna) because
+  #    Go's text/template rejects hyphens (U+002D) in dot-field access; the
+  #    engine binds the decoded response as <step_name>_response_json.
+  #
+  #    DNAInfo.Attributes is a flat map[string]string (features/controller/api/
+  #    types.go) keyed by the "<resourceID>.<field>" convention from
+  #    CollectModuleDNAAttributes (features/steward/execution/monitor.go).
+  #    There is no nested "modules" object on the DNA response — the condition
+  #    reads the flat attribute key "github_runner.state" directly.
   - name: await-runner-enrollment
     type: while
     loop:
@@ -109,9 +133,9 @@ steps:
         type: expression
         # Keep looping while the github_runner module has not yet reported the
         # service enrolled and running in the polled steward DNA.
-        expression: '{{ ne (index .poll_steward_dna_http_response.modules "github_runner").state "enrolled-running" }}'
+        expression: '{{ ne (index .poll_steward_dna_response_json.attributes "github_runner.state") "enrolled-running" }}'
     steps:
-      - name: poll-steward-dna
+      - name: poll_steward_dna
         type: http
         timeout: 15s
         http:


### PR DESCRIPTION
## Summary

- **Bug #1+2 (stage schema + OS coupling):** The stage step used flat `script_id`/`script_version` keys that `scriptConfigFromMap` never reads (it only decodes the nested `stage:{id,version}` block), causing `Validate()` failure. Additionally, the script id and version were disconnected from `runner_os` — changing the OS without updating both literals in lockstep silently picked the wrong script (Issue #2336 regression). Fixed by restructuring to the nested `stage:` schema with OS-derived templates: `id: "register-github-runner-{{ .runner_os }}"` and `version: '{{ if eq .runner_os "windows" }}1.1.0{{ else }}1.0.0{{ end }}'`.
- **Bug #3 (await condition nonexistent shape):** The while condition referenced `.poll_steward_dna_http_response.modules["github_runner"].state` — wrong suffix (`_http_response` vs `_response_json`), wrong separator (hyphen rejected by Go template lexer), and wrong shape (`DNAInfo.Attributes` is a flat `map[string]string` keyed by `"<resourceID>.<field>"`, not a nested `.modules` object). Fixed by renaming the poll step to `poll_steward_dna` and rewriting the condition to the real binding: `{{ ne (index .poll_steward_dna_response_json.attributes "github_runner.state") "enrolled-running" }}`.
- **Bug #4 (placeholders):** All placeholder variables (`your-org`, `your-repo`, `your-steward-id`, `controller.example.com`) marked with `# REQUIRED:` comments.

## Specialist review results

| Lens | Result | Findings |
|------|--------|----------|
| Code review (qa-code-reviewer) | ✅ PASS | 0 |
| Security (security-engineer) | ✅ PASS | 0 |
| Tests (make test-agent-complete) | ✅ PASS | 0 |

Story-review verdict: `passed: true`, 1 round, 0 fix rounds.

## Test plan

- [x] `TestCIRunnerProvisionWorkflowDescriptor` updated with AC #2 assertions: nested `stage.id`/`stage.version` present, flat `script_id`/`script_version` absent, version template branches on `runner_os` with both `1.0.0` and `1.1.0` literals gated by `eq .runner_os`
- [x] AC #4 assertions added: condition contains `.attributes` and `"github_runner.state"`, does NOT contain `.modules`
- [x] Poll step name hyphen-free assertion added
- [x] `go test github.com/cfgis/cfgms/features/workflow` passes
- [x] `make test-agent-complete` passes (all platforms compile, all tests pass)

Fixes #2708

🤖 Generated with [Claude Code](https://claude.com/claude-code)