### PR TITLE
controller: wire session managers + durable store into bootstrap (Issue #2774)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -405,6 +405,17 @@ The controller replaces a steward's DNA wholesale on every `DNARefreshLoop` cycl
 - `GetAll(ctx) (map[string][]string, error)` — all entries
 - `TagsFor(stewardID) []string` — convenience accessor with no error return; logs failures
 
+### Session Token Store (Issue #2774)
+
+The session token store (`pkg/session` + `pkg/storage/providers/sqlite`) provides a durable backing store for `pkg/session.Manager`. At bootstrap the controller calls `initializeSessionStore` (`features/controller/server/server.go`) which selects the backing store based on `storage.sqlite_path`:
+
+- **SQLite configured** — `SQLiteSessionTokenStore` is opened at `cfg.Storage.SQLitePath` (a dedicated handle, separate from the shared business-store handle). Both the CLI session manager (ADR-014 defaults: idle 15m / absolute 8h / grace 30s) and the web session manager (idle 60m / absolute 12h / grace 30s) share this store. Sessions survive controller restarts and, with the multi-node store backend (separate story), cluster failovers.
+- **SQLite absent** — `session.NewMemStore()` is used. Sessions are operational but are lost when the controller process stops.
+
+Either way, `httpServer.SetDurableSessionStore(sessionStore)` is called on every startup path so `sessionManager` and `webSessionManager` are never nil, and `POST /api/v1/sessions` / `POST /api/v1/web/login` never return 503 SESSION_UNAVAILABLE.
+
+The security invariant is unchanged by the backing store: `session.Manager` always passes `session.HashToken(token)` to `Store.Set`/`Get` — the raw token value is never stored or logged.
+
 ### Steward Tracking
 
 For each steward, the controller tracks:
@@ -909,7 +920,7 @@ For the operator-facing CLI workflow (first connect, reconnect, session status, 
 - Token values are sanitized from all log output via `logging.SanitizeLogValue()`.
 - Session-token principals carry `IsAdmin=true` with the same tenant scope as the originating mTLS cert (typically empty for admin certs, meaning no tenant restriction).
 - Session tokens are length-distinguishable from API keys: session tokens are 43 chars (base64url without padding), API keys are 44 chars (base64url with padding). The middleware uses this length difference to route auth correctly.
-- A controller restart drops all sessions (re-auth required); durable session store is deferred to the SaaS cluster story (#2051).
+- Session durability follows `storage.sqlite_path`: when SQLite is configured, sessions survive a controller restart and the `cfg` CLI can reconnect without re-authenticating; when SQLite is absent, an in-memory store is used and sessions are lost on restart. The store selection happens at bootstrap (`initializeSessionStore`, story #2774) using the same config signal as the upgrade-store and tag-store fallback paths.
 - The `cfg` CLI stores the session token in the OS-native secret store (Windows Credential Manager, macOS Keychain, Linux Secret Service or kernel keyring) — never in a file on disk. The encrypted admin bundle stored alongside it is machine-bound and cannot be reused from another machine.
 
 ## Multi-Tenancy

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -70,6 +70,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	pkgRegistration "github.com/cfgis/cfgms/pkg/registration"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	"github.com/cfgis/cfgms/pkg/session"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -126,6 +127,7 @@ type Server struct {
 	runManager              *controllerrun.Manager                   // Issue #1673: run/job tracking (must be closed on Stop to release SQLite handle)
 	upgradeStore            business.UpgradeStore                    // Issue #2464: durable upgrade store (must be closed on Stop to release SQLite handle)
 	tagStore                *tagstore.Store                          // Issue #2542: durable tag store (must be closed on Stop to release SQLite handle)
+	sessionStore            session.Store                            // Issue #2774: durable session token store (must be closed on Stop to release SQLite handle)
 	ipTrustExpiryJob        *controllerRegistration.IPTrustExpiryJob // Issue #1697: 30-day dark-window expiry
 	pendingExpiryJob        *controllerRegistration.PendingExpiryJob // Issue #1697: 5-day pending-registration expiry
 	stewardEventManager     *logging.LoggingManager                  // Issue #2139: dedicated sink for ingested steward events
@@ -1092,6 +1094,15 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	upgradeStore := initializeUpgradeStore(context.Background(), cfg, logger)
 	httpServer.SetUpgradeStore(upgradeStore)
 
+	// Issue #2774: Wire durable SQLite-backed session token store; falls back to
+	// in-memory when SQLite is not configured. SetDurableSessionStore wires both the
+	// CLI session manager (ADR-014 defaults) and the web session manager (60m/12h/30s)
+	// from a single shared store, so POST /api/v1/sessions and POST /api/v1/auth/login
+	// are operational on every startup path and never return 503 SESSION_UNAVAILABLE.
+	// The store is held in srv.sessionStore so Stop() can close the SQLite handle.
+	sessionStore := initializeSessionStore(context.Background(), cfg, logger)
+	httpServer.SetDurableSessionStore(sessionStore)
+
 	// Issue #2296: Wire batch job store and rolling-batch executor so that
 	// POST /api/v1/jobs and GET /api/v1/jobs/{id} are operational.
 	// The in-memory store is used for the OSS composite deployment; a durable
@@ -1182,6 +1193,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		storageManager:          storageManager,
 		upgradeStore:            upgradeStore,     // Issue #2464: closed in Stop() to release SQLite handle on Windows
 		tagStore:                tagStoreInstance, // Issue #2542: closed in Stop() to release SQLite handle on Windows
+		sessionStore:            sessionStore,     // Issue #2774: closed in Stop() to release SQLite handle on Windows
 		executionQueue:          executionQueue,   // Issue #1672
 		jobDispatcher:           jobDispatcher,    // Issue #1672
 		ipTrustExpiryJob:        ipTrustExpiryJob, // Issue #1697
@@ -1924,6 +1936,21 @@ func (s *Server) Stop() error {
 		}
 	}
 
+	// Close session store — releases the SQLite connection so temp-directory cleanup
+	// succeeds on Windows (Issue #2774). MemStore.Close() has no error return while
+	// SQLiteSessionTokenStore.Close() does — use a type switch since the two concrete
+	// Close signatures do not unify into a shared interface.
+	if s.sessionStore != nil {
+		switch st := s.sessionStore.(type) {
+		case *session.MemStore:
+			st.Close()
+		case *sqliteprovider.SQLiteSessionTokenStore:
+			if err := st.Close(); err != nil {
+				s.logger.Warn("Failed to close session store", "error", err)
+			}
+		}
+	}
+
 	// Drain in-flight webhook-triggered syncs before closing storage (Issue #681).
 	// WaitForPendingSyncs must run before storageManager.Close() because webhook
 	// sync goroutines write to the config store.
@@ -2425,6 +2452,36 @@ func initializeTagStore(
 	}
 
 	logger.Info("Tag store initialized with SQLite backend (Issue #2542)", "sqlite_path", cfg.Storage.SQLitePath)
+	return store
+}
+
+// initializeSessionStore opens a SQLite-backed session.Store at cfg.Storage.SQLitePath
+// and returns it. Falls back to an in-memory store (logging a warning, no startup failure)
+// when SQLitePath is empty or the SQLite open fails — controller startup is never blocked
+// on session store availability, matching the degrade-gracefully pattern of
+// initializeUpgradeStore and initializeTagStore.
+//
+// The raw path is passed directly to CreateSessionTokenStore (no "file:" DSN prefix).
+// CreateSessionTokenStore calls openAndInit internally, which runs schema DDL — no
+// separate Initialize() call is required.
+func initializeSessionStore(
+	ctx context.Context,
+	cfg *config.Config,
+	logger logging.Logger,
+) session.Store {
+	_ = ctx // reserved for future use (consistent with initializeUpgradeStore)
+	if cfg.Storage == nil || cfg.Storage.SQLitePath == "" {
+		logger.Warn("Session store: SQLite path not configured, using in-memory store (sessions will not survive restart)")
+		return session.NewMemStore(session.DefaultConfig(), time.Now)
+	}
+
+	store, err := (&sqliteprovider.SQLiteProvider{}).CreateSessionTokenStore(map[string]interface{}{"path": cfg.Storage.SQLitePath})
+	if err != nil {
+		logger.Warn("Session store: failed to open SQLite, falling back to in-memory store", "error", err)
+		return session.NewMemStore(session.DefaultConfig(), time.Now)
+	}
+
+	logger.Info("Session store initialized with SQLite backend (Issue #2774)", "sqlite_path", cfg.Storage.SQLitePath)
 	return store
 }
 

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +23,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	sqliteprovider "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // testNonClusterProvider implements interfaces.StorageProvider with ClusterCapable() == false.
@@ -1043,8 +1043,11 @@ func assertUpgradeStoreFunctional(t *testing.T, ctx context.Context, store busin
 	assert.Equal(t, business.UpgradeStatusDispatched, got.Status)
 }
 
-// TestInitializeSessionStore_SQLitePath verifies that initializeSessionStore returns a
-// *sqliteprovider.SQLiteSessionTokenStore when cfg.Storage.SQLitePath is set.
+// TestInitializeSessionStore_SQLitePath verifies that a configured SQLite path yields a
+// durable, disk-backed session store rather than the in-memory fallback. The assertion is
+// behavioral (durability across a fresh store on the same path) plus a negative check on the
+// in-memory type, so the test does not need to import the concrete provider package
+// (pkg/storage/providers/sqlite is off the architecture import allowlist for this file).
 func TestInitializeSessionStore_SQLitePath(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := &config.Config{
@@ -1056,13 +1059,47 @@ func TestInitializeSessionStore_SQLitePath(t *testing.T) {
 	store := initializeSessionStore(context.Background(), cfg, logging.NewNoopLogger())
 	require.NotNil(t, store)
 
-	_, ok := store.(*sqliteprovider.SQLiteSessionTokenStore)
-	assert.True(t, ok, "expected *sqliteprovider.SQLiteSessionTokenStore, got %T", store)
+	// A configured SQLite path must NOT yield the in-memory fallback.
+	_, isMem := store.(*session.MemStore)
+	assert.False(t, isMem, "expected durable SQLite-backed store, got *session.MemStore")
 
-	// Close must succeed without error to prove SQLite handle is owned and releasable.
-	if sqliteStore, cast := store.(*sqliteprovider.SQLiteSessionTokenStore); cast {
-		assert.NoError(t, sqliteStore.Close())
+	// Prove durability through the session.Store contract: a session written here must
+	// survive a fresh store opened on the same path. An in-memory store could not.
+	ctx := context.Background()
+	tokenHash := "hash-durable-2774"
+	now := time.Now().UTC().Truncate(time.Second)
+	sess := &session.Session{
+		ID:                "sess-durable-2774",
+		ConnectionName:    "conn-a",
+		PrincipalID:       "admin-a",
+		TenantID:          "root",
+		IssuedAt:          now,
+		LastActivity:      now,
+		AbsoluteExpiresAt: now.Add(time.Hour),
 	}
+	require.NoError(t, store.Set(ctx, tokenHash, sess))
+
+	// Close the first handle to prove it is owned and releasable, and to let the second
+	// store own the file cleanly. The concrete durable store implements io.Closer.
+	closer, ok := store.(io.Closer)
+	require.True(t, ok, "durable store must implement io.Closer, got %T", store)
+	require.NoError(t, closer.Close(), "durable store must own and release its handle")
+
+	// Reopen on the same path and confirm the session persisted to disk.
+	reopened := initializeSessionStore(context.Background(), cfg, logging.NewNoopLogger())
+	require.NotNil(t, reopened)
+	t.Cleanup(func() {
+		if c, isCloser := reopened.(io.Closer); isCloser {
+			_ = c.Close()
+		}
+	})
+
+	got, err := reopened.Get(ctx, tokenHash)
+	require.NoError(t, err, "session written before restart must survive on disk")
+	require.NotNil(t, got)
+	assert.Equal(t, sess.ID, got.ID)
+	assert.Equal(t, sess.PrincipalID, got.PrincipalID)
+	assert.Equal(t, sess.TenantID, got.TenantID)
 }
 
 // TestInitializeSessionStore_EmptyPath verifies that initializeSessionStore returns a

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/cfgis/cfgms/features/workflow"
 	"github.com/cfgis/cfgms/pkg/ha"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	sqliteprovider "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // testNonClusterProvider implements interfaces.StorageProvider with ClusterCapable() == false.
@@ -1039,4 +1041,86 @@ func assertUpgradeStoreFunctional(t *testing.T, ctx context.Context, store busin
 	require.NoError(t, err, "fallback store must serve reads")
 	assert.Equal(t, "upg-fallback-001", got.ID)
 	assert.Equal(t, business.UpgradeStatusDispatched, got.Status)
+}
+
+// TestInitializeSessionStore_SQLitePath verifies that initializeSessionStore returns a
+// *sqliteprovider.SQLiteSessionTokenStore when cfg.Storage.SQLitePath is set.
+func TestInitializeSessionStore_SQLitePath(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{
+			SQLitePath: filepath.Join(tempDir, "sessions.db"),
+		},
+	}
+
+	store := initializeSessionStore(context.Background(), cfg, logging.NewNoopLogger())
+	require.NotNil(t, store)
+
+	_, ok := store.(*sqliteprovider.SQLiteSessionTokenStore)
+	assert.True(t, ok, "expected *sqliteprovider.SQLiteSessionTokenStore, got %T", store)
+
+	// Close must succeed without error to prove SQLite handle is owned and releasable.
+	if sqliteStore, cast := store.(*sqliteprovider.SQLiteSessionTokenStore); cast {
+		assert.NoError(t, sqliteStore.Close())
+	}
+}
+
+// TestInitializeSessionStore_EmptyPath verifies that initializeSessionStore returns a
+// *session.MemStore when cfg.Storage.SQLitePath is empty.
+func TestInitializeSessionStore_EmptyPath(t *testing.T) {
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{
+			SQLitePath: "",
+		},
+	}
+
+	store := initializeSessionStore(context.Background(), cfg, logging.NewNoopLogger())
+	require.NotNil(t, store)
+
+	_, ok := store.(*session.MemStore)
+	assert.True(t, ok, "expected *session.MemStore, got %T", store)
+
+	if memStore, cast := store.(*session.MemStore); cast {
+		memStore.Close()
+	}
+}
+
+// TestInitializeSessionStore_NilStorage verifies that initializeSessionStore returns
+// a *session.MemStore when cfg.Storage is nil.
+func TestInitializeSessionStore_NilStorage(t *testing.T) {
+	cfg := &config.Config{
+		Storage: nil,
+	}
+
+	store := initializeSessionStore(context.Background(), cfg, logging.NewNoopLogger())
+	require.NotNil(t, store)
+
+	_, ok := store.(*session.MemStore)
+	assert.True(t, ok, "expected *session.MemStore on nil Storage, got %T", store)
+
+	if memStore, cast := store.(*session.MemStore); cast {
+		memStore.Close()
+	}
+}
+
+// TestInitializeSessionStore_BadPath verifies that initializeSessionStore falls back to
+// a *session.MemStore without panicking or returning an error when the SQLite path is
+// unwritable (open failure path).
+func TestInitializeSessionStore_BadPath(t *testing.T) {
+	cfg := &config.Config{
+		Storage: &config.StorageConfig{
+			// Deliberately unwritable: directory that does not exist under a read-only root.
+			SQLitePath: "/nonexistent-readonly-dir/sessions.db",
+		},
+	}
+
+	store := initializeSessionStore(context.Background(), cfg, logging.NewNoopLogger())
+	require.NotNil(t, store, "fallback must not be nil even on SQLite open failure")
+
+	_, ok := store.(*session.MemStore)
+	assert.True(t, ok, "expected *session.MemStore fallback on bad path, got %T", store)
+
+	if memStore, cast := store.(*session.MemStore); cast {
+		memStore.Close()
+	}
 }

--- a/pkg/session/contract.go
+++ b/pkg/session/contract.go
@@ -93,9 +93,8 @@ type Manager interface {
 // The key for Set/Get is SHA-256(token) encoded as hex — the controller never persists
 // the raw token. Delete removes by session ID. The durable implementation lives in
 // pkg/storage/providers/sqlite and enables sessions to survive controller restarts
-// (epic #2735, story #2736).
-//
-// The implementation lives in Story #4 of epic #2213.
+// (epic #2735, story #2736). The bootstrap wiring that selects durable vs. in-memory
+// store based on cfg.Storage.SQLitePath lives in story #2774.
 type Store interface {
 	Set(ctx context.Context, tokenHash string, session *Session) error
 	Get(ctx context.Context, tokenHash string) (*Session, error)

--- a/test/integration/session_store_test.go
+++ b/test/integration/session_store_test.go
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller"
+	controllerConfig "github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// sessionCapturingLogger records every log message (all levels) so the test can assert
+// that raw session token values never appear in controller log output (ADR-014 security
+// invariant: the controller stores and logs only SHA-256(token), never the raw token).
+type sessionCapturingLogger struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func newSessionCapturingLogger() *sessionCapturingLogger { return &sessionCapturingLogger{} }
+
+func (l *sessionCapturingLogger) record(msg string, kv ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.buf.WriteString(msg)
+	for i := 0; i+1 < len(kv); i += 2 {
+		fmt.Fprintf(&l.buf, " %v=%v", kv[i], kv[i+1])
+	}
+	l.buf.WriteByte('\n')
+}
+func (l *sessionCapturingLogger) captured() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+func (l *sessionCapturingLogger) Debug(msg string, kv ...interface{}) { l.record(msg, kv...) }
+func (l *sessionCapturingLogger) Info(msg string, kv ...interface{})  { l.record(msg, kv...) }
+func (l *sessionCapturingLogger) Warn(msg string, kv ...interface{})  { l.record(msg, kv...) }
+func (l *sessionCapturingLogger) Error(msg string, kv ...interface{}) { l.record(msg, kv...) }
+func (l *sessionCapturingLogger) Fatal(msg string, kv ...interface{}) { l.record(msg, kv...) }
+func (l *sessionCapturingLogger) DebugCtx(_ context.Context, msg string, kv ...interface{}) {
+	l.record(msg, kv...)
+}
+func (l *sessionCapturingLogger) InfoCtx(_ context.Context, msg string, kv ...interface{}) {
+	l.record(msg, kv...)
+}
+func (l *sessionCapturingLogger) WarnCtx(_ context.Context, msg string, kv ...interface{}) {
+	l.record(msg, kv...)
+}
+func (l *sessionCapturingLogger) ErrorCtx(_ context.Context, msg string, kv ...interface{}) {
+	l.record(msg, kv...)
+}
+func (l *sessionCapturingLogger) FatalCtx(_ context.Context, msg string, kv ...interface{}) {
+	l.record(msg, kv...)
+}
+
+// sessionFreePort returns an available TCP port on localhost.
+func sessionFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// sessionCreateResponse mirrors the JSON returned by POST /api/v1/sessions.
+type sessionCreateResponse struct {
+	SessionID string    `json:"session_id"`
+	Token     string    `json:"token"`
+	IssuedAt  time.Time `json:"issued_at"`
+}
+
+// sessionListResponse mirrors the JSON returned by GET /api/v1/sessions.
+type sessionListResponse struct {
+	Sessions []struct {
+		SessionID string `json:"session_id"`
+	} `json:"sessions"`
+}
+
+// newTestCertManager initialises a cert.Manager with a fresh CA at certPath.
+func newTestCertManager(t *testing.T, certPath string) *cert.Manager {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(certPath, 0755))
+	mgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: certPath,
+		CAConfig: &cert.CAConfig{
+			Organization:       "CFGMS Session Store Integration Test CA",
+			Country:            "US",
+			ValidityDays:       1,
+			KeySize:            2048,
+		},
+		LoadExistingCA:       false,
+		RenewalThresholdDays: 1,
+	})
+	require.NoError(t, err, "cert.NewManager")
+	return mgr
+}
+
+// newTestControllerConfig builds a minimal controller config for integration tests.
+// httpPort must be a specific port (not 0) so GetHTTPListenAddr() returns a usable address.
+func newTestControllerConfig(httpPort int, certPath, storageRoot, sqlitePath string) *controllerConfig.Config {
+	return &controllerConfig.Config{
+		ListenAddr: fmt.Sprintf("127.0.0.1:%d", httpPort),
+		CertPath:   certPath,
+		Storage: &controllerConfig.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: storageRoot,
+			SQLitePath:   sqlitePath,
+		},
+		Certificate: &controllerConfig.CertificateConfig{
+			EnableCertManagement:   true,
+			CAPath:                 filepath.Join(certPath, "ca"),
+			RenewalThresholdDays:   1,
+			ServerCertValidityDays: 1,
+			ClientCertValidityDays: 1,
+			Server: &controllerConfig.ServerCertificateConfig{
+				CommonName:   "localhost",
+				DNSNames:     []string{"localhost", "127.0.0.1"},
+				IPAddresses:  []string{"127.0.0.1", "::1"},
+				Organization: "Test Organization",
+			},
+		},
+	}
+}
+
+// adminHTTPClient builds an *http.Client that presents the given admin mTLS cert and
+// trusts the CA from certMgr.
+func adminHTTPClient(t *testing.T, certMgr *cert.Manager, adminTLSCert tls.Certificate) *http.Client {
+	t.Helper()
+	caPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+	caPool := x509.NewCertPool()
+	require.True(t, caPool.AppendCertsFromPEM(caPEM), "CA pool append")
+
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{adminTLSCert},
+				RootCAs:      caPool,
+				MinVersion:   tls.VersionTLS12,
+			},
+		},
+	}
+}
+
+// noAuthHTTPClient builds an *http.Client that trusts the CA but presents no client cert.
+func noAuthHTTPClient(t *testing.T, certMgr *cert.Manager) *http.Client {
+	t.Helper()
+	caPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+	caPool := x509.NewCertPool()
+	require.True(t, caPool.AppendCertsFromPEM(caPEM), "CA pool append")
+
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    caPool,
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+}
+
+// waitForHTTPReady polls GET /api/v1/health until the controller answers or times out.
+func waitForHTTPReady(t *testing.T, httpClient *http.Client, base string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := httpClient.Get(base + "/api/v1/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("controller HTTP not ready at %s within %v", base, timeout)
+}
+
+// startController boots a controller, waits for it to be ready, and registers cleanup.
+// Returns the running controller and the HTTPS base URL.
+func startController(t *testing.T, cfg *controllerConfig.Config, logger logging.Logger, httpClient *http.Client) (*controller.Controller, string) {
+	t.Helper()
+	ctrl, err := controller.New(cfg, logger)
+	require.NoError(t, err, "controller.New")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- ctrl.Start(ctx) }()
+
+	base := fmt.Sprintf("https://%s", cfg.ListenAddr)
+	waitForHTTPReady(t, httpClient, base, 30*time.Second)
+
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		if err := ctrl.Stop(stopCtx); err != nil && !strings.Contains(err.Error(), "not running") {
+			t.Logf("controller Stop: %v", err)
+		}
+	})
+
+	return ctrl, base
+}
+
+// issueSession calls POST /api/v1/sessions with the given HTTP client (must carry admin
+// mTLS cert) and returns the session token.
+func issueSession(t *testing.T, client *http.Client, base string) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"connection_name": "integ-test"})
+	require.NoError(t, err)
+
+	resp, err := client.Post(base+"/api/v1/sessions", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode,
+		"POST /api/v1/sessions must return 201; body: %s", string(bodyBytes))
+
+	var respData sessionCreateResponse
+	require.NoError(t, json.Unmarshal(bodyBytes, &respData))
+	require.NotEmpty(t, respData.Token, "response must contain a token")
+	return respData.Token
+}
+
+// validateSession calls GET /api/v1/sessions using the given Bearer token.
+// Returns (statusCode, response body).
+func validateSession(t *testing.T, client *http.Client, base, token string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, base+"/api/v1/sessions", nil)
+	require.NoError(t, err)
+	// Use the session token as a Bearer credential; middleware validates it.
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(bodyBytes)
+}
+
+// TestSessionStore_SQLite_PersistenceAcrossRestart verifies the full session store
+// bootstrap path (Issue #2774, epic #2735):
+//
+//  1. A real controller boots via server.New() + server.Start() with SQLite configured.
+//  2. A real POST /api/v1/sessions issues a token via mTLS admin cert.
+//  3. The controller is stopped (simulating a restart).
+//  4. A second controller opens the same SQLite path.
+//  5. The original token validates against the new controller — proving session durability.
+//  6. The raw token value never appears in controller log output or the SQLite file bytes.
+func TestSessionStore_SQLite_PersistenceAcrossRestart(t *testing.T) {
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "certs")
+	sqlitePath := filepath.Join(tempDir, "cfgms.db")
+	storageRoot := filepath.Join(tempDir, "storage")
+
+	certMgr := newTestCertManager(t, certPath)
+
+	// Issue admin mTLS client cert (carries the CFGMS admin marker extension).
+	adminCertBundle, err := certMgr.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:       "integ-session-admin",
+		Organization:     "CFGMS",
+		ValidityDays:     1,
+		KeySize:          2048,
+		TemplateModifier: cert.SetAdminMarker,
+	})
+	require.NoError(t, err, "generate admin cert")
+
+	adminTLSCert, err := tls.X509KeyPair(adminCertBundle.CertificatePEM, adminCertBundle.PrivateKeyPEM)
+	require.NoError(t, err)
+
+	adminClient := adminHTTPClient(t, certMgr, adminTLSCert)
+	healthClient := noAuthHTTPClient(t, certMgr)
+
+	// ── Phase 1: first controller ──────────────────────────────────────────────
+	httpPort1 := sessionFreePort(t)
+	cfg1 := newTestControllerConfig(httpPort1, certPath, storageRoot, sqlitePath)
+
+	logger1 := newSessionCapturingLogger()
+	ctrl1, base1 := startController(t, cfg1, logger1, healthClient)
+	_ = ctrl1
+
+	token := issueSession(t, adminClient, base1)
+	t.Logf("issued session token (length=%d)", len(token))
+
+	// Immediately validate: proves the token works on the issuing controller.
+	code, _ := validateSession(t, adminClient, base1, token)
+	assert.Equal(t, http.StatusOK, code, "token must validate on issuing controller")
+
+	// Assert raw token never appears in log output from the issuing controller.
+	log1 := logger1.captured()
+	assert.NotContains(t, log1, token,
+		"raw session token must not appear in controller log output (ADR-014 security invariant)")
+
+	// Stop the first controller (simulates a process restart).
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopCancel()
+	err = ctrl1.Stop(stopCtx)
+	if err != nil && !strings.Contains(err.Error(), "not running") {
+		t.Logf("ctrl1.Stop: %v", err)
+	}
+	// Remove the cleanup registered by startController so we don't double-stop.
+	// (t.Cleanup callbacks run in reverse order — the registered one fires last; it
+	// checks "not running" so a second Stop is safe.)
+
+	// ── Phase 2: second controller against the same SQLite ─────────────────────
+	httpPort2 := sessionFreePort(t)
+	cfg2 := newTestControllerConfig(httpPort2, certPath, storageRoot, sqlitePath)
+
+	logger2 := newSessionCapturingLogger()
+	ctrl2, base2 := startController(t, cfg2, logger2, healthClient)
+	_ = ctrl2
+
+	// The token issued by controller-1 must still validate on controller-2.
+	// The manager's loadFromStore path queries SQLite to rebuild the in-memory state.
+	code2, body2 := validateSession(t, adminClient, base2, token)
+	assert.Equal(t, http.StatusOK, code2,
+		"session token must survive controller restart when SQLite is configured; body: %s", body2)
+
+	// Assert raw token never appears in log output from the second controller either.
+	log2 := logger2.captured()
+	assert.NotContains(t, log2, token,
+		"raw session token must not appear in second controller log output")
+
+	// Assert raw token is not present in the SQLite file bytes.
+	// Only session.HashToken(token) output may appear as the stored key.
+	dbBytes, err := os.ReadFile(sqlitePath)
+	require.NoError(t, err, "SQLite file must be readable for byte-level assertion")
+	assert.NotContains(t, string(dbBytes), token,
+		"raw session token must not appear in SQLite file bytes; only its SHA-256 hash may be stored")
+
+	// Verify the hash IS present in the file (proving the record was written).
+	tokenHash := session.HashToken(token)
+	assert.Contains(t, string(dbBytes), tokenHash,
+		"SHA-256 hash of session token must appear in SQLite file (proves the record was written)")
+}
+
+// TestSessionStore_InMemoryFallback_SessionsWorkAndAreNonDurable verifies:
+//
+//   - When no SQLitePath is configured, POST /api/v1/sessions returns 201 (not 503),
+//     proving sessionManager is never nil even on the in-memory fallback path (Issue #2774).
+//   - A session token issued by controller-1 is rejected by a fresh controller-2
+//     started against the same config (no shared durable store), proving the fallback
+//     store is genuinely non-durable.
+func TestSessionStore_InMemoryFallback_SessionsWorkAndAreNonDurable(t *testing.T) {
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "certs")
+	storageRoot := filepath.Join(tempDir, "storage")
+
+	certMgr := newTestCertManager(t, certPath)
+
+	adminCertBundle, err := certMgr.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:       "integ-session-inmem-admin",
+		Organization:     "CFGMS",
+		ValidityDays:     1,
+		KeySize:          2048,
+		TemplateModifier: cert.SetAdminMarker,
+	})
+	require.NoError(t, err, "generate admin cert")
+
+	adminTLSCert, err := tls.X509KeyPair(adminCertBundle.CertificatePEM, adminCertBundle.PrivateKeyPEM)
+	require.NoError(t, err)
+
+	adminClient := adminHTTPClient(t, certMgr, adminTLSCert)
+	healthClient := noAuthHTTPClient(t, certMgr)
+
+	// ── Phase 1: controller with NO SQLitePath ─────────────────────────────────
+	httpPort1 := sessionFreePort(t)
+	// No SQLitePath — triggers in-memory fallback path in initializeSessionStore.
+	cfg1 := newTestControllerConfig(httpPort1, certPath, storageRoot, "")
+
+	ctrl1, base1 := startController(t, cfg1, logging.NewNoopLogger(), healthClient)
+	_ = ctrl1
+
+	// POST /api/v1/sessions must return 201 (not 503 SESSION_UNAVAILABLE).
+	// This is the direct AC for the nil-manager gap at handlers_sessions.go:42.
+	token := issueSession(t, adminClient, base1)
+	t.Logf("in-memory session token issued (length=%d)", len(token))
+
+	// Validate it works on the same controller (proves the manager is wired correctly).
+	code, _ := validateSession(t, adminClient, base1, token)
+	assert.Equal(t, http.StatusOK, code, "session must validate on issuing in-memory controller")
+
+	// Stop controller-1 (in-memory store is lost).
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopCancel()
+	if err := ctrl1.Stop(stopCtx); err != nil && !strings.Contains(err.Error(), "not running") {
+		t.Logf("ctrl1.Stop: %v", err)
+	}
+
+	// ── Phase 2: second controller with NO SQLitePath ──────────────────────────
+	httpPort2 := sessionFreePort(t)
+	cfg2 := newTestControllerConfig(httpPort2, certPath, storageRoot, "")
+
+	ctrl2, base2 := startController(t, cfg2, logging.NewNoopLogger(), healthClient)
+	_ = ctrl2
+
+	// The token issued by controller-1 must NOT validate on controller-2 (no shared store).
+	// A 401 proves that in-memory sessions are non-durable — the session is genuinely gone
+	// after the restart, ruling out any accidental durable path.
+	code2, body2 := validateSession(t, adminClient, base2, token)
+	assert.Equal(t, http.StatusUnauthorized, code2,
+		"in-memory session token must not survive restart (non-durable); body: %s", body2)
+}


### PR DESCRIPTION
## Summary

- Wires the existing session-manager infrastructure into the controller bootstrap so `POST /api/v1/sessions` and `POST /api/v1/auth/login` are always operational and **never return 503 SESSION_UNAVAILABLE**.
- When `cfg.Storage.SQLitePath` is set, a SQLite-backed `SQLiteSessionTokenStore` is opened so sessions survive a controller restart (validated via `loadFromStore` on next boot).
- When `SQLitePath` is empty or the SQLite open fails, falls back to `MemStore` so sessions remain functional (non-durable but not broken).
- `SetDurableSessionStore` wires both the CLI manager (idle 15 m / abs 8 h) and the web manager (idle 60 m / abs 12 h) from a single shared store.
- The store handle is held in `srv.sessionStore` and closed in `Stop()` via a type switch (the two `Close()` signatures are incompatible via a common interface).
- **Security invariant maintained end-to-end**: raw tokens are never stored or logged; only `session.HashToken()` results are persisted.

## Changes

| File | Change |
|------|--------|
| `features/controller/server/server.go` | Added `sessionStore` field, `initializeSessionStore()` helper, wiring in `New()`, close in `Stop()` |
| `features/controller/server/server_test.go` | 4 unit tests for `initializeSessionStore` (SQLite, empty path, nil Storage, bad path → fallback) |
| `test/integration/session_store_test.go` | 2 integration tests: SQLite persistence across restart; in-memory non-durability |
| `pkg/session/contract.go` | Doc comment pointing to bootstrap wiring story |
| `docs/architecture/controller-operating-model.md` | Updated to reflect durable-vs-in-memory session store behaviour |

## Test plan

- [x] `make test` passes (pre-flight)
- [x] `make test-commit` passes (all unit + security + lint)
- [x] `TestInitializeSessionStore_*` (4 unit tests) — cover all store-selection paths
- [x] `TestSessionStore_SQLite_PersistenceAcrossRestart` — boots two sequential real controllers; verifies token valid after restart; asserts raw token absent from logs and SQLite bytes; hash present in SQLite bytes
- [x] `TestSessionStore_InMemoryFallback_SessionsWorkAndAreNonDurable` — boots two real controllers with no SQLitePath; verifies 201 on issue, 401 on second controller (proves non-durability)
- [x] No mocks — all tests use real CFGMS components (`controller.New()` + `cert.NewManager`)
- [x] No hardcoded secrets
- [x] `make check-architecture` passes (no central provider violations)

Fixes #2774