### PR TITLE
controller: additive setter registration on compositeTransportServer (Issue #2795)

### DIFF
--- a/features/controller/server/composite_handler.go
+++ b/features/controller/server/composite_handler.go
@@ -28,23 +28,37 @@ type compositeTransportServer struct {
 	logger           logging.Logger
 }
 
-// newCompositeTransportServer creates a composite handler that delegates RPCs.
+// newCompositeTransportServer creates a composite handler with the always-required
+// CP handler and logger. Wire optional data-plane handlers via SetConfigHandler,
+// SetDNAHandler, SetBulkHandler, and SetLogStreamHandler before serving.
 func newCompositeTransportServer(
 	cpHandler transportpb.StewardTransportServer,
-	dnaHandler *controllerTransport.DNAHandler,
-	bulkHandler *controllerTransport.BulkHandler,
-	configHandler *controllerTransport.ConfigHandler,
-	logStreamHandler *controllerTransport.LogStreamHandler,
 	logger logging.Logger,
 ) *compositeTransportServer {
 	return &compositeTransportServer{
-		cpHandler:        cpHandler,
-		configHandler:    configHandler,
-		dnaHandler:       dnaHandler,
-		bulkHandler:      bulkHandler,
-		logStreamHandler: logStreamHandler,
-		logger:           logger,
+		cpHandler: cpHandler,
+		logger:    logger,
 	}
+}
+
+// SetConfigHandler sets the SyncConfig handler. Call after newCompositeTransportServer.
+func (c *compositeTransportServer) SetConfigHandler(h *controllerTransport.ConfigHandler) {
+	c.configHandler = h
+}
+
+// SetDNAHandler sets the SyncDNA handler. Call after newCompositeTransportServer.
+func (c *compositeTransportServer) SetDNAHandler(h *controllerTransport.DNAHandler) {
+	c.dnaHandler = h
+}
+
+// SetBulkHandler sets the BulkTransfer handler. Call after newCompositeTransportServer.
+func (c *compositeTransportServer) SetBulkHandler(h *controllerTransport.BulkHandler) {
+	c.bulkHandler = h
+}
+
+// SetLogStreamHandler sets the LogStream handler. Call after newCompositeTransportServer.
+func (c *compositeTransportServer) SetLogStreamHandler(h *controllerTransport.LogStreamHandler) {
+	c.logStreamHandler = h
 }
 
 // --- Control Plane RPCs (delegated to CP handler) ---

--- a/features/controller/server/composite_handler_test.go
+++ b/features/controller/server/composite_handler_test.go
@@ -109,12 +109,39 @@ func (s *emptyLogStream) RecvMsg(interface{}) error                         { re
 var _ grpc.ClientStreamingServer[transportpb.LogEntry, transportpb.LogStreamResponse] = (*emptyLogStream)(nil)
 
 // ---------------------------------------------------------------------------
+// Additive-extension helpers (TestComposite_AdditiveExtension)
+// ---------------------------------------------------------------------------
+
+// testFooHandler is a throwaway handler representing a hypothetical 7th RPC
+// (standing in for Terminal/TelemetryStream from stories #2761/#2765).
+type testFooHandler struct{ called bool }
+
+// fooCompositeExt shows that adding a new data-plane RPC handler is purely
+// additive: embed compositeTransportServer, add one field, one setter, and one
+// delegation method — zero edits to newCompositeTransportServer, struct fields,
+// or any existing handler's setter or delegation method.
+type fooCompositeExt struct {
+	*compositeTransportServer
+	fooHandler *testFooHandler
+}
+
+func (c *fooCompositeExt) SetFooHandler(h *testFooHandler) { c.fooHandler = h }
+
+func (c *fooCompositeExt) callFoo() bool {
+	if c.fooHandler != nil {
+		c.fooHandler.called = true
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 func TestComposite_RegisterDelegatesToCP(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil)
 
 	_, err := composite.Register(context.Background(), &controllerpb.RegisterRequest{})
 	require.NoError(t, err)
@@ -123,7 +150,7 @@ func TestComposite_RegisterDelegatesToCP(t *testing.T) {
 
 func TestComposite_PingDelegatesToCP(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil)
 
 	_, err := composite.Ping(context.Background(), &transportpb.PingRequest{})
 	require.NoError(t, err)
@@ -132,7 +159,7 @@ func TestComposite_PingDelegatesToCP(t *testing.T) {
 
 func TestComposite_ControlChannelDelegatesToCP(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil)
 
 	err := composite.ControlChannel(nil)
 	require.NoError(t, err)
@@ -141,7 +168,7 @@ func TestComposite_ControlChannelDelegatesToCP(t *testing.T) {
 
 func TestComposite_SyncDNA_NilHandler(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil)
 
 	err := composite.SyncDNA(&emptyDNAStream{})
 	require.Error(t, err, "SyncDNA with nil dnaHandler should return unimplemented error")
@@ -151,7 +178,8 @@ func TestComposite_SyncDNA_WithHandler(t *testing.T) {
 	cp := newRecordingHandler()
 	logger := logging.NewNoopLogger()
 	dnaHandler := controllerTransport.NewDNAHandler(logger, controllerTransport.NewTenantQueue(), nil)
-	composite := newCompositeTransportServer(cp, dnaHandler, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, logger)
+	composite.SetDNAHandler(dnaHandler)
 
 	// Empty stream with background context (no mTLS peer) → Unauthenticated from handler.
 	// This proves that dnaHandler.HandleGRPC is called, not the Unimplemented fallback.
@@ -163,7 +191,7 @@ func TestComposite_SyncDNA_WithHandler(t *testing.T) {
 
 func TestComposite_BulkTransfer_NilHandler(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil)
 
 	err := composite.BulkTransfer(&emptyBulkStream{})
 	require.Error(t, err, "BulkTransfer with nil bulkHandler should return unimplemented error")
@@ -173,7 +201,8 @@ func TestComposite_BulkTransfer_WithHandler(t *testing.T) {
 	cp := newRecordingHandler()
 	logger := logging.NewNoopLogger()
 	bulkHandler := controllerTransport.NewBulkHandler(logger, controllerTransport.NewTenantQueue())
-	composite := newCompositeTransportServer(cp, nil, bulkHandler, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, logger)
+	composite.SetBulkHandler(bulkHandler)
 
 	err := composite.BulkTransfer(&emptyBulkStream{})
 	require.NoError(t, err, "BulkTransfer with valid handler and empty stream must succeed")
@@ -181,7 +210,7 @@ func TestComposite_BulkTransfer_WithHandler(t *testing.T) {
 
 func TestComposite_SyncConfigWithoutHandler(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil)
 
 	err := composite.SyncConfig(&transportpb.ConfigSyncRequest{}, nil)
 	require.Error(t, err, "SyncConfig without handler should return unimplemented error")
@@ -189,10 +218,47 @@ func TestComposite_SyncConfigWithoutHandler(t *testing.T) {
 
 func TestComposite_LogStream_NilHandler(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil)
 
 	err := composite.LogStream(&emptyLogStream{})
 	require.Error(t, err, "LogStream with nil logStreamHandler should return unimplemented error")
 	assert.Contains(t, err.Error(), "not implemented",
 		"LogStream with nil handler must return Unimplemented")
+}
+
+// TestComposite_AdditiveExtension proves that adding a new data-plane handler
+// (as stories #2761/#2765 will do for Terminal/TelemetryStream) requires zero
+// edits to newCompositeTransportServer or any existing handler field, setter, or
+// delegation method. The fooCompositeExt type above demonstrates the additive
+// pattern: one new field + one new setter + one new delegation method.
+func TestComposite_AdditiveExtension(t *testing.T) {
+	cp := newRecordingHandler()
+
+	// 2-arg constructor — unchanged whether 1 or 10 optional handlers exist.
+	base := newCompositeTransportServer(cp, nil)
+
+	// All four existing setters work; no constructor signature edit required.
+	base.SetConfigHandler(nil)
+	base.SetDNAHandler(nil)
+	base.SetBulkHandler(nil)
+	base.SetLogStreamHandler(nil)
+
+	// Wire in the hypothetical 7th handler. Zero changes to the constructor or
+	// any of the four existing handlers' fields, setters, or delegation methods.
+	ext := &fooCompositeExt{compositeTransportServer: base}
+	fooH := &testFooHandler{}
+	ext.SetFooHandler(fooH)
+
+	// Existing CP delegation still works through the embedded composite.
+	_, err := ext.Register(context.Background(), &controllerpb.RegisterRequest{})
+	require.NoError(t, err)
+	assert.True(t, cp.called["Register"], "existing CP delegation is unaffected by the new handler")
+
+	// New handler routes correctly.
+	assert.True(t, ext.callFoo(), "new handler setter and delegation work correctly")
+	assert.True(t, fooH.called, "new handler was invoked")
+
+	// Nil-check: the fallthrough pattern holds without calling SetFooHandler.
+	ext2 := &fooCompositeExt{compositeTransportServer: newCompositeTransportServer(cp, nil)}
+	assert.False(t, ext2.callFoo(), "nil handler falls through correctly")
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -1667,7 +1667,11 @@ func (s *Server) Start() error {
 			controllerTransport.DefaultLogStreamConfig(),
 		)
 		s.logStreamHandler = logStreamHandler
-		composite := newCompositeTransportServer(cpHandler, dnaHandler, bulkHandler, s.configHandler, logStreamHandler, s.logger)
+		composite := newCompositeTransportServer(cpHandler, s.logger)
+		composite.SetConfigHandler(s.configHandler)
+		composite.SetDNAHandler(dnaHandler)
+		composite.SetBulkHandler(bulkHandler)
+		composite.SetLogStreamHandler(logStreamHandler)
 		transportpb.RegisterStewardTransportServer(s.grpcServer, composite)
 
 		// Start serving on the shared QUIC listener


### PR DESCRIPTION
## Summary

- Replaces the 6-parameter `newCompositeTransportServer` constructor with a 2-parameter form `(cpHandler, logger)` — the only two dependencies every composite instance always needs.
- Adds `SetConfigHandler`, `SetDNAHandler`, `SetBulkHandler`, `SetLogStreamHandler` setter methods so each optional data-plane handler wires itself in additively, with no constructor-signature edits required for future handlers.
- Updates the sole call site (`server.go`) and all 9 existing `composite_handler_test.go` construction call sites to the new pattern; dispatch assertions are unmodified.
- Adds `TestComposite_AdditiveExtension` proving the #2761/#2765 constructor-collision is retired: a hypothetical 7th handler (`fooCompositeExt`) requires zero edits to the constructor or any existing handler field/setter/delegation method.

Fixes #2795

## Specialist Review Results

- **Code Review**: PASS (0 findings)
- **Test Quality**: PASS (0 findings)
- **Security**: PASS (0 findings)

Review ran 1 round, 0 fix iterations, 3 agents, no remaining findings.

## Test plan

- [x] `TestComposite_RegisterDelegatesToCP` — CP delegation unchanged
- [x] `TestComposite_PingDelegatesToCP` — CP delegation unchanged
- [x] `TestComposite_ControlChannelDelegatesToCP` — CP delegation unchanged
- [x] `TestComposite_SyncDNA_NilHandler` — nil fallthrough
- [x] `TestComposite_SyncDNA_WithHandler` — routes through handler
- [x] `TestComposite_BulkTransfer_NilHandler` — nil fallthrough
- [x] `TestComposite_BulkTransfer_WithHandler` — routes through handler
- [x] `TestComposite_SyncConfigWithoutHandler` — nil fallthrough
- [x] `TestComposite_LogStream_NilHandler` — nil fallthrough + error message check
- [x] `TestComposite_AdditiveExtension` — new test proving additive extension pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)