### PR TITLE
controller+web: fleet health aggregate endpoint and overview tiles (Issue #2729)

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -310,6 +310,40 @@ List all currently-connected stewards from the live connection registry, filtere
 }
 ```
 
+### Fleet Health
+
+#### GET /api/v1/fleet/health
+
+Return tenant-scoped counts of stewards by health classification.
+
+**Authentication:** Required  
+**Required permission:** `steward:list`
+
+**Degraded rule:** A steward with `status == "active"` whose last heartbeat arrived more than 5 minutes ago is counted as Degraded (`DegradedHeartbeatAge = 5m`, defined in `features/controller/api/handlers_fleet.go`).
+
+**Classification:**
+
+| Bucket | Condition |
+|--------|-----------|
+| `healthy` | `status == "active"` and heartbeat within 5 minutes |
+| `degraded` | `status == "active"` and heartbeat older than 5 minutes |
+| `unreachable` | `status == "lost"` |
+
+Lifecycle terminal states (registered, deregistered, archived, dormant, revoked) are not counted in any bucket. Scoping includes the caller's full tenant subtree (caller plus all descendants).
+
+**Response:**
+
+```json
+{
+  "data": {
+    "healthy": 42,
+    "degraded": 3,
+    "unreachable": 1
+  },
+  "timestamp": "2026-07-18T10:30:05Z"
+}
+```
+
 ### Configuration Management
 
 #### GET /api/v1/stewards/{id}/config

--- a/features/controller/api/handlers_fleet.go
+++ b/features/controller/api/handlers_fleet.go
@@ -6,11 +6,28 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// DegradedHeartbeatAge is the heartbeat age beyond which an otherwise-active
+// steward is counted as Degraded in the fleet health aggregate
+// (GET /api/v1/fleet/health). An active steward whose last heartbeat arrived
+// more than DegradedHeartbeatAge ago is experiencing connectivity issues and
+// warrants attention. Mirrors the client-side STALE_AFTER_MS threshold
+// (web/src/fleet/health.ts) so aggregate counts align with per-row health pills.
+const DegradedHeartbeatAge = 5 * time.Minute
+
+// FleetHealthResponse is the response payload for GET /api/v1/fleet/health.
+type FleetHealthResponse struct {
+	Healthy     int `json:"healthy"`
+	Degraded    int `json:"degraded"`
+	Unreachable int `json:"unreachable"`
+}
 
 // SelectorResolveRequest is the request body for POST /api/v1/fleet/resolve.
 type SelectorResolveRequest struct {
@@ -92,4 +109,54 @@ func (s *Server) handleResolveSelector(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("Resolved selector",
 		"selector", logging.SanitizeLogValue(req.Selector), "count", len(stewardList))
 	s.writeSuccessResponse(w, stewardList)
+}
+
+// handleFleetHealth handles GET /api/v1/fleet/health.
+//
+// Returns tenant-scoped counts of stewards by health classification:
+//   - healthy:     status=="active" with a heartbeat within DegradedHeartbeatAge
+//   - degraded:    status=="active" with a heartbeat older than DegradedHeartbeatAge
+//   - unreachable: status=="lost"
+//
+// Other lifecycle states (registered, deregistered, archived, dormant, revoked)
+// are not counted. Scoping includes the caller's full tenant subtree (the caller
+// plus all descendant tenants), consistent with handleResolveSelector.
+// Admin callers (empty TenantID) see the full fleet.
+func (s *Server) handleFleetHealth(w http.ResponseWriter, r *http.Request) {
+	tid, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
+	filter := fleet.Filter{}
+	if tid != "" {
+		filter.TenantSubtree = tid
+	}
+
+	results, err := s.fleetQuery.Search(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("Fleet health query failed", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to query fleet", "INTERNAL_ERROR")
+		return
+	}
+
+	now := time.Now()
+	resp := FleetHealthResponse{}
+	for _, res := range results {
+		switch res.Status {
+		case "active":
+			if now.Sub(res.LastHeartbeat) <= DegradedHeartbeatAge {
+				resp.Healthy++
+			} else {
+				resp.Degraded++
+			}
+		case "lost":
+			resp.Unreachable++
+		}
+	}
+
+	s.logger.Info("Fleet health query",
+		"tenant_id", logging.SanitizeLogValue(tid),
+		"healthy", resp.Healthy,
+		"degraded", resp.Degraded,
+		"unreachable", resp.Unreachable,
+	)
+	s.writeSuccessResponse(w, resp)
 }

--- a/features/controller/api/handlers_fleet_test.go
+++ b/features/controller/api/handlers_fleet_test.go
@@ -17,6 +17,165 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ── handleFleetHealth ─────────────────────────────────────────────────────────
+
+func getFleetHealth(server *Server) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet/health", nil)
+	rec := httptest.NewRecorder()
+	server.handleFleetHealth(rec, req)
+	return rec
+}
+
+func getFleetHealthWithTenant(server *Server, tenantID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet/health", nil)
+	if tenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	}
+	rec := httptest.NewRecorder()
+	server.handleFleetHealth(rec, req)
+	return rec
+}
+
+// fleetHealthData mirrors FleetHealthResponse for test unmarshaling.
+type fleetHealthData struct {
+	Healthy     int `json:"healthy"`
+	Degraded    int `json:"degraded"`
+	Unreachable int `json:"unreachable"`
+}
+
+func extractFleetHealth(t *testing.T, rec *httptest.ResponseRecorder) fleetHealthData {
+	t.Helper()
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	raw, err := json.Marshal(resp.Data)
+	require.NoError(t, err)
+	var h fleetHealthData
+	require.NoError(t, json.Unmarshal(raw, &h))
+	return h
+}
+
+func TestHandleFleetHealth_EmptyFleet_ReturnsZeroCounts(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = seededFleetQuery()
+
+	rec := getFleetHealth(server)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	h := extractFleetHealth(t, rec)
+	assert.Equal(t, 0, h.Healthy)
+	assert.Equal(t, 0, h.Degraded)
+	assert.Equal(t, 0, h.Unreachable)
+}
+
+func TestHandleFleetHealth_ClassifiesByStatusAndHeartbeat(t *testing.T) {
+	now := time.Now()
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{
+		stewards: []fleet.StewardData{
+			// healthy: active + heartbeat within DegradedHeartbeatAge (5 min)
+			{ID: "s1", TenantID: "t", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+			{ID: "s2", TenantID: "t", Status: "active", LastHeartbeat: now.Add(-4 * time.Minute)},
+			// degraded: active + heartbeat older than DegradedHeartbeatAge
+			{ID: "s3", TenantID: "t", Status: "active", LastHeartbeat: now.Add(-6 * time.Minute)},
+			{ID: "s4", TenantID: "t", Status: "active", LastHeartbeat: now.Add(-30 * time.Minute)},
+			// unreachable: lost
+			{ID: "s5", TenantID: "t", Status: "lost", LastHeartbeat: now.Add(-2 * time.Hour)},
+			// not counted: other lifecycle states
+			{ID: "s6", TenantID: "t", Status: "registered", LastHeartbeat: time.Time{}},
+			{ID: "s7", TenantID: "t", Status: "archived", LastHeartbeat: now.Add(-24 * time.Hour)},
+			{ID: "s8", TenantID: "t", Status: "deregistered", LastHeartbeat: now.Add(-48 * time.Hour)},
+		},
+	})
+
+	rec := getFleetHealth(server)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	h := extractFleetHealth(t, rec)
+	assert.Equal(t, 2, h.Healthy, "2 active stewards with fresh heartbeats")
+	assert.Equal(t, 2, h.Degraded, "2 active stewards with stale heartbeats")
+	assert.Equal(t, 1, h.Unreachable, "1 lost steward")
+}
+
+// TestHandleFleetHealth_TenantIsolation is the REQUIRED acceptance-criteria test:
+// a caller scoped to tenant-a must never see tenant-b counts in the aggregate.
+func TestHandleFleetHealth_TenantIsolation(t *testing.T) {
+	now := time.Now()
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{
+		stewards: []fleet.StewardData{
+			// tenant-a stewards (caller's tenant — must appear)
+			{ID: "ta-1", TenantID: "tenant-a", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+			{ID: "ta-2", TenantID: "tenant-a", Status: "active", LastHeartbeat: now.Add(-2 * time.Minute)},
+			// tenant-b stewards (different tenant — must NOT appear)
+			{ID: "tb-1", TenantID: "tenant-b", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+			{ID: "tb-2", TenantID: "tenant-b", Status: "lost", LastHeartbeat: now.Add(-2 * time.Hour)},
+		},
+	})
+
+	rec := getFleetHealthWithTenant(server, "tenant-a")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	h := extractFleetHealth(t, rec)
+	assert.Equal(t, 2, h.Healthy, "tenant-a must only see its own 2 healthy stewards")
+	assert.Equal(t, 0, h.Degraded)
+	assert.Equal(t, 0, h.Unreachable, "tenant-b lost steward must not appear in tenant-a response")
+}
+
+// TestHandleFleetHealth_SubtreeIncludesDescendants verifies that a caller scoped
+// to an ancestor tenant also sees stewards in descendant tenants.
+func TestHandleFleetHealth_SubtreeIncludesDescendants(t *testing.T) {
+	now := time.Now()
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{
+		stewards: []fleet.StewardData{
+			{ID: "s-root", TenantID: "msp-a", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+			{ID: "s-child", TenantID: "msp-a/client-1", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+			{ID: "s-other", TenantID: "msp-b", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+		},
+	})
+
+	rec := getFleetHealthWithTenant(server, "msp-a")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	h := extractFleetHealth(t, rec)
+	assert.Equal(t, 2, h.Healthy, "msp-a parent must see its own steward and child tenant's steward")
+	assert.Equal(t, 0, h.Degraded)
+	assert.Equal(t, 0, h.Unreachable)
+}
+
+// TestHandleFleetHealth_AdminSeesFull verifies that an unauthenticated (admin mTLS)
+// caller with no tenant in context sees the full fleet.
+func TestHandleFleetHealth_AdminSeesFull(t *testing.T) {
+	now := time.Now()
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{
+		stewards: []fleet.StewardData{
+			{ID: "s1", TenantID: "tenant-a", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+			{ID: "s2", TenantID: "tenant-b", Status: "lost", LastHeartbeat: now.Add(-2 * time.Hour)},
+		},
+	})
+
+	rec := getFleetHealth(server) // no tenant in context = admin
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	h := extractFleetHealth(t, rec)
+	assert.Equal(t, 1, h.Healthy)
+	assert.Equal(t, 0, h.Degraded)
+	assert.Equal(t, 1, h.Unreachable)
+}
+
+func TestHandleFleetHealth_FleetQueryError_Returns500(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = &failingFleetQuery{}
+
+	rec := getFleetHealth(server)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "INTERNAL_ERROR", resp.Error.Code)
+}
+
 // fleetTestStewardProvider backs MemoryQuery with a fixed steward list for resolve tests.
 type fleetTestStewardProvider struct {
 	stewards []fleet.StewardData

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -534,6 +534,8 @@ func (s *Server) setupRouter() {
 	// Fleet selector resolve endpoint (Issue #1640)
 	fleetRouter := api.PathPrefix("/fleet").Subrouter()
 	fleetRouter.Handle("/resolve", s.requirePermission("steward", "list")(http.HandlerFunc(s.handleResolveSelector))).Methods("POST")
+	// Fleet health aggregate endpoint (Issue #2729)
+	fleetRouter.Handle("/health", s.requirePermission("steward", "list")(http.HandlerFunc(s.handleFleetHealth))).Methods("GET")
 
 	// Configuration push endpoint (Issue #1318) and push-status read (Issue #2366)
 	cfgPush := api.PathPrefix("/config").Subrouter()

--- a/web/src/fleet/FleetOverview.css
+++ b/web/src/fleet/FleetOverview.css
@@ -10,6 +10,46 @@
  * `pop-views` and `.det`).
  */
 
+/* Fleet health tiles (Issue #2729) — three side-by-side summary cards above the table */
+.health-tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  padding: 0 0 14px;
+}
+.ht {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+.ht .ht-count {
+  font-size: 26px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.ht .ht-label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+.ht.ok .ht-count,
+.ht.ok .ht-label {
+  color: var(--state-ok);
+}
+.ht.warn .ht-count,
+.ht.warn .ht-label {
+  color: var(--state-warn);
+}
+.ht.crit .ht-count,
+.ht.crit .ht-label {
+  color: var(--state-crit);
+}
+
 .ptool {
   display: flex;
   align-items: center;

--- a/web/src/fleet/FleetOverview.test.tsx
+++ b/web/src/fleet/FleetOverview.test.tsx
@@ -76,10 +76,18 @@ function makeSteward(spec: StewardSpec): Steward {
  * When ?q= is present, performs a substring filter on hostname or id to simulate
  * server-side selector filtering (approximation for test purposes — real server
  * applies the full selector grammar).
+ *
+ * Health tiles are best-effort; the mock returns a 503 for /api/v1/fleet/health so
+ * tiles stay hidden in tests that don't specifically test tile rendering.
  */
 function mockFleet(stewards: Steward[]) {
   fetchMock.mockImplementation((input) => {
     const url = new URL(String(input), 'https://controller.test')
+
+    if (url.pathname === '/api/v1/fleet/health') {
+      return Promise.resolve(new Response('{}', { status: 503 }))
+    }
+
     const limit = Number(url.searchParams.get('limit'))
     const offset = Number(url.searchParams.get('offset'))
     const q = url.searchParams.get('q') ?? ''
@@ -96,6 +104,43 @@ function mockFleet(stewards: Steward[]) {
       data: {
         stewards: filtered.slice(offset, offset + limit),
         total: filtered.length,
+        limit,
+        offset,
+      },
+      timestamp: new Date().toISOString(),
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+}
+
+/** Mock both the steward list and the fleet health aggregate. */
+function mockFleetAndHealth(
+  stewards: Steward[],
+  health: { healthy: number; degraded: number; unreachable: number },
+) {
+  fetchMock.mockImplementation((input) => {
+    const url = new URL(String(input), 'https://controller.test')
+
+    if (url.pathname === '/api/v1/fleet/health') {
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: health }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    }
+
+    const limit = Number(url.searchParams.get('limit'))
+    const offset = Number(url.searchParams.get('offset'))
+    const body = {
+      data: {
+        stewards: stewards.slice(offset, offset + limit),
+        total: stewards.length,
         limit,
         offset,
       },
@@ -170,10 +215,14 @@ describe('pagination', () => {
     renderFleet()
     await screen.findByRole('table')
 
-    const firstUrl = String(fetchMock.mock.calls[0]?.[0])
-    expect(firstUrl).toContain('/api/v1/stewards?')
-    expect(firstUrl).toContain('limit=50')
-    expect(firstUrl).toContain('offset=0')
+    // Find the stewards call — health tiles also fire a fetch, so calls[0] is not always stewards.
+    const stewardsArgs = fetchMock.mock.calls.find(
+      (args) => String(args[0]).includes('/api/v1/stewards'),
+    )
+    const stewardsUrl = String(stewardsArgs?.[0])
+    expect(stewardsUrl).toContain('/api/v1/stewards?')
+    expect(stewardsUrl).toContain('limit=50')
+    expect(stewardsUrl).toContain('offset=0')
 
     expect(screen.getByTestId('fleet-count').textContent).toBe('120 stewards')
     expect(screen.getByTestId('fleet-pager').textContent).toContain(
@@ -447,11 +496,17 @@ describe('data states', () => {
   })
 
   it('treats an unexpected response shape as an error, never renders garbage', async () => {
-    fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ data: { wrong: true } }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+    // Use mockImplementation to create a fresh Response per call — the health
+    // tiles also fetch on mount and would consume a shared body created by
+    // mockResolvedValue, causing the stewards call to fail with a body-read error
+    // rather than the expected "unexpected response shape" message.
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ data: { wrong: true } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
     )
     renderFleet()
     await screen.findByRole('alert')
@@ -597,5 +652,29 @@ describe('hostile steward values (security A9.1)', () => {
     expect(document.querySelector('img')).toBeNull()
     expect(document.querySelector('script')).toBeNull()
     expect(document.title).not.toBe('pwned')
+  })
+})
+
+describe('fleet health tiles (Issue #2729)', () => {
+  it('renders three tiles with counts from GET /api/v1/fleet/health', async () => {
+    mockFleetAndHealth(
+      [makeSteward({ id: 's1', hostname: 'host-a', status: 'active' })],
+      { healthy: 12, degraded: 3, unreachable: 1 },
+    )
+    renderFleet()
+    await screen.findByTestId('fleet-health-tiles')
+
+    expect(screen.getByTestId('health-tile-healthy').textContent).toContain('12')
+    expect(screen.getByTestId('health-tile-degraded').textContent).toContain('3')
+    expect(screen.getByTestId('health-tile-unreachable').textContent).toContain('1')
+  })
+
+  it('hides the tiles when the health endpoint is unavailable', async () => {
+    // mockFleet returns 503 for the health endpoint by default.
+    mockFleet([makeSteward({ id: 's1', hostname: 'host-a' })])
+    renderFleet()
+    await screen.findByRole('table')
+
+    expect(screen.queryByTestId('fleet-health-tiles')).not.toBeInTheDocument()
   })
 })

--- a/web/src/fleet/FleetOverview.tsx
+++ b/web/src/fleet/FleetOverview.tsx
@@ -20,7 +20,7 @@
  * from component state to a real route: clicking a row navigates to
  * /stewards/:id (StewardAssetPage).
  */
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useOutletContext } from 'react-router-dom'
 import { isScopeMatch, useTenantScope } from '../shell/TenantScopeContext.tsx'
 import {
@@ -31,7 +31,7 @@ import {
   type ColumnKey,
   type Steward,
 } from './columns.ts'
-import { deriveHealth, parseLastSeen } from './health.ts'
+import { deriveHealth, fetchFleetHealth, parseLastSeen, type FleetHealth } from './health.ts'
 import ColumnPicker from './ColumnPicker.tsx'
 import FleetTable, { type SortState } from './FleetTable.tsx'
 import { ErrorNotice, FleetEmpty, LoadingRows, NoMatch } from './FleetStates.tsx'
@@ -82,6 +82,16 @@ export default function FleetOverview() {
   const [visible, setVisible] = useState<ReadonlySet<ColumnKey>>(
     () => new Set(loadColumnPrefs() ?? DEFAULT_VISIBLE),
   )
+
+  const [fleetHealth, setFleetHealth] = useState<FleetHealth | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchFleetHealth()
+      .then((h) => { if (!cancelled) setFleetHealth(h) })
+      .catch(() => { /* tiles are best-effort; errors are non-blocking */ })
+    return () => { cancelled = true }
+  }, [])
 
   // Reset to page 0 whenever the selector changes so stale pages are not shown.
   // Adjusted during render rather than in an effect: this way the first render
@@ -197,6 +207,24 @@ export default function FleetOverview() {
         <h1>Fleet</h1>
         <p>Stewards enrolled to this controller, with the device DNA you choose.</p>
       </div>
+
+      {fleetHealth !== null && (
+        <div className="health-tiles" data-testid="fleet-health-tiles">
+          <div className="ht ok" data-testid="health-tile-healthy">
+            <span className="ht-count">{formatCount.format(fleetHealth.healthy)}</span>
+            <span className="ht-label">Healthy</span>
+          </div>
+          <div className="ht warn" data-testid="health-tile-degraded">
+            <span className="ht-count">{formatCount.format(fleetHealth.degraded)}</span>
+            <span className="ht-label">Degraded</span>
+          </div>
+          <div className="ht crit" data-testid="health-tile-unreachable">
+            <span className="ht-count">{formatCount.format(fleetHealth.unreachable)}</span>
+            <span className="ht-label">Unreachable</span>
+          </div>
+        </div>
+      )}
+
       <section className="panel">
         <div className="ptool">
           <SavedViews current={currentConfig} onApply={applyView} />

--- a/web/src/fleet/health.test.ts
+++ b/web/src/fleet/health.test.ts
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   STALE_AFTER_MS,
   deriveHealth,
+  fetchFleetHealth,
   formatLastSeen,
   parseLastSeen,
 } from './health.ts'
@@ -98,5 +99,68 @@ describe('formatLastSeen', () => {
 
   it('clamps clock skew (future last_seen) to 0s ago', () => {
     expect(formatLastSeen(iso(-30_000), NOW)).toBe('0s ago')
+  })
+})
+
+// ── fetchFleetHealth (Issue #2729) ────────────────────────────────────────────
+
+const fetchMock = vi.fn<typeof fetch>()
+
+describe('fetchFleetHealth', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    // stub document.cookie so apiFetch doesn't throw in the test environment
+    vi.stubGlobal('document', { cookie: '' })
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns healthy/degraded/unreachable counts from a valid response', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: { healthy: 5, degraded: 2, unreachable: 1 } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    const result = await fetchFleetHealth()
+    expect(result).toEqual({ healthy: 5, degraded: 2, unreachable: 1 })
+  })
+
+  it('returns zeros when all counts are zero', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: { healthy: 0, degraded: 0, unreachable: 0 } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    const result = await fetchFleetHealth()
+    expect(result).toEqual({ healthy: 0, degraded: 0, unreachable: 0 })
+  })
+
+  it('throws when the server returns a non-2xx status', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 503 }))
+    await expect(fetchFleetHealth()).rejects.toThrow('GET /api/v1/fleet/health — 503')
+  })
+
+  it('throws when the response data shape is unexpected', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: { wrong: true } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    await expect(fetchFleetHealth()).rejects.toThrow('unexpected health response shape')
+  })
+
+  it('throws when data is missing entirely', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    await expect(fetchFleetHealth()).rejects.toThrow('unexpected health response shape')
   })
 })

--- a/web/src/fleet/health.ts
+++ b/web/src/fleet/health.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
 
+import { apiFetch } from '../api/client.ts'
+
 /*
  * Health derivation for the fleet view (Story #2497).
  *
@@ -81,6 +83,45 @@ export function deriveHealth(
     default:
       // Unknown lifecycle states render as inert text, never a guessed tone.
       return { label: status?.trim() ? status.trim() : 'Unknown', tone: 'neutral' }
+  }
+}
+
+// ── Fleet health aggregate (Issue #2729) ─────────────────────────────────────
+
+/**
+ * Server-side fleet health aggregate returned by GET /api/v1/fleet/health.
+ * Counts are tenant-scoped and classified by the same degradation rule as
+ * DegradedHeartbeatAge on the controller (5 min stale heartbeat).
+ */
+export interface FleetHealth {
+  healthy: number
+  degraded: number
+  unreachable: number
+}
+
+/**
+ * Fetch the fleet health aggregate from GET /api/v1/fleet/health.
+ * Throws on non-2xx or an unrecognized response shape.
+ */
+export async function fetchFleetHealth(): Promise<FleetHealth> {
+  const resp = await apiFetch('/api/v1/fleet/health')
+  if (!resp.ok) {
+    throw new Error(`GET /api/v1/fleet/health — ${resp.status}`)
+  }
+  const body: unknown = await resp.json()
+  const d = (body as Record<string, unknown> | null)?.['data']
+  const rec = d as Record<string, unknown> | null | undefined
+  if (
+    typeof rec?.['healthy'] !== 'number' ||
+    typeof rec?.['degraded'] !== 'number' ||
+    typeof rec?.['unreachable'] !== 'number'
+  ) {
+    throw new Error('unexpected health response shape')
+  }
+  return {
+    healthy: rec['healthy'] as number,
+    degraded: rec['degraded'] as number,
+    unreachable: rec['unreachable'] as number,
   }
 }
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -13,15 +13,19 @@ const fetchMock = vi.fn<typeof fetch>()
 beforeEach(() => {
   vi.stubGlobal('fetch', fetchMock)
   fetchMock.mockReset()
-  // The fleet view (#2497) fetches its steward page on mount; shell tests
-  // serve it an empty page so the chrome renders over a quiet content area.
-  fetchMock.mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        data: { stewards: [], total: 0, limit: 50, offset: 0 },
-        timestamp: new Date().toISOString(),
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
+  // The fleet view (#2497) fetches its steward page on mount; the health tiles
+  // (Issue #2729) also fetch on mount. Use mockImplementation to create a fresh
+  // Response per call — a shared Response from mockResolvedValue would have its
+  // body consumed by the health fetch, breaking the stewards fetch.
+  fetchMock.mockImplementation(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: { stewards: [], total: 0, limit: 50, offset: 0 },
+          timestamp: new Date().toISOString(),
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
     ),
   )
   document.body.className = ''


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/fleet/health` returning tenant-scoped counts of `healthy`, `degraded`, and `unreachable` stewards
- Active stewards with heartbeats older than `DegradedHeartbeatAge` (5 min) are classified degraded; `"lost"` status maps to unreachable; other lifecycle states (registered, archived, dormant, deregistered, revoked) are not counted
- Route is protected by `requirePermission("steward", "list")`; tenant callers scope to subtree via `fleet.Filter.TenantSubtree`; admin (empty `TenantID`) sees full fleet
- Frontend adds health fetcher (`web/src/fleet/health.ts`) and renders three tiles (Healthy / Degraded / Unreachable) above the steward table; tile fetch is best-effort — errors are silently ignored so the table is never blocked

## Test plan

- [x] `TestHandleFleetHealth_EmptyFleet_ReturnsZeroCounts` — zero counts when fleet is empty
- [x] `TestHandleFleetHealth_ClassifiesByStatusAndHeartbeat` — active+fresh→healthy, active+stale→degraded, lost→unreachable, other statuses ignored
- [x] `TestHandleFleetHealth_TenantIsolation` — tenant-a caller never sees tenant-b counts (required by issue AC)
- [x] `TestHandleFleetHealth_SubtreeIncludesDescendants` — subtree filter includes child tenants
- [x] `TestHandleFleetHealth_AdminSeesFull` — empty TenantID returns full fleet
- [x] `TestHandleFleetHealth_FleetQueryError_Returns500` — storage errors return 500 with generic message
- [x] Frontend: `fetchFleetHealth` — 5 tests covering valid response, zeros, non-2xx, bad shape, missing data key
- [x] Frontend: `FleetOverview` health tiles — renders tiles on success, hides on error
- [x] `make test-agent-complete` passed (all CI gates)
- [x] story-review: 3/3 reviewers passed (QA code, Security, QA test-runner), 0 findings

Fixes #2729

🤖 Generated with [Claude Code](https://claude.com/claude-code)