### PR TITLE
ci: bump zizmorcore/zizmor-action v0.5.7 → v0.6.0 (Issue #2793)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           upload: always
         env:


### PR DESCRIPTION
## Summary

Advance the pinned SHA for `zizmorcore/zizmor-action` from
`192e21d79ab29983730a13d1382995c2307fbcaa` (v0.5.7) to
`6599ee8b7a49aef6a770f63d261d214911a7ce02` (v0.6.0).

v0.6.0 changes are purely additive: the default scanned zizmor version moves to 1.27.0, a new optional `collect` input is added, and Docker pull output is folded into a collapsed log group. No existing inputs or behaviour are removed or altered.

Cooldown policy satisfied: 4.0 days elapsed since the 2026-07-15 release (threshold: 3 days). No GHSA CVE found for this action.

Fixes #2793

## Acceptance Criteria Verified

- [x] `.github/workflows/zizmor.yml:28` updated from `192e21d79...# v0.5.7` to `6599ee8b...# v0.6.0`
- [x] Old SHA absent: `grep -rE "192e21d79ab29983730a13d1382995c2307fbcaa" .github/workflows/` → 0 matches
- [x] New SHA present: `grep -rE "6599ee8b7a49aef6a770f63d261d214911a7ce02" .github/workflows/` → 1 match

## Specialist Review Results

All three review lenses (code review, test quality, security) returned **PASS** in round 1 with 0 fix rounds and 0 remaining findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)