### PR TITLE
workflow: promote-hv-role reference template (Issue #2669)

### DIFF
--- a/features/workflow/parser.go
+++ b/features/workflow/parser.go
@@ -71,9 +71,15 @@ type stepDefinition struct {
 	Config    map[string]interface{} `yaml:"config,omitempty"`
 	Steps     []stepDefinition       `yaml:"steps,omitempty"`
 	Condition *conditionDefinition   `yaml:"condition,omitempty"`
+	Delay     *delayDefinition       `yaml:"delay,omitempty"`
 	Timeout   string                 `yaml:"timeout,omitempty"`
 	OnFailure string                 `yaml:"on_failure,omitempty"`
 	Variables map[string]interface{} `yaml:"variables,omitempty"`
+}
+
+type delayDefinition struct {
+	Duration string `yaml:"duration"`
+	Message  string `yaml:"message,omitempty"`
 }
 
 type conditionDefinition struct {
@@ -160,6 +166,18 @@ func (p *Parser) convertSteps(stepDefs []stepDefinition) ([]Step, error) {
 				return nil, fmt.Errorf("failed to convert condition for step %s: %w", stepDef.Name, err)
 			}
 			step.Condition = &condition
+		}
+
+		// Convert delay config
+		if stepDef.Delay != nil {
+			dur, err := time.ParseDuration(stepDef.Delay.Duration)
+			if err != nil {
+				return nil, fmt.Errorf("invalid delay duration for step %s: %w", stepDef.Name, err)
+			}
+			step.Delay = &DelayConfig{
+				Duration: dur,
+				Message:  stepDef.Delay.Message,
+			}
 		}
 
 		steps[i] = step
@@ -318,7 +336,7 @@ func (p *Parser) validateCondition(condition Condition) error {
 func isValidStepType(stepType StepType) bool {
 	switch stepType {
 	case StepTypeTask, StepTypeSequential, StepTypeParallel, StepTypeConditional,
-		StepTypeSetHARole, StepTypeMoveResourceToCluster:
+		StepTypeDelay, StepTypeSetHARole, StepTypeMoveResourceToCluster:
 		return true
 	default:
 		return false

--- a/features/workflow/templates/promote-hv-role.yaml
+++ b/features/workflow/templates/promote-hv-role.yaml
@@ -1,0 +1,59 @@
+workflow:
+  name: promote-hv-role
+  description: >
+    Hyper-V VM promotion from standalone to Failover Cluster role.
+
+    Writes the ha_role block into the target VM's device-scope config
+    (set_ha_role step), soaks for a fixed delay to allow the steward's
+    convergence loop to register the cluster VM role, then moves the VM
+    resource definition from device scope to cluster-policies scope
+    (move_resource_to_cluster step).
+
+    The soak delay is a fixed wait, not an active convergence check.
+    ConfigurationServiceV2.SetConfiguration triggers an immediate fanout push
+    to the steward, so the delay window is tight; the steward does not need to
+    poll before acting. For slow cluster registration, increase the delay at
+    execute time by passing an updated workflow definition — this default (30s)
+    is intentionally conservative.
+
+    The workflow halts (on_failure: stop) if set_ha_role fails, ensuring no
+    cluster-scope write is attempted when the device-scope config is incomplete.
+
+    Operator setup:
+      1. Supply vm_name, steward_id, cluster_name, and tenant_id at execute
+         time via "cfg workflow promote-hv-role" (S5) or directly via
+         POST .../execute {"variables": {...}}.  Do NOT edit the variable
+         placeholders in this file — they are intentionally empty strings;
+         real values are always injected at execute time, not templated here.
+      2. Ensure the target steward (steward_id) is registered, reachable, and
+         already manages the VM (vm_name) before executing this workflow.
+      3. The soak delay (step 2, default 30s) is a fixed wait, not an active
+         convergence check. Epic #2520 tracks convergence-poll gaps; this
+         workflow intentionally avoids unreliable DNA polling in v1.
+
+    Durability note (v1): this workflow runs on the in-memory engine. A
+    controller restart during execution loses progress; re-run the workflow.
+    Config writes that completed before the restart are durable (git-backed).
+
+  version: "1.0"
+  timeout: 10m
+  on_failure: stop
+
+  variables:
+    vm_name: ""
+    steward_id: ""
+    cluster_name: ""
+    tenant_id: ""
+
+  steps:
+    - name: set-ha-role
+      type: set_ha_role
+
+    - name: soak-before-cluster-move
+      type: delay
+      delay:
+        duration: 30s
+        message: "Waiting for steward convergence loop to register the cluster VM role before moving resource to cluster scope"
+
+    - name: move-to-cluster
+      type: move_resource_to_cluster

--- a/features/workflow/templates/promote-hv-role_test.go
+++ b/features/workflow/templates/promote-hv-role_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package templates_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/workflow"
+)
+
+func TestPromoteHVRoleTemplateParses(t *testing.T) {
+	parser := workflow.NewParser()
+	wf, err := parser.ParseFile("promote-hv-role.yaml")
+	require.NoError(t, err, "promote-hv-role.yaml must parse without error via Parser.ParseFile")
+
+	assert.Equal(t, "promote-hv-role", wf.Name)
+	assert.Equal(t, workflow.ActionStop, wf.OnFailure, "on_failure must be stop so set_ha_role failure halts before cluster-scope write")
+
+	// Variables block declares the four runtime parameters with empty placeholders.
+	require.NotNil(t, wf.Variables)
+	assert.Contains(t, wf.Variables, "vm_name")
+	assert.Contains(t, wf.Variables, "steward_id")
+	assert.Contains(t, wf.Variables, "cluster_name")
+	assert.Contains(t, wf.Variables, "tenant_id")
+
+	// Step-type sequence: set_ha_role → delay → move_resource_to_cluster.
+	require.Len(t, wf.Steps, 3, "template must have exactly three top-level steps")
+	assert.Equal(t, workflow.StepTypeSetHARole, wf.Steps[0].Type, "step 1 must be set_ha_role")
+	assert.Equal(t, workflow.StepTypeDelay, wf.Steps[1].Type, "step 2 must be delay")
+	assert.Equal(t, workflow.StepTypeMoveResourceToCluster, wf.Steps[2].Type, "step 3 must be move_resource_to_cluster")
+
+	// Delay step must carry a positive duration so the engine can execute it.
+	require.NotNil(t, wf.Steps[1].Delay, "delay step must have a delay config block")
+	assert.Greater(t, wf.Steps[1].Delay.Duration, time.Duration(0), "delay duration must be positive")
+}


### PR DESCRIPTION
## Summary

- Adds `features/workflow/templates/promote-hv-role.yaml`: a `Parser.ParseFile`-compatible reference template expressing the three-step Hyper-V VM promotion sequence (`set_ha_role` → 30 s soak `delay` → `move_resource_to_cluster`). Uses `on_failure: stop` so a failed `set_ha_role` halts before any cluster-scope write. Four empty-string variables (`vm_name`, `steward_id`, `cluster_name`, `tenant_id`) are supplied at execute time, never edited in the YAML.
- Adds `features/workflow/templates/promote-hv-role_test.go`: asserts successful `Parser.ParseFile` parse, verifies `on_failure`, all four variables, and the exact step-type sequence including a positive delay duration.
- Extends `features/workflow/parser.go`: adds `delayDefinition` struct and `Delay` field on `stepDefinition`, converts it to `step.Delay` via `time.ParseDuration`, and adds `StepTypeDelay` to `isValidStepType` — without this the parser rejected any `type: delay` step.

## Reviewer results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

All three passed in round 1, zero fix rounds required.

## Test plan

- [ ] `go test ./features/workflow/templates/...` — `TestPromoteHVRoleTemplateParses` passes
- [ ] `go test ./features/workflow/ -run Parser\|Validation` — all existing parser/validation tests pass
- [ ] `make test-agent-complete` passes (run by CI)

Fixes #2669