### PR TITLE
pipeline: fix po-live silent launch failure on a skip-worktree .mcp.json

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -1073,7 +1073,22 @@ case "$cmd" in
       for a in "$@"; do
         escaped+=" $(printf '%q' "$a")"
       done
-      exec tmux split-window -h "POLIVE_INNER=1 $0 po-live${escaped}"
+      # `tmux split-window` exits 0 for *creating the pane*, not for the command
+      # inside it surviving. A pane whose command dies immediately is closed by
+      # tmux, so a failed launch used to report success with nothing running.
+      # Capture the pane id, keep a dead pane visible so its error survives, and
+      # verify the pane still exists before claiming the session started.
+      pane=$(tmux split-window -h -P -F '#{pane_id}' \
+        "POLIVE_INNER=1 $0 po-live${escaped}") || exit 1
+      tmux set-option -p -t "$pane" remain-on-exit on 2>/dev/null || true
+      sleep 2
+      if ! tmux list-panes -a -F '#{pane_id}' | grep -qx "$pane"; then
+        echo "ERROR: po-live pane exited immediately — the container never started." >&2
+        echo "       Re-run the inner path to see the failure:" >&2
+        echo "         POLIVE_INNER=1 $0 po-live${escaped}" >&2
+        exit 1
+      fi
+      exit 0
     fi
 
     if [[ -z "$TMUX" && -z "${POLIVE_INNER:-}" ]]; then
@@ -1116,6 +1131,23 @@ case "$cmd" in
       echo "Refreshing po-live workspace to a clean, up-to-date develop..."
       git -C "$clone_dir" fetch --quiet origin develop \
         || echo "  ! warning: fetch of origin/develop failed; refreshing against last-known origin/develop" >&2
+      # Clear skip-worktree / assume-unchanged before inspecting the tree.
+      # `.devcontainer/scripts/setup-env.sh` marks `.mcp.json` skip-worktree so
+      # its per-container rewrite doesn't dirty every agent's clone. That hides
+      # the file from `status --porcelain`, so the stash below never fired and
+      # the checkout then refused with "local changes would be overwritten" —
+      # a silent, permanent break of every fresh po-live session. Clearing the
+      # bits first lets the existing stash-then-checkout path see the truth and
+      # preserve the content instead of discarding it.
+      # In `ls-files -v`, `S` marks skip-worktree and a LOWERCASE tag marks
+      # assume-unchanged; `H` is an ordinary cached file, so it must not match.
+      # The two --no-* flags MUST be separate invocations: passing both in one
+      # `update-index` call exits 0 and silently applies neither (verified —
+      # the S bit survives), which is exactly how this stayed broken.
+      git -C "$clone_dir" ls-files -v 2>/dev/null | awk '/^S / {print $2}' \
+        | xargs -r git -C "$clone_dir" update-index --no-skip-worktree || true
+      git -C "$clone_dir" ls-files -v 2>/dev/null | awk '/^[[:lower:]] / {print $2}' \
+        | xargs -r git -C "$clone_dir" update-index --no-assume-unchanged || true
       if [[ -n "$(git -C "$clone_dir" status --porcelain 2>/dev/null)" ]]; then
         stash_label="po-live-autobackup-$(date -u +%Y%m%dT%H%M%SZ)"
         if git -C "$clone_dir" stash push -u -m "$stash_label" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Fresh `po-live` sessions were failing on **every** invocation, and the failure was invisible — the launcher reported **exit 0** while starting no container and leaving no pane. Two independent defects combined.

## Defect 1 — the workspace refresh aborted

`.devcontainer/scripts/setup-env.sh:65` marks `.mcp.json` **skip-worktree** so its per-container rewrite doesn't dirty every agent's clone. That flag also hides the file from `git status --porcelain` — so the refresh's stash branch, which is gated on status being non-empty, **never fired**. `git checkout -B develop origin/develop` then refused:

```
error: Your local changes to the following files would be overwritten by checkout:
	.mcp.json
```

and the launch died.

## Defect 2 — the failure was silent

The outer path ran `exec tmux split-window -h "..."`. **tmux exits 0 for creating a pane**, not for the command inside it surviving. tmux then closes the pane whose command died — leaving exit 0, no pane, and no error text anywhere. This caused two consecutive false "session launched" reports before anyone checked `docker ps`.

## Two traps found while smoke-testing the fix

Both are recorded in the code comments, because each looked correct and silently was not:

- **`git update-index --no-skip-worktree --no-assume-unchanged <path>` exits 0 and applies NEITHER flag** — the `S` bit survives. They must be separate invocations. The first draft of this fix used one combined call and reproduced the original failure exactly.
- **In `git ls-files -v`, `H` marks an ordinary cached file**, not a flagged one. An `/^[SH] /` match selects every tracked file in the repo.

## Changes

- **Workspace refresh**: clear skip-worktree and assume-unchanged (two separate `update-index` passes) before the status check, so the existing stash-then-checkout path sees the real tree state and **preserves** content. Deliberately not `checkout -f` / `reset --hard`, which would discard and violate the block's stated stash-not-destroy contract.
- **Launcher**: capture the pane id via `split-window -P -F '#{pane_id}'`, set `remain-on-exit` so a dying inner command leaves its error on screen, verify the pane still exists, and exit non-zero when it does not.

## Testing

Reconstructed the exact failure state in the shared po-live clone — `.mcp.json` modified with a sentinel value **and** flagged skip-worktree, so `status --porcelain` reported clean.

| | Result |
|---|---|
| Before | refresh aborted on the checkout |
| After | `Stashed uncommitted changes as 'po-live-autobackup-20260719T230547Z'` |
| Stashes created | 1 |
| Sentinel recoverable from `stash@{0}` | yes |
| Sentinel remaining in worktree | no |
| HEAD | advanced to current develop |

The inner path then proceeds to `docker run` and stops only at the expected TTY check when run outside a tmux pane. `bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5e2oETfBbpBFadKkjY8B