### PR TITLE
pipeline: gate dispatch on the story's own issue state

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -1048,6 +1048,7 @@ def parse_story(issue):
     return {
         "number": number,
         "title": issue.get("title", ""),
+        "state": issue.get("state"),
         "parse_ok": len(warnings) == 0,
         "parse_warnings": warnings,
         "deps_parsed": deps_parsed,
@@ -1153,6 +1154,8 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states, 
     """Greedy conflict-free selection.
 
     Order: ascending story number (stable, predictable); pure drafts (number=None) last.
+    Hold if the story's own issue is already CLOSED/MERGED — the board item is
+    stale and dispatching would burn an agent on delivered work.
     Hold if the story's required execution env is not in this host's caps (routing
     to another host — e.g. windows stories on the linux orchestrator).
     Skip if any dep is not CLOSED.
@@ -1171,6 +1174,27 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states, 
         num = s["number"]
         item_id = s.get("item_id", "")
         req_env = s.get("requires_env", DEFAULT_ENV)
+
+        # Self-closure gate. A story whose own issue is CLOSED (or whose number
+        # resolves to a MERGED PR) was delivered out-of-band — merged under
+        # another PR, or closed by hand — while its project item stayed at
+        # Ready. Without this check the item is re-recommended every cycle and
+        # an agent is dispatched onto already-shipped work until a sweep
+        # happens to notice. Runs before the env/dep gates so the stale board
+        # state is reported regardless of routing. Draft items (number=None)
+        # and stories fetched without a state carry state=None and fall
+        # through — absence of state is never treated as closed.
+        state = s.get("state")
+        if state in ("CLOSED", "MERGED"):
+            recommendations.append({
+                "number": num,
+                "item_id": item_id,
+                "action": "hold",
+                "reason": f"story issue is {state} — board item is stale, move it to Done",
+                "stale_board": True,
+            })
+            continue
+
         if req_env not in caps:
             recommendations.append({
                 "number": num,

--- a/.claude/scripts/tests/self_closure_gate.test.sh
+++ b/.claude/scripts/tests/self_closure_gate.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Regression test for the self-closure dispatch gate in po-cycle-preflight.py.
+#
+# A story whose own GitHub issue is already CLOSED (delivered under another PR,
+# or closed by hand) while its project item still sits at Ready must never be
+# recommended for dispatch. Before this gate the preflight checked only
+# *dependency* closure, so such an item was re-recommended every cycle and an
+# agent was dispatched onto already-shipped work (observed 2026-07-18 on #2726,
+# closed 2026-07-17 with its item still at Ready).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export CFGMS_TEST_PIPELINE_HELPER="${SCRIPT_DIR}/mock-pipeline-helper.sh"
+export CFGMS_AGENT_CAPACITY_GATE=off
+PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
+
+if [[ ! -f "${PREFLIGHT}" ]]; then
+  printf 'FAIL: preflight not found at %s\n' "${PREFLIGHT}" >&2
+  exit 1
+fi
+
+echo "self_closure_gate.test.sh"
+echo "-------------------------"
+
+PREFLIGHT_PATH="$PREFLIGHT" python3 - <<'PY'
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("preflight", os.environ["PREFLIGHT_PATH"])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+ran = 0
+fail = 0
+
+def check(desc, got, want):
+    global ran, fail
+    ran += 1
+    if got == want:
+        print(f"  ok    {desc}")
+    else:
+        fail += 1
+        print(f"  FAIL  {desc}\n         expected: {want!r}\n         actual:   {got!r}")
+
+def story(num, state=None, env="linux", files=None, deps=None):
+    s = {
+        "number": num,
+        "item_id": f"item-{num}",
+        "requires_env": env,
+        "files_parsed": files or [f"pkg/f{num}.go"],
+        "deps_parsed": deps or [],
+    }
+    if state is not None:
+        s["state"] = state
+    return s
+
+# ── parse_story surfaces the issue's own state ──
+check("parse_story carries state=CLOSED",
+      m.parse_story({"number": 1, "title": "t", "body": "", "state": "CLOSED"})["state"],
+      "CLOSED")
+check("parse_story state absent -> None",
+      m.parse_story({"number": 1, "title": "t", "body": ""})["state"],
+      None)
+
+# ── the gate itself ──
+recs = m.compute_dispatch_recommendations(
+    [story(1, state="CLOSED"), story(2, state="OPEN"), story(3)], [], {}, {"linux"}
+)
+by_num = {r["number"]: r for r in recs}
+check("closed story is held", by_num[1]["action"], "hold")
+check("hold reason names closure", "CLOSED" in by_num[1]["reason"], True)
+check("hold flags stale board", by_num[1].get("stale_board"), True)
+check("open story still dispatches", by_num[2]["action"], "dispatch")
+# Backwards compatibility: a story dict with no "state" key (draft items, and
+# any caller predating this field) must not be treated as closed.
+check("missing state still dispatches", by_num[3]["action"], "dispatch")
+
+# A number that resolves to a MERGED PR is likewise delivered.
+recs = m.compute_dispatch_recommendations([story(1, state="MERGED")], [], {}, {"linux"})
+check("merged story is held", recs[0]["action"], "hold")
+
+# The self-closure gate precedes the env gate: a closed windows story on a linux
+# host reports the closure, not the routing hold.
+recs = m.compute_dispatch_recommendations(
+    [story(1, state="CLOSED", env="windows")], [], {}, {"linux"}
+)
+check("closure gate precedes env gate", recs[0].get("stale_board"), True)
+check("closure hold carries no route hint", recs[0].get("route"), None)
+
+# ...and precedes the dep gate: closure is reported over an open dependency.
+recs = m.compute_dispatch_recommendations(
+    [story(1, state="CLOSED", deps=[999])], [], {999: "OPEN"}, {"linux"}
+)
+check("closure gate precedes dep gate", recs[0].get("stale_board"), True)
+
+# A file conflict against an active story must not mask the closure either.
+recs = m.compute_dispatch_recommendations(
+    [story(1, state="CLOSED", files=["pkg/shared.go"])],
+    [story(2, files=["pkg/shared.go"])],
+    {},
+    {"linux"},
+)
+check("closure gate precedes file-conflict gate", recs[0].get("stale_board"), True)
+
+print(f"\nran={ran}  fail={fail}")
+sys.exit(1 if fail else 0)
+PY


### PR DESCRIPTION
## Summary

The `/po` preflight's dispatch gate checked whether a story's *dependencies* were closed but never whether the story's **own issue** was already closed. A story delivered out-of-band — merged under another PR, or closed by hand — while its project item stayed at `Ready` was re-recommended for dispatch every cycle, launching an agent onto already-shipped work until a board sweep happened to catch it.

## Problem Context

Observed during the 2026-07-18 22:12 EDT cron cycle. The preflight recommended item **#2726** ("fleet-wide search with cfg selector grammar") for dispatch and the container was launched. The subsequent pipeline sweep revealed the GitHub issue had closed **2026-07-17 15:31Z** with its project item still sitting at `Ready`. The container was killed, the clone removed, and the orphaned `story-` lease released. Cost: ~5 minutes of one agent's runtime, no PR created.

Left unfixed this repeats every cycle for any story whose issue closes out-of-band, and the failure is silent — the dispatch looks entirely normal until something inspects the issue state.

## Changes

- `parse_story`: surface the issue's own `state` on the parsed story dict (the batched GraphQL fetch already returned it; it was being dropped)
- `compute_dispatch_recommendations`: hold any story whose state is `CLOSED` or `MERGED`, with `stale_board: true` so the consumer can move the board item to Done
- The check runs **before** the env, dependency, and file-conflict gates, so stale board state is reported regardless of routing rather than being masked by an unrelated hold
- `tests/self_closure_gate.test.sh`: new regression test

## Backwards compatibility

Stories carrying no `state` fall through unchanged — absence of state is never read as closed. Project draft items are fetched with `state: "OPEN"` and dispatch normally. Callers constructing story dicts without the field (including the existing `env_routing.test.sh` helper) are unaffected.

## Testing

| Suite | Result |
|---|---|
| `.claude/scripts/tests/*.test.sh` (10 files) | all pass |
| `test-preflight-external-pr.py` | 53 tests, OK |
| `self_closure_gate.test.sh` (new) | 12 assertions, all pass |

The new test covers the gate itself, its precedence over each downstream gate (env / dependency / file-conflict), the `MERGED` case, and the missing-state backwards-compatibility path.

A live `po-act.sh preflight` run against the current board produces well-formed recommendations. Note the gate could not be observed firing live, because the sweep had already corrected #2726's board status before this run — coverage for the firing path is the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5e2oETfBbpBFadKkjY8B