### PR TITLE
session: durable shared store for pkg/session — restart and multi-node survival (Issue #2736)

### DIFF
--- a/docs/architecture/decisions/014-cfg-sessions-and-credential-unlock.md
+++ b/docs/architecture/decisions/014-cfg-sessions-and-credential-unlock.md
@@ -37,6 +37,8 @@ There is no path by which `cfg` uses the long-lived admin credential without an 
 
 On a valid connect (admin mTLS), the controller mints an opaque token: **32 bytes from `crypto/rand`, base64url** (≥256-bit entropy), non-JWT for v1. Each authenticated request carries `Authorization: Bearer <token>`; each authenticated response returns a freshly-TTL'd replacement in the **`X-Session-Token`** header, so continuous use stays valid. The controller stores **`SHA-256(token)`**, never the raw token, and **never logs token values** (`logging.SanitizeLogValue`). The session store is **in-memory for v1** (controller restart ⇒ re-auth).
 
+**Addendum (story #2736, epic #2735):** A durable `session.Store` implementation backed by SQLite (`pkg/storage/providers/sqlite.SQLiteSessionTokenStore`) is now available. When wired via `server.SetDurableSessionStore`, both the CLI session manager and the web session manager share the same store, enabling sessions to survive controller restarts with no re-authentication. Nodes in a cluster that share the same SQLite file can validate each other's sessions (cache miss → store lookup) and detect cross-node revocation (store record deleted on revoke; the next Validate on any node sees ErrSessionNotFound). The SHA-256(token) key invariant is maintained: the raw token is never written to the durable store.
+
 ### 3. Lifecycle: idle TTL + absolute cap + immediate revocation
 
 Defaults: **idle TTL 15m**, **absolute cap 8h** (measured from the original connect — caps even a continuously-active session), **grace window 30s**. An idle gap beyond the TTL lapses the session. Revocation takes effect within **≤ 1 token TTL**. The revoke endpoint accepts **either a valid session token or an admin mTLS cert**, so a client holding an already-expired token can still clean up server-side. The grace window is **time-only** for v1 (the prior token stays valid for 30s after a renewal, tolerating concurrent/racing requests from a stateless CLI); consume-on-first-use-after-renewal is a documented future hardening.
@@ -87,6 +89,6 @@ Session-token principals are **RBAC-equivalent to API-key principals**. This mod
 **Negative / costs**
 
 - The `pkg/secrets/providers/oskeychain` provider is **net-new, security-sensitive, and per-platform** (Credential Manager / Keychain / Secret Service / keyring). Each backend is only fully testable on its OS; Windows is the priority backend and is live-validated on the Windows e2e host rather than in a Linux container — it must not merge as never-run code.
-- The in-memory controller session store drops all sessions on restart (re-auth). Acceptable for a single-controller v1; **revisit for the SaaS cluster** (#2051, durable/shared session store).
+- The in-memory controller session store drops all sessions on restart. Resolved by story #2736 (see §2 addendum): `SetDurableSessionStore` wires a SQLite-backed store so sessions survive restarts and validate across nodes.
 - The time-only 30s grace window is a bounded replay surface; documented, with consume-on-first-use as the upgrade.
 - The machine-bound credential is non-portable between hosts — intended (per-host "remember this controller"), but it means the encrypted credential cannot be copied to another machine; re-import the bundle there.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -1226,6 +1226,24 @@ func (s *Server) SetWebSessionManager(mgr session.Manager) {
 	s.webSessionManager = mgr
 }
 
+// SetDurableSessionStore wires both session managers with a shared durable session.Store
+// (Issue #2736, epic #2735). The CLI manager uses ADR-014 defaults (idle 15m / absolute 8h /
+// grace 30s); the web manager uses a longer-lived config (idle 60m / absolute 12h / grace 30s).
+// Sharing the same store lets sessions survive controller restarts and validate across cluster
+// nodes. Call after New() but before Start(); it overwrites any prior SetSessionManager /
+// SetWebSessionManager wiring.
+func (s *Server) SetDurableSessionStore(store session.Store) {
+	webCfg := session.Config{
+		IdleTimeout:     60 * time.Minute,
+		AbsoluteTimeout: 12 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessionManager = session.NewManager(s.sessionCfg, store, time.Now)
+	s.webSessionManager = session.NewManager(webCfg, store, time.Now)
+}
+
 // SetMembershipStore wires the cluster MembershipStore used by the drain endpoint
 // (Issue #2283). When nil (default), POST /api/v1/cluster/nodes/{id}/drain returns
 // 503. Call after New() but before Start().

--- a/pkg/session/contract.go
+++ b/pkg/session/contract.go
@@ -89,10 +89,11 @@ type Manager interface {
 	List(ctx context.Context) ([]*Session, error)
 }
 
-// Store is the in-memory backing store for the session Manager (ADR-014 §2, v1).
+// Store is the backing store for the session Manager (ADR-014 §2).
 // The key for Set/Get is SHA-256(token) encoded as hex — the controller never persists
-// the raw token. Delete removes by session ID. A controller restart drops all sessions
-// (re-auth required); durable/shared store is deferred to the SaaS cluster story (#2051).
+// the raw token. Delete removes by session ID. The durable implementation lives in
+// pkg/storage/providers/sqlite and enables sessions to survive controller restarts
+// (epic #2735, story #2736).
 //
 // The implementation lives in Story #4 of epic #2213.
 type Store interface {

--- a/pkg/session/contract_test.go
+++ b/pkg/session/contract_test.go
@@ -101,3 +101,215 @@ func TestSessionStruct(t *testing.T) {
 		t.Error("Session time fields must be zero by default")
 	}
 }
+
+// ---- Shared Store contract suite -----------------------------------------------
+
+// makeTestSession returns a minimal session ready for store insertion.
+func makeTestSession(id string, cfg session.Config) *session.Session {
+	now := time.Now()
+	return &session.Session{
+		ID:                id,
+		PrincipalID:       "test-principal",
+		ConnectionName:    "test-ctrl",
+		TenantID:          "tenant-1",
+		IssuedAt:          now,
+		LastActivity:      now,
+		AbsoluteExpiresAt: now.Add(cfg.AbsoluteTimeout),
+	}
+}
+
+// RunStoreContractSuite executes the shared contract test suite against any session.Store
+// implementation. It covers Set/Get, Get-miss, Delete (revocation), ListAll dedup, and
+// the invariant that the raw token is never a valid store key.
+func RunStoreContractSuite(t *testing.T, store session.Store) {
+	t.Helper()
+	cfg := session.DefaultConfig()
+	ctx := context.Background()
+
+	t.Run("SetAndGetByHash", func(t *testing.T) {
+		tok, err := session.GenerateToken()
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+		hash := session.HashToken(tok)
+		sess := makeTestSession("sc-set-get", cfg)
+
+		if err := store.Set(ctx, hash, sess); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		got, err := store.Get(ctx, hash)
+		if err != nil {
+			t.Fatalf("Get by hash: %v", err)
+		}
+		if got.ID != sess.ID {
+			t.Errorf("session ID: got %q, want %q", got.ID, sess.ID)
+		}
+		if got.PrincipalID != sess.PrincipalID {
+			t.Errorf("PrincipalID: got %q, want %q", got.PrincipalID, sess.PrincipalID)
+		}
+	})
+
+	t.Run("RawTokenNotAValidKey", func(t *testing.T) {
+		tok, err := session.GenerateToken()
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+		hash := session.HashToken(tok)
+		sess := makeTestSession("sc-raw-token", cfg)
+		if err := store.Set(ctx, hash, sess); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		// Looking up the raw token (not its hash) must miss — the raw token is never persisted.
+		_, err = store.Get(ctx, tok)
+		if !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("raw-token lookup: got %v, want ErrSessionNotFound", err)
+		}
+		// Hash lookup must hit.
+		if _, err := store.Get(ctx, hash); err != nil {
+			t.Errorf("hash lookup: unexpected error %v", err)
+		}
+	})
+
+	t.Run("GetMissingHashReturnsNotFound", func(t *testing.T) {
+		_, err := store.Get(ctx, "0000000000000000000000000000000000000000000000000000000000000000")
+		if !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("missing hash: got %v, want ErrSessionNotFound", err)
+		}
+	})
+
+	t.Run("DeleteBySessionIDRemovesAllHashes", func(t *testing.T) {
+		t1, _ := session.GenerateToken()
+		t2, _ := session.GenerateToken()
+		h1, h2 := session.HashToken(t1), session.HashToken(t2)
+		sess := makeTestSession("sc-delete", cfg)
+
+		if err := store.Set(ctx, h1, sess); err != nil {
+			t.Fatalf("Set h1: %v", err)
+		}
+		if err := store.Set(ctx, h2, sess); err != nil {
+			t.Fatalf("Set h2: %v", err)
+		}
+		if err := store.Delete(ctx, sess.ID); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if _, err := store.Get(ctx, h1); !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("after Delete, Get h1: got %v, want ErrSessionNotFound", err)
+		}
+		if _, err := store.Get(ctx, h2); !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("after Delete, Get h2: got %v, want ErrSessionNotFound", err)
+		}
+	})
+
+	t.Run("DeleteIdempotent", func(t *testing.T) {
+		tok, _ := session.GenerateToken()
+		sess := makeTestSession("sc-delete-idem", cfg)
+		if err := store.Set(ctx, session.HashToken(tok), sess); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		if err := store.Delete(ctx, sess.ID); err != nil {
+			t.Errorf("first Delete: %v", err)
+		}
+		// Second Delete finds no records and returns ErrSessionNotFound — safe to call.
+		if err := store.Delete(ctx, sess.ID); !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("second Delete: got %v, want ErrSessionNotFound", err)
+		}
+	})
+
+	t.Run("SetUpdatesExistingEntry", func(t *testing.T) {
+		tok, _ := session.GenerateToken()
+		hash := session.HashToken(tok)
+		sess := makeTestSession("sc-update", cfg)
+		if err := store.Set(ctx, hash, sess); err != nil {
+			t.Fatalf("initial Set: %v", err)
+		}
+		// Update LastActivity.
+		updated := *sess
+		updated.LastActivity = updated.LastActivity.Add(5 * time.Minute)
+		if err := store.Set(ctx, hash, &updated); err != nil {
+			t.Fatalf("update Set: %v", err)
+		}
+		got, err := store.Get(ctx, hash)
+		if err != nil {
+			t.Fatalf("Get after update: %v", err)
+		}
+		if !got.LastActivity.Equal(updated.LastActivity) {
+			t.Errorf("LastActivity: got %v, want %v", got.LastActivity, updated.LastActivity)
+		}
+	})
+
+	t.Run("ListAllDedupsBySessionID", func(t *testing.T) {
+		// s1: single hash entry.
+		t1, _ := session.GenerateToken()
+		s1 := makeTestSession("sc-list-s1", cfg)
+		if err := store.Set(ctx, session.HashToken(t1), s1); err != nil {
+			t.Fatalf("Set s1: %v", err)
+		}
+		// s2: two hash entries (current + prior-token grace), as produced by a Renew.
+		t2a, _ := session.GenerateToken()
+		t2b, _ := session.GenerateToken()
+		s2 := makeTestSession("sc-list-s2", cfg)
+		if err := store.Set(ctx, session.HashToken(t2a), s2); err != nil {
+			t.Fatalf("Set s2a: %v", err)
+		}
+		if err := store.Set(ctx, session.HashToken(t2b), s2); err != nil {
+			t.Fatalf("Set s2b: %v", err)
+		}
+
+		all, err := store.ListAll(ctx)
+		if err != nil {
+			t.Fatalf("ListAll: %v", err)
+		}
+		counts := make(map[string]int)
+		for _, s := range all {
+			counts[s.ID]++
+		}
+		if counts["sc-list-s1"] != 1 {
+			t.Errorf("s1 count = %d, want 1", counts["sc-list-s1"])
+		}
+		if counts["sc-list-s2"] != 1 {
+			t.Errorf("s2 count = %d, want 1 (dedup expected); full list: %v", counts["sc-list-s2"], all)
+		}
+	})
+
+	t.Run("GraceWindowRenewalRoundTrip", func(t *testing.T) {
+		// Simulate the two-hash state produced by Manager.Renew:
+		// hashOld = prior-token (in grace), hashNew = current.
+		tokOld, _ := session.GenerateToken()
+		tokNew, _ := session.GenerateToken()
+		hashOld, hashNew := session.HashToken(tokOld), session.HashToken(tokNew)
+		sess := makeTestSession("sc-grace", cfg)
+
+		// Both hashes point at the same session record.
+		if err := store.Set(ctx, hashOld, sess); err != nil {
+			t.Fatalf("Set hashOld: %v", err)
+		}
+		if err := store.Set(ctx, hashNew, sess); err != nil {
+			t.Fatalf("Set hashNew: %v", err)
+		}
+		// Both must be retrievable by their respective hash.
+		if _, err := store.Get(ctx, hashOld); err != nil {
+			t.Errorf("Get hashOld: %v", err)
+		}
+		if _, err := store.Get(ctx, hashNew); err != nil {
+			t.Errorf("Get hashNew: %v", err)
+		}
+		// After revocation (Delete by session ID) both must be gone.
+		if err := store.Delete(ctx, sess.ID); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if _, err := store.Get(ctx, hashOld); !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("after Delete, Get hashOld: got %v, want ErrSessionNotFound", err)
+		}
+		if _, err := store.Get(ctx, hashNew); !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("after Delete, Get hashNew: got %v, want ErrSessionNotFound", err)
+		}
+	})
+}
+
+// TestStoreContract_MemStore runs the shared contract suite against the in-memory MemStore.
+func TestStoreContract_MemStore(t *testing.T) {
+	cfg := session.DefaultConfig()
+	store := session.NewMemStore(cfg, time.Now)
+	t.Cleanup(store.Close)
+	RunStoreContractSuite(t, store)
+}

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -4,6 +4,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -31,6 +32,13 @@ type manager struct {
 	mu       sync.RWMutex
 	sessions map[string]*managedSession // key = session ID
 	byHash   map[string]*managedSession // key = token hash (current or prev)
+}
+
+// graceStamper is optionally implemented by stores that can record a per-hash expiry
+// so that prior-token grace slots are bounded on cluster nodes and after restarts.
+// MemStore omits this since it manages grace in-memory; SQLiteSessionTokenStore implements it.
+type graceStamper interface {
+	StampGraceExpiry(ctx context.Context, tokenHash string, expiresAt time.Time) error
 }
 
 // NewManager creates a Manager that delegates persistence to store.
@@ -86,15 +94,55 @@ func (m *manager) Issue(ctx context.Context, principalID, connectionName, tenant
 	return &out, token, nil
 }
 
+// loadFromStore attempts to load a session from the durable store on in-memory cache miss.
+// This supports sessions that survived a controller restart or were issued by another node.
+// After loading, the session is registered in the in-memory index so subsequent calls are fast.
+// Returns nil when the session is not found in or was deleted from the store.
+func (m *manager) loadFromStore(ctx context.Context, hash string) *managedSession {
+	sess, err := m.store.Get(ctx, hash)
+	if err != nil {
+		return nil // not found, revoked, or store error — treat as absent
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Double-check: another goroutine may have registered this hash while we were in the store.
+	if existing, ok := m.byHash[hash]; ok {
+		return existing
+	}
+	// If a managedSession for this session ID already exists (e.g., loaded via another hash
+	// such as the grace-window token), reuse it to keep revocation state consistent.
+	if existing, ok := m.sessions[sess.ID]; ok {
+		m.byHash[hash] = existing
+		return existing
+	}
+	// First time loading this session: create a new managedSession from store data.
+	// After a restart, any prior-token grace window has long expired (restart > 30s grace),
+	// so we treat the loaded hash as the current token.
+	ms := &managedSession{
+		session:     sess,
+		currentHash: hash,
+	}
+	m.byHash[hash] = ms
+	m.sessions[sess.ID] = ms
+	return ms
+}
+
 // Validate authenticates the bearer token and returns the live session, updating
 // LastActivity. It returns ErrSessionExpired or ErrSessionRevoked on failure.
 // Prior-token grace entries (within GraceWindow after a Renew) are also accepted
 // but do NOT update LastActivity (the renewed token owns the idle TTL).
+//
+// Validate falls back to the durable store on cache miss (supporting restart survival
+// and cross-node validation) and verifies the store record on every call so that a
+// revocation issued on another node propagates immediately.
 func (m *manager) Validate(ctx context.Context, token string) (*Session, error) {
 	hash := HashToken(token)
 	m.mu.RLock()
 	ms := m.byHash[hash]
 	m.mu.RUnlock()
+	if ms == nil {
+		ms = m.loadFromStore(ctx, hash)
+	}
 	if ms == nil {
 		return nil, ErrSessionNotFound
 	}
@@ -102,6 +150,16 @@ func (m *manager) Validate(ctx context.Context, token string) (*Session, error) 
 	defer ms.mu.Unlock()
 	if ms.revoked {
 		return nil, ErrSessionRevoked
+	}
+	// Cross-node revocation: verify the store still holds this token hash.
+	// Another node's Revoke deletes all hashes for the session from the store;
+	// a Get miss here means the session was revoked remotely.
+	if _, storeErr := m.store.Get(ctx, hash); storeErr != nil {
+		if errors.Is(storeErr, ErrSessionNotFound) || errors.Is(storeErr, ErrSessionRevoked) {
+			ms.revoked = true
+			return nil, ErrSessionRevoked
+		}
+		// Non-fatal store errors: proceed with in-memory state (best-effort).
 	}
 	now := m.clockFn()
 	if now.After(ms.session.AbsoluteExpiresAt) {
@@ -118,7 +176,7 @@ func (m *manager) Validate(ctx context.Context, token string) (*Session, error) 
 			return nil, ErrSessionExpired
 		}
 		ms.session.LastActivity = now
-		_ = m.store.Set(ctx, hash, ms.session) // best-effort sync; in-memory is authoritative
+		_ = m.store.Set(ctx, hash, ms.session) // best-effort sync to durable store
 	}
 	out := *ms.session
 	return &out, nil
@@ -130,11 +188,17 @@ func (m *manager) Validate(ctx context.Context, token string) (*Session, error) 
 // grace slot (concurrent prior-token request), no rotation occurs and the returned
 // new-token string is empty — the caller should not overwrite any X-Session-Token
 // header the client may have already received.
+//
+// Renew falls back to the durable store on cache miss (supporting restart survival
+// and cross-node renewal).
 func (m *manager) Renew(ctx context.Context, token string) (*Session, string, error) {
 	hash := HashToken(token)
 	m.mu.RLock()
 	ms := m.byHash[hash]
 	m.mu.RUnlock()
+	if ms == nil {
+		ms = m.loadFromStore(ctx, hash)
+	}
 	if ms == nil {
 		return nil, "", ErrSessionNotFound
 	}
@@ -178,8 +242,13 @@ func (m *manager) Renew(ctx context.Context, token string) (*Session, string, er
 	m.mu.Lock()
 	m.byHash[newHash] = ms
 	m.mu.Unlock()
-	// Persist the new hash mapping.
+	// best-effort sync of the new token to the durable store
 	_ = m.store.Set(ctx, newHash, ms.session)
+	// Bound the prior token's validity in the durable store so that cross-node and
+	// post-restart lookups of the rotated-away hash are rejected once the grace window elapses.
+	if gs, ok := m.store.(graceStamper); ok {
+		_ = gs.StampGraceExpiry(ctx, ms.prevHash, ms.prevExpiry)
+	}
 	out := *ms.session
 	return &out, newToken, nil
 }
@@ -188,7 +257,10 @@ func (m *manager) Renew(ctx context.Context, token string) (*Session, string, er
 // revoked, not absolute-expired, and not idle-expired — the same three checks Validate
 // applies. Tenant scoping is the caller's responsibility. Results are copies so callers
 // cannot mutate manager-internal state through the returned pointers.
-func (m *manager) List(_ context.Context) ([]*Session, error) {
+//
+// When the in-memory session map is empty (e.g., immediately after a controller restart),
+// List falls back to the durable store so the admin session listing survives restarts.
+func (m *manager) List(ctx context.Context) ([]*Session, error) {
 	now := m.clockFn()
 	// Snapshot the managedSession pointers under m.mu, then release m.mu BEFORE
 	// acquiring any per-session ms.mu. Holding m.mu while taking ms.mu would invert
@@ -199,8 +271,10 @@ func (m *manager) List(_ context.Context) ([]*Session, error) {
 	for _, ms := range m.sessions {
 		snapshot = append(snapshot, ms)
 	}
+	hasInMemory := len(m.sessions) > 0
 	m.mu.RUnlock()
 
+	seen := make(map[string]struct{}, len(snapshot))
 	out := make([]*Session, 0, len(snapshot))
 	for _, ms := range snapshot {
 		ms.mu.Lock()
@@ -214,23 +288,59 @@ func (m *manager) List(_ context.Context) ([]*Session, error) {
 		}
 		ms.mu.Unlock()
 		if copy != nil {
+			seen[copy.ID] = struct{}{}
 			out = append(out, copy)
 		}
 	}
+
+	// After a restart the in-memory map is empty; fall back to the durable store
+	// so that existing sessions are visible before their owners re-validate.
+	if !hasInMemory {
+		stored, err := m.store.ListAll(ctx)
+		if err == nil {
+			for _, sess := range stored {
+				if _, dup := seen[sess.ID]; dup {
+					continue
+				}
+				live := now.Before(sess.AbsoluteExpiresAt) &&
+					now.Before(sess.LastActivity.Add(m.cfg.IdleTimeout))
+				if live {
+					seen[sess.ID] = struct{}{}
+					c := *sess
+					out = append(out, &c)
+				}
+			}
+		}
+	}
+
 	return out, nil
 }
 
 // Revoke immediately invalidates the session identified by id. Subsequent Validate
 // or Renew calls for any token belonging to this session return ErrSessionRevoked.
+// Revoke deletes all token-hash records from the durable store so revocation is
+// visible to other nodes that share the store: the Validate store-check detects
+// the missing record and returns ErrSessionRevoked on any node's next request.
+//
+// After a controller restart the in-memory index is empty; Revoke falls back to the
+// durable store so administrative revocation works before any Validate re-populates
+// the cache. Returns ErrSessionNotFound when the session is in neither the cache nor
+// the store.
 func (m *manager) Revoke(ctx context.Context, id string) error {
 	m.mu.RLock()
 	ms := m.sessions[id]
 	m.mu.RUnlock()
 	if ms == nil {
-		return ErrSessionNotFound
+		// Cache miss — attempt the durable store delete (post-restart support).
+		// store.Delete returns ErrSessionNotFound when the session has no records.
+		return m.store.Delete(ctx, id)
 	}
 	ms.mu.Lock()
 	ms.revoked = true
 	ms.mu.Unlock()
-	return m.store.Delete(ctx, id)
+	// Ignore ErrSessionNotFound: another node may have already deleted the records.
+	if err := m.store.Delete(ctx, id); err != nil && !errors.Is(err, ErrSessionNotFound) {
+		return err
+	}
+	return nil
 }

--- a/pkg/session/providers_test.go
+++ b/pkg/session/providers_test.go
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/session"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+// newSQLiteSessionStore creates a file-backed SQLite session token store for testing.
+// Each call gets an isolated database in t.TempDir().
+func newSQLiteSessionStore(t *testing.T) session.Store {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateSessionTokenStore(map[string]interface{}{"path": filepath.Join(dir, "sessions.db")})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestStoreContract_SQLite runs the shared contract suite against the SQLite-backed store.
+func TestStoreContract_SQLite(t *testing.T) {
+	RunStoreContractSuite(t, newSQLiteSessionStore(t))
+}
+
+// TestManagerSurvivesRestartViaDurableStore verifies that sessions issued by one manager
+// instance remain valid for a fresh manager instance that shares the same durable store.
+// This simulates a controller restart: the first manager is discarded but the store persists.
+func TestManagerSurvivesRestartViaDurableStore(t *testing.T) {
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	dbPath := filepath.Join(dir, "sessions.db")
+	cfg := session.Config{
+		IdleTimeout:     5 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	ctx := context.Background()
+
+	// --- "Before restart": first manager issues a session ---
+	store1, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore (store1): %v", err)
+	}
+	mgr1 := session.NewManager(cfg, store1, time.Now)
+	_, token, err := mgr1.Issue(ctx, "alice", "ctrl", "tenant-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if _, err := mgr1.Validate(ctx, token); err != nil {
+		t.Fatalf("Validate on mgr1: %v", err)
+	}
+	_ = store1.Close()
+
+	// --- "After restart": second manager with the SAME store file ---
+	store2, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore (store2): %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+	mgr2 := session.NewManager(cfg, store2, time.Now)
+
+	// The token issued by mgr1 must still be valid on mgr2.
+	got, err := mgr2.Validate(ctx, token)
+	if err != nil {
+		t.Fatalf("Validate on mgr2 after restart: %v (session not found in durable store)", err)
+	}
+	if got.PrincipalID != "alice" {
+		t.Errorf("PrincipalID: got %q, want %q", got.PrincipalID, "alice")
+	}
+}
+
+// TestRevocationPropagatesAcrossManagers verifies that revoking a session on one manager
+// makes the session invalid on a second manager sharing the same durable store.
+// This simulates cross-node revocation: node A revokes, node B detects it on next Validate.
+func TestRevocationPropagatesAcrossManagers(t *testing.T) {
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	dbPath := filepath.Join(dir, "sessions.db")
+	cfg := session.Config{
+		IdleTimeout:     5 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	ctx := context.Background()
+
+	// Both "nodes" share the same SQLite file.
+	storeA, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore A: %v", err)
+	}
+	defer func() { _ = storeA.Close() }()
+
+	storeB, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore B: %v", err)
+	}
+	defer func() { _ = storeB.Close() }()
+
+	mgrA := session.NewManager(cfg, storeA, time.Now)
+	mgrB := session.NewManager(cfg, storeB, time.Now)
+
+	// Node A issues a session.
+	sess, token, err := mgrA.Issue(ctx, "bob", "ctrl", "tenant-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Node B can validate it (cache miss → durable store lookup).
+	if _, err := mgrB.Validate(ctx, token); err != nil {
+		t.Fatalf("Validate on mgrB before revocation: %v", err)
+	}
+
+	// Node A revokes the session — this deletes all token hashes from the shared store.
+	if err := mgrA.Revoke(ctx, sess.ID); err != nil {
+		t.Fatalf("Revoke on mgrA: %v", err)
+	}
+
+	// Node B must now reject the token (the store record was deleted by mgrA's Revoke).
+	_, err = mgrB.Validate(ctx, token)
+	if err == nil {
+		t.Fatal("Validate on mgrB after cross-node revocation: expected error, got nil")
+	}
+	if !errors.Is(err, session.ErrSessionRevoked) && !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("Validate on mgrB after revocation: got %v, want ErrSessionRevoked or ErrSessionNotFound", err)
+	}
+}
+
+// TestManagerSurvivesRestartAfterRenew verifies that the NEW token produced by Renew
+// is persisted in the durable store and survives a controller restart.
+func TestManagerSurvivesRestartAfterRenew(t *testing.T) {
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	dbPath := filepath.Join(dir, "sessions.db")
+	cfg := session.Config{
+		IdleTimeout:     5 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	ctx := context.Background()
+
+	// Issue and immediately renew on the first manager.
+	store1, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore (store1): %v", err)
+	}
+	mgr1 := session.NewManager(cfg, store1, time.Now)
+	_, oldToken, err := mgr1.Issue(ctx, "alice", "ctrl", "tenant-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	_, newToken, err := mgr1.Renew(ctx, oldToken)
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	_ = store1.Close()
+
+	// After restart: second manager with the same db file must accept the new token.
+	store2, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore (store2): %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+	mgr2 := session.NewManager(cfg, store2, time.Now)
+
+	got, err := mgr2.Validate(ctx, newToken)
+	if err != nil {
+		t.Fatalf("Validate new token on mgr2 after restart: %v", err)
+	}
+	if got.PrincipalID != "alice" {
+		t.Errorf("PrincipalID: got %q, want %q", got.PrincipalID, "alice")
+	}
+}
+
+// TestGraceExpiryHonouredAcrossNodes verifies that a rotated-away token hash is rejected
+// on a sibling node once its grace window elapses. This is the cross-node analogue of the
+// in-memory ms.prevExpiry check — enforced via the hash_expires_at column in the store.
+func TestGraceExpiryHonouredAcrossNodes(t *testing.T) {
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	dbPath := filepath.Join(dir, "sessions.db")
+	// Use a very short GraceWindow so we can expire it with a short sleep.
+	cfg := session.Config{
+		IdleTimeout:     5 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     10 * time.Millisecond,
+	}
+	ctx := context.Background()
+
+	storeA, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore A: %v", err)
+	}
+	defer func() { _ = storeA.Close() }()
+
+	storeB, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore B: %v", err)
+	}
+	defer func() { _ = storeB.Close() }()
+
+	mgrA := session.NewManager(cfg, storeA, time.Now)
+	mgrB := session.NewManager(cfg, storeB, time.Now)
+
+	// Node A: issue → renew; oldToken is rotated away into grace.
+	_, oldToken, err := mgrA.Issue(ctx, "dave", "ctrl", "tenant-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	_, newToken, err := mgrA.Renew(ctx, oldToken)
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+
+	// Wait for the grace window to expire.
+	time.Sleep(30 * time.Millisecond)
+
+	// Node B: new token is always valid.
+	if _, err := mgrB.Validate(ctx, newToken); err != nil {
+		t.Errorf("Validate new token on mgrB: %v", err)
+	}
+	// Node B: old token's hash_expires_at has passed → must be rejected.
+	_, err = mgrB.Validate(ctx, oldToken)
+	if err == nil {
+		t.Error("Validate old (grace-expired) token on mgrB: expected error, got nil")
+	}
+}
+
+// TestRevokeAfterRestartViaDurableStore verifies that Revoke works post-restart even when
+// the session is not in the revoking node's in-memory index (store-fallback path).
+func TestRevokeAfterRestartViaDurableStore(t *testing.T) {
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	dbPath := filepath.Join(dir, "sessions.db")
+	cfg := session.Config{
+		IdleTimeout:     5 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	ctx := context.Background()
+
+	// Issue on the first manager.
+	store1, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore (store1): %v", err)
+	}
+	mgr1 := session.NewManager(cfg, store1, time.Now)
+	sess, token, err := mgr1.Issue(ctx, "eve", "ctrl", "tenant-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	_ = store1.Close()
+
+	// After restart: mgr2 has an empty in-memory index.
+	store2, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore (store2): %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+	mgr2 := session.NewManager(cfg, store2, time.Now)
+
+	// Revoke on mgr2 must succeed via the store fallback path.
+	if err := mgr2.Revoke(ctx, sess.ID); err != nil {
+		t.Fatalf("Revoke on mgr2 after restart: %v", err)
+	}
+
+	// Token is now gone from the store — Validate on a third fresh manager must reject it.
+	store3, err := p.CreateSessionTokenStore(map[string]interface{}{"path": dbPath})
+	if err != nil {
+		t.Fatalf("CreateSessionTokenStore (store3): %v", err)
+	}
+	defer func() { _ = store3.Close() }()
+	mgr3 := session.NewManager(cfg, store3, time.Now)
+
+	_, err = mgr3.Validate(ctx, token)
+	if err == nil {
+		t.Error("Validate after post-restart Revoke: expected error, got nil")
+	}
+}
+
+// TestNoRawTokenInDurableStore verifies that the SQLite-backed store never persists
+// the raw bearer token — only SHA-256(token) hex.
+func TestNoRawTokenInDurableStore(t *testing.T) {
+	store := newSQLiteSessionStore(t)
+	cfg := session.DefaultConfig()
+	ctx := context.Background()
+
+	mgr := session.NewManager(cfg, store, time.Now)
+	_, token, err := mgr.Issue(ctx, "carol", "ctrl", "tenant-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Raw token lookup must miss — the store key is SHA-256(token), not the token itself.
+	_, err = store.Get(ctx, token)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("raw-token lookup in durable store: got %v, want ErrSessionNotFound", err)
+	}
+
+	// Hash lookup must hit.
+	hash := session.HashToken(token)
+	if _, err := store.Get(ctx, hash); err != nil {
+		t.Errorf("hash lookup in durable store: got %v, want nil", err)
+	}
+}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -74,12 +74,16 @@ func (s *MemStore) Get(_ context.Context, tokenHash string) (*Session, error) {
 	return entry.session, nil
 }
 
-// Delete removes all token-hash entries associated with the given session ID,
-// effectively invalidating any tokens that map to this session.
+// Delete removes all token-hash entries associated with the given session ID.
+// Returns ErrSessionNotFound when no entries exist for id (mirrors SQLiteSessionTokenStore).
 func (s *MemStore) Delete(_ context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, h := range s.byID[id] {
+	hashes, ok := s.byID[id]
+	if !ok {
+		return ErrSessionNotFound
+	}
+	for _, h := range hashes {
 		delete(s.records, h)
 	}
 	delete(s.byID, id)

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -319,6 +319,18 @@ func (p *SQLiteProvider) CreatePendingRegistrationStore(config map[string]interf
 	return &SQLitePendingRegistrationStore{db: db}, nil
 }
 
+// CreateSessionTokenStore returns a SQLite-backed session.Store for pkg/session.Manager
+// (Issue #2736). This store is distinct from CreateSessionStore (business.SessionStore):
+// it uses token-hash keys and enables sessions to survive controller restarts and to
+// validate across cluster nodes that share the same SQLite file.
+func (p *SQLiteProvider) CreateSessionTokenStore(config map[string]interface{}) (*SQLiteSessionTokenStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteSessionTokenStore{db: db}, nil
+}
+
 // CreateIPTrustStore is not yet supported by the SQLite provider.
 // IP trust storage is implemented by the database (PostgreSQL) provider (Issue #1691).
 func (p *SQLiteProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -498,6 +498,28 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_sessions_session_type ON sessions(session_type)`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_status       ON sessions(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_expires_at   ON sessions(expires_at)`,
+
+		// Session token records for pkg/session.Store (Issue #2736 / epic #2735).
+		// Key is SHA-256(token) hex — the raw token is NEVER stored here or in any log.
+		// Multiple rows can share a session_id: one for the current token and one for
+		// the prior-token grace slot produced by Manager.Renew. Both rows hold identical
+		// session data; the distinction is maintained only in the Manager's in-memory state.
+		//
+		// hash_expires_at (nullable): set by StampGraceExpiry after Renew so that prior-token
+		// grace slots expire on cluster peers and after controller restarts, bounding the
+		// window in which a rotated-away token hash remains a valid credential.
+		`CREATE TABLE IF NOT EXISTS session_token_records (
+			token_hash            TEXT PRIMARY KEY,
+			session_id            TEXT NOT NULL,
+			principal_id          TEXT NOT NULL,
+			connection_name       TEXT NOT NULL,
+			tenant_id             TEXT NOT NULL,
+			issued_at             TEXT NOT NULL,
+			last_activity         TEXT NOT NULL,
+			absolute_expires_at   TEXT NOT NULL,
+			hash_expires_at       TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_session_token_records_session_id ON session_token_records(session_id)`,
 	}
 
 	tx, err := db.BeginTx(ctx, nil)

--- a/pkg/storage/providers/sqlite/session_token_store.go
+++ b/pkg/storage/providers/sqlite/session_token_store.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// SQLiteSessionTokenStore implements pkg/session.Store using SQLite.
+// The primary key is SHA-256(token) hex; the raw token is never stored or logged.
+// Multiple rows may share a session_id (current token + prior-token grace slot after Renew).
+// Delete removes all rows for a session_id, making revocation visible across restarts and nodes.
+type SQLiteSessionTokenStore struct {
+	db *sql.DB
+}
+
+// Compile-time assertion.
+var _ session.Store = (*SQLiteSessionTokenStore)(nil)
+
+// NewSessionTokenStore wraps an already-opened, schema-initialised *sql.DB as a session.Store.
+// The caller retains ownership of db and must call db.Close() when done.
+func NewSessionTokenStore(db *sql.DB) *SQLiteSessionTokenStore {
+	return &SQLiteSessionTokenStore{db: db}
+}
+
+// Close closes the underlying database connection. Only call this when the
+// store owns its *sql.DB exclusively (i.e. created via CreateSessionTokenStore,
+// not via NewSessionTokenStore with a shared handle).
+func (s *SQLiteSessionTokenStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// Set stores or updates the Session under the given token hash (SHA-256 hex).
+// The raw token is never passed to this method; callers must hash via session.HashToken.
+//
+// Set always inserts with hash_expires_at = NULL (no per-hash expiry). On conflict,
+// session data is updated but hash_expires_at is left untouched so that a grace expiry
+// stamped by StampGraceExpiry is not erased by a subsequent LastActivity sync.
+func (s *SQLiteSessionTokenStore) Set(ctx context.Context, tokenHash string, sess *session.Session) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO session_token_records
+			(token_hash, session_id, principal_id, connection_name, tenant_id,
+			 issued_at, last_activity, absolute_expires_at, hash_expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+		ON CONFLICT(token_hash) DO UPDATE SET
+			session_id          = excluded.session_id,
+			principal_id        = excluded.principal_id,
+			connection_name     = excluded.connection_name,
+			tenant_id           = excluded.tenant_id,
+			issued_at           = excluded.issued_at,
+			last_activity       = excluded.last_activity,
+			absolute_expires_at = excluded.absolute_expires_at`,
+		tokenHash,
+		sess.ID,
+		sess.PrincipalID,
+		sess.ConnectionName,
+		sess.TenantID,
+		formatTime(sess.IssuedAt),
+		formatTime(sess.LastActivity),
+		formatTime(sess.AbsoluteExpiresAt),
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: session token set failed: %w", err)
+	}
+	return nil
+}
+
+// Get returns the Session for the given token hash.
+// Returns ErrSessionNotFound when the hash is absent (including after Delete)
+// or when the hash has passed its per-hash expiry set by StampGraceExpiry.
+func (s *SQLiteSessionTokenStore) Get(ctx context.Context, tokenHash string) (*session.Session, error) {
+	now := formatTime(time.Now().UTC())
+	var sess session.Session
+	var issuedAt, lastActivity, absoluteExpiresAt string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT session_id, principal_id, connection_name, tenant_id,
+		       issued_at, last_activity, absolute_expires_at
+		FROM session_token_records
+		WHERE token_hash = ?
+		  AND (hash_expires_at IS NULL OR hash_expires_at > ?)`, tokenHash, now,
+	).Scan(
+		&sess.ID, &sess.PrincipalID, &sess.ConnectionName, &sess.TenantID,
+		&issuedAt, &lastActivity, &absoluteExpiresAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, session.ErrSessionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: session token get failed: %w", err)
+	}
+	sess.IssuedAt = parseTime(issuedAt)
+	sess.LastActivity = parseTime(lastActivity)
+	sess.AbsoluteExpiresAt = parseTime(absoluteExpiresAt)
+	return &sess, nil
+}
+
+// Delete removes all token-hash rows associated with the given session ID,
+// invalidating the current token and any in-grace prior token simultaneously.
+// Returns ErrSessionNotFound when no rows matched (session was not in the store).
+func (s *SQLiteSessionTokenStore) Delete(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx,
+		`DELETE FROM session_token_records WHERE session_id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("sqlite: session token delete failed: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return session.ErrSessionNotFound
+	}
+	return nil
+}
+
+// ListAll returns one Session per unique session_id, de-duplicating rows that share
+// a session_id (current token + grace slot). Grace-expired rows (hash_expires_at < now)
+// are excluded. The returned slice is ordered by insertion order (ascending rowid).
+// ListAll does not filter by session idle/absolute expiry; the caller (Manager.List) does.
+func (s *SQLiteSessionTokenStore) ListAll(ctx context.Context) ([]*session.Session, error) {
+	now := formatTime(time.Now().UTC())
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT token_hash, session_id, principal_id, connection_name, tenant_id,
+		       issued_at, last_activity, absolute_expires_at
+		FROM session_token_records
+		WHERE hash_expires_at IS NULL OR hash_expires_at > ?
+		ORDER BY rowid`, now)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: session token list failed: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	seen := make(map[string]struct{})
+	var sessions []*session.Session
+	for rows.Next() {
+		var tokenHash string
+		var sess session.Session
+		var issuedAt, lastActivity, absoluteExpiresAt string
+		if err := rows.Scan(
+			&tokenHash, &sess.ID, &sess.PrincipalID, &sess.ConnectionName, &sess.TenantID,
+			&issuedAt, &lastActivity, &absoluteExpiresAt,
+		); err != nil {
+			return nil, fmt.Errorf("sqlite: session token list scan failed: %w", err)
+		}
+		if _, dup := seen[sess.ID]; dup {
+			continue
+		}
+		seen[sess.ID] = struct{}{}
+		sess.IssuedAt = parseTime(issuedAt)
+		sess.LastActivity = parseTime(lastActivity)
+		sess.AbsoluteExpiresAt = parseTime(absoluteExpiresAt)
+		cp := sess
+		sessions = append(sessions, &cp)
+	}
+	return sessions, rows.Err()
+}
+
+// StampGraceExpiry sets the per-hash expiry on a prior-token grace entry.
+// Called by manager.Renew (via the graceStamper type assertion) after rotation
+// so that the old hash is rejected by cluster peers and after controller restarts
+// once the grace window elapses. The manager's in-memory grace tracking (ms.prevExpiry)
+// continues to be authoritative on the issuing node.
+func (s *SQLiteSessionTokenStore) StampGraceExpiry(ctx context.Context, tokenHash string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE session_token_records SET hash_expires_at = ? WHERE token_hash = ?`,
+		formatTime(expiresAt.UTC()), tokenHash)
+	return err
+}


### PR DESCRIPTION
Fixes #2736

## Summary

- Adds `SQLiteSessionTokenStore` (`pkg/storage/providers/sqlite`) implementing `pkg/session.Store`; SHA-256(token) hex is the only key — raw tokens never touch the store or logs.
- `Manager.Validate` and `Renew` fall back to the durable store on cache miss, enabling sessions to survive controller restarts with no re-authentication.
- `Manager.Validate` calls `store.Get` on every live session to detect cross-node revocation within one request cycle.
- `Manager.Revoke` falls back to `store.Delete` on cache miss so post-restart administrative revocation works before any `Validate` re-warms the cache.
- **Grace-window cross-node fix**: `StampGraceExpiry` writes `hash_expires_at` to the rotated-away token row after each `Renew`; `Get`/`ListAll` filter by this column so rotated hashes are rejected by cluster peers once the 30 s grace window elapses, closing the leaked-token replay surface the security review identified.
- `MemStore.Delete` and `SQLiteSessionTokenStore.Delete` return `ErrSessionNotFound` when no records match, giving `Revoke` a clean way to distinguish unknown sessions from successful revocations.
- `server.SetDurableSessionStore` wires both `sessionManager` and `webSessionManager` to the shared store.
- ADR-014 §2 addendum added; stale §3 "revisit #2051" reference updated.

## Test plan

- [x] `RunStoreContractSuite` runs against both `MemStore` and `SQLiteSessionTokenStore`
- [x] `TestManagerSurvivesRestartViaDurableStore` — token issued before restart validates after
- [x] `TestManagerSurvivesRestartAfterRenew` — new token (post-Renew) persists across restart
- [x] `TestRevocationPropagatesAcrossManagers` — node A revokes; node B rejects on next Validate
- [x] `TestRevokeAfterRestartViaDurableStore` — Revoke on empty-cache manager via store fallback
- [x] `TestGraceExpiryHonouredAcrossNodes` — rotated-away hash rejected on peer after grace elapses
- [x] `TestNoRawTokenInDurableStore` — raw-token lookup in SQLite returns ErrSessionNotFound
- [x] `make check-architecture` — no central-provider violations
- [x] `make test-agent-complete` — all 211 script tests + full Go test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)