### PR TITLE
deps: bump gosec v2.27.1 → v2.28.0 (Issue #2756)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,7 +64,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Go-based security and quality tools
 # Versions MUST match .github/workflows/dependency-pin-check.yml
-RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1 \
+RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0 \
     && go install honnef.co/go/tools/cmd/staticcheck@2026.1 \
     && go install github.com/zricethezav/gitleaks/v8@v8.30.1 \
     && go install github.com/google/go-licenses/v2@v2.0.1 \

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -116,7 +116,7 @@ jobs:
         }
 
         echo "Checking pinned tool versions..."
-        check_version "gosec"       "securego/gosec"                          "v2.27.1"
+        check_version "gosec"       "securego/gosec"                          "v2.28.0"
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.1.0"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -205,7 +205,7 @@ jobs:
       continue-on-error: true
 
     - name: Install gosec
-      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
     
     - name: Run gosec Scan
       id: scan
@@ -371,7 +371,7 @@ jobs:
         sudo .github/scripts/install-trivy.sh 'v0.72.0' 'bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea'
 
         # Install gosec and staticcheck
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+        go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
         go install honnef.co/go/tools/cmd/staticcheck@2026.1
     
     - name: Generate Remediation Report on Failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 repos:
   # Go security pattern analysis with gosec
   - repo: https://github.com/securego/gosec
-    rev: v2.27.1
+    rev: v2.28.0
     hooks:
       - id: gosec
         name: gosec security scan

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,7 +60,7 @@ This guide provides instructions for setting up a local CFGMS development enviro
 
 - **gosec** - Security scanning
   ```bash
-  go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+  go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
   ```
 
 - **Serena MCP server** - Semantic code navigation/editing for Claude Code. The

--- a/Makefile
+++ b/Makefile
@@ -1045,7 +1045,7 @@ security-gosec:
 		echo "❌ Error: gosec is not installed"; \
 		echo ""; \
 		echo "Install gosec using Go:"; \
-		echo "  go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1"; \
+		echo "  go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0"; \
 		echo ""; \
 		echo "For more info: https://github.com/securego/gosec"; \
 		exit 1; \

--- a/docs/development/security-setup.md
+++ b/docs/development/security-setup.md
@@ -17,7 +17,7 @@ CFGMS uses a multi-layered security scanning approach with four primary tools:
 # 1. Install security tools
 ./.github/scripts/install-trivy.sh v0.71.0 \
     30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814
-go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 make install-nancy     # Auto-install Nancy for your platform
 
@@ -136,7 +136,7 @@ gosec analyzes Go source code for security problems and anti-patterns.
 
 ```bash
 # Go installation (all platforms) - RECOMMENDED
-go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 
 # Verify installation
 gosec --version
@@ -422,7 +422,7 @@ Current tool versions (as of v0.3.1):
 
 - **Trivy**: v0.71.0 (pinned — v0.69.4-v0.69.6 compromised per CVE-2026-33634; v0.71.0 is the post-incident clean release. Install via `./.github/scripts/install-trivy.sh`. NEVER use @latest, NEVER use `go install`.)
 - **Nancy**: v1.2.0
-- **gosec**: v2.27.1 (pinned — avoid @latest)
+- **gosec**: v2.28.0 (pinned — avoid @latest)
 - **staticcheck**: 2026.1 (pinned — avoid @latest)
 
 ## Contributing to Security Setup
@@ -560,7 +560,7 @@ pre-commit install --install-hooks
 ```bash
 # Install missing Go tools
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
-go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 
 # Verify PATH
 which staticcheck gosec

--- a/docs/development/security-troubleshooting.md
+++ b/docs/development/security-troubleshooting.md
@@ -416,11 +416,11 @@ make security-remediation-report 2>&1 | tee remediation-debug.log
 # Check current versions
 trivy --version      # Should be latest stable
 nancy --version      # Should be v1.0.51+
-gosec -version       # Should be v2.27.1+
+gosec -version       # Should be v2.28.0+
 staticcheck -version # Should be 2023.1+
 
 # Update to compatible versions
-go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 ```
 
@@ -541,7 +541,7 @@ rm -rf ~/.cache/staticcheck
 
 # Reinstall tools
 make install-nancy
-go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
 # Test installations

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -94,7 +94,7 @@ make install-nancy
 
 # Install individual tools (Ubuntu/Debian)
 sudo apt-get install trivy
-go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 ```
 


### PR DESCRIPTION
## Summary

Routine pin refresh: gosec `v2.27.1` → `v2.28.0`. Published 2026-07-14T11:26:26Z; the 3-day cooldown elapsed 2026-07-17T11:26:26Z. A GHSA query against `github.com/securego/gosec/v2` returned zero advisories for `v2.27.1` — no CVE, not urgent.

## Scope correction — the story under-scoped the work

Story #2756 declared **"5 occurrences — lockstep required"** and **"Docs In Scope: None"**. Both were wrong. Per DSD ("trace the full path — source, tests, fixtures, configs, Docker, docs, CI must all reflect the new state"), this PR covers the actual desired state:

**A 6th executable site the story missed:**
- `.pre-commit-config.yaml:12` pinned the gosec repo at `rev: v2.27.1`.

**Nine doc references still telling developers to install the old version:**
- `DEVELOPMENT.md`, `docs/development/security-workflow-guide.md`
- `docs/development/security-setup.md` — including the pinned-versions table (`**gosec**: v2.27.1 (pinned — avoid @latest)`)
- `docs/development/security-troubleshooting.md` — including `gosec -version  # Should be v2.27.1+`

The story asserted *"no architecture doc, pkg/README, or deployment/testing/troubleshooting guide references the gosec version"* — `security-troubleshooting.md` referenced it three times.

**Deliberately left at v2.27.1:** `.claude/skills/refresh-pins/references/decision-matrix.md` — that is an illustrative worked example ("Example 3 — newer release, past cooldown, no CVE"), not a live pin.

## Verification

- `grep -rE "v2\.27\.1" .github .devcontainer Makefile` → **0 matches** (AC #2)
- `gosec@v2.28.0` present at all **6** executable sites (AC #3, +1 over the story's count)
- No `v2.27.1` remains tree-wide outside the worked example
- `make test` passes locally — **211 passed, 0 failed** (AC #4)

## Note on provenance

Recovered from a salvaged worktree patch. The dev agent completed the 5 scoped sites but exited 0 without committing or opening a PR (the intermittent background-bash stall: it backgrounded `make test`, ended its turn awaiting a notification, and print mode terminated it). The worktree diff was saved before the story was Blocked; `cleanup-stale` reaped the worktree seconds later.

Per AC #7: if the `security-scan` gosec step surfaces new findings under v2.28.0 (plausible — v2.28.0 adds a G101 AWS temporary-access-key detector and changes G404/G115), they will be triaged, not suppressed.

Fixes #2756

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3JJNX4W9RLtMCZSXV4Wg2