### PR TITLE
web: asset-page tab self-registration via TabSpec.Panel field (Issue #2797)

### DIFF
--- a/web/src/fleet/StewardAssetPage.test.tsx
+++ b/web/src/fleet/StewardAssetPage.test.tsx
@@ -12,7 +12,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import StewardAssetPage from './StewardAssetPage.tsx'
+import StewardAssetPage, { PanelContent, TABS } from './StewardAssetPage.tsx'
 
 const fetchMock = vi.fn<typeof fetch>()
 
@@ -91,9 +91,9 @@ describe('tab strip', () => {
     fetchMock.mockReturnValue(new Promise(() => {}))
     renderAssetPage()
 
-    for (const name of [/^Config/i, /^Shell/i, /^Live Activity/i]) {
-      const tab = screen.getByRole('tab', { name })
-      expect(within(tab).getByText(/soon/i)).toBeInTheDocument()
+    for (const tab of TABS.filter((t) => t.soon)) {
+      const tabEl = screen.getByRole('tab', { name: (n) => n.startsWith(tab.label) })
+      expect(within(tabEl).getByText(/soon/i)).toBeInTheDocument()
     }
   })
 
@@ -244,5 +244,35 @@ describe('navigation', () => {
     renderAssetPage('stw-99')
 
     expect(screen.getByText('stw-99')).toBeInTheDocument()
+  })
+})
+
+describe('panel resolution', () => {
+  it('renders each tab\'s own Panel when two entries each carry a distinct Panel', () => {
+    function AlphaPanel() {
+      return <div data-testid="alpha-panel">Alpha</div>
+    }
+    function BetaPanel() {
+      return <div data-testid="beta-panel">Beta</div>
+    }
+
+    const { rerender } = render(
+      <PanelContent spec={{ key: 'dna', label: 'Alpha', soon: false, Panel: AlphaPanel }} />,
+    )
+    expect(screen.getByTestId('alpha-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('beta-panel')).not.toBeInTheDocument()
+
+    rerender(
+      <PanelContent spec={{ key: 'config', label: 'Beta', soon: false, Panel: BetaPanel }} />,
+    )
+    expect(screen.getByTestId('beta-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('alpha-panel')).not.toBeInTheDocument()
+  })
+
+  it('falls back to SoonPanel when no Panel is set', () => {
+    render(
+      <PanelContent spec={{ key: 'shell', label: 'Shell', soon: true }} />,
+    )
+    expect(screen.getByText(/Shell is not yet available/i)).toBeInTheDocument()
   })
 })

--- a/web/src/fleet/StewardAssetPage.tsx
+++ b/web/src/fleet/StewardAssetPage.tsx
@@ -18,7 +18,7 @@
  * broken aria-controls references in the DOM. Roving tabindex keeps Tab focus
  * on a single active tab; ArrowLeft/ArrowRight cycle between tabs.
  */
-import { useRef, useState } from 'react'
+import { type ComponentType, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import DnaDrawer from './DnaDrawer.tsx'
 
@@ -28,10 +28,11 @@ interface TabSpec {
   key: TabKey
   label: string
   soon: boolean
+  Panel?: ComponentType
 }
 
-const TABS: readonly TabSpec[] = [
-  { key: 'dna', label: 'DNA', soon: false },
+export const TABS: readonly TabSpec[] = [
+  { key: 'dna', label: 'DNA', soon: false, Panel: DnaDrawer },
   { key: 'config', label: 'Config', soon: true },
   { key: 'shell', label: 'Shell', soon: true },
   { key: 'live', label: 'Live Activity', soon: true },
@@ -46,6 +47,11 @@ function SoonPanel({ label }: { label: string }) {
   )
 }
 
+export function PanelContent({ spec }: { spec: TabSpec }) {
+  const Panel = spec.Panel
+  return Panel ? <Panel /> : <SoonPanel label={spec.label} />
+}
+
 export default function StewardAssetPage() {
   // useParams returns an already-decoded value from React Router — do not
   // call decodeURIComponent again or bare % chars in IDs throw URIError.
@@ -53,7 +59,7 @@ export default function StewardAssetPage() {
   const [activeTab, setActiveTab] = useState<TabKey>('dna')
   const tabRefs = useRef<Map<TabKey, HTMLButtonElement>>(new Map())
 
-  const activeSpec = TABS.find((t) => t.key === activeTab) ?? TABS[0]
+  const activeSpec = (TABS.find((t) => t.key === activeTab) ?? TABS[0])!
 
   function activateTab(key: TabKey) {
     setActiveTab(key)
@@ -116,11 +122,7 @@ export default function StewardAssetPage() {
         role="tabpanel"
         aria-labelledby={`asset-tab-${activeTab}`}
       >
-        {activeSpec?.soon ? (
-          <SoonPanel label={activeSpec.label} />
-        ) : (
-          <DnaDrawer />
-        )}
+        <PanelContent spec={activeSpec} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds optional `Panel?: ComponentType` to `TabSpec`; sets `Panel: DnaDrawer` on the `dna` entry so content is self-contained in the TABS declaration
- Extracts exported `PanelContent({ spec })` component: renders `spec.Panel` when set, else `<SoonPanel>` — no edits needed when future stories (e.g. #2762, #2766) add their own panels
- Exports `TABS` so the test file derives "soon tab" expectations from the source of truth; replaces the hardcoded `[/^Config/, /^Shell/, /^Live Activity/]` list in the test with `TABS.filter((t) => t.soon)`
- Adds `panel resolution` describe block with the REQUIRED TEST: two synthetic `TabSpec` entries each carrying a distinct `Panel`, asserting `PanelContent` renders the active one — proves the dual-story collision on this file is retired

Fixes #2797

## Specialist Review Results

**Code Review:** PASS — no findings  
**Test Quality:** PASS — no findings  
**Security:** PASS — no findings  

All three lenses green in round 1, zero fix rounds required.

## Test plan

- [ ] All 18 `StewardAssetPage.test.tsx` tests pass (`npm test`)
- [ ] `make test-agent-complete` passes (verified locally)
- [ ] DNA tab still renders `DnaDrawer` (existing tests cover this)
- [ ] Config/Shell/Live Activity still show `SoonPanel` (existing tests cover this)
- [ ] `panel resolution` describe: two-Panel synthetic test verifies resolution logic without touching shared conditional

🤖 Generated with [Claude Code](https://claude.ai/claude-code)