### PR TITLE
api: gate workflow and trigger routes with per-route RBAC permissions (Issue #2725)

### DIFF
--- a/cmd/cfg/cmd/workflow_test.go
+++ b/cmd/cfg/cmd/workflow_test.go
@@ -807,8 +807,8 @@ func TestDeriveHVPromoteCluster_MalformedClusterKey_Ignored(t *testing.T) {
 	s := StewardInfo{
 		ID: "s1",
 		DNA: &StewardInfoDNA{Attributes: map[string]string{
-			"cluster:nodot":          "true", // malformed — no dot after name
-			"cluster:good.member":    "true", // valid
+			"cluster:nodot":       "true", // malformed — no dot after name
+			"cluster:good.member": "true", // valid
 		}},
 	}
 	name, err := deriveHVPromoteCluster(s, "")

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -28,6 +28,9 @@ type WorkflowHandler struct {
 	triggerAPI     *trigger.APIHandler
 	logger         logging.Logger
 	fleetQuery     fleet.FleetQuery // Issue #609: fleet query for script dispatch targeting
+	// requirePermFn gates workflow routes by permission. When nil, routes are ungated (test use only).
+	// Wired from Server.requirePermission via SetRequirePermFn in SetWorkflowHandler (Issue #2725).
+	requirePermFn func(resourceType, action string) func(http.Handler) http.Handler
 }
 
 // NewWorkflowHandler creates a new WorkflowHandler.
@@ -55,17 +58,32 @@ func (h *WorkflowHandler) SetFleetQuery(q fleet.FleetQuery) {
 	h.fleetQuery = q
 }
 
+// SetRequirePermFn wires the server's permission-check factory into WorkflowHandler so
+// RegisterWorkflowRoutes can gate each route without importing the concrete Server type (Issue #2725).
+func (h *WorkflowHandler) SetRequirePermFn(fn func(resourceType, action string) func(http.Handler) http.Handler) {
+	h.requirePermFn = fn
+}
+
 // RegisterWorkflowRoutes registers workflow CRUD and execution routes on the provided subrouter.
+// Each route is wrapped with the permission gate set by SetRequirePermFn (Issue #2725).
+// When requirePermFn is nil (unit-test scenarios without RBAC wiring) routes are ungated.
 func (h *WorkflowHandler) RegisterWorkflowRoutes(router *mux.Router) {
-	router.HandleFunc("", h.handleListWorkflows).Methods("GET")
-	router.HandleFunc("", h.handleCreateWorkflow).Methods("POST")
-	router.HandleFunc("/{id}", h.handleGetWorkflow).Methods("GET")
-	router.HandleFunc("/{id}", h.handleUpdateWorkflow).Methods("PUT")
-	router.HandleFunc("/{id}", h.handleDeleteWorkflow).Methods("DELETE")
-	router.HandleFunc("/{id}/execute", h.handleExecuteWorkflow).Methods("POST")
-	router.HandleFunc("/{id}/executions", h.handleGetWorkflowExecutions).Methods("GET")
-	router.HandleFunc("/{id}/executions/{exec_id}", h.handleGetExecution).Methods("GET")
-	router.HandleFunc("/{id}/executions/{exec_id}/cancel", h.handleCancelExecution).Methods("POST")
+	gate := h.requirePermFn
+	wrap := func(action string, fn http.HandlerFunc) http.Handler {
+		if gate == nil {
+			return fn
+		}
+		return gate("workflow", action)(fn)
+	}
+	router.Handle("", wrap("list", h.handleListWorkflows)).Methods("GET")
+	router.Handle("", wrap("write", h.handleCreateWorkflow)).Methods("POST")
+	router.Handle("/{id}", wrap("read", h.handleGetWorkflow)).Methods("GET")
+	router.Handle("/{id}", wrap("write", h.handleUpdateWorkflow)).Methods("PUT")
+	router.Handle("/{id}", wrap("write", h.handleDeleteWorkflow)).Methods("DELETE")
+	router.Handle("/{id}/execute", wrap("execute", h.handleExecuteWorkflow)).Methods("POST")
+	router.Handle("/{id}/executions", wrap("read", h.handleGetWorkflowExecutions)).Methods("GET")
+	router.Handle("/{id}/executions/{exec_id}", wrap("read", h.handleGetExecution)).Methods("GET")
+	router.Handle("/{id}/executions/{exec_id}/cancel", wrap("cancel", h.handleCancelExecution)).Methods("POST")
 }
 
 // NewRegistrationApprovalHook creates a RegistrationApprovalHook backed by this handler's

--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -827,6 +827,226 @@ func TestWorkflowHandler_GetExecution_SpecialCharsInVars_HandledSafely(t *testin
 	}
 }
 
+// --- permission gating (Issue #2725) -----------------------------------------
+
+// testRequirePermFn is a minimal requirePermFn for WorkflowHandler unit tests.
+// It mirrors the real s.requirePermission logic: admin principals always pass,
+// non-admin principals need the exact "resourceType:action" permission string.
+func testRequirePermFn(resourceType, action string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p, _ := r.Context().Value(principalContextKey).(*Principal)
+			if p == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"authentication required"}`))
+				return
+			}
+			if p.IsAdmin {
+				next.ServeHTTP(w, r)
+				return
+			}
+			need := resourceType + ":" + action
+			for _, have := range p.Permissions {
+				if have == need {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"insufficient permissions"}`))
+		})
+	}
+}
+
+// withPermissions injects a non-admin principal carrying the listed permissions.
+func withPermissions(r *http.Request, perms ...string) *http.Request {
+	p := &Principal{ID: "test-key", IsAdmin: false, Permissions: perms}
+	return r.WithContext(context.WithValue(r.Context(), principalContextKey, p))
+}
+
+// newPermGatedWorkflowRouter creates a mux.Router with workflow routes registered
+// under /workflows using testRequirePermFn permission gating.
+func newPermGatedWorkflowRouter(h *WorkflowHandler) *mux.Router {
+	h.SetRequirePermFn(testRequirePermFn)
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/workflows").Subrouter()
+	h.RegisterWorkflowRoutes(sub)
+	return router
+}
+
+// TestWorkflowPermission_Execute_ForbiddenWithoutPermission verifies that
+// POST /workflows/{id}/execute returns 403 when the caller lacks workflow:execute.
+func TestWorkflowPermission_Execute_ForbiddenWithoutPermission(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newPermGatedWorkflowRouter(h)
+
+	// Create workflow as admin so the execute target exists.
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("perm-exec-wf")))
+	createReq = withTenantContext(withAdminPrincipal(createReq), "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code, "setup: create workflow must succeed")
+
+	// Caller has workflow:read but not workflow:execute → 403.
+	req := httptest.NewRequest("POST", "/workflows/perm-exec-wf/execute", nil)
+	req = withTenantContext(withPermissions(req, "workflow:read"), "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestWorkflowPermission_Execute_SucceedsWithPermission verifies that
+// POST /workflows/{id}/execute returns 202 when the caller has workflow:execute.
+func TestWorkflowPermission_Execute_SucceedsWithPermission(t *testing.T) {
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
+	router := newPermGatedWorkflowRouter(h)
+
+	// Create workflow as admin.
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("perm-exec-ok-wf")))
+	createReq = withTenantContext(withAdminPrincipal(createReq), "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// Caller has workflow:execute → 202.
+	req := httptest.NewRequest("POST", "/workflows/perm-exec-ok-wf/execute", nil)
+	req = withTenantContext(withPermissions(req, "workflow:execute"), "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Clean up the execution goroutine so it doesn't outlive the test.
+	if engine != nil {
+		var execResp map[string]interface{}
+		if jsonErr := json.Unmarshal(rec.Body.Bytes(), &execResp); jsonErr == nil {
+			if execID, ok := execResp["execution_id"].(string); ok && execID != "" {
+				t.Cleanup(func() { _ = engine.CancelExecution(execID) })
+			}
+		}
+	}
+}
+
+// TestWorkflowPermission_Delete_ForbiddenWithoutPermission verifies that
+// DELETE /workflows/{id} returns 403 when the caller lacks workflow:write.
+func TestWorkflowPermission_Delete_ForbiddenWithoutPermission(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newPermGatedWorkflowRouter(h)
+
+	// Create workflow as admin.
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("perm-del-wf")))
+	createReq = withTenantContext(withAdminPrincipal(createReq), "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// Caller has workflow:read but not workflow:write → 403.
+	req := httptest.NewRequest("DELETE", "/workflows/perm-del-wf", nil)
+	req = withTenantContext(withPermissions(req, "workflow:read"), "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestWorkflowPermission_Delete_SucceedsWithPermission verifies that
+// DELETE /workflows/{id} returns 200 when the caller has workflow:write.
+func TestWorkflowPermission_Delete_SucceedsWithPermission(t *testing.T) {
+	h, _, _ := newTestWorkflowHandlerAndEngine(t)
+	router := newPermGatedWorkflowRouter(h)
+
+	// Create workflow as admin.
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("perm-del-ok-wf")))
+	createReq = withTenantContext(withAdminPrincipal(createReq), "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// Caller has workflow:write → 200.
+	req := httptest.NewRequest("DELETE", "/workflows/perm-del-ok-wf", nil)
+	req = withTenantContext(withPermissions(req, "workflow:write"), "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestWorkflowPermission_Cancel_ForbiddenWithoutPermission verifies that
+// POST /workflows/{id}/executions/{exec_id}/cancel returns 403 without workflow:cancel.
+func TestWorkflowPermission_Cancel_ForbiddenWithoutPermission(t *testing.T) {
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
+	router := newPermGatedWorkflowRouter(h)
+
+	// Create and execute a long-running workflow as admin so the execution is non-terminal.
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(mustMarshal(CreateWorkflowRequest{
+		Name: "perm-cancel-wf",
+		Steps: []workflow.Step{
+			{Name: "wait", Type: workflow.StepTypeDelay, Delay: &workflow.DelayConfig{Duration: 30 * time.Second}},
+		},
+	})))
+	createReq = withTenantContext(withAdminPrincipal(createReq), "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	execReq := httptest.NewRequest("POST", "/workflows/perm-cancel-wf/execute", nil)
+	execReq = withTenantContext(withAdminPrincipal(execReq), "test-tenant")
+	execRec := httptest.NewRecorder()
+	router.ServeHTTP(execRec, execReq)
+	require.Equal(t, http.StatusAccepted, execRec.Code)
+
+	var execResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(execRec.Body.Bytes(), &execResp))
+	execID, ok := execResp["execution_id"].(string)
+	require.True(t, ok && execID != "", "execution_id must be non-empty")
+	t.Cleanup(func() { _ = engine.CancelExecution(execID) })
+
+	// Caller has workflow:execute but not workflow:cancel → 403.
+	req := httptest.NewRequest("POST", "/workflows/perm-cancel-wf/executions/"+execID+"/cancel", nil)
+	req = withTenantContext(withPermissions(req, "workflow:execute"), "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestWorkflowPermission_Cancel_SucceedsWithPermission verifies that
+// POST /workflows/{id}/executions/{exec_id}/cancel returns 200 with workflow:cancel.
+func TestWorkflowPermission_Cancel_SucceedsWithPermission(t *testing.T) {
+	h, _, engine := newTestWorkflowHandlerAndEngine(t)
+	router := newPermGatedWorkflowRouter(h)
+
+	// Create and execute a long-running workflow as admin.
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(mustMarshal(CreateWorkflowRequest{
+		Name: "perm-cancel-ok-wf",
+		Steps: []workflow.Step{
+			{Name: "wait", Type: workflow.StepTypeDelay, Delay: &workflow.DelayConfig{Duration: 30 * time.Second}},
+		},
+	})))
+	createReq = withTenantContext(withAdminPrincipal(createReq), "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	execReq := httptest.NewRequest("POST", "/workflows/perm-cancel-ok-wf/execute", nil)
+	execReq = withTenantContext(withAdminPrincipal(execReq), "test-tenant")
+	execRec := httptest.NewRecorder()
+	router.ServeHTTP(execRec, execReq)
+	require.Equal(t, http.StatusAccepted, execRec.Code)
+
+	var execResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(execRec.Body.Bytes(), &execResp))
+	execID, ok := execResp["execution_id"].(string)
+	require.True(t, ok && execID != "", "execution_id must be non-empty")
+
+	// Caller has workflow:cancel → 200.
+	req := httptest.NewRequest("POST", "/workflows/perm-cancel-ok-wf/executions/"+execID+"/cancel", nil)
+	req = withTenantContext(withPermissions(req, "workflow:cancel"), "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// Execution already cancelled; cleanup is a no-op but kept for consistency.
+	t.Cleanup(func() { _ = engine.CancelExecution(execID) })
+}
+
 // TestWorkflowHandler_CancelExecution_SpecialCharsInVars_HandledSafely mirrors the get
 // variant above for the cancel path, which exercises the same engine error-embedding
 // pattern and the same CodeQL-recognised sanitization fix.

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -95,6 +95,14 @@ var knownPermissions = map[string]bool{
 	// Cluster registry (Issue #2424)
 	"cluster:list": true,
 	"cluster:read": true,
+	// Workflow management (Issue #2725)
+	"workflow:list":    true,
+	"workflow:read":    true,
+	"workflow:write":   true,
+	"workflow:execute": true,
+	"workflow:cancel":  true,
+	// Trigger management (Issue #2725)
+	"trigger:manage": true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -963,7 +963,9 @@ func (s *Server) SetReportsHandler(h *reportapi.Handler) {
 
 // SetWorkflowHandler sets the workflow handler and registers workflow and trigger API routes
 // (Issue #414). Propagates the server's fleet query so that script dispatch targeting is wired
-// at setup time (Issue #609). Call this after New() returns but before Start() is called.
+// at setup time (Issue #609). Wires requirePermission into the handler so every workflow route
+// is RBAC-gated and the trigger subrouter carries a coarse-grained trigger:manage gate (Issue #2725).
+// Call this after New() returns but before Start() is called.
 func (s *Server) SetWorkflowHandler(h *WorkflowHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -974,9 +976,11 @@ func (s *Server) SetWorkflowHandler(h *WorkflowHandler) {
 	if h == nil {
 		return
 	}
+	h.SetRequirePermFn(s.requirePermission)
 	workflowRouter := s.apiRouter.PathPrefix("/workflows").Subrouter()
 	h.RegisterWorkflowRoutes(workflowRouter)
 	triggerRouter := s.apiRouter.PathPrefix("/triggers").Subrouter()
+	triggerRouter.Use(s.requirePermission("trigger", "manage"))
 	h.RegisterTriggerRoutes(triggerRouter)
 	s.logger.Info("Workflow and trigger API routes registered")
 }


### PR DESCRIPTION
## Summary

- Every workflow route now requires a specific permission (`workflow:list/read/write/execute/cancel`) — previously all routes were open to any authenticated caller regardless of role.
- The trigger subrouter is gated with `trigger:manage` via `triggerRouter.Use(...)` in `SetWorkflowHandler`.
- `WorkflowHandler` gains a `requirePermFn` field (set via `SetRequirePermFn`) that keeps it decoupled from the concrete `Server` type.
- Six new permission tests added: 403-without-permission / 200-with-permission pairs for execute, delete, and cancel routes.

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| Code Review | PASS |
| Test Quality | PASS (after fix round) |
| Security | PASS |

Fix round: minor map-literal alignment in `cmd/cfg/cmd/workflow_test.go` surfaced by linter.

## Test Plan

- [x] `TestWorkflowPermission_Execute_ForbiddenWithoutPermission` — 403 without `workflow:execute`
- [x] `TestWorkflowPermission_Execute_SucceedsWithPermission` — 202 with `workflow:execute`
- [x] `TestWorkflowPermission_Delete_ForbiddenWithoutPermission` — 403 without `workflow:write`
- [x] `TestWorkflowPermission_Delete_SucceedsWithPermission` — 200 with `workflow:write`
- [x] `TestWorkflowPermission_Cancel_ForbiddenWithoutPermission` — 403 without `workflow:cancel`
- [x] `TestWorkflowPermission_Cancel_SucceedsWithPermission` — 200 with `workflow:cancel`
- [x] All existing workflow handler tests pass (ungated path preserved when `requirePermFn` is nil)
- [x] `make check-architecture` passes
- [x] Full API package test suite passes

Fixes #2725

🤖 Generated with [Claude Code](https://claude.com/claude-code)