### PR TITLE
hyperv.vm: declarative in-place rename via old_name (Issue #2776)

### DIFF
--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -51,6 +51,9 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 				optArg(psArgs, "Path", "Path"))
 	case psRemoveVM:
 		return t.run(ctx, "Cfgms-RemoveVM -Name "+quoteArg(psArgs, "Name"))
+	case psRenameVM:
+		return t.run(ctx, "Cfgms-RenameVM -OldName "+quoteArg(psArgs, "OldName")+
+			" -NewName "+quoteArg(psArgs, "NewName"))
 	case psStartVM:
 		return t.run(ctx, "Cfgms-StartVM -Name "+quoteArg(psArgs, "Name"))
 	case psStopVM:

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -174,6 +174,15 @@ function Cfgms-RemoveVM {
         Remove-VM -Name $Name -Force
     }
 }
+function Cfgms-RenameVM {
+    param([Parameter(Mandatory)][string]$OldName, [Parameter(Mandatory)][string]$NewName)
+    Rename-VM -Name $OldName -NewName $NewName -ErrorAction Stop
+    # If the VM was registered as a clustered role whose group is named after the
+    # old VM name, rename the group too so it tracks the VM. Standalone VMs (no
+    # matching cluster group) skip this silently.
+    $grp = Get-ClusterGroup -Name $OldName -ErrorAction SilentlyContinue
+    if ($grp) { $grp.Name = $NewName }
+}
 function Cfgms-StartVM      { param([Parameter(Mandatory)][string]$Name) Start-VM -Name $Name }
 function Cfgms-StopVM       { param([Parameter(Mandatory)][string]$Name) Stop-VM  -Name $Name -Force }
 

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -145,7 +145,14 @@ type SourceConfig struct {
 // holds the FULL desired/observed set. Both are populated by FromYAML /
 // AsMap so a single switch_name string behaves exactly as before.
 type VMConfig struct {
-	Name        string             `yaml:"name"`
+	Name string `yaml:"name"`
+	// OldName, when set, enables declarative in-place rename (#2776). The module
+	// keys a VM by its name, so a bare Name change would create a NEW VM and
+	// orphan the old one. When Name is absent but a VM named OldName exists on
+	// this host, the module renames OldName → Name (and its cluster group +
+	// provisioning record) instead of creating. Idempotent: once Name exists,
+	// OldName is ignored, so leaving OldName in config after the rename is a no-op.
+	OldName     string             `yaml:"old_name,omitempty"`
 	MemoryMB    int64              `yaml:"memory_mb"`
 	CPUCount    int                `yaml:"cpu_count"`
 	VHDPath     string             `yaml:"vhd_path"`
@@ -407,6 +414,10 @@ func switchSetDiff(desired, current []string) (toConnect, toDisconnect []string)
 // Validate checks all VMConfig fields against their respective constraints.
 func (c *VMConfig) Validate() error {
 	if !vmNamePattern.MatchString(c.Name) {
+		return ErrInvalidVMName
+	}
+	// old_name (#2776), when set, must satisfy the same VM-name allowlist as Name.
+	if c.OldName != "" && !vmNamePattern.MatchString(c.OldName) {
 		return ErrInvalidVMName
 	}
 	// 0 means "accept the default" (Generation 2). 1 and 2 are explicitly valid
@@ -704,6 +715,12 @@ const psCreateVM = `$vmArgs = @{}; if ($Path) { $vmArgs['Path'] = $Path }; New-V
 // deletion — so a running VM is hard-powered-off first, then removed. A no-op
 // when the VM is already gone. $Name travels via ArgumentList.
 const psRemoveVM = `$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue; if ($vm) { if ($vm.State -ne 'Off') { Stop-VM -Name $Name -Force -TurnOff }; Remove-VM -Name $Name -Force }`
+
+// psRenameVM renames a VM object in place (#2776), and — if the VM is registered
+// as a clustered role whose group is named after the old VM name — renames that
+// cluster group too so the group name tracks the VM. A standalone VM (no matching
+// cluster group) skips the group rename. $OldName / $NewName travel via ArgumentList.
+const psRenameVM = `Rename-VM -Name $OldName -NewName $NewName -ErrorAction Stop; $grp = Get-ClusterGroup -Name $OldName -ErrorAction SilentlyContinue; if ($grp) { $grp.Name = $NewName }`
 
 // psConnectVMNic connects a NEW network adapter on the VM to the named switch.
 // Both $Name (host-side VM name) and $SwitchName travel via ArgumentList —
@@ -1082,6 +1099,10 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	if v, ok := configMap["vhd_path"].(string); ok {
 		cfg.VHDPath = v
 	}
+	// old_name (#2776): the previous VM name, for declarative in-place rename.
+	if v, ok := configMap["old_name"].(string); ok {
+		cfg.OldName = v
+	}
 	// switch_name (the user-facing key) accepts a single string OR a list of
 	// switch names. The desired config arrives here as a generic config map
 	// (config.AsMap), so parse BOTH shapes into the desired set — the
@@ -1164,6 +1185,28 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	if current.State != "absent" {
 		vmExists = true
 		currentVM = *current
+	}
+
+	// Declarative in-place rename (#2776): the desired VM `name` is absent but an
+	// `old_name` is declared. If a VM by that old_name exists on this host, rename
+	// it (module keys VMs by name, so a bare name change would create-new +
+	// orphan-old). Runs BEFORE the create/HA gates so a rename is preferred over a
+	// create. Idempotent: once `name` exists this is skipped on the next converge.
+	if !vmExists && cfg.OldName != "" && cfg.OldName != vmName {
+		renamed, rerr := m.renameFromOldName(ctx, cfg, vmName)
+		if rerr != nil {
+			return fmt.Errorf("hyperv: set VM %q: %w", vmName, rerr)
+		}
+		if renamed {
+			current, err = m.getVMLocal(ctx, vmName)
+			if err != nil {
+				return fmt.Errorf("hyperv: re-check VM %q after rename: %w", vmName, err)
+			}
+			if current.State != "absent" {
+				vmExists = true
+				currentVM = *current
+			}
+		}
 	}
 
 	// The host object name is the exact VM name — no namespacing.
@@ -1529,6 +1572,71 @@ func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName st
 	// policy self-heals identically to a plain-lifecycle VM. No-op when the policy
 	// is nil (observe-only).
 	return m.reconcileCheckpoints(ctx, hostName, cfg.CheckpointPolicy)
+}
+
+// renameFromOldName performs the #2776 declarative rename: when the desired VM
+// newName is absent on this host but cfg.OldName names an EXISTING local VM, it
+// renames that VM (and its cluster group, if any) to newName and migrates the
+// provisioning record. Returns (true, nil) when a rename occurred, or (false,
+// nil) when there is nothing to rename (the old-named VM is also absent — the
+// caller then creates newName fresh, so old_name on a first-ever provision is
+// harmless). VHD file relocation stays the separate concern of vhd_path + the
+// storage-location convergence (#2411); rename is name-only.
+func (m *hypervModule) renameFromOldName(ctx context.Context, cfg *VMConfig, newName string) (bool, error) {
+	oldName := cfg.OldName
+
+	old, err := m.getVMLocal(ctx, oldName)
+	if err != nil {
+		if errors.Is(err, ErrVMNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("check old VM %q for rename: %w", oldName, err)
+	}
+	if old.State == "absent" {
+		return false, nil
+	}
+
+	if _, err := m.transport.ExecutePS(ctx, psRenameVM,
+		map[string]string{"OldName": oldName, "NewName": newName}); err != nil {
+		return false, fmt.Errorf("rename VM %q -> %q: %w", oldName, newName, err)
+	}
+
+	// Migrate the provisioning record (keyed by VM name) so the renamed VM is not
+	// treated as unprovisioned — which could otherwise trigger a rebuild.
+	m.renameProvisionRecord(ctx, cfg, oldName, newName)
+
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+		"vm-rename", "vm:"+newName, nil,
+		map[string]interface{}{
+			"old_name":  oldName,
+			"new_name":  newName,
+			"clustered": old.HARole != nil,
+		}, nil)
+	return true, nil
+}
+
+// renameProvisionRecord moves a provisioning record from oldName to newName.
+// Best-effort: a VM with no record (e.g. a non-source-provisioned VM) needs no
+// migration, and a store error is logged but does not fail the rename (the VM is
+// already renamed; a missing record only risks a benign re-provision decision the
+// existence gate still guards against).
+func (m *hypervModule) renameProvisionRecord(ctx context.Context, cfg *VMConfig, oldName, newName string) {
+	store := m.storeFor(cfg)
+	rec, err := store.GetProvision(ctx, oldName)
+	if err != nil || rec == nil {
+		return // no record to migrate
+	}
+	rec.VMName = newName
+	if err := store.SetProvision(ctx, rec); err != nil {
+		if logger, ok := m.GetLogger(); ok {
+			logger.Warn("hyperv: rename provisioning record failed",
+				"old_name", logging.SanitizeLogValue(oldName),
+				"new_name", logging.SanitizeLogValue(newName),
+				"error", err.Error())
+		}
+		return
+	}
+	_ = store.DeleteProvision(ctx, oldName)
 }
 
 // createVM issues New-VM with the desired generation and connects every

--- a/features/modules/hyperv/vm_rename_test.go
+++ b/features/modules/hyperv/vm_rename_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callUsed reports whether any recorded transport call used the given script.
+func callUsed(transport *testWinRMTransport, script string) bool {
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	for _, c := range transport.calls {
+		if c.scriptBlock == script {
+			return true
+		}
+	}
+	return false
+}
+
+// TestVMRename_OldExistsNewAbsent_RenamesInPlace is the core #2776 behavior: when
+// the desired VM name is absent but old_name names an existing VM, the module
+// renames it in place (Rename-VM) rather than creating a new VM.
+func TestVMRename_OldExistsNewAbsent_RenamesInPlace(t *testing.T) {
+	const oldName = "cfgms-ci-lin-01"
+	const newName = "lab-lin-01"
+
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,                       // call0: getVMLocal(newName) → absent
+			hostVMJSON(oldName, "stopped", 2, 4096), // call1: getVMLocal(oldName) → found
+			``,                                      // call2: Rename-VM (psRenameVM)
+			hostVMJSON(newName, "stopped", 2, 4096), // call3: getVMLocal(newName) after rename → found
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	cfg := &VMConfig{Name: newName, OldName: oldName, State: "stopped", MemoryMB: 4096, CPUCount: 2, Generation: 2}
+	require.NoError(t, m.Set(context.Background(), "vm:"+newName, cfg))
+
+	require.True(t, callUsed(transport, psRenameVM), "expected a Rename-VM transport call")
+	assert.False(t, callUsed(transport, psCreateVM), "must NOT create a new VM when renaming")
+
+	// The rename call carries both the old and the new name (via ArgumentList).
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	for _, c := range transport.calls {
+		if c.scriptBlock == psRenameVM {
+			assert.Contains(t, c.args, oldName)
+			assert.Contains(t, c.args, newName)
+		}
+	}
+}
+
+// TestVMRename_NewAlreadyExists_Idempotent verifies the rename is a no-op once the
+// VM already has the desired name: no Rename-VM call, no duplicate.
+func TestVMRename_NewAlreadyExists_Idempotent(t *testing.T) {
+	const oldName = "cfgms-ci-lin-01"
+	const newName = "lab-lin-01"
+
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			hostVMJSON(newName, "stopped", 2, 4096), // call0: getVMLocal(newName) → already exists
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	cfg := &VMConfig{Name: newName, OldName: oldName, State: "stopped", MemoryMB: 4096, CPUCount: 2, Generation: 2}
+	require.NoError(t, m.Set(context.Background(), "vm:"+newName, cfg))
+
+	assert.False(t, callUsed(transport, psRenameVM), "no rename once the VM already has the desired name")
+	assert.False(t, callUsed(transport, psCreateVM), "no create when the VM already exists")
+}
+
+// TestRenameFromOldName_OldAbsent_NoOp verifies renameFromOldName is a clean no-op
+// when the old-named VM does not exist (so the caller creates the new VM fresh).
+func TestRenameFromOldName_OldAbsent_NoOp(t *testing.T) {
+	transport := &testWinRMTransport{output: `{"found":false}`} // getVMLocal(old) → absent
+	m := vmModuleWithTransport(transport, "t")
+
+	cfg := &VMConfig{Name: "lab-lin-01", OldName: "cfgms-ci-lin-01"}
+	renamed, err := m.renameFromOldName(context.Background(), cfg, "lab-lin-01")
+	require.NoError(t, err)
+	assert.False(t, renamed, "no rename when the old VM is absent")
+	assert.False(t, callUsed(transport, psRenameVM))
+}
+
+// TestRenameFromOldName_MigratesProvisionRecord verifies the provisioning record
+// follows the rename (old_name → name), so the renamed VM is not treated as
+// unprovisioned.
+func TestRenameFromOldName_MigratesProvisionRecord(t *testing.T) {
+	const oldName = "cfgms-ci-lin-01"
+	const newName = "lab-lin-01"
+	ctx := context.Background()
+
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			hostVMJSON(oldName, "stopped", 2, 4096), // call0: getVMLocal(oldName) → found
+			``,                                      // call1: Rename-VM
+		},
+	}
+	m := vmModuleWithTransport(transport, "t")
+
+	// Seed a provisioning record under the OLD name.
+	store := m.storeFor(&VMConfig{})
+	require.NoError(t, store.SetProvision(ctx, &ProvisionRecord{VMName: oldName, State: ProvisionStateReady}))
+
+	cfg := &VMConfig{Name: newName, OldName: oldName}
+	renamed, err := m.renameFromOldName(ctx, cfg, newName)
+	require.NoError(t, err)
+	require.True(t, renamed)
+
+	// Record now lives under the new name, and the old record is gone.
+	rec, err := store.GetProvision(ctx, newName)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Equal(t, newName, rec.VMName)
+
+	_, err = store.GetProvision(ctx, oldName)
+	assert.Error(t, err, "the old-named provisioning record must be removed after migration")
+}
+
+// TestVMConfig_Validate_InvalidOldName verifies old_name is held to the same
+// VM-name allowlist as name.
+func TestVMConfig_Validate_InvalidOldName(t *testing.T) {
+	c := &VMConfig{Name: "lab-lin-01", OldName: "bad name!", Generation: 2}
+	assert.ErrorIs(t, c.Validate(), ErrInvalidVMName)
+
+	ok := &VMConfig{Name: "lab-lin-01", OldName: "cfgms-ci-lin-01", Generation: 2}
+	assert.NoError(t, ok.Validate())
+}

--- a/test/e2e/hyperv/vm_rename_test.go
+++ b/test/e2e/hyperv/vm_rename_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build e2e
+
+// Live validation of the declarative hyperv.vm in-place rename (old_name → name,
+// Issue #2776) against a real Hyper-V host. It drives the REAL hyperv module
+// (ps-host transport) as the node it runs on — the same "real component, not a
+// mock" approach the cluster suites use — creating a throwaway VM, renaming it
+// via a converge with old_name set, and asserting the module renamed in place
+// (new exists, old gone, no duplicate) rather than creating a second VM.
+//
+// The rename needs no guest OS (Rename-VM operates on the VM object regardless of
+// boot state), so a bare stopped VM with a tiny blank VHD is sufficient. Excluded
+// from CI / make test-complete by the e2e build tag; skips cleanly when
+// CFGMS_E2E_HYPERV_RENAME is unset or the host is not a Hyper-V host.
+package hyperv_e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/modules/hyperv"
+	"github.com/cfgis/cfgms/pkg/audit"
+)
+
+const envRenameE2E = "CFGMS_E2E_HYPERV_RENAME"
+
+// rnBuildModule constructs the real hyperv module wired for ps-host (local
+// PowerShell) transport — no cluster, so the rename path exercises the standalone
+// (non-clustered) VM case. Reuses the package's in-memory audit + secret stores.
+func rnBuildModule(t *testing.T) modules.Module {
+	t.Helper()
+	store := &ccAuditStore{}
+	mgr, err := audit.NewManager(store, "hyperv-rename-e2e")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	m := hyperv.New(hyperv.NewDefaultDetector(), hyperv.WithProvisionStore(hyperv.NewMemProvisionStore()))
+	inj, ok := m.(modules.SecretStoreInjectable)
+	require.True(t, ok)
+	require.NoError(t, inj.SetSecretStore(&e2eSecretStore{secrets: map[string]string{}}))
+
+	cfgbl, ok := m.(modules.Configurable)
+	require.True(t, ok)
+	require.NoError(t, cfgbl.Configure(e2eConfigState{
+		"transport":     "ps-host",
+		"seed_dir":      getenvDefault(envSeedDir, `C:\cfgms\e2e-seed`),
+		"audit_manager": mgr,
+		"steward_id":    "cfgms-e2e-rename-steward",
+	}))
+	return m
+}
+
+// rnVMExists reports whether a VM with the given name exists on the local host.
+func rnVMExists(t *testing.T, name string) bool {
+	out, _ := ccPS(t, `try { if (Get-VM -Name '`+name+`' -ErrorAction Stop) { "yes" } } catch { "" }`)
+	return strings.TrimSpace(out) == "yes"
+}
+
+// rnCleanup removes the named VMs and their VHDs, best-effort.
+func rnCleanup(t *testing.T, vhd string, names ...string) {
+	for _, n := range names {
+		ccPS(t, `try { Stop-VM -Name '`+n+`' -TurnOff -Force -ErrorAction SilentlyContinue; $d=(Get-VMHardDiskDrive -VMName '`+n+`' -ErrorAction SilentlyContinue).Path; Remove-VM -Name '`+n+`' -Force -ErrorAction SilentlyContinue; foreach($x in $d){ Remove-Item $x -Force -ErrorAction SilentlyContinue } } catch {}`)
+	}
+	if vhd != "" {
+		ccPS(t, `Remove-Item '`+vhd+`' -Force -ErrorAction SilentlyContinue`)
+	}
+}
+
+// TestE2E_VMRename_InPlace (REQUIRED, #2776) — a managed VM named old_name is
+// renamed in place to name by a converge, not duplicated, and the rename is
+// idempotent on re-run.
+func TestE2E_VMRename_InPlace(t *testing.T) {
+	if os.Getenv(envRenameE2E) == "" {
+		t.Skipf("live rename e2e: set %s=1 on a Hyper-V host to run", envRenameE2E)
+	}
+	ctx := context.Background()
+
+	const oldName = "cfgms-e2e-rename-old"
+	const newName = "cfgms-e2e-rename-new"
+	vhdDir := getenvDefault("CFGMS_E2E_RENAME_VHD_DIR", `C:\VMs`)
+	vhd := vhdDir + `\` + oldName + `.vhdx`
+
+	rnCleanup(t, vhd, oldName, newName)
+	t.Cleanup(func() { rnCleanup(t, vhd, oldName, newName) })
+
+	// Create a bare stopped VM under the OLD name (blank tiny dynamic VHD — the
+	// rename needs no guest OS).
+	ccPSFatal(t, `New-VHD -Path '`+vhd+`' -SizeBytes 2GB -Dynamic -ErrorAction Stop | Out-Null; `+
+		`New-VM -Name '`+oldName+`' -MemoryStartupBytes 512MB -VHDPath '`+vhd+`' -Generation 2 -ErrorAction Stop | Out-Null`)
+	require.True(t, rnVMExists(t, oldName), "precondition: old-named VM created")
+	require.False(t, rnVMExists(t, newName), "precondition: new name must not exist yet")
+
+	m := rnBuildModule(t)
+
+	// Converge the desired state: name=newName, old_name=oldName. The module must
+	// RENAME the existing oldName VM rather than create a new newName VM.
+	cfg := &hyperv.VMConfig{
+		Name: newName, OldName: oldName, State: "stopped",
+		MemoryMB: 512, Generation: 2, VHDPath: vhd,
+	}
+	require.NoError(t, m.Set(ctx, "vm:"+newName, cfg), "rename converge must succeed")
+
+	assert.True(t, rnVMExists(t, newName), "the VM must now exist under the new name")
+	assert.False(t, rnVMExists(t, oldName), "the old name must be gone (renamed in place, not duplicated)")
+
+	// Idempotent re-run: no error, still exactly the new name, no rename attempt.
+	require.NoError(t, m.Set(ctx, "vm:"+newName, cfg), "idempotent re-converge must succeed")
+	assert.True(t, rnVMExists(t, newName))
+	assert.False(t, rnVMExists(t, oldName))
+}


### PR DESCRIPTION
## Summary

Fixes #2776 (`needs-windows`): the `hyperv.vm` module keys a VM by its name (`getVM` → `Get-VM -Name`), so changing a managed VM's resource name created a **new** VM and orphaned the old one — there was no way to rename a cfgms-managed VM. This adds a declarative `old_name` field so a rename is a first-class, idempotent convergence.

## Behavior

`old_name` (optional): when the desired VM `name` is **absent** on the host but a VM named `old_name` **exists**, the module **renames it in place** (`Rename-VM` + its cluster group, if any) and migrates the provisioning record — instead of creating. Idempotent: once `name` exists, `old_name` is ignored, so leaving it in config after the rename is a no-op. VHD-file relocation stays the separate concern of `vhd_path` + the #2411 storage-location convergence; rename is name-only.

```yaml
- name: lab-lin-01
  old_name: cfgms-ci-lin-01   # renames the existing VM in place, once
  module: hyperv.vm
  config: { ... }
```

## Changes

- `VMConfig.OldName` (yaml `old_name`) + `Validate` (same VM-name allowlist as `name`).
- `setVM` parses `old_name`; a rename hook runs **before** the create/HA gates (rename preferred over create) and re-reads local state so the rest of the converge (power/resize/network) applies to the renamed VM.
- `renameFromOldName` + `renameProvisionRecord` + `psRenameVM`.
- **ps-host transport wiring:** `Cfgms-RenameVM` preamble function + dispatch case (the transport dispatches each `psCommand` to a curated `Cfgms-*` function — declared-functions posture, no arbitrary script). `Cfgms-RenameVM` also renames the cluster group when one is named after the old VM.

## Testing

**Unit** (`vm_rename_test.go`, real module + recording transport): rename fires (old exists, new absent); idempotent (new exists → no rename); no-op (old absent); provision-record migration (`old_name` → `name`); `old_name` validation.

**Live e2e** (`test/e2e/hyperv/vm_rename_test.go`, build tag `e2e`, drives the real module via ps-host transport against a real Hyper-V host):

```
--- PASS: TestE2E_VMRename_InPlace (18.85s)   # CFG-70-02, cfg-lab
```

A real managed VM renamed in place (new exists, old gone, no duplicate), idempotent on re-run. **The live run also caught a gap unit tests couldn't** — `psRenameVM` needed a `Cfgms-RenameVM` dispatch entry, which the recording fake transport doesn't require — now fixed and re-validated live.

## Validation

- `go build ./...`, `go vet`, `gofmt` clean; full `features/modules/hyperv` suite passes; `make check-architecture` clean.
- Live e2e PASS on cfg-lab (above). The `e2e`-tagged test is excluded from `make test-complete` per convention.

## Notes / edge cases

- **Both `name` and `old_name` VMs exist:** the hook only fires when `name` is absent, so `name` wins and the `old_name` VM is left as-is (no action) — documented; the operator resolves the stray VM.
- Discovered doing lab housekeeping (renaming CI runner VMs); this is the clean, declarative path the module needed.

Fixes #2776

🤖 Generated with [Claude Code](https://claude.com/claude-code)