### PR TITLE
controller: migrate non-route IsAdmin readers to Assurance and delete field (Issue #2781)

### DIFF
--- a/features/controller/api/handlers_certificates.go
+++ b/features/controller/api/handlers_certificates.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 )
 
 // RotateSigningCertRequest is the optional JSON body for the rotate endpoint.
@@ -39,8 +40,10 @@ type RotateSigningCertResponse struct {
 }
 
 // handleRotateSigningCert handles POST /api/v1/certificates/signing/rotate.
-// Requires mTLS admin cert (IsAdmin=true); non-admin principals are rejected with 403
-// even when rbacService is nil, preventing the RBAC-nil bypass.
+// Requires AssuranceStrong (mTLS admin cert); weaker principals are rejected with 403
+// even when rbacService is nil, preventing the RBAC-nil bypass. certificate:rotate is
+// AssuranceStrong-gated in permissionAssurance — this guard mirrors that bar so the
+// defense holds even if rbacService is nil.
 func (s *Server) handleRotateSigningCert(w http.ResponseWriter, r *http.Request) {
 	principal, ok := r.Context().Value(principalContextKey).(*Principal)
 	if !ok || principal == nil {
@@ -48,10 +51,10 @@ func (s *Server) handleRotateSigningCert(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Explicit IsAdmin guard — must precede any RBAC or rotation logic.
+	// Defense-in-depth: mirror the AssuranceStrong bar for certificate:rotate.
 	// requirePermission skips checks when rbacService is nil (RBAC-nil bypass);
-	// a CA-key operation must NEVER be reachable by a non-admin principal.
-	if !principal.IsAdmin {
+	// a CA-key operation must NEVER be reachable by a sub-Strong-assurance principal.
+	if principal.Assurance < session.AssuranceStrong {
 		s.writeErrorResponse(w, http.StatusForbidden, "Admin certificate required", "FORBIDDEN")
 		return
 	}

--- a/features/controller/api/handlers_certificates_test.go
+++ b/features/controller/api/handlers_certificates_test.go
@@ -332,11 +332,12 @@ func setupRotationTestServer(t *testing.T) (*Server, *cert.Manager, *service.Sig
 }
 
 // TestHandleRotateSigningCertRequiresAdminCert verifies that the rotate endpoint
-// returns 403 for any non-admin principal, even when rbacService is nil.
+// returns 403 for any sub-Strong-assurance principal, even when rbacService is nil.
 //
-// (a) API-key principal → 403 (issued by X-API-Key header, IsAdmin == false).
-// (b) rbacService == nil + non-admin cert (no admin marker) → 403.
-// The explicit IsAdmin guard must block both before any rotation logic runs.
+// (a) API-key principal → 403 (AssuranceMachine, does not meet AssuranceStrong bar).
+// (b) rbacService == nil + non-Strong-assurance cert → 403.
+// The defense-in-depth Assurance < AssuranceStrong guard must block both before any
+// rotation logic runs, mirroring the certificate:rotate permissionAssurance entry.
 func TestHandleRotateSigningCertRequiresAdminCert(t *testing.T) {
 	server, _, _ := setupRotationTestServer(t)
 
@@ -349,15 +350,15 @@ func TestHandleRotateSigningCertRequiresAdminCert(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 		var errResp ErrorResponse
 		require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
-		// Assurance gate (requirePermission) fires before the handler's own IsAdmin check:
+		// Assurance gate (requirePermission) fires before the handler's own Assurance check:
 		// Machine-assurance API keys get INSUFFICIENT_PERMISSIONS, not MTLS_REQUIRED (Issue #2780).
 		assert.Equal(t, "INSUFFICIENT_PERMISSIONS", errResp.Error.Code)
 	})
 
 	t.Run("nil_rbac_non_admin_principal_rejected", func(t *testing.T) {
 		// Build a server with rbacService == nil to exercise the RBAC-nil bypass path.
-		// requirePermission skips the check when rbacService is nil; the explicit IsAdmin
-		// guard in the handler must catch non-admin principals before rotation is reached.
+		// requirePermission skips the check when rbacService is nil; the defense-in-depth
+		// Assurance < AssuranceStrong guard in the handler must be the sole gate.
 		t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
 		cfg := config.DefaultConfig()
 		cfg.Certificate.EnableCertManagement = false
@@ -381,9 +382,9 @@ func TestHandleRotateSigningCertRequiresAdminCert(t *testing.T) {
 			_ = nilRBACServer.Close(closeCtx)
 		})
 
-		// Use an API-key principal (IsAdmin == false). With rbacService == nil,
-		// requirePermission skips the RBAC check — the explicit IsAdmin guard in the
-		// handler must be the sole gate.
+		// Use an API-key principal (AssuranceMachine). With rbacService == nil,
+		// requirePermission skips the RBAC check — the Assurance < AssuranceStrong guard
+		// in the handler must be the sole gate.
 		apiKey := NewTestKey(t, nilRBACServer, []string{"certificate:rotate"})
 		req := httptest.NewRequest("POST", "/api/v1/certificates/signing/rotate", nil)
 		req.Header.Set("X-API-Key", apiKey)

--- a/features/controller/api/handlers_cluster_test.go
+++ b/features/controller/api/handlers_cluster_test.go
@@ -63,7 +63,6 @@ func TestAssuranceGate_ClusterDrain_BasicAssuranceGetsStepUp(t *testing.T) {
 	basicPrincipal := &Principal{
 		ID:        "web-user",
 		Name:      "web-session:web-user",
-		IsAdmin:   true,
 		Assurance: session.AssuranceBasic,
 	}
 	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
@@ -216,7 +215,6 @@ func TestAssuranceGate_ClusterDecommission_BasicAssuranceGetsStepUp(t *testing.T
 	basicPrincipal := &Principal{
 		ID:        "web-user",
 		Name:      "web-session:web-user",
-		IsAdmin:   true,
 		Assurance: session.AssuranceBasic,
 	}
 	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })

--- a/features/controller/api/handlers_fleet_test.go
+++ b/features/controller/api/handlers_fleet_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -468,9 +469,9 @@ func postResolveSelectorWithPrincipal(server *Server, body, tenantID string, isA
 		ctx = context.WithValue(ctx, ctxkeys.TenantID, tenantID)
 	}
 	if isAdmin {
-		ctx = context.WithValue(ctx, principalContextKey, &Principal{IsAdmin: true, TenantID: ""})
+		ctx = context.WithValue(ctx, principalContextKey, &Principal{Assurance: session.AssuranceBasic, TenantID: ""})
 	} else {
-		ctx = context.WithValue(ctx, principalContextKey, &Principal{IsAdmin: false, TenantID: tenantID})
+		ctx = context.WithValue(ctx, principalContextKey, &Principal{Assurance: session.AssuranceMachine, TenantID: tenantID})
 	}
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()

--- a/features/controller/api/handlers_jobs.go
+++ b/features/controller/api/handlers_jobs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/batchjob"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 )
 
 // jobExecutor is the minimal interface satisfied by *batchjob.RollingBatchExecutor.
@@ -98,7 +99,7 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	// the caller's subtree; absent prefix defaults to tenantID and all descendants.
 	// Admin callers (empty tenantID) are unrestricted.
 	if parsedTenantPath != "" {
-		if !principal.IsAdmin && tenantID != "" &&
+		if principal.Assurance < session.AssuranceBasic && tenantID != "" &&
 			parsedTenantPath != tenantID &&
 			!strings.HasPrefix(parsedTenantPath, tenantID+"/") {
 			s.writeErrorResponse(w, http.StatusForbidden,
@@ -106,7 +107,7 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		filter.TenantSubtree = parsedTenantPath
-	} else if !principal.IsAdmin {
+	} else if principal.Assurance < session.AssuranceBasic {
 		filter.TenantSubtree = tenantID
 	}
 
@@ -207,7 +208,7 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !principal.IsAdmin && job.TenantID != tenantID {
+	if principal.Assurance < session.AssuranceBasic && job.TenantID != tenantID {
 		s.writeErrorResponse(w, http.StatusForbidden, "Access denied", "FORBIDDEN")
 		return
 	}

--- a/features/controller/api/handlers_jobs_test.go
+++ b/features/controller/api/handlers_jobs_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/controller/batchjob"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,13 +30,13 @@ func newTestBatchJobStoreForAPI() batchjob.BatchJobStore {
 // adminPrincipal returns a global-admin principal with no tenant scope,
 // mirroring the mTLS admin certificate path in authenticationMiddleware.
 func adminPrincipal() *Principal {
-	return &Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}
+	return &Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""}
 }
 
-// tenantPrincipal returns a non-admin principal scoped to the given tenant,
+// tenantPrincipal returns a machine-assurance principal scoped to the given tenant,
 // mirroring an API-key caller authenticated by authenticationMiddleware.
 func tenantPrincipal(tenantID string) *Principal {
-	return &Principal{ID: "api-key-" + tenantID, IsAdmin: false, TenantID: tenantID}
+	return &Principal{ID: "api-key-" + tenantID, Assurance: session.AssuranceMachine, TenantID: tenantID}
 }
 
 // postCreateJobAs sends POST /api/v1/jobs as the given principal.
@@ -118,7 +119,7 @@ func TestHandleCreateJob_NonAdminEmptyTenant_Returns401(t *testing.T) {
 	server := setupTestServer(t)
 	server.batchJobStore = newTestBatchJobStoreForAPI()
 
-	nonAdminNoTenant := &Principal{ID: "bad-key", IsAdmin: false, TenantID: ""}
+	nonAdminNoTenant := &Principal{ID: "bad-key", Assurance: session.AssuranceMachine, TenantID: ""}
 	rec := postCreateJobAs(server, nonAdminNoTenant, `{"selector":"all","batch_size":3}`)
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
@@ -338,7 +339,7 @@ func TestHandleGetJob_NonAdminEmptyTenant_Returns401(t *testing.T) {
 	}
 	require.NoError(t, store.CreateBatchJob(context.Background(), seedJob))
 
-	nonAdminNoTenant := &Principal{ID: "bad-key", IsAdmin: false, TenantID: ""}
+	nonAdminNoTenant := &Principal{ID: "bad-key", Assurance: session.AssuranceMachine, TenantID: ""}
 	rec := getJobAs(server, nonAdminNoTenant, "job-any-tenant")
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
@@ -439,6 +440,81 @@ func TestHandleGetJob_NilStore_Returns503(t *testing.T) {
 	// batchJobStore is nil by default.
 	rec := getJobWithTenant(server, "any-id", "tenant-a")
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// ── Tenant isolation regression tests — Issue #2781 ──────────────────────────
+
+// TestJobsTenantIsolation_AssuranceBoundary is a table-driven regression test
+// verifying that the Assurance-based tenant-isolation gates in handlers_jobs.go
+// are byte-for-byte equivalent to the deleted IsAdmin-based checks:
+//   - AssuranceBasic (admin) principal gets global access regardless of the job's tenant.
+//   - AssuranceMachine (API key) principal is confined to its own tenant.
+func TestJobsTenantIsolation_AssuranceBoundary(t *testing.T) {
+	cases := []struct {
+		name       string
+		principal  *Principal
+		jobTenant  string
+		wantStatus int
+	}{
+		{
+			name:       "admin_AssuranceBasic_any_tenant",
+			principal:  &Principal{ID: "mTLS-admin", Assurance: session.AssuranceBasic, TenantID: ""},
+			jobTenant:  "tenant-z",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "machine_AssuranceMachine_same_tenant",
+			principal:  &Principal{ID: "api-key-a", Assurance: session.AssuranceMachine, TenantID: "tenant-a"},
+			jobTenant:  "tenant-a",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "machine_AssuranceMachine_cross_tenant_blocked",
+			principal:  &Principal{ID: "api-key-a", Assurance: session.AssuranceMachine, TenantID: "tenant-a"},
+			jobTenant:  "tenant-b",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			// Relay-grant principals carry AssuranceMachine; this case confirms that even
+			// a relay-grant principal with tenant-a scoping cannot access tenant-b's jobs —
+			// the handler's Assurance check is the defense-in-depth barrier.
+			name: "relay_grant_AssuranceMachine_cross_tenant_blocked",
+			principal: &Principal{
+				ID:        "relay:device-1:exec-001",
+				Name:      "relay-script:device-1",
+				Assurance: session.AssuranceMachine,
+				TenantID:  "tenant-a",
+			},
+			jobTenant:  "tenant-b",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := setupTestServer(t)
+			store := newTestBatchJobStoreForAPI()
+			server.batchJobStore = store
+
+			jobID := "job-iso-" + tc.name
+			require.NoError(t, store.CreateBatchJob(context.Background(), &batchjob.BatchJob{
+				ID:       jobID,
+				TenantID: tc.jobTenant,
+				Selector: "all",
+				Config:   batchjob.BatchJobConfig{BatchSize: 1},
+				Status:   batchjob.BatchJobStatusPending,
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/"+jobID, nil)
+			req = mux.SetURLVars(req, map[string]string{"id": jobID})
+			req = withPrincipal(req, tc.principal)
+			rec := httptest.NewRecorder()
+			server.handleGetJob(rec, req)
+
+			assert.Equal(t, tc.wantStatus, rec.Code, "principal %+v accessing job in %q", tc.principal, tc.jobTenant)
+		})
+	}
 }
 
 // ── log-injection sanitization (AC: CodeQL go/log-injection) ─────────────────

--- a/features/controller/api/handlers_push.go
+++ b/features/controller/api/handlers_push.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
@@ -233,9 +234,9 @@ func (s *Server) handleGetConfigPush(w http.ResponseWriter, r *http.Request) {
 	// Tenant isolation: return 404 (not 403) on mismatch to avoid leaking
 	// cross-tenant push existence. requirePermission path-var isolation does not
 	// cover push-ID path vars (middleware.go:775), so this check is explicit here.
-	// Admin callers (IsAdmin == true, TenantID == "") may read any push record.
+	// Human-authenticated callers (Assurance >= AssuranceBasic, empty TenantID) may read any push record.
 	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if !principal.IsAdmin && record.TenantID != callerTenant {
+	if principal.Assurance < session.AssuranceBasic && record.TenantID != callerTenant {
 		s.respondError(w, http.StatusNotFound, "push not found")
 		return
 	}

--- a/features/controller/api/handlers_push_test.go
+++ b/features/controller/api/handlers_push_test.go
@@ -31,6 +31,7 @@ import (
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
@@ -1171,4 +1172,70 @@ func TestHandleConfigPush_FleetQueryError_Returns500(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, pending, "500 fleet-query failure must not create a push record")
 	assert.Empty(t, cp.ReceivedIDs(), "500 fleet-query failure must not trigger fan-out")
+}
+
+// ── Tenant isolation regression test — Issue #2781 ───────────────────────────
+
+// TestGetConfigPush_AssuranceBoundary is a table-driven regression test
+// confirming that the Assurance-based tenant-isolation gate in handlers_push.go
+// is byte-for-byte equivalent to the deleted IsAdmin-based check:
+//   - AssuranceBasic (admin) principal gets global read access regardless of the record's tenant.
+//   - AssuranceMachine (API key) principal sees only same-tenant records (404 otherwise).
+func TestGetConfigPush_AssuranceBoundary(t *testing.T) {
+	const recordTenant = "tenant-abc"
+
+	cases := []struct {
+		name       string
+		principal  *Principal
+		callerTID  string // tenantID context value
+		wantStatus int
+	}{
+		{
+			name:       "AssuranceBasic_admin_any_tenant",
+			principal:  &Principal{ID: "mtls-admin", Assurance: session.AssuranceBasic, TenantID: ""},
+			callerTID:  "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "AssuranceMachine_same_tenant",
+			principal:  &Principal{ID: "api-key-abc", Assurance: session.AssuranceMachine, TenantID: recordTenant},
+			callerTID:  recordTenant,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "AssuranceMachine_cross_tenant_404",
+			principal:  &Principal{ID: "api-key-other", Assurance: session.AssuranceMachine, TenantID: "tenant-other"},
+			callerTID:  "tenant-other",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			// Defense-in-depth: relay-grant principal (AssuranceMachine, tenant-other scoped)
+			// must not see tenant-abc's push record — the handler's Assurance check is the barrier.
+			name:       "relay_grant_AssuranceMachine_cross_tenant_404",
+			principal:  &Principal{ID: "relay:device-1:exec-001", Name: "relay-script:device-1", Assurance: session.AssuranceMachine, TenantID: "tenant-other"},
+			callerTID:  "tenant-other",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cp := &syncedControlPlane{}
+			server, pushStore := makePushServerWithStore(t, cp)
+
+			rec := createPushRecord(t, pushStore, "push-iso-"+tc.name, recordTenant, "cfg-001")
+
+			req := newGetPushRequest(t, rec.ID)
+			ctx := context.WithValue(req.Context(), principalContextKey, tc.principal)
+			ctx = context.WithValue(ctx, ctxkeys.TenantID, tc.callerTID)
+			req = req.WithContext(ctx)
+			httpRec := httptest.NewRecorder()
+
+			server.handleGetConfigPush(httpRec, req)
+
+			assert.Equal(t, tc.wantStatus, httpRec.Code,
+				"principal %+v accessing record in %q", tc.principal, recordTenant)
+		})
+	}
 }

--- a/features/controller/api/handlers_rollout.go
+++ b/features/controller/api/handlers_rollout.go
@@ -17,6 +17,7 @@ import (
 	controllerconfig "github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
@@ -110,7 +111,7 @@ func (s *Server) handleStartRollout(w http.ResponseWriter, r *http.Request) {
 	// against a victim tenant's fleet (Issue #2340).
 	tenantID := callerTenantID
 	if req.TenantID != "" && req.TenantID != callerTenantID {
-		if !principal.IsAdmin {
+		if principal.Assurance < session.AssuranceBasic {
 			s.writeErrorResponse(w, http.StatusForbidden,
 				"Cannot start a rollout for another tenant",
 				"CROSS_TENANT")

--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
@@ -110,7 +111,7 @@ func (s *Server) authRunAccess(w http.ResponseWriter, r *http.Request) (principa
 		return nil, "", false
 	}
 	tenantID, _ = r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" && !principal.IsAdmin {
+	if tenantID == "" && principal.Assurance < session.AssuranceBasic {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return nil, "", false
 	}
@@ -122,7 +123,7 @@ func (s *Server) authRunAccess(w http.ResponseWriter, r *http.Request) (principa
 // owned by their tenant. Callers return 404 (not 403) on false to avoid leaking
 // cross-tenant run existence (Issue #1990).
 func runVisibleTo(principal *Principal, run *controllerrun.RunRecord, tenantID string) bool {
-	return principal.IsAdmin || run.TenantID == tenantID
+	return principal.Assurance >= session.AssuranceBasic || run.TenantID == tenantID
 }
 
 // handlePostRunScript handles POST /api/v1/runs/script.

--- a/features/controller/api/handlers_runs_test.go
+++ b/features/controller/api/handlers_runs_test.go
@@ -21,6 +21,7 @@ import (
 	controllerrun "github.com/cfgis/cfgms/features/controller/run"
 	scriptmodule "github.com/cfgis/cfgms/features/modules/stdlib/script"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/session"
 	_ "modernc.org/sqlite"
 )
 
@@ -232,7 +233,7 @@ func TestRunCommand_AdminMTLSEmptyTenant_NotUnauthorized(t *testing.T) {
 		"shell":   "pwsh",
 	}
 	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command",
-		&Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}, body)
+		&Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""}, body)
 
 	require.NotEqual(t, http.StatusUnauthorized, rec.Code,
 		"admin mTLS principal (empty tenant) must not be rejected as unauthenticated; body: %s", rec.Body.String())
@@ -246,7 +247,7 @@ func TestRunScript_AdminMTLSEmptyTenant_NotUnauthorized(t *testing.T) {
 
 	body := map[string]interface{}{"target": "all", "script_id": "scripts/check.sh"}
 	rec := postRunWithPrincipal(t, server.handlePostRunScript, "/api/v1/runs/script",
-		&Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}, body)
+		&Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""}, body)
 
 	require.NotEqual(t, http.StatusUnauthorized, rec.Code,
 		"admin mTLS principal (empty tenant) must not be rejected; body: %s", rec.Body.String())
@@ -264,7 +265,7 @@ func TestRunCommand_NonAdminEmptyTenant_StillUnauthorized(t *testing.T) {
 		"shell":   "pwsh",
 	}
 	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command",
-		&Principal{ID: "scoped-key", IsAdmin: false, TenantID: ""}, body)
+		&Principal{ID: "scoped-key", Assurance: session.AssuranceMachine, TenantID: ""}, body)
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"a non-admin principal with no tenant must remain unauthorized")
@@ -278,7 +279,7 @@ func TestRunCommand_NonAdminEmptyTenant_StillUnauthorized(t *testing.T) {
 func TestRunLifecycle_AdminMTLSEmptyTenant(t *testing.T) {
 	stewards := []fleet.StewardResult{{ID: "steward-1", TenantID: "infra-hyperv"}}
 	server, _, _ := setupRunServer(t, stewards)
-	admin := &Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}
+	admin := &Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""}
 
 	// 1. Dispatch (POST) as admin.
 	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command", admin, map[string]interface{}{
@@ -320,7 +321,7 @@ func TestGetRun_NonAdminCrossTenant_NotFound(t *testing.T) {
 
 	// Admin dispatches a run owned by the global/empty tenant.
 	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command",
-		&Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}, map[string]interface{}{
+		&Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""}, map[string]interface{}{
 			"target":  "id:steward-1",
 			"content": base64.StdEncoding.EncodeToString([]byte("hostname")),
 			"shell":   "pwsh",
@@ -331,7 +332,7 @@ func TestGetRun_NonAdminCrossTenant_NotFound(t *testing.T) {
 	runID := resp.Data.(map[string]interface{})["run_id"].(string)
 
 	// A tenant-scoped (non-admin) caller from a different tenant must get 404.
-	scoped := &Principal{ID: "tenant-b-key", IsAdmin: false, TenantID: "tenant-b"}
+	scoped := &Principal{ID: "tenant-b-key", Assurance: session.AssuranceMachine, TenantID: "tenant-b"}
 	getReq := withPrincipal(mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID, nil), map[string]string{"run_id": runID}), scoped)
 	getRec := httptest.NewRecorder()
 	server.handleGetRun(getRec, getReq)
@@ -672,6 +673,64 @@ func TestRunEndpoints_TenantIsolation(t *testing.T) {
 	otherExecKey := NewEphemeralTestKey(t, server, []string{"steward:execute-scripts"}, "other-tenant", 5*60*1000000000)
 	rec = deleteRun(t, server, otherExecKey, runID)
 	assert.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant DELETE must return 404")
+}
+
+// TestRunVisibleTo_AssuranceBoundary is a table-driven regression test for the
+// runVisibleTo helper (handlers_runs.go) confirming that the Assurance-based
+// isolation gate is byte-for-byte equivalent to the deleted IsAdmin check:
+//   - AssuranceBasic (admin) principal always sees the run regardless of tenant.
+//   - AssuranceMachine (API key / relay-grant) principal sees only same-tenant runs.
+//   - Relay-grant principals (AssuranceMachine) cannot see another tenant's run.
+func TestRunVisibleTo_AssuranceBoundary(t *testing.T) {
+	run := &controllerrun.RunRecord{RunID: "r1", TenantID: "tenant-a"}
+
+	cases := []struct {
+		name      string
+		principal *Principal
+		tenantID  string
+		wantVis   bool
+	}{
+		{
+			name:      "AssuranceBasic_admin_any_tenant",
+			principal: &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""},
+			tenantID:  "tenant-b",
+			wantVis:   true,
+		},
+		{
+			name:      "AssuranceMachine_same_tenant",
+			principal: &Principal{ID: "key-a", Assurance: session.AssuranceMachine, TenantID: "tenant-a"},
+			tenantID:  "tenant-a",
+			wantVis:   true,
+		},
+		{
+			name:      "AssuranceMachine_cross_tenant_hidden",
+			principal: &Principal{ID: "key-b", Assurance: session.AssuranceMachine, TenantID: "tenant-b"},
+			tenantID:  "tenant-b",
+			wantVis:   false,
+		},
+		{
+			// Defense-in-depth: relay-grant principal (AssuranceMachine, tenant-a scoped)
+			// must not see a tenant-b run even if the grant's tenantID were somehow wrong.
+			name: "relay_grant_cross_tenant_hidden",
+			principal: &Principal{
+				ID:        "relay:device-1:exec-001",
+				Assurance: session.AssuranceMachine,
+				TenantID:  "tenant-b", // mis-scoped grant scenario
+			},
+			tenantID: "tenant-b",
+			wantVis:  false, // run.TenantID=tenant-a ≠ tenantID=tenant-b
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := runVisibleTo(tc.principal, run, tc.tenantID)
+			assert.Equal(t, tc.wantVis, got,
+				"runVisibleTo(%+v, run{TenantID=%q}, tenantID=%q)",
+				tc.principal, run.TenantID, tc.tenantID)
+		})
+	}
 }
 
 // ---- [REQUIRED TEST] Banned-pattern enforcement (C2) -------------------------

--- a/features/controller/api/handlers_sessions.go
+++ b/features/controller/api/handlers_sessions.go
@@ -32,8 +32,8 @@ type sessionCreateResponse struct {
 
 // handleSessionCreate handles POST /api/v1/sessions.
 // Authorization is enforced at the router level via requirePermission("session", "create"),
-// which requires AssuranceStrong (ADR-021, Issue #2780). The in-handler IsAdmin check
-// has been removed — the router gate is the sole authority.
+// which requires AssuranceStrong (ADR-021, Issue #2780). No in-handler assurance
+// re-check is needed — the router gate is the sole authority.
 func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	principal, ok := r.Context().Value(principalContextKey).(*Principal)
 	if !ok || principal == nil {

--- a/features/controller/api/handlers_sessions_test.go
+++ b/features/controller/api/handlers_sessions_test.go
@@ -101,7 +101,6 @@ func injectAdminPrincipal(r *http.Request, principalID string) *http.Request {
 	p := &Principal{
 		ID:        principalID,
 		Name:      "mtls-admin:" + principalID,
-		IsAdmin:   true,
 		Assurance: session.AssuranceStrong,
 	}
 	return r.WithContext(context.WithValue(r.Context(), principalContextKey, p))
@@ -112,7 +111,6 @@ func injectNonAdminPrincipal(r *http.Request) *http.Request {
 	p := &Principal{
 		ID:          "api-key-user",
 		Name:        "apikey",
-		IsAdmin:     false,
 		Assurance:   session.AssuranceMachine,
 		Permissions: []string{"steward:list"},
 		TenantID:    "default",
@@ -349,8 +347,8 @@ func TestSessionTokenAuthMiddleware_ValidToken(t *testing.T) {
 	if capturedPrincipal == nil {
 		t.Fatal("principal not set in context")
 	}
-	if !capturedPrincipal.IsAdmin {
-		t.Error("session-token principal must have IsAdmin=true")
+	if capturedPrincipal.Assurance < session.AssuranceBasic {
+		t.Error("session-token principal must have Assurance >= AssuranceBasic")
 	}
 	if capturedPrincipal.ID != "carol" {
 		t.Errorf("principal ID = %q, want %q", capturedPrincipal.ID, "carol")
@@ -511,7 +509,6 @@ func injectAdminPrincipalWithTenant(r *http.Request, principalID, tenantID strin
 	p := &Principal{
 		ID:        principalID,
 		Name:      "mtls-admin:" + principalID,
-		IsAdmin:   true,
 		Assurance: session.AssuranceStrong,
 		TenantID:  tenantID,
 	}

--- a/features/controller/api/handlers_steward_binary_test.go
+++ b/features/controller/api/handlers_steward_binary_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/modules/trust"
+	"github.com/cfgis/cfgms/pkg/session"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 )
 
@@ -94,22 +95,22 @@ func doPublish(server *Server, version, platform, arch, tenantID, sigBase64 stri
 	return rec
 }
 
-// withScopedPrincipal injects a non-admin principal bound to tenantID plus the tenant
-// context value, mirroring authenticationMiddleware for an API-key request. An empty
-// tenantID models a non-admin caller with no tenant (a genuine auth failure).
+// withScopedPrincipal injects a machine-assurance principal bound to tenantID plus the
+// tenant context value, mirroring authenticationMiddleware for an API-key request. An
+// empty tenantID models a non-human caller with no tenant (a genuine auth failure).
 func withScopedPrincipal(req *http.Request, tenantID string) *http.Request {
-	p := &Principal{ID: "api-key:" + tenantID, IsAdmin: false, TenantID: tenantID}
+	p := &Principal{ID: "api-key:" + tenantID, Assurance: session.AssuranceMachine, TenantID: tenantID}
 	ctx := context.WithValue(req.Context(), principalContextKey, p)
 	ctx = context.WithValue(ctx, ctxkeys.TenantID, tenantID)
 	return req.WithContext(ctx)
 }
 
-// withAdminPrincipal injects an admin mTLS principal (IsAdmin=true, empty tenant) plus
+// withAdminPrincipal injects an mTLS admin principal (AssuranceBasic, empty tenant) plus
 // the empty tenant context value, mirroring authenticationMiddleware for an mTLS admin
 // cert (middleware.go:173). This is the global-scope path that cannot be reached via an
 // X-API-Key request (Issue #1999).
 func withAdminPrincipal(req *http.Request) *http.Request {
-	p := &Principal{ID: "mtls-admin:cn", Name: "mtls-admin:cn", IsAdmin: true, TenantID: ""}
+	p := &Principal{ID: "mtls-admin:cn", Name: "mtls-admin:cn", Assurance: session.AssuranceBasic, TenantID: ""}
 	ctx := context.WithValue(req.Context(), principalContextKey, p)
 	ctx = context.WithValue(ctx, ctxkeys.TenantID, "")
 	return req.WithContext(ctx)

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	loggingInterfaces "github.com/cfgis/cfgms/pkg/logging/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/logging/providers/file"
+	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
@@ -49,7 +50,7 @@ func setupDecommissionServer(t *testing.T) (*Server, business.StewardStore) {
 // middleware) with a root-admin mTLS principal so we can exercise the handler in isolation.
 func deleteDecommissionSteward(server *Server, stewardID string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/"+stewardID, nil)
-	req = withPrincipal(req, &Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": stewardID})
 	rec := httptest.NewRecorder()
 	server.handleDecommissionSteward(rec, req)
@@ -103,7 +104,7 @@ func TestHandleDecommissionSteward_InvalidID(t *testing.T) {
 	server, _ := setupDecommissionServer(t)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/bad.id:here", nil)
-	req = withPrincipal(req, &Principal{ID: "admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": "bad.id:here"})
 	rec := httptest.NewRecorder()
 	server.handleDecommissionSteward(rec, req)
@@ -120,7 +121,7 @@ func TestHandleDecommissionSteward_NilStore(t *testing.T) {
 	// stewardStore is nil in the default setup.
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/some-steward", nil)
-	req = withPrincipal(req, &Principal{ID: "admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": "some-steward"})
 	rec := httptest.NewRecorder()
 	server.handleDecommissionSteward(rec, req)
@@ -156,7 +157,7 @@ func TestHandleDecommissionSteward_CrossTenant(t *testing.T) {
 
 	// Caller is scoped to "tenant-a"; steward belongs to "tenant-b".
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/s-cross-tenant", nil)
-	req = withPrincipal(req, &Principal{ID: "tenant-a-admin", IsAdmin: true, TenantID: "tenant-a"})
+	req = withPrincipal(req, &Principal{ID: "tenant-a-admin", Assurance: session.AssuranceBasic, TenantID: "tenant-a"})
 	req = withVars(req, map[string]string{"id": "s-cross-tenant"})
 	rec := httptest.NewRecorder()
 	server.handleDecommissionSteward(rec, req)
@@ -179,7 +180,7 @@ func TestHandleDecommissionSteward_AuditEmitted(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/s-audit-decomm", nil)
-	req = withPrincipal(req, &Principal{ID: "audit-admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "audit-admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": "s-audit-decomm"})
 	rec := httptest.NewRecorder()
 	server.handleDecommissionSteward(rec, req)
@@ -2102,7 +2103,7 @@ func postMoveSteward(server *Server, stewardID, newTenantID string) *httptest.Re
 	body := strings.NewReader(`{"new_tenant_id":"` + newTenantID + `"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/"+stewardID+"/move", body)
 	req.Header.Set("Content-Type", "application/json")
-	req = withPrincipal(req, &Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": stewardID})
 	rec := httptest.NewRecorder()
 	server.handleMoveSteward(rec, req)
@@ -2334,7 +2335,7 @@ func TestHandleMoveSteward_InvalidStewardID(t *testing.T) {
 	body := strings.NewReader(`{"new_tenant_id":"dest"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/bad.id:here/move", body)
 	req.Header.Set("Content-Type", "application/json")
-	req = withPrincipal(req, &Principal{ID: "admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": "bad.id:here"})
 	rec := httptest.NewRecorder()
 	server.handleMoveSteward(rec, req)
@@ -2352,7 +2353,7 @@ func TestHandleMoveSteward_MissingNewTenantID(t *testing.T) {
 	body := strings.NewReader(`{}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/some-steward/move", body)
 	req.Header.Set("Content-Type", "application/json")
-	req = withPrincipal(req, &Principal{ID: "admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": "some-steward"})
 	rec := httptest.NewRecorder()
 	server.handleMoveSteward(rec, req)
@@ -2370,7 +2371,7 @@ func TestHandleMoveSteward_InvalidTenantIDFormat(t *testing.T) {
 	body := strings.NewReader(`{"new_tenant_id":"bad.tenant:id"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/some-steward/move", body)
 	req.Header.Set("Content-Type", "application/json")
-	req = withPrincipal(req, &Principal{ID: "admin", IsAdmin: true, TenantID: ""})
+	req = withPrincipal(req, &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""})
 	req = withVars(req, map[string]string{"id": "some-steward"})
 	rec := httptest.NewRecorder()
 	server.handleMoveSteward(rec, req)
@@ -2444,7 +2445,7 @@ func TestHandleMoveSteward_ScopedAdmin_NoAuthorityOverSource(t *testing.T) {
 	require.NoError(t, server.controllerService.RegisterSteward("s-auth-nosrc", "source-tenant", "addr", "registered"))
 
 	// dest-tenant is in scope but source is not
-	scopedPrincipal := &Principal{ID: "scoped-admin", IsAdmin: true, TenantID: "other-msp", CertSerial: "SN-001", CertFingerprint: "fp-001"}
+	scopedPrincipal := &Principal{ID: "scoped-admin", Assurance: session.AssuranceStrong, TenantID: "other-msp", CertSerial: "SN-001", CertFingerprint: "fp-001"}
 	rec := postMoveStewardWithPrincipal(server, "s-auth-nosrc", "dest-tenant", scopedPrincipal)
 
 	require.Equal(t, http.StatusForbidden, rec.Code)
@@ -2467,7 +2468,7 @@ func TestHandleMoveSteward_ScopedAdmin_NoAuthorityOverDestination(t *testing.T) 
 	require.NoError(t, server.controllerService.RegisterSteward("s-auth-nodst", "msp-a", "addr", "registered"))
 
 	// "other-msp" is not in "msp-a" scope
-	scopedPrincipal := &Principal{ID: "scoped-admin", IsAdmin: true, TenantID: "msp-a", CertSerial: "SN-002", CertFingerprint: "fp-002"}
+	scopedPrincipal := &Principal{ID: "scoped-admin", Assurance: session.AssuranceStrong, TenantID: "msp-a", CertSerial: "SN-002", CertFingerprint: "fp-002"}
 	rec := postMoveStewardWithPrincipal(server, "s-auth-nodst", "other-msp", scopedPrincipal)
 
 	require.Equal(t, http.StatusForbidden, rec.Code)
@@ -2514,7 +2515,7 @@ func TestHandleMoveSteward_ScopedAdmin_AuthorityOverBoth_AnchoredPrefix(t *testi
 	// now accepts slashes, this is valid. The tenant store won't have this exact path-style ID
 	// (the tenant manager uses flat IDs), so GetTenant returns not-found → 400 TENANT_NOT_FOUND.
 	// That means the AUTH check passed (no 403) and the failure is the subsequent tenant lookup.
-	scopedPrincipal := &Principal{ID: "msp-admin", IsAdmin: true, TenantID: "msp-a", CertSerial: "SN-003", CertFingerprint: "fp-003"}
+	scopedPrincipal := &Principal{ID: "msp-admin", Assurance: session.AssuranceStrong, TenantID: "msp-a", CertSerial: "SN-003", CertFingerprint: "fp-003"}
 	rec := postMoveStewardWithPrincipal(server, "s-auth-both", "msp-a/child-dst", scopedPrincipal)
 
 	// The authorization check PASSES (both in scope), but the destination tenant isn't
@@ -2542,7 +2543,7 @@ func TestHandleMoveSteward_ScopedAdmin_ExactTenantMatch(t *testing.T) {
 	require.NoError(t, server.controllerService.RegisterSteward("s-auth-exact", "msp-a", "addr", "registered"))
 
 	// Caller has exact match on source; dest = "msp-a" is also exact match → self-move
-	scopedPrincipal := &Principal{ID: "msp-admin", IsAdmin: true, TenantID: "msp-a", CertSerial: "SN-004", CertFingerprint: "fp-004"}
+	scopedPrincipal := &Principal{ID: "msp-admin", Assurance: session.AssuranceStrong, TenantID: "msp-a", CertSerial: "SN-004", CertFingerprint: "fp-004"}
 	rec := postMoveStewardWithPrincipal(server, "s-auth-exact", "msp-a", scopedPrincipal)
 
 	// Auth passes (exact match on both), self-move short-circuits → no_change
@@ -2567,7 +2568,7 @@ func TestHandleMoveSteward_UnscopedRootAdmin_Allowed(t *testing.T) {
 	})
 	require.NoError(t, server.controllerService.RegisterSteward("s-auth-root", "source-tenant", "addr", "registered"))
 
-	rootPrincipal := &Principal{ID: "root-admin", IsAdmin: true, TenantID: "", CertSerial: "SN-ROOT", CertFingerprint: "fp-root"}
+	rootPrincipal := &Principal{ID: "root-admin", Assurance: session.AssuranceStrong, TenantID: "", CertSerial: "SN-ROOT", CertFingerprint: "fp-root"}
 	rec := postMoveStewardWithPrincipal(server, "s-auth-root", "dest-tenant", rootPrincipal)
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -2609,7 +2610,7 @@ func TestHandleMoveSteward_AuditOnSuccess(t *testing.T) {
 
 	rootPrincipal := &Principal{
 		ID:              "audit-admin",
-		IsAdmin:         true,
+		Assurance:       session.AssuranceStrong,
 		TenantID:        "",
 		CertSerial:      "SERIAL-OK",
 		CertFingerprint: "FPRINT-OK",
@@ -2672,7 +2673,7 @@ func TestHandleMoveSteward_AuditOnDenial(t *testing.T) {
 
 	scopedPrincipal := &Principal{
 		ID:              "scoped-deny-admin",
-		IsAdmin:         true,
+		Assurance:       session.AssuranceStrong,
 		TenantID:        "other-msp",
 		CertSerial:      "SERIAL-DENY",
 		CertFingerprint: "FPRINT-DENY",
@@ -2732,7 +2733,7 @@ func TestHandleMoveSteward_TenantPathWithSlash(t *testing.T) {
 
 	// Request with hierarchical new_tenant_id — format validation must pass.
 	// The tenant doesn't exist in the store, so we expect TENANT_NOT_FOUND (400), not INVALID_TENANT_ID (400).
-	scopedPrincipal := &Principal{ID: "msp-admin", IsAdmin: true, TenantID: "msp-a", CertSerial: "SN-007", CertFingerprint: "fp-007"}
+	scopedPrincipal := &Principal{ID: "msp-admin", Assurance: session.AssuranceStrong, TenantID: "msp-a", CertSerial: "SN-007", CertFingerprint: "fp-007"}
 	rec := postMoveStewardWithPrincipal(server, "s-slash-test", "msp-a/other-child", scopedPrincipal)
 
 	var errResp ErrorResponse

--- a/features/controller/api/handlers_upgrade.go
+++ b/features/controller/api/handlers_upgrade.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -135,7 +136,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 	// the caller's subtree; absent prefix defaults to callerTenantID and all
 	// descendants. Admin callers (empty callerTenantID) are unrestricted.
 	if parsedTenantPath != "" {
-		if !principal.IsAdmin && callerTenantID != "" &&
+		if principal.Assurance < session.AssuranceBasic && callerTenantID != "" &&
 			parsedTenantPath != callerTenantID &&
 			!strings.HasPrefix(parsedTenantPath, callerTenantID+"/") {
 			s.writeErrorResponse(w, http.StatusForbidden,
@@ -143,7 +144,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		filter.TenantSubtree = parsedTenantPath
-	} else if !principal.IsAdmin {
+	} else if principal.Assurance < session.AssuranceBasic {
 		filter.TenantSubtree = callerTenantID
 	}
 
@@ -251,7 +252,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 		// (Issue #1999).
 		recordTenantID := callerTenantID
 		authMethod := "api_key"
-		if principal.IsAdmin {
+		if principal.Assurance >= session.AssuranceBasic {
 			recordTenantID = st.TenantID
 			authMethod = "mtls_admin"
 		}
@@ -421,9 +422,9 @@ func (s *Server) handleUpgradeStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Tenant isolation: scoped (non-admin) callers can only view records in their own
-	// tenant; admin mTLS principals have global access (Issue #1999).
-	if !principal.IsAdmin && record.TenantID != callerTenantID {
+	// Tenant isolation: machine-assurance callers can only view records in their own
+	// tenant; human-authenticated principals have global access (Issue #1999).
+	if principal.Assurance < session.AssuranceBasic && record.TenantID != callerTenantID {
 		s.writeErrorResponse(w, http.StatusForbidden, "Access denied", "FORBIDDEN")
 		return
 	}
@@ -474,17 +475,18 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve upgrade record", "GET_RECORD_ERROR")
 		return
 	}
-	// Tenant isolation: scoped (non-admin) callers can only roll back records in their own
-	// tenant; admin mTLS principals have global access (Issue #1999).
-	if !principal.IsAdmin && original.TenantID != callerTenantID {
+	// Tenant isolation: machine-assurance callers can only roll back records in their own
+	// tenant; human-authenticated principals have global access (Issue #1999).
+	if principal.Assurance < session.AssuranceBasic && original.TenantID != callerTenantID {
 		s.writeErrorResponse(w, http.StatusForbidden, "Access denied", "FORBIDDEN")
 		return
 	}
 	// Record tenant: the rollback record is attributed to the original record's tenant for
-	// admins (global scope) and to the caller's tenant for scoped callers (== original tenant
-	// by the isolation check above), so per-tenant status/listing stays consistent (Issue #1999).
+	// human-authenticated callers (global scope) and to the caller's tenant for machine-assurance
+	// callers (== original tenant by the isolation check above), so per-tenant status/listing
+	// stays consistent (Issue #1999).
 	effectiveTenantID := callerTenantID
-	if principal.IsAdmin {
+	if principal.Assurance >= session.AssuranceBasic {
 		effectiveTenantID = original.TenantID
 	}
 	// Blob namespace: the rollback binary is read from the caller's namespace, the same place
@@ -561,7 +563,7 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rollbackAuthMethod := "api_key"
-	if principal.IsAdmin {
+	if principal.Assurance >= session.AssuranceBasic {
 		rollbackAuthMethod = "mtls_admin"
 	}
 	rollbackUpgradeID := uuid.New().String()

--- a/features/controller/api/handlers_upgrade_test.go
+++ b/features/controller/api/handlers_upgrade_test.go
@@ -1197,3 +1197,69 @@ func TestAdminDispatch_EndToEndDeliveryPath_DefaultNamespace(t *testing.T) {
 	assert.Equal(t, approvedContent, getRec.Body.Bytes(),
 		"public download must return the exact bytes published under default")
 }
+
+// ── Tenant isolation regression test — Issue #2781 ───────────────────────────
+
+// TestUpgradeStatus_AssuranceBoundary is a table-driven regression test
+// confirming that the Assurance-based tenant-isolation gates in handlers_upgrade.go
+// are byte-for-byte equivalent to the deleted IsAdmin-based checks:
+//   - AssuranceBasic (admin) principal gets global read access regardless of the record's tenant.
+//   - AssuranceMachine (API key) principal sees only same-tenant records (403 otherwise).
+func TestUpgradeStatus_AssuranceBoundary(t *testing.T) {
+	const recordTenant = "tenant-a"
+
+	stewards := []fleet.StewardData{{ID: "steward-1", TenantID: recordTenant, Status: "online"}}
+	server, _ := setupUpgradeServer(t, recordTenant, stewards)
+	publishApprovedBinary(t, server, recordTenant, "v0.5.12", "linux", "amd64")
+
+	// Create one upgrade record owned by tenant-a.
+	dispRec := doDispatchUpgrade(server, recordTenant, "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, dispRec.Code)
+	var dispResp APIResponse
+	require.NoError(t, json.Unmarshal(dispRec.Body.Bytes(), &dispResp))
+	upgradeID := dispResp.Data.(map[string]interface{})["upgrade_id"].(string)
+
+	cases := []struct {
+		name       string
+		tenantID   string
+		isAdmin    bool
+		wantStatus int
+	}{
+		{
+			name:       "AssuranceBasic_admin_any_tenant",
+			tenantID:   "",
+			isAdmin:    true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "AssuranceMachine_same_tenant",
+			tenantID:   recordTenant,
+			isAdmin:    false,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "AssuranceMachine_cross_tenant_403",
+			tenantID:   "tenant-b",
+			isAdmin:    false,
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var rec *httptest.ResponseRecorder
+			if tc.isAdmin {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/upgrade/"+upgradeID, nil)
+				req = withAdminPrincipal(req)
+				req = mux.SetURLVars(req, map[string]string{"upgrade_id": upgradeID})
+				rec = httptest.NewRecorder()
+				server.handleUpgradeStatus(rec, req)
+			} else {
+				rec = doUpgradeStatus(server, tc.tenantID, upgradeID)
+			}
+			assert.Equal(t, tc.wantStatus, rec.Code,
+				"tenantID=%q isAdmin=%v accessing upgrade record in %q", tc.tenantID, tc.isAdmin, recordTenant)
+		})
+	}
+}

--- a/features/controller/api/handlers_web_accounts_test.go
+++ b/features/controller/api/handlers_web_accounts_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cfgis/cfgms/pkg/session"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 

--- a/features/controller/api/handlers_web_accounts_test.go
+++ b/features/controller/api/handlers_web_accounts_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/session"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -45,7 +46,7 @@ func deleteWebAccount(t *testing.T, server *Server, principal *Principal, userna
 }
 
 func testAdminPrincipal() *Principal {
-	return &Principal{ID: "test-mtls-admin", Name: "mtls-admin:test", IsAdmin: true}
+	return &Principal{ID: "test-mtls-admin", Name: "mtls-admin:test", Assurance: session.AssuranceBasic}
 }
 
 // dropWebAccountCache clears the in-memory web-account cache so the next lookup

--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cfgis/cfgms/features/workflow/trigger"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
@@ -842,7 +843,7 @@ func testRequirePermFn(resourceType, action string) func(http.Handler) http.Hand
 				_, _ = w.Write([]byte(`{"error":"authentication required"}`))
 				return
 			}
-			if p.IsAdmin {
+			if p.Assurance >= session.AssuranceBasic {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -862,7 +863,7 @@ func testRequirePermFn(resourceType, action string) func(http.Handler) http.Hand
 
 // withPermissions injects a non-admin principal carrying the listed permissions.
 func withPermissions(r *http.Request, perms ...string) *http.Request {
-	p := &Principal{ID: "test-key", IsAdmin: false, Permissions: perms}
+	p := &Principal{ID: "test-key", Assurance: session.AssuranceMachine, Permissions: perms}
 	return r.WithContext(context.WithValue(r.Context(), principalContextKey, p))
 }
 

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -49,22 +49,19 @@ const (
 
 // Principal represents an authenticated entity — either an mTLS admin cert, an API key,
 // a cfg-CLI Bearer session (ADR-014), or a web session cookie (ADR-018).
-// IsAdmin == true is set by three paths: mTLS admin cert, cfg-CLI Bearer session, and
-// web session cookie. API-key principals always have IsAdmin == false.
 //
-// Assurance is the identity assurance level (ADR-021 Decision 1); it is the primary
-// gating field for route authorization in requirePermission. IsAdmin is retained for
-// backwards compatibility with non-route readers (handlers_certificates.go etc.) — a
-// dependent follow-on story migrates and removes it.
+// Assurance is the identity assurance level (ADR-021 Decision 1). It is the authoritative
+// gating field: Assurance >= AssuranceBasic covers the three human-authenticated paths
+// (mTLS admin cert, cfg-CLI Bearer session, web session cookie); AssuranceMachine covers
+// API-key principals.
 type Principal struct {
 	ID           string
 	Name         string
-	IsAdmin      bool
 	Assurance    session.AssuranceLevel
 	LastProvenAt time.Time // time of last strong-factor proof; set by mTLS path (others: follow-on story)
 	Permissions  []string
 	TenantID     string
-	// Cert-auth fields — non-empty only when IsAdmin == true (H3)
+	// Cert-auth fields — non-empty only for mTLS principals (Assurance == AssuranceStrong, H3)
 	CertSerial      string
 	CertFingerprint string
 	CertNotAfter    time.Time
@@ -179,7 +176,6 @@ func (s *Server) extractAdminPrincipal(r *http.Request) *Principal {
 	return &Principal{
 		ID:        peerCert.Subject.CommonName,
 		Name:      "mtls-admin:" + peerCert.Subject.CommonName,
-		IsAdmin:   true,
 		Assurance: session.AssuranceStrong,
 		// Admin principals have NO tenant scope. Earlier this was
 		// hardcoded to "default" which silently restricted every admin
@@ -187,7 +183,7 @@ func (s *Server) extractAdminPrincipal(r *http.Request) *Principal {
 		// records on any deployment with non-default tenants (caught
 		// during the CFG-70-02 launcher install: the host's steward
 		// registered with tenant_id=infra-hyperv via its regtoken; the
-		// admin bundle's cert had IsAdmin=true but TenantID="default"
+		// admin bundle's cert had Assurance=AssuranceBasic but TenantID="default"
 		// so handleListStewards never saw it). Empty means
 		// isEmptyFilter() returns true for the admin-no-query case →
 		// GetAllStewards() returns every tenant's stewards.
@@ -316,11 +312,10 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 					if renewErr == nil && newToken != "" {
 						w.Header().Set("X-Session-Token", newToken)
 					}
-					// Build an admin Principal from session state.
+					// Build a Principal from session state.
 					sessionPrincipal := &Principal{
 						ID:        sess.PrincipalID,
 						Name:      "session:" + logging.SanitizeLogValue(sess.PrincipalID),
-						IsAdmin:   true,
 						Assurance: session.AssuranceBasic,
 						// TenantID mirrors the issuing admin cert; "" means no tenant scope
 						// (same semantics as extractAdminPrincipal for mTLS admin certs).
@@ -379,7 +374,6 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 				webPrincipal := &Principal{
 					ID:        webSess.PrincipalID,
 					Name:      "web-session:" + logging.SanitizeLogValue(webSess.PrincipalID),
-					IsAdmin:   true,
 					Assurance: session.AssuranceBasic,
 					TenantID:  webSess.TenantID,
 				}
@@ -438,7 +432,6 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 		principal := &Principal{
 			ID:          keyInfo.ID,
 			Name:        keyInfo.Name,
-			IsAdmin:     false,
 			Assurance:   session.AssuranceMachine,
 			Permissions: keyInfo.Permissions,
 			TenantID:    keyInfo.TenantID,
@@ -548,7 +541,7 @@ type AuthorizationDecision struct {
 }
 
 // requirePermission creates middleware that enforces specific permission requirements.
-// Admin principals (IsAdmin == true) short-circuit to ALLOW for any permission.
+// Human-authenticated principals (Assurance >= AssuranceBasic) short-circuit to ALLOW for any permission.
 func (s *Server) requirePermission(resourceType, action string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -640,12 +633,11 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 				return
 			}
 
-			// Tenant isolation check for scoped (non-admin) API-key principals.
-			// TODO(follow-on story): replace !principal.IsAdmin with Assurance-based check.
+			// Tenant isolation check for API-key (machine-assurance) principals.
 			s.mu.RLock()
 			engine := s.isolationEngine
 			s.mu.RUnlock()
-			if engine != nil && !principal.IsAdmin && principal.TenantID != "" {
+			if engine != nil && principal.Assurance < session.AssuranceBasic && principal.TenantID != "" {
 				targetTenant := s.extractTargetTenantFromRequest(r, resourceType)
 				if targetTenant != "" && targetTenant != principal.TenantID {
 					isoResp, isoErr := engine.ValidateTenantAccess(r.Context(), &tenantsecurity.TenantAccessRequest{
@@ -676,9 +668,8 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 
 			// Principal has required permission — grant access.
 			reason := "API key has required permission: " + permissionID
-			// TODO(follow-on story): replace IsAdmin check with Assurance-based audit reason.
-			if principal.IsAdmin {
-				reason = "Admin principal granted full access"
+			if principal.Assurance >= session.AssuranceBasic {
+				reason = "principal assurance sufficient for full access"
 			}
 			decision := &AuthorizationDecision{
 				Granted:      true,
@@ -697,7 +688,7 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 
 			s.logger.Debug("Access granted",
 				"subject_id", userID,
-				"is_admin", principal.IsAdmin,
+				"assurance_sufficient", principal.Assurance >= session.AssuranceBasic,
 				"permission_id", permissionID,
 				"resource", resource,
 			)
@@ -793,10 +784,11 @@ func (s *Server) auditAuthorizationDecision(r *http.Request, decision *Authoriza
 		"severity":       s.getAuditSeverity(decision),
 	}
 
-	// H3: Include auth method and cert details in audit log.
-	// TODO(follow-on story): replace IsAdmin-based auth_method with Assurance-based discriminator.
+	// H3: Include auth method and cert details in audit log. CertSerial is only
+	// populated for mTLS principals (Assurance == AssuranceStrong), making it a
+	// more precise discriminator than the general assurance level here.
 	principal, _ := r.Context().Value(principalContextKey).(*Principal)
-	if principal != nil && principal.IsAdmin {
+	if principal != nil && principal.CertSerial != "" {
 		auditFields["auth_method"] = "cert"
 		auditFields["cert_serial"] = logging.SanitizeLogValue(principal.CertSerial)
 		auditFields["cert_fingerprint"] = logging.SanitizeLogValue(principal.CertFingerprint)
@@ -866,15 +858,15 @@ func (s *Server) getAuditSeverity(decision *AuthorizationDecision) string {
 }
 
 // hasPermission checks whether principal has permissionID.
-// Admin principals (IsAdmin == true) short-circuit to true regardless of permissionID.
+// Human-authenticated principals (Assurance >= AssuranceBasic) short-circuit to true
+// regardless of permissionID — they carry an empty Permissions list and rely on this
+// bypass for every requirePermission check.
 // C1: "*" is treated as a literal permission name — it will not match any real permissionID.
-// TODO(follow-on story): replace IsAdmin short-circuit with Assurance-based check once
-// all non-route IsAdmin readers are migrated (middleware.go:600,631,651,749 and handlers).
 func (s *Server) hasPermission(principal *Principal, permissionID string) bool {
 	if principal == nil {
 		return false
 	}
-	if principal.IsAdmin {
+	if principal.Assurance >= session.AssuranceBasic {
 		return true
 	}
 	for _, p := range principal.Permissions {

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -499,7 +499,7 @@ func TestMTLSAuth_AdminMarker_Granted(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code, "admin cert must be granted access")
 	require.NotNil(t, capturedPrincipal)
-	assert.True(t, capturedPrincipal.IsAdmin, "principal from admin cert must have IsAdmin == true")
+	assert.Equal(t, session.AssuranceStrong, capturedPrincipal.Assurance, "principal from admin cert must have AssuranceStrong")
 	assert.NotEmpty(t, capturedPrincipal.CertSerial)
 	assert.NotEmpty(t, capturedPrincipal.CertFingerprint)
 	assert.False(t, capturedPrincipal.CertNotAfter.IsZero())
@@ -527,7 +527,7 @@ func TestMTLSAuth_NoMarker_FallsThrough(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code, "cert without marker + valid API key must succeed via API-key path")
 	require.NotNil(t, capturedPrincipal)
-	assert.False(t, capturedPrincipal.IsAdmin, "principal from API-key path must not be admin")
+	assert.Equal(t, session.AssuranceMachine, capturedPrincipal.Assurance, "principal from API-key path must have AssuranceMachine")
 }
 
 // TestMTLSAuth_ConflictingCredentials_Rejected verifies that presenting an admin cert AND
@@ -590,14 +590,14 @@ func TestMTLSAuth_NoCert_FallsBackToAPIKey(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code, "no cert + valid API key must succeed")
 	require.NotNil(t, capturedPrincipal)
-	assert.False(t, capturedPrincipal.IsAdmin)
+	assert.Equal(t, session.AssuranceMachine, capturedPrincipal.Assurance)
 }
 
 // TestHasPermission_AdminPrincipal verifies that hasPermission returns true for any
-// permissionID when the principal has IsAdmin == true.
+// permissionID when the principal has Assurance >= AssuranceBasic.
 func TestHasPermission_AdminPrincipal(t *testing.T) {
 	server := setupTestServer(t)
-	admin := &Principal{IsAdmin: true}
+	admin := &Principal{Assurance: session.AssuranceBasic}
 
 	assert.True(t, server.hasPermission(admin, "steward:read"))
 	assert.True(t, server.hasPermission(admin, "rbac:delete-role"))
@@ -610,7 +610,7 @@ func TestHasPermission_AdminPrincipal(t *testing.T) {
 func TestHasPermission_WildcardStringRejected(t *testing.T) {
 	server := setupTestServer(t)
 	wildcardPrincipal := &Principal{
-		IsAdmin:     false,
+		Assurance:   session.AssuranceMachine,
 		Permissions: []string{"*"},
 	}
 
@@ -761,7 +761,7 @@ func TestExtractAdminPrincipal_ChecksRevocation(t *testing.T) {
 	// Before revocation: extractAdminPrincipal must return a non-nil principal
 	principal := server.extractAdminPrincipal(req)
 	require.NotNil(t, principal, "admin-marked cert must be accepted before revocation")
-	assert.True(t, principal.IsAdmin)
+	assert.Equal(t, session.AssuranceStrong, principal.Assurance)
 
 	// Revoke the cert
 	require.NoError(t, certManager.Revoke(serial))
@@ -781,7 +781,7 @@ func TestExtractAdminPrincipal_NilCertManager_AllowsUnrevoked(t *testing.T) {
 	req := requestWithTLSCert(http.MethodGet, "/api/v1/test", adminCert)
 	principal := server.extractAdminPrincipal(req)
 	require.NotNil(t, principal, "admin cert must be accepted when certManager is nil (no revocation checking)")
-	assert.True(t, principal.IsAdmin)
+	assert.Equal(t, session.AssuranceStrong, principal.Assurance)
 }
 
 // TestAuthMiddleware_SetsUserIDKey_APIKey verifies that the API-key auth path writes
@@ -1112,7 +1112,7 @@ func TestWebSessionCookie_ValidCookie_BuildsPrincipal(t *testing.T) {
 	require.NotNil(t, capturedPrincipal, "Principal must be set in context")
 	assert.Equal(t, "alice", capturedPrincipal.ID)
 	assert.Equal(t, "tenant-a", capturedPrincipal.TenantID)
-	assert.True(t, capturedPrincipal.IsAdmin, "web session principal must have IsAdmin == true")
+	assert.Equal(t, session.AssuranceBasic, capturedPrincipal.Assurance, "web session principal must have AssuranceBasic")
 	assert.Equal(t, "web-session:alice", capturedPrincipal.Name)
 }
 

--- a/features/controller/api/no_isadmin_test.go
+++ b/features/controller/api/no_isadmin_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoIsAdminInGoSource verifies that Principal.IsAdmin has been fully deleted
+// from all non-test Go source files. Any hit means a site was missed during the
+// migration to principal.Assurance >= session.AssuranceBasic (Issue #2781).
+//
+// This runs as a CI-runnable check rather than a manual grep step.
+func TestNoIsAdminInGoSource(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	// grep -rn '\.IsAdmin\b' --include=*.go, then filter out _test.go and docs/.
+	cmd := exec.Command("grep", "-rn", `\.IsAdmin\b`, "--include=*.go", repoRoot)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err != nil {
+		// grep exits 1 when no matches found — that is the success case.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return // zero hits — correct
+		}
+		require.NoError(t, err, "grep failed unexpectedly: %s", out.String())
+	}
+
+	// grep exited 0 → matches found. Filter out test files and docs/.
+	lines := bytes.Split(bytes.TrimSpace(out.Bytes()), []byte("\n"))
+	var violations []string
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		s := string(line)
+		if isTestFile(s) || isDocsPath(s) {
+			continue
+		}
+		violations = append(violations, s)
+	}
+
+	assert.Empty(t, violations,
+		"Principal.IsAdmin must be fully deleted from non-test Go source files (Issue #2781).\n"+
+			"Found %d remaining site(s):\n%s",
+		len(violations), bytes.Join(func() [][]byte {
+			var bs [][]byte
+			for _, v := range violations {
+				bs = append(bs, []byte("  "+v))
+			}
+			return bs
+		}(), []byte("\n")))
+}
+
+// findRepoRoot walks up from the current source file until it finds go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must succeed")
+
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root (no go.mod found walking up from test file)")
+		}
+		dir = parent
+	}
+}
+
+// isTestFile reports whether the grep output line references a _test.go file.
+func isTestFile(line string) bool {
+	// grep output format: path/to/file.go:line:match
+	for i, c := range line {
+		if c == ':' {
+			return len(line) >= i && containsTestSuffix(line[:i])
+		}
+	}
+	return false
+}
+
+func containsTestSuffix(path string) bool {
+	base := filepath.Base(path)
+	return len(base) > 8 && base[len(base)-8:] == "_test.go"
+}
+
+// isDocsPath reports whether the grep output line refers to a file under docs/.
+func isDocsPath(line string) bool {
+	for i, c := range line {
+		if c == ':' {
+			path := line[:i]
+			rel := filepath.ToSlash(path)
+			// Match both absolute paths containing /docs/ and relative paths starting with docs/
+			for j := 0; j < len(rel)-5; j++ {
+				if rel[j:j+5] == "/docs" {
+					return true
+				}
+			}
+			if len(rel) >= 5 && rel[:5] == "docs/" {
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}

--- a/features/controller/api/no_isadmin_test.go
+++ b/features/controller/api/no_isadmin_test.go
@@ -82,15 +82,35 @@ func findRepoRoot(t *testing.T) string {
 	}
 }
 
-// isTestFile reports whether the grep output line references a _test.go file.
-func isTestFile(line string) bool {
-	// grep output format: path/to/file.go:line:match
-	for i, c := range line {
-		if c == ':' {
-			return len(line) >= i && containsTestSuffix(line[:i])
+// extractGrepPath returns the file path portion of a grep output line.
+//
+// grep output format: path:linenum:match
+//
+// On Windows, the path may begin with a drive-letter prefix such as "D:\",
+// so the first ':' in the line is the drive colon, not the path/linenum separator.
+// We detect this case (single ASCII letter followed by ':') and skip over the
+// volume prefix before scanning for the real separator colon.
+func extractGrepPath(line string) string {
+	start := 0
+	// Windows volume prefix: single ASCII letter + ':' (e.g. "D:").
+	if len(line) >= 2 && line[1] == ':' && isASCIILetter(line[0]) {
+		start = 2
+	}
+	for i := start; i < len(line); i++ {
+		if line[i] == ':' {
+			return line[:i]
 		}
 	}
-	return false
+	return line
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// isTestFile reports whether the grep output line references a _test.go file.
+func isTestFile(line string) bool {
+	return containsTestSuffix(extractGrepPath(line))
 }
 
 func containsTestSuffix(path string) bool {
@@ -100,23 +120,138 @@ func containsTestSuffix(path string) bool {
 
 // isDocsPath reports whether the grep output line refers to a file under docs/.
 func isDocsPath(line string) bool {
-	for i, c := range line {
-		if c == ':' {
-			path := line[:i]
-			rel := filepath.ToSlash(path)
-			// Require the full directory boundary: "/docs/" or a relative path starting "docs/".
-			// Checking "/docs/" (6 chars) avoids false positives from filenames like
-			// "features/config/docstore.go" which contain "/docs" without being in docs/.
-			for j := 0; j < len(rel)-6; j++ {
-				if rel[j:j+6] == "/docs/" {
-					return true
-				}
-			}
-			if len(rel) >= 5 && rel[:5] == "docs/" {
-				return true
-			}
-			return false
+	path := extractGrepPath(line)
+	rel := filepath.ToSlash(path)
+	// Require the full directory boundary: "/docs/" or a relative path starting "docs/".
+	// Checking "/docs/" (6 chars) avoids false positives from filenames like
+	// "features/config/docstore.go" which contain "/docs" without being in docs/.
+	for j := 0; j < len(rel)-6; j++ {
+		if rel[j:j+6] == "/docs/" {
+			return true
 		}
 	}
-	return false
+	return len(rel) >= 5 && rel[:5] == "docs/"
+}
+
+// TestExtractGrepPath_WindowsDriveLetter verifies that extractGrepPath correctly
+// skips the Windows drive-letter colon so _test.go and docs/ filtering works
+// on merge-group Windows runners. Regression test for the eviction bug where
+// D:\...\foo_test.go:17:match was split at 'D' instead of the actual path.
+func TestExtractGrepPath_WindowsDriveLetter(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "unix_path",
+			line: "/home/runner/work/cfgms/features/controller/api/handlers.go:42:match",
+			want: "/home/runner/work/cfgms/features/controller/api/handlers.go",
+		},
+		{
+			name: "unix_test_path",
+			line: "/home/runner/work/cfgms/features/controller/api/no_isadmin_test.go:17:// TestNoIsAdminInGoSource",
+			want: "/home/runner/work/cfgms/features/controller/api/no_isadmin_test.go",
+		},
+		{
+			name: "windows_uppercase_drive",
+			line: `D:\a\cfgms\cfgms/features/controller/api/handlers.go:42:match`,
+			want: `D:\a\cfgms\cfgms/features/controller/api/handlers.go`,
+		},
+		{
+			name: "windows_test_file",
+			line: `D:\a\cfgms\cfgms/features/controller/api/no_isadmin_test.go:17:// TestNoIsAdminInGoSource`,
+			want: `D:\a\cfgms\cfgms/features/controller/api/no_isadmin_test.go`,
+		},
+		{
+			name: "windows_lowercase_drive",
+			line: `c:\workspace\cfgms\features\controller\api\handlers.go:100:match`,
+			want: `c:\workspace\cfgms\features\controller\api\handlers.go`,
+		},
+		{
+			name: "relative_path_no_drive",
+			line: "features/controller/api/handlers.go:42:match",
+			want: "features/controller/api/handlers.go",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractGrepPath(tc.line)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIsTestFile_WindowsDriveLetter verifies that _test.go files are correctly
+// identified when the grep line contains a Windows drive-letter prefix.
+func TestIsTestFile_WindowsDriveLetter(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "windows_test_file_is_test",
+			line: `D:\a\cfgms\cfgms/features/controller/api/no_isadmin_test.go:17:// TestNoIsAdminInGoSource`,
+			want: true,
+		},
+		{
+			name: "windows_prod_file_not_test",
+			line: `D:\a\cfgms\cfgms/features/controller/api/handlers.go:42:.IsAdmin`,
+			want: false,
+		},
+		{
+			name: "unix_test_file_is_test",
+			line: "/workspace/features/controller/api/no_isadmin_test.go:25:s := string(line)",
+			want: true,
+		},
+		{
+			name: "unix_prod_file_not_test",
+			line: "/workspace/features/controller/api/handlers.go:42:.IsAdmin",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isTestFile(tc.line)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIsDocsPath_WindowsDriveLetter verifies that docs/ paths are correctly
+// identified when the grep line contains a Windows drive-letter prefix.
+func TestIsDocsPath_WindowsDriveLetter(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "windows_docs_path",
+			line: `D:\a\cfgms\cfgms/docs/architecture/operating-model.md:5:IsAdmin`,
+			want: true,
+		},
+		{
+			name: "windows_non_docs_path",
+			line: `D:\a\cfgms\cfgms/features/controller/api/handlers.go:42:.IsAdmin`,
+			want: false,
+		},
+		{
+			name: "unix_docs_path",
+			line: "/workspace/docs/architecture/operating-model.md:5:IsAdmin",
+			want: true,
+		},
+		{
+			name: "windows_docstore_not_docs_dir",
+			line: `D:\a\cfgms\cfgms/features/config/docstore.go:10:.IsAdmin`,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isDocsPath(tc.line)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/features/controller/api/no_isadmin_test.go
+++ b/features/controller/api/no_isadmin_test.go
@@ -104,9 +104,11 @@ func isDocsPath(line string) bool {
 		if c == ':' {
 			path := line[:i]
 			rel := filepath.ToSlash(path)
-			// Match both absolute paths containing /docs/ and relative paths starting with docs/
-			for j := 0; j < len(rel)-5; j++ {
-				if rel[j:j+5] == "/docs" {
+			// Require the full directory boundary: "/docs/" or a relative path starting "docs/".
+			// Checking "/docs/" (6 chars) avoids false positives from filenames like
+			// "features/config/docstore.go" which contain "/docs" without being in docs/.
+			for j := 0; j < len(rel)-6; j++ {
+				if rel[j:j+6] == "/docs/" {
 					return true
 				}
 			}

--- a/features/controller/api/relay_handler.go
+++ b/features/controller/api/relay_handler.go
@@ -116,14 +116,13 @@ func (h *RelayHandler) handleRelayEvent(ctx context.Context, event *cpTypes.Even
 		return h.sendErrorResponse(ctx, deviceID, event.StewardID, executionID, seq, http.StatusForbidden)
 	}
 
-	// Construct scope-limited, non-admin Principal. TenantID comes from the grant
+	// Construct scope-limited Principal. TenantID comes from the grant
 	// (set at dispatch time from device registration) — not from the event body.
 	// AssuranceMachine is deliberate: it makes the relay-script principal fail every
 	// Assurance >= AssuranceBasic check by construction (ADR-021, Issue #2780).
 	principal := &Principal{
 		ID:          fmt.Sprintf("relay:%s:%s", deviceID, executionID),
 		Name:        fmt.Sprintf("relay-script:%s", deviceID),
-		IsAdmin:     false,
 		Assurance:   session.AssuranceMachine,
 		Permissions: grant.Scope,
 		TenantID:    grant.TenantID,

--- a/features/controller/api/relay_handler_test.go
+++ b/features/controller/api/relay_handler_test.go
@@ -113,8 +113,8 @@ func newRelayTestHandler() http.Handler {
 			perms = principal.Permissions
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"permissions": perms,
-			"is_admin":    principal != nil && principal.IsAdmin,
+			"permissions":          perms,
+			"assurance_sufficient": principal != nil && principal.Assurance >= session.AssuranceBasic,
 		})
 	})
 }
@@ -123,8 +123,8 @@ func newRelayTestHandler() http.Handler {
 func newRelayForbiddenHandler(requiredPerm string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		principal, _ := r.Context().Value(principalContextKey).(*Principal)
-		if principal == nil || principal.IsAdmin {
-			// Admin or nil — not expected in relay path.
+		if principal == nil || principal.Assurance >= session.AssuranceBasic {
+			// Human-authenticated or nil — not expected in relay path.
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
@@ -341,7 +341,7 @@ func TestRelayHandler_AdminPrincipal_NeverConstructed(t *testing.T) {
 	}))
 
 	require.NotNil(t, capturedPrincipal)
-	assert.False(t, capturedPrincipal.IsAdmin, "relay principal must never be admin")
+	assert.Equal(t, session.AssuranceMachine, capturedPrincipal.Assurance, "relay principal must always be Machine assurance")
 	assert.Equal(t, session.AssuranceMachine, capturedPrincipal.Assurance, "relay principal must always be Machine assurance")
 	assert.Equal(t, "tenant-1", capturedPrincipal.TenantID)
 }
@@ -504,7 +504,7 @@ func TestRequirePermission_RelayPrincipal_ScopeEnforcedWhenRBACNil(t *testing.T)
 	handler := s.requirePermission("steward", "execute-scripts")(inner)
 
 	// Relay principal has only read-scripts — not execute-scripts.
-	relay := &Principal{IsAdmin: false, Permissions: []string{"steward:read-scripts"}, TenantID: "t1"}
+	relay := &Principal{Assurance: session.AssuranceMachine, Permissions: []string{"steward:read-scripts"}, TenantID: "t1"}
 	ctx := context.WithValue(
 		context.WithValue(context.Background(), relayPrincipalKey, relay),
 		principalContextKey, relay)

--- a/features/controller/api/relay_handler_test.go
+++ b/features/controller/api/relay_handler_test.go
@@ -342,7 +342,6 @@ func TestRelayHandler_AdminPrincipal_NeverConstructed(t *testing.T) {
 
 	require.NotNil(t, capturedPrincipal)
 	assert.Equal(t, session.AssuranceMachine, capturedPrincipal.Assurance, "relay principal must always be Machine assurance")
-	assert.Equal(t, session.AssuranceMachine, capturedPrincipal.Assurance, "relay principal must always be Machine assurance")
 	assert.Equal(t, "tenant-1", capturedPrincipal.TenantID)
 }
 

--- a/features/controller/api/rollback_handler.go
+++ b/features/controller/api/rollback_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cfgis/cfgms/features/config/rollback"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
@@ -166,7 +167,7 @@ func (h *RollbackHandler) ExecuteRollback(w http.ResponseWriter, r *http.Request
 	//     this is always used in production and cannot be bypassed by the caller.
 	//   Phase 2 (fallback): caller-supplied steward_tenant_path field — used when
 	//     stewardTenantLookup is nil (e.g. handler unit tests).
-	if principal != nil && !principal.IsAdmin && principal.TenantID != "" {
+	if principal != nil && principal.Assurance < session.AssuranceBasic && principal.TenantID != "" {
 		var resolvedTenant string
 		if h.stewardTenantLookup != nil {
 			resolvedTenant = h.stewardTenantLookup(req.TargetID)

--- a/features/controller/api/rollback_handler_test.go
+++ b/features/controller/api/rollback_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/config/rollback"
+	"github.com/cfgis/cfgms/pkg/session"
 )
 
 // testRollbackManager implements rollback.RollbackManager for handler-level tests.
@@ -59,9 +60,9 @@ func (m *testRollbackManager) ListRollbackHistory(_ context.Context, _ rollback.
 func scopedPrincipalExtractor(tenantID string) func(*http.Request) *Principal {
 	return func(_ *http.Request) *Principal {
 		return &Principal{
-			ID:       "admin-api-key",
-			TenantID: tenantID,
-			IsAdmin:  false,
+			ID:        "admin-api-key",
+			TenantID:  tenantID,
+			Assurance: session.AssuranceMachine,
 		}
 	}
 }
@@ -69,8 +70,8 @@ func scopedPrincipalExtractor(tenantID string) func(*http.Request) *Principal {
 func adminPrincipalExtractor() func(*http.Request) *Principal {
 	return func(_ *http.Request) *Principal {
 		return &Principal{
-			ID:      "admin-cert-cn",
-			IsAdmin: true,
+			ID:        "admin-cert-cn",
+			Assurance: session.AssuranceBasic,
 		}
 	}
 }
@@ -145,7 +146,7 @@ func TestConfigRollback_AllowsChildTenant(t *testing.T) {
 }
 
 func TestConfigRollback_AdminPrincipalSkipsTenantCheck(t *testing.T) {
-	// Full admin (IsAdmin=true, TenantID="") can access any tenant.
+	// Full admin (Assurance >= AssuranceBasic, TenantID="") can access any tenant.
 	mgr := &testRollbackManager{}
 	handler := NewRollbackHandler(mgr, adminPrincipalExtractor(), nil, nil)
 

--- a/features/controller/api/tier_enforcement_test.go
+++ b/features/controller/api/tier_enforcement_test.go
@@ -190,7 +190,6 @@ func TestF2_AssuranceGate_ParityWithPermissionRegistry(t *testing.T) {
 	strongPrincipal := &Principal{
 		ID:         "cert-admin",
 		Name:       "mtls-cert:cert-admin",
-		IsAdmin:    true,
 		Assurance:  session.AssuranceStrong,
 		CertSerial: "abc123",
 	}
@@ -256,7 +255,6 @@ func TestAssuranceGate_BasicAssurance_GetsStepUp(t *testing.T) {
 	basicPrincipal := &Principal{
 		ID:        "web-admin",
 		Name:      "web-session:web-admin",
-		IsAdmin:   true,
 		Assurance: session.AssuranceBasic,
 	}
 
@@ -298,7 +296,6 @@ func TestAssuranceGate_MachineAssurance_Gets403NotStepUp(t *testing.T) {
 	machinePrincipal := &Principal{
 		ID:        "machine-agent",
 		Name:      "api-key:machine-agent",
-		IsAdmin:   true,
 		Assurance: session.AssuranceMachine,
 	}
 
@@ -332,7 +329,6 @@ func TestAssuranceGate_StrongAssurance_ReachesHandler(t *testing.T) {
 	strongPrincipal := &Principal{
 		ID:         "cert-admin",
 		Name:       "mtls-cert:cert-admin",
-		IsAdmin:    true,
 		Assurance:  session.AssuranceStrong,
 		CertSerial: "abc123",
 	}
@@ -368,7 +364,6 @@ func TestAssuranceGate_RelayPrincipal_Gets403(t *testing.T) {
 	relayPrincipal := &Principal{
 		ID:          "relay-1",
 		Name:        "relay:relay-1",
-		IsAdmin:     false,
 		Assurance:   session.AssuranceMachine,
 		Permissions: []string{"api-key:create"},
 		TenantID:    "relay-tenant",
@@ -419,7 +414,7 @@ func assertStepUpFromRequirePermission(t *testing.T, server *Server, resource, a
 	t.Helper()
 	basicPrincipal := &Principal{
 		ID: "web-admin", Name: "web-session:web-admin",
-		IsAdmin: true, Assurance: session.AssuranceBasic,
+		Assurance: session.AssuranceBasic,
 	}
 	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 	handler := server.requirePermission(resource, action)(probe)
@@ -462,7 +457,7 @@ func TestAssuranceGate_StepUp_ResponseContainsRequiredAssuranceField(t *testing.
 
 	basicPrincipal := &Principal{
 		ID: "web-admin", Name: "web-session:web-admin",
-		IsAdmin: true, Assurance: session.AssuranceBasic,
+		Assurance: session.AssuranceBasic,
 	}
 	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 	handler := server.requirePermission("api-key", "create")(probe)

--- a/features/controller/dispatcher/dispatcher.go
+++ b/features/controller/dispatcher/dispatcher.go
@@ -530,7 +530,10 @@ func (d *Dispatcher) sendCommand(ctx context.Context, deviceID string, exec *scr
 		params["required_api_scope"] = scope
 
 		if d.grantManager != nil {
-			tenantID, _ := exec.Metadata["tenant_id"].(string)
+			tenantID, ok := exec.Metadata["tenant_id"].(string)
+			if !ok || tenantID == "" {
+				return fmt.Errorf("create execution grant: missing or invalid tenant_id in script metadata")
+			}
 			ttl := exec.Timeout
 			if ttl <= 0 {
 				ttl = 15 * time.Minute // matches defaultScriptTimeoutSec in steward handler

--- a/features/controller/dispatcher/dispatcher_test.go
+++ b/features/controller/dispatcher/dispatcher_test.go
@@ -1389,6 +1389,148 @@ func mustOpenMemDB(t *testing.T) *sql.DB {
 	return db
 }
 
+// ----------------------------------------------------------------------------
+// Dispatcher hardening tests — Issue #2781
+// ----------------------------------------------------------------------------
+
+// testGrantManager is a minimal in-process GrantManager for dispatcher hardening
+// tests. It records all CreateGrant calls so tests can assert on them.
+type testGrantManager struct {
+	mu     sync.Mutex
+	grants []grantRecord
+}
+
+type grantRecord struct {
+	deviceID    string
+	tenantID    string
+	executionID string
+	scope       []string
+}
+
+func (g *testGrantManager) CreateGrant(deviceID, tenantID, executionID string, scope []string, ttl time.Duration) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.grants = append(g.grants, grantRecord{deviceID: deviceID, tenantID: tenantID, executionID: executionID, scope: scope})
+	return nil
+}
+
+func (g *testGrantManager) ConsumeGrant(_ string) error { return nil }
+
+func (g *testGrantManager) createdGrants() []grantRecord {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]grantRecord, len(g.grants))
+	copy(out, g.grants)
+	return out
+}
+
+// minimalPrepared returns a PreparedExecution with empty content suitable for
+// sendCommand unit tests. Size and shell are valid; script content is a one-byte
+// no-op so the content-size guard does not fire.
+func minimalPrepared() *script.PreparedExecution {
+	return &script.PreparedExecution{
+		ExecutionID:   "exec-harden-1",
+		ScriptContent: "#",
+		Shell:         script.ShellBash,
+	}
+}
+
+// newHardenDispatcher creates a Dispatcher wired to a real (non-nil) grant manager
+// so the tenant_id validation path in sendCommand is exercised.
+func newHardenDispatcher(t *testing.T, gm GrantManager) *Dispatcher {
+	t.Helper()
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d, err := New(&Config{
+		Queue:        q,
+		ControlPlane: cp,
+		PollInterval: 24 * time.Hour,
+		Logger:       logging.NewLogger("debug"),
+	})
+	require.NoError(t, err)
+	d.SetGrantManager(gm)
+	return d
+}
+
+// TestDispatcher_Harden_MissingTenantID_FailsClosed verifies Issue #2781's
+// dispatcher hardening: when a script's Metadata has required_api_scope set but
+// tenant_id is absent, sendCommand must return an explicit error rather than
+// silently calling CreateGrant with tenantID="".
+func TestDispatcher_Harden_MissingTenantID_FailsClosed(t *testing.T) {
+	gm := &testGrantManager{}
+	d := newHardenDispatcher(t, gm)
+
+	exec := &script.QueuedExecution{
+		ExecutionID: "exec-harden-missing",
+		ScriptID:    "s1",
+		ScriptRef:   "s1",
+		Shell:       script.ShellBash,
+		Timeout:     5 * time.Minute,
+		Metadata: map[string]interface{}{
+			"required_api_scope": []interface{}{"steward:read-scripts"},
+			// tenant_id intentionally absent
+		},
+	}
+
+	err := d.sendCommand(context.Background(), "device-1", exec, minimalPrepared())
+	require.Error(t, err, "sendCommand must fail when tenant_id is missing from script metadata")
+	assert.Contains(t, err.Error(), "missing or invalid tenant_id")
+	assert.Empty(t, gm.createdGrants(), "CreateGrant must not be called when tenant_id is missing")
+}
+
+// TestDispatcher_Harden_WrongTypeTenantID_FailsClosed verifies that a non-string
+// tenant_id in script metadata is treated identically to a missing one — fail
+// closed, never silently create an unscoped grant.
+func TestDispatcher_Harden_WrongTypeTenantID_FailsClosed(t *testing.T) {
+	gm := &testGrantManager{}
+	d := newHardenDispatcher(t, gm)
+
+	exec := &script.QueuedExecution{
+		ExecutionID: "exec-harden-wrongtype",
+		ScriptID:    "s1",
+		ScriptRef:   "s1",
+		Shell:       script.ShellBash,
+		Timeout:     5 * time.Minute,
+		Metadata: map[string]interface{}{
+			"required_api_scope": []interface{}{"steward:read-scripts"},
+			"tenant_id":          42, // int, not string
+		},
+	}
+
+	err := d.sendCommand(context.Background(), "device-1", exec, minimalPrepared())
+	require.Error(t, err, "sendCommand must fail when tenant_id has wrong type")
+	assert.Contains(t, err.Error(), "missing or invalid tenant_id")
+	assert.Empty(t, gm.createdGrants(), "CreateGrant must not be called for wrong-typed tenant_id")
+}
+
+// TestDispatcher_Harden_ValidTenantID_CreatesGrant verifies the positive path:
+// when tenant_id is a valid non-empty string, CreateGrant is called with exactly
+// that tenantID, and sendCommand succeeds.
+func TestDispatcher_Harden_ValidTenantID_CreatesGrant(t *testing.T) {
+	gm := &testGrantManager{}
+	d := newHardenDispatcher(t, gm)
+
+	exec := &script.QueuedExecution{
+		ExecutionID: "exec-harden-valid",
+		ScriptID:    "s1",
+		ScriptRef:   "s1",
+		Shell:       script.ShellBash,
+		Timeout:     5 * time.Minute,
+		Metadata: map[string]interface{}{
+			"required_api_scope": []interface{}{"steward:read-scripts"},
+			"tenant_id":          "root/tenant-a",
+		},
+	}
+
+	err := d.sendCommand(context.Background(), "device-1", exec, minimalPrepared())
+	require.NoError(t, err, "sendCommand must succeed with a valid tenant_id")
+	grants := gm.createdGrants()
+	require.Len(t, grants, 1)
+	assert.Equal(t, "root/tenant-a", grants[0].tenantID)
+	assert.Equal(t, "device-1", grants[0].deviceID)
+	assert.Equal(t, "exec-harden-valid", grants[0].executionID)
+}
+
 // TestDispatcher_New_ValidationErrors verifies that New rejects nil config fields.
 func TestDispatcher_New_ValidationErrors(t *testing.T) {
 	cp := &testControlPlane{}


### PR DESCRIPTION
## Summary

- Deletes `Principal.IsAdmin` field and migrates all ~22 non-route readers across 8 files to `principal.Assurance >= session.AssuranceBasic`
- Semantic preservation: `IsAdmin==true` was exactly {mTLS cert, cfg-Bearer session, web session} = `Assurance >= AssuranceBasic`; `IsAdmin==false` was exactly {API key} = `AssuranceMachine` — byte-for-byte identical behavior
- One deliberate exception: `handlers_certificates.go:54` uses `Assurance < AssuranceStrong` to mirror the `certificate:rotate` permissionAssurance entry's stronger bar, preserving the RBAC-nil-bypass defense-in-depth guard
- Dispatcher hardening (Issue #1675 context): `dispatcher.go:531` now fails closed on missing/wrong-typed `tenant_id` instead of silently creating an unscoped JIT relay grant

## Required tests added

- `TestNoIsAdminInGoSource` — CI-runnable grep check; fails if `.IsAdmin` re-appears in non-test Go source
- `TestDispatcher_Harden_MissingTenantID_FailsClosed` / `TestDispatcher_Harden_WrongTypeTenantID_FailsClosed` — dispatcher hardening regression tests
- `TestDispatcher_Harden_ValidTenantID_CreatesGrant` — positive path for grant creation
- `TestJobsTenantIsolation_AssuranceBoundary` — table-driven; includes explicit relay-grant principal case confirming `AssuranceMachine` cannot access cross-tenant job records
- `TestRunVisibleTo_AssuranceBoundary` — table-driven unit test of `runVisibleTo`; includes relay-grant cross-tenant case
- `TestGetConfigPush_AssuranceBoundary` — table-driven; includes relay-grant principal case
- `TestUpgradeStatus_AssuranceBoundary` — table-driven assurance boundary test

## Implementation notes

- `auditAuthorizationDecision` uses `principal.CertSerial != ""` as the discriminator for cert-auth audit fields (more precise than the general rule: cert fields are only populated for mTLS principals)
- Audit log field renamed: `is_admin` → `assurance_sufficient`
- Audit reason string updated: `"Admin principal granted full access"` → `"principal assurance sufficient for full access"`
- `handlers_sessions.go` and `middleware.go` comment references to `IsAdmin` updated to use `Assurance` terminology

Fixes #2781

🤖 Generated with [Claude Code](https://claude.com/claude-code)