### PR TITLE
modules: kill whole process tree on script timeout via Windows Job Object (Issue #2715)

### DIFF
--- a/features/modules/stdlib/script/executor.go
+++ b/features/modules/stdlib/script/executor.go
@@ -17,6 +17,14 @@ import (
 	"github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 
+// reapGracePeriod bounds how long Execute waits for cmd.Wait to return after it
+// has terminated a timed-out process tree. A successful tree kill closes the
+// inherited pipe handles and Wait returns almost immediately, well within this
+// window; the timer only fires in the pathological case where a handle lingers,
+// guaranteeing Execute returns rather than wedging the steward's exec channel
+// indefinitely (Issue #2715).
+const reapGracePeriod = 10 * time.Second
+
 // Executor handles cross-platform script execution
 type Executor struct {
 	config         *ScriptConfig
@@ -140,11 +148,24 @@ func (e *Executor) Execute(ctx context.Context) (*ExecutionResult, error) {
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 
+	// Prepare process-tree tracking BEFORE Start so the Job Object exists and the
+	// process can be assigned to it as the very first post-Start action. On Windows
+	// this closes Issue #2715: a detached grandchild (e.g. a `--runasservice` step)
+	// that inherited the stdout/stderr pipe would otherwise keep cmd.Wait() — and
+	// this goroutine, plus the steward's per-device execution slot — blocked forever
+	// after a top-level-only cmd.Process.Kill().
+	tree := newProcessTree(e.logger)
+	tree.prepare()
+	defer tree.close()
+
 	// Start the command
 	if err := cmd.Start(); err != nil {
 		cleanupToken()
 		return nil, fmt.Errorf("failed to start command: %w", err)
 	}
+	// Assign the process to its Job Object immediately, before any other work, so
+	// it becomes a job member before it can spawn descendants.
+	tree.track(cmd)
 	// Token (Windows) or no-op (Unix): release the handle after the process is created.
 	cleanupToken()
 
@@ -177,13 +198,24 @@ func (e *Executor) Execute(ctx context.Context) (*ExecutionResult, error) {
 		return result, nil
 
 	case <-timeoutCtx.Done():
-		// Timeout occurred
-		if err := cmd.Process.Kill(); err != nil {
-			e.logger.Warn("failed to kill timed-out script process", "error", err)
-		}
+		// Timeout occurred. Terminate the ENTIRE process tree (Issue #2715), not
+		// just the top-level process — otherwise a grandchild holding an inherited
+		// stdout/stderr pipe keeps cmd.Wait() blocked forever below.
+		tree.terminate(cmd)
+
 		// Reap the killed process so cmd.Wait returns and its output-copy
-		// goroutines exit; partial output is discarded on timeout.
-		<-done
+		// goroutines exit; partial output is discarded on timeout. With the tree
+		// terminated the inherited pipe handles close and done fires promptly. The
+		// grace timer is a bounded backstop so Execute can never block the exec
+		// channel indefinitely even in the pathological case where the tree kill
+		// did not release every handle (AC2). A working tree kill always reaches
+		// done first, so the executor goroutine exits and is not leaked.
+		select {
+		case <-done:
+		case <-time.After(reapGracePeriod):
+			e.logger.Warn("script process tree did not reap within grace period after termination",
+				"grace", reapGracePeriod, "pid", result.PID)
+		}
 		result.EndTime = time.Now()
 		result.Duration = result.EndTime.Sub(result.StartTime)
 		result.ExitCode = -1

--- a/features/modules/stdlib/script/executor_processtree_other.go
+++ b/features/modules/stdlib/script/executor_processtree_other.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package script
+
+import (
+	"os/exec"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// processTree on non-Windows platforms preserves the pre-#2715 behavior:
+// terminate kills the top-level process only. Issue #2715 (a detached grandchild
+// inheriting the stdout/stderr pipe and blocking cmd.Wait forever after a
+// top-level kill) is Windows-specific — the Unix executor path is not known to
+// exhibit it — so this is intentionally a thin wrapper that does not change Unix
+// process semantics. If evidence of the same leak surfaces on Unix, the fix is a
+// process group (Setpgid + kill(-pgid)) added here, isolated from Windows.
+type processTree struct {
+	logger logging.Logger
+}
+
+// newProcessTree returns a process-tree tracker. It holds no OS resources.
+func newProcessTree(logger logging.Logger) *processTree {
+	return &processTree{logger: logger}
+}
+
+// prepare is a no-op on non-Windows platforms.
+func (p *processTree) prepare() {}
+
+// track is a no-op on non-Windows platforms.
+func (p *processTree) track(_ *exec.Cmd) {}
+
+// terminate kills the top-level process (unchanged pre-#2715 Unix behavior).
+func (p *processTree) terminate(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		if err := cmd.Process.Kill(); err != nil {
+			p.logger.Warn("process-tree: failed to kill script process", "error", err)
+		}
+	}
+}
+
+// close is a no-op on non-Windows platforms.
+func (p *processTree) close() {}

--- a/features/modules/stdlib/script/executor_processtree_windows.go
+++ b/features/modules/stdlib/script/executor_processtree_windows.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package script
+
+// This file is compiled only on Windows (Go filename convention: _windows.go suffix).
+
+import (
+	"os/exec"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	"golang.org/x/sys/windows"
+)
+
+// processTree tracks a launched command together with every descendant it
+// spawns, so a timeout/cancel can terminate the whole tree at once rather than
+// just the top-level process.
+//
+// Issue #2715: a Windows `.cmd` job (e.g. `cmd.exe /c config.cmd`) can spawn a
+// detached grandchild — such as a `--runasservice` registration that backgrounds
+// a service-install step. `cmd.Process.Kill()` terminates only the top-level
+// `cmd.exe`; the grandchild survives and, if it inherited the stdout/stderr pipe
+// handles, keeps the write end open. `cmd.Wait()` then blocks forever waiting for
+// the output-copy goroutines to see EOF, wedging the executor goroutine and the
+// steward's per-device execution slot indefinitely.
+//
+// The fix assigns the top-level process to a Job Object. Descendants
+// automatically join the job (a plain job does not permit breakaway), so a single
+// TerminateJobObject on timeout kills the entire tree — the grandchild dies, its
+// pipe handle closes, and cmd.Wait() returns promptly.
+//
+// The job is intentionally created WITHOUT JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE:
+// termination happens only via the explicit TerminateJobObject in terminate()
+// (the timeout path). This preserves the behavior of a script that completes
+// successfully after deliberately backgrounding a detached descendant — that
+// descendant is not collaterally killed when close() releases the job handle on
+// the success path.
+type processTree struct {
+	logger logging.Logger
+	job    windows.Handle
+}
+
+// newProcessTree returns a process-tree tracker. It holds no OS resources until
+// prepare is called, so close is always safe.
+func newProcessTree(logger logging.Logger) *processTree {
+	return &processTree{logger: logger}
+}
+
+// prepare creates the Job Object BEFORE the process is started, so that track
+// (called immediately after Start) only has to open the process and assign it.
+// Creating the job up front minimizes the window between cmd.Start() and job
+// assignment in which a descendant could spawn and escape the job.
+//
+// Failure is logged, never fatal: with no job, terminate falls back to killing
+// the top-level process only — the pre-#2715 behavior — so a missing job never
+// makes execution worse than it already was.
+func (p *processTree) prepare() {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		p.logger.Warn("process-tree: CreateJobObject failed; timeout will kill top-level process only",
+			"error", err)
+		return
+	}
+	p.job = job
+}
+
+// track assigns the freshly started process to the Job Object created by prepare.
+//
+// It must be called immediately after cmd.Start(), as the very first post-Start
+// action, so the top-level process becomes a job member before it has run the
+// script body and spawned any grandchildren; every descendant then inherits job
+// membership. The residual window is just this OpenProcess + assignment (two
+// in-process syscalls). os/exec offers no CREATE_SUSPENDED + ResumeThread hook
+// to make the assignment provably pre-execution, but the launchers here are
+// heavyweight interpreters (cmd.exe, powershell.exe, pwsh.exe, python.exe) whose
+// own startup far exceeds those two syscalls, so a descendant cannot realistically
+// spawn inside the window. Assignment failure downgrades to top-level-only kill.
+func (p *processTree) track(cmd *exec.Cmd) {
+	if p.job == 0 || cmd == nil || cmd.Process == nil {
+		return
+	}
+
+	// AssignProcessToJobObject needs a process handle with PROCESS_SET_QUOTA and
+	// PROCESS_TERMINATE rights; os/exec does not expose the handle it opened, so
+	// re-open by PID.
+	//nolint:gosec // Pid is a valid process id owned by this executor
+	hProc, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		p.logger.Warn("process-tree: OpenProcess failed; timeout will kill top-level process only",
+			"error", err)
+		p.releaseJob()
+		return
+	}
+	defer func() { _ = windows.CloseHandle(hProc) }()
+
+	if err := windows.AssignProcessToJobObject(p.job, hProc); err != nil {
+		p.logger.Warn("process-tree: AssignProcessToJobObject failed; timeout will kill top-level process only",
+			"error", err)
+		p.releaseJob()
+		return
+	}
+}
+
+// terminate kills the entire tracked process tree. When the process was assigned
+// to a job this is a single TerminateJobObject call that reaches every
+// descendant; otherwise it falls back to killing the top-level process only.
+func (p *processTree) terminate(cmd *exec.Cmd) {
+	if p.job != 0 {
+		if err := windows.TerminateJobObject(p.job, 1); err != nil {
+			p.logger.Warn("process-tree: TerminateJobObject failed; killing top-level process",
+				"error", err)
+			p.killTopLevel(cmd)
+		}
+		return
+	}
+	p.killTopLevel(cmd)
+}
+
+func (p *processTree) killTopLevel(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		if err := cmd.Process.Kill(); err != nil {
+			p.logger.Warn("process-tree: failed to kill top-level process", "error", err)
+		}
+	}
+}
+
+// releaseJob closes and clears the job handle so terminate/close fall back to the
+// top-level path.
+func (p *processTree) releaseJob() {
+	if p.job != 0 {
+		_ = windows.CloseHandle(p.job)
+		p.job = 0
+	}
+}
+
+// close releases the Job Object handle without terminating its members (the job
+// carries no kill-on-close limit). On the timeout path terminate has already
+// killed the tree; on the success path any deliberately-detached descendant is
+// left running. Idempotent.
+func (p *processTree) close() {
+	p.releaseJob()
+}

--- a/features/modules/stdlib/script/executor_windows_test.go
+++ b/features/modules/stdlib/script/executor_windows_test.go
@@ -7,7 +7,11 @@ package script
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -170,6 +174,176 @@ func TestApplyExecutionContext_Windows_LoggedInUser_WithUser(t *testing.T) {
 	// Token must be set on SysProcAttr; a non-zero token confirms the WTS path was taken.
 	require.NotNil(t, cmd.SysProcAttr, "SysProcAttr must be non-nil after token attachment")
 	assert.NotZero(t, cmd.SysProcAttr.Token, "Token must be set to the active console session token")
+}
+
+// TestExecute_Windows_TimeoutKillsProcessTree reproduces Issue #2715: a Windows
+// `.cmd` job backgrounds a detached grandchild (via `start /b`) that inherits the
+// executor's stdout/stderr pipe and outlives the configured timeout. Before the
+// Job Object fix, the timeout path called cmd.Process.Kill(), which terminated
+// only the top-level cmd.exe; the grandchild survived, kept the inherited pipe
+// write handle open, and cmd.Wait() — and therefore Execute — blocked forever,
+// wedging the steward's per-device execution slot.
+//
+// With the fix the whole process tree is terminated on timeout, so Execute
+// returns promptly (well within the bounded reap window, never the grandchild's
+// full sleep) and the grandchild process is gone. Reaching the timeout path at
+// all proves the grandchild held the pipe — otherwise cmd.exe would have exited
+// immediately and Execute would have returned success before the timeout.
+func TestExecute_Windows_TimeoutKillsProcessTree(t *testing.T) {
+	if _, err := exec.LookPath("powershell.exe"); err != nil {
+		t.Skip("powershell.exe not available; cannot spawn the grandchild for this test")
+	}
+
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+
+	// The grandchild records its own PID, then holds the inherited stdout/stderr
+	// open by sleeping far past the timeout. `start /b` runs it in the same
+	// console (inheriting the redirected pipe) and backgrounds it, so cmd.exe
+	// returns immediately, leaving only the grandchild holding the pipe.
+	const grandchildSleep = 30 // seconds; must exceed timeout + reap window below
+	script := "@echo off\r\n" +
+		"start /b \"\" powershell.exe -NoProfile -NonInteractive -Command " +
+		"\"Set-Content -LiteralPath '" + pidFile + "' -Value $PID; Start-Sleep -Seconds " +
+		strconv.Itoa(grandchildSleep) + "\"\r\n"
+
+	const timeout = 4 * time.Second
+	cfg := &ScriptConfig{
+		Content:          script,
+		Shell:            ShellCmd,
+		Timeout:          timeout,
+		ExecutionContext: ExecutionContextSystem,
+	}
+	exe := NewExecutor(cfg)
+
+	// Run Execute under a hard wall-clock guard so a regression (infinite block)
+	// fails the test instead of hanging the whole suite. The guard is shorter than
+	// the grandchild's sleep, so a hang is caught before the grandchild would
+	// self-exit and mask the bug.
+	type outcome struct {
+		res *ExecutionResult
+		err error
+	}
+	ch := make(chan outcome, 1)
+	start := time.Now()
+	go func() {
+		res, err := exe.Execute(context.Background())
+		ch <- outcome{res: res, err: err}
+	}()
+
+	var got outcome
+	select {
+	case got = <-ch:
+	case <-time.After(timeout + reapGracePeriod + 10*time.Second):
+		t.Fatalf("Execute did not return within the bounded reap window — process-tree kill regressed (Issue #2715)")
+	}
+	elapsed := time.Since(start)
+
+	// Best-effort cleanup in case a regression left the grandchild running.
+	pid := readPIDFile(t, pidFile)
+	if pid != 0 {
+		t.Cleanup(func() { _ = exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid)).Run() })
+	}
+
+	// Must have hit the timeout path (confirms the grandchild held the pipe).
+	require.Error(t, got.err, "expected a timeout error from Execute")
+	assert.Contains(t, got.err.Error(), "timed out", "error must report the timeout")
+	require.NotNil(t, got.res)
+	assert.Equal(t, -1, got.res.ExitCode, "timed-out execution must report exit code -1")
+
+	// Returned promptly after the timeout, not after the grandchild's long sleep.
+	assert.Less(t, elapsed, timeout+reapGracePeriod,
+		"Execute must return shortly after the timeout once the process tree is killed")
+
+	// AC3: the grandchild must be terminated along with the tree.
+	require.NotZero(t, pid, "grandchild must have recorded its PID before the timeout")
+	assert.Eventually(t, func() bool { return !isProcessAlive(pid) },
+		5*time.Second, 100*time.Millisecond,
+		"grandchild process (pid %d) must be terminated with the tree", pid)
+}
+
+// TestExecute_Windows_SuccessLeavesDetachedGrandchildRunning guards against the
+// process-tree kill over-reaching: a script that completes successfully after
+// deliberately backgrounding a detached descendant (one that does not inherit the
+// stdout/stderr pipe, so cmd.Wait returns normally) must NOT have that descendant
+// collaterally killed when Execute returns. This is why the Job Object is created
+// without JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE — termination happens only on the
+// timeout path, never on the success path.
+func TestExecute_Windows_SuccessLeavesDetachedGrandchildRunning(t *testing.T) {
+	if _, err := exec.LookPath("powershell.exe"); err != nil {
+		t.Skip("powershell.exe not available; cannot spawn the detached grandchild for this test")
+	}
+
+	pidFile := filepath.Join(t.TempDir(), "detached.pid")
+
+	// Start-Process launches a new process that does NOT inherit the parent's
+	// stdio handles, so it holds no pipe and cmd.exe/powershell exit immediately
+	// (Execute takes the success path). The grandchild sleeps well past the run so
+	// we can observe whether Execute's cleanup left it alive.
+	const grandchildSleep = 30 // seconds; must outlast the whole Execute call
+	script := "@echo off\r\n" +
+		"powershell.exe -NoProfile -NonInteractive -Command " +
+		"\"$p = Start-Process powershell.exe -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds " +
+		strconv.Itoa(grandchildSleep) + "' -WindowStyle Hidden -PassThru; " +
+		"Set-Content -LiteralPath '" + pidFile + "' -Value $p.Id\"\r\n"
+
+	cfg := &ScriptConfig{
+		Content:          script,
+		Shell:            ShellCmd,
+		Timeout:          20 * time.Second, // generous; the script itself completes in ~1-2s
+		ExecutionContext: ExecutionContextSystem,
+	}
+	exe := NewExecutor(cfg)
+
+	res, err := exe.Execute(context.Background())
+	require.NoError(t, err, "script must complete successfully, not time out")
+	require.NotNil(t, res)
+	assert.Equal(t, 0, res.ExitCode, "successful script must report exit code 0")
+
+	pid := readPIDFile(t, pidFile)
+	require.NotZero(t, pid, "detached grandchild must have recorded its PID")
+	t.Cleanup(func() { _ = exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid)).Run() })
+
+	assert.True(t, isProcessAlive(pid),
+		"a deliberately-detached grandchild (pid %d) must survive a successful Execute — "+
+			"the job must not kill it on the success path", pid)
+}
+
+// readPIDFile polls briefly for the grandchild's PID file and returns the parsed
+// PID, or 0 if it was never written or is unparseable.
+func readPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if data, err := readFileTrim(path); err == nil && data != "" {
+			if pid, perr := strconv.Atoi(data); perr == nil {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			return 0
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// readFileTrim reads a file and returns its whitespace-trimmed contents.
+func readFileTrim(path string) (string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// isProcessAlive reports whether a process with the given PID is currently
+// running, via tasklist (a stable, always-present Windows utility). tasklist
+// emits the PID quoted in its CSV output only when the process exists.
+func isProcessAlive(pid int) bool {
+	out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH", "/FO", "CSV").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), fmt.Sprintf("\"%d\"", pid))
 }
 
 // TestResolveExecutionUID_Windows verifies that ResolveExecutionUID returns -1


### PR DESCRIPTION
## Summary

Fixes a Windows-specific leak in the steward script executor (`features/modules/stdlib/script`) where a `.cmd` job that spawns a detached grandchild could block `Execute` forever, wedging the steward's per-device execution slot and leaking the controller dispatch lock (observed live during #2336's `--runasservice` registration).

**Root cause.** On timeout, `Execute` relied on `cmd.Process.Kill()`, which on Windows terminates only the top-level `cmd.exe`. A grandchild (e.g. a backgrounded service-install step) that inherited the executor's stdout/stderr pipe survives, keeps the pipe write handle open, and `cmd.Wait()` — hence `Execute` — never returns.

**Fix.** Assign the launched process to a Windows **Job Object**; descendants auto-join, so a single `TerminateJobObject` on timeout kills the entire tree. The grandchild dies, its pipe handle closes, and `cmd.Wait()` returns promptly. The reap now also waits on a bounded grace period, so `Execute` can never block the exec channel indefinitely even in a pathological case.

## Design notes

- **Job created before `Start`, assigned as the first post-`Start` action** — minimizes the window in which a descendant could spawn before the top-level process is a job member. `os/exec` exposes no `CREATE_SUSPENDED` + `ResumeThread` hook, but the launchers are heavyweight interpreters (cmd.exe/powershell/pwsh/python) whose startup far exceeds the two syscalls in the window, so it is not exploitable in practice.
- **No `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`** — termination happens only on the timeout path via explicit `TerminateJobObject`. A script that completes successfully after deliberately backgrounding a detached descendant does not have it collaterally killed on the success path. (Properly-registered Windows services run under the SCM, outside the job, and are unaffected regardless.)
- **Unix unchanged** — the `!windows` tracker is a no-op that kills the top-level process only; the leak is Windows-specific (`## Out of Scope` in the story).

## Tests (Windows-only)

- `TestExecute_Windows_TimeoutKillsProcessTree` — backgrounds a pipe-inheriting grandchild via `start /b`; asserts `Execute` returns shortly after the timeout (not the grandchild's long sleep) and the grandchild is terminated. Reaching the timeout path at all proves the grandchild held the pipe. Verified this test fails on the pre-fix top-level-only kill.
- `TestExecute_Windows_SuccessLeavesDetachedGrandchildRunning` — a successfully-completing script backgrounds a detached (non-pipe-inheriting, via `Start-Process`) grandchild; asserts it survives `Execute` returning. Verified this test fails if the job kills on close (guards against the tree-kill over-reaching).

## Validation

- Full `features/modules/stdlib/script` package suite green (Windows, `GOOS=windows`).
- `go build ./...`, `gofmt`, `go vet`, `make check-architecture` clean.
- Adversarial pre-PR review: QA code-review + security-engineer (handle hygiene, termination scope, PID-reuse safety, banned-pattern check) — no blocking findings.

Fixes #2715

🤖 Generated with [Claude Code](https://claude.com/claude-code)
