### PR TITLE
hyperv: gate existing-VM clustered-role reconcile on host ownership, not CNO ownership

### DIFF
--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -759,9 +759,12 @@ func (m *hypervModule) setCluster(ctx context.Context, resourceID string, config
 // single internal engine behind the hyperv.vm ha_role setting (#2372). It is
 // called only by registerClusteredRole (promote, state "present") and
 // demoteClusteredRole (demote, state "absent"); hyperv.cluster's operator
-// surface never reaches it. Gates mirror setCluster: scope cap (S5), transport,
-// CNO ownership (S1 — a non-owner audits a skip and returns nil; coordination,
-// not authorization). Membership mutations are idempotent: an existing member
+// surface never reaches it. Gates: scope cap (S5), transport, and HOST ownership
+// (S1 — a node that does not host the VM audits a skip and returns nil;
+// coordination, not authorization). Unlike setCluster (which is CNO-gated for
+// ownerless cluster-scoped work), work on an existing VM's role is gated on
+// hosting that VM: the register/demote cmdlets resolve the VM node-locally, so
+// only its host can act. Membership mutations are idempotent: an existing member
 // is not re-added, an absent member is not re-removed, and Add's
 // "already registered" error class is normalised to nil (post-failover
 // existence-check↔Add race).
@@ -787,24 +790,36 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 		return fmt.Errorf("hyperv: reconcile role membership %q/%q: %w", clusterName, role, ErrTransportNotConfigured)
 	}
 
-	// (3) CNO gate (S1). The helper audits the ownership decision and returns
-	// the role-owner map, which doubles as the existence oracle below.
-	ownsCNO, resourceOwners, err := m.clusterOwnershipHelper(ctx, clusterName)
+	// (3) Host-ownership gate. Reconciling the clustered-role membership of an
+	// EXISTING VM is gated on HOSTING that VM, not on CNO ownership. The register
+	// and demote cmdlets are node-local — psAddClusterVMRole resolves the VM via
+	// `Get-VM -Name` on the acting node before Add-ClusterVirtualMachineRole — so
+	// only the node that hosts the VM can perform the mutation, and only that node
+	// reaches this path (non-hosting members short-circuit as managed-elsewhere in
+	// getVM). The CNO gate is reserved for ownerless cluster tasks — creating a
+	// brand-new clustered VM that exists on no node (the vm.go create path,
+	// !vmExists && HARole) — where there is no host to serialise on. The ownership
+	// helper is still consulted for its role-owner map, which doubles as the
+	// existence oracle below.
+	_, resourceOwners, err := m.clusterOwnershipHelper(ctx, clusterName)
 	if err != nil {
 		return fmt.Errorf("hyperv: reconcile role membership %q/%q: %w", clusterName, role, err)
 	}
 
-	cnoOwner := m.readCNOOwner(ctx, clusterName)
-
-	if !ownsCNO {
-		// Non-owner: record an ownership-gated-skip and return nil.
+	_, hostsVM, hostErr := m.readVMState(ctx, role)
+	if hostErr != nil {
+		return fmt.Errorf("hyperv: reconcile role membership %q/%q: host-ownership probe: %w", clusterName, role, hostErr)
+	}
+	if !hostsVM {
+		// Not the host: the node that runs this VM owns its role reconcile and
+		// will converge it. Record a host-gated skip and return nil — coordination,
+		// not authorization.
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 			"cluster-set-skip", "cluster:"+clusterName, nil,
 			map[string]interface{}{
-				"owns_cno":  false,
-				"cno_owner": cnoOwner,
-				"skipped":   true,
-				"roles":     []string{role},
+				"hosts_vm": false,
+				"skipped":  true,
+				"roles":    []string{role},
 			}, nil)
 		return nil
 	}
@@ -828,7 +843,7 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 				"cluster-set-remove-noop", "cluster:"+clusterName,
 				map[string]interface{}{"role": role, "exists": false},
-				map[string]interface{}{"removed": false, "cno_owner": cnoOwner}, nil)
+				map[string]interface{}{"removed": false}, nil)
 			return nil
 		}
 		if _, rmErr := m.transport.ExecutePS(ctx, psRemoveClusterResource, map[string]string{"Name": role}); rmErr != nil {
@@ -841,7 +856,7 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 			"cluster-set-remove", "cluster:"+clusterName,
 			map[string]interface{}{"role": role, "exists": true},
-			map[string]interface{}{"removed": true, "cno_owner": cnoOwner}, nil)
+			map[string]interface{}{"removed": true}, nil)
 		// Membership changed — drop the Story #2577 read cache so the next probe
 		// sees the removed role.
 		m.invalidateClusterOwnersCache()
@@ -853,7 +868,7 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 			"cluster-set-noop", "cluster:"+clusterName,
 			map[string]interface{}{"role": role, "exists": true},
-			map[string]interface{}{"created": false, "cno_owner": cnoOwner}, nil)
+			map[string]interface{}{"created": false}, nil)
 		return nil
 	}
 	_, addErr := m.transport.ExecutePS(ctx, psAddClusterVMRole, map[string]string{
@@ -865,7 +880,7 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 			"cluster-set-create", "cluster:"+clusterName,
 			map[string]interface{}{"role": role, "exists": false},
-			map[string]interface{}{"created": true, "cno_owner": cnoOwner}, nil)
+			map[string]interface{}{"created": true}, nil)
 	case isAlreadyRegistered(addErr):
 		// Idempotency: an "already registered"/"already exists" error means a
 		// concurrent owner (or a stale existence read post-failover) created
@@ -873,7 +888,7 @@ func (m *hypervModule) reconcileRoleMembership(ctx context.Context, clusterName,
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 			"cluster-set-noop", "cluster:"+clusterName,
 			map[string]interface{}{"role": role, "exists": false},
-			map[string]interface{}{"created": false, "already_registered": true, "cno_owner": cnoOwner}, nil)
+			map[string]interface{}{"created": false, "already_registered": true}, nil)
 	default:
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 			"cluster-set-create", "cluster:"+clusterName,

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -706,10 +706,10 @@ func TestSetCluster_NonOwnerSkipsProperties(t *testing.T) {
 func TestRoleMembership_CNOOwner_Create(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
-			`{"owner":"NODE1"}`, // helper: CNO owner read → this node (NODE1) owns it
-			`{"owners":{}}`,     // helper: resource owners → role absent
-			`{"owner":"NODE1"}`, // engine: cnoOwner re-read
-			``,                  // Add-ClusterVirtualMachineRole → success (empty output)
+			`{"owner":"NODE1"}`,                      // helper: CNO owner read → this node (NODE1) owns it
+			`{"owners":{}}`,                          // helper: resource owners → role absent
+			hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+			``,                                       // Add-ClusterVirtualMachineRole → success (empty output)
 		},
 	}
 	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1", clusterName == "lab-hv"
@@ -803,9 +803,9 @@ func TestRoleMembership_Idempotent(t *testing.T) {
 	t.Run("existence-check short-circuit", func(t *testing.T) {
 		transport := &testWinRMTransport{
 			perCallOutputs: []string{
-				`{"owner":"NODE1"}`,             // helper CNO owner (this node)
-				`{"owners":{"web-01":"NODE1"}}`, // role already exists
-				`{"owner":"NODE1"}`,             // cnoOwner re-read
+				`{"owner":"NODE1"}`,                      // helper CNO owner (this node)
+				`{"owners":{"web-01":"NODE1"}}`,          // role already exists
+				hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
 			},
 		}
 		m, _ := clusterTestModule(t, transport)
@@ -821,10 +821,10 @@ func TestRoleMembership_Idempotent(t *testing.T) {
 	t.Run("already-registered error normalised", func(t *testing.T) {
 		transport := &testWinRMTransport{
 			perCallOutputs: []string{
-				`{"owner":"NODE1"}`, // helper CNO owner (this node)
-				`{"owners":{}}`,     // existence read: role absent
-				`{"owner":"NODE1"}`, // cnoOwner re-read
-				``,                  // Add call (output ignored; error supplied below)
+				`{"owner":"NODE1"}`,                      // helper CNO owner (this node)
+				`{"owners":{}}`,                          // existence read: role absent
+				hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+				``,                                       // Add call (output ignored; error supplied below)
 			},
 			perCallErrors: []error{
 				nil, nil, nil,
@@ -847,7 +847,7 @@ func TestRoleMembership_Idempotent(t *testing.T) {
 			perCallOutputs: []string{
 				`{"owner":"NODE1"}`,
 				`{"owners":{}}`,
-				`{"owner":"NODE1"}`,
+				hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
 				``,
 			},
 			perCallErrors: []error{
@@ -872,9 +872,9 @@ func TestRoleMembership_Idempotent(t *testing.T) {
 func TestRoleMembership_DestructiveGate(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
-			`{"owner":"NODE1"}`,             // helper CNO owner (this node owns it)
-			`{"owners":{"web-01":"NODE1"}}`, // role present
-			`{"owner":"NODE1"}`,             // cnoOwner re-read
+			`{"owner":"NODE1"}`,                      // helper CNO owner (this node owns it)
+			`{"owners":{"web-01":"NODE1"}}`,          // role present
+			hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
 		},
 	}
 	m, _ := clusterTestModule(t, transport)
@@ -899,10 +899,10 @@ func TestRoleMembership_DestructiveGate(t *testing.T) {
 func TestRoleMembership_DriftNotAdopted(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
-			`{"owner":"NODE1"}`,            // helper CNO owner (this node)
-			`{"owners":{"db-99":"NODE1"}}`, // undeclared role db-99 present; declared web-01 absent
-			`{"owner":"NODE1"}`,            // cnoOwner re-read
-			``,                             // Add web-01 → success
+			`{"owner":"NODE1"}`,                      // helper CNO owner (this node)
+			`{"owners":{"db-99":"NODE1"}}`,           // undeclared role db-99 present; declared web-01 absent
+			hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+			``,                                       // Add web-01 → success
 		},
 	}
 	m, _ := clusterTestModule(t, transport)
@@ -939,10 +939,10 @@ func TestRoleMembership_DriftNotAdopted(t *testing.T) {
 func TestRoleMembership_Remove_Success(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
-			`{"owner":"NODE1"}`,             // helper CNO owner → this node (NODE1) owns it
-			`{"owners":{"web-01":"NODE1"}}`, // helper resource owners → role present
-			`{"owner":"NODE1"}`,             // setCluster cnoOwner re-read
-			``,                              // Remove-ClusterResource → success
+			`{"owner":"NODE1"}`,                      // helper CNO owner → this node (NODE1) owns it
+			`{"owners":{"web-01":"NODE1"}}`,          // helper resource owners → role present
+			hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+			``,                                       // Remove-ClusterResource → success
 		},
 	}
 	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
@@ -993,10 +993,10 @@ func TestRoleMembership_Remove_Success(t *testing.T) {
 func TestRoleMembership_Remove_TransportError(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
-			`{"owner":"NODE1"}`,             // helper CNO owner (this node owns it)
-			`{"owners":{"web-01":"NODE1"}}`, // role present
-			`{"owner":"NODE1"}`,             // cnoOwner re-read
-			``,                              // Remove call (error supplied below)
+			`{"owner":"NODE1"}`,                      // helper CNO owner (this node owns it)
+			`{"owners":{"web-01":"NODE1"}}`,          // role present
+			hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+			``,                                       // Remove call (error supplied below)
 		},
 		perCallErrors: []error{
 			nil, nil, nil,
@@ -1037,9 +1037,9 @@ func TestRoleMembership_Remove_TransportError(t *testing.T) {
 func TestRoleMembership_Remove_AlreadyGone(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{
-			`{"owner":"NODE1"}`, // helper CNO owner (this node owns it)
-			`{"owners":{}}`,     // resource owners → role already gone
-			`{"owner":"NODE1"}`, // cnoOwner re-read
+			`{"owner":"NODE1"}`,                      // helper CNO owner (this node owns it)
+			`{"owners":{}}`,                          // resource owners → role already gone
+			hostVMJSON("web-01", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
 		},
 	}
 	m, store := clusterTestModule(t, transport)

--- a/features/modules/hyperv/vm_harole_convergence_test.go
+++ b/features/modules/hyperv/vm_harole_convergence_test.go
@@ -475,8 +475,8 @@ func TestSetVM_ClusterWideAbsentRole_OwnerCreates(t *testing.T) {
 		``,                  // Cfgms-SetVMHome: config-home move (#2411)
 		`{"owner":"NODE1"}`, // registerClusteredRole ownership helper: CNO owner
 		`{"owners":{}}`,     // registerClusteredRole ownership helper: role owners
-		`{"owner":"NODE1"}`, // registerClusteredRole audit cnoOwner re-read
-		``,                  // Add-ClusterVirtualMachineRole
+		hostVMJSON("ha-first-vm", "stopped", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+		``, // Add-ClusterVirtualMachineRole
 	}}
 	m := vmModuleWithTransport(transport, "t-2421")
 	m.clusterName = cluster
@@ -575,13 +575,13 @@ func TestSetVM_HARole_PromoteExistingVM(t *testing.T) {
 	const cluster = "lab-hv"
 
 	transport := &testWinRMTransport{perCallOutputs: []string{
-		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
-		`{"owners":{}}`,                        // getVM probe: not a member
-		`{"owners":{}}`,                        // #2422 lifecycle owner gate: role not yet registered → proceed (first-time promote)
-		`{"owner":"NODE1"}`,                    // ownership helper: CNO owner
-		`{"owners":{}}`,                        // ownership helper: role owners
-		`{"owner":"NODE1"}`,                    // audit cnoOwner re-read
-		``,                                     // Add-ClusterVirtualMachineRole
+		hostVMJSON(vmName, "stopped", 2, 4096),          // getVM: VM exists
+		`{"owners":{}}`,                                 // getVM probe: not a member
+		`{"owners":{}}`,                                 // #2422 lifecycle owner gate: role not yet registered → proceed (first-time promote)
+		`{"owner":"NODE1"}`,                             // ownership helper: CNO owner
+		`{"owners":{}}`,                                 // ownership helper: role owners
+		hostVMJSON("ha-promote-vm", "stopped", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+		``, // Add-ClusterVirtualMachineRole
 	}}
 	m := vmModuleWithTransport(transport, "t-ha")
 	m.clusterName = cluster
@@ -609,12 +609,12 @@ func TestSetVM_HARole_DemoteRemovesRoleOnly(t *testing.T) {
 	const cluster = "lab-hv"
 
 	transport := &testWinRMTransport{perCallOutputs: []string{
-		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
-		`{"owners":{"ha-demote-vm":"NODE1"}}`,  // getVM probe: member
-		`{"owner":"NODE1"}`,                    // ownership helper: CNO owner
-		`{"owners":{"ha-demote-vm":"NODE1"}}`,  // ownership helper: role owners
-		`{"owner":"NODE1"}`,                    // audit cnoOwner re-read
-		``,                                     // Remove-ClusterGroup
+		hostVMJSON(vmName, "stopped", 2, 4096),         // getVM: VM exists
+		`{"owners":{"ha-demote-vm":"NODE1"}}`,          // getVM probe: member
+		`{"owner":"NODE1"}`,                            // ownership helper: CNO owner
+		`{"owners":{"ha-demote-vm":"NODE1"}}`,          // ownership helper: role owners
+		hostVMJSON("ha-demote-vm", "stopped", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+		``, // Remove-ClusterGroup
 	}}
 	m := vmModuleWithTransport(transport, "t-ha")
 	m.clusterName = cluster
@@ -693,21 +693,26 @@ func TestSetVM_HARole_DemoteIdempotent(t *testing.T) {
 	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole))
 }
 
-// ─── AC3 (REQUIRED TEST): non-CNO-owner nodes no-op ────────────────────────────
+// ─── AC3 (REQUIRED TEST): promotion is host-gated, not CNO-gated ───────────────
 
-// TestSetVM_HARole_NonOwnerNoop: promote on a non-CNO-owner node performs no
-// membership mutation and returns nil — coordination, not authorization.
-func TestSetVM_HARole_NonOwnerNoop(t *testing.T) {
+// TestSetVM_HARole_HostPromotesEvenIfNonCNOOwner: promoting an EXISTING VM is
+// gated on HOST ownership, not CNO ownership. The node that hosts the VM
+// registers its clustered role even when another node owns the CNO — the
+// register cmdlet resolves the VM node-locally, so only its host can (and must)
+// act. Previously a non-CNO-owner silently no-op'd, which stranded any VM not
+// living on the CNO-owning node.
+func TestSetVM_HARole_HostPromotesEvenIfNonCNOOwner(t *testing.T) {
 	const vmName = "ha-nonowner-vm"
 	const cluster = "lab-hv"
 
 	transport := &testWinRMTransport{perCallOutputs: []string{
-		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists
+		hostVMJSON(vmName, "stopped", 2, 4096), // getVM: VM exists locally (this node hosts it)
 		`{"owners":{}}`,                        // getVM probe: not a member
 		`{"owners":{}}`,                        // #2422 lifecycle owner gate: role not registered → proceed (first-time promote)
-		`{"owner":"NODE2"}`,                    // ownership helper: another node owns CNO
+		`{"owner":"NODE2"}`,                    // ownership helper: ANOTHER node (NODE2) owns the CNO
 		`{"owners":{}}`,                        // ownership helper: role owners
-		`{"owner":"NODE2"}`,                    // audit cnoOwner re-read
+		hostVMJSON(vmName, "stopped", 2, 4096), // host-ownership probe (Get-VM): NODE1 hosts the VM → it promotes
+		``,                                     // Add-ClusterVirtualMachineRole
 	}}
 	m := vmModuleWithTransport(transport, "t-ha")
 	m.clusterName = cluster
@@ -722,8 +727,8 @@ func TestSetVM_HARole_NonOwnerNoop(t *testing.T) {
 		"ha_role":   map[string]interface{}{"cluster_name": cluster},
 	}))
 
-	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
-		"a non-owner node must not mutate cluster membership")
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"the hosting node must promote its VM even when another node owns the CNO")
 }
 
 // ─── AC2 (REQUIRED TEST): source-provisioned VM registered by finalizing ──────
@@ -755,8 +760,8 @@ func TestFinalizeProvision_HARole_RegistersBeforeFinalizing(t *testing.T) {
 		``,                                     // Remove-Item (answer ISO)
 		`{"owner":"NODE1"}`,                    // ownership helper: CNO owner
 		`{"owners":{}}`,                        // ownership helper: role owners
-		`{"owner":"NODE1"}`,                    // audit cnoOwner re-read
-		``,                                     // Add-ClusterVirtualMachineRole
+		hostVMJSON("ha-src-vm", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+		``, // Add-ClusterVirtualMachineRole
 	}}
 	m := vmModuleWithTransport(transport, "t-ha")
 	m.clusterName = cluster
@@ -812,8 +817,8 @@ func TestFinalizeProvision_HARole_RegistrationFailureRetries(t *testing.T) {
 			``,                                     // Remove-Item (iso)
 			`{"owner":"NODE1"}`,                    // CNO owner
 			`{"owners":{}}`,                        // role owners
-			`{"owner":"NODE1"}`,                    // audit re-read
-			``,                                     // Add — errors below
+			hostVMJSON("ha-src-fail-vm", "running", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+			``, // Add — errors below
 		},
 		perCallErrors: []error{nil, nil, nil, nil, nil, nil, nil, nil, errors.New("cluster add failed")},
 	}

--- a/features/modules/hyperv/vm_lifecycle_owner_gate_test.go
+++ b/features/modules/hyperv/vm_lifecycle_owner_gate_test.go
@@ -85,11 +85,11 @@ func TestApplyVMState_Owner_ConvergesNormally(t *testing.T) {
 		// call0: gate probe — role absent cluster-wide (no entry ⇒ do NOT skip).
 		// calls 1-4: registerClusteredRole on the CNO owner (this node).
 		transport := &testWinRMTransport{perCallOutputs: []string{
-			`{"owners":{}}`,     // gate: role not yet registered → local possession decides
-			`{"owner":"NODE1"}`, // reconcileRoleMembership: CNO owner
-			`{"owners":{}}`,     // reconcileRoleMembership: role owners
-			`{"owner":"NODE1"}`, // reconcileRoleMembership: audit cnoOwner re-read
-			``,                  // Add-ClusterVirtualMachineRole
+			`{"owners":{}}`,                        // gate: role not yet registered → local possession decides
+			`{"owner":"NODE1"}`,                    // reconcileRoleMembership: CNO owner
+			`{"owners":{}}`,                        // reconcileRoleMembership: role owners
+			hostVMJSON(vmName, "stopped", 2, 4096), // host-ownership probe (Get-VM): this node hosts the VM
+			``,                                     // Add-ClusterVirtualMachineRole
 		}}
 		m := vmModuleWithTransport(transport, "t-2422")
 		m.nodeHostname = "NODE1"

--- a/features/modules/hyperv/vm_role_host_owner_gate_test.go
+++ b/features/modules/hyperv/vm_role_host_owner_gate_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// reconcileRoleMembership gates work on an EXISTING VM's clustered role on HOST
+// ownership, not CNO ownership: the node that runs the VM promotes/demotes its
+// role, because Add/Remove-ClusterVirtualMachineRole resolve the VM node-locally
+// (only its host can act). The CNO gate is reserved for ownerless cluster tasks
+// (creating a brand-new clustered VM — the vm.go create path). These tests pin
+// the inversion both ways.
+
+// TestRoleMembership_HostOwner_NonCNO_Promotes is the core fix: a node that
+// HOSTS the VM but does NOT own the CNO still promotes it. Under the old
+// CNO-ownership gate this silently skipped, so a VM on any non-CNO node could
+// never be promoted via config.
+func TestRoleMembership_HostOwner_NonCNO_Promotes(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE2"}`,                      // helper: CNO owner is NODE2 — this node (NODE1) does NOT own the CNO
+			`{"owners":{}}`,                          // helper: resource owners → web-01 not yet a clustered role
+			hostVMJSON("web-01", "running", 2, 4096), // host probe: NODE1 HOSTS web-01
+			``,                                       // Add-ClusterVirtualMachineRole → success
+		},
+	}
+	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "present", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countCmd(transport, psAddClusterVMRole),
+		"the hosting node must promote its local VM even though it does NOT own the CNO")
+
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var createEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-set-create" {
+			createEvt = e
+		}
+	}
+	require.NotNil(t, createEvt, "a create audit event must be recorded on the hosting node")
+	require.NotNil(t, createEvt.Changes)
+	assert.Equal(t, true, createEvt.Changes.After["created"])
+}
+
+// TestRoleMembership_NotHost_Skips is the other half of the inversion: even the
+// CNO-owner node does NOT promote a VM it does not host — the gate is host
+// ownership, not CNO ownership. It records a host-gated skip and issues no
+// cluster write. (Another node hosts the VM and owns its reconcile.)
+func TestRoleMembership_NotHost_Skips(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`,             // helper: this node (NODE1) DOES own the CNO ...
+			`{"owners":{"web-01":"NODE2"}}`, // ... but the VM's role is owned/hosted by NODE2
+			`{"found":false}`,               // host probe: NODE1 does NOT host web-01
+		},
+	}
+	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "present", false)
+	require.NoError(t, err, "a non-host must return nil — coordination, not authorization")
+
+	assert.Equal(t, 0, countCmd(transport, psAddClusterVMRole),
+		"a node that does not host the VM must issue no Add — even when it owns the CNO")
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),
+		"a non-host must issue no Remove")
+
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var skipEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-set-skip" {
+			skipEvt = e
+		}
+	}
+	require.NotNil(t, skipEvt, "a host-gated skip audit event must be recorded")
+	require.NotNil(t, skipEvt.Changes)
+	assert.Equal(t, false, skipEvt.Changes.After["hosts_vm"], "the skip must record hosts_vm: false")
+	assert.Equal(t, true, skipEvt.Changes.After["skipped"])
+}
+
+// TestRoleMembership_NotHost_Demote_Skips verifies the host gate also guards the
+// demote path: a node that does not host the VM issues no Remove even with
+// allowDestructive true.
+func TestRoleMembership_NotHost_Demote_Skips(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE1"}`,             // helper: this node owns the CNO
+			`{"owners":{"web-01":"NODE2"}}`, // role hosted by NODE2
+			`{"found":false}`,               // host probe: NODE1 does NOT host web-01
+		},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	err := m.reconcileRoleMembership(context.Background(), "lab-hv", "web-01", "absent", true)
+	require.NoError(t, err, "a non-host demote is a coordinated no-op")
+	assert.Equal(t, 0, countCmd(transport, psRemoveClusterResource),
+		"a non-host must issue no Remove even on the destructive path")
+}

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -1445,8 +1445,8 @@ func TestSetVM_HARole_RegistersClusteredRole(t *testing.T) {
 			``,                  // Cfgms-SetVMHome: config-home move (#2411)
 			`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)
 			`{"owners":{}}`,     // ownership helper: resource owners (role absent)
-			`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read
-			``,                  // Add-ClusterVirtualMachineRole: success
+			hostVMJSON("ha-map-vm", "stopped", 2, 4096), // host-ownership probe (Get-VM): VM present locally after create
+			``, // Add-ClusterVirtualMachineRole: success
 		}}
 		m := vmModuleWithTransport(transport, "t-ha")
 		m.clusterName = cluster
@@ -1555,8 +1555,8 @@ func TestSetVM_HARole_MapShapeRegistersClusteredRole(t *testing.T) {
 		``,                  // Cfgms-SetVMHome: config-home move (#2411)
 		`{"owner":"NODE1"}`, // ownership helper: CNO owner read (this node)
 		`{"owners":{}}`,     // ownership helper: resource owners (role absent)
-		`{"owner":"NODE1"}`, // setCluster: cnoOwner re-read
-		``,                  // Add-ClusterVirtualMachineRole: success
+		hostVMJSON("ha-map-vm", "stopped", 2, 4096), // host-ownership probe (Get-VM): VM local after create
+		``, // Add-ClusterVirtualMachineRole: success
 	}}
 	m := vmModuleWithTransport(transport, "t-ha")
 	m.clusterName = cluster


### PR DESCRIPTION
## Problem

`reconcileRoleMembership` — the `hyperv.vm` `ha_role` promote/demote engine — gated on **CNO ownership**. But the register/demote cmdlets are node-local: `psAddClusterVMRole` runs `Get-VM -Name` on the acting node before `Add-ClusterVirtualMachineRole`. So the only node that can register a role for a VM is the node that **hosts** it — which is not necessarily the CNO owner. Result: a VM hosted on any non-CNO node was **never** promoted to a clustered role via config; it silently recorded `cluster-set-skip owns_cno=false` every converge.

## Fix

Gate work on an **existing** VM's clustered role on **host ownership** (`readVMState` — is the VM local?) instead of CNO ownership. Only the hosting node acts, which also guarantees the node-local `Get-VM` in the cmdlet resolves. The **CNO gate is unchanged for the ownerless case** — creating a brand-new clustered VM that exists on no node (`vm.go` create path, `!vmExists && HARole`), where there is no host to serialize on. Non-hosting members already short-circuit as managed-elsewhere in `getVM`, so exactly one node acts.

`setCluster` (the `hyperv.cluster` resource) is untouched — it keeps its CNO gate and never reaches this engine.

## Tests

- New `vm_role_host_owner_gate_test.go` pins the inversion both ways: a node that **hosts** the VM promotes it **without** owning the CNO; a node that does **not** host the VM skips **even when it owns** the CNO (promote and demote).
- Existing membership-engine + full-`setVM`/`applyVMState`/`finalizeProvision` tests updated for the host-ownership probe; the former "non-CNO-owner no-ops" case is reframed to "the host promotes regardless of CNO owner."
- Full `features/modules/hyperv` package passes; `go vet` clean.

## Live validation

On the lab failover cluster (CNO owner = one node; two lab VMs hosted on a **different** node): after deploying the fixed steward, the non-CNO node promoted both of its local VMs to Online clustered roles — which the CNO-gated code refused to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)