### PR TITLE
workflow: set_ha_role step executor (device-scope config write) (Issue #2667)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -205,6 +205,8 @@ A device-level resource always wins. A role resource overrides cluster-policies 
 
 Non-healthy statuses surface as `health.Alert` entries (critical for missing/split-brain, warning for dead-owner) and `health.ComponentHealth` entries in the response. Detection is on-demand (no background poll): the endpoint scans the current DNA snapshot and config store on each call.
 
+**Workflow-driven `ha_role` writes (Issue #2667):** the `set_ha_role` workflow step is the first production writer of a resource's `ha_role` field via the workflow engine. It reads the target steward's device-scope config document (`stewards/<steward_id>`), locates the named `hyperv.vm` resource, and merges `{cluster_name, resource_group_name}` into its `ha_role` block. The write goes through `ConfigurationServiceV2.SetConfiguration` — the same validated + fan-out path as every other device-scope write — ensuring `ValidateConfiguration` runs and the registered `FanoutCallback` (Save = Deploy) fires an immediate push to the steward.
+
 **No-op for non-clustered stewards:** when a steward has no cluster membership, the cluster-policies step is skipped entirely. The `EffectiveConfiguration` output is byte-identical to before this cascade level was introduced, verified by regression tests.
 
 ### Role-Policies Namespace (Issues #2543, #2546)

--- a/features/controller/api/handlers_clusters.go
+++ b/features/controller/api/handlers_clusters.go
@@ -27,9 +27,9 @@ type ClusterInfo struct {
 
 // ClusterReconciliationResponse is returned by GET /api/v1/clusters/{name}/reconciliation.
 type ClusterReconciliationResponse struct {
-	ClusterName string                         `json:"cluster_name"`
-	Resources   []ClusterResourceStatus        `json:"resources"`
-	Alerts      []health.Alert                 `json:"alerts,omitempty"`
+	ClusterName string                            `json:"cluster_name"`
+	Resources   []ClusterResourceStatus           `json:"resources"`
+	Alerts      []health.Alert                    `json:"alerts,omitempty"`
 	Components  map[string]health.ComponentHealth `json:"components,omitempty"`
 }
 

--- a/features/controller/api/handlers_clusters_test.go
+++ b/features/controller/api/handlers_clusters_test.go
@@ -17,8 +17,8 @@ import (
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/controller/clusterregistry"
 	"github.com/cfgis/cfgms/features/controller/health"
-	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
 // seedClusterSteward registers a steward and sets its DNA to carry the given

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -53,6 +53,7 @@ import (
 	stewarddna "github.com/cfgis/cfgms/features/steward/dna"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/features/workflow"
+	workflownodes "github.com/cfgis/cfgms/features/workflow/nodes"
 	workflowruntime "github.com/cfgis/cfgms/features/workflow/runtime"
 	workflowtrigger "github.com/cfgis/cfgms/features/workflow/trigger"
 	"github.com/cfgis/cfgms/pkg/audit"
@@ -1228,7 +1229,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	}
 	workflowRuntimeDir := filepath.Join(resolveDNADataRoot(cfg), "workflow-runtime")
 	workflowModuleRuntime := workflowruntime.NewModuleRuntime(workflowRuntimeDir)
-	workflowHandler, triggerMgr := initializeWorkflowHandler(storageManager, moduleCache, workflowModuleRuntime, logger, httpServer.GetSecretStore())
+	workflowHandler, triggerMgr := initializeWorkflowHandler(storageManager, moduleCache, workflowModuleRuntime, logger, httpServer.GetSecretStore(), configService)
 	if workflowHandler != nil {
 		httpServer.SetWorkflowHandler(workflowHandler)
 		srv.triggerManager = triggerMgr
@@ -1485,6 +1486,7 @@ func initializeWorkflowHandler(
 	workflowRT *workflowruntime.ModuleRuntime,
 	logger logging.Logger,
 	secrets secretsif.SecretStore,
+	configService *service.ConfigurationServiceV2,
 ) (*api.WorkflowHandler, *workflowtrigger.TriggerManagerImpl) {
 	// Workflow module factory: looks up controller-kind module bundles by
 	// name in the controller's module cache (#1883) and fork/execs them as
@@ -1496,9 +1498,10 @@ func initializeWorkflowHandler(
 	// REST-only deployments that never resolve modules through the engine are unaffected.
 	moduleFactory := workflow.NewWorkflowModuleFactory(moduleCache, workflowRT)
 
-	workflowEngine := workflow.NewEngine(moduleFactory, logger, secrets, nil, nil, nil, nil)
-
 	configStore := storageManager.GetConfigStore()
+
+	setHARoleExecutor := workflownodes.NewSetHARoleNodeExecutor(configStore, configService)
+	workflowEngine := workflow.NewEngine(moduleFactory, logger, secrets, nil, nil, setHARoleExecutor, nil)
 
 	// workflowEngineAdapter bridges workflow.Engine to trigger.WorkflowTrigger.
 	// Triggers resolve workflows by name from the default tenant store.

--- a/features/workflow/nodes/harole_step.go
+++ b/features/workflow/nodes/harole_step.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package nodes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/workflow"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	"gopkg.in/yaml.v3"
+)
+
+// SetHARoleNodeExecutor implements workflow.SetHARoleStepExecutor.
+// It reads a steward's device-scope config document, finds the named hyperv.vm
+// resource, and merges the ha_role block via ConfigurationServiceV2.SetConfiguration.
+type SetHARoleNodeExecutor struct {
+	store     cfgconfig.ConfigStore
+	configSvc *service.ConfigurationServiceV2
+}
+
+// NewSetHARoleNodeExecutor constructs a SetHARoleNodeExecutor.
+// store is used read-only (GetConfig). configSvc is used for the validated,
+// fan-out write path (SetConfiguration) — never raw ConfigStore.StoreConfig.
+func NewSetHARoleNodeExecutor(store cfgconfig.ConfigStore, configSvc *service.ConfigurationServiceV2) *SetHARoleNodeExecutor {
+	return &SetHARoleNodeExecutor{
+		store:     store,
+		configSvc: configSvc,
+	}
+}
+
+// ExecuteSetHARoleStep satisfies workflow.SetHARoleStepExecutor.
+// Required variables in execution.Variables: steward_id, tenant_id, vm_name, cluster_name.
+// Optional variable: resource_group_name.
+// Missing or wrong-type required variables fail the step with StatusFailed.
+func (e *SetHARoleNodeExecutor) ExecuteSetHARoleStep(ctx context.Context, step workflow.Step, execution *workflow.WorkflowExecution) (workflow.StepResult, error) {
+	startTime := time.Now()
+
+	stewardID, err := requireStringVar(execution, "steward_id")
+	if err != nil {
+		return failedHARoleResult(startTime, fmt.Errorf("set_ha_role step %q: %w", step.Name, err)), err
+	}
+	tenantID, err := requireStringVar(execution, "tenant_id")
+	if err != nil {
+		return failedHARoleResult(startTime, fmt.Errorf("set_ha_role step %q: %w", step.Name, err)), err
+	}
+	vmName, err := requireStringVar(execution, "vm_name")
+	if err != nil {
+		return failedHARoleResult(startTime, fmt.Errorf("set_ha_role step %q: %w", step.Name, err)), err
+	}
+	clusterName, err := requireStringVar(execution, "cluster_name")
+	if err != nil {
+		return failedHARoleResult(startTime, fmt.Errorf("set_ha_role step %q: %w", step.Name, err)), err
+	}
+
+	resourceGroupName, _ := optionalStringVar(execution, "resource_group_name")
+
+	// Read the steward's device-scope config document.
+	entry, err := e.store.GetConfig(ctx, &cfgconfig.ConfigKey{
+		TenantID:  tenantID,
+		Namespace: "stewards",
+		Name:      stewardID,
+	})
+	if err != nil {
+		if errors.Is(err, cfgconfig.ErrConfigNotFound) {
+			err = fmt.Errorf("set_ha_role step %q: device config for steward %q not found", step.Name, stewardID)
+		} else {
+			err = fmt.Errorf("set_ha_role step %q: read device config for steward %q: %w", step.Name, stewardID, err)
+		}
+		return failedHARoleResult(startTime, err), err
+	}
+
+	var cfg stewardtypes.StewardConfig
+	if unmarshalErr := yaml.Unmarshal(entry.Data, &cfg); unmarshalErr != nil {
+		err = fmt.Errorf("set_ha_role step %q: unmarshal steward config for %q: %w", step.Name, stewardID, unmarshalErr)
+		return failedHARoleResult(startTime, err), err
+	}
+
+	// Find the hyperv.vm resource named vmName.
+	resourceIdx := -1
+	for i, r := range cfg.Resources {
+		if r.Name == vmName && r.Module == "hyperv.vm" {
+			resourceIdx = i
+			break
+		}
+	}
+	if resourceIdx < 0 {
+		err = fmt.Errorf("set_ha_role step %q: hyperv.vm resource %q not found in steward %q device config", step.Name, vmName, stewardID)
+		return failedHARoleResult(startTime, err), err
+	}
+
+	resource := &cfg.Resources[resourceIdx]
+
+	// Idempotent re-run: if ha_role already matches desired state, no write needed.
+	if haRoleAlreadySet(resource.Config, clusterName, resourceGroupName) {
+		return completedHARoleResult(startTime), nil
+	}
+
+	// Write ha_role — field names match features/modules/hyperv/vm.go:512-517 (AsMap).
+	if resource.Config == nil {
+		resource.Config = make(map[string]interface{})
+	}
+	haRole := map[string]interface{}{
+		"cluster_name": clusterName,
+	}
+	if resourceGroupName != "" {
+		haRole["resource_group_name"] = resourceGroupName
+	}
+	resource.Config["ha_role"] = haRole
+
+	if writeErr := e.configSvc.SetConfiguration(ctx, tenantID, stewardID, &cfg); writeErr != nil {
+		err = fmt.Errorf("set_ha_role step %q: persist config for steward %q: %w", step.Name, stewardID, writeErr)
+		return failedHARoleResult(startTime, err), err
+	}
+
+	return completedHARoleResult(startTime), nil
+}
+
+// haRoleAlreadySet returns true when ha_role in the resource config already matches
+// the desired cluster_name and resource_group_name (idempotent re-run guard).
+func haRoleAlreadySet(resourceConfig map[string]interface{}, clusterName, resourceGroupName string) bool {
+	v, ok := resourceConfig["ha_role"]
+	if !ok || v == nil {
+		return false
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	existingCluster, _ := m["cluster_name"].(string)
+	existingRG, _ := m["resource_group_name"].(string)
+	return existingCluster == clusterName && existingRG == resourceGroupName
+}
+
+// requireStringVar extracts a non-empty string from execution.Variables or returns an error.
+func requireStringVar(execution *workflow.WorkflowExecution, key string) (string, error) {
+	v, ok := execution.GetVariable(key)
+	if !ok {
+		return "", fmt.Errorf("missing required variable %q", key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("variable %q must be a string, got %T", key, v)
+	}
+	if s == "" {
+		return "", fmt.Errorf("variable %q must not be empty", key)
+	}
+	return s, nil
+}
+
+// optionalStringVar extracts an optional string from execution.Variables.
+// Returns ("", false) when absent or not a string.
+func optionalStringVar(execution *workflow.WorkflowExecution, key string) (string, bool) {
+	v, ok := execution.GetVariable(key)
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func failedHARoleResult(startTime time.Time, err error) workflow.StepResult {
+	endTime := time.Now()
+	return workflow.StepResult{
+		Status:    workflow.StatusFailed,
+		StartTime: startTime,
+		EndTime:   &endTime,
+		Duration:  endTime.Sub(startTime),
+		Error:     err.Error(),
+	}
+}
+
+func completedHARoleResult(startTime time.Time) workflow.StepResult {
+	endTime := time.Now()
+	return workflow.StepResult{
+		Status:    workflow.StatusCompleted,
+		StartTime: startTime,
+		EndTime:   &endTime,
+		Duration:  endTime.Sub(startTime),
+	}
+}

--- a/features/workflow/nodes/harole_step_test.go
+++ b/features/workflow/nodes/harole_step_test.go
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package nodes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
+	controllersvc "github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/pkg/logging"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// newHARoleExecution returns a WorkflowExecution populated with the given variables.
+func newHARoleExecution(vars map[string]interface{}) *workflow.WorkflowExecution {
+	ex := &workflow.WorkflowExecution{
+		ID:          "exec-ha-test",
+		Status:      workflow.StatusRunning,
+		StepResults: make(map[string]workflow.StepResult),
+		Variables:   make(map[string]interface{}),
+		Done:        make(chan struct{}),
+	}
+	for k, v := range vars {
+		ex.SetVariable(k, v)
+	}
+	return ex
+}
+
+// newHARoleStep returns a minimal set_ha_role Step for testing.
+func newHARoleStep(name string) workflow.Step {
+	return workflow.Step{
+		Name: name,
+		Type: workflow.StepTypeSetHARole,
+	}
+}
+
+// storeInitialStewardConfig stores a StewardConfig directly via ConfigStore so that
+// ExecuteSetHARoleStep has a pre-existing device-scope document to read.
+func storeInitialStewardConfig(t *testing.T, store cfgconfig.ConfigStore, tenantID, stewardID string, cfg stewardtypes.StewardConfig) {
+	t.Helper()
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, store.StoreConfig(context.Background(), &cfgconfig.ConfigEntry{
+		Key:    &cfgconfig.ConfigKey{TenantID: tenantID, Namespace: "stewards", Name: stewardID},
+		Data:   data,
+		Format: cfgconfig.ConfigFormatYAML,
+	}))
+}
+
+// minimalStewardCfg builds the smallest StewardConfig that passes validation.
+func minimalStewardCfg(stewardID string, resources []stewardtypes.ResourceConfig) stewardtypes.StewardConfig {
+	return stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{
+			ID:   stewardID,
+			Mode: stewardtypes.ModeController,
+		},
+		Resources: resources,
+	}
+}
+
+// readStewardConfig reads and unmarshals the stored device-scope config for verification.
+func readStewardConfig(t *testing.T, store cfgconfig.ConfigStore, tenantID, stewardID string) stewardtypes.StewardConfig {
+	t.Helper()
+	entry, err := store.GetConfig(context.Background(), &cfgconfig.ConfigKey{
+		TenantID:  tenantID,
+		Namespace: "stewards",
+		Name:      stewardID,
+	})
+	require.NoError(t, err)
+	var cfg stewardtypes.StewardConfig
+	require.NoError(t, yaml.Unmarshal(entry.Data, &cfg))
+	return cfg
+}
+
+// findResourceByName returns the ResourceConfig with the given name, or fails the test.
+func findResourceByName(t *testing.T, cfg stewardtypes.StewardConfig, name string) stewardtypes.ResourceConfig {
+	t.Helper()
+	for _, r := range cfg.Resources {
+		if r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("resource %q not found in steward config", name)
+	return stewardtypes.ResourceConfig{}
+}
+
+// TestSetHARoleNode_SetsPersistsHARole is the REQUIRED AC test:
+// a hyperv.vm resource that does not yet have ha_role gets ha_role set and
+// the change is persisted via ConfigurationServiceV2.SetConfiguration.
+func TestSetHARoleNode_SetsPersistsHARole(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+
+	const tenantID = "tenant-ha"
+	const stewardID = "steward-ha-1"
+	const vmName = "vm-alpha"
+	const clusterName = "cluster-prod"
+
+	configSvc := controllersvc.NewConfigurationServiceV2(logger, sm, nil)
+	store := sm.GetConfigStore()
+
+	// Pre-populate device config with a standalone hyperv.vm resource.
+	storeInitialStewardConfig(t, store, tenantID, stewardID,
+		minimalStewardCfg(stewardID, []stewardtypes.ResourceConfig{
+			{
+				Name:   vmName,
+				Module: "hyperv.vm",
+				Config: map[string]interface{}{
+					"memory_mb": 4096,
+					"cpu_count": 2,
+				},
+			},
+		}))
+
+	executor := NewSetHARoleNodeExecutor(store, configSvc)
+	step := newHARoleStep("promote-vm")
+	execution := newHARoleExecution(map[string]interface{}{
+		"steward_id":   stewardID,
+		"tenant_id":    tenantID,
+		"vm_name":      vmName,
+		"cluster_name": clusterName,
+	})
+
+	result, err := executor.ExecuteSetHARoleStep(ctx, step, execution)
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+
+	// Verify ha_role was written to the store.
+	stored := readStewardConfig(t, store, tenantID, stewardID)
+	vmResource := findResourceByName(t, stored, vmName)
+	haRole, ok := vmResource.Config["ha_role"].(map[string]interface{})
+	require.True(t, ok, "ha_role must be a map after SetHARoleStep")
+	assert.Equal(t, clusterName, haRole["cluster_name"])
+	_, hasRG := haRole["resource_group_name"]
+	assert.False(t, hasRG, "resource_group_name must be absent when not specified")
+}
+
+// TestSetHARoleNode_WithResourceGroupName verifies that resource_group_name is
+// included in ha_role when provided as an optional variable.
+func TestSetHARoleNode_WithResourceGroupName(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+
+	const tenantID = "tenant-ha-rg"
+	const stewardID = "steward-rg"
+	const vmName = "vm-beta"
+	const clusterName = "cluster-prod"
+	const resourceGroup = "rg-prod-vms"
+
+	configSvc := controllersvc.NewConfigurationServiceV2(logger, sm, nil)
+	store := sm.GetConfigStore()
+
+	storeInitialStewardConfig(t, store, tenantID, stewardID,
+		minimalStewardCfg(stewardID, []stewardtypes.ResourceConfig{
+			{Name: vmName, Module: "hyperv.vm", Config: map[string]interface{}{"memory_mb": 2048}},
+		}))
+
+	executor := NewSetHARoleNodeExecutor(store, configSvc)
+	result, err := executor.ExecuteSetHARoleStep(ctx, newHARoleStep("promote-with-rg"),
+		newHARoleExecution(map[string]interface{}{
+			"steward_id":          stewardID,
+			"tenant_id":           tenantID,
+			"vm_name":             vmName,
+			"cluster_name":        clusterName,
+			"resource_group_name": resourceGroup,
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+
+	stored := readStewardConfig(t, store, tenantID, stewardID)
+	vmResource := findResourceByName(t, stored, vmName)
+	haRole, ok := vmResource.Config["ha_role"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, clusterName, haRole["cluster_name"])
+	assert.Equal(t, resourceGroup, haRole["resource_group_name"])
+}
+
+// TestSetHARoleNode_IdempotentWhenAlreadySet verifies that re-running the step
+// when ha_role already matches is a no-op: the result is success and no additional
+// SetConfiguration write occurs (verified by checking the stored config is unchanged).
+func TestSetHARoleNode_IdempotentWhenAlreadySet(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+
+	const tenantID = "tenant-idem"
+	const stewardID = "steward-idem"
+	const vmName = "vm-gamma"
+	const clusterName = "cluster-ha"
+
+	configSvc := controllersvc.NewConfigurationServiceV2(logger, sm, nil)
+	store := sm.GetConfigStore()
+
+	// Pre-populate with ha_role already set to the desired value.
+	storeInitialStewardConfig(t, store, tenantID, stewardID,
+		minimalStewardCfg(stewardID, []stewardtypes.ResourceConfig{
+			{
+				Name:   vmName,
+				Module: "hyperv.vm",
+				Config: map[string]interface{}{
+					"memory_mb": 4096,
+					"ha_role":   map[string]interface{}{"cluster_name": clusterName},
+				},
+			},
+		}))
+
+	// Record the stored config before the step so we can verify it didn't change.
+	before := readStewardConfig(t, store, tenantID, stewardID)
+
+	fanoutCalled := false
+	configSvc.RegisterFanoutCallback(func(_ context.Context, _, _ string) {
+		fanoutCalled = true
+	})
+
+	executor := NewSetHARoleNodeExecutor(store, configSvc)
+	result, err := executor.ExecuteSetHARoleStep(ctx, newHARoleStep("idempotent-promote"),
+		newHARoleExecution(map[string]interface{}{
+			"steward_id":   stewardID,
+			"tenant_id":    tenantID,
+			"vm_name":      vmName,
+			"cluster_name": clusterName,
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+
+	// SetConfiguration must NOT have been called (no fanout).
+	assert.False(t, fanoutCalled, "SetConfiguration must not be called when ha_role already matches")
+
+	// Stored config must be byte-identical to before the step.
+	after := readStewardConfig(t, store, tenantID, stewardID)
+	assert.Equal(t, before, after, "stored config must be unchanged on idempotent re-run")
+}
+
+// TestSetHARoleNode_ResourceNotFound verifies that a missing hyperv.vm resource
+// fails the step with a clear error rather than auto-creating it.
+func TestSetHARoleNode_ResourceNotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+
+	const tenantID = "tenant-miss"
+	const stewardID = "steward-miss"
+
+	configSvc := controllersvc.NewConfigurationServiceV2(logger, sm, nil)
+	store := sm.GetConfigStore()
+
+	// Steward config exists, but has no hyperv.vm resource.
+	storeInitialStewardConfig(t, store, tenantID, stewardID,
+		minimalStewardCfg(stewardID, []stewardtypes.ResourceConfig{
+			{Name: "other-resource", Module: "file", Config: map[string]interface{}{"path": "/tmp/x"}},
+		}))
+
+	executor := NewSetHARoleNodeExecutor(store, configSvc)
+	result, err := executor.ExecuteSetHARoleStep(ctx, newHARoleStep("miss-vm"),
+		newHARoleExecution(map[string]interface{}{
+			"steward_id":   stewardID,
+			"tenant_id":    tenantID,
+			"vm_name":      "nonexistent-vm",
+			"cluster_name": "cluster-x",
+		}))
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, result.Status)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestSetHARoleNode_StewardConfigNotFound verifies that a missing device config
+// document fails the step with a clear error.
+func TestSetHARoleNode_StewardConfigNotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+
+	const tenantID = "tenant-nodev"
+	const stewardID = "steward-nodev"
+
+	configSvc := controllersvc.NewConfigurationServiceV2(logger, sm, nil)
+	store := sm.GetConfigStore()
+	// No device config stored for stewardID.
+
+	executor := NewSetHARoleNodeExecutor(store, configSvc)
+	result, err := executor.ExecuteSetHARoleStep(ctx, newHARoleStep("miss-config"),
+		newHARoleExecution(map[string]interface{}{
+			"steward_id":   stewardID,
+			"tenant_id":    tenantID,
+			"vm_name":      "vm-x",
+			"cluster_name": "cluster-x",
+		}))
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, result.Status)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestSetHARoleNode_MissingVariable verifies that each required variable, when
+// absent, causes StatusFailed with a descriptive error.
+func TestSetHARoleNode_MissingVariable(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+
+	configSvc := controllersvc.NewConfigurationServiceV2(logger, sm, nil)
+	store := sm.GetConfigStore()
+	executor := NewSetHARoleNodeExecutor(store, configSvc)
+
+	fullVars := map[string]interface{}{
+		"steward_id":   "s1",
+		"tenant_id":    "t1",
+		"vm_name":      "vm1",
+		"cluster_name": "c1",
+	}
+	for _, drop := range []string{"steward_id", "tenant_id", "vm_name", "cluster_name"} {
+		vars := make(map[string]interface{})
+		for k, v := range fullVars {
+			if k != drop {
+				vars[k] = v
+			}
+		}
+		result, err := executor.ExecuteSetHARoleStep(ctx, newHARoleStep("missing-"+drop),
+			newHARoleExecution(vars))
+		require.Error(t, err, "missing %q must return error", drop)
+		assert.Equal(t, workflow.StatusFailed, result.Status, "missing %q must produce StatusFailed", drop)
+		assert.Contains(t, err.Error(), drop, "error must mention missing variable %q", drop)
+	}
+}
+
+// TestSetHARoleNode_WrongVariableType verifies that a non-string required variable
+// fails with StatusFailed.
+func TestSetHARoleNode_WrongVariableType(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNoopLogger()
+	sm := pkgtesting.SetupTestStorage(t)
+
+	configSvc := controllersvc.NewConfigurationServiceV2(logger, sm, nil)
+	store := sm.GetConfigStore()
+	executor := NewSetHARoleNodeExecutor(store, configSvc)
+
+	result, err := executor.ExecuteSetHARoleStep(ctx, newHARoleStep("bad-type"),
+		newHARoleExecution(map[string]interface{}{
+			"steward_id":   42, // wrong type
+			"tenant_id":    "t1",
+			"vm_name":      "vm1",
+			"cluster_name": "c1",
+		}))
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, result.Status)
+	assert.Contains(t, err.Error(), "steward_id")
+}


### PR DESCRIPTION
## Summary

- Implements `SetHARoleNodeExecutor` in `features/workflow/nodes/harole_step.go` satisfying `workflow.SetHARoleStepExecutor`. Reads `steward_id`, `tenant_id`, `vm_name`, `cluster_name` (and optional `resource_group_name`) from `execution.Variables`, locates the `hyperv.vm` resource in the steward's device-scope config, and merges the `ha_role` block via `ConfigurationServiceV2.SetConfiguration` (validated + fan-out path per grounding note 4).
- Wires the real executor into `initializeWorkflowHandler` via one new `configService *service.ConfigurationServiceV2` parameter, replacing the `nil` placeholder S1 left in place.
- Adds a note to `docs/architecture/controller-operating-model.md` documenting `set_ha_role` as the first production workflow-engine writer of the `ha_role` field.

## Implementation details

- **Read**: `ConfigStore.GetConfig` (storage interface, `pkg/storage/interfaces/config`)
- **Write**: `ConfigurationServiceV2.SetConfiguration` (validates + fires fan-out callback = immediate push to steward)
- **Idempotent**: if `ha_role` already matches desired `{cluster_name, resource_group_name}`, returns success without issuing a write or triggering fan-out
- **Hard errors** (no auto-create): missing steward config document or missing `hyperv.vm` resource → `StatusFailed` with descriptive error

## Test plan

- [x] `TestSetHARoleNode_SetsPersistsHARole` — ha_role set and persisted via `SetConfiguration`, verified with subsequent `GetConfig`
- [x] `TestSetHARoleNode_WithResourceGroupName` — optional `resource_group_name` included correctly
- [x] `TestSetHARoleNode_IdempotentWhenAlreadySet` — no `SetConfiguration` call when ha_role already matches (verified via fanout callback sentinel)
- [x] `TestSetHARoleNode_ResourceNotFound` — missing hyperv.vm resource → `StatusFailed`
- [x] `TestSetHARoleNode_StewardConfigNotFound` — missing device config document → `StatusFailed`
- [x] `TestSetHARoleNode_MissingVariable` — each required variable when absent → `StatusFailed`
- [x] `TestSetHARoleNode_WrongVariableType` — non-string required variable → `StatusFailed`

All tests use real `ConfigStore` and `ConfigurationServiceV2` — no mocks.

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

Fixes #2667