### PR TITLE
steward/terminal: Terminal RPC dial-out PTY bridge (Issue #2760)

### DIFF
--- a/api/proto/transport/control.pb.go
+++ b/api/proto/transport/control.pb.go
@@ -41,6 +41,7 @@ const (
 	CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT   CommandType = 9  // Issue #1817: controller pushes current signing cert on every steward connect
 	CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY CommandType = 10 // Issue #1943: controller pushes a new steward binary for self-upgrade
 	CommandType_COMMAND_TYPE_RELAY_RESPONSE      CommandType = 11 // Issue #1994: controller sends relay response back to steward relay goroutine
+	CommandType_COMMAND_TYPE_OPEN_TERMINAL       CommandType = 12 // Issue #2760: steward dials out Terminal RPC and bridges to a local PTY
 )
 
 // Enum value maps for CommandType.
@@ -58,6 +59,7 @@ var (
 		9:  "COMMAND_TYPE_PUSH_SIGNING_CERT",
 		10: "COMMAND_TYPE_PUSH_STEWARD_BINARY",
 		11: "COMMAND_TYPE_RELAY_RESPONSE",
+		12: "COMMAND_TYPE_OPEN_TERMINAL",
 	}
 	CommandType_value = map[string]int32{
 		"COMMAND_TYPE_UNSPECIFIED":         0,
@@ -72,6 +74,7 @@ var (
 		"COMMAND_TYPE_PUSH_SIGNING_CERT":   9,
 		"COMMAND_TYPE_PUSH_STEWARD_BINARY": 10,
 		"COMMAND_TYPE_RELAY_RESPONSE":      11,
+		"COMMAND_TYPE_OPEN_TERMINAL":       12,
 	}
 )
 
@@ -870,7 +873,7 @@ const file_transport_control_proto_rawDesc = "" +
 	"\adetails\x18\x06 \x03(\v2&.cfgms.transport.Response.DetailsEntryR\adetails\x1a:\n" +
 	"\fDetailsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\x8c\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\xac\x03\n" +
 	"\vCommandType\x12\x1c\n" +
 	"\x18COMMAND_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18COMMAND_TYPE_SYNC_CONFIG\x10\x01\x12\x19\n" +
@@ -884,7 +887,8 @@ const file_transport_control_proto_rawDesc = "" +
 	"\x1eCOMMAND_TYPE_PUSH_SIGNING_CERT\x10\t\x12$\n" +
 	" COMMAND_TYPE_PUSH_STEWARD_BINARY\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bCOMMAND_TYPE_RELAY_RESPONSE\x10\v*\xf8\x03\n" +
+	"\x1bCOMMAND_TYPE_RELAY_RESPONSE\x10\v\x12\x1e\n" +
+	"\x1aCOMMAND_TYPE_OPEN_TERMINAL\x10\f*\xf8\x03\n" +
 	"\tEventType\x12\x1a\n" +
 	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19EVENT_TYPE_CONFIG_APPLIED\x10\x01\x12\x19\n" +

--- a/api/proto/transport/control.proto
+++ b/api/proto/transport/control.proto
@@ -22,6 +22,9 @@ enum CommandType {
   COMMAND_TYPE_PUSH_SIGNING_CERT = 9; // Issue #1817: controller pushes current signing cert on every steward connect
   COMMAND_TYPE_PUSH_STEWARD_BINARY = 10; // Issue #1943: controller pushes a new steward binary for self-upgrade
   COMMAND_TYPE_RELAY_RESPONSE = 11;      // Issue #1994: controller sends relay response back to steward relay goroutine
+  // Issue #2760: steward dials out Terminal RPC and bridges to a local PTY.
+  // Command.params keys: session_id (string), shell (string), cols (int32), rows (int32).
+  COMMAND_TYPE_OPEN_TERMINAL = 12;
 }
 
 // EventType enumerates the types of events a steward emits to a controller.

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -917,6 +917,16 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 	// the script module executor and publishes EventScriptCompleted (Issue #1669).
 	handler.RegisterExecuteScriptHandler()
 
+	// Register open_terminal handler — steward dials out Terminal RPC and bridges
+	// it to a local PTY for an interactive admin session. (Issue #2760)
+	//
+	// The dialer resolves the gRPC transport client lazily at Dial() time rather
+	// than at setup time. Registering unconditionally (like every other handler)
+	// removes the silent "no handler for command type" failure mode that occurred
+	// when the transport client was not yet available at setup, and makes the
+	// wiring exercisable with an in-process control plane.
+	handler.RegisterOpenTerminalHandler(&terminalDialer{c: c})
+
 	// Register push_signing_cert handler — controller pushes current signing cert on connect
 	// or after rotation. The handler persists before updating in-memory state (Issue #1816).
 	handler.RegisterHandler(cpTypes.CommandPushSigningCert, func(ctx context.Context, cmd *cpTypes.Command) error {

--- a/features/steward/client/open_terminal_handler_test.go
+++ b/features/steward/client/open_terminal_handler_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package client exercises the CommandOpenTerminal handler registered in setupCommandHandler.
+//
+// Issue #2760: setupCommandHandler must call handler.RegisterOpenTerminalHandler()
+// so a controller-sent open_terminal command is dispatched through the terminal
+// bridge and produces EventCommandCompleted — not EventCommandFailed
+// ("no handler for command type"). Without this wiring an open_terminal command
+// dispatched by the controller silently fails.
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/steward/execution"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+)
+
+// TestSetupCommandHandler_RegistersOpenTerminal verifies that the command handler
+// built by setupCommandHandler dispatches CommandOpenTerminal through the
+// production registration path rather than falling through to EventCommandFailed.
+// A real TransportClient with an in-process eventCapture control plane is used —
+// no mocks (Issue #2760).
+//
+// This guards against accidental removal of the RegisterOpenTerminalHandler call
+// from setupCommandHandler, which would cause a controller-dispatched open_terminal
+// command to silently produce EventCommandFailed with "no handler for command type".
+func TestSetupCommandHandler_RegistersOpenTerminal(t *testing.T) {
+	exec, err := execution.NewExecutor(&execution.ExecutorConfig{Logger: newTestLogger(t)})
+	require.NoError(t, err)
+
+	capture := newEventCapture()
+	c := newMinimalClientWithCP(t, newTestSession(), exec, capture, "steward-open-term", "tenant-open-term")
+
+	handler, err := c.setupCommandHandler(context.Background(), "steward-open-term")
+	require.NoError(t, err)
+
+	// Omitting the shell param makes handleOpenTerminal fall back to the platform
+	// default shell, which is always in the platform allowlist, so shell validation
+	// passes and the handler returns nil (EventCommandCompleted). The actual PTY
+	// bridge runs in a background goroutine and is not part of this assertion — the
+	// bridge is exercised end-to-end in terminal_bridge_test.go.
+	cmd := &cpTypes.SignedCommand{Command: cpTypes.Command{
+		ID:        "cmd-open-term-1",
+		Type:      cpTypes.CommandOpenTerminal,
+		StewardID: "steward-open-term",
+		TenantID:  "tenant-open-term",
+		Timestamp: time.Now(),
+		Params: map[string]interface{}{
+			"session_id": "sess-2760-test",
+			"cols":       float64(80),
+			"rows":       float64(24),
+		},
+	}}
+	require.NoError(t, handler.HandleCommand(context.Background(), cmd))
+	handler.Wait()
+
+	events := drainEvents(capture.events)
+	require.NotEmpty(t, events, "open_terminal dispatch must publish a status event")
+
+	var completed *cpTypes.Event
+	for _, evt := range events {
+		require.NotEqualf(t, cpTypes.EventCommandFailed, evt.Type,
+			"open_terminal must be registered in setupCommandHandler — got EventCommandFailed: %v", evt.Details)
+		if evt.Type == cpTypes.EventCommandCompleted {
+			completed = evt
+		}
+	}
+	require.NotNil(t, completed, "open_terminal dispatch must publish EventCommandCompleted")
+	require.Equal(t, "cmd-open-term-1", completed.CommandID)
+}

--- a/features/steward/client/terminal_bridge.go
+++ b/features/steward/client/terminal_bridge.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/steward/commands"
+	"github.com/cfgis/cfgms/features/terminal/shell"
+	grpcCP "github.com/cfgis/cfgms/pkg/controlplane/providers/grpc"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TerminalBridge dials the controller's Terminal RPC and bridges the bidirectional
+// stream to a local PTY for the lifetime of an interactive admin session (Issue #2760).
+// Implements commands.TerminalDialer; a single bridge handles one session.
+type TerminalBridge struct {
+	client  transportpb.StewardTransportClient
+	logger  logging.Logger
+	factory *shell.Factory
+
+	mu             sync.Mutex
+	activeExecutor shell.Executor
+}
+
+// Compile-time check: TerminalBridge implements commands.TerminalDialer.
+var _ commands.TerminalDialer = (*TerminalBridge)(nil)
+
+// terminalDialer is the commands.TerminalDialer registered in setupCommandHandler.
+// It resolves the gRPC transport client lazily at Dial() time and constructs a
+// fresh TerminalBridge per session, so the open_terminal handler can be
+// registered unconditionally without depending on the transport client being
+// available at setup time (Issue #2760).
+type terminalDialer struct {
+	c *TransportClient
+}
+
+// Compile-time check: terminalDialer implements commands.TerminalDialer.
+var _ commands.TerminalDialer = (*terminalDialer)(nil)
+
+// Dial resolves the current gRPC transport client and bridges a Terminal session.
+// It returns a descriptive error when no gRPC transport client is available so the
+// failure is surfaced as a session-level error rather than a missing handler.
+func (d *terminalDialer) Dial(ctx context.Context, sessionID, shellStr string, cols, rows int) error {
+	d.c.mu.RLock()
+	cp := d.c.controlPlane
+	d.c.mu.RUnlock()
+
+	grpcProv, ok := cp.(*grpcCP.Provider)
+	if !ok {
+		return fmt.Errorf("open_terminal: gRPC transport client unavailable (control plane is not a gRPC provider)")
+	}
+	tc := grpcProv.TransportClient()
+	if tc == nil {
+		return fmt.Errorf("open_terminal: gRPC transport client not yet established")
+	}
+	return NewTerminalBridge(tc, d.c.logger).Dial(ctx, sessionID, shellStr, cols, rows)
+}
+
+// NewTerminalBridge returns a TerminalBridge that uses client to open the
+// Terminal RPC stream.
+func NewTerminalBridge(client transportpb.StewardTransportClient, logger logging.Logger) *TerminalBridge {
+	return &TerminalBridge{
+		client:  client,
+		logger:  logger,
+		factory: shell.NewFactory(),
+	}
+}
+
+// ActiveExecutor returns the shell.Executor created during Dial, or nil if Dial
+// has not been called yet. Exposed for test assertions on executor lifecycle.
+func (b *TerminalBridge) ActiveExecutor() shell.Executor {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.activeExecutor
+}
+
+// Dial opens the Terminal RPC stream to the controller, launches a local PTY,
+// and bridges both directions until ctx is cancelled, the stream closes, or the
+// PTY process exits. Blocking — callers must run it in a goroutine if they need
+// to stay responsive. Returns nil for normal close (EOF / context cancel).
+func (b *TerminalBridge) Dial(ctx context.Context, sessionID, shellStr string, cols, rows int) error {
+	stream, err := b.client.Terminal(ctx)
+	if err != nil {
+		return fmt.Errorf("terminal bridge: open stream: %w", err)
+	}
+
+	exec, err := b.factory.CreateExecutor(&shell.Config{Shell: shellStr})
+	if err != nil {
+		return fmt.Errorf("terminal bridge: create executor: %w", err)
+	}
+
+	b.mu.Lock()
+	b.activeExecutor = exec
+	b.mu.Unlock()
+
+	// execCtx is shared between the two goroutines. Cancelling it shuts down the
+	// PTY and unblocks the inbound loop via stream.Recv returning an error.
+	execCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if err := exec.Start(execCtx, &shell.Config{Shell: shellStr, Cols: cols, Rows: rows}); err != nil {
+		_ = exec.Close(context.Background())
+		return fmt.Errorf("terminal bridge: start executor: %w", err)
+	}
+	defer func() { _ = exec.Close(context.Background()) }()
+
+	// Outbound goroutine: PTY output → controller stream.
+	// Calls cancel() on exit so the inbound loop (and exec context) also terminate.
+	go func() {
+		defer cancel()
+		for {
+			select {
+			case data, ok := <-exec.OutputChannel():
+				if !ok {
+					return
+				}
+				if sendErr := stream.Send(&transportpb.TerminalData{
+					SessionId: sessionID,
+					Data:      data,
+				}); sendErr != nil {
+					b.logger.Warn("terminal bridge: stream send failed", "error", sendErr)
+					return
+				}
+			case execErr, ok := <-exec.ErrorChannel():
+				if !ok {
+					return
+				}
+				if execErr != nil {
+					b.logger.Info("terminal bridge: executor exited", "error", execErr)
+				}
+				return
+			case <-execCtx.Done():
+				return
+			}
+		}
+	}()
+
+	// Inbound loop: controller stream → PTY.
+	for {
+		frame, recvErr := stream.Recv()
+		if recvErr != nil {
+			// EOF or context cancellation — normal session close.
+			return nil
+		}
+
+		// Ignore frames belonging to a different session. The controller may
+		// multiplex frames for multiple concurrent sessions over one connection.
+		if frame.GetSessionId() != sessionID {
+			continue
+		}
+
+		if frame.GetIsResize() {
+			if resizeErr := exec.Resize(execCtx, int(frame.GetCols()), int(frame.GetRows())); resizeErr != nil {
+				b.logger.Warn("terminal bridge: resize failed", "error", resizeErr)
+			}
+			continue
+		}
+
+		if len(frame.GetData()) > 0 {
+			if writeErr := exec.WriteData(execCtx, frame.GetData()); writeErr != nil {
+				b.logger.Warn("terminal bridge: write data failed", "error", writeErr)
+				return writeErr
+			}
+		}
+	}
+}

--- a/features/steward/client/terminal_bridge_test.go
+++ b/features/steward/client/terminal_bridge_test.go
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package client_test
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/steward/client"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ---------------------------------------------------------------------------
+// Test gRPC server for Terminal RPC
+// ---------------------------------------------------------------------------
+
+// terminalTestServer is a minimal StewardTransportServer that exposes each
+// Terminal stream so tests can send/recv frames directly.
+type terminalTestServer struct {
+	transportpb.UnimplementedStewardTransportServer
+	// streamCh receives each new Terminal stream; buffered so the handler does
+	// not block the gRPC goroutine while the test hasn't received yet.
+	streamCh chan grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData]
+}
+
+func (s *terminalTestServer) Terminal(
+	stream grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData],
+) error {
+	s.streamCh <- stream
+	// Hold the stream open until the client disconnects.
+	<-stream.Context().Done()
+	return nil
+}
+
+// Compile-time check.
+var _ transportpb.StewardTransportServer = (*terminalTestServer)(nil)
+
+// ---------------------------------------------------------------------------
+// Test env helpers
+// ---------------------------------------------------------------------------
+
+// newBridgeTestEnv starts an in-process gRPC server implementing the Terminal
+// RPC and returns a connected TerminalBridge ready for testing.
+func newBridgeTestEnv(t *testing.T) (*client.TerminalBridge, *terminalTestServer) {
+	t.Helper()
+	srv := &terminalTestServer{
+		streamCh: make(chan grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData], 1),
+	}
+	grpcSrv := grpc.NewServer()
+	transportpb.RegisterStewardTransportServer(grpcSrv, srv)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Forward the Serve error to the test goroutine. GracefulStop causes Serve
+	// to return nil, so a non-nil error here means the server exited
+	// unexpectedly — surface it instead of swallowing it behind opaque
+	// downstream transport failures.
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- grpcSrv.Serve(lis) }()
+	t.Cleanup(func() {
+		grpcSrv.GracefulStop()
+		if err := <-serveErr; err != nil {
+			t.Errorf("gRPC test server exited with error: %v", err)
+		}
+	})
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	bridge := client.NewTerminalBridge(
+		transportpb.NewStewardTransportClient(conn),
+		logging.NewLogger("debug"),
+	)
+	return bridge, srv
+}
+
+// collectOutput reads frames from serverStream in a goroutine, writing received
+// data bytes to outputCh. The goroutine stops when Recv returns an error or ctx
+// is done.
+func collectOutput(
+	ctx context.Context,
+	serverStream grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData],
+) <-chan []byte {
+	ch := make(chan []byte, 256)
+	go func() {
+		defer close(ch)
+		for {
+			frame, err := serverStream.Recv()
+			if err != nil {
+				return
+			}
+			if len(frame.GetData()) > 0 {
+				select {
+				case ch <- frame.GetData():
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return ch
+}
+
+// waitForString collects output from ch until the accumulated bytes contain
+// want or until the deadline fires, then returns the full collected string.
+func waitForString(t *testing.T, ch <-chan []byte, want string, deadline time.Duration) string {
+	t.Helper()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	var buf bytes.Buffer
+	for {
+		select {
+		case data, ok := <-ch:
+			if !ok {
+				return buf.String()
+			}
+			buf.Write(data)
+			if bytes.Contains(buf.Bytes(), []byte(want)) {
+				return buf.String()
+			}
+		case <-timer.C:
+			t.Fatalf("timed out after %s waiting for %q in PTY output; got: %q",
+				deadline, want, buf.String())
+			return buf.String()
+		}
+	}
+}
+
+// waitForPrompt collects output from ch until an interactive shell prompt
+// character ('$' for a normal user or '#' for root) appears, then returns the
+// collected string. Interactive bash on a PTY writes its PS1 prompt to the
+// terminal before it is ready to read input, so this is the correct readiness
+// signal to wait for instead of sleeping a fixed duration.
+func waitForPrompt(t *testing.T, ch <-chan []byte, deadline time.Duration) string {
+	t.Helper()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	var buf bytes.Buffer
+	for {
+		select {
+		case data, ok := <-ch:
+			if !ok {
+				t.Fatalf("output channel closed before shell prompt appeared; got: %q", buf.String())
+				return buf.String()
+			}
+			buf.Write(data)
+			if bytes.ContainsAny(buf.Bytes(), "$#") {
+				return buf.String()
+			}
+		case <-timer.C:
+			t.Fatalf("timed out after %s waiting for shell prompt; got: %q", deadline, buf.String())
+			return buf.String()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestTerminalBridge_RoundTrip verifies the full input→PTY→output loop:
+// a command sent by the controller ("echo hi\n") produces shell output that
+// contains "hi" in frames sent back to the controller.
+func TestTerminalBridge_RoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY round-trip requires a Unix PTY — not supported on Windows")
+	}
+
+	bridge, srv := newBridgeTestEnv(t)
+	const sessionID = "sess-roundtrip-001"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dialDone := make(chan error, 1)
+	go func() { dialDone <- bridge.Dial(ctx, sessionID, "bash", 80, 24) }()
+
+	// Wait for the server-side stream to be established.
+	var serverStream grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData]
+	select {
+	case serverStream = <-srv.streamCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Terminal stream")
+	}
+
+	// Start collecting PTY output before we send input.
+	outputCh := collectOutput(ctx, serverStream)
+
+	// Wait for bash to emit its initial prompt before sending input, rather
+	// than sleeping a fixed duration that may be too short on a loaded host.
+	waitForPrompt(t, outputCh, 15*time.Second)
+
+	// Send "echo hi" to the PTY via the controller stream.
+	require.NoError(t, serverStream.Send(&transportpb.TerminalData{
+		SessionId: sessionID,
+		Data:      []byte("echo hi\n"),
+	}))
+
+	// Collect output until we see "hi" (present in echoed input or command output).
+	out := waitForString(t, outputCh, "hi", 15*time.Second)
+	assert.Contains(t, out, "hi", "PTY output must contain 'hi'")
+
+	// Close the session cleanly.
+	cancel()
+	select {
+	case err := <-dialDone:
+		assert.NoError(t, err, "Dial must return nil on context cancel")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Dial did not return after context cancel")
+	}
+}
+
+// TestTerminalBridge_Teardown verifies that cancelling the Dial context terminates
+// the PTY process: executor.IsRunning() must be false after Dial returns.
+func TestTerminalBridge_Teardown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY teardown test not supported on Windows")
+	}
+
+	bridge, srv := newBridgeTestEnv(t)
+	const sessionID = "sess-teardown-001"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	dialDone := make(chan error, 1)
+	go func() { dialDone <- bridge.Dial(ctx, sessionID, "bash", 80, 24) }()
+
+	select {
+	case <-srv.streamCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Terminal stream")
+	}
+
+	// Poll until the PTY process is running instead of sleeping a fixed duration.
+	require.Eventually(t, func() bool {
+		e := bridge.ActiveExecutor()
+		return e != nil && e.IsRunning()
+	}, 10*time.Second, 10*time.Millisecond, "executor must be running before teardown")
+
+	exec := bridge.ActiveExecutor()
+	require.NotNil(t, exec, "executor must be set after Dial opens the stream")
+	assert.True(t, exec.IsRunning(), "executor must be running before teardown")
+
+	// Trigger teardown via context cancel.
+	cancel()
+
+	select {
+	case <-dialDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Dial did not return after context cancel")
+	}
+
+	assert.False(t, exec.IsRunning(),
+		"executor must not be running after Dial returns from context cancel")
+}
+
+// TestTerminalBridge_ResizeFrame verifies that a resize frame (is_resize=true)
+// reaches Executor.Resize and the executor remains running afterwards.
+func TestTerminalBridge_ResizeFrame(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY resize test not supported on Windows")
+	}
+
+	bridge, srv := newBridgeTestEnv(t)
+	const sessionID = "sess-resize-001"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	dialDone := make(chan error, 1)
+	go func() { dialDone <- bridge.Dial(ctx, sessionID, "bash", 80, 24) }()
+
+	var serverStream grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData]
+	select {
+	case serverStream = <-srv.streamCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Terminal stream")
+	}
+
+	outputCh := collectOutput(ctx, serverStream)
+
+	// Poll until the PTY process is running instead of sleeping a fixed duration.
+	require.Eventually(t, func() bool {
+		e := bridge.ActiveExecutor()
+		return e != nil && e.IsRunning()
+	}, 10*time.Second, 10*time.Millisecond, "executor must be running before resize")
+
+	// Send a resize frame — bridge must forward it to Executor.Resize.
+	require.NoError(t, serverStream.Send(&transportpb.TerminalData{
+		SessionId: sessionID,
+		IsResize:  true,
+		Cols:      200,
+		Rows:      50,
+	}))
+
+	// The bridge processes the resize synchronously on the recv goroutine, so
+	// there is no direct PTY-side signal that it completed. Confirm the resize
+	// was consumed and the inbound loop is still serving by sending a data frame
+	// and observing its output — sleeping a fixed duration would be flaky.
+	require.NoError(t, serverStream.Send(&transportpb.TerminalData{
+		SessionId: sessionID,
+		Data:      []byte("echo resized\n"),
+	}))
+	out := waitForString(t, outputCh, "resized", 15*time.Second)
+	assert.Contains(t, out, "resized", "PTY must remain responsive after resize")
+
+	exec := bridge.ActiveExecutor()
+	require.NotNil(t, exec)
+	assert.True(t, exec.IsRunning(), "executor must still be running after resize")
+
+	cancel()
+	select {
+	case <-dialDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Dial did not return after context cancel")
+	}
+}
+
+// TestTerminalBridge_SessionIDFilter verifies that frames with a mismatched
+// session_id are ignored by the bridge and never forwarded to the PTY.
+func TestTerminalBridge_SessionIDFilter(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY session filter test not supported on Windows")
+	}
+
+	bridge, srv := newBridgeTestEnv(t)
+	const sessionID = "sess-filter-001"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	dialDone := make(chan error, 1)
+	go func() { dialDone <- bridge.Dial(ctx, sessionID, "bash", 80, 24) }()
+
+	var serverStream grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData]
+	select {
+	case serverStream = <-srv.streamCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Terminal stream")
+	}
+
+	outputCh := collectOutput(ctx, serverStream)
+
+	// Wait for bash to emit its prompt before injecting frames, rather than
+	// sleeping a fixed duration that may be too short on a loaded host.
+	waitForPrompt(t, outputCh, 15*time.Second)
+
+	// Frame with wrong session_id — must be silently dropped by bridge.
+	require.NoError(t, serverStream.Send(&transportpb.TerminalData{
+		SessionId: "wrong-session-id",
+		Data:      []byte("echo shouldnotappear\n"),
+	}))
+
+	// Frame with correct session_id — "echo marker" must reach the PTY.
+	require.NoError(t, serverStream.Send(&transportpb.TerminalData{
+		SessionId: sessionID,
+		Data:      []byte("echo marker\n"),
+	}))
+
+	// Wait for "marker" to appear in the output.
+	out := waitForString(t, outputCh, "marker", 15*time.Second)
+	assert.Contains(t, out, "marker", "output must contain 'marker' from the correctly-scoped frame")
+	assert.NotContains(t, out, "shouldnotappear",
+		"output must not contain output from a frame with mismatched session_id")
+
+	cancel()
+	select {
+	case <-dialDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Dial did not return after context cancel")
+	}
+}

--- a/features/steward/commands/open_terminal.go
+++ b/features/steward/commands/open_terminal.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cfgis/cfgms/features/terminal/shell"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TerminalDialer opens a bidirectional Terminal RPC stream to the controller
+// and bridges it to a local PTY for the duration of the session.
+// Implemented by client.TerminalBridge.
+type TerminalDialer interface {
+	Dial(ctx context.Context, sessionID, shellStr string, cols, rows int) error
+}
+
+// RegisterOpenTerminalHandler registers the open_terminal command handler on h.
+// dialer opens the Terminal RPC stream and bridges it to a PTY; it is created
+// by the client package and injected here so the commands package does not import
+// the transport client directly.
+func (h *Handler) RegisterOpenTerminalHandler(dialer TerminalDialer) {
+	h.RegisterHandler(cpTypes.CommandOpenTerminal, func(ctx context.Context, cmd *cpTypes.Command) error {
+		return h.handleOpenTerminal(ctx, cmd, dialer)
+	})
+}
+
+// handleOpenTerminal validates params and starts the terminal bridge in a background
+// goroutine. It returns an error synchronously when the shell param is not in the
+// platform allowlist, ensuring shell.Factory is never invoked on an untrusted string.
+// On success the command completes immediately and the bridge runs independently.
+func (h *Handler) handleOpenTerminal(ctx context.Context, cmd *cpTypes.Command, dialer TerminalDialer) error {
+	sessionID, _ := cmd.Params["session_id"].(string)
+	shellStr, _ := cmd.Params["shell"].(string)
+
+	var cols, rows int
+	if c, ok := cmd.Params["cols"].(float64); ok && c > 0 {
+		cols = int(c)
+	}
+	if r, ok := cmd.Params["rows"].(float64); ok && r > 0 {
+		rows = int(r)
+	}
+	if cols <= 0 {
+		cols = 80
+	}
+	if rows <= 0 {
+		rows = 24
+	}
+
+	// Fall back to platform default when caller omits the shell param.
+	if shellStr == "" {
+		shellStr = shell.GetDefaultShell()
+	}
+
+	// Validate against the platform allowlist BEFORE touching shell.Factory.
+	// An arbitrary string from Command.params must never reach CreateExecutor.
+	if !isAllowedShell(shellStr) {
+		h.logger.Warn("open_terminal: rejected non-allowlisted shell param",
+			"command_id", cmd.ID,
+			"session_id", logging.SanitizeLogValue(sessionID))
+		return fmt.Errorf("open_terminal: unsupported shell %q", shellStr)
+	}
+
+	h.logger.Info("open_terminal: starting bridge",
+		"command_id", cmd.ID,
+		"session_id", logging.SanitizeLogValue(sessionID),
+		"shell", shellStr,
+		"cols", cols,
+		"rows", rows)
+
+	// Run the bridge in a background goroutine; the command itself returns
+	// immediately (EventCommandCompleted) while the PTY session runs as long as
+	// the stream stays open. The bridge is responsible for its own teardown.
+	go func() {
+		if err := dialer.Dial(context.Background(), sessionID, shellStr, cols, rows); err != nil {
+			h.logger.Error("open_terminal: bridge exited with error",
+				"session_id", logging.SanitizeLogValue(sessionID),
+				"error", err)
+		}
+		h.logger.Info("open_terminal: bridge closed", "session_id", logging.SanitizeLogValue(sessionID))
+	}()
+
+	return nil
+}
+
+// isAllowedShell returns true when s is in the platform-specific shell allowlist
+// enforced by features/terminal/shell.GetSupportedShells.
+func isAllowedShell(s string) bool {
+	for _, allowed := range shell.GetSupportedShells() {
+		if s == allowed {
+			return true
+		}
+	}
+	return false
+}

--- a/features/steward/commands/open_terminal_test.go
+++ b/features/steward/commands/open_terminal_test.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package commands
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+)
+
+// ---------------------------------------------------------------------------
+// recordingDialer — real in-process TerminalDialer for tests (no mocks).
+// ---------------------------------------------------------------------------
+
+// recordingDialer implements TerminalDialer and records every Dial call for
+// assertion. It blocks until the test signals it via allow or until the context
+// is cancelled, simulating a long-lived bridge session without a real PTY.
+type recordingDialer struct {
+	mu      sync.Mutex
+	calls   []dialCall
+	callCh  chan dialCall // non-nil allows callers to receive dial events
+	allowCh chan struct{} // closed by allowReturn to unblock Dial
+	dialErr error         // error Dial returns after unblocking
+}
+
+type dialCall struct {
+	SessionID string
+	Shell     string
+	Cols      int
+	Rows      int
+}
+
+// newRecordingDialer returns a recordingDialer whose Dial returns immediately
+// with nil.
+func newRecordingDialer() *recordingDialer {
+	ch := make(chan struct{})
+	close(ch) // Dial returns immediately unless blocked
+	return &recordingDialer{allowCh: ch}
+}
+
+// newBlockingDialer returns a recordingDialer whose Dial blocks until
+// allowReturn or ctx cancellation. Use for testing concurrent behaviour.
+func newBlockingDialer() *recordingDialer {
+	return &recordingDialer{
+		callCh:  make(chan dialCall, 1),
+		allowCh: make(chan struct{}),
+	}
+}
+
+// allowReturn unblocks a Dial call that is currently blocking.
+func (d *recordingDialer) allowReturn(err error) {
+	d.mu.Lock()
+	d.dialErr = err
+	d.mu.Unlock()
+	close(d.allowCh)
+}
+
+func (d *recordingDialer) Dial(_ context.Context, sessionID, shellStr string, cols, rows int) error {
+	call := dialCall{SessionID: sessionID, Shell: shellStr, Cols: cols, Rows: rows}
+	d.mu.Lock()
+	d.calls = append(d.calls, call)
+	d.mu.Unlock()
+	if d.callCh != nil {
+		d.callCh <- call
+	}
+	<-d.allowCh
+	d.mu.Lock()
+	err := d.dialErr
+	d.mu.Unlock()
+	return err
+}
+
+func (d *recordingDialer) dialCalls() []dialCall {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]dialCall, len(d.calls))
+	copy(out, d.calls)
+	return out
+}
+
+// Compile-time check: recordingDialer implements TerminalDialer.
+var _ TerminalDialer = (*recordingDialer)(nil)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newOpenTerminalHandler(t *testing.T) *Handler {
+	t.Helper()
+	h, err := New(&Config{
+		StewardID: "steward-test",
+		OnStatus:  noopStatus,
+		Logger:    newTestLogger(t),
+	})
+	require.NoError(t, err)
+	return h
+}
+
+// allowedShell returns a shell name that is valid on the current platform.
+func allowedShell() string {
+	if runtime.GOOS == "windows" {
+		return "powershell"
+	}
+	return "bash"
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestOpenTerminal_InvalidShell_Rejected verifies that an unsupported shell in
+// Command.params is rejected synchronously without ever calling TerminalDialer.Dial.
+func TestOpenTerminal_InvalidShell_Rejected(t *testing.T) {
+	dialer := newRecordingDialer()
+	h := newOpenTerminalHandler(t)
+	h.RegisterOpenTerminalHandler(dialer)
+
+	sc := testSignedCommandWithParams("ot-bad-shell-001", cpTypes.CommandOpenTerminal, map[string]interface{}{
+		"session_id": "sess-001",
+		"shell":      "/bin/evil-shell",
+		"cols":       float64(80),
+		"rows":       float64(24),
+	})
+
+	require.NoError(t, h.HandleCommand(context.Background(), sc))
+	h.Wait()
+
+	// The command must have failed (EventCommandFailed) because the handler returned an error.
+	// The dialer must never have been called.
+	assert.Empty(t, dialer.dialCalls(), "Dial must not be called for a non-allowlisted shell")
+}
+
+// TestOpenTerminal_ValidShell_DialerCalled verifies that a valid shell param causes
+// TerminalDialer.Dial to be invoked with the correct session_id, shell, cols, and rows.
+func TestOpenTerminal_ValidShell_DialerCalled(t *testing.T) {
+	dialer := newBlockingDialer()
+	h := newOpenTerminalHandler(t)
+	h.RegisterOpenTerminalHandler(dialer)
+
+	sc := testSignedCommandWithParams("ot-valid-001", cpTypes.CommandOpenTerminal, map[string]interface{}{
+		"session_id": "sess-abc",
+		"shell":      allowedShell(),
+		"cols":       float64(120),
+		"rows":       float64(40),
+	})
+
+	require.NoError(t, h.HandleCommand(context.Background(), sc))
+	h.Wait() // waits for the executeCommand goroutine; bridge goroutine still blocking
+
+	// Wait for Dial to be called (bridge goroutine runs concurrently).
+	select {
+	case call := <-dialer.callCh:
+		assert.Equal(t, "sess-abc", call.SessionID)
+		assert.Equal(t, allowedShell(), call.Shell)
+		assert.Equal(t, 120, call.Cols)
+		assert.Equal(t, 40, call.Rows)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for TerminalDialer.Dial to be called")
+	}
+
+	// Unblock the bridge goroutine so the test exits cleanly.
+	dialer.allowReturn(nil)
+}
+
+// TestOpenTerminal_DefaultShell_UsedWhenOmitted verifies that when no shell is
+// provided in params the platform default shell is used and is allowlist-valid.
+func TestOpenTerminal_DefaultShell_UsedWhenOmitted(t *testing.T) {
+	dialer := newBlockingDialer()
+	h := newOpenTerminalHandler(t)
+	h.RegisterOpenTerminalHandler(dialer)
+
+	sc := testSignedCommandWithParams("ot-default-shell-001", cpTypes.CommandOpenTerminal, map[string]interface{}{
+		"session_id": "sess-def",
+		// shell omitted intentionally
+	})
+
+	require.NoError(t, h.HandleCommand(context.Background(), sc))
+	h.Wait()
+
+	select {
+	case call := <-dialer.callCh:
+		assert.NotEmpty(t, call.Shell, "shell must not be empty when default is used")
+		assert.Equal(t, allowedShell(), call.Shell,
+			"default shell must match platform default")
+		assert.Equal(t, 80, call.Cols, "default cols must be 80 when omitted")
+		assert.Equal(t, 24, call.Rows, "default rows must be 24 when omitted")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for TerminalDialer.Dial with default shell")
+	}
+
+	dialer.allowReturn(nil)
+}
+
+// TestOpenTerminal_CommandCompletesBeforeBridgeDone verifies that handleOpenTerminal
+// returns nil immediately (allowing EventCommandCompleted) while the bridge goroutine
+// is still running. This decouples the command handler timeout from the PTY session.
+func TestOpenTerminal_CommandCompletesBeforeBridgeDone(t *testing.T) {
+	dialer := newBlockingDialer()
+	h := newOpenTerminalHandler(t)
+	h.RegisterOpenTerminalHandler(dialer)
+
+	var commandCompletedAt atomic.Int64
+
+	// Capture when EventCommandCompleted is emitted.
+	cb := func(_ context.Context, evt *cpTypes.Event) {
+		if evt.Type == cpTypes.EventCommandCompleted {
+			commandCompletedAt.Store(time.Now().UnixNano())
+		}
+	}
+	h2, err := New(&Config{
+		StewardID: "steward-test",
+		OnStatus:  cb,
+		Logger:    newTestLogger(t),
+	})
+	require.NoError(t, err)
+	h2.RegisterOpenTerminalHandler(dialer)
+
+	sc := testSignedCommandWithParams("ot-timing-001", cpTypes.CommandOpenTerminal, map[string]interface{}{
+		"session_id": "sess-timing",
+		"shell":      allowedShell(),
+		"cols":       float64(80),
+		"rows":       float64(24),
+	})
+
+	require.NoError(t, h2.HandleCommand(context.Background(), sc))
+	h2.Wait() // returns once executeCommand goroutine completes (bridge still blocked)
+
+	// At this point EventCommandCompleted should have been emitted.
+	assert.NotZero(t, commandCompletedAt.Load(),
+		"EventCommandCompleted must be emitted before Dial returns")
+
+	// Unblock the bridge goroutine.
+	dialer.allowReturn(nil)
+}

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -34,6 +34,7 @@ var commandTypeToProto = map[types.CommandType]transportpb.CommandType{
 	types.CommandRelayResponse:     transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE, // Issue #1994
 	types.CommandPushSigningCert:   transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT,
 	types.CommandPushStewardBinary: transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY,
+	types.CommandOpenTerminal:      transportpb.CommandType_COMMAND_TYPE_OPEN_TERMINAL, // Issue #2760
 }
 
 // protoToCommandType maps proto enum to semantic CommandType.
@@ -45,6 +46,7 @@ var protoToCommandType = map[transportpb.CommandType]types.CommandType{
 	transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE:      types.CommandRelayResponse, // Issue #1994
 	transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT:   types.CommandPushSigningCert,
 	transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY: types.CommandPushStewardBinary,
+	transportpb.CommandType_COMMAND_TYPE_OPEN_TERMINAL:       types.CommandOpenTerminal, // Issue #2760
 }
 
 func commandToProto(cmd *types.Command) *transportpb.Command {

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -100,6 +100,7 @@ var allCommandTypes = []types.CommandType{
 	types.CommandRelayResponse,
 	types.CommandPushSigningCert,
 	types.CommandPushStewardBinary,
+	types.CommandOpenTerminal, // Issue #2760
 }
 
 func TestCommandTypeRoundTrip(t *testing.T) {
@@ -152,6 +153,7 @@ func TestCommandTypeProtoDescriptorComplete(t *testing.T) {
 		transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT:   "COMMAND_TYPE_PUSH_SIGNING_CERT",
 		transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY: "COMMAND_TYPE_PUSH_STEWARD_BINARY",
 		transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE:      "COMMAND_TYPE_RELAY_RESPONSE",
+		transportpb.CommandType_COMMAND_TYPE_OPEN_TERMINAL:       "COMMAND_TYPE_OPEN_TERMINAL", // Issue #2760
 	}
 	for ct, name := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -48,6 +48,11 @@ const (
 	// Params: version (string), download_url (string), sha256 (string),
 	// platform (string), arch (string), publisher (string), bundle_signature ([]byte base64).
 	CommandPushStewardBinary CommandType = "push_steward_binary"
+
+	// CommandOpenTerminal instructs the steward to dial the controller's Terminal RPC
+	// and bridge the stream to a local PTY for an interactive admin session. (Issue #2760)
+	// Params: session_id (string), shell (string), cols (int32), rows (int32).
+	CommandOpenTerminal CommandType = "open_terminal"
 )
 
 // Command represents a command sent from controller to steward.


### PR DESCRIPTION
## Summary

Implements the steward-side terminal bridge for Issue #2760. When the steward receives a `COMMAND_TYPE_OPEN_TERMINAL` command over its `ControlChannel`, it dials the controller's `Terminal(stream TerminalData)` RPC and bridges the bidirectional stream to a real local PTY via `features/terminal/shell.Factory`.

- **`COMMAND_TYPE_OPEN_TERMINAL = 12`** added to proto, generated code (rawDesc updated manually — protoc unavailable), semantic type constant, and both convert maps
- **Shell allowlist validation** happens synchronously before `shell.Factory` is ever touched — an untrusted shell string from `Command.params` never reaches `CreateExecutor`
- **`TerminalBridge`** runs two goroutines: inbound (stream→PTY) and outbound (PTY→stream), each cancelling the shared context on exit for clean teardown
- **Session-ID filter** drops frames whose `session_id` doesn't match the bridge's session
- **`terminalDialer` wrapper** resolves the gRPC transport client lazily at `Dial()` time, so `RegisterOpenTerminalHandler` is called unconditionally (like every other handler) without requiring the client to be available at setup time
- **Command returns immediately** — the bridge goroutine is background so `EventCommandCompleted` fires before the PTY session ends, decoupling the 30s handler timeout from the session lifetime

## Test plan

- [ ] `TestOpenTerminal_InvalidShell_Rejected` — non-allowlisted shell returns error, dialer never called
- [ ] `TestOpenTerminal_ValidShell_DialerCalled` — valid shell params forwarded correctly to dialer
- [ ] `TestOpenTerminal_DefaultShell_UsedWhenOmitted` — platform default shell used when param omitted
- [ ] `TestOpenTerminal_CommandCompletesBeforeBridgeDone` — `EventCommandCompleted` emitted before `Dial` returns
- [ ] `TestTerminalBridge_RoundTrip` — `echo hi\n` → PTY → outbound contains "hi"
- [ ] `TestTerminalBridge_Teardown` — context cancel → `executor.IsRunning() == false`
- [ ] `TestTerminalBridge_ResizeFrame` — resize frame reaches `Executor.Resize`, executor keeps running
- [ ] `TestTerminalBridge_SessionIDFilter` — wrong-session frame ignored, correct-session frame processed
- [ ] `TestSetupCommandHandler_RegistersOpenTerminal` — `setupCommandHandler` wiring guard, produces `EventCommandCompleted` not `EventCommandFailed`
- [ ] `TestCommandTypeRoundTrip/open_terminal` — semantic↔proto round-trip
- [ ] `TestCommandTypeConvertMapsComplete` — allCommandTypes in sync with convert maps
- [ ] `TestCommandTypeProtoDescriptorComplete/COMMAND_TYPE_OPEN_TERMINAL` — rawDesc carries symbolic name

Fixes #2760

🤖 Generated with [Claude Code](https://claude.com/claude-code)