### PR TITLE
pipeline: resolve pipeline-helper from repo root in epic-review remediation

### DIFF
--- a/.claude/skills/epic-review/SKILL.md
+++ b/.claude/skills/epic-review/SKILL.md
@@ -187,7 +187,14 @@ EOF
 # Remediation is repo-artifact dev work → a PRIVATE project draft under the epic,
 # never a public issue. create-story returns CREATED_DRAFT:<item_id> at Draft
 # status (Tech Lead validates before it becomes Ready/dispatchable).
-/workspace/scripts/pipeline-helper.sh create-story <epic_num> \
+#
+# Resolve the helper from the repo root so this works in BOTH the container
+# (repo at /workspace) and a host session (repo elsewhere). Do NOT hardcode
+# /workspace — on the host that path does not exist, so this branch dies with
+# "No such file or directory" and the epic's remediation is silently never
+# drafted. Same rule as pipeline-sweep's Phase 2.
+HELPER="$(git rev-parse --show-toplevel)/scripts/pipeline-helper.sh"
+"$HELPER" create-story <epic_num> \
   "remediation: <shortened epic title> — <one-line gap>" \
   /tmp/epic-remediation-<N>.md
 ```


### PR DESCRIPTION
## Summary

The epic-review skill's Phase 4 FAIL branch invoked `/workspace/scripts/pipeline-helper.sh create-story` by **absolute path**. That path exists only inside an agent container; in a host session — which is where `/po cron` runs the sweep — it does not. The branch dies with "No such file or directory" and the remediation story for a failing epic is **never drafted**.

The failure is silent in the way that matters: Phase 4 is only reached when an epic's sub-issues are all closed **and** its AC verification FAILS. So the one case this code exists to handle is the one case it cannot complete.

`pipeline-sweep`'s Phase 2 already carries this exact warning and resolves via `git rev-parse --show-toplevel`. epic-review now matches.

## Scope and honesty about the hang

This branch has **never executed**. Sweep run 18 (2026-07-19) was the first to reach Phase 3 at all, and its verdict was PASS, so Phase 4 took the close path. This is a latent bug found by inspection, not one observed failing.

**It is not the cause of the 3.8-hour sweep hang** and should not be recorded as such — a missing interpreter path fails in milliseconds, it does not block for hours. At most it is a plausible *trigger* for an agent flailing after an unexpected error. The hang remains unexplained, and Phase 4's FAIL branch remains unexercised.

## Changes

- `.claude/skills/epic-review/SKILL.md`: resolve the helper via `git rev-parse --show-toplevel`, with a comment naming the container-vs-host failure mode

## Testing

Documentation-only change to a skill — no code path altered, and no test covers skill prose. Verified by grep that no other hardcoded `/workspace` invocation remains anywhere under `.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5e2oETfBbpBFadKkjY8B