### PR TITLE
po-cycle-preflight: fix env-gate false positive on negated windows mentions

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -91,7 +91,16 @@ def detect_required_env(env_section, labels):
         return "windows"
     if env_section:
         t = env_section.strip().lower()
-        if "windows" in t:
+        # The `## Environment` convention: when windows IS required, the section's
+        # first word is "windows" (optionally followed by more context on the same
+        # or later lines, e.g. "windows\nRouted to the Windows host because..."). When
+        # windows is NOT required, the section instead opens with an explanation
+        # (e.g. "(omit — ordinary Linux-buildable Go change ... no Windows API)") that
+        # may itself mention "windows" in passing. A substring search over the whole
+        # section false-positives on exactly those omission explanations — only the
+        # leading-word form is a routing directive.
+        first_word = t.split(None, 1)[0].strip(".,:;()") if t else ""
+        if first_word == "windows":
             return "windows"
     return DEFAULT_ENV
 

--- a/.claude/scripts/tests/env_routing.test.sh
+++ b/.claude/scripts/tests/env_routing.test.sh
@@ -49,6 +49,11 @@ check("env body 'Windows 11 host'", m.detect_required_env("Windows 11 host", [])
 # macOS is not a routing env — no macOS dev host; dev on Linux, validate in CI.
 check("env body 'macos' -> linux", m.detect_required_env("macos", []), "linux")
 check("env body 'darwin' alias -> linux", m.detect_required_env("build on a darwin runner", []), "linux")
+# A negated/omission mention of "windows" must not route to windows — the
+# section's leading word is what matters, not any substring occurrence.
+check("env body omission mentioning windows -> linux",
+      m.detect_required_env("(omit — ordinary Linux-buildable Go change; storage-layer only, no Windows API)", []),
+      "linux")
 check("env body 'linux'", m.detect_required_env("linux", []), "linux")
 check("env body None -> linux", m.detect_required_env(None, []), "linux")
 check("env body empty -> linux", m.detect_required_env("", []), "linux")


### PR DESCRIPTION
## Summary
- `detect_required_env()` in `.claude/scripts/po-cycle-preflight.py` did a plain substring search for `"windows"` over the entire `## Environment` body section. Story #2667's section — `"(omit — ordinary Linux-buildable Go change; storage-layer only, no Windows API)"` — false-positived on the word "Windows" inside the negation "no Windows API," routing a plain Go/Linux story into the windows-only self-dispatch queue and refusing to dispatch it on the Linux orchestrator (`DISPATCH_REFUSED:2667:requires windows env`). This blocked the entire #2668→#2669→#2670 dependency chain in epic #2657.
- Same bug latently affects at least two other stories currently in the repo (#2378, #2423) — both mention "windows" inside an omission explanation ("no Windows API", "manager_windows_test.go") but aren't currently on the active dispatch path, so it hadn't surfaced yet.
- Fix: check only the section's **leading word** instead of a substring search anywhere in the text. Every real windows-routed story in the repo opens its `## Environment` section with the literal word "windows" first (optionally followed by more context on the same or later lines, e.g. `#2147`'s `"windows (final AC validation is Windows-only — see below)"`); every non-windows story that happens to mention "windows" in passing opens with something else instead (usually an `"(omit …"` explanation).
- `po-act.sh`'s `_requires_env` calls into this same function, so both call sites are fixed together.

## Verification
Tested the fix against every `## Environment` section currently in the repo (~50 stories sampled via `gh issue list --search "windows in:body"`), including the tricky inline-parenthetical case (#2147) and the other two latent false positives (#2378, #2423) — all resolve correctly with no regressions on real windows-routed stories.

## Test plan
- [x] Unit-verified `detect_required_env()` against 9 representative real story bodies (windows-bare, windows-with-inline-context, windows-with-trailing-paragraphs, linux-bare, macos, and 3 windows-mentioning-but-not-required omission texts) — all resolve as expected
- [x] `make test` — 211/211 script tests + full Go suite, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)