### PR TITLE
deps: bump trufflehog v3.95.8 → v3.95.9 (Issue #2719)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eu; \
     && chmod +x "$GOPATH/bin/nancy"
 
 # truffleHog (optional, best-effort secret scanning — pinned version, not @main)
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.8/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.8 || true
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.9/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.9 || true
 
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -120,7 +120,7 @@ jobs:
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.1.0"
-        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.8"
+        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.9"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.72.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"


### PR DESCRIPTION
## Summary

- Bumps `trufflehog` from `v3.95.8` to `v3.95.9` across all pinned locations (lockstep)
- Cooldown elapsed: 6.8 days since release, threshold is 3 days
- No CVE on the current pinned version; the one advisory (GHSA-3r74-v83p-f4f4, blind SSRF) was patched at 3.81.9

## Changed files

| File | Line | Change |
|------|------|--------|
| `.devcontainer/Dockerfile` | 110 | curl installer URL + `-b` version arg |
| `.github/workflows/dependency-pin-check.yml` | 123 | `check_version` table entry |

## Verification

- `grep -rE "v3\.95\.8"` → 0 matches (old version absent ✓)
- `grep -rE "v3\.95\.9"` → 2 matches (new version present ✓)
- `make test` → 211/211 passed ✓

## Specialist review results

- **Code review**: PASS
- **Test quality**: PASS
- **Security**: PASS (1 fix round — resolved)

Fixes #2719

## Test plan

- [x] `make test` passes locally
- [x] Old version string absent from both files
- [x] New version string present in both files
- [x] Story-review workflow passed (0 remaining findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)