### PR TITLE
hyperv.vm: declarative checkpoint policy (none/retain/max/max-age), merge-to-clean, opt-in (Issue #2627)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -269,7 +269,58 @@ drifts (real drift preserved).
 Checkpoints are surfaced as **observed-only DNA**: `checkpoint_count` appears on
 the `Get`/DNA surface but is absent from the managed fields, so it is *visible*
 fleet-wide yet never counts as drift. Declaratively *managing* checkpoints
-(policy-driven merge-to-clean) is a separate, opt-in capability.
+(policy-driven merge-to-clean) is a separate, opt-in capability — see below.
+
+### Declarative checkpoint policy (#2627)
+
+A VM may **declare a checkpoint policy** the module converges to — true
+self-healing to a clean checkpoint state. It is **opt-in**: with no `checkpoints`
+block the module stays observe-only (the #2626 default above — checkpoints are
+reported as DNA and never touched).
+
+Cleanup is **merge-only**. `Remove-VMSnapshot` folds a checkpoint's differencing
+disk (`.avhdx`) into its parent, committing that data upward — it flattens the
+chain **without reverting** the VM's current running state. Reverting
+(`Restore-VMSnapshot`, destructive) is deliberately **out of scope** and is never
+issued.
+
+The `checkpoints` block:
+
+```yaml
+resources:
+  - name: db-vm
+    module: hyperv
+    config:
+      vm:
+        name: db-vm
+        # ...
+        checkpoints:
+          policy: retain   # none | retain
+          max: 3           # retain the newest N; 0 (or policy: none) = merge all
+          max_age: 168h    # retain checkpoints younger than this Go duration
+```
+
+Semantics:
+
+| Declaration | Effect |
+|---|---|
+| *(no `checkpoints` block)* | **Observe-only** — checkpoints reported as DNA, never merged (#2626 default). |
+| `policy: none` **or** `max: 0` | **Merge all** — "this VM should have no checkpoints." |
+| `policy: retain`, `max: N` | Retain the newest **N**, merge the rest (oldest-first). |
+| `policy: retain`, `max_age: D` | Retain checkpoints younger than **D**, merge the older ones. |
+| `max`/`max_age` set with no `policy` | Implicit `retain` (a bound with no policy means retain-with-bound). |
+| `max` **and** `max_age` together | A checkpoint is retained only if it satisfies **both** bounds; anything violating either is merged. |
+| `policy: retain` with **neither** `max` nor `max_age` | **Invalid config** (`ErrInvalidCheckpointPolicy`) — indistinguishable from observe-only, so rejected fail-closed rather than silently no-op. |
+
+Merges always run **oldest-first** (from the base of the chain upward). Because
+`Remove-VMSnapshot` is a non-destructive merge, the VM's current state and data
+are preserved; only the stray checkpoint layers are collapsed.
+
+Convergence trigger: `checkpoint_policy` is a **managed field** whose desired
+value is the declared policy, while `Get` never reports one (observe-only stays
+`""`). A declared policy therefore registers as drift and drives the reconcile
+each convergence; an absent policy compares equal (`""` on both sides) and never
+drifts, so opting out costs nothing.
 
 ### Create an external virtual switch
 
@@ -541,6 +592,7 @@ store, large-object transfer, or ISO distribution path.
 7. **No host ISO-builder dependency for the seed** — the unattended answer file is delivered on a host-native VHDX seed disk built with `New-VHD`/`Mount-VHD`/`Format-Volume` (present with the Hyper-V + Storage roles the host already runs), so it needs **no** `oscdimg.exe` (Windows ADK) or `mkisofs` on the host. If you choose to author a profile that ships its answer file via a secondary ISO instead of the VHDX seed, building that ISO on the host would require `oscdimg.exe` or `mkisofs` — neither is present on a stock Hyper-V host, which is why the VHDX seed is the supported mechanism.
 8. **Windows enrollment `.ppkg` must be pre-signed** — the Windows path applies a provisioning package (`.ppkg`) at first logon for steward enrollment. The package is referenced by host path (via a secret key) and must be signed ahead of time; this module does not sign `.ppkg` artifacts. An unsigned/self-signed package is acceptable only for lab/dogfood under `module_trust.mode: bypass`.
 9. **Provisioning advances one step per convergence cycle** — a long-running OS install does not block the convergence loop. The host-side module advances only as far as `finalizing`; the `ready` transition is controller-side.
+10. **A declared checkpoint policy reconciles every convergence cycle (#2627)** — because `Get` never reports a policy, the managed `checkpoint_policy` field always differs from a declared policy, so a VM with a `checkpoints` block registers as drift and runs the (idempotent, merge-only) reconcile each cycle even when already compliant. This keeps the merge-to-clean self-healing but re-reports "drift" on a compliant VM. Opting out (no `checkpoints` block) is fully drift-free — the observe-only default compares equal on both sides. Making a *compliant* declared policy converge drift-free (a policy-aware `Get`) is a deferred refinement; it needs `Get` to evaluate the live checkpoint set against the desired policy, which is out of this story's scope.
 
 ## Host detection
 

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -284,20 +284,21 @@ chain **without reverting** the VM's current running state. Reverting
 (`Restore-VMSnapshot`, destructive) is deliberately **out of scope** and is never
 issued.
 
-The `checkpoints` block:
+The `checkpoints` block (a top-level key of the resource `config:`, alongside
+`memory_mb`, `vhd_path`, etc.):
 
 ```yaml
 resources:
   - name: db-vm
-    module: hyperv
+    module: hyperv.vm
     config:
-      vm:
-        name: db-vm
-        # ...
-        checkpoints:
-          policy: retain   # none | retain
-          max: 3           # retain the newest N; 0 (or policy: none) = merge all
-          max_age: 168h    # retain checkpoints younger than this Go duration
+      memory_mb: 4096
+      vhd_path: "C:\\VMs\\db-vm.vhdx"
+      state: running
+      checkpoints:
+        policy: retain   # none | retain
+        max: 3           # retain the newest N; 0 (or policy: none) = merge all
+        max_age: 168h    # retain checkpoints younger than this Go duration
 ```
 
 Semantics:
@@ -316,11 +317,18 @@ Merges always run **oldest-first** (from the base of the chain upward). Because
 `Remove-VMSnapshot` is a non-destructive merge, the VM's current state and data
 are preserved; only the stray checkpoint layers are collapsed.
 
-Convergence trigger: `checkpoint_policy` is a **managed field** whose desired
-value is the declared policy, while `Get` never reports one (observe-only stays
-`""`). A declared policy therefore registers as drift and drives the reconcile
-each convergence; an absent policy compares equal (`""` on both sides) and never
-drifts, so opting out costs nothing.
+Convergence trigger (drift-free at steady state): the authored `checkpoints`
+block is a managed config key, so it is compared against what `Get` reports.
+`Get` is **policy-aware** — it evaluates the live checkpoint set against the
+declared policy and **echoes the block back only when the VM already complies**.
+So a compliant VM reports the block that matches desired (no drift), while a VM
+with stray checkpoints omits it (drift → reconcile → merge → compliant next
+cycle). A VM with no `checkpoints` block has no managed key to compare, so
+opting out costs nothing. This mirrors the observed-block pattern the `ha_role`
+setting already uses, and means a compliant checkpointed VM does **not** report
+false drift every cycle. (For a `max_age` policy, `Get` issues one extra
+read-only `Get-VMSnapshot` to judge per-checkpoint ages; `none`/`max` policies
+are judged from the observed count with no extra call.)
 
 ### Create an external virtual switch
 
@@ -592,7 +600,7 @@ store, large-object transfer, or ISO distribution path.
 7. **No host ISO-builder dependency for the seed** — the unattended answer file is delivered on a host-native VHDX seed disk built with `New-VHD`/`Mount-VHD`/`Format-Volume` (present with the Hyper-V + Storage roles the host already runs), so it needs **no** `oscdimg.exe` (Windows ADK) or `mkisofs` on the host. If you choose to author a profile that ships its answer file via a secondary ISO instead of the VHDX seed, building that ISO on the host would require `oscdimg.exe` or `mkisofs` — neither is present on a stock Hyper-V host, which is why the VHDX seed is the supported mechanism.
 8. **Windows enrollment `.ppkg` must be pre-signed** — the Windows path applies a provisioning package (`.ppkg`) at first logon for steward enrollment. The package is referenced by host path (via a secret key) and must be signed ahead of time; this module does not sign `.ppkg` artifacts. An unsigned/self-signed package is acceptable only for lab/dogfood under `module_trust.mode: bypass`.
 9. **Provisioning advances one step per convergence cycle** — a long-running OS install does not block the convergence loop. The host-side module advances only as far as `finalizing`; the `ready` transition is controller-side.
-10. **A declared checkpoint policy reconciles every convergence cycle (#2627)** — because `Get` never reports a policy, the managed `checkpoint_policy` field always differs from a declared policy, so a VM with a `checkpoints` block registers as drift and runs the (idempotent, merge-only) reconcile each cycle even when already compliant. This keeps the merge-to-clean self-healing but re-reports "drift" on a compliant VM. Opting out (no `checkpoints` block) is fully drift-free — the observe-only default compares equal on both sides. Making a *compliant* declared policy converge drift-free (a policy-aware `Get`) is a deferred refinement; it needs `Get` to evaluate the live checkpoint set against the desired policy, which is out of this story's scope.
+10. **A `max_age` checkpoint policy costs one extra read per convergence (#2627)** — judging age-based compliance needs per-checkpoint creation times, so a VM with a `max_age` policy issues one additional read-only `Get-VMSnapshot` in `Get` each cycle. `none`/`max` policies add no extra call (judged from the observed checkpoint count). Checkpoint reconciliation is opt-in, so VMs with no `checkpoints` block are unaffected.
 
 ## Host detection
 

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -83,12 +83,19 @@ type hypervModule struct {
 	clusterOwnersAt  time.Time
 	clusterOwnersTTL time.Duration
 
-	// desiredCheckpointsRaw is the authored `checkpoints` block for the resource
-	// this module instance is converging (#2627), stashed by Configure. A fresh
-	// module instance is created per resource (executor.executeResource), Configured
-	// then Get/Set/verified, so a single per-instance value is safe. getVM reads it
-	// to make its compliance echo policy-aware; nil ⇒ observe-only.
-	desiredCheckpointsRaw interface{}
+	// checkpointDesired maps a VM name to the authored `checkpoints` block last
+	// seen for it, so getVM's compliance echo is policy-aware (#2627). It is
+	// keyed by VM name and mutex-guarded because the factory caches ONE module
+	// instance per bundle (factory.LoadModule) — every hyperv resource on a
+	// steward shares this instance, and the monitor goroutine's targeted
+	// reconciles run concurrently with the convergence loop. It is populated by
+	// setVM (which receives the per-resource desired config as an argument, so it
+	// is correctly scoped per VM), NOT by Configure (a module-level hook on the
+	// shared instance — using it for per-VM state would race/leak across VMs). A
+	// VM converges its policy on the first Set (the authored `checkpoints` key
+	// drifts until getVM can echo it); an empty entry ⇒ observe-only.
+	checkpointDesiredMu sync.RWMutex
+	checkpointDesired   map[string]interface{}
 
 	// vswitches is the write-through vSwitch cache. Keys are the exact switch
 	// names admins specify (identical to the host-side names). Updated on
@@ -229,11 +236,12 @@ func WithProfileStore(s ProfileStore) HypervOption {
 // record store, which otherwise defaults to an in-memory store).
 func New(detector HypervDetector, opts ...HypervOption) modules.Module {
 	m := &hypervModule{
-		executor:       newExecutor(),
-		vms:            make(map[string]VMConfig),
-		vswitches:      make(map[string]VSwitchConfig),
-		detector:       detector,
-		provisionStore: NewMemProvisionStore(),
+		executor:          newExecutor(),
+		vms:               make(map[string]VMConfig),
+		vswitches:         make(map[string]VSwitchConfig),
+		checkpointDesired: make(map[string]interface{}),
+		detector:          detector,
+		provisionStore:    NewMemProvisionStore(),
 		// Freshness window for the bulk cluster-owner read cache (Story #2577).
 		// Long enough to collapse the per-VM membership probes of a single
 		// converge pass into one cluster read, short enough that an external
@@ -333,12 +341,6 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.enrollCAPath, _ = configMap["enroll_ca_path"].(string)
 	m.debugSSHAuthorizedKey, _ = configMap["debug_ssh_authorized_key"].(string)
 	m.seedDir, _ = configMap["seed_dir"].(string)
-
-	// Stash the authored `checkpoints` block so getVM's compliance echo is
-	// policy-aware (#2627). This is the SAME object the drift comparator sees as
-	// desired.AsMap()["checkpoints"], so echoing it back on compliance compares
-	// equal (reflect.DeepEqual) and produces no false drift. nil ⇒ observe-only.
-	m.desiredCheckpointsRaw = configMap["checkpoints"]
 
 	// Failover-cluster scope cap (S5). cluster_name bounds which cluster this
 	// steward will read; cluster_role_names bounds the clustered VM roles in

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -83,6 +83,13 @@ type hypervModule struct {
 	clusterOwnersAt  time.Time
 	clusterOwnersTTL time.Duration
 
+	// desiredCheckpointsRaw is the authored `checkpoints` block for the resource
+	// this module instance is converging (#2627), stashed by Configure. A fresh
+	// module instance is created per resource (executor.executeResource), Configured
+	// then Get/Set/verified, so a single per-instance value is safe. getVM reads it
+	// to make its compliance echo policy-aware; nil ⇒ observe-only.
+	desiredCheckpointsRaw interface{}
+
 	// vswitches is the write-through vSwitch cache. Keys are the exact switch
 	// names admins specify (identical to the host-side names). Updated on
 	// transport success only.
@@ -326,6 +333,12 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.enrollCAPath, _ = configMap["enroll_ca_path"].(string)
 	m.debugSSHAuthorizedKey, _ = configMap["debug_ssh_authorized_key"].(string)
 	m.seedDir, _ = configMap["seed_dir"].(string)
+
+	// Stash the authored `checkpoints` block so getVM's compliance echo is
+	// policy-aware (#2627). This is the SAME object the drift comparator sees as
+	// desired.AsMap()["checkpoints"], so echoing it back on compliance compares
+	// equal (reflect.DeepEqual) and produces no false drift. nil ⇒ observe-only.
+	m.desiredCheckpointsRaw = configMap["checkpoints"]
 
 	// Failover-cluster scope cap (S5). cluster_name bounds which cluster this
 	// steward will read; cluster_role_names bounds the clustered VM roles in

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -64,6 +64,14 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 			"Cfgms-SetVMMemory -Name "+quoteArg(psArgs, "Name")+
 				" -MemoryMB "+intArg(psArgs, "MemoryMB"))
 
+	// ── Declarative checkpoint policy (#2627) ────────────────────────
+	case psGetVMSnapshots:
+		return t.run(ctx, "Cfgms-GetVMSnapshots -Name "+quoteArg(psArgs, "Name"))
+	case psRemoveVMSnapshot:
+		return t.run(ctx,
+			"Cfgms-RemoveVMSnapshot -Name "+quoteArg(psArgs, "Name")+
+				" -SnapshotName "+quoteArg(psArgs, "SnapshotName"))
+
 	// ── VM provisioning: seed VHDX disk ops (#2044) ──────────────────
 	// These four use runFresh (a fresh `powershell -File` process), NOT the
 	// persistent `-Command -` host: Mount-VHD/Dismount-VHD deadlock there

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -187,6 +187,22 @@ function Cfgms-SetVMMemory {
     Set-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB)
 }
 
+# ── Declarative checkpoint policy (#2627) ──────────────────────────────
+# Cfgms-GetVMSnapshots lists checkpoints oldest-first as JSON (Name + UTC ISO
+# CreationTime) for the Go-side policy evaluation. Cfgms-RemoveVMSnapshot MERGES
+# one checkpoint by name (Remove-VMSnapshot folds its differencing disk into the
+# parent — non-destructive; never Restore/revert). Both take values only as
+# declared params (never string-interpolated).
+function Cfgms-GetVMSnapshots {
+    param([Parameter(Mandatory)][string]$Name)
+    $snaps = @(Get-VMSnapshot -VMName $Name -ErrorAction SilentlyContinue | Sort-Object CreationTime | ForEach-Object { [pscustomobject]@{ Name = $_.Name; CreationTime = $_.CreationTime.ToUniversalTime().ToString('o') } })
+    ConvertTo-Json @($snaps) -Compress -Depth 3
+}
+function Cfgms-RemoveVMSnapshot {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$SnapshotName)
+    Remove-VMSnapshot -VMName $Name -Name $SnapshotName -ErrorAction Stop
+}
+
 # ── VM network reconcile (declarative multi-NIC, #2021) ────────────────
 # Connect/disconnect primitives driven by the VM's desired switch set in
 # vm.go reconcileNetwork — NOT a standalone resource. Resurrected from the

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -843,12 +843,17 @@ func (m *hypervModule) getVMLocal(ctx context.Context, vmName string) (*VMConfig
 	cfg.HARole = m.probeClusterRoleMembership(ctx, vmName)
 
 	// Checkpoint-policy compliance echo (#2627): when a checkpoints policy is
-	// declared for this resource (stashed by Configure), report the desired block
-	// back on the Get surface IFF the live checkpoint set already complies — so a
-	// compliant VM shows no drift, and a VM with stray checkpoints omits the key
-	// and drifts (→ setVM reconcile). Best-effort: a probe error degrades to "omit
-	// the echo" (treated as drift, reconciled next Set) rather than failing Get.
-	if policy := parseCheckpointPolicyMap(m.desiredCheckpointsRaw); policy != nil {
+	// known for this VM (recorded by a prior setVM, keyed by VM name), report the
+	// desired block back on the Get surface IFF the live checkpoint set already
+	// complies — so a compliant VM shows no drift, and a VM with stray checkpoints
+	// omits the key and drifts (→ setVM reconcile). Until the first Set records the
+	// policy the authored `checkpoints` key drifts (no echo), which drives that
+	// first Set; thereafter a compliant VM is drift-free. Best-effort: a probe
+	// error degrades to "omit the echo" (treated as drift) rather than failing Get.
+	m.checkpointDesiredMu.RLock()
+	desiredCheckpoints := m.checkpointDesired[vmName]
+	m.checkpointDesiredMu.RUnlock()
+	if policy := parseCheckpointPolicyMap(desiredCheckpoints); policy != nil {
 		if comply, cErr := m.checkpointsComply(ctx, vmName, policy, cfg.CheckpointCount); cErr != nil {
 			if logger, ok := m.GetLogger(); ok {
 				logger.Warn("hyperv: checkpoint compliance probe failed; reporting as drift this cycle",
@@ -856,7 +861,7 @@ func (m *hypervModule) getVMLocal(ctx context.Context, vmName string) (*VMConfig
 					"error", cErr.Error())
 			}
 		} else if comply {
-			cfg.checkpointsEcho = m.desiredCheckpointsRaw
+			cfg.checkpointsEcho = desiredCheckpoints
 		}
 	}
 
@@ -1000,6 +1005,21 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	vmName := parts[1]
 
 	configMap := config.AsMap()
+
+	// Record the authored `checkpoints` block for this VM so getVM's compliance
+	// echo is policy-aware (#2627). Keyed by VM name + mutex-guarded: the module
+	// instance is SHARED across all hyperv resources (factory caches one instance
+	// per bundle) and the monitor and convergence goroutines converge concurrently,
+	// so per-VM state must be keyed, not a single instance field. Populated here —
+	// Set receives the correctly-scoped per-resource config as an argument — rather
+	// than in Configure (a module-level hook that would race/leak across VMs).
+	m.checkpointDesiredMu.Lock()
+	if m.checkpointDesired == nil {
+		m.checkpointDesired = make(map[string]interface{})
+	}
+	m.checkpointDesired[vmName] = configMap["checkpoints"]
+	m.checkpointDesiredMu.Unlock()
+
 	state, _ := configMap["state"].(string)
 
 	if state == "absent" {

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -64,6 +64,13 @@ var (
 	// the build); this is enforced eagerly at validate-time rather than letting
 	// the provisioning path stall (see vm_provision.go CSV seed-dir hang).
 	ErrInvalidHARoleSeedDir = errors.New("hyperv: invalid ha_role: a CSV primary vhd_path requires a host-local seed_dir (seed_dir must be set and not under C:\\ClusterStorage\\)")
+
+	// ErrInvalidCheckpointPolicy is returned when a checkpoints block declares
+	// policy: retain with neither max nor max_age set (#2627). "retain everything,
+	// no cap" is indistinguishable from the absent-block (observe-only) default, so
+	// it is rejected fail-closed rather than left as an ambiguous no-op that two
+	// reasonable implementations could read differently.
+	ErrInvalidCheckpointPolicy = errors.New("hyperv: invalid checkpoints: policy retain requires max or max_age (a bare retain with no bound is indistinguishable from observe-only)")
 )
 
 // csvPathPrefix is the Cluster Shared Volume mount root. A VHDX or seed dir under
@@ -155,6 +162,14 @@ type VMConfig struct {
 	// (non-HA) resource with unchanged behavior.
 	HARole *HARoleConfig `yaml:"ha_role,omitempty"`
 
+	// CheckpointPolicy, when non-nil, opts the VM into declarative checkpoint
+	// lifecycle management (#2627): setVM converges the VM's checkpoint set to the
+	// policy by MERGING stray checkpoints (Remove-VMSnapshot folds the differencing
+	// disk into its parent — non-destructive; never Restore/revert). Absent
+	// (nil) = observe-only, the #2626 default: checkpoints are surfaced as DNA via
+	// CheckpointCount but never touched. See vm_checkpoint.go.
+	CheckpointPolicy *CheckpointPolicy `yaml:"checkpoints,omitempty"`
+
 	// ConfigLocation is the OBSERVED configuration-file location (Hyper-V
 	// ConfigurationLocation), populated by getVM and exposed on the Get/DNA
 	// surface. It is never declared in config — the desired location is always
@@ -207,6 +222,36 @@ type HARoleConfig struct {
 	// ResourceGroupName is the optional cluster resource-group name. It defaults
 	// to the VM name (the clustered role is registered under the VM name).
 	ResourceGroupName string `yaml:"resource_group_name,omitempty"`
+}
+
+// CheckpointPolicy is the declarative checkpoint lifecycle a hyperv.vm opts into
+// (#2627). Cleanup is MERGE-ONLY (Remove-VMSnapshot folds a checkpoint's
+// differencing disk into its parent — it never reverts VM state); Restore-VMSnapshot
+// is deliberately out of scope. Semantics (see resolveCheckpointAction / Validate):
+//
+//   - Policy "none", or Max == 0 → merge ALL checkpoints ("this VM should have none").
+//   - Policy "retain" with Max N → retain the newest N, merge the rest (oldest-first).
+//   - Policy "retain" with MaxAge D → retain checkpoints younger than D, merge the rest.
+//   - Max and MaxAge together → a checkpoint is retained only if it satisfies BOTH
+//     bounds (within the newest N AND younger than D); anything violating either is merged.
+//   - Policy "" with only Max/MaxAge set → implicit "retain" (a bound with no explicit
+//     policy means retain-with-bound, never observe-only).
+//   - Policy "retain" with neither Max nor MaxAge → invalid (ErrInvalidCheckpointPolicy).
+//
+// A nil *CheckpointPolicy (absent checkpoints block) is observe-only (#2626 default).
+type CheckpointPolicy struct {
+	// Policy is the lifecycle mode: "none" (merge all), "retain" (keep a bounded
+	// set), or "" (implicit retain when Max/MaxAge is set; otherwise treated as
+	// observe-only by resolveCheckpointAction).
+	Policy string `yaml:"policy,omitempty"`
+	// Max is a pointer so an explicit `max: 0` (a merge-all trigger, equivalent to
+	// policy: none — AC1) is distinguishable from an unset max (no count bound, used
+	// with max_age). *&0 → merge all; *&N (N>0) → retain the newest N; nil → no
+	// count bound.
+	Max *int `yaml:"max,omitempty"`
+	// MaxAge is a Go duration string (e.g. "24h"); checkpoints older than this are
+	// merged. Empty means "no age bound". Validated as a duration in Validate().
+	MaxAge string `yaml:"max_age,omitempty"`
 }
 
 // stringOrStringList is a YAML scalar-or-sequence: switch_name may be a single
@@ -385,6 +430,14 @@ func (c *VMConfig) Validate() error {
 			return ErrInvalidHARoleSeedDir
 		}
 	}
+	// Declarative checkpoint policy (#2627): reject a bare `policy: retain` with no
+	// bound and a malformed max_age fail-closed, mirroring the sentinel-error
+	// pattern above. See CheckpointPolicy.validate in vm_checkpoint.go.
+	if c.CheckpointPolicy != nil {
+		if err := c.CheckpointPolicy.validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -510,6 +563,12 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 		// from GetManagedFields so they never participate in drift comparison.
 		"configuration_location": c.ConfigLocation,
 		"checkpoint_count":       c.CheckpointCount,
+		// Declarative checkpoint policy (#2627). Unlike checkpoint_count this IS a
+		// managed field (see GetManagedFields): the desired config emits its declared
+		// policy while getVM never sets CheckpointPolicy (emits ""), so declaring a
+		// policy drifts and drives setVM → reconcileCheckpoints each converge. An
+		// absent policy emits "" on both sides ⇒ no drift ⇒ #2626 observe-only default.
+		"checkpoint_policy": canonicalCheckpointPolicy(c.CheckpointPolicy),
 	}
 	if c.Source != nil {
 		m["source"] = map[string]interface{}{
@@ -585,7 +644,7 @@ func (c *VMConfig) FromYAML(data []byte) error {
 
 // GetManagedFields returns the list of fields this configuration manages.
 func (c *VMConfig) GetManagedFields() []string {
-	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state", "source", "ha_role"}
+	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state", "source", "ha_role", "checkpoint_policy"}
 }
 
 // psGetVM is the script block passed to ExecutePS for VM retrieval.
@@ -1014,6 +1073,11 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	// as a clustered role; absent ⇒ standalone VM (unchanged behavior).
 	cfg.HARole = parseHARoleMap(configMap["ha_role"])
 
+	// checkpoints (the declarative checkpoint policy, #2627) arrives as a nested
+	// map on the executor-supplied config map. Parse it so the reconcile-via-merge
+	// runs on convergence; absent ⇒ nil ⇒ observe-only (#2626 default).
+	cfg.CheckpointPolicy = parseCheckpointPolicyMap(configMap["checkpoints"])
+
 	// Also handle *VMConfig passed directly
 	if vc, ok := config.(*VMConfig); ok {
 		*cfg = *vc
@@ -1138,7 +1202,13 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	}
 
 	if vmExists {
-		return m.applyVMState(ctx, vmName, hostName, cfg, &currentVM, state)
+		if err := m.applyVMState(ctx, vmName, hostName, cfg, &currentVM, state); err != nil {
+			return err
+		}
+		// Converge the checkpoint set to the declared policy (#2627). No-op when
+		// CheckpointPolicy is nil (observe-only). Runs after the power/resource
+		// reconcile so it operates on the settled VM.
+		return m.reconcileCheckpoints(ctx, hostName, cfg.CheckpointPolicy)
 	}
 
 	// VM does not exist — create it (plain lifecycle, no source block).

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -200,6 +200,14 @@ type VMConfig struct {
 	// it does not host. Unexported and untagged: it never serializes, never
 	// participates in the drift comparison.
 	managedElsewhereOwner string
+
+	// checkpointsEcho, when non-nil, is the desired `checkpoints` block that getVM
+	// echoes on the Get surface to signal the VM COMPLIES with its declared
+	// checkpoint policy (#2627). AsMap emits it under the managed `checkpoints`
+	// key so a compliant VM matches desired (no drift); getVM leaves it nil when
+	// the live set violates the policy (drift → setVM reconcile). Observed/computed
+	// only — never authored, never round-trips through YAML.
+	checkpointsEcho interface{}
 }
 
 // ManagedElsewhere implements modules.ManagedElsewhere. It reports true (naming
@@ -563,12 +571,18 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 		// from GetManagedFields so they never participate in drift comparison.
 		"configuration_location": c.ConfigLocation,
 		"checkpoint_count":       c.CheckpointCount,
-		// Declarative checkpoint policy (#2627). Unlike checkpoint_count this IS a
-		// managed field (see GetManagedFields): the desired config emits its declared
-		// policy while getVM never sets CheckpointPolicy (emits ""), so declaring a
-		// policy drifts and drives setVM → reconcileCheckpoints each converge. An
-		// absent policy emits "" on both sides ⇒ no drift ⇒ #2626 observe-only default.
-		"checkpoint_policy": canonicalCheckpointPolicy(c.CheckpointPolicy),
+	}
+	// Declarative checkpoint policy (#2627): the drift comparator compares the
+	// AUTHORED `checkpoints` block (a managed config key) against what getVM
+	// reports here. getVM echoes the desired block back (checkpointsEcho) ONLY when
+	// the live checkpoint set already COMPLIES with the policy — so a compliant VM
+	// shows NO drift, while a VM with stray checkpoints omits the key and drifts,
+	// driving setVM → reconcileCheckpoints. This mirrors the ha_role observed-block
+	// pattern (a nested managed block getVM reports to match desired when in state).
+	// A desired config with no checkpoints block has no managed `checkpoints` key,
+	// so the comparison never runs — the #2626 observe-only default, drift-free.
+	if c.checkpointsEcho != nil {
+		m["checkpoints"] = c.checkpointsEcho
 	}
 	if c.Source != nil {
 		m["source"] = map[string]interface{}{
@@ -644,7 +658,7 @@ func (c *VMConfig) FromYAML(data []byte) error {
 
 // GetManagedFields returns the list of fields this configuration manages.
 func (c *VMConfig) GetManagedFields() []string {
-	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state", "source", "ha_role", "checkpoint_policy"}
+	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state", "source", "ha_role"}
 }
 
 // psGetVM is the script block passed to ExecutePS for VM retrieval.
@@ -827,6 +841,24 @@ func (m *hypervModule) getVMLocal(ctx context.Context, vmName string) (*VMConfig
 	// Cluster-role membership probe (#2372/#2420) — see
 	// probeClusterRoleMembership for the scope-cap and degrade semantics.
 	cfg.HARole = m.probeClusterRoleMembership(ctx, vmName)
+
+	// Checkpoint-policy compliance echo (#2627): when a checkpoints policy is
+	// declared for this resource (stashed by Configure), report the desired block
+	// back on the Get surface IFF the live checkpoint set already complies — so a
+	// compliant VM shows no drift, and a VM with stray checkpoints omits the key
+	// and drifts (→ setVM reconcile). Best-effort: a probe error degrades to "omit
+	// the echo" (treated as drift, reconciled next Set) rather than failing Get.
+	if policy := parseCheckpointPolicyMap(m.desiredCheckpointsRaw); policy != nil {
+		if comply, cErr := m.checkpointsComply(ctx, vmName, policy, cfg.CheckpointCount); cErr != nil {
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: checkpoint compliance probe failed; reporting as drift this cycle",
+					"vm_name", logging.SanitizeLogValue(vmName),
+					"error", cErr.Error())
+			}
+		} else if comply {
+			cfg.checkpointsEcho = m.desiredCheckpointsRaw
+		}
+	}
 
 	// Write-through: update cache on successful read
 	m.vmsMu.Lock()
@@ -1469,7 +1501,14 @@ func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName st
 	// (UpdatedAt = now) is naturally excluded by the TTL check. Best-effort —
 	// a sweep failure does not block convergence.
 	m.sweepStaleSeedMedia(ctx)
-	return m.applyVMState(ctx, vmName, hostName, cfg, currentVM, state)
+	if err := m.applyVMState(ctx, vmName, hostName, cfg, currentVM, state); err != nil {
+		return err
+	}
+	// Converge the checkpoint set to the declared policy (#2627) on the
+	// source-provisioned existing-VM path too — a source: VM with a checkpoints
+	// policy self-heals identically to a plain-lifecycle VM. No-op when the policy
+	// is nil (observe-only).
+	return m.reconcileCheckpoints(ctx, hostName, cfg.CheckpointPolicy)
 }
 
 // createVM issues New-VM with the desired generation and connects every

--- a/features/modules/hyperv/vm_checkpoint.go
+++ b/features/modules/hyperv/vm_checkpoint.go
@@ -134,29 +134,39 @@ func (p *CheckpointPolicy) validate() error {
 	return nil
 }
 
-// canonicalCheckpointPolicy renders a policy as the stable string the drift
-// comparator sees for the managed "checkpoint_policy" field (vm.go AsMap). The
-// desired config emits its declared policy; getVM never sets CheckpointPolicy so
-// the observed side emits "" — a declared (non-observe) policy therefore drifts
-// and drives setVM → reconcileCheckpoints, while an absent/observe-only policy
-// emits "" on both sides (no drift, #2626 default preserved).
-func canonicalCheckpointPolicy(p *CheckpointPolicy) string {
-	a := resolveCheckpointAction(p)
+// checkpointsComply reports whether a VM's live checkpoint set already satisfies
+// the declared policy — the signal getVM uses to decide whether to echo the
+// desired `checkpoints` block (no drift) or omit it (drift → reconcile, #2627).
+// Count-only policies (none / max with no max_age) are judged from the
+// already-observed count with NO extra PowerShell; only a max_age bound needs the
+// per-snapshot creation times, so it (and only it) issues psGetVMSnapshots.
+func (m *hypervModule) checkpointsComply(ctx context.Context, hostName string, policy *CheckpointPolicy, observedCount int) (bool, error) {
+	action := resolveCheckpointAction(policy)
 	switch {
-	case a.observe:
-		return ""
-	case a.mergeAll:
-		return "merge-all"
-	default:
-		parts := []string{"retain"}
-		if a.hasMax {
-			parts = append(parts, fmt.Sprintf("max=%d", a.max))
+	case action.observe:
+		return true, nil
+	case action.mergeAll:
+		return observedCount == 0, nil
+	case action.maxAge == 0:
+		// Count-only retain: compliant when within the newest-N bound (or no bound).
+		if action.hasMax {
+			return observedCount <= action.max, nil
 		}
-		if a.maxAge > 0 {
-			parts = append(parts, "max_age="+a.maxAge.String())
-		}
-		return strings.Join(parts, ":")
+		return true, nil
 	}
+	// A max_age bound needs per-snapshot times to judge — fetch and evaluate.
+	if m.transport == nil {
+		return false, modules.ErrNotImplemented
+	}
+	output, err := m.transport.ExecutePS(ctx, psGetVMSnapshots, map[string]string{"Name": hostName})
+	if err != nil {
+		return false, err
+	}
+	snaps, err := parseVMSnapshots(output)
+	if err != nil {
+		return false, err
+	}
+	return len(checkpointsToMerge(snaps, policy, time.Now().UTC())) == 0, nil
 }
 
 // parseCheckpointPolicyMap reconstructs a *CheckpointPolicy from the generic

--- a/features/modules/hyperv/vm_checkpoint.go
+++ b/features/modules/hyperv/vm_checkpoint.go
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package hyperv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// Declarative checkpoint lifecycle (#2627). This file implements the reconcile-
+// via-MERGE half of the checkpoint policy declared on a VMConfig (see
+// CheckpointPolicy in vm.go). Cleanup MERGES stray checkpoints —
+// Remove-VMSnapshot folds a checkpoint's differencing disk (.avhdx) into its
+// parent, committing that data upward. It is NON-DESTRUCTIVE to the VM's current
+// running state (the active disk above the chain is untouched); it never reverts.
+// Restore-VMSnapshot (revert, destructive) is deliberately out of scope and never
+// issued — a guarantee asserted by TestCheckpointReconcile_NeverRestores.
+//
+// It builds on the observed-only checkpoint DNA from #2626 (VMConfig.CheckpointCount,
+// the chain-root vhd_path resolution in psGetVM); this story adds the DESIRED side.
+
+// psGetVMSnapshots lists a VM's checkpoints oldest-first as JSON. Only $Name
+// travels via ArgumentList — never interpolated. CreationTime is normalised to a
+// UTC ISO-8601 round-trip string ('o') so the Go side parses it uniformly across
+// Windows PowerShell 5.1 (which otherwise serialises DateTime as "/Date(ms)/") and
+// pwsh 7. An empty checkpoint set yields an empty/`[]`/`null` payload (handled by
+// parseVMSnapshots).
+const psGetVMSnapshots = `$snaps = @(Get-VMSnapshot -VMName $Name -ErrorAction SilentlyContinue | Sort-Object CreationTime | ForEach-Object { [pscustomobject]@{ Name = $_.Name; CreationTime = $_.CreationTime.ToUniversalTime().ToString('o') } }); ConvertTo-Json @($snaps) -Compress -Depth 3`
+
+// psRemoveVMSnapshot MERGES a single checkpoint by name into its parent. Both
+// $Name and $SnapshotName travel via ArgumentList. Remove-VMSnapshot is the
+// merge primitive (Hyper-V "delete checkpoint" = merge differencing disk into
+// parent) — it is NOT a revert. -ErrorAction Stop surfaces a merge failure to
+// the caller rather than letting it vanish as a non-terminating error.
+const psRemoveVMSnapshot = `Remove-VMSnapshot -VMName $Name -Name $SnapshotName -ErrorAction Stop`
+
+// vmSnapshot is a parsed checkpoint: its name (the Remove-VMSnapshot selector) and
+// creation time (for max/max_age retention ordering).
+type vmSnapshot struct {
+	Name         string
+	CreationTime time.Time
+}
+
+// checkpointAction is the resolved, machine-actionable form of a CheckpointPolicy.
+// observe short-circuits all transport calls (the #2626 observe-only default);
+// mergeAll merges every checkpoint; otherwise the retain bounds apply.
+type checkpointAction struct {
+	observe  bool          // take no action (nil/empty policy)
+	mergeAll bool          // merge every checkpoint (policy none, or explicit max:0)
+	hasMax   bool          // a positive count bound is set
+	max      int           // retain the newest max checkpoints (valid when hasMax)
+	maxAge   time.Duration // retain checkpoints younger than this (0 = no age bound)
+}
+
+// resolveCheckpointAction reduces a declared policy to a checkpointAction,
+// applying the equivalences documented on CheckpointPolicy: policy none (or an
+// explicit max:0 with no age bound) → merge all; an unset/empty block → observe;
+// a bound (max>0 and/or max_age) → retain. A malformed max_age has already been
+// rejected by validate() before convergence, so parse errors here degrade to "no
+// age bound" rather than failing the reconcile.
+func resolveCheckpointAction(p *CheckpointPolicy) checkpointAction {
+	if p == nil {
+		return checkpointAction{observe: true}
+	}
+	pol := strings.ToLower(strings.TrimSpace(p.Policy))
+
+	hasMax := p.Max != nil
+	maxVal := 0
+	if hasMax {
+		maxVal = *p.Max
+	}
+
+	var age time.Duration
+	if p.MaxAge != "" {
+		if d, err := time.ParseDuration(p.MaxAge); err == nil && d > 0 {
+			age = d
+		}
+	}
+
+	// Merge all: an explicit policy none, or an explicit max:0 with no age bound
+	// (policy none and max:0 are equivalent "this VM should have no checkpoints"
+	// triggers).
+	if pol == "none" || (hasMax && maxVal == 0 && age == 0) {
+		return checkpointAction{mergeAll: true}
+	}
+
+	// A present-but-empty block (no policy, no bound) behaves like an absent one:
+	// observe-only, so an accidental `checkpoints: {}` never merges everything.
+	if pol != "retain" && !hasMax && age == 0 {
+		return checkpointAction{observe: true}
+	}
+
+	// Retain with bound(s). A max:0 reaching here only happens alongside an age
+	// bound (max:0 + max_age) — treat it as "no count cap, age bound only".
+	return checkpointAction{
+		hasMax: maxVal > 0,
+		max:    maxVal,
+		maxAge: age,
+	}
+}
+
+// validate enforces the fail-closed config rules for a checkpoints block. The
+// headline rule (#2627): policy retain with neither a positive max nor a max_age
+// is invalid — it is indistinguishable from the observe-only default. Also
+// rejects an unknown policy, a negative max, and a malformed max_age duration.
+func (p *CheckpointPolicy) validate() error {
+	switch strings.ToLower(strings.TrimSpace(p.Policy)) {
+	case "", "none", "retain":
+	default:
+		return ErrInvalidCheckpointPolicy
+	}
+	if p.Max != nil && *p.Max < 0 {
+		return ErrInvalidCheckpointPolicy
+	}
+	if p.MaxAge != "" {
+		if _, err := time.ParseDuration(p.MaxAge); err != nil {
+			return ErrInvalidCheckpointPolicy
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(p.Policy), "retain") {
+		hasCount := p.Max != nil && *p.Max > 0
+		hasAge := strings.TrimSpace(p.MaxAge) != ""
+		if !hasCount && !hasAge {
+			return ErrInvalidCheckpointPolicy
+		}
+	}
+	return nil
+}
+
+// canonicalCheckpointPolicy renders a policy as the stable string the drift
+// comparator sees for the managed "checkpoint_policy" field (vm.go AsMap). The
+// desired config emits its declared policy; getVM never sets CheckpointPolicy so
+// the observed side emits "" — a declared (non-observe) policy therefore drifts
+// and drives setVM → reconcileCheckpoints, while an absent/observe-only policy
+// emits "" on both sides (no drift, #2626 default preserved).
+func canonicalCheckpointPolicy(p *CheckpointPolicy) string {
+	a := resolveCheckpointAction(p)
+	switch {
+	case a.observe:
+		return ""
+	case a.mergeAll:
+		return "merge-all"
+	default:
+		parts := []string{"retain"}
+		if a.hasMax {
+			parts = append(parts, fmt.Sprintf("max=%d", a.max))
+		}
+		if a.maxAge > 0 {
+			parts = append(parts, "max_age="+a.maxAge.String())
+		}
+		return strings.Join(parts, ":")
+	}
+}
+
+// parseCheckpointPolicyMap reconstructs a *CheckpointPolicy from the generic
+// executor-supplied config map (the shape VMConfig.AsMap and the executor
+// produce), mirroring parseSourceMap / parseHARoleMap. Returns nil for an absent
+// or entirely-empty block so the reconcile stays observe-only. max is threaded as
+// *int so an explicit max:0 (merge-all) survives (the map carries the key when set).
+func parseCheckpointPolicyMap(v interface{}) *CheckpointPolicy {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	p := &CheckpointPolicy{}
+	p.Policy, _ = m["policy"].(string)
+	p.MaxAge, _ = m["max_age"].(string)
+	if raw, present := m["max"]; present {
+		switch t := raw.(type) {
+		case int:
+			n := t
+			p.Max = &n
+		case int64:
+			n := int(t)
+			p.Max = &n
+		case float64:
+			n := int(t)
+			p.Max = &n
+		}
+	}
+	if p.Policy == "" && p.Max == nil && p.MaxAge == "" {
+		return nil
+	}
+	return p
+}
+
+// checkpointsToMerge selects, from a VM's checkpoints, the set to MERGE under the
+// policy — returned OLDEST-FIRST so the caller merges from the base of the chain
+// upward. A checkpoint is RETAINED only if it satisfies every active bound: within
+// the newest-N window (when max is set) AND younger than max_age (when set);
+// anything violating either bound is merged. mergeAll returns all; observe-only
+// returns none. Pure and time-injectable (now) so the age logic is deterministic
+// in tests.
+func checkpointsToMerge(snaps []vmSnapshot, policy *CheckpointPolicy, now time.Time) []vmSnapshot {
+	action := resolveCheckpointAction(policy)
+	if action.observe || len(snaps) == 0 {
+		return nil
+	}
+
+	ordered := make([]vmSnapshot, len(snaps))
+	copy(ordered, snaps)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].CreationTime.Before(ordered[j].CreationTime)
+	})
+
+	if action.mergeAll {
+		return ordered
+	}
+
+	n := len(ordered)
+	var merge []vmSnapshot
+	for i, s := range ordered {
+		retained := true
+		if action.hasMax && i < n-action.max {
+			retained = false // beyond the newest-N retention window
+		}
+		if retained && action.maxAge > 0 && now.Sub(s.CreationTime) > action.maxAge {
+			retained = false // older than the max_age window
+		}
+		if !retained {
+			merge = append(merge, s)
+		}
+	}
+	return merge
+}
+
+// reconcileCheckpoints converges a VM's checkpoint set to its declared policy by
+// MERGING the stray checkpoints (oldest-first). It is a no-op (issues no PS at
+// all) when the policy is observe-only (nil/empty), preserving the #2626 default.
+// Called from setVM after the power/resource reconcile of an existing VM.
+func (m *hypervModule) reconcileCheckpoints(ctx context.Context, hostName string, policy *CheckpointPolicy) error {
+	if resolveCheckpointAction(policy).observe {
+		return nil
+	}
+	if m.transport == nil {
+		return modules.ErrNotImplemented
+	}
+
+	output, err := m.transport.ExecutePS(ctx, psGetVMSnapshots, map[string]string{"Name": hostName})
+	if err != nil {
+		return fmt.Errorf("hyperv: list checkpoints for %q: %w", hostName, err)
+	}
+	snaps, err := parseVMSnapshots(output)
+	if err != nil {
+		return fmt.Errorf("hyperv: parse checkpoints for %q: %w", hostName, err)
+	}
+
+	for _, s := range checkpointsToMerge(snaps, policy, time.Now().UTC()) {
+		if _, err := m.transport.ExecutePS(ctx, psRemoveVMSnapshot,
+			map[string]string{"Name": hostName, "SnapshotName": s.Name}); err != nil {
+			return fmt.Errorf("hyperv: merge checkpoint %q on %q: %w", s.Name, hostName, err)
+		}
+	}
+	return nil
+}
+
+// parseVMSnapshots normalises the psGetVMSnapshots JSON payload into []vmSnapshot.
+// ConvertTo-Json emits an array for 0/2+ elements and may collapse a single
+// element to a bare object; an empty set yields ""/"null"/"[]". All shapes are
+// handled. A checkpoint whose CreationTime fails to parse keeps a zero time
+// (sorts oldest / treated as very old for max_age) rather than dropping it.
+func parseVMSnapshots(output string) ([]vmSnapshot, error) {
+	s := strings.TrimSpace(output)
+	if s == "" || s == "null" || s == "[]" {
+		return nil, nil
+	}
+
+	var arr []map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &arr); err != nil {
+		var obj map[string]interface{}
+		if err2 := json.Unmarshal([]byte(s), &obj); err2 != nil {
+			return nil, fmt.Errorf("unmarshal checkpoint list: %w", err)
+		}
+		arr = []map[string]interface{}{obj}
+	}
+
+	var out []vmSnapshot
+	for _, mp := range arr {
+		name, _ := mp["Name"].(string)
+		if name == "" {
+			continue
+		}
+		var ct time.Time
+		if cs, ok := mp["CreationTime"].(string); ok && cs != "" {
+			if t, perr := time.Parse(time.RFC3339Nano, cs); perr == nil {
+				ct = t.UTC()
+			}
+		}
+		out = append(out, vmSnapshot{Name: name, CreationTime: ct})
+	}
+	return out, nil
+}

--- a/features/modules/hyperv/vm_checkpoint_test.go
+++ b/features/modules/hyperv/vm_checkpoint_test.go
@@ -275,23 +275,161 @@ func TestCheckpointReconcile_NeverRestores(t *testing.T) {
 	}
 }
 
-// TestCheckpointPolicy_ManagedFieldDrivesConvergence (#2627 convergence trigger):
-// checkpoint_policy is a MANAGED field (so a declared policy drifts vs getVM's
-// empty observed value and drives setVM), while an absent policy emits "" on both
-// sides — preserving the #2626 observe-only default (no false drift).
-func TestCheckpointPolicy_ManagedFieldDrivesConvergence(t *testing.T) {
-	assert.Contains(t, (&VMConfig{}).GetManagedFields(), "checkpoint_policy",
-		"checkpoint_policy must be a managed field so a declared policy triggers Set")
+// hostVMJSONWithCheckpoints builds a psGetVM response for a VM with the given
+// observed checkpoint count (the field getVM reads for count-based compliance).
+func hostVMJSONWithCheckpoints(name string, count int) string {
+	return fmt.Sprintf(`{"found":true,"Name":%q,"MemoryStartupBytes":2147483648,"ProcessorCount":2,"Generation":2,"Path":"C:\\VMs\\%s.vhdx","ConfigurationLocation":"C:\\VMs","CheckpointCount":%d,"SwitchName":"","SwitchNames":[],"State":"Running"}`, name, name, count)
+}
 
-	// Observed side (getVM never sets CheckpointPolicy) → empty canonical string.
-	observed := &VMConfig{Name: "cp-vm", CheckpointCount: 3}
-	assert.Equal(t, "", observed.AsMap()["checkpoint_policy"],
-		"getVM output has no policy ⇒ empty ⇒ no drift when the config declares none (observe-only)")
+// TestGetVM_CheckpointEcho_CompliantEchoesNoncompliantDrifts (#2627, the
+// false-drift fix): getVM echoes the authored `checkpoints` block on the Get
+// surface ONLY when the live set complies with the policy, so a compliant VM
+// matches desired (no drift) while a VM with stray checkpoints omits the key and
+// drifts (→ reconcile). No declared policy ⇒ no `checkpoints` key at all
+// (observe-only, #2626). This is the policy-aware-Get behaviour that eliminates
+// the every-cycle false drift.
+func TestGetVM_CheckpointEcho_CompliantEchoesNoncompliantDrifts(t *testing.T) {
+	desired := map[string]interface{}{"policy": "none"}
 
-	// Desired side with a policy → non-empty canonical string ⇒ drifts vs observed "".
-	three := 3
-	desired := &VMConfig{Name: "cp-vm", CheckpointPolicy: &CheckpointPolicy{Policy: "retain", Max: &three}}
-	assert.Equal(t, "retain:max=3", desired.AsMap()["checkpoint_policy"])
-	assert.NotEqual(t, observed.AsMap()["checkpoint_policy"], desired.AsMap()["checkpoint_policy"],
-		"a declared policy must differ from the observed empty value so Set (reconcile) runs")
+	// Compliant: 0 checkpoints under policy none → echo the block → no drift.
+	mc := vmModuleWithTransport(&testWinRMTransport{
+		perCallOutputs: []string{hostVMJSONWithCheckpoints("cp-vm", 0)}}, "t-echo-clean")
+	mc.desiredCheckpointsRaw = desired
+	cc, err := mc.getVM(context.Background(), "cp-vm")
+	require.NoError(t, err)
+	assert.Equal(t, desired, cc.AsMap()["checkpoints"],
+		"a compliant VM must echo the desired checkpoints block so it compares equal (no false drift)")
+
+	// Non-compliant: 2 checkpoints under policy none → omit the block → drift.
+	md := vmModuleWithTransport(&testWinRMTransport{
+		perCallOutputs: []string{hostVMJSONWithCheckpoints("cp-vm", 2)}}, "t-echo-dirty")
+	md.desiredCheckpointsRaw = desired
+	cd, err := md.getVM(context.Background(), "cp-vm")
+	require.NoError(t, err)
+	_, present := cd.AsMap()["checkpoints"]
+	assert.False(t, present,
+		"a VM with stray checkpoints must omit the block so it drifts vs desired and triggers reconcile")
+
+	// Observe-only (no stashed policy): getVM never emits a checkpoints key.
+	mo := vmModuleWithTransport(&testWinRMTransport{
+		perCallOutputs: []string{hostVMJSONWithCheckpoints("cp-vm", 5)}}, "t-echo-observe")
+	co, err := mo.getVM(context.Background(), "cp-vm")
+	require.NoError(t, err)
+	_, present = co.AsMap()["checkpoints"]
+	assert.False(t, present,
+		"no declared policy ⇒ getVM emits no checkpoints key (observe-only #2626 default, drift-free)")
+}
+
+// TestGetVM_CheckpointEcho_MaxAgeFetchesSnapshotList (#2627): a max_age policy
+// can't be judged from the count alone, so getVM issues a second call
+// (psGetVMSnapshots) to evaluate per-snapshot ages. A wide window ⇒ all retained
+// ⇒ compliant ⇒ echo.
+func TestGetVM_CheckpointEcho_MaxAgeFetchesSnapshotList(t *testing.T) {
+	desired := map[string]interface{}{"policy": "retain", "max_age": "100000h"}
+	snapJSON := snapshotListJSON(t, vmSnapshot{Name: "cp1", CreationTime: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)})
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSONWithCheckpoints("cp-vm", 1), // 1st: psGetVM
+		snapJSON,                              // 2nd: psGetVMSnapshots (max_age needs times)
+	}}
+	m := vmModuleWithTransport(transport, "t-echo-age")
+	m.desiredCheckpointsRaw = desired
+	cfg, err := m.getVM(context.Background(), "cp-vm")
+	require.NoError(t, err)
+	assert.Equal(t, desired, cfg.AsMap()["checkpoints"],
+		"a checkpoint within the max_age window is retained ⇒ compliant ⇒ echo")
+	assert.Equal(t, psGetVMSnapshots, transport.calls[1].scriptBlock,
+		"a max_age policy must fetch the snapshot list to judge compliance")
+}
+
+// TestParseCheckpointPolicyMap (#2627, QA gap): the executor-map parse path,
+// including the JSON-sourced float64 max and the explicit-max:0-vs-unset *int
+// distinction that the whole feature hinges on.
+func TestParseCheckpointPolicyMap(t *testing.T) {
+	assert.Nil(t, parseCheckpointPolicyMap(nil))
+	assert.Nil(t, parseCheckpointPolicyMap(map[string]interface{}{}), "empty block ⇒ nil (observe-only)")
+
+	// float64 (JSON/executor-sourced) max survives as *int.
+	p := parseCheckpointPolicyMap(map[string]interface{}{"policy": "retain", "max": float64(3)})
+	require.NotNil(t, p)
+	require.NotNil(t, p.Max)
+	assert.Equal(t, 3, *p.Max)
+
+	// Explicit max: 0 ⇒ *int &0 (merge-all), distinct from absent.
+	pz := parseCheckpointPolicyMap(map[string]interface{}{"max": 0})
+	require.NotNil(t, pz)
+	require.NotNil(t, pz.Max)
+	assert.Equal(t, 0, *pz.Max)
+	assert.True(t, resolveCheckpointAction(pz).mergeAll, "explicit max: 0 resolves to merge-all")
+
+	// max_age only ⇒ implicit retain with Max nil (no count bound).
+	pa := parseCheckpointPolicyMap(map[string]interface{}{"max_age": "24h"})
+	require.NotNil(t, pa)
+	assert.Nil(t, pa.Max)
+	assert.Equal(t, "24h", pa.MaxAge)
+}
+
+// TestVMConfig_FromYAML_CheckpointsMaxZeroVsUnset (#2627, QA gap): the YAML parse
+// path must preserve the explicit-max:0-vs-unset distinction end to end.
+func TestVMConfig_FromYAML_CheckpointsMaxZeroVsUnset(t *testing.T) {
+	var withZero VMConfig
+	require.NoError(t, withZero.FromYAML([]byte("name: v\ncheckpoints:\n  max: 0\n")))
+	require.NotNil(t, withZero.CheckpointPolicy)
+	require.NotNil(t, withZero.CheckpointPolicy.Max, "explicit max: 0 must parse as *int &0, not nil")
+	assert.Equal(t, 0, *withZero.CheckpointPolicy.Max)
+	assert.True(t, resolveCheckpointAction(withZero.CheckpointPolicy).mergeAll, "max: 0 ⇒ merge-all")
+
+	var withAge VMConfig
+	require.NoError(t, withAge.FromYAML([]byte("name: v\ncheckpoints:\n  policy: retain\n  max_age: 24h\n")))
+	require.NotNil(t, withAge.CheckpointPolicy)
+	assert.Nil(t, withAge.CheckpointPolicy.Max, "unset max must parse as nil (no count bound), distinct from max: 0")
+	assert.Equal(t, "24h", withAge.CheckpointPolicy.MaxAge)
+}
+
+// TestParseVMSnapshots_Shapes (#2627, QA gap): empty/array/single-object payloads
+// and an unparsable CreationTime (kept as a zero-time snapshot, not dropped).
+func TestParseVMSnapshots_Shapes(t *testing.T) {
+	for _, empty := range []string{"", "  ", "null", "[]"} {
+		s, err := parseVMSnapshots(empty)
+		require.NoError(t, err)
+		assert.Empty(t, s, "empty payload %q ⇒ no snapshots", empty)
+	}
+
+	// Single object — PS collapses a 1-element array to a bare object.
+	s, err := parseVMSnapshots(`{"Name":"only","CreationTime":"2026-07-01T00:00:00Z"}`)
+	require.NoError(t, err)
+	require.Len(t, s, 1)
+	assert.Equal(t, "only", s[0].Name)
+	assert.False(t, s[0].CreationTime.IsZero())
+
+	// Array of two.
+	s, err = parseVMSnapshots(`[{"Name":"a","CreationTime":"2026-07-01T00:00:00Z"},{"Name":"b","CreationTime":"2026-07-02T00:00:00Z"}]`)
+	require.NoError(t, err)
+	require.Len(t, s, 2)
+
+	// Unparsable CreationTime ⇒ zero time, snapshot still retained.
+	s, err = parseVMSnapshots(`[{"Name":"weird","CreationTime":"not-a-time"}]`)
+	require.NoError(t, err)
+	require.Len(t, s, 1)
+	assert.True(t, s[0].CreationTime.IsZero(), "an unparsable timestamp keeps the snapshot with a zero time")
+}
+
+// TestCheckpointsToMerge_BothBounds (#2627, QA warning): with max AND max_age set,
+// a checkpoint is retained only if it satisfies BOTH bounds; anything violating
+// either is merged, oldest-first.
+func TestCheckpointsToMerge_BothBounds(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	snaps := []vmSnapshot{
+		{Name: "old-outside-n", CreationTime: now.Add(-72 * time.Hour)}, // beyond newest-2 AND too old
+		{Name: "old-inside-n", CreationTime: now.Add(-48 * time.Hour)},  // within newest-2 but too old
+		{Name: "young-inside-n", CreationTime: now.Add(-1 * time.Hour)}, // within newest-2 and young
+	}
+	two := 2
+	merge := checkpointsToMerge(snaps, &CheckpointPolicy{Policy: "retain", Max: &two, MaxAge: "24h"}, now)
+
+	names := make([]string, 0, len(merge))
+	for _, s := range merge {
+		names = append(names, s.Name)
+	}
+	assert.Equal(t, []string{"old-outside-n", "old-inside-n"}, names,
+		"retained only if within newest-N AND younger than max_age; violating either bound is merged, oldest-first")
 }

--- a/features/modules/hyperv/vm_checkpoint_test.go
+++ b/features/modules/hyperv/vm_checkpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -294,7 +295,7 @@ func TestGetVM_CheckpointEcho_CompliantEchoesNoncompliantDrifts(t *testing.T) {
 	// Compliant: 0 checkpoints under policy none → echo the block → no drift.
 	mc := vmModuleWithTransport(&testWinRMTransport{
 		perCallOutputs: []string{hostVMJSONWithCheckpoints("cp-vm", 0)}}, "t-echo-clean")
-	mc.desiredCheckpointsRaw = desired
+	mc.checkpointDesired["cp-vm"] = desired
 	cc, err := mc.getVM(context.Background(), "cp-vm")
 	require.NoError(t, err)
 	assert.Equal(t, desired, cc.AsMap()["checkpoints"],
@@ -303,7 +304,7 @@ func TestGetVM_CheckpointEcho_CompliantEchoesNoncompliantDrifts(t *testing.T) {
 	// Non-compliant: 2 checkpoints under policy none → omit the block → drift.
 	md := vmModuleWithTransport(&testWinRMTransport{
 		perCallOutputs: []string{hostVMJSONWithCheckpoints("cp-vm", 2)}}, "t-echo-dirty")
-	md.desiredCheckpointsRaw = desired
+	md.checkpointDesired["cp-vm"] = desired
 	cd, err := md.getVM(context.Background(), "cp-vm")
 	require.NoError(t, err)
 	_, present := cd.AsMap()["checkpoints"]
@@ -332,13 +333,65 @@ func TestGetVM_CheckpointEcho_MaxAgeFetchesSnapshotList(t *testing.T) {
 		snapJSON,                              // 2nd: psGetVMSnapshots (max_age needs times)
 	}}
 	m := vmModuleWithTransport(transport, "t-echo-age")
-	m.desiredCheckpointsRaw = desired
+	m.checkpointDesired["cp-vm"] = desired
 	cfg, err := m.getVM(context.Background(), "cp-vm")
 	require.NoError(t, err)
 	assert.Equal(t, desired, cfg.AsMap()["checkpoints"],
 		"a checkpoint within the max_age window is retained ⇒ compliant ⇒ echo")
 	assert.Equal(t, psGetVMSnapshots, transport.calls[1].scriptBlock,
 		"a max_age policy must fetch the snapshot list to judge compliance")
+}
+
+// TestCheckpointDesired_KeyedPerVM_NoCrossLeak (#2627): the factory caches ONE
+// hyperv module instance per bundle, so every VM shares it. The desired-policy
+// store must be keyed by VM name — VM-A's policy must never leak into VM-B's
+// compliance judgment. Here VM-A (policy none) has 0 checkpoints (compliant) and
+// VM-B (retain max 5) has 3 (compliant); each must echo ITS OWN block.
+func TestCheckpointDesired_KeyedPerVM_NoCrossLeak(t *testing.T) {
+	blockA := map[string]interface{}{"policy": "none"}
+	blockB := map[string]interface{}{"policy": "retain", "max": 5}
+
+	// One shared module/transport instance serving both VMs (call 0 = A, 1 = B).
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		hostVMJSONWithCheckpoints("vm-a", 0),
+		hostVMJSONWithCheckpoints("vm-b", 3),
+	}}
+	m := vmModuleWithTransport(transport, "t-cp-keyed")
+	m.checkpointDesired["vm-a"] = blockA
+	m.checkpointDesired["vm-b"] = blockB
+
+	ca, err := m.getVM(context.Background(), "vm-a")
+	require.NoError(t, err)
+	cb, err := m.getVM(context.Background(), "vm-b")
+	require.NoError(t, err)
+
+	assert.Equal(t, blockA, ca.AsMap()["checkpoints"], "VM-A must echo its own policy block")
+	assert.Equal(t, blockB, cb.AsMap()["checkpoints"], "VM-B must echo its own policy block (no leak from VM-A)")
+}
+
+// TestCheckpointDesired_ConcurrentAccess_NoRace (#2627): the monitor goroutine's
+// targeted reconciles run concurrently with the convergence loop on the SAME
+// shared module instance, so the per-VM policy store must be mutex-guarded.
+// Exercises concurrent writes (setVM-style) and reads (getVM) for distinct VMs;
+// run under `go test -race` this fails if the map access is unguarded.
+func TestCheckpointDesired_ConcurrentAccess_NoRace(t *testing.T) {
+	m := vmModuleWithTransport(&testWinRMTransport{output: hostVMJSONWithCheckpoints("x", 0)}, "t-cp-race")
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		vm := fmt.Sprintf("vm-%d", i)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			m.checkpointDesiredMu.Lock()
+			m.checkpointDesired[vm] = map[string]interface{}{"policy": "none"}
+			m.checkpointDesiredMu.Unlock()
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = m.getVM(context.Background(), vm)
+		}()
+	}
+	wg.Wait()
 }
 
 // TestParseCheckpointPolicyMap (#2627, QA gap): the executor-map parse path,

--- a/features/modules/hyperv/vm_checkpoint_test.go
+++ b/features/modules/hyperv/vm_checkpoint_test.go
@@ -5,7 +5,10 @@ package hyperv
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,4 +97,201 @@ func TestVMConfig_CheckpointCount_ObservedOnly(t *testing.T) {
 		"checkpoint_count must be exposed on the AsMap/DNA surface")
 	assert.NotContains(t, cfg.GetManagedFields(), "checkpoint_count",
 		"checkpoint_count must be absent from GetManagedFields so it never counts as drift")
+}
+
+// ─── Issue #2627: declarative checkpoint policy (merge-to-clean) ────────────────
+//
+// Cleanup MERGES stray checkpoints (Remove-VMSnapshot folds the differencing disk
+// into its parent — non-destructive; never Restore/revert). Opt-in: absent block =
+// observe-only (#2626 default). These tests exercise the Go-side policy resolution,
+// merge-set selection, and the transport calls reconcileCheckpoints issues.
+
+// snapshotListJSON builds the psGetVMSnapshots payload for a set of checkpoints,
+// matching the JSON the PowerShell emits (Name + UTC ISO-8601 CreationTime).
+func snapshotListJSON(t *testing.T, snaps ...vmSnapshot) string {
+	t.Helper()
+	parts := make([]string, 0, len(snaps))
+	for _, s := range snaps {
+		parts = append(parts, fmt.Sprintf(`{"Name":%q,"CreationTime":%q}`,
+			s.Name, s.CreationTime.UTC().Format(time.RFC3339Nano)))
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+// mergedSnapshotNames returns the checkpoint names passed to Remove-VMSnapshot
+// (the merge primitive), in call order. psArgs are recorded in sorted-key order,
+// so for {Name, SnapshotName} the snapshot name is args[1].
+func mergedSnapshotNames(calls []winRMCall) []string {
+	var names []string
+	for _, c := range calls {
+		if c.scriptBlock == psRemoveVMSnapshot && len(c.args) == 2 {
+			if s, ok := c.args[1].(string); ok {
+				names = append(names, s)
+			}
+		}
+	}
+	return names
+}
+
+// TestCheckpointReconcile_PolicyNone_MergesAllOldestFirst (REQUIRED, AC1): a
+// policy: none config merges every checkpoint (post-converge count = 0),
+// oldest-first.
+func TestCheckpointReconcile_PolicyNone_MergesAllOldestFirst(t *testing.T) {
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []vmSnapshot{
+		{Name: "cp-old", CreationTime: base},
+		{Name: "cp-mid", CreationTime: base.Add(24 * time.Hour)},
+		{Name: "cp-new", CreationTime: base.Add(48 * time.Hour)},
+	}
+	transport := &testWinRMTransport{perCallOutputs: []string{snapshotListJSON(t, snaps...)}}
+	m := vmModuleWithTransport(transport, "t-cp-none")
+
+	require.NoError(t, m.reconcileCheckpoints(context.Background(), "cp-vm", &CheckpointPolicy{Policy: "none"}))
+
+	assert.Equal(t, psGetVMSnapshots, transport.calls[0].scriptBlock,
+		"reconcile must first LIST checkpoints")
+	assert.Equal(t, []string{"cp-old", "cp-mid", "cp-new"}, mergedSnapshotNames(transport.calls),
+		"policy none must merge ALL checkpoints, oldest-first (post-converge count = 0)")
+	assert.Len(t, transport.calls, 4, "exactly one list + three merges")
+}
+
+// TestCheckpointReconcile_MaxZero_MergesAll (REQUIRED, AC1): max: 0 is equivalent
+// to policy: none — merge all.
+func TestCheckpointReconcile_MaxZero_MergesAll(t *testing.T) {
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []vmSnapshot{
+		{Name: "a", CreationTime: base},
+		{Name: "b", CreationTime: base.Add(time.Hour)},
+	}
+	transport := &testWinRMTransport{perCallOutputs: []string{snapshotListJSON(t, snaps...)}}
+	m := vmModuleWithTransport(transport, "t-cp-max0")
+
+	zero := 0
+	require.NoError(t, m.reconcileCheckpoints(context.Background(), "cp-vm", &CheckpointPolicy{Max: &zero}))
+	assert.Equal(t, []string{"a", "b"}, mergedSnapshotNames(transport.calls),
+		"max: 0 must merge all checkpoints (equivalent to policy: none)")
+}
+
+// TestCheckpointReconcile_MaxN_RetainsNewestMergesRest (REQUIRED, AC2): max: N
+// retains the newest N and merges the rest, oldest-first.
+func TestCheckpointReconcile_MaxN_RetainsNewestMergesRest(t *testing.T) {
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []vmSnapshot{
+		{Name: "cp1", CreationTime: base},
+		{Name: "cp2", CreationTime: base.Add(1 * time.Hour)},
+		{Name: "cp3", CreationTime: base.Add(2 * time.Hour)},
+		{Name: "cp4", CreationTime: base.Add(3 * time.Hour)},
+		{Name: "cp5", CreationTime: base.Add(4 * time.Hour)},
+	}
+	transport := &testWinRMTransport{perCallOutputs: []string{snapshotListJSON(t, snaps...)}}
+	m := vmModuleWithTransport(transport, "t-cp-max")
+
+	three := 3
+	require.NoError(t, m.reconcileCheckpoints(context.Background(), "cp-vm",
+		&CheckpointPolicy{Policy: "retain", Max: &three}))
+
+	assert.Equal(t, []string{"cp1", "cp2"}, mergedSnapshotNames(transport.calls),
+		"max: 3 must retain the newest 3 (cp3–cp5) and merge the oldest 2, oldest-first")
+}
+
+// TestCheckpointsToMerge_MaxAge_RetainsYoungerMergesOlder (REQUIRED, AC2): max_age
+// retains checkpoints younger than the window and merges older ones, oldest-first.
+// The age comparison is time-injected here for determinism.
+func TestCheckpointsToMerge_MaxAge_RetainsYoungerMergesOlder(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	snaps := []vmSnapshot{
+		{Name: "old-2d", CreationTime: now.Add(-48 * time.Hour)},
+		{Name: "old-25h", CreationTime: now.Add(-25 * time.Hour)},
+		{Name: "young-1h", CreationTime: now.Add(-1 * time.Hour)},
+	}
+	merge := checkpointsToMerge(snaps, &CheckpointPolicy{Policy: "retain", MaxAge: "24h"}, now)
+
+	names := make([]string, 0, len(merge))
+	for _, s := range merge {
+		names = append(names, s.Name)
+	}
+	assert.Equal(t, []string{"old-2d", "old-25h"}, names,
+		"max_age: 24h must merge checkpoints older than 24h (oldest-first) and retain younger ones")
+}
+
+// TestCheckpointReconcile_NoPolicy_ObserveOnly (REQUIRED, AC3): an absent (nil) or
+// empty checkpoints block issues NO PowerShell at all — no Get-VMSnapshot, no
+// Remove-VMSnapshot. This is the #2626 observe-only default.
+func TestCheckpointReconcile_NoPolicy_ObserveOnly(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m := vmModuleWithTransport(transport, "t-cp-observe")
+
+	require.NoError(t, m.reconcileCheckpoints(context.Background(), "cp-vm", nil))
+	require.NoError(t, m.reconcileCheckpoints(context.Background(), "cp-vm", &CheckpointPolicy{}))
+
+	assert.Empty(t, transport.calls,
+		"observe-only (absent/empty checkpoints block) must issue NO PowerShell — no list, no merge")
+}
+
+// TestVMConfig_Validate_CheckpointRetainWithoutBounds (REQUIRED, AC4): policy:
+// retain with neither max nor max_age fails Validate with ErrInvalidCheckpointPolicy;
+// a bound (or policy none) validates.
+func TestVMConfig_Validate_CheckpointRetainWithoutBounds(t *testing.T) {
+	bare := &VMConfig{Name: "cp-vm", CheckpointPolicy: &CheckpointPolicy{Policy: "retain"}}
+	assert.ErrorIs(t, bare.Validate(), ErrInvalidCheckpointPolicy,
+		"policy retain with no max/max_age must be rejected fail-closed")
+
+	three := 3
+	assert.NoError(t, (&VMConfig{Name: "cp-vm",
+		CheckpointPolicy: &CheckpointPolicy{Policy: "retain", Max: &three}}).Validate())
+	assert.NoError(t, (&VMConfig{Name: "cp-vm",
+		CheckpointPolicy: &CheckpointPolicy{Policy: "retain", MaxAge: "24h"}}).Validate())
+	assert.NoError(t, (&VMConfig{Name: "cp-vm",
+		CheckpointPolicy: &CheckpointPolicy{Policy: "none"}}).Validate())
+
+	// A malformed max_age duration is also rejected.
+	assert.ErrorIs(t, (&VMConfig{Name: "cp-vm",
+		CheckpointPolicy: &CheckpointPolicy{Policy: "retain", MaxAge: "not-a-duration"}}).Validate(),
+		ErrInvalidCheckpointPolicy)
+}
+
+// TestCheckpointReconcile_NeverRestores (REQUIRED, AC5): cleanup is merge-only —
+// no code path ever issues Restore-VMSnapshot (revert is out of scope, destructive).
+func TestCheckpointReconcile_NeverRestores(t *testing.T) {
+	// Static guarantee on the PS primitives.
+	assert.NotContains(t, psRemoveVMSnapshot, "Restore-VMSnapshot")
+	assert.NotContains(t, psGetVMSnapshots, "Restore-VMSnapshot")
+	assert.Contains(t, psRemoveVMSnapshot, "Remove-VMSnapshot",
+		"cleanup must MERGE via Remove-VMSnapshot (folds the differencing disk into its parent)")
+
+	// Dynamic guarantee: a full merge-all reconcile issues only list + Remove.
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []vmSnapshot{
+		{Name: "cp1", CreationTime: base},
+		{Name: "cp2", CreationTime: base.Add(time.Hour)},
+	}
+	transport := &testWinRMTransport{perCallOutputs: []string{snapshotListJSON(t, snaps...)}}
+	m := vmModuleWithTransport(transport, "t-cp-restore")
+
+	require.NoError(t, m.reconcileCheckpoints(context.Background(), "cp-vm", &CheckpointPolicy{Policy: "none"}))
+	for _, c := range transport.calls {
+		assert.NotContains(t, c.scriptBlock, "Restore-VMSnapshot",
+			"no reconcile path may ever issue Restore-VMSnapshot")
+	}
+}
+
+// TestCheckpointPolicy_ManagedFieldDrivesConvergence (#2627 convergence trigger):
+// checkpoint_policy is a MANAGED field (so a declared policy drifts vs getVM's
+// empty observed value and drives setVM), while an absent policy emits "" on both
+// sides — preserving the #2626 observe-only default (no false drift).
+func TestCheckpointPolicy_ManagedFieldDrivesConvergence(t *testing.T) {
+	assert.Contains(t, (&VMConfig{}).GetManagedFields(), "checkpoint_policy",
+		"checkpoint_policy must be a managed field so a declared policy triggers Set")
+
+	// Observed side (getVM never sets CheckpointPolicy) → empty canonical string.
+	observed := &VMConfig{Name: "cp-vm", CheckpointCount: 3}
+	assert.Equal(t, "", observed.AsMap()["checkpoint_policy"],
+		"getVM output has no policy ⇒ empty ⇒ no drift when the config declares none (observe-only)")
+
+	// Desired side with a policy → non-empty canonical string ⇒ drifts vs observed "".
+	three := 3
+	desired := &VMConfig{Name: "cp-vm", CheckpointPolicy: &CheckpointPolicy{Policy: "retain", Max: &three}}
+	assert.Equal(t, "retain:max=3", desired.AsMap()["checkpoint_policy"])
+	assert.NotEqual(t, observed.AsMap()["checkpoint_policy"], desired.AsMap()["checkpoint_policy"],
+		"a declared policy must differ from the observed empty value so Set (reconcile) runs")
 }

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -20,11 +20,12 @@ import (
 // and tenantID for VM operation tests. vms cache is initialised empty.
 func vmModuleWithTransport(transport winrmTransport, tenantID string) *hypervModule {
 	return &hypervModule{
-		executor:  &stubHypervExecutor{},
-		transport: transport,
-		tenantID:  tenantID,
-		vms:       make(map[string]VMConfig),
-		detector:  &fakeDetector{result: true},
+		executor:          &stubHypervExecutor{},
+		transport:         transport,
+		tenantID:          tenantID,
+		vms:               make(map[string]VMConfig),
+		checkpointDesired: make(map[string]interface{}),
+		detector:          &fakeDetector{result: true},
 		// Production parity: New() sets this so the bulk cluster-owner read is
 		// cached within a converge pass (Story #2577). Without it caching is off
 		// and the read-path owner lookup would re-query the cluster per concern.


### PR DESCRIPTION
## Summary

Lets a `hyperv.vm` config **declare a checkpoint policy** the module converges to — true self-healing to a clean checkpoint state. **Opt-in**: with no `checkpoints` block the module stays observe-only (the #2626 default — checkpoints reported as DNA, never touched). Builds on #2626 (checkpoint-aware `vhd_path` + `CheckpointCount` DNA).

Cleanup is **merge-only**: `Remove-VMSnapshot` folds a checkpoint's differencing disk into its parent (non-destructive to current VM state) — it never reverts. `Restore-VMSnapshot` is out of scope and is never issued (test-enforced).

## Changes

- **Config surface** (`vm.go`): `CheckpointPolicy{policy, max, max_age}` on `VMConfig`, parsed on both YAML and executor-map paths. `max` is `*int` so an explicit `max: 0` (merge-all, ≡ `policy: none`) is distinct from unset (no count bound).
- **Validation**: `policy: retain` with neither `max` nor `max_age` → `ErrInvalidCheckpointPolicy` (fail-closed), plus bad `max_age` / negative `max`.
- **Reconcile** (`vm_checkpoint.go`, new): `reconcileCheckpoints` merges stray checkpoints **oldest-first**; selection is a pure, time-injectable helper (newest-N and/or younger-than-`max_age`; both bounds ⇒ retained only if it satisfies both). Wired into both `setVM` existing-VM paths (plain + source-provisioned).
- **Policy-aware `Get` (no false drift)**: the drift comparator compares the authored `checkpoints` key against `getVM`. `getVM` evaluates the live set against the policy and **echoes the block back only when the VM already complies** — so a compliant VM is drift-free and a VM with stray checkpoints drifts → reconcile. Mirrors the `ha_role` observed-block pattern. The desired policy is recorded per-VM by `setVM` in a **mutex-guarded, VM-name-keyed map** (the module instance is shared per bundle and the monitor reconciles concurrently, so per-VM state must be keyed, not a Configure-set field). `none`/`max` judged from the observed count; `max_age` fetches the snapshot list.
- **Windows persistent-PS-host dispatch**: `Cfgms-GetVMSnapshots` / `Cfgms-RemoveVMSnapshot` added to the preamble + dispatch switch (values only via declared params).
- **Docs**: README section + semantics table; `max_age` extra-read noted in Known Limitations.

## Test results

All local gates green: `go build ./...`, `go vet`, `gofmt`, `make check-architecture`, full `features/modules/hyperv` package under `-race`, and the drift-engine consumer packages (`features/steward/execution`, `.../testing`). New tests cover all 6 ACs plus the parse paths (`parseCheckpointPolicyMap` incl. `float64`/`max:0`, `FromYAML` `max:0`-vs-unset), `parseVMSnapshots` shapes/zero-time, the both-bounds case, the compliant-echo/non-compliant-drift `getVM` behavior, cross-VM keying (no leak), and concurrent access (`-race`). Full `make test-complete` / lint / secret-scan defer to CI per the documented Windows self-dispatch host gaps.

## Review

Pre-PR adversarial review (acceptance + QA code review + security) run via the story-complete team: **acceptance PASS** (all 6 ACs verified), **security PASS** (PS injection-safe, merge-only guarantee test-enforced), **QA PASS** (after fixing a real shared-instance concurrency race the reviewer caught — now keyed + mutex-guarded + `-race`-tested).

Fixes #2627

Co-Authored-By: Claude <noreply@anthropic.com>