### PR TITLE
hyperv.vm: echo desired vhd_path when disk is in the desired home directory (rename converges clean, #2776 follow-up)

### DIFF
--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -97,6 +97,20 @@ type hypervModule struct {
 	checkpointDesiredMu sync.RWMutex
 	checkpointDesired   map[string]interface{}
 
+	// vhdPathDesired maps a VM name to the authored `vhd_path` last seen for it,
+	// so getVM can echo the desired path back on the Get surface WHEN the VM's
+	// disk already lives in the desired home directory (#2776 follow-up). The
+	// module manages the VHD's home DIRECTORY (#2411 convergeStorageLocation keys
+	// on vmHomeDir), never the file's leaf name — a rename (Rename-VM) does not
+	// rename the VHD, and the module never renames disk files. Without the echo, a
+	// declared vhd_path whose leaf differs from the on-disk file (e.g. after a
+	// rename) drifts forever on a difference the module will not reconcile. Keyed
+	// by VM name + mutex-guarded for the same shared-instance reason as
+	// checkpointDesired; populated by setVM, echoed by getVM only when the home
+	// directory already matches (a wrong directory still drifts → storage move).
+	vhdPathDesiredMu sync.RWMutex
+	vhdPathDesired   map[string]string
+
 	// vswitches is the write-through vSwitch cache. Keys are the exact switch
 	// names admins specify (identical to the host-side names). Updated on
 	// transport success only.
@@ -240,6 +254,7 @@ func New(detector HypervDetector, opts ...HypervOption) modules.Module {
 		vms:               make(map[string]VMConfig),
 		vswitches:         make(map[string]VSwitchConfig),
 		checkpointDesired: make(map[string]interface{}),
+		vhdPathDesired:    make(map[string]string),
 		detector:          detector,
 		provisionStore:    NewMemProvisionStore(),
 		// Freshness window for the bulk cluster-owner read cache (Story #2577).

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -215,6 +215,18 @@ type VMConfig struct {
 	// the live set violates the policy (drift → setVM reconcile). Observed/computed
 	// only — never authored, never round-trips through YAML.
 	checkpointsEcho interface{}
+
+	// vhdPathEcho, when non-empty, is the desired `vhd_path` that getVM echoes on
+	// the Get surface to signal the VM's disk already lives in the desired HOME
+	// DIRECTORY (#2776 follow-up). The module manages the VHD's home directory
+	// (#2411), never the file's leaf name — Rename-VM does not rename the disk, so
+	// after a rename the on-disk leaf (e.g. cfgms-ci-01.vhdx) differs from a
+	// declared vhd_path whose leaf tracks the new VM name (lab-01.vhdx). AsMap
+	// emits this echo under the managed `vhd_path` key so a directory-compliant VM
+	// matches desired (no drift); getVM leaves it empty when the disk is in the
+	// WRONG directory, so a genuine storage-location drift still surfaces and
+	// convergeStorageLocation moves it. Observed/computed only — never authored.
+	vhdPathEcho string
 }
 
 // ManagedElsewhere implements modules.ManagedElsewhere. It reports true (naming
@@ -595,6 +607,15 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 	if c.checkpointsEcho != nil {
 		m["checkpoints"] = c.checkpointsEcho
 	}
+	// Directory-compliant vhd_path echo (#2776 follow-up): when the disk already
+	// lives in the desired home directory, report the DESIRED path so a
+	// leaf-name-only difference (e.g. a VHD not renamed by Rename-VM) does not
+	// drift on something the module never reconciles. A wrong directory leaves the
+	// echo empty, so the observed (actual) path is reported and storage drift
+	// surfaces normally.
+	if c.vhdPathEcho != "" {
+		m["vhd_path"] = c.vhdPathEcho
+	}
 	if c.Source != nil {
 		m["source"] = map[string]interface{}{
 			"iso":       c.Source.ISO,
@@ -882,6 +903,22 @@ func (m *hypervModule) getVMLocal(ctx context.Context, vmName string) (*VMConfig
 		}
 	}
 
+	// Directory-compliant vhd_path echo (#2776 follow-up): when a desired vhd_path
+	// is known for this VM (recorded by a prior setVM) and the observed disk already
+	// lives in the SAME home directory, echo the desired path so a leaf-name-only
+	// difference — e.g. a VHD that Rename-VM left under the old name — does not drift
+	// on something the module never reconciles (it renames no disk files). A disk in
+	// a DIFFERENT directory leaves the echo empty, so storageLocationDrift still
+	// fires and convergeStorageLocation moves it. Until the first Set records the
+	// path the authored vhd_path drifts (no echo), which drives that first Set.
+	m.vhdPathDesiredMu.RLock()
+	desiredVHDPath := m.vhdPathDesired[vmName]
+	m.vhdPathDesiredMu.RUnlock()
+	if desiredVHDPath != "" && cfg.VHDPath != "" &&
+		sameWindowsPath(vmHomeDir(cfg.VHDPath), vmHomeDir(desiredVHDPath)) {
+		cfg.vhdPathEcho = desiredVHDPath
+	}
+
 	// Write-through: update cache on successful read
 	m.vmsMu.Lock()
 	m.vms[vmName] = *cfg
@@ -1036,6 +1073,19 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	}
 	m.checkpointDesired[vmName] = configMap["checkpoints"]
 	m.checkpointDesiredMu.Unlock()
+
+	// Record the authored `vhd_path` for this VM so getVM can echo it back when the
+	// disk is already in the desired home directory (#2776 follow-up) — the same
+	// keyed, mutex-guarded per-VM record as checkpointDesired, for the same
+	// shared-instance reason.
+	if vhd, ok := configMap["vhd_path"].(string); ok && vhd != "" {
+		m.vhdPathDesiredMu.Lock()
+		if m.vhdPathDesired == nil {
+			m.vhdPathDesired = make(map[string]string)
+		}
+		m.vhdPathDesired[vmName] = vhd
+		m.vhdPathDesiredMu.Unlock()
+	}
 
 	state, _ := configMap["state"].(string)
 

--- a/features/modules/hyperv/vm_vhdpath_echo_test.go
+++ b/features/modules/hyperv/vm_vhdpath_echo_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getVMJSONWithPath builds a found-VM Get-VM JSON payload with an explicit disk
+// Path — used to place the disk in a chosen directory/leaf the default
+// hostVMJSON helper does not expose.
+func getVMJSONWithPath(name, diskPath string) string {
+	return `{"found":true,"Name":"` + name + `","MemoryStartupBytes":4294967296,"ProcessorCount":2,` +
+		`"Generation":2,"Path":"` + diskPath + `","ConfigurationLocation":"","CheckpointCount":0,` +
+		`"SwitchName":"","SwitchNames":[],"State":"Off"}`
+}
+
+// TestGetVM_VHDPathEcho_DirectoryCompliant_NoDrift is the #2776 follow-up: after a
+// rename, Rename-VM leaves the VHD under its OLD leaf name (the module renames no
+// disk files), so a declared vhd_path whose leaf tracks the new VM name differs
+// from the on-disk leaf while the home DIRECTORY matches. getVM must echo the
+// desired vhd_path so this leaf-only difference does not drift forever on
+// something the module never reconciles.
+func TestGetVM_VHDPathEcho_DirectoryCompliant_NoDrift(t *testing.T) {
+	const vmName = "lab-01"
+	const desiredPath = `C:\ClusterStorage\CSV01\lab-01\lab-01.vhdx`
+	// Actual disk: SAME home directory, OLD leaf (Rename-VM did not rename it).
+	const actualDisk = `C:\ClusterStorage\CSV01\lab-01\cfgms-ci-01.vhdx`
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		getVMJSONWithPath(vmName, `C:\\ClusterStorage\\CSV01\\lab-01\\cfgms-ci-01.vhdx`),
+	}}
+	m := vmModuleWithTransport(transport, "t")
+	// Seed the authored vhd_path as a prior setVM would.
+	m.vhdPathDesired = map[string]string{vmName: desiredPath}
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+
+	// The observed disk is read as-is on the struct...
+	assert.Equal(t, actualDisk, cfg.VHDPath, "the struct still carries the true on-disk path")
+	// ...but the drift SURFACE (AsMap) echoes the desired path, so a leaf-only
+	// difference compares equal to desired and does not drift.
+	assert.Equal(t, desiredPath, cfg.AsMap()["vhd_path"],
+		"a disk already in the desired home directory must echo the desired vhd_path (no leaf-name drift)")
+}
+
+// TestGetVM_VHDPathEcho_WrongDirectory_ReportsActual verifies the echo is NOT
+// applied when the disk is in a DIFFERENT directory: the actual path is reported
+// so storageLocationDrift still fires and convergeStorageLocation moves the VM.
+func TestGetVM_VHDPathEcho_WrongDirectory_ReportsActual(t *testing.T) {
+	const vmName = "lab-01"
+	const desiredPath = `C:\ClusterStorage\CSV01\lab-01\lab-01.vhdx`
+	const actualDisk = `C:\VMs\lab-01.vhdx` // wrong home directory
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		getVMJSONWithPath(vmName, `C:\\VMs\\lab-01.vhdx`),
+	}}
+	m := vmModuleWithTransport(transport, "t")
+	m.vhdPathDesired = map[string]string{vmName: desiredPath}
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+
+	assert.Equal(t, actualDisk, cfg.AsMap()["vhd_path"],
+		"a disk in the WRONG home directory must report the actual path so storage-location drift surfaces")
+}
+
+// TestGetVM_VHDPathEcho_NoDesiredRecorded_ReportsActual verifies that before any
+// setVM records a desired path (e.g. a fresh steward's first Get), getVM reports
+// the actual disk — the authored vhd_path then drifts and drives that first Set,
+// which records the path so subsequent Gets echo it. Mirrors the checkpoints echo.
+func TestGetVM_VHDPathEcho_NoDesiredRecorded_ReportsActual(t *testing.T) {
+	const vmName = "lab-01"
+	const actualDisk = `C:\ClusterStorage\CSV01\lab-01\cfgms-ci-01.vhdx`
+
+	transport := &testWinRMTransport{perCallOutputs: []string{
+		getVMJSONWithPath(vmName, `C:\\ClusterStorage\\CSV01\\lab-01\\cfgms-ci-01.vhdx`),
+	}}
+	m := vmModuleWithTransport(transport, "t")
+	// No vhdPathDesired seeded.
+
+	cfg, err := m.getVM(context.Background(), vmName)
+	require.NoError(t, err)
+	assert.Equal(t, actualDisk, cfg.AsMap()["vhd_path"],
+		"with no desired path recorded yet, getVM reports the actual disk (drives the first Set)")
+}


### PR DESCRIPTION
## Problem

The `hyperv.vm` module manages a VM's VHD **home directory** (`#2411 convergeStorageLocation` keys on `vmHomeDir`), never the file's leaf name — and `Rename-VM` does **not** rename the VHD. So after a declarative rename (`old_name → name`, #2776), the on-disk leaf still tracks the *old* name (`cfgms-ci-01.vhdx`) while a declared `vhd_path` whose leaf tracks the *new* name (`lab-01.vhdx`) points at the **same directory**.

The generic drift comparator compares the full `vhd_path` string, so it drifts every convergence cycle on a leaf-name difference the module never reconciles — holding the resource at a permanent non-compliant / `ERROR` status. (Observed live on the renamed lab VMs once the `old_name` drift was cleared: `changed_fields: ["vhd_path"]` forever.)

## Fix

`getVM` now echoes the desired `vhd_path` on its Get surface **when the observed disk already lives in the desired home directory** — mirroring the existing `checkpoints` (#2627) and `ConfigLocation` (#2411) echo patterns:

- **Directory compliant** → echo the desired path → matches desired → no drift.
- **Wrong directory** → echo empty → report the actual path → `storageLocationDrift` fires and `convergeStorageLocation` moves the VM (real storage drift preserved).

The desired path is recorded per-VM by `setVM` (keyed + mutex-guarded like `checkpointDesired`, since the factory shares one module instance per bundle). Until the first `Set` records it, `vhd_path` drifts (no echo) and drives that `Set` — the same convergence shape as the checkpoints echo.

## Tests

`vm_vhdpath_echo_test.go`: directory-compliant → echo (no drift); wrong directory → actual reported (storage drift surfaces); no desired recorded yet → actual reported (drives first Set). Full `features/modules/hyperv` package passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)