### PR TITLE
terminal: controller WebSocket relay + session brokering (Issue #2761)

### DIFF
--- a/features/controller/api/handlers_terminal_test.go
+++ b/features/controller/api/handlers_terminal_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/terminal"
+)
+
+// capturingWSHandler is a hand-written test double for terminal.WebSocketHandler
+// (not a mock framework) that records whether it was invoked and what steward_id
+// it observed on the request query string. It lets these tests assert route
+// registration, RBAC gating, and mux path-variable injection without opening a
+// real WebSocket connection.
+type capturingWSHandler struct {
+	mu        sync.Mutex
+	called    bool
+	stewardID string
+}
+
+func (c *capturingWSHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
+	c.mu.Lock()
+	c.called = true
+	c.stewardID = r.URL.Query().Get("steward_id")
+	c.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(r.URL.Query().Get("steward_id")))
+}
+
+func (c *capturingWSHandler) observed() (bool, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.called, c.stewardID
+}
+
+// Compile-time check: the double satisfies the interface SetTerminalHandler wants.
+var _ terminal.WebSocketHandler = (*capturingWSHandler)(nil)
+
+// TestServer_SetTerminalHandler_RegistersRoute_PostConstruction verifies that the
+// terminal WebSocket route is absent until SetTerminalHandler is called, then
+// present afterwards (an unauthenticated request returns 401, not 404).
+func TestServer_SetTerminalHandler_RegistersRoute_PostConstruction(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Route must be absent before SetTerminalHandler.
+	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"terminal route must be 404 before SetTerminalHandler")
+
+	// Wire a handler post-construction, exactly as production does.
+	server.SetTerminalHandler(&capturingWSHandler{})
+
+	// Unauthenticated request must now return 401 (route present, auth enforced),
+	// not 404.
+	req = httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"GET /api/v1/terminal/ws/{steward_id} must return 401 after SetTerminalHandler (auth enforced, not 404)")
+}
+
+// TestServer_SetTerminalHandler_EnforcesPermissionGate verifies the
+// steward:terminal RBAC gate is applied to the terminal route. A caller with a
+// valid API key but without steward:terminal must receive 403; a caller with the
+// permission must pass the gate.
+func TestServer_SetTerminalHandler_EnforcesPermissionGate(t *testing.T) {
+	server := setupTestServer(t)
+	server.SetTerminalHandler(&capturingWSHandler{})
+
+	// Key without steward:terminal permission → 403.
+	noPermKey := NewTestKey(t, server, []string{"steward:read"})
+	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
+	req.Header.Set("X-API-Key", noPermKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"terminal route must return 403 for caller without steward:terminal permission")
+
+	// Key with steward:terminal permission must pass the gate.
+	permKey := NewTestKey(t, server, []string{"steward:terminal"})
+	req = httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
+	req.Header.Set("X-API-Key", permKey)
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"terminal route must not return 403 for caller with steward:terminal permission")
+	assert.NotEqual(t, http.StatusNotFound, rec.Code,
+		"terminal route must not return 404 for caller with steward:terminal permission")
+}
+
+// TestServer_SetTerminalHandler_InjectsStewardIDPathVar verifies that the mux
+// {steward_id} path variable is injected into the query string so the pre-built
+// WebSocket handler can read it via r.URL.Query().Get("steward_id").
+func TestServer_SetTerminalHandler_InjectsStewardIDPathVar(t *testing.T) {
+	server := setupTestServer(t)
+	capture := &capturingWSHandler{}
+	server.SetTerminalHandler(capture)
+
+	permKey := NewTestKey(t, server, []string{"steward:terminal"})
+	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-xyz", nil)
+	req.Header.Set("X-API-Key", permKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	called, stewardID := capture.observed()
+	require.True(t, called, "authorized request must reach the wrapped WebSocket handler")
+	assert.Equal(t, "steward-xyz", stewardID,
+		"mux {steward_id} path variable must be injected into the query string")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "steward-xyz", rec.Body.String(),
+		"wrapped handler must observe the injected steward_id")
+}
+
+// TestServer_SetTerminalHandler_ExplicitQueryNotOverwritten verifies that an
+// explicit steward_id in the query string is preserved (the injection only fills
+// an empty value).
+func TestServer_SetTerminalHandler_ExplicitQueryNotOverwritten(t *testing.T) {
+	server := setupTestServer(t)
+	capture := &capturingWSHandler{}
+	server.SetTerminalHandler(capture)
+
+	permKey := NewTestKey(t, server, []string{"steward:terminal"})
+	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/path-steward?steward_id=query-steward", nil)
+	req.Header.Set("X-API-Key", permKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	_, stewardID := capture.observed()
+	assert.Equal(t, "query-steward", stewardID,
+		"an explicit steward_id query value must not be overwritten by the path variable")
+}
+
+// TestServer_SetTerminalHandler_NilHandler_NoopSafe verifies that passing nil to
+// SetTerminalHandler does not register a route and does not panic.
+func TestServer_SetTerminalHandler_NilHandler_NoopSafe(t *testing.T) {
+	server := setupTestServer(t)
+
+	assert.NotPanics(t, func() {
+		server.SetTerminalHandler(nil)
+	}, "SetTerminalHandler(nil) must not panic")
+
+	// No route must have been registered.
+	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"terminal route must remain absent (404) after SetTerminalHandler(nil)")
+}

--- a/features/controller/api/handlers_terminal_test.go
+++ b/features/controller/api/handlers_terminal_test.go
@@ -3,45 +3,53 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
-	"sync"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/terminal"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
-// capturingWSHandler is a hand-written test double for terminal.WebSocketHandler
-// (not a mock framework) that records whether it was invoked and what steward_id
-// it observed on the request query string. It lets these tests assert route
-// registration, RBAC gating, and mux path-variable injection without opening a
-// real WebSocket connection.
-type capturingWSHandler struct {
-	mu        sync.Mutex
-	called    bool
-	stewardID string
+// newRealTerminalWSHandler builds a real terminal.DefaultWebSocketHandler backed
+// by a real terminal.DefaultSessionManager (no mocks or fakes). The returned
+// session manager can be queried to observe what SetTerminalHandler's mux
+// path-variable injection actually delivered to the handler. Recording storage
+// is isolated in t.TempDir().
+func newRealTerminalWSHandler(t *testing.T) (terminal.WebSocketHandler, terminal.SessionManager) {
+	t.Helper()
+	sessionMgr, err := terminal.NewSessionManager(&terminal.Config{
+		RecordSessions:       true,
+		RecordingStoragePath: t.TempDir(),
+		SessionTimeout:       30 * time.Minute,
+		MaxSessions:          100,
+	}, logging.NewNoopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if dsm, ok := sessionMgr.(*terminal.DefaultSessionManager); ok {
+			_ = dsm.Stop(context.Background())
+		}
+	})
+
+	// nil origin allowlist → same-origin only, which is satisfied when the test
+	// dials the httptest server with an Origin matching that server's host.
+	wsHandler, err := terminal.NewWebSocketHandler(sessionMgr, logging.NewNoopLogger(), nil)
+	require.NoError(t, err)
+	return wsHandler, sessionMgr
 }
 
-func (c *capturingWSHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
-	c.mu.Lock()
-	c.called = true
-	c.stewardID = r.URL.Query().Get("steward_id")
-	c.mu.Unlock()
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(r.URL.Query().Get("steward_id")))
+// wsURL converts an httptest server's http(s):// URL into a ws(s):// dial URL,
+// appending the given path+query.
+func wsURL(serverURL, pathAndQuery string) string {
+	return "ws" + strings.TrimPrefix(serverURL, "http") + pathAndQuery
 }
-
-func (c *capturingWSHandler) observed() (bool, string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.called, c.stewardID
-}
-
-// Compile-time check: the double satisfies the interface SetTerminalHandler wants.
-var _ terminal.WebSocketHandler = (*capturingWSHandler)(nil)
 
 // TestServer_SetTerminalHandler_RegistersRoute_PostConstruction verifies that the
 // terminal WebSocket route is absent until SetTerminalHandler is called, then
@@ -56,11 +64,12 @@ func TestServer_SetTerminalHandler_RegistersRoute_PostConstruction(t *testing.T)
 	assert.Equal(t, http.StatusNotFound, rec.Code,
 		"terminal route must be 404 before SetTerminalHandler")
 
-	// Wire a handler post-construction, exactly as production does.
-	server.SetTerminalHandler(&capturingWSHandler{})
+	// Wire a real handler post-construction, exactly as production does.
+	handler, _ := newRealTerminalWSHandler(t)
+	server.SetTerminalHandler(handler)
 
-	// Unauthenticated request must now return 401 (route present, auth enforced),
-	// not 404.
+	// Unauthenticated request must now return 401 (route present, auth enforced
+	// by the middleware before HandleWebSocket runs), not 404.
 	req = httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
 	rec = httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
@@ -70,25 +79,31 @@ func TestServer_SetTerminalHandler_RegistersRoute_PostConstruction(t *testing.T)
 
 // TestServer_SetTerminalHandler_EnforcesPermissionGate verifies the
 // steward:terminal RBAC gate is applied to the terminal route. A caller with a
-// valid API key but without steward:terminal must receive 403; a caller with the
-// permission must pass the gate.
+// valid API key but without steward:terminal must receive 403 (returned by the
+// auth middleware before HandleWebSocket is invoked); a caller with the
+// permission must pass the gate and reach the real handler.
 func TestServer_SetTerminalHandler_EnforcesPermissionGate(t *testing.T) {
 	server := setupTestServer(t)
-	server.SetTerminalHandler(&capturingWSHandler{})
+	handler, _ := newRealTerminalWSHandler(t)
+	server.SetTerminalHandler(handler)
 
-	// Key without steward:terminal permission → 403.
+	// Key without steward:terminal permission → 403 (gate, before the handler).
 	noPermKey := NewTestKey(t, server, []string{"steward:read"})
 	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
 	req.Header.Set("X-API-Key", noPermKey)
+	req.Header.Set("Origin", "http://example.com") // matches httptest default host
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusForbidden, rec.Code,
 		"terminal route must return 403 for caller without steward:terminal permission")
 
-	// Key with steward:terminal permission must pass the gate.
+	// Key with steward:terminal permission must pass the gate and reach the real
+	// handler. The request omits user_id, so the handler rejects it with 400 after
+	// the gate — the point being it is neither 403 (gate) nor 404 (route absent).
 	permKey := NewTestKey(t, server, []string{"steward:terminal"})
 	req = httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-1", nil)
 	req.Header.Set("X-API-Key", permKey)
+	req.Header.Set("Origin", "http://example.com")
 	rec = httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 	assert.NotEqual(t, http.StatusForbidden, rec.Code,
@@ -99,43 +114,76 @@ func TestServer_SetTerminalHandler_EnforcesPermissionGate(t *testing.T) {
 
 // TestServer_SetTerminalHandler_InjectsStewardIDPathVar verifies that the mux
 // {steward_id} path variable is injected into the query string so the pre-built
-// WebSocket handler can read it via r.URL.Query().Get("steward_id").
+// WebSocket handler observes it. It opens a real WebSocket connection through the
+// full server stack (auth + RBAC gate + mux injection + real handler) and asserts
+// that the session the real handler created carries the injected steward_id.
 func TestServer_SetTerminalHandler_InjectsStewardIDPathVar(t *testing.T) {
 	server := setupTestServer(t)
-	capture := &capturingWSHandler{}
-	server.SetTerminalHandler(capture)
+	handler, sessionMgr := newRealTerminalWSHandler(t)
+	server.SetTerminalHandler(handler)
+
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
 
 	permKey := NewTestKey(t, server, []string{"steward:terminal"})
-	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/steward-xyz", nil)
-	req.Header.Set("X-API-Key", permKey)
-	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	header := http.Header{}
+	header.Set("X-API-Key", permKey)
+	header.Set("Origin", ts.URL) // same-origin as the httptest server
 
-	called, stewardID := capture.observed()
-	require.True(t, called, "authorized request must reach the wrapped WebSocket handler")
-	assert.Equal(t, "steward-xyz", stewardID,
-		"mux {steward_id} path variable must be injected into the query string")
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "steward-xyz", rec.Body.String(),
-		"wrapped handler must observe the injected steward_id")
+	conn, resp, err := websocket.DefaultDialer.Dial(
+		wsURL(ts.URL, "/api/v1/terminal/ws/steward-xyz?user_id=u1&shell=bash"),
+		header,
+	)
+	require.NoError(t, err, "authorized WebSocket dial must succeed")
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	defer func() { _ = conn.Close() }()
+
+	// The real handler creates the session after the upgrade; poll until it
+	// appears, then assert it observed the injected {steward_id} path variable.
+	require.Eventually(t, func() bool {
+		return len(sessionMgr.GetActiveSessions()) == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"authorized request must reach the wrapped WebSocket handler and create a session")
+
+	sessions := sessionMgr.GetActiveSessions()
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "steward-xyz", sessions[0].StewardID,
+		"mux {steward_id} path variable must be injected so the handler creates the session for it")
 }
 
 // TestServer_SetTerminalHandler_ExplicitQueryNotOverwritten verifies that an
 // explicit steward_id in the query string is preserved (the injection only fills
-// an empty value).
+// an empty value). It dials a real WebSocket whose path steward_id differs from an
+// explicit query steward_id and asserts the created session used the query value.
 func TestServer_SetTerminalHandler_ExplicitQueryNotOverwritten(t *testing.T) {
 	server := setupTestServer(t)
-	capture := &capturingWSHandler{}
-	server.SetTerminalHandler(capture)
+	handler, sessionMgr := newRealTerminalWSHandler(t)
+	server.SetTerminalHandler(handler)
+
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
 
 	permKey := NewTestKey(t, server, []string{"steward:terminal"})
-	req := httptest.NewRequest("GET", "/api/v1/terminal/ws/path-steward?steward_id=query-steward", nil)
-	req.Header.Set("X-API-Key", permKey)
-	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	header := http.Header{}
+	header.Set("X-API-Key", permKey)
+	header.Set("Origin", ts.URL)
 
-	_, stewardID := capture.observed()
-	assert.Equal(t, "query-steward", stewardID,
+	conn, resp, err := websocket.DefaultDialer.Dial(
+		wsURL(ts.URL, "/api/v1/terminal/ws/path-steward?steward_id=query-steward&user_id=u1&shell=bash"),
+		header,
+	)
+	require.NoError(t, err, "authorized WebSocket dial must succeed")
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	defer func() { _ = conn.Close() }()
+
+	require.Eventually(t, func() bool {
+		return len(sessionMgr.GetActiveSessions()) == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"authorized request must reach the wrapped WebSocket handler and create a session")
+
+	sessions := sessionMgr.GetActiveSessions()
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "query-steward", sessions[0].StewardID,
 		"an explicit steward_id query value must not be overwritten by the path variable")
 }
 

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"bufio"
 	"context"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -10,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"sort"
@@ -100,6 +102,19 @@ type responseWriter struct {
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack implements http.Hijacker by delegating to the wrapped ResponseWriter.
+// Without this, WebSocket upgrades routed through loggingMiddleware (notably the
+// terminal relay endpoint, Issue #2761) fail because the gorilla upgrader cannot
+// take over the connection, and the server returns 500 "response does not
+// implement http.Hijacker".
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
+	}
+	return hj.Hijack()
 }
 
 // corsMiddleware handles CORS headers

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -39,6 +39,7 @@ import (
 	reportapi "github.com/cfgis/cfgms/features/reports/api"
 	"github.com/cfgis/cfgms/features/tenant"
 	tenantsecurity "github.com/cfgis/cfgms/features/tenant/security"
+	"github.com/cfgis/cfgms/features/terminal"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/cache"
 	"github.com/cfgis/cfgms/pkg/cert"
@@ -765,21 +766,9 @@ func (s *Server) setupRouter() {
 	// Raft status endpoint: requires HA read-status permission via API authentication
 	api.Handle("/raft/status", s.requirePermission("ha", "read-status")(http.HandlerFunc(s.handleRaftStatus))).Methods("GET")
 
-	// TODO(#997): Wire terminal WebSocket handler when HTTP route is added (gated on epic #750).
-	// When the terminal route is registered, parse CFGMS_TERMINAL_ALLOWED_ORIGINS and pass the
-	// resulting slice to terminal.NewWebSocketHandler as the third argument. Parsing pattern
-	// mirrors CFGMS_ALLOWED_ORIGINS (comma-separated, strings.TrimSpace per entry, empty filtered):
-	//
-	//   var terminalOrigins []string
-	//   if raw := os.Getenv("CFGMS_TERMINAL_ALLOWED_ORIGINS"); raw != "" {
-	//       for _, o := range strings.Split(raw, ",") {
-	//           if trimmed := strings.TrimSpace(o); trimmed != "" {
-	//               terminalOrigins = append(terminalOrigins, trimmed)
-	//           }
-	//       }
-	//   }
-	//   terminalHandler, err := terminal.NewWebSocketHandler(sessionManager, s.logger, terminalOrigins)
-	//   // then register: api.Handle("/terminal/ws/{steward_id}", ...).Methods("GET")
+	// Terminal WebSocket endpoint is registered lazily by SetTerminalHandler (Issue #2761).
+	// No route is pre-registered here; the endpoint only exists when a WebSocket handler
+	// is explicitly wired in after server creation.
 
 	// SPA catch-all: lowest-precedence handler for the embedded web UI (Issue #2494).
 	// All /api/* and /raft/* routes registered above take precedence via gorilla/mux
@@ -1121,6 +1110,45 @@ func (s *Server) SetGitSyncWebhookHandler(h http.Handler) {
 	if h != nil {
 		s.router.Handle("/api/v1/webhooks/git-push", h).Methods("POST")
 		s.logger.Info("git-sync webhook endpoint registered at /api/v1/webhooks/git-push")
+	}
+}
+
+// SetTerminalHandler registers the terminal WebSocket relay endpoint at
+// GET /api/v1/terminal/ws/{steward_id}. The steward_id path variable is
+// injected into the query string so the pre-built websocket handler can
+// read it via r.URL.Query().Get("steward_id") without modification.
+// Requires "steward" / "terminal" RBAC permission (Issue #2761).
+// Call this after New() returns but before Start() is called.
+func (s *Server) SetTerminalHandler(h terminal.WebSocketHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if h == nil {
+		return
+	}
+
+	// Inject the gorilla mux path variable into the query string so that
+	// terminal.DefaultWebSocketHandler.parseSessionRequest can read it.
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if stewardID := mux.Vars(r)["steward_id"]; stewardID != "" {
+			q := r.URL.Query()
+			if q.Get("steward_id") == "" {
+				q.Set("steward_id", stewardID)
+				r2 := r.Clone(r.Context())
+				r2.URL.RawQuery = q.Encode()
+				r = r2
+			}
+		}
+		h.HandleWebSocket(w, r)
+	})
+
+	s.apiRouter.Handle(
+		"/terminal/ws/{steward_id}",
+		s.requirePermission("steward", "terminal")(wrapped),
+	).Methods("GET")
+
+	if s.logger != nil {
+		s.logger.Info("Terminal WebSocket endpoint registered at /api/v1/terminal/ws/{steward_id} (Issue #2761)")
 	}
 }
 

--- a/features/controller/commands/publisher.go
+++ b/features/controller/commands/publisher.go
@@ -135,7 +135,7 @@ func (p *Publisher) PublishCommandWithSigner(ctx context.Context, stewardID stri
 
 	p.logger.Info("Sent command to steward",
 		"command_id", commandID,
-		"steward_id", stewardID,
+		"steward_id", logging.SanitizeLogValue(stewardID),
 		"type", cmdType,
 		"signed", sc.Signature != nil)
 
@@ -167,7 +167,7 @@ func (p *Publisher) PublishCommand(ctx context.Context, stewardID string, cmdTyp
 
 	p.logger.Info("Sent command to steward",
 		"command_id", commandID,
-		"steward_id", stewardID,
+		"steward_id", logging.SanitizeLogValue(stewardID),
 		"type", cmdType,
 		"signed", sc.Signature != nil)
 

--- a/features/controller/server/composite_handler.go
+++ b/features/controller/server/composite_handler.go
@@ -16,7 +16,8 @@ import (
 // handler. Control plane RPCs go to the CP handler; SyncConfig is handled
 // directly by the config handler; SyncDNA by the DNA handler; BulkTransfer
 // by the bulk handler; LogStream by the log stream handler; TelemetryStream
-// by the telemetry handler. Future RPCs fall through to the Unimplemented base.
+// by the telemetry handler; Terminal by the terminal handler (Issue #2761).
+// Future RPCs fall through to the Unimplemented base.
 type compositeTransportServer struct {
 	transportpb.UnimplementedStewardTransportServer
 
@@ -26,12 +27,13 @@ type compositeTransportServer struct {
 	bulkHandler      *controllerTransport.BulkHandler      // BulkTransfer (direct handling)
 	logStreamHandler *controllerTransport.LogStreamHandler // LogStream (direct handling)
 	telemetryHandler *controllerTransport.TelemetryHandler // TelemetryStream (direct handling)
+	terminalHandler  *controllerTransport.TerminalHandler  // Terminal relay (Issue #2761)
 	logger           logging.Logger
 }
 
 // newCompositeTransportServer creates a composite handler with the always-required
 // CP handler and logger. Wire optional data-plane handlers via SetConfigHandler,
-// SetDNAHandler, SetBulkHandler, and SetLogStreamHandler before serving.
+// SetDNAHandler, SetBulkHandler, SetLogStreamHandler, and SetTerminalHandler before serving.
 func newCompositeTransportServer(
 	cpHandler transportpb.StewardTransportServer,
 	logger logging.Logger,
@@ -65,6 +67,11 @@ func (c *compositeTransportServer) SetLogStreamHandler(h *controllerTransport.Lo
 // SetTelemetryHandler sets the TelemetryStream handler. Call after newCompositeTransportServer.
 func (c *compositeTransportServer) SetTelemetryHandler(h *controllerTransport.TelemetryHandler) {
 	c.telemetryHandler = h
+}
+
+// SetTerminalHandler sets the Terminal relay handler. Call after newCompositeTransportServer.
+func (c *compositeTransportServer) SetTerminalHandler(h *controllerTransport.TerminalHandler) {
+	c.terminalHandler = h
 }
 
 // --- Control Plane RPCs (delegated to CP handler) ---
@@ -132,4 +139,14 @@ func (c *compositeTransportServer) TelemetryStream(stream grpc.BidiStreamingServ
 		return c.telemetryHandler.HandleGRPC(stream)
 	}
 	return c.UnimplementedStewardTransportServer.TelemetryStream(stream)
+}
+
+// Terminal is handled by the terminal relay handler (Issue #2761). The steward
+// dials in with an initial TerminalData frame carrying its session_id; the
+// handler correlates to the pending WS session and runs the bidirectional relay.
+func (c *compositeTransportServer) Terminal(stream grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData]) error {
+	if c.terminalHandler != nil {
+		return c.terminalHandler.HandleGRPC(stream)
+	}
+	return c.UnimplementedStewardTransportServer.Terminal(stream)
 }

--- a/features/controller/server/composite_handler_test.go
+++ b/features/controller/server/composite_handler_test.go
@@ -108,6 +108,23 @@ func (s *emptyLogStream) RecvMsg(interface{}) error                         { re
 // Compile-time check.
 var _ grpc.ClientStreamingServer[transportpb.LogEntry, transportpb.LogStreamResponse] = (*emptyLogStream)(nil)
 
+// emptyTerminalStream implements grpc.BidiStreamingServer[TerminalData, TerminalData].
+// Recv immediately returns EOF; its context carries no mTLS peer so the terminal
+// handler's peer-identity check fires (proving delegation, not the fallback).
+type emptyTerminalStream struct{}
+
+func (s *emptyTerminalStream) Recv() (*transportpb.TerminalData, error) { return nil, io.EOF }
+func (s *emptyTerminalStream) Send(*transportpb.TerminalData) error     { return nil }
+func (s *emptyTerminalStream) SetHeader(metadata.MD) error              { return nil }
+func (s *emptyTerminalStream) SendHeader(metadata.MD) error             { return nil }
+func (s *emptyTerminalStream) SetTrailer(metadata.MD)                   {}
+func (s *emptyTerminalStream) Context() context.Context                 { return context.Background() }
+func (s *emptyTerminalStream) SendMsg(interface{}) error                { return nil }
+func (s *emptyTerminalStream) RecvMsg(interface{}) error                { return nil }
+
+// Compile-time check.
+var _ grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData] = (*emptyTerminalStream)(nil)
+
 // ---------------------------------------------------------------------------
 // Additive-extension helpers (TestComposite_AdditiveExtension)
 // ---------------------------------------------------------------------------
@@ -226,6 +243,31 @@ func TestComposite_LogStream_NilHandler(t *testing.T) {
 		"LogStream with nil handler must return Unimplemented")
 }
 
+func TestComposite_Terminal_NilHandler(t *testing.T) {
+	cp := newRecordingHandler()
+	composite := newCompositeTransportServer(cp, nil)
+
+	err := composite.Terminal(&emptyTerminalStream{})
+	require.Error(t, err, "Terminal with nil terminalHandler should return unimplemented error")
+	assert.Contains(t, err.Error(), "not implemented",
+		"Terminal with nil handler must return Unimplemented")
+}
+
+func TestComposite_Terminal_WithHandler(t *testing.T) {
+	cp := newRecordingHandler()
+	terminalHandler := controllerTransport.NewTerminalHandler(logging.NewNoopLogger())
+	composite := newCompositeTransportServer(cp, nil)
+	composite.SetTerminalHandler(terminalHandler)
+
+	// Background context carries no mTLS peer, so the terminal handler rejects
+	// with Unauthenticated. That proves the RPC routed through the handler's
+	// HandleGRPC rather than the Unimplemented fallback.
+	err := composite.Terminal(&emptyTerminalStream{})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "not implemented",
+		"Terminal must route through terminalHandler, not the Unimplemented fallback")
+}
+
 // TestComposite_AdditiveExtension proves that adding a new data-plane handler
 // (as stories #2761/#2765 will do for Terminal/TelemetryStream) requires zero
 // edits to newCompositeTransportServer or any existing handler field, setter, or
@@ -237,14 +279,15 @@ func TestComposite_AdditiveExtension(t *testing.T) {
 	// 2-arg constructor — unchanged whether 1 or 10 optional handlers exist.
 	base := newCompositeTransportServer(cp, nil)
 
-	// All four existing setters work; no constructor signature edit required.
+	// All five existing setters work; no constructor signature edit required.
 	base.SetConfigHandler(nil)
 	base.SetDNAHandler(nil)
 	base.SetBulkHandler(nil)
 	base.SetLogStreamHandler(nil)
+	base.SetTerminalHandler(nil)
 
 	// Wire in the hypothetical 7th handler. Zero changes to the constructor or
-	// any of the four existing handlers' fields, setters, or delegation methods.
+	// any of the five existing handlers' fields, setters, or delegation methods.
 	ext := &fooCompositeExt{compositeTransportServer: base}
 	fooH := &testFooHandler{}
 	ext.SetFooHandler(fooH)

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -1343,14 +1343,18 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	srv.terminalHandler = terminalH
 	if commandPublisher != nil && connRegistry != nil {
 		terminalRecordingPath := filepath.Join(resolveDNADataRoot(cfg), "terminal-recordings")
-		terminalMgr, terminalMgrErr := terminal.NewSessionManager(&terminal.Config{
-			RecordSessions:       true,
-			RecordingStoragePath: terminalRecordingPath,
-		}, logger)
+		// Use DefaultConfig() as the base so SessionTimeout and MaxSessions carry
+		// valid (positive) defaults; NewSessionManager validates both are > 0
+		// (manager.go:36,40). Overriding only the recording path preserves the
+		// established DefaultConfig() pattern used elsewhere in server.New().
+		terminalCfg := terminal.DefaultConfig()
+		terminalCfg.RecordSessions = true
+		terminalCfg.RecordingStoragePath = terminalRecordingPath
+		terminalMgr, terminalMgrErr := terminal.NewSessionManager(terminalCfg, logger)
 		if terminalMgrErr != nil {
 			logger.Warn("Failed to initialize terminal session manager; terminal relay unavailable (Issue #2761)", "error", terminalMgrErr)
 		} else {
-			relaySM := controllerTransport.NewRelaySessionManager(terminalMgr, terminalH, commandPublisher, connRegistry, nil, logger)
+			relaySM := controllerTransport.NewRelaySessionManager(terminalMgr, terminalH, commandPublisher, connRegistry, auditManager, logger)
 			var terminalOrigins []string
 			if raw := os.Getenv("CFGMS_TERMINAL_ALLOWED_ORIGINS"); raw != "" {
 				for _, o := range strings.Split(raw, ",") {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -1354,7 +1354,26 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		if terminalMgrErr != nil {
 			logger.Warn("Failed to initialize terminal session manager; terminal relay unavailable (Issue #2761)", "error", terminalMgrErr)
 		} else {
-			relaySM := controllerTransport.NewRelaySessionManager(terminalMgr, terminalH, commandPublisher, connRegistry, auditManager, logger)
+			// Construct AuthenticatedTerminalManager (Issue #2761 AC 2) wrapping the
+			// base session manager. Browser WebSocket clients cannot provide mTLS
+			// client certificates, so mTLS and cert requirements are disabled and the
+			// ATM is used for session lifecycle management (session token cleanup,
+			// session monitor removal, and session.end audit on termination) rather
+			// than AuthenticateAndCreateSession; RBAC is enforced at the HTTP layer
+			// via requirePermission("steward","terminal").
+			authCfg := terminal.DefaultAuthConfig()
+			authCfg.RequireMTLS = false
+			authCfg.ClientCertRequired = false
+			authCfg.IPBindingEnabled = false
+			authCfg.TLSFingerprintCheck = false
+			authMgr, authMgrErr := terminal.NewAuthenticatedTerminalManager(
+				terminalMgr, rbacManager, nil, auditManager, authCfg,
+			)
+			if authMgrErr != nil {
+				logger.Warn("Failed to create AuthenticatedTerminalManager; terminal relay continues without it (Issue #2761)", "error", authMgrErr)
+				authMgr = nil
+			}
+			relaySM := controllerTransport.NewRelaySessionManager(terminalMgr, terminalH, commandPublisher, connRegistry, auditManager, authMgr, logger)
 			var terminalOrigins []string
 			if raw := os.Getenv("CFGMS_TERMINAL_ALLOWED_ORIGINS"); raw != "" {
 				for _, o := range strings.Split(raw, ",") {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -53,6 +53,7 @@ import (
 	reportstemplates "github.com/cfgis/cfgms/features/reports/templates"
 	stewarddna "github.com/cfgis/cfgms/features/steward/dna"
 	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/features/terminal"
 	"github.com/cfgis/cfgms/features/workflow"
 	workflownodes "github.com/cfgis/cfgms/features/workflow/nodes"
 	workflowruntime "github.com/cfgis/cfgms/features/workflow/runtime"
@@ -113,6 +114,7 @@ type Server struct {
 	dataPlaneProvider       dataplaneInterfaces.DataPlaneProvider
 	configHandler           *controllerTransport.ConfigHandler
 	logStreamHandler        *controllerTransport.LogStreamHandler // Issue #2140: LogStream ingestion handler
+	terminalHandler         *controllerTransport.TerminalHandler  // Issue #2761: Terminal relay handler
 	grpcServer              *grpc.Server                          // Shared gRPC server for CP+DP (Story #515)
 	quicListener            *quictransport.Listener               // Shared QUIC listener (Story #515)
 	signerCertSerial        string                                // Serial number of server cert used for config signing (Story #378)
@@ -1334,6 +1336,39 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		}
 	}
 
+	// Issue #2761: Wire terminal WebSocket relay endpoint and gRPC terminal handler.
+	// The TerminalHandler correlates steward gRPC Terminal streams to pending WS sessions.
+	// Only wired when commandPublisher is available (requires a running control plane).
+	terminalH := controllerTransport.NewTerminalHandler(logger)
+	srv.terminalHandler = terminalH
+	if commandPublisher != nil && connRegistry != nil {
+		terminalRecordingPath := filepath.Join(resolveDNADataRoot(cfg), "terminal-recordings")
+		terminalMgr, terminalMgrErr := terminal.NewSessionManager(&terminal.Config{
+			RecordSessions:       true,
+			RecordingStoragePath: terminalRecordingPath,
+		}, logger)
+		if terminalMgrErr != nil {
+			logger.Warn("Failed to initialize terminal session manager; terminal relay unavailable (Issue #2761)", "error", terminalMgrErr)
+		} else {
+			relaySM := controllerTransport.NewRelaySessionManager(terminalMgr, terminalH, commandPublisher, connRegistry, nil, logger)
+			var terminalOrigins []string
+			if raw := os.Getenv("CFGMS_TERMINAL_ALLOWED_ORIGINS"); raw != "" {
+				for _, o := range strings.Split(raw, ",") {
+					if trimmed := strings.TrimSpace(o); trimmed != "" {
+						terminalOrigins = append(terminalOrigins, trimmed)
+					}
+				}
+			}
+			wsHandler, wsErr := terminal.NewWebSocketHandler(relaySM, logger, terminalOrigins)
+			if wsErr != nil {
+				logger.Warn("Failed to create terminal WebSocket handler; terminal relay unavailable (Issue #2761)", "error", wsErr)
+			} else {
+				httpServer.SetTerminalHandler(wsHandler)
+				logger.Info("Terminal WebSocket relay wired (Issue #2761)")
+			}
+		}
+	}
+
 	return srv, nil
 }
 
@@ -1680,6 +1715,7 @@ func (s *Server) Start() error {
 		composite.SetBulkHandler(bulkHandler)
 		composite.SetLogStreamHandler(logStreamHandler)
 		composite.SetTelemetryHandler(telemetryHandler)
+		composite.SetTerminalHandler(s.terminalHandler)
 		transportpb.RegisterStewardTransportServer(s.grpcServer, composite)
 		// Wire telemetry WebSocket fan-out into the REST API (Issue #2765).
 		if s.httpServer != nil {

--- a/features/controller/server/terminal_wiring_test.go
+++ b/features/controller/server/terminal_wiring_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestServer_New_WiresTerminalWebSocketRoute is the regression guard for the
+// production defect where New() constructed the terminal SessionManager from a
+// bare &terminal.Config{RecordSessions: true, RecordingStoragePath: ...} that
+// omitted SessionTimeout and MaxSessions. NewSessionManager validates both are
+// positive, so the call always errored, the terminal relay block was skipped,
+// and the /api/v1/terminal/ws route was never registered — silently disabling
+// the terminal feature in every transport-enabled deployment (Issue #2761).
+//
+// This exercises the full New() terminal wiring path (which requires a running
+// control plane: commandPublisher + connRegistry, both created only when
+// transport is configured) and asserts the terminal WebSocket route is present.
+// A GET against the route returns a non-404 status only when SetTerminalHandler
+// registered it — a bare 404 means the session manager failed to initialize.
+func TestServer_New_WiresTerminalWebSocketRoute(t *testing.T) {
+	logger := logging.NewNoopLogger()
+
+	tempDir := t.TempDir()
+	certDir := tempDir + "/ca"
+
+	// Create the CA up front so EnableCertManagement startup succeeds.
+	_, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: certDir,
+		CAConfig: &cert.CAConfig{
+			Organization: "Terminal Wiring Test",
+			Country:      "US",
+			ValidityDays: 3650,
+			StoragePath:  certDir,
+		},
+		LoadExistingCA: false,
+	})
+	require.NoError(t, err, "failed to create test CA")
+
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		CertPath:   certDir,
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: true,
+			CAPath:               certDir,
+			Server: &config.ServerCertificateConfig{
+				CommonName:   "terminal-wiring-controller",
+				Organization: "Terminal Wiring Test",
+			},
+		},
+		Transport: &config.TransportConfig{
+			ListenAddr:     "127.0.0.1:0",
+			UseCertManager: true,
+			MaxConnections: 10,
+		},
+		Storage: createTestStorageConfig(tempDir, "terminal-wiring"),
+	}
+
+	srv, err := New(cfg, logger)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	// Transport is configured, so the terminal relay block must have run and the
+	// session manager must have initialized successfully.
+	require.NotNil(t, srv.httpServer, "API server must be initialized")
+
+	// A GET to the terminal WS route must be matched by the router. Without the
+	// fix the route is absent and the router returns 404; with it, the request
+	// reaches the permission middleware (401/403) — anything but 404 proves the
+	// route was registered.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/terminal/ws/steward-123", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.GetRouter().ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusNotFound, rec.Code,
+		"terminal WebSocket route must be registered when transport is configured; "+
+			"a 404 means the terminal session manager failed to initialize (Issue #2761)")
+}

--- a/features/controller/transport/terminal_handler.go
+++ b/features/controller/transport/terminal_handler.go
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package transport
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/features/terminal"
+	"github.com/cfgis/cfgms/pkg/audit"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+)
+
+// pendingRelay holds the in-flight relay state for a terminal session that
+// has been created on the WebSocket side but not yet joined by the steward.
+type pendingRelay struct {
+	stewardID   string // target steward the session was dispatched to (mTLS binding)
+	session     *terminal.Session
+	exec        *terminal.RelayExecutor
+	connectedCh chan struct{} // closed once the steward dials in
+}
+
+// TerminalHandler handles inbound Terminal bidirectional gRPC streams from
+// stewards.  On each stream, it:
+//
+//  1. Reads the first TerminalData frame to extract the session_id.
+//  2. Correlates session_id to the WS-side Session registered by
+//     relaySessionManager.CreateSession.
+//  3. Runs two relay goroutines for the life of the session:
+//     steward→browser: stream.Recv → session.HandleOutput → session.outputCh
+//     browser→steward: RelayExecutor.InputChan / ResizeChan → stream.Send
+type TerminalHandler struct {
+	mu      sync.RWMutex
+	pending map[string]*pendingRelay
+	logger  logging.Logger
+}
+
+// NewTerminalHandler creates a TerminalHandler.
+func NewTerminalHandler(logger logging.Logger) *TerminalHandler {
+	return &TerminalHandler{
+		pending: make(map[string]*pendingRelay),
+		logger:  logger,
+	}
+}
+
+// register stores a pending relay entry created at WS-session creation time.
+// stewardID is the target steward the session was dispatched to; HandleGRPC
+// requires the dialing steward's mTLS identity to match it before relaying.
+func (h *TerminalHandler) register(sessionID, stewardID string, session *terminal.Session, exec *terminal.RelayExecutor) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.pending[sessionID] = &pendingRelay{
+		stewardID:   stewardID,
+		session:     session,
+		exec:        exec,
+		connectedCh: make(chan struct{}),
+	}
+}
+
+// unregister removes the pending relay entry for sessionID (called on disconnect
+// or on error during session creation).
+func (h *TerminalHandler) unregister(sessionID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.pending, sessionID)
+}
+
+// peerStewardIDFromContext extracts the authenticated steward ID (mTLS peer
+// certificate CN) from the gRPC stream context, mirroring the extraction done
+// by DNAHandler, BulkHandler, ConfigHandler and LogStreamHandler.
+func peerStewardIDFromContext(ctx context.Context) (string, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("no peer information in context")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return "", fmt.Errorf("peer auth info is not mTLS")
+	}
+	return quictransport.PeerStewardID(tlsInfo.State)
+}
+
+// HandleGRPC processes the Terminal bidirectional streaming RPC from a steward.
+func (h *TerminalHandler) HandleGRPC(stream grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData]) error {
+	ctx := stream.Context()
+
+	// Establish the dialing steward's mTLS identity up front. The Terminal relay
+	// carries an interactive admin shell, so a session_id alone must never be
+	// sufficient to join — parity with the other security-critical data-plane
+	// handlers (DNAHandler/ConfigHandler/BulkHandler/LogStreamHandler).
+	peerID, err := peerStewardIDFromContext(ctx)
+	if err != nil {
+		return status.Error(codes.Unauthenticated, "mTLS certificate required")
+	}
+
+	firstFrame, err := stream.Recv()
+	if err != nil {
+		return status.Error(codes.InvalidArgument, "expected initial TerminalData frame")
+	}
+
+	sessionID := firstFrame.GetSessionId()
+	if sessionID == "" {
+		return status.Error(codes.InvalidArgument, "session_id required in first TerminalData frame")
+	}
+
+	h.mu.RLock()
+	relay, ok := h.pending[sessionID]
+	h.mu.RUnlock()
+	if !ok {
+		return status.Errorf(codes.NotFound, "no pending terminal session for session_id %q", logging.SanitizeLogValue(sessionID))
+	}
+
+	// Bind the authenticated peer to the target steward recorded at session
+	// creation. A leaked or guessed session_id presented by any other fleet
+	// steward (including cross-tenant) must not be able to hijack the relay,
+	// capture admin keystrokes, or inject output into the admin browser.
+	if relay.stewardID != peerID {
+		return status.Error(codes.PermissionDenied, "steward ID mismatch")
+	}
+
+	// Signal WebSocket side that the steward has connected.
+	close(relay.connectedCh)
+
+	if h.logger != nil {
+		h.logger.Info("Terminal relay established",
+			"session_id", logging.RedactedID(sessionID))
+	}
+
+	// Any payload piggybacked on the first frame goes directly to the browser.
+	// A closed-session error means the WS side is already gone: tear down the
+	// relay rather than proceeding to run goroutines with nothing to feed.
+	if len(firstFrame.GetData()) > 0 {
+		if outErr := relay.session.HandleOutput(ctx, firstFrame.GetData()); outErr != nil {
+			h.unregister(sessionID)
+			return nil
+		}
+	}
+
+	relayErrCh := make(chan error, 2)
+
+	// browser→steward: relay data/resize frames from the RelayExecutor channels.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				relayErrCh <- nil
+				return
+			case data, open := <-relay.exec.InputChan():
+				if !open {
+					relayErrCh <- nil
+					return
+				}
+				if sendErr := stream.Send(&transportpb.TerminalData{
+					SessionId: sessionID,
+					Data:      data,
+				}); sendErr != nil {
+					relayErrCh <- sendErr
+					return
+				}
+			case dims, open := <-relay.exec.ResizeChan():
+				if !open {
+					relayErrCh <- nil
+					return
+				}
+				if sendErr := stream.Send(&transportpb.TerminalData{
+					SessionId: sessionID,
+					IsResize:  true,
+					Cols:      dims[0],
+					Rows:      dims[1],
+				}); sendErr != nil {
+					relayErrCh <- sendErr
+					return
+				}
+			}
+		}
+	}()
+
+	// steward→browser: receive frames and push output to the WS session channel.
+	go func() {
+		for {
+			frame, recvErr := stream.Recv()
+			if recvErr != nil {
+				if recvErr == io.EOF {
+					relayErrCh <- nil
+				} else {
+					relayErrCh <- recvErr
+				}
+				return
+			}
+			if data := frame.GetData(); len(data) > 0 {
+				// A closed-session error is actionable: the WS session is gone,
+				// so stop receiving and discarding steward frames and exit the
+				// goroutine instead of spinning until context cancellation.
+				if outErr := relay.session.HandleOutput(ctx, data); outErr != nil {
+					relayErrCh <- nil
+					return
+				}
+			}
+		}
+	}()
+
+	relayErr := <-relayErrCh
+	h.unregister(sessionID)
+
+	if relayErr != nil && relayErr != io.EOF {
+		if st, ok2 := status.FromError(relayErr); ok2 && st.Code() == codes.Canceled {
+			return nil // normal WS close — not an error
+		}
+		return relayErr
+	}
+	return nil
+}
+
+// relaySessionManager wraps a SessionManager to add controller-side relay
+// behaviour at CreateSession time:
+//
+//  1. Rejects session creation when the target steward is not connected.
+//  2. Replaces the platform shell executor with a channel-based RelayExecutor.
+//  3. Registers the relay in TerminalHandler so HandleGRPC can correlate it.
+//  4. Dispatches COMMAND_TYPE_OPEN_TERMINAL to the steward.
+//  5. Records terminal.session.start / terminal.session.end audit events when
+//     auditManager is non-nil (Issue #2761: RBAC-gated, recorded sessions).
+type relaySessionManager struct {
+	base             terminal.SessionManager
+	terminalHandler  *TerminalHandler
+	commandPublisher *commands.Publisher
+	connRegistry     registry.Registry
+	auditManager     *audit.Manager
+	logger           logging.Logger
+}
+
+// NewRelaySessionManager returns a SessionManager suitable for the controller
+// WebSocket handler. All session creation side-effects described on
+// relaySessionManager are applied atomically from the caller's perspective.
+// auditManager may be nil — when non-nil, session.start / session.end audit
+// events are recorded.
+func NewRelaySessionManager(
+	base terminal.SessionManager,
+	terminalHandler *TerminalHandler,
+	commandPublisher *commands.Publisher,
+	connRegistry registry.Registry,
+	auditManager *audit.Manager,
+	logger logging.Logger,
+) terminal.SessionManager {
+	return &relaySessionManager{
+		base:             base,
+		terminalHandler:  terminalHandler,
+		commandPublisher: commandPublisher,
+		connRegistry:     connRegistry,
+		auditManager:     auditManager,
+		logger:           logger,
+	}
+}
+
+func (m *relaySessionManager) CreateSession(ctx context.Context, req *terminal.SessionRequest) (*terminal.Session, error) {
+	// Fail fast when the target steward has no active ControlChannel.
+	if m.connRegistry != nil {
+		if _, online := m.connRegistry.Get(req.StewardID); !online {
+			return nil, fmt.Errorf("steward %q is not connected", logging.SanitizeLogValue(req.StewardID))
+		}
+	}
+
+	session, err := m.base.CreateSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace the platform shell executor with a channel-based relay executor
+	// so WriteData from the WebSocket handler is forwarded to the steward
+	// stream rather than a (non-running) local shell process.
+	relayExec := terminal.NewRelayExecutor()
+	session.SetExecutor(relayExec)
+
+	// Register before dispatching the command so HandleGRPC can correlate
+	// immediately when the steward dials in.
+	m.terminalHandler.register(session.ID, req.StewardID, session, relayExec)
+
+	// Dispatch COMMAND_TYPE_OPEN_TERMINAL to the target steward.
+	if m.commandPublisher != nil {
+		params := map[string]interface{}{
+			"session_id": session.ID,
+			"shell":      req.Shell,
+			"cols":       int32(req.Cols), //nolint:gosec // terminal dimensions are far below int32 max
+			"rows":       int32(req.Rows), //nolint:gosec // terminal dimensions are far below int32 max
+		}
+		if _, dispatchErr := m.commandPublisher.PublishCommand(
+			ctx, req.StewardID, controlplaneTypes.CommandOpenTerminal, params,
+		); dispatchErr != nil {
+			m.terminalHandler.unregister(session.ID)
+			_ = m.base.TerminateSession(ctx, session.ID)
+			return nil, fmt.Errorf("failed to dispatch open_terminal to steward %q: %w",
+				logging.SanitizeLogValue(req.StewardID), dispatchErr)
+		}
+	}
+
+	if m.auditManager != nil {
+		_ = m.auditManager.RecordEvent(ctx,
+			audit.NewEventBuilder().
+				Tenant(req.TenantID).
+				Type(business.AuditEventSystemAccess).
+				Action("terminal.session.start").
+				User(req.UserID, business.AuditUserTypeHuman).
+				Session(session.ID).
+				Resource("terminal", req.StewardID, "").
+				Result(business.AuditResultSuccess).
+				Severity(business.AuditSeverityMedium).
+				Details(map[string]interface{}{
+					"shell": req.Shell,
+				}),
+		)
+	}
+
+	if m.logger != nil {
+		m.logger.Info("Terminal relay session created, awaiting steward dial-in",
+			"session_id", logging.RedactedID(session.ID),
+			"steward_id", logging.SanitizeLogValue(req.StewardID))
+	}
+
+	return session, nil
+}
+
+func (m *relaySessionManager) GetSession(sessionID string) (*terminal.Session, error) {
+	return m.base.GetSession(sessionID)
+}
+
+func (m *relaySessionManager) TerminateSession(ctx context.Context, sessionID string) error {
+	m.terminalHandler.unregister(sessionID)
+	if err := m.base.TerminateSession(ctx, sessionID); err != nil {
+		return err
+	}
+	if m.auditManager != nil {
+		_ = m.auditManager.RecordEvent(ctx,
+			audit.NewEventBuilder().
+				Tenant(audit.SystemTenantID).
+				Type(business.AuditEventSystemAccess).
+				Action("terminal.session.end").
+				User(audit.SystemUserID, business.AuditUserTypeHuman).
+				Session(sessionID).
+				Resource("session", sessionID, "").
+				Result(business.AuditResultSuccess).
+				Severity(business.AuditSeverityMedium),
+		)
+	}
+	return nil
+}
+
+func (m *relaySessionManager) GetActiveSessions() []*terminal.Session {
+	return m.base.GetActiveSessions()
+}
+
+func (m *relaySessionManager) RecordData(sessionID string, data []byte, direction terminal.DataDirection) error {
+	return m.base.RecordData(sessionID, data, direction)
+}
+
+func (m *relaySessionManager) GetSessionRecording(sessionID string) (*terminal.SessionRecording, error) {
+	return m.base.GetSessionRecording(sessionID)
+}

--- a/features/controller/transport/terminal_handler.go
+++ b/features/controller/transport/terminal_handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -291,24 +292,48 @@ func (m *relaySessionManager) CreateSession(ctx context.Context, req *terminal.S
 
 	// Dispatch COMMAND_TYPE_OPEN_TERMINAL to the target steward.
 	if m.commandPublisher != nil {
+		// Clamp terminal dimensions to int32 range before conversion; session.go
+		// already defaults <=0 to 80/24, so the lower bound is only a safety net.
+		var cols, rows int32
+		if req.Cols > 0 && req.Cols <= math.MaxInt32 {
+			cols = int32(req.Cols) //nolint:gosec // bounds-checked above
+		} else {
+			cols = 80
+		}
+		if req.Rows > 0 && req.Rows <= math.MaxInt32 {
+			rows = int32(req.Rows) //nolint:gosec // bounds-checked above
+		} else {
+			rows = 24
+		}
 		params := map[string]interface{}{
 			"session_id": session.ID,
 			"shell":      req.Shell,
-			"cols":       int32(req.Cols), //nolint:gosec // terminal dimensions are far below int32 max
-			"rows":       int32(req.Rows), //nolint:gosec // terminal dimensions are far below int32 max
+			"cols":       cols,
+			"rows":       rows,
 		}
 		if _, dispatchErr := m.commandPublisher.PublishCommand(
 			ctx, req.StewardID, controlplaneTypes.CommandOpenTerminal, params,
 		); dispatchErr != nil {
 			m.terminalHandler.unregister(session.ID)
-			_ = m.base.TerminateSession(ctx, session.ID)
+			// Roll back the base session. If teardown itself fails the session
+			// would otherwise leak in the base manager with no trace, so surface
+			// the inconsistency rather than discarding the error.
+			if termErr := m.base.TerminateSession(ctx, session.ID); termErr != nil && m.logger != nil {
+				m.logger.Warn("failed to terminate terminal session during dispatch rollback",
+					"session_id", logging.RedactedID(session.ID),
+					"steward_id", logging.SanitizeLogValue(req.StewardID),
+					"error", termErr)
+			}
 			return nil, fmt.Errorf("failed to dispatch open_terminal to steward %q: %w",
 				logging.SanitizeLogValue(req.StewardID), dispatchErr)
 		}
 	}
 
 	if m.auditManager != nil {
-		_ = m.auditManager.RecordEvent(ctx,
+		// Session recording is a documented compliance requirement (Issue #2761).
+		// A silent audit failure would make compliance gaps undetectable, so the
+		// error is logged even though it is intentionally non-fatal for the session.
+		if err := m.auditManager.RecordEvent(ctx,
 			audit.NewEventBuilder().
 				Tenant(req.TenantID).
 				Type(business.AuditEventSystemAccess).
@@ -321,7 +346,12 @@ func (m *relaySessionManager) CreateSession(ctx context.Context, req *terminal.S
 				Details(map[string]interface{}{
 					"shell": req.Shell,
 				}),
-		)
+		); err != nil && m.logger != nil {
+			m.logger.Warn("failed to record terminal.session.start audit event",
+				"session_id", logging.RedactedID(session.ID),
+				"steward_id", logging.SanitizeLogValue(req.StewardID),
+				"error", err)
+		}
 	}
 
 	if m.logger != nil {
@@ -343,7 +373,9 @@ func (m *relaySessionManager) TerminateSession(ctx context.Context, sessionID st
 		return err
 	}
 	if m.auditManager != nil {
-		_ = m.auditManager.RecordEvent(ctx,
+		// A missing end-of-session audit record is undetectable otherwise; log the
+		// failure so the compliance gap is observable in production (Issue #2761).
+		if err := m.auditManager.RecordEvent(ctx,
 			audit.NewEventBuilder().
 				Tenant(audit.SystemTenantID).
 				Type(business.AuditEventSystemAccess).
@@ -353,7 +385,11 @@ func (m *relaySessionManager) TerminateSession(ctx context.Context, sessionID st
 				Resource("session", sessionID, "").
 				Result(business.AuditResultSuccess).
 				Severity(business.AuditSeverityMedium),
-		)
+		); err != nil && m.logger != nil {
+			m.logger.Warn("failed to record terminal.session.end audit event",
+				"session_id", logging.RedactedID(sessionID),
+				"error", err)
+		}
 	}
 	return nil
 }

--- a/features/controller/transport/terminal_handler.go
+++ b/features/controller/transport/terminal_handler.go
@@ -235,12 +235,17 @@ func (h *TerminalHandler) HandleGRPC(stream grpc.BidiStreamingServer[transportpb
 //  4. Dispatches COMMAND_TYPE_OPEN_TERMINAL to the steward.
 //  5. Records terminal.session.start / terminal.session.end audit events when
 //     auditManager is non-nil (Issue #2761: RBAC-gated, recorded sessions).
+//
+// When authManager is non-nil (AC 2, Issue #2761), TerminateSession routes
+// through AuthenticatedTerminalManager for session token cleanup, session
+// monitor removal, and audit logging instead of the relay's own audit path.
 type relaySessionManager struct {
 	base             terminal.SessionManager
 	terminalHandler  *TerminalHandler
 	commandPublisher *commands.Publisher
 	connRegistry     registry.Registry
 	auditManager     *audit.Manager
+	authManager      *terminal.AuthenticatedTerminalManager
 	logger           logging.Logger
 }
 
@@ -248,13 +253,16 @@ type relaySessionManager struct {
 // WebSocket handler. All session creation side-effects described on
 // relaySessionManager are applied atomically from the caller's perspective.
 // auditManager may be nil — when non-nil, session.start / session.end audit
-// events are recorded.
+// events are recorded. authManager may be nil; when non-nil it takes over
+// TerminateSession for session token cleanup and security audit logging
+// (Issue #2761 AC 2: AuthenticatedTerminalManager constructed and used).
 func NewRelaySessionManager(
 	base terminal.SessionManager,
 	terminalHandler *TerminalHandler,
 	commandPublisher *commands.Publisher,
 	connRegistry registry.Registry,
 	auditManager *audit.Manager,
+	authManager *terminal.AuthenticatedTerminalManager,
 	logger logging.Logger,
 ) terminal.SessionManager {
 	return &relaySessionManager{
@@ -263,6 +271,7 @@ func NewRelaySessionManager(
 		commandPublisher: commandPublisher,
 		connRegistry:     connRegistry,
 		auditManager:     auditManager,
+		authManager:      authManager,
 		logger:           logger,
 	}
 }
@@ -369,6 +378,16 @@ func (m *relaySessionManager) GetSession(sessionID string) (*terminal.Session, e
 
 func (m *relaySessionManager) TerminateSession(ctx context.Context, sessionID string) error {
 	m.terminalHandler.unregister(sessionID)
+
+	// When AuthenticatedTerminalManager is wired (Issue #2761 AC 2), route
+	// termination through it: it handles base session teardown, session token
+	// invalidation, session monitor removal, and session.end audit logging.
+	// This avoids double-auditing since authManager.TerminateSession records
+	// terminal.session.end internally via its own auditManager.
+	if m.authManager != nil {
+		return m.authManager.TerminateSession(ctx, sessionID, "relay_terminated")
+	}
+
 	if err := m.base.TerminateSession(ctx, sessionID); err != nil {
 		return err
 	}

--- a/features/controller/transport/terminal_handler_test.go
+++ b/features/controller/transport/terminal_handler_test.go
@@ -21,8 +21,10 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/features/terminal"
 	"github.com/cfgis/cfgms/pkg/audit"
+	cpgrpc "github.com/cfgis/cfgms/pkg/controlplane/providers/grpc"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -263,6 +265,64 @@ func TestRelaySessionManagerOfflineSteward(t *testing.T) {
 	// No session must have been created in the base manager.
 	assert.Empty(t, baseMgr.GetActiveSessions(),
 		"base manager must have no active sessions after offline rejection")
+}
+
+// ---------------------------------------------------------------------------
+// Test: dispatch failure → rollback (unregister + terminate) + error propagated
+// ---------------------------------------------------------------------------
+
+// TestRelaySessionManagerDispatchFailureRollsBack verifies the error path added
+// to CreateSession: when PublishCommand fails to dispatch COMMAND_TYPE_OPEN_TERMINAL
+// to the steward, CreateSession must (1) return the dispatch error, (2) unregister
+// the pending relay, and (3) tear down the base session so nothing leaks.
+//
+// A real commands.Publisher is wired over a real gRPC control plane provider in
+// server mode whose connection registry is empty, so SendCommand returns a
+// genuine "steward not connected" error — no fakes or mocks.
+func TestRelaySessionManagerDispatchFailureRollsBack(t *testing.T) {
+	const stewardID = "steward-dispatch-fail"
+
+	baseMgr := newTestSessionManager(t)
+	th := NewTerminalHandler(logging.NewNoopLogger())
+
+	// Real control plane provider in server mode with an empty steward registry.
+	// SendCommand consults this registry and fails when the target is absent.
+	cp := cpgrpc.New(cpgrpc.ModeServer)
+	require.NoError(t, cp.Initialize(context.Background(), map[string]interface{}{
+		"grpc_server": grpc.NewServer(),
+		"registry":    registry.NewRegistry(),
+	}))
+	publisher, err := commands.New(&commands.Config{
+		ControlPlane: cp,
+		Logger:       logging.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+
+	// nil connRegistry so the online pre-check is skipped and we exercise the
+	// dispatch path itself; the dispatch fails because cp's registry is empty.
+	rsm := NewRelaySessionManager(baseMgr, th, publisher, nil, nil, logging.NewNoopLogger())
+
+	_, err = rsm.CreateSession(context.Background(), &terminal.SessionRequest{
+		TenantID:  "test-tenant",
+		StewardID: stewardID,
+		UserID:    "test-user",
+		Shell:     "bash",
+		Cols:      80,
+		Rows:      24,
+	})
+	require.Error(t, err, "CreateSession must return an error when dispatch fails")
+	assert.Contains(t, err.Error(), "failed to dispatch open_terminal",
+		"the returned error must identify the dispatch failure")
+
+	// The pending relay must have been unregistered during rollback.
+	th.mu.RLock()
+	pending := len(th.pending)
+	th.mu.RUnlock()
+	assert.Equal(t, 0, pending, "pending relay must be unregistered after dispatch failure")
+
+	// The base session must have been torn down (no leak).
+	assert.Empty(t, baseMgr.GetActiveSessions(),
+		"base manager must have no active sessions after dispatch-failure rollback")
 }
 
 // ---------------------------------------------------------------------------

--- a/features/controller/transport/terminal_handler_test.go
+++ b/features/controller/transport/terminal_handler_test.go
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package transport
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/terminal"
+	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+)
+
+// ---------------------------------------------------------------------------
+// testBidiStream — fake grpc.BidiStreamingServer for TerminalData
+// ---------------------------------------------------------------------------
+
+type testBidiStream struct {
+	ctx     context.Context
+	recvCh  chan *transportpb.TerminalData
+	mu      sync.Mutex
+	sent    []*transportpb.TerminalData
+	sendErr error
+	// sentSignal, when non-nil, receives a non-blocking notification after each
+	// successful Send so tests can block on delivery instead of polling.
+	sentSignal chan struct{}
+}
+
+func newTestBidiStream(ctx context.Context) *testBidiStream {
+	return &testBidiStream{
+		ctx:    ctx,
+		recvCh: make(chan *transportpb.TerminalData, 32),
+	}
+}
+
+func (s *testBidiStream) Recv() (*transportpb.TerminalData, error) {
+	select {
+	case <-s.ctx.Done():
+		return nil, io.EOF
+	case msg, ok := <-s.recvCh:
+		if !ok {
+			return nil, io.EOF
+		}
+		return msg, nil
+	}
+}
+
+func (s *testBidiStream) Send(msg *transportpb.TerminalData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sent = append(s.sent, proto.Clone(msg).(*transportpb.TerminalData))
+	if s.sentSignal != nil {
+		select {
+		case s.sentSignal <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (s *testBidiStream) getSent() []*transportpb.TerminalData {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*transportpb.TerminalData, len(s.sent))
+	copy(out, s.sent)
+	return out
+}
+
+func (s *testBidiStream) SetHeader(metadata.MD) error  { return nil }
+func (s *testBidiStream) SendHeader(metadata.MD) error { return nil }
+func (s *testBidiStream) SetTrailer(metadata.MD)       {}
+func (s *testBidiStream) Context() context.Context     { return s.ctx }
+func (s *testBidiStream) SendMsg(interface{}) error    { return nil }
+func (s *testBidiStream) RecvMsg(interface{}) error    { return nil }
+
+// Compile-time interface check.
+var _ grpc.BidiStreamingServer[transportpb.TerminalData, transportpb.TerminalData] = (*testBidiStream)(nil)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// newTestSessionManager creates a DefaultSessionManager with an isolated
+// recording directory in t.TempDir() and recording enabled.
+func newTestSessionManager(t *testing.T) terminal.SessionManager {
+	t.Helper()
+	mgr, err := terminal.NewSessionManager(&terminal.Config{
+		RecordSessions:       true,
+		RecordingStoragePath: t.TempDir(),
+		SessionTimeout:       30 * time.Minute,
+		MaxSessions:          100,
+	}, logging.NewNoopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if dsm, ok := mgr.(*terminal.DefaultSessionManager); ok {
+			_ = dsm.Stop(context.Background())
+		}
+	})
+	return mgr
+}
+
+// newTestSession creates a new session via mgr and injects a RelayExecutor so
+// that WriteData forwards through channels rather than a local shell process.
+func newTestSession(t *testing.T, mgr terminal.SessionManager, stewardID string) *terminal.Session {
+	t.Helper()
+	ctx := context.Background()
+	session, err := mgr.CreateSession(ctx, &terminal.SessionRequest{
+		TenantID:  "test-tenant",
+		StewardID: stewardID,
+		UserID:    "test-user",
+		Shell:     "bash",
+		Cols:      80,
+		Rows:      24,
+	})
+	require.NoError(t, err)
+	relayExec := terminal.NewRelayExecutor()
+	session.SetExecutor(relayExec)
+	return session
+}
+
+// withTestTenant injects a test tenant ID into every request context.
+func withTestTenant(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), ctxkeys.TenantID, "test-tenant")
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: TerminalData frame from simulated steward → session.OutputChan
+// ---------------------------------------------------------------------------
+
+// TestTerminalHandlerRelayGRPCToSession verifies that data received from the
+// steward's gRPC Terminal stream is forwarded to the WS session's outputCh so
+// that the WebSocket write goroutine can relay it to the browser.
+func TestTerminalHandlerRelayGRPCToSession(t *testing.T) {
+	const stewardID = "steward-relay-test"
+	mgr := newTestSessionManager(t)
+
+	h := NewTerminalHandler(logging.NewNoopLogger())
+
+	// Create a session and register a pending relay — mirrors what
+	// relaySessionManager.CreateSession does.
+	session := newTestSession(t, mgr, stewardID)
+	relayExec := terminal.NewRelayExecutor()
+	session.SetExecutor(relayExec)
+	h.register(session.ID, stewardID, session, relayExec)
+
+	// The relay requires the dialing steward's mTLS identity to match the
+	// registered target steward, so dial with a matching client cert CN.
+	ca := newTestCA(t)
+	ctx, cancel := context.WithTimeout(peerContextWithCA(t, ca, stewardID), 5*time.Second)
+	defer cancel()
+
+	stream := newTestBidiStream(ctx)
+
+	// First frame carries the session_id (handshake).
+	sentinel := []byte("CFGMS_RELAY_SENTINEL_2761")
+	stream.recvCh <- &transportpb.TerminalData{
+		SessionId: session.ID,
+		Data:      sentinel, // piggybacked on first frame
+	}
+
+	// HandleGRPC runs until context expires or stream closes.
+	handleDone := make(chan error, 1)
+	go func() {
+		handleDone <- h.HandleGRPC(stream)
+	}()
+
+	// The piggybacked payload should arrive on session.OutputChan.
+	select {
+	case data := <-session.OutputChan():
+		assert.Equal(t, sentinel, data, "steward payload must arrive on session.OutputChan")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for relay data on session.OutputChan")
+	}
+
+	// Additional steward-to-browser frame sent after the handshake.
+	extra := []byte("CFGMS_EXTRA_OUTPUT")
+	stream.recvCh <- &transportpb.TerminalData{
+		SessionId: session.ID,
+		Data:      extra,
+	}
+	select {
+	case data := <-session.OutputChan():
+		assert.Equal(t, extra, data, "extra steward payload must also be relayed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for extra relay data on session.OutputChan")
+	}
+
+	// Close stream and ensure HandleGRPC exits without error.
+	close(stream.recvCh)
+	cancel()
+	select {
+	case err := <-handleDone:
+		// nil or context-cancelled are both acceptable exit conditions.
+		if err != nil {
+			assert.ErrorIs(t, ctx.Err(), context.DeadlineExceeded,
+				"HandleGRPC must only return a non-nil error on genuine stream failures, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleGRPC did not exit after stream close")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Offline steward → CreateSession returns error (no hang/leak)
+// ---------------------------------------------------------------------------
+
+// TestRelaySessionManagerOfflineSteward verifies that CreateSession returns a
+// clear error immediately when the target steward has no active ControlChannel
+// in the registry, rather than hanging or leaking a pending relay entry.
+func TestRelaySessionManagerOfflineSteward(t *testing.T) {
+	baseMgr := newTestSessionManager(t)
+	th := NewTerminalHandler(logging.NewNoopLogger())
+
+	// An empty registry has no registered connections.
+	reg := registry.NewRegistry()
+
+	rsm := NewRelaySessionManager(baseMgr, th, nil, reg, nil, logging.NewNoopLogger())
+
+	ctx := context.Background()
+	_, err := rsm.CreateSession(ctx, &terminal.SessionRequest{
+		TenantID:  "test-tenant",
+		StewardID: "offline-steward",
+		UserID:    "test-user",
+		Shell:     "bash",
+		Cols:      80,
+		Rows:      24,
+	})
+	require.Error(t, err, "CreateSession must return an error when steward is offline")
+	assert.Contains(t, err.Error(), "not connected",
+		"error message must indicate the steward is not connected")
+
+	// No pending relay must have been registered (no leak).
+	th.mu.RLock()
+	pending := len(th.pending)
+	th.mu.RUnlock()
+	assert.Equal(t, 0, pending, "no pending relay must be registered when steward is offline")
+
+	// No session must have been created in the base manager.
+	assert.Empty(t, baseMgr.GetActiveSessions(),
+		"base manager must have no active sessions after offline rejection")
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Non-allowlisted Origin → HTTP 403 from WS handler
+// ---------------------------------------------------------------------------
+
+// TestTerminalWebSocketBadOriginRejected verifies that the terminal WebSocket
+// handler rejects connections whose Origin header is not same-origin and not in
+// the configured allowlist, returning HTTP 403 Forbidden.
+func TestTerminalWebSocketBadOriginRejected(t *testing.T) {
+	baseMgr := newTestSessionManager(t)
+	th := NewTerminalHandler(logging.NewNoopLogger())
+	rsm := NewRelaySessionManager(baseMgr, th, nil, nil, nil, logging.NewNoopLogger())
+
+	// No origin allowlist — only same-origin connections are accepted.
+	wsHandler, err := terminal.NewWebSocketHandler(rsm, logging.NewNoopLogger(), nil)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(withTestTenant(http.HandlerFunc(wsHandler.HandleWebSocket)))
+	defer server.Close()
+
+	// Craft a non-WebSocket GET request with a cross-origin Origin header.
+	// We send a plain HTTP request (not a WebSocket dial) because the Go HTTP
+	// client cannot dial a WebSocket; the 403 is returned before the upgrade.
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		server.URL+"?steward_id=s1&user_id=u1&shell=bash",
+		nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "http://evil.example.com")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"WebSocket upgrade from a non-allowlisted origin must be rejected with 403")
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Session open+close → audit record + session recording exists
+// ---------------------------------------------------------------------------
+
+// TestRelaySessionManagerAuditAndRecording verifies that:
+//  1. A terminal.session.start audit event is recorded when CreateSession succeeds.
+//  2. A terminal.session.end audit event is recorded when TerminateSession is called.
+//  3. A session recording file is written by the underlying DefaultSessionManager.
+func TestRelaySessionManagerAuditAndRecording(t *testing.T) {
+	// Set up a real audit manager backed by a real storage stack.
+	storageManager := pkgtesting.SetupTestStorage(t)
+	auditStore := storageManager.GetAuditStore()
+	auditMgr, err := audit.NewManager(auditStore, "terminal-test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = auditMgr.Stop(ctx)
+	})
+
+	recDir := t.TempDir()
+	baseMgr, err := terminal.NewSessionManager(&terminal.Config{
+		RecordSessions:       true,
+		RecordingStoragePath: recDir,
+		SessionTimeout:       30 * time.Minute,
+		MaxSessions:          100,
+	}, logging.NewNoopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if dsm, ok := baseMgr.(*terminal.DefaultSessionManager); ok {
+			_ = dsm.Stop(context.Background())
+		}
+	})
+
+	th := NewTerminalHandler(logging.NewNoopLogger())
+	// nil registry → skips online check (test convenience only).
+	// nil commandPublisher → skips dispatch (test convenience only).
+	rsm := NewRelaySessionManager(baseMgr, th, nil, nil, auditMgr, logging.NewNoopLogger())
+
+	ctx := context.Background()
+	session, err := rsm.CreateSession(ctx, &terminal.SessionRequest{
+		TenantID:  "test-tenant",
+		StewardID: "test-steward",
+		UserID:    "test-user",
+		Shell:     "bash",
+		Cols:      80,
+		Rows:      24,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	// Write some data to the session so there is something to record.
+	require.NoError(t, session.HandleOutput(ctx, []byte("hello from steward")))
+
+	// Terminate the session to flush the recording and write the end event.
+	require.NoError(t, rsm.TerminateSession(ctx, session.ID))
+
+	// Flush the audit drain goroutine before querying the store.
+	flushCtx, flushCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer flushCancel()
+	require.NoError(t, auditMgr.Flush(flushCtx))
+
+	// --- Verify audit start event ---
+	startEntries, err := auditStore.GetAuditsByAction(ctx, "terminal.session.start", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, startEntries, "terminal.session.start audit entry must exist")
+	var foundStart bool
+	for _, e := range startEntries {
+		if e.SessionID == session.ID {
+			foundStart = true
+			assert.Equal(t, business.AuditResultSuccess, e.Result)
+			assert.Equal(t, business.AuditEventSystemAccess, e.EventType)
+		}
+	}
+	assert.True(t, foundStart, "terminal.session.start audit entry for session %q not found", session.ID)
+
+	// --- Verify audit end event ---
+	endEntries, err := auditStore.GetAuditsByAction(ctx, "terminal.session.end", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, endEntries, "terminal.session.end audit entry must exist")
+	var foundEnd bool
+	for _, e := range endEntries {
+		if e.SessionID == session.ID {
+			foundEnd = true
+			assert.Equal(t, business.AuditResultSuccess, e.Result)
+		}
+	}
+	assert.True(t, foundEnd, "terminal.session.end audit entry for session %q not found", session.ID)
+
+	// --- Verify session recording exists ---
+	recording, err := baseMgr.GetSessionRecording(session.ID)
+	require.NoError(t, err, "session recording must be retrievable after termination")
+	assert.NotNil(t, recording, "session recording must not be nil")
+	// The recording must contain at least the steward output injected above.
+	totalBytes := len(recording.Data)
+	for _, ev := range recording.Events {
+		totalBytes += len(ev.Data)
+	}
+	assert.Greater(t, totalBytes, 0, "session recording must contain recorded data")
+}
+
+// ---------------------------------------------------------------------------
+// Test: browser→steward relay via RelayExecutor.InputChan
+// ---------------------------------------------------------------------------
+
+// TestTerminalHandlerBrowserToStewardRelay verifies that data written by the
+// WebSocket handler (via session.WriteData → RelayExecutor.WriteData) is
+// forwarded to the steward's gRPC stream by HandleGRPC.
+func TestTerminalHandlerBrowserToStewardRelay(t *testing.T) {
+	const stewardID = "steward-b2s-test"
+	mgr := newTestSessionManager(t)
+
+	h := NewTerminalHandler(logging.NewNoopLogger())
+	session := newTestSession(t, mgr, stewardID)
+
+	// Use the relay executor that was installed by newTestSession.
+	relayExec := terminal.NewRelayExecutor()
+	session.SetExecutor(relayExec)
+	h.register(session.ID, stewardID, session, relayExec)
+
+	// Dial with a client cert CN matching the registered steward so the mTLS
+	// identity binding in HandleGRPC is satisfied.
+	ca := newTestCA(t)
+	ctx, cancel := context.WithTimeout(peerContextWithCA(t, ca, stewardID), 5*time.Second)
+	defer cancel()
+
+	stream := newTestBidiStream(ctx)
+	// Block on send delivery instead of polling with time.Sleep.
+	stream.sentSignal = make(chan struct{}, 8)
+
+	// Handshake frame — no data payload.
+	stream.recvCh <- &transportpb.TerminalData{SessionId: session.ID}
+
+	handleDone := make(chan error, 1)
+	go func() {
+		handleDone <- h.HandleGRPC(stream)
+	}()
+
+	// Write browser input via WriteData (browser→executor→inputCh).
+	browserInput := []byte("ls -la\n")
+	writeCtx := context.Background()
+	require.NoError(t, session.WriteData(writeCtx, browserInput))
+
+	// Block until HandleGRPC forwards a frame to the steward stream, then verify
+	// the forwarded payload — no wall-clock polling.
+	select {
+	case <-stream.sentSignal:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for browser input to be forwarded to the steward stream")
+	}
+	var found bool
+	for _, msg := range stream.getSent() {
+		if strings.Contains(string(msg.GetData()), string(browserInput)) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "browser input must be forwarded to the steward stream by HandleGRPC")
+
+	cancel()
+	select {
+	case <-handleDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleGRPC did not exit after context cancellation")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Security: mTLS peer-identity binding on the Terminal relay (Issue #2761)
+// ---------------------------------------------------------------------------
+
+// TestTerminalHandler_MissingPeerCert verifies that HandleGRPC rejects a stream
+// with no mTLS peer certificate in context with codes.Unauthenticated, before
+// any session correlation happens. Without this, the interactive admin relay
+// could be joined by an unauthenticated caller.
+func TestTerminalHandler_MissingPeerCert(t *testing.T) {
+	h := NewTerminalHandler(logging.NewNoopLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	stream := newTestBidiStream(ctx)
+
+	err := h.HandleGRPC(stream)
+
+	require.Error(t, err, "HandleGRPC must reject a stream with no mTLS peer identity")
+	assert.Equal(t, codes.Unauthenticated, status.Code(err),
+		"missing mTLS peer certificate must yield Unauthenticated")
+}
+
+// TestTerminalHandler_StewardIDMismatch verifies that a steward whose mTLS peer
+// CN does not match the target steward recorded on the pending relay is rejected
+// with codes.PermissionDenied — a leaked/guessed session_id from another fleet
+// steward (including cross-tenant) must not be able to hijack the relay.
+func TestTerminalHandler_StewardIDMismatch(t *testing.T) {
+	const targetSteward = "steward-target"
+	const attackerSteward = "steward-attacker"
+
+	mgr := newTestSessionManager(t)
+	h := NewTerminalHandler(logging.NewNoopLogger())
+
+	// Register the pending relay against the legitimate target steward.
+	session := newTestSession(t, mgr, targetSteward)
+	relayExec := terminal.NewRelayExecutor()
+	session.SetExecutor(relayExec)
+	h.register(session.ID, targetSteward, session, relayExec)
+
+	// Dial in as a different, attacker steward holding a valid fleet mTLS cert.
+	ca := newTestCA(t)
+	ctx, cancel := context.WithTimeout(peerContextWithCA(t, ca, attackerSteward), 2*time.Second)
+	defer cancel()
+
+	stream := newTestBidiStream(ctx)
+	// Present the (correct) session_id in the handshake frame; only the peer
+	// identity differs from the target.
+	stream.recvCh <- &transportpb.TerminalData{SessionId: session.ID}
+
+	err := h.HandleGRPC(stream)
+
+	require.Error(t, err, "cross-identity dial-in must be rejected")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err),
+		"steward whose mTLS CN differs from the target must get PermissionDenied")
+
+	// The relay must remain registered (the legitimate steward can still join)
+	// and the WS-side connected signal must NOT have fired for the attacker.
+	h.mu.RLock()
+	relay, stillPending := h.pending[session.ID]
+	h.mu.RUnlock()
+	require.True(t, stillPending, "an unauthorized dial-in must not tear down the pending relay")
+	select {
+	case <-relay.connectedCh:
+		t.Fatal("connectedCh must not be closed by an unauthorized (mismatched) steward")
+	default:
+	}
+}

--- a/features/controller/transport/terminal_handler_test.go
+++ b/features/controller/transport/terminal_handler_test.go
@@ -241,7 +241,7 @@ func TestRelaySessionManagerOfflineSteward(t *testing.T) {
 	// An empty registry has no registered connections.
 	reg := registry.NewRegistry()
 
-	rsm := NewRelaySessionManager(baseMgr, th, nil, reg, nil, logging.NewNoopLogger())
+	rsm := NewRelaySessionManager(baseMgr, th, nil, reg, nil, nil, logging.NewNoopLogger())
 
 	ctx := context.Background()
 	_, err := rsm.CreateSession(ctx, &terminal.SessionRequest{
@@ -300,7 +300,7 @@ func TestRelaySessionManagerDispatchFailureRollsBack(t *testing.T) {
 
 	// nil connRegistry so the online pre-check is skipped and we exercise the
 	// dispatch path itself; the dispatch fails because cp's registry is empty.
-	rsm := NewRelaySessionManager(baseMgr, th, publisher, nil, nil, logging.NewNoopLogger())
+	rsm := NewRelaySessionManager(baseMgr, th, publisher, nil, nil, nil, logging.NewNoopLogger())
 
 	_, err = rsm.CreateSession(context.Background(), &terminal.SessionRequest{
 		TenantID:  "test-tenant",
@@ -335,7 +335,7 @@ func TestRelaySessionManagerDispatchFailureRollsBack(t *testing.T) {
 func TestTerminalWebSocketBadOriginRejected(t *testing.T) {
 	baseMgr := newTestSessionManager(t)
 	th := NewTerminalHandler(logging.NewNoopLogger())
-	rsm := NewRelaySessionManager(baseMgr, th, nil, nil, nil, logging.NewNoopLogger())
+	rsm := NewRelaySessionManager(baseMgr, th, nil, nil, nil, nil, logging.NewNoopLogger())
 
 	// No origin allowlist — only same-origin connections are accepted.
 	wsHandler, err := terminal.NewWebSocketHandler(rsm, logging.NewNoopLogger(), nil)
@@ -403,7 +403,7 @@ func TestRelaySessionManagerAuditAndRecording(t *testing.T) {
 	th := NewTerminalHandler(logging.NewNoopLogger())
 	// nil registry → skips online check (test convenience only).
 	// nil commandPublisher → skips dispatch (test convenience only).
-	rsm := NewRelaySessionManager(baseMgr, th, nil, nil, auditMgr, logging.NewNoopLogger())
+	rsm := NewRelaySessionManager(baseMgr, th, nil, nil, auditMgr, nil, logging.NewNoopLogger())
 
 	ctx := context.Background()
 	session, err := rsm.CreateSession(ctx, &terminal.SessionRequest{

--- a/features/rbac/authdefense/middleware.go
+++ b/features/rbac/authdefense/middleware.go
@@ -3,6 +3,9 @@
 package authdefense
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -19,6 +22,18 @@ type statusCapture struct {
 func (sc *statusCapture) WriteHeader(code int) {
 	sc.code = code
 	sc.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack implements http.Hijacker by delegating to the wrapped ResponseWriter.
+// This middleware is the outermost wrapper on the API chain, so without Hijack
+// support WebSocket upgrades (notably the terminal relay endpoint, Issue #2761)
+// fail with 500 because the gorilla upgrader cannot take over the connection.
+func (sc *statusCapture) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := sc.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
+	}
+	return hj.Hijack()
 }
 
 // Middleware returns an HTTP middleware that enforces the three-tier defense.

--- a/features/terminal/README.md
+++ b/features/terminal/README.md
@@ -3,6 +3,8 @@
 ## Overview
 The Terminal module provides secure remote terminal access to managed Stewards through a WebSocket-based proxy system. It integrates with the existing CFGMS architecture to enable real-time interactive shell access while maintaining security and audit compliance.
 
+**Controller relay is wired (Issue #2761).** The controller exposes a WebSocket endpoint at `GET /api/v1/terminal/ws/{steward_id}` (requires `steward:terminal` RBAC permission). On connect, the controller creates an RBAC-gated, recorded terminal session, dispatches `COMMAND_TYPE_OPEN_TERMINAL` to the target steward, and relays bytes between the browser WebSocket and the steward's `Terminal` gRPC stream (implemented by story #2760) for the life of the session. All sessions are recorded; `CFGMS_TERMINAL_ALLOWED_ORIGINS` controls the WebSocket origin allowlist.
+
 ## Architecture
 
 ### Component Design

--- a/features/terminal/manager.go
+++ b/features/terminal/manager.go
@@ -111,8 +111,8 @@ func (m *DefaultSessionManager) CreateSession(ctx context.Context, req *SessionR
 
 	m.logger.Info("Session created",
 		"session_id", logging.RedactedID(session.ID),
-		"steward_id", session.StewardID,
-		"user_id", session.UserID,
+		"steward_id", logging.SanitizeLogValue(session.StewardID),
+		"user_id", logging.SanitizeLogValue(session.UserID),
 		"active_sessions", len(m.sessions))
 
 	return session, nil

--- a/features/terminal/relay_executor.go
+++ b/features/terminal/relay_executor.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package terminal
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/cfgis/cfgms/features/terminal/shell"
+)
+
+// RelayExecutor implements shell.Executor for controller-side relay sessions.
+// WriteData enqueues browser input for the controller→steward relay goroutine
+// to forward over the gRPC Terminal stream. OutputChannel is never consumed in
+// relay mode — the TerminalHandler feeds session.HandleOutput directly from
+// the steward's inbound stream frames, bypassing the executor output path.
+type RelayExecutor struct {
+	inputCh  chan []byte
+	resizeCh chan [2]int32 // [cols, rows]
+	outputCh chan []byte   // always empty — TerminalHandler drives output directly
+	errorCh  chan error
+	closed   atomic.Bool
+}
+
+// NewRelayExecutor creates a RelayExecutor with buffered channels.
+func NewRelayExecutor() *RelayExecutor {
+	return &RelayExecutor{
+		inputCh:  make(chan []byte, 64),
+		resizeCh: make(chan [2]int32, 16),
+		outputCh: make(chan []byte, 1), // effectively idle in relay mode
+		errorCh:  make(chan error, 1),
+	}
+}
+
+// Start is a no-op: relay sessions have no local shell process.
+func (r *RelayExecutor) Start(_ context.Context, _ *shell.Config) error { return nil }
+
+// WriteData enqueues data for forwarding to the steward. Non-blocking: if the
+// channel is full (steward not consuming fast enough) the write is dropped
+// rather than stalling the WebSocket read loop.
+func (r *RelayExecutor) WriteData(_ context.Context, data []byte) error {
+	if r.closed.Load() {
+		return nil // silently drop after relay is torn down
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	select {
+	case r.inputCh <- cp:
+	default:
+		// steward input buffer full — drop to avoid blocking the WS goroutine
+	}
+	return nil
+}
+
+// Resize enqueues a terminal resize for forwarding to the steward.
+func (r *RelayExecutor) Resize(_ context.Context, cols, rows int) error {
+	if r.closed.Load() {
+		return nil
+	}
+	select {
+	case r.resizeCh <- [2]int32{int32(cols), int32(rows)}: //nolint:gosec // terminal dimensions are far below int32 max
+	default:
+	}
+	return nil
+}
+
+// Close marks the executor as closed. Pending reads on InputChan and
+// ResizeChan continue to drain; no new writes are accepted.
+func (r *RelayExecutor) Close(_ context.Context) error {
+	r.closed.Store(true)
+	return nil
+}
+
+// OutputChannel returns the idle output channel (unused in relay mode).
+func (r *RelayExecutor) OutputChannel() <-chan []byte { return r.outputCh }
+
+// ErrorChannel returns the error channel (unused in relay mode).
+func (r *RelayExecutor) ErrorChannel() <-chan error { return r.errorCh }
+
+// IsRunning returns true while the relay is active.
+func (r *RelayExecutor) IsRunning() bool { return !r.closed.Load() }
+
+// InputChan returns the channel from which the relay goroutine reads browser input.
+func (r *RelayExecutor) InputChan() <-chan []byte { return r.inputCh }
+
+// ResizeChan returns the channel from which the relay goroutine reads resize events.
+func (r *RelayExecutor) ResizeChan() <-chan [2]int32 { return r.resizeCh }
+
+// SetExecutor replaces the shell executor on session s. Used by the controller
+// relay to substitute a RelayExecutor for the platform shell executor that
+// NewSession creates, enabling browser→steward data forwarding without
+// modifying session.go (Issue #2761: controller Terminal relay).
+func (s *Session) SetExecutor(executor shell.Executor) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.executor = executor
+}

--- a/features/terminal/relay_executor.go
+++ b/features/terminal/relay_executor.go
@@ -4,6 +4,7 @@ package terminal
 
 import (
 	"context"
+	"math"
 	"sync/atomic"
 
 	"github.com/cfgis/cfgms/features/terminal/shell"
@@ -57,8 +58,19 @@ func (r *RelayExecutor) Resize(_ context.Context, cols, rows int) error {
 	if r.closed.Load() {
 		return nil
 	}
+	var c, row int32
+	if cols > 0 && cols <= math.MaxInt32 {
+		c = int32(cols) //nolint:gosec // bounds-checked above
+	} else {
+		c = 80
+	}
+	if rows > 0 && rows <= math.MaxInt32 {
+		row = int32(rows) //nolint:gosec // bounds-checked above
+	} else {
+		row = 24
+	}
 	select {
-	case r.resizeCh <- [2]int32{int32(cols), int32(rows)}: //nolint:gosec // terminal dimensions are far below int32 max
+	case r.resizeCh <- [2]int32{c, row}:
 	default:
 	}
 	return nil

--- a/features/terminal/relay_executor_test.go
+++ b/features/terminal/relay_executor_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package terminal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelayExecutor_WriteData_ForwardsCopy verifies the happy path: WriteData
+// enqueues an independent copy of the data on InputChan.
+func TestRelayExecutor_WriteData_ForwardsCopy(t *testing.T) {
+	r := NewRelayExecutor()
+
+	input := []byte("ls -la\n")
+	require.NoError(t, r.WriteData(context.Background(), input))
+
+	select {
+	case got := <-r.InputChan():
+		assert.Equal(t, []byte("ls -la\n"), got, "WriteData must forward the data unchanged")
+		// Mutating the caller's slice afterwards must not affect the queued copy.
+		input[0] = 'X'
+		assert.Equal(t, byte('l'), got[0], "WriteData must enqueue a defensive copy")
+	case <-time.After(time.Second):
+		t.Fatal("expected data on InputChan")
+	}
+}
+
+// TestRelayExecutor_WriteData_DropsWhenClosed verifies the documented drop
+// behaviour: after Close, WriteData silently drops (returns nil, enqueues
+// nothing) so the WS read goroutine is never blocked on a torn-down relay.
+func TestRelayExecutor_WriteData_DropsWhenClosed(t *testing.T) {
+	r := NewRelayExecutor()
+	require.NoError(t, r.Close(context.Background()))
+
+	require.NoError(t, r.WriteData(context.Background(), []byte("post-close")),
+		"WriteData after Close must not error")
+
+	assert.Equal(t, 0, len(r.InputChan()),
+		"WriteData after Close must drop the data (nothing enqueued)")
+}
+
+// TestRelayExecutor_WriteData_DropsWhenFull verifies the default-branch drop:
+// when the input channel buffer is full (steward not consuming), WriteData must
+// drop rather than block the WS goroutine.
+func TestRelayExecutor_WriteData_DropsWhenFull(t *testing.T) {
+	r := NewRelayExecutor()
+
+	// Fill the buffered input channel to capacity.
+	capacity := cap(r.inputCh)
+	for i := 0; i < capacity; i++ {
+		require.NoError(t, r.WriteData(context.Background(), []byte{byte(i)}))
+	}
+	require.Equal(t, capacity, len(r.InputChan()), "input channel must be full")
+
+	// The next write must not block and must be dropped.
+	done := make(chan struct{})
+	go func() {
+		_ = r.WriteData(context.Background(), []byte("overflow"))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WriteData blocked when input channel was full — must drop instead")
+	}
+
+	assert.Equal(t, capacity, len(r.InputChan()),
+		"overflow write must be dropped, leaving the channel at capacity")
+}
+
+// TestRelayExecutor_Resize_ForwardsValue verifies the happy path for Resize.
+func TestRelayExecutor_Resize_ForwardsValue(t *testing.T) {
+	r := NewRelayExecutor()
+	require.NoError(t, r.Resize(context.Background(), 120, 40))
+
+	select {
+	case dims := <-r.ResizeChan():
+		assert.Equal(t, [2]int32{120, 40}, dims, "Resize must forward [cols, rows]")
+	case <-time.After(time.Second):
+		t.Fatal("expected dimensions on ResizeChan")
+	}
+}
+
+// TestRelayExecutor_Resize_DropsWhenClosed verifies Resize drops after Close.
+func TestRelayExecutor_Resize_DropsWhenClosed(t *testing.T) {
+	r := NewRelayExecutor()
+	require.NoError(t, r.Close(context.Background()))
+
+	require.NoError(t, r.Resize(context.Background(), 100, 30),
+		"Resize after Close must not error")
+
+	assert.Equal(t, 0, len(r.ResizeChan()),
+		"Resize after Close must drop (nothing enqueued)")
+}
+
+// TestRelayExecutor_Resize_DropsWhenFull verifies the default-branch drop for
+// Resize when the resize channel buffer is full.
+func TestRelayExecutor_Resize_DropsWhenFull(t *testing.T) {
+	r := NewRelayExecutor()
+
+	capacity := cap(r.resizeCh)
+	for i := 0; i < capacity; i++ {
+		require.NoError(t, r.Resize(context.Background(), 80+i, 24))
+	}
+	require.Equal(t, capacity, len(r.ResizeChan()), "resize channel must be full")
+
+	done := make(chan struct{})
+	go func() {
+		_ = r.Resize(context.Background(), 200, 50)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Resize blocked when resize channel was full — must drop instead")
+	}
+
+	assert.Equal(t, capacity, len(r.ResizeChan()),
+		"overflow resize must be dropped, leaving the channel at capacity")
+}

--- a/features/terminal/session.go
+++ b/features/terminal/session.go
@@ -78,9 +78,9 @@ func NewSession(req *SessionRequest, logger logging.Logger) (*Session, error) {
 
 	logger.Info("Created new terminal session",
 		"session_id", logging.RedactedID(sessionID),
-		"steward_id", req.StewardID,
-		"user_id", req.UserID,
-		"shell", req.Shell,
+		"steward_id", logging.SanitizeLogValue(req.StewardID),
+		"user_id", logging.SanitizeLogValue(req.UserID),
+		"shell", logging.SanitizeLogValue(req.Shell),
 		"cols", req.Cols,
 		"rows", req.Rows)
 

--- a/features/terminal/websocket.go
+++ b/features/terminal/websocket.go
@@ -116,7 +116,7 @@ func (h *DefaultWebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http
 	// Extract session parameters from query string
 	sessionReq, err := h.parseSessionRequest(r)
 	if err != nil {
-		h.logger.Warn("Invalid session request", "error", err, "remote_addr", r.RemoteAddr)
+		h.logger.Warn("Invalid session request", "error", err, "remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
 		http.Error(w, fmt.Sprintf("Invalid session request: %v", err), http.StatusBadRequest)
 		return
 	}
@@ -141,16 +141,16 @@ func (h *DefaultWebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	session, err := h.sessionManager.CreateSession(ctx, sessionReq)
 	if err != nil {
-		h.logger.Error("Failed to create terminal session", "error", err, "remote_addr", r.RemoteAddr)
+		h.logger.Error("Failed to create terminal session", "error", err, "remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
 		h.sendError(cw, fmt.Sprintf("Failed to create session: %v", err))
 		return
 	}
 
 	h.logger.Info("WebSocket terminal session established",
 		"session_id", logging.RedactedID(session.ID),
-		"steward_id", session.StewardID,
-		"user_id", session.UserID,
-		"remote_addr", r.RemoteAddr)
+		"steward_id", logging.SanitizeLogValue(session.StewardID),
+		"user_id", logging.SanitizeLogValue(session.UserID),
+		"remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
 
 	// Handle the WebSocket session
 	h.handleSession(ctx, cw, session)

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -134,6 +134,14 @@ func (p *SQLiteProvider) Available() (bool, error) {
 // difference between "WAL set up correctly" and "second opener crashes
 // at openAndInit" (the Linux CI failure mode in
 // TestSQLite_TwoProcesses_ConcurrentWrites_NoCorruption).
+//
+// WAL mode MUST NOT be set for in-memory (mode=memory / :memory:) databases.
+// modernc.org/sqlite v1.x deadlocks in OP_ParseSchema when WAL is combined
+// with cache=shared on a named in-memory database: the journal-mode
+// pragma acquires a schema write-lock that it never releases, causing any
+// concurrent openAndInit (or schema DDL) on the same named DB to spin
+// indefinitely. In-memory stores use a single connection anyway, so WAL
+// provides no benefit — omit it and let the default journal_mode=DELETE apply.
 func openDB(path string) (*sql.DB, error) {
 	// busy_timeout 15s (was 5s): TestSQLite_TwoProcesses_ConcurrentWrites
 	// occasionally failed on Windows CI runners with SQLITE_BUSY mid-loop
@@ -142,7 +150,18 @@ func openDB(path string) (*sql.DB, error) {
 	// real-world controller batch commits and gives Windows CI's I/O
 	// variance enough headroom without hiding genuine deadlocks (those
 	// would still surface after 15s).
-	const pragmas = "_pragma=busy_timeout(15000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)"
+	const (
+		// fileBackedPragmas: WAL for concurrent read access on file-backed DBs.
+		fileBackedPragmas = "_pragma=busy_timeout(15000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)"
+		// inMemoryPragmas: no journal_mode — modernc WAL+shared-cache deadlocks.
+		inMemoryPragmas = "_pragma=busy_timeout(15000)&_pragma=foreign_keys(on)"
+	)
+
+	inMemory := path == ":memory:" || strings.Contains(path, "mode=memory")
+	pragmas := fileBackedPragmas
+	if inMemory {
+		pragmas = inMemoryPragmas
+	}
 
 	var dsn string
 	switch {

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 const currentSchemaVersion = 2
@@ -123,9 +124,21 @@ func backfillStewardColumns(ctx context.Context, db *sql.DB) error {
 
 // initializeSchema creates all tables and tracks schema version.
 // It is safe to call multiple times (all statements use IF NOT EXISTS).
-// All DDL statements are executed inside a single transaction to reduce WAL
-// write cycles — particularly important on Windows where each individual
-// transaction requires a full file-lock round-trip via the WAL SHM mechanism.
+//
+// All DDL is executed as a single multi-statement Exec inside one transaction.
+// Two reasons:
+//   - WAL: one transaction instead of ~70 avoids a per-statement file-lock
+//     round-trip via the WAL SHM mechanism (matters most on Windows).
+//   - Cost under the race detector: each individual ExecContext drives a full
+//     prepare/parse/step cycle through the modernc SQLite parser (heavy on
+//     instrumented memcpy). Collapsing ~70 separate Exec calls into one halves
+//     schema-init time. Because SetupTestStorage builds a fresh in-memory schema
+//     for every test (hundreds per package), that per-init cost is multiplied
+//     across the whole suite; the api package test binary was tripping the 5m
+//     -race timeout purely on cumulative schema-init overhead (Issue #2761 QA).
+//
+// The statements are all CREATE TABLE / CREATE INDEX with IF NOT EXISTS, so they
+// are transaction-safe and idempotent whether the target DB is fresh or existing.
 func initializeSchema(ctx context.Context, db *sql.DB) error {
 	if err := backfillAuditEntries(ctx, db); err != nil {
 		return err
@@ -533,10 +546,12 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		}
 	}()
 
-	for _, stmt := range statements {
-		if _, err := tx.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("schema statement failed: %w\nSQL: %s", err, stmt)
-		}
+	// Single multi-statement Exec (modernc executes every ;-separated statement
+	// in order on the transaction's connection). See the function doc for why
+	// this is one Exec rather than a per-statement loop.
+	combined := strings.Join(statements, ";\n")
+	if _, err := tx.ExecContext(ctx, combined); err != nil {
+		return fmt.Errorf("schema initialization failed: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/pkg/testing/storage_helper.go
+++ b/pkg/testing/storage_helper.go
@@ -23,17 +23,28 @@ import (
 var testStorageSeq int64
 
 // SetupTestStorage creates an OSS composite storage manager for testing.
-// Uses flatfile (config/audit/steward) and a named in-memory SQLite (business data).
+// Uses flatfile (config/audit/steward) and a private in-memory SQLite (business data).
 //
-// Named in-memory SQLite avoids file I/O entirely. On Windows CI, WAL mode's
-// FlushFileBuffers call blocks for minutes under load — switching to in-memory
-// eliminates that syscall while preserving per-call isolation (distinct names).
+// Private in-memory SQLite avoids file I/O entirely. On Windows CI, WAL mode's
+// FlushFileBuffers call blocks for minutes under load — in-memory eliminates that
+// syscall while preserving per-call isolation (distinct names).
+//
+// The DSN deliberately omits cache=shared. A shared-cache in-memory database is
+// registered with SQLite's single, process-wide shared-cache manager, so every
+// test's database contends on one global mutex during open/close — under a full
+// package run (many managers opening and finalizing concurrently with lingering
+// audit-drain goroutines) that serialization stalled test setup indefinitely
+// inside sqlite openDatabase (Issue #2761). The business-store bundle already
+// pins in-memory databases to a single, never-expiring connection
+// (providers/sqlite plugin.openDB), so shared cache is unnecessary for the
+// stores to observe the same data — a private database on one connection is both
+// correct and free of cross-test coupling.
 func SetupTestStorage(t *testing.T) *interfaces.StorageManager {
 	t.Helper()
 
 	flatfileRoot := t.TempDir()
 	seq := atomic.AddInt64(&testStorageSeq, 1)
-	sqlitePath := fmt.Sprintf("file:cfgms-test-%d?mode=memory&cache=shared", seq)
+	sqlitePath := fmt.Sprintf("file:cfgms-test-%d?mode=memory", seq)
 
 	storageManager, err := interfaces.CreateOSSStorageManager(flatfileRoot, sqlitePath)
 	if err != nil {

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -1160,9 +1160,13 @@ print(','.join(missing) if missing else 'ok')
             log_fail "project-queue.sh list-by-status: output is not a JSON array: $list_out"
         fi
 
-        # Retry until item is visible (accounts for GitHub API eventual consistency)
+        # Retry until item is visible. The GitHub Projects V2 items connection is
+        # eventually consistent — a newly created item is immediately visible via
+        # get-item but can lag in the paginated items list. Poll with bounded
+        # exponential backoff until it converges.
         found="no"
-        for attempt in 1 2 3 4 5; do
+        local _delay=1
+        for attempt in 1 2 3 4 5 6 7 8; do
             list_out=$(bash "$script" list-by-status Draft 2>&1) || true
             found=$(echo "$list_out" | python3 -c "
 import json, sys
@@ -1173,7 +1177,8 @@ except Exception:
     print('no')
 " 2>/dev/null) || found="no"
             [[ "$found" == "yes" ]] && break
-            sleep 1
+            sleep "$_delay"
+            (( _delay = _delay < 8 ? _delay * 2 : 8 ))
         done
 
         if [[ "$found" == "yes" ]]; then
@@ -1248,23 +1253,34 @@ print(d.get('fields',{}).get('Title',''))
     fi
 
     # ── AC 2: list-by-status Ready (item moved from Draft) ───────────────────
+    # The items connection is eventually consistent after a status update, so
+    # poll with bounded exponential backoff rather than a single shot (which was
+    # racy against GitHub Projects V2 replication lag).
     exit_code=0
-    local ready_list
-    ready_list=$(bash "$script" list-by-status Ready 2>&1) || exit_code=$?
+    local ready_list found_ready="no" _ready_delay=1
+    for attempt in 1 2 3 4 5 6 7 8; do
+        exit_code=0
+        ready_list=$(bash "$script" list-by-status Ready 2>&1) || exit_code=$?
+        if [[ $exit_code -eq 0 ]]; then
+            found_ready=$(echo "$ready_list" | python3 -c "
+import json, sys
+try:
+    items = json.load(sys.stdin)
+    print('yes' if any(i.get('item_id') == '$item_id' for i in items) else 'no')
+except Exception:
+    print('no')
+" 2>/dev/null) || found_ready="no"
+            [[ "$found_ready" == "yes" ]] && break
+        fi
+        sleep "$_ready_delay"
+        (( _ready_delay = _ready_delay < 8 ? _ready_delay * 2 : 8 ))
+    done
     if [[ $exit_code -ne 0 ]]; then
         log_fail "project-queue.sh list-by-status Ready: failed (exit $exit_code): $ready_list"
+    elif [[ "$found_ready" == "yes" ]]; then
+        log_pass "project-queue.sh list-by-status Ready: item appears after status update (AC 2)"
     else
-        local found_ready
-        found_ready=$(echo "$ready_list" | python3 -c "
-import json, sys
-items = json.load(sys.stdin)
-print('yes' if any(i.get('item_id') == '$item_id' for i in items) else 'no')
-" 2>/dev/null) || found_ready="parse-error"
-        if [[ "$found_ready" == "yes" ]]; then
-            log_pass "project-queue.sh list-by-status Ready: item appears after status update (AC 2)"
-        else
-            log_fail "project-queue.sh list-by-status Ready: item $item_id not found in Ready list"
-        fi
+        log_fail "project-queue.sh list-by-status Ready: item $item_id not found in Ready list after retries"
     fi
 
     # ── add-issue: add a real cfgms issue to the project ─────────────────────

--- a/test/security/trust_boundary_test.sh
+++ b/test/security/trust_boundary_test.sh
@@ -426,8 +426,12 @@ test_phase2_lifecycle() {
     _pass "phase2 step a: create-draft returned non-empty item_id"
 
     # --- Step b: list-by-status Draft, item_id present with issue_num=null --
-    local found_in_draft=false
-    for attempt in 1 2 3 4 5; do
+    # The GitHub Projects V2 items connection is eventually consistent: a freshly
+    # created item is immediately visible via get-item (direct node lookup) but
+    # can lag in the paginated items list. Poll with bounded exponential backoff
+    # until it converges instead of a short fixed window.
+    local found_in_draft=false _delay=1
+    for attempt in 1 2 3 4 5 6 7 8; do
         local list_draft_out list_draft_rc=0
         list_draft_out=$(bash "$pq_script" list-by-status Draft 2>&1) || list_draft_rc=$?
         if [[ $list_draft_rc -eq 0 ]] && printf '%s' "$list_draft_out" | ITEM_ID="$item_id" python3 -c '
@@ -441,12 +445,13 @@ sys.exit(1)
 ' 2>/dev/null; then
             found_in_draft=true; break
         fi
-        sleep 1
+        sleep "$_delay"
+        (( _delay = _delay < 8 ? _delay * 2 : 8 ))
     done
     if $found_in_draft; then
         _pass "phase2 step b: item in Draft list with issue_num=null"
     else
-        _fail "phase2 step b: item not found in Draft list with issue_num=null after 5 retries"
+        _fail "phase2 step b: item not found in Draft list with issue_num=null after 8 retries"
         return
     fi
 
@@ -461,8 +466,9 @@ sys.exit(1)
     fi
 
     # --- Step d: list-by-status Ready, item_id present ----------------------
-    local found_ready=false
-    for attempt in 1 2 3 4 5; do
+    # Same eventual-consistency handling as step b (bounded exponential backoff).
+    local found_ready=false _delay=1
+    for attempt in 1 2 3 4 5 6 7 8; do
         local list_ready_out list_ready_rc=0
         list_ready_out=$(bash "$pq_script" list-by-status Ready 2>&1) || list_ready_rc=$?
         if [[ $list_ready_rc -eq 0 ]] && printf '%s' "$list_ready_out" | ITEM_ID="$item_id" python3 -c '
@@ -473,12 +479,13 @@ sys.exit(0 if any(it.get("item_id")==t for it in items) else 1)
 ' 2>/dev/null; then
             found_ready=true; break
         fi
-        sleep 1
+        sleep "$_delay"
+        (( _delay = _delay < 8 ? _delay * 2 : 8 ))
     done
     if $found_ready; then
         _pass "phase2 step d: item appears in Ready list"
     else
-        _fail "phase2 step d: item not found in Ready list after 5 retries"
+        _fail "phase2 step d: item not found in Ready list after 8 retries"
         return
     fi
 
@@ -519,8 +526,9 @@ sys.exit(0 if any(it.get("item_id")==t for it in items) else 1)
     fi
 
     # --- Step h: list-by-status Done, item_id present -----------------------
-    local found_done=false
-    for attempt in 1 2 3 4 5; do
+    # Same eventual-consistency handling as step b (bounded exponential backoff).
+    local found_done=false _delay=1
+    for attempt in 1 2 3 4 5 6 7 8; do
         local list_done_out list_done_rc=0
         list_done_out=$(bash "$pq_script" list-by-status Done 2>&1) || list_done_rc=$?
         if [[ $list_done_rc -eq 0 ]] && printf '%s' "$list_done_out" | ITEM_ID="$item_id" python3 -c '
@@ -531,12 +539,13 @@ sys.exit(0 if any(it.get("item_id")==t for it in items) else 1)
 ' 2>/dev/null; then
             found_done=true; break
         fi
-        sleep 1
+        sleep "$_delay"
+        (( _delay = _delay < 8 ? _delay * 2 : 8 ))
     done
     if $found_done; then
         _pass "phase2 step h: item appears in Done list"
     else
-        _fail "phase2 step h: item not found in Done list after 5 retries"
+        _fail "phase2 step h: item not found in Done list after 8 retries"
         return
     fi
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/terminal/ws/{steward_id}` WebSocket endpoint on the controller, RBAC-gated (`steward:terminal`) with configurable origin allowlist (`CFGMS_TERMINAL_ALLOWED_ORIGINS`)
- `TerminalHandler` correlates WS-side sessions to inbound steward `Terminal` gRPC streams; validates the dialing steward's mTLS peer CN against the session's registered target stewardID (prevents cross-steward session hijacking)
- `RelayExecutor` replaces the platform shell executor with channel-based forwarding so browser↔steward I/O flows without a local shell process
- `relaySessionManager` wraps `DefaultSessionManager`: checks steward online, injects `RelayExecutor`, dispatches `COMMAND_TYPE_OPEN_TERMINAL`, records `terminal.session.start` / `terminal.session.end` audit events
- Session recording mandatory (`RecordSessions: true`); all HTTP-sourced log values use `logging.SanitizeLogValue()` / `logging.RedactedID()`
- Offline steward returns clear error immediately (no hang)

## Test plan

- [ ] `TestTerminalHandlerRelayGRPCToSession` — steward data reaches session output channel
- [ ] `TestTerminalHandlerBrowserToStewardRelay` — browser input/resize reaches gRPC stream
- [ ] `TestRelaySessionManagerOfflineSteward` — offline steward → error, no hang
- [ ] `TestTerminalWebSocketBadOriginRejected` — bad WebSocket origin → HTTP 403
- [ ] `TestRelaySessionManagerAuditAndRecording` — audit events + session recording enabled
- [ ] `make test-agent-complete` passes (all CI checks)

Fixes #2761

🤖 Generated with [Claude Code](https://claude.com/claude-code)