### PR TITLE
steward/execution: exclude old_name from drift comparison so a completed rename converges clean

### DIFF
--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -147,6 +147,7 @@ func (g *genericConfigState) GetManagedFields() []string {
 		"winrm_user_secret":        true, // module operational: SecretStore key
 		"winrm_pass_secret":        true, // module operational: SecretStore key
 		"source":                   true, // create-time provisioning directive (existence-gated, ADR-009); never reported by getVM (source: nil), so comparing it drifts every cycle on a provisioned VM
+		"old_name":                 true, // #2776 in-place rename directive: consumed by setVM to locate the source VM, never reported by getVM (which returns the VM under its NEW name), so comparing it drifts every cycle after a completed rename. The rename still triggers — the VM under the new name is absent, so its other fields drift.
 		"enroll_token":             true, // module operational: hyperv create-from-source join token (ADR-010)
 		"enroll_ca_fingerprint":    true, // module operational: controller CA fingerprint for guest TOFU
 		"enroll_steward_path":      true, // module operational: host path to steward binary staged on seed

--- a/features/steward/execution/execution_internal_test.go
+++ b/features/steward/execution/execution_internal_test.go
@@ -123,6 +123,7 @@ func TestGenericConfigState_ExcludesModuleOperationalKeys(t *testing.T) {
 		"source":                   map[string]interface{}{"image": "x.raw"},
 		"enroll_launcher_path":     `C:\seed\launcher`,
 		"debug_ssh_authorized_key": "ssh-ed25519 AAAA...",
+		"old_name":                 "demo-vm-old", // #2776 rename directive: consumed by setVM, never reported by getVM
 		// Actual resource state — must remain.
 		"switch_type": "internal",
 		"state":       "present",
@@ -135,7 +136,7 @@ func TestGenericConfigState_ExcludesModuleOperationalKeys(t *testing.T) {
 		"path", "name",
 		"transport", "tenant_id", "steward_id", "audit_manager",
 		"winrm_host", "winrm_user_secret", "winrm_pass_secret",
-		"source", "enroll_launcher_path", "debug_ssh_authorized_key",
+		"source", "enroll_launcher_path", "debug_ssh_authorized_key", "old_name",
 	} {
 		assert.NotContains(t, fields, key,
 			"%q is a module-operational/identifier key and must not appear in managed fields", key)
@@ -225,10 +226,14 @@ func TestCompareStates_ProvisionedVM_NoFalseDrift(t *testing.T) {
 		"source":                   map[string]interface{}{"image": `C:\iso\debian.raw`, "os_family": "linux", "on_existing": "never"},
 		"enroll_launcher_path":     `C:\ClusterStorage\CSV01\seed-assets\cfgms-steward-launcher-linux`,
 		"debug_ssh_authorized_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 cfgms-lab@cfg-lab",
+		// #2776 in-place rename directive left in config after the rename completed:
+		// consumed by setVM to locate the source VM, never reported by getVM (which
+		// returns the VM under its NEW name). Must not drift once the rename is done.
+		"old_name": "cfgms-ci-lin-01-old",
 	}}
 
 	// What getVM reports for the same running VM: observable state matches, but
-	// source is nil and the enrollment/ssh fields are absent.
+	// source is nil and the enrollment/ssh/old_name fields are absent.
 	current := &genericConfigState{data: map[string]interface{}{
 		"name":      "cfgms-ci-lin-01",
 		"state":     "running",


### PR DESCRIPTION
## Problem

The `hyperv.vm` `old_name` in-place rename directive (#2776) is consumed by `setVM` to locate the source VM, but `getVM` never reports it — it returns the VM under its **new** name. The generic drift comparator (`genericConfigState.GetManagedFields`) keys off the authored config, so once a rename completes, `old_name` is present in *desired* but never in *observed*, and is flagged as an `added` field on **every** convergence cycle. That holds the resource at a permanent non-compliant / `ERROR` status.

Observed live: renamed lab VMs reported `added_fields: [old_name]` and `failed` converges indefinitely after the rename succeeded.

## Fix

Add `old_name` to `genericConfigState`'s `excludedFields` — the same pan-module exclusion that already covers create-time directives `getVM` cannot echo (`source`, `enroll_*`, `debug_ssh_authorized_key`, `seed_dir`). This is the established mechanism for "a key `setVM` consumes but `getVM` never reports."

The rename still triggers correctly: when the VM under the new name is absent, its other managed fields (`state`, `vhd_path`, `memory_mb`, …) drift and drive `setVM`, which performs the rename. Thereafter the VM converges clean.

## Tests

- `TestGenericConfigState_ExcludesModuleOperationalKeys` extended to assert `old_name` is excluded.
- `TestCompareStates_ProvisionedVM_NoFalseDrift` extended: a running VM whose config still carries `old_name` shows no drift.
- Full `features/steward/execution` package passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)