### PR TITLE
deps: bump serena v1.5.3 → v1.6.0 (Issue #2794)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -181,7 +181,7 @@ RUN set -eu; \
 RUN go install golang.org/x/tools/gopls@v0.22.0 \
     && install -m 0755 "$(go env GOPATH)/bin/gopls" /usr/local/bin/gopls
 
-# Install serena (pinned v1.5.3) as a self-contained tool for the agent user.
+# Install serena (pinned v1.6.0) as a self-contained tool for the agent user.
 # This bakes serena + all its Python deps into the image (~/.local/share/uv +
 # the `serena` launcher on ~/.local/bin), so at runtime serena starts directly
 # from the binary with no uvx git re-resolution and no pypi/astral egress.
@@ -189,7 +189,7 @@ RUN go install golang.org/x/tools/gopls@v0.22.0 \
 ENV UV_CACHE_DIR=/home/agent/.cache/uv
 RUN install -d -o agent -g agent /home/agent/.cache/uv /home/agent/.local \
     && su agent -c 'set -e; export UV_CACHE_DIR=/home/agent/.cache/uv; \
-         uv tool install --from git+https://github.com/oraios/serena@v1.5.3 serena-agent' \
+         uv tool install --from git+https://github.com/oraios/serena@v1.6.0 serena-agent' \
     && chown -R agent:agent /home/agent/.cache/uv /home/agent/.local
 # Defense-in-depth: keep any stray uv invocation offline behind the firewall.
 ENV UV_OFFLINE=1

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/oraios/serena@v1.5.3",
+        "git+https://github.com/oraios/serena@v1.6.0",
         "serena",
         "start-mcp-server",
         "--context",


### PR DESCRIPTION
## Summary

Bumps the serena MCP server from v1.5.3 to v1.6.0 in the two locations that together determine the actual runtime version:

- `.mcp.json`: uvx install source (used outside the devcontainer)
- `.devcontainer/Dockerfile`: baked binary in the agent devcontainer image (the actual runtime source of truth inside the container, since `setup-env.sh` rewrites `.mcp.json` at container start to point at the baked binary)

Fixes #2794

## Changes

Only 2 files changed — purely a version string update:

| File | Change |
|------|--------|
| `.mcp.json` | `@v1.5.3` → `@v1.6.0` |
| `.devcontainer/Dockerfile` | Install tag + adjacent comment: `v1.5.3` → `v1.6.0` |

## v1.6.0 Impact on Consumed-Tool Surface

Our consumed tools (`find_symbol`, `find_declaration`, `find_implementations`, `find_referencing_symbols`, `get_symbols_overview`) are all unchanged or improved:

- `find_symbol`: `name_path` added as **additive alias** for `name_path_pattern` — existing calls unaffected
- `check_onboarding_performed` removed — **not in our consumed set**
- `replace_in_files` added — **not adopted in this PR** (out of scope)
- Minor behavior improvements to `search_for_pattern`, `get_symbols_overview` depth defaults, `safe_delete`

No consumed tool was renamed, removed, or had a breaking signature change.

## Verification Results

**AC#2** — old version absent: `grep -rE "oraios/serena@v1\.5\.3" .mcp.json .devcontainer/Dockerfile` → **0 matches** ✓  
**AC#3** — new version present: `grep -rE "oraios/serena@v1\.6\.0" .mcp.json .devcontainer/Dockerfile` → **2 matches** ✓  
**AC#4** — `make test`: **211/211 passed, 0 failed** ✓  
**AC#7** — `mcp__serena__find_symbol` smoke test against `pkg/cert.Manager` → resolved successfully ✓

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| Code Review | **PASS** | Infrastructure config only; no blocking issues |
| Security | **PASS** | Version bump aligned in both files; no secrets, no violations |
| QA/Tests | **PASS** | 211/211 script tests; all Go packages; cross-platform compilation |

Workflow: `passed: true`, 1 review round, 0 fix rounds, 0 remaining findings.