### PR TITLE
web: task-manager tab on the asset page (Issue #2766)

### DIFF
--- a/docs/design/web-ui-design-system.md
+++ b/docs/design/web-ui-design-system.md
@@ -139,6 +139,12 @@ assembled answer; any card can be peeled back to raw telemetry for deeper tiers.
   the `soon` badge and a short label; they do not throw or navigate.
   Back-navigation is a breadcrumb `Fleet / {hostname}` above the `<h1>`;
   the browser's own back button and the link both return to `/`.
+- **Sortable data table** (Story #2766; convention established in `FleetTable.tsx`) —
+  click any `<th>` to sort by that column; a second click on the same header reverses
+  direction. Sort state is `{ key: string; direction: 1 | -1 }` (from `FleetTable.tsx`)
+  where `direction=1` is ascending and `direction=-1` is descending. The active column
+  carries `aria-sort="ascending"|"descending"` on the `<th>` (no attribute when inactive)
+  and a `sort` CSS class. All sort interactions remain client-side — no re-fetch on sort.
 
 ---
 

--- a/web/src/fleet/LiveActivityTab.test.tsx
+++ b/web/src/fleet/LiveActivityTab.test.tsx
@@ -41,7 +41,7 @@ class FakeWebSocket {
     this.onopen?.(new Event('open'))
   }
 
-  send(_: string) {
+  send() {
     // browser → server direction; ignored in these tests
   }
 

--- a/web/src/fleet/LiveActivityTab.test.tsx
+++ b/web/src/fleet/LiveActivityTab.test.tsx
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * LiveActivityTab suite (Story #2766): WebSocket lifecycle, process table
+ * sorting, service list, disconnect/403 error states.
+ *
+ * WebSocket is stubbed at the global level; every test verifies observable
+ * DOM behaviour, not internal state.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, act } from '@testing-library/react'
+import LiveActivityTab from './LiveActivityTab.tsx'
+
+// ---------------------------------------------------------------------------
+// WebSocket stub
+// ---------------------------------------------------------------------------
+
+interface WSMessage {
+  data: string
+}
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+
+  url: string
+  readyState: number = WebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onmessage: ((ev: WSMessage) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  closed = false
+
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = WebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  send(_: string) {
+    // browser → server direction; ignored in these tests
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    this.readyState = WebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close', { code: 1000 }))
+  }
+
+  deliver(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) })
+  }
+
+  closeWithCode(code: number, reason?: string) {
+    this.closed = true
+    this.readyState = WebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close', { code, reason }))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot helpers
+// ---------------------------------------------------------------------------
+
+function makeSnapshot(overrides?: Partial<{
+  processes: unknown[]
+  services: unknown[]
+}>) {
+  return {
+    type: 'snapshot',
+    steward_id: 'stw-test',
+    processes: overrides?.processes ?? [
+      { pid: 1, name: 'init', cpu_percent: 0.1, memory_bytes: 4096, disk_read_bytes: 0, disk_write_bytes: 0, net_rx_bytes: 0, net_tx_bytes: 0 },
+      { pid: 42, name: 'nginx', cpu_percent: 3.5, memory_bytes: 52428800, disk_read_bytes: 1024, disk_write_bytes: 512, net_rx_bytes: 0, net_tx_bytes: 0 },
+      { pid: 99, name: 'postgres', cpu_percent: 12.0, memory_bytes: 209715200, disk_read_bytes: 4096, disk_write_bytes: 2048, net_rx_bytes: 0, net_tx_bytes: 0 },
+    ],
+    services: overrides?.services ?? [
+      { name: 'nginx', state: 'running' },
+      { name: 'sshd', state: 'running' },
+      { name: 'cron', state: 'stopped' },
+    ],
+    timestamp: '2026-07-20T10:00:00Z',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let origWebSocket: typeof WebSocket
+
+beforeEach(() => {
+  FakeWebSocket.instances = []
+  origWebSocket = globalThis.WebSocket
+  // @ts-expect-error intentional stub
+  globalThis.WebSocket = FakeWebSocket
+})
+
+afterEach(() => {
+  globalThis.WebSocket = origWebSocket
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Connection lifecycle
+// ---------------------------------------------------------------------------
+
+describe('WebSocket lifecycle', () => {
+  it('opens a WebSocket connection on mount', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(FakeWebSocket.instances[0]!.url).toContain('stw-001')
+  })
+
+  it('uses the correct telemetry endpoint URL', () => {
+    render(<LiveActivityTab stewardId="stw-007" />)
+    const ws = FakeWebSocket.instances[0]!
+    expect(ws.url).toMatch(/\/api\/v1\/telemetry\/ws\/stw-007$/)
+  })
+
+  it('closes the WebSocket on unmount', () => {
+    const { unmount } = render(<LiveActivityTab stewardId="stw-001" />)
+    const ws = FakeWebSocket.instances[0]!
+    expect(ws.closed).toBe(false)
+    unmount()
+    expect(ws.closed).toBe(true)
+  })
+
+  it('does not open a second connection if already mounted', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('reconnects if stewardId prop changes', () => {
+    const { rerender } = render(<LiveActivityTab stewardId="stw-001" />)
+    const first = FakeWebSocket.instances[0]!
+    rerender(<LiveActivityTab stewardId="stw-002" />)
+    expect(first.closed).toBe(true)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect(FakeWebSocket.instances[1]!.url).toContain('stw-002')
+  })
+
+  it('shows a loading indicator before the first snapshot arrives', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    expect(screen.getByTestId('live-loading')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Process table rendering
+// ---------------------------------------------------------------------------
+
+describe('process table', () => {
+  function setup(stewardId = 'stw-001') {
+    render(<LiveActivityTab stewardId={stewardId} />)
+    const ws = FakeWebSocket.instances[0]!
+    act(() => {
+      ws.open()
+      ws.deliver(makeSnapshot())
+    })
+    return ws
+  }
+
+  it('renders a process table with CPU, memory, disk, and network columns', () => {
+    setup()
+    expect(screen.getByRole('table', { name: /processes/i })).toBeInTheDocument()
+    const headers = screen.getAllByRole('columnheader')
+    const headerText = headers.map((h) => h.textContent?.toLowerCase() ?? '')
+    expect(headerText.some((t) => t.includes('cpu'))).toBe(true)
+    expect(headerText.some((t) => t.includes('mem'))).toBe(true)
+    expect(headerText.some((t) => t.includes('disk'))).toBe(true)
+    expect(headerText.some((t) => t.includes('net'))).toBe(true)
+  })
+
+  it('renders process names in the table', () => {
+    setup()
+    // nginx appears in both process and service lists; getAllByText handles multiple matches
+    expect(screen.getAllByText('nginx').length).toBeGreaterThan(0)
+    expect(screen.getByText('postgres')).toBeInTheDocument()
+  })
+
+  it('updates in place when a new snapshot arrives', () => {
+    const ws = setup()
+    act(() => {
+      ws.deliver(makeSnapshot({
+        processes: [
+          { pid: 1, name: 'updated-proc', cpu_percent: 99.9, memory_bytes: 1024, disk_read_bytes: 0, disk_write_bytes: 0, net_rx_bytes: 0, net_tx_bytes: 0 },
+        ],
+        services: [],
+      }))
+    })
+    expect(screen.getByText('updated-proc')).toBeInTheDocument()
+    expect(screen.queryByText('nginx')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Process table sorting
+// ---------------------------------------------------------------------------
+
+describe('process table sorting', () => {
+  function deliverSnapshot() {
+    const ws = FakeWebSocket.instances[0]!
+    act(() => {
+      ws.open()
+      ws.deliver(makeSnapshot())
+    })
+  }
+
+  it('sorts by CPU descending when CPU header is clicked', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    deliverSnapshot()
+
+    const cpuHeader = screen.getByRole('columnheader', { name: /cpu/i })
+    fireEvent.click(cpuHeader)
+
+    const rows = screen.getAllByRole('row').slice(1) // skip header
+    const names = rows.map((r) => r.querySelector('td')?.textContent ?? '')
+    expect(names[0]).toBe('postgres') // 12.0%
+    expect(names[1]).toBe('nginx')    // 3.5%
+    expect(names[2]).toBe('init')     // 0.1%
+  })
+
+  it('reverses sort direction on second click of the same column', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    deliverSnapshot()
+
+    const cpuHeader = screen.getByRole('columnheader', { name: /cpu/i })
+    fireEvent.click(cpuHeader)
+    fireEvent.click(cpuHeader)
+
+    const rows = screen.getAllByRole('row').slice(1)
+    const names = rows.map((r) => r.querySelector('td')?.textContent ?? '')
+    expect(names[0]).toBe('init')     // 0.1% — ascending
+  })
+
+  it('sorts by memory when memory header is clicked', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    deliverSnapshot()
+
+    const memHeader = screen.getByRole('columnheader', { name: /mem/i })
+    fireEvent.click(memHeader)
+
+    const rows = screen.getAllByRole('row').slice(1)
+    const names = rows.map((r) => r.querySelector('td')?.textContent ?? '')
+    expect(names[0]).toBe('postgres') // 200 MB
+  })
+
+  it('applies aria-sort attribute on the active sort column', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    deliverSnapshot()
+
+    const cpuHeader = screen.getByRole('columnheader', { name: /cpu/i })
+    fireEvent.click(cpuHeader)
+
+    expect(cpuHeader).toHaveAttribute('aria-sort', 'descending')
+    fireEvent.click(cpuHeader)
+    expect(cpuHeader).toHaveAttribute('aria-sort', 'ascending')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Service list
+// ---------------------------------------------------------------------------
+
+describe('service list', () => {
+  it('renders a service list with name and state', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    const ws = FakeWebSocket.instances[0]!
+    act(() => {
+      ws.open()
+      ws.deliver(makeSnapshot())
+    })
+
+    expect(screen.getByText('sshd')).toBeInTheDocument()
+    expect(screen.getByText('cron')).toBeInTheDocument()
+    // state values are present
+    const runningCells = screen.getAllByText('running')
+    expect(runningCells.length).toBeGreaterThan(0)
+    expect(screen.getByText('stopped')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error states
+// ---------------------------------------------------------------------------
+
+describe('error states', () => {
+  it('shows a clear denied error state on WebSocket close with code 4403', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    const ws = FakeWebSocket.instances[0]!
+    act(() => {
+      ws.closeWithCode(4403, 'forbidden')
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent?.toLowerCase()).toMatch(/denied|forbidden|permission/i)
+  })
+
+  it('shows a disconnect error state when the steward goes offline', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    const ws = FakeWebSocket.instances[0]!
+    act(() => {
+      ws.open()
+      ws.deliver({ type: 'disconnect', reason: 'steward disconnected' })
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent?.toLowerCase()).toMatch(/offline|disconnect/i)
+  })
+
+  it('shows a connection error when WebSocket closes unexpectedly', () => {
+    render(<LiveActivityTab stewardId="stw-001" />)
+    const ws = FakeWebSocket.instances[0]!
+    act(() => {
+      ws.open()
+      ws.closeWithCode(1006, '')
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toBeInTheDocument()
+  })
+})

--- a/web/src/fleet/LiveActivityTab.tsx
+++ b/web/src/fleet/LiveActivityTab.tsx
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * LiveActivityTab (Story #2766) — real-time process table and service list for
+ * one steward, streamed from /api/v1/telemetry/ws/{id}.
+ *
+ * Lifecycle: the WebSocket opens on mount and closes on unmount, implementing
+ * the connect-on-open/disconnect-on-close discipline that makes the upstream
+ * fan-out chain (steward → controller → browser) actually collect-only-while-
+ * watched in practice.
+ *
+ * Network column caveat: NetRxBytes/NetTxBytes are structurally present in
+ * the wire format but the collector never populates them (usermode-only;
+ * reserved for a future kernel-assisted story). They are always 0 today.
+ *
+ * Sort convention: reuses the SortState shape from FleetTable.tsx
+ * ({ key, direction: 1|-1 }) and the click-header-to-sort interaction with
+ * aria-sort on the active column.
+ *
+ * ADR-018: same-origin cookie auth — no token handling in JS.
+ * No client-side RBAC: render a clear denied state on close code 4403.
+ */
+import { useEffect, useReducer, useRef } from 'react'
+import type { SortState } from './FleetTable.tsx'
+
+// ---------------------------------------------------------------------------
+// Wire types (matches telemetry_handler.go JSON serialisation)
+// ---------------------------------------------------------------------------
+
+interface ProcessSnapshot {
+  pid: number
+  name: string
+  cpu_percent: number
+  memory_bytes: number
+  disk_read_bytes: number
+  disk_write_bytes: number
+  net_rx_bytes: number
+  net_tx_bytes: number
+}
+
+interface ServiceSnapshot {
+  name: string
+  state: string
+}
+
+interface TelemetrySnapshotMessage {
+  type: 'snapshot'
+  steward_id: string
+  processes: ProcessSnapshot[]
+  services: ServiceSnapshot[]
+  timestamp?: string
+}
+
+interface DisconnectMessage {
+  type: 'disconnect'
+  reason?: string
+}
+
+type TelemetryMessage = TelemetrySnapshotMessage | DisconnectMessage
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+type ErrorKind = 'denied' | 'offline' | 'connection'
+
+interface TabState {
+  loading: boolean
+  error: { kind: ErrorKind; detail?: string } | null
+  processes: ProcessSnapshot[]
+  services: ServiceSnapshot[]
+  sort: SortState
+}
+
+type TabAction =
+  | { type: 'snapshot'; processes: ProcessSnapshot[]; services: ServiceSnapshot[] }
+  | { type: 'disconnect' }
+  | { type: 'denied'; detail?: string }
+  | { type: 'connection-error' }
+  | { type: 'sort'; key: string }
+
+const initialState: TabState = {
+  loading: true,
+  error: null,
+  processes: [],
+  services: [],
+  // Initial sort on 'name' so the first click on any numeric column defaults to descending.
+  sort: { key: 'name', direction: 1 },
+}
+
+function reducer(state: TabState, action: TabAction): TabState {
+  switch (action.type) {
+    case 'snapshot':
+      return { ...state, loading: false, error: null, processes: action.processes, services: action.services }
+    case 'disconnect':
+      return { ...state, loading: false, error: { kind: 'offline' } }
+    case 'denied':
+      return { ...state, loading: false, error: { kind: 'denied', detail: action.detail } }
+    case 'connection-error':
+      return { ...state, loading: false, error: { kind: 'connection' } }
+    case 'sort': {
+      const sameKey = state.sort.key === action.key
+      return {
+        ...state,
+        sort: {
+          key: action.key,
+          direction: sameKey ? (state.sort.direction === -1 ? 1 : -1) : -1,
+        },
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sort helpers
+// ---------------------------------------------------------------------------
+
+function readSortValue(proc: ProcessSnapshot, key: string): number | string {
+  switch (key) {
+    case 'pid': return proc.pid
+    case 'name': return proc.name
+    case 'cpu_percent': return proc.cpu_percent
+    case 'memory_bytes': return proc.memory_bytes
+    case 'disk_read_bytes': return proc.disk_read_bytes
+    case 'disk_write_bytes': return proc.disk_write_bytes
+    case 'net_rx_bytes': return proc.net_rx_bytes
+    case 'net_tx_bytes': return proc.net_tx_bytes
+    default: return 0
+  }
+}
+
+function sortProcesses(procs: ProcessSnapshot[], sort: SortState): ProcessSnapshot[] {
+  return [...procs].sort((a, b) => {
+    const av = readSortValue(a, sort.key)
+    const bv = readSortValue(b, sort.key)
+    if (typeof av === 'string' && typeof bv === 'string') {
+      return sort.direction * av.localeCompare(bv)
+    }
+    // Numeric columns: direction=1 → ascending, direction=-1 → descending.
+    // Matches FleetTable convention: direction > 0 = ascending.
+    return sort.direction * ((av as number) - (bv as number))
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+function fmtBytes(n: number): string {
+  if (n === 0) return '0'
+  const thresholds: [number, string][] = [
+    [1024 * 1024 * 1024, 'GB'],
+    [1024 * 1024, 'MB'],
+    [1024, 'KB'],
+  ]
+  for (const [threshold, label] of thresholds) {
+    if (n >= threshold) return `${(n / threshold).toFixed(1)} ${label}`
+  }
+  return `${n} B`
+}
+
+function fmtCPU(n: number): string {
+  return `${n.toFixed(1)}%`
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function SortArrow({ active, direction }: { active: boolean; direction: 1 | -1 }) {
+  if (!active) return <span className="ar" aria-hidden="true">▼</span>
+  return (
+    <span className="ar" aria-hidden="true">
+      {direction < 0 ? '▲' : '▼'}
+    </span>
+  )
+}
+
+interface ProcessTableProps {
+  processes: ProcessSnapshot[]
+  sort: SortState
+  onSort: (key: string) => void
+}
+
+function ProcessTable({ processes, sort, onSort }: ProcessTableProps) {
+  const sorted = sortProcesses(processes, sort)
+
+  const cols: { key: string; label: string; fmt: (p: ProcessSnapshot) => string }[] = [
+    { key: 'name', label: 'Name', fmt: (p) => p.name },
+    { key: 'pid', label: 'PID', fmt: (p) => String(p.pid) },
+    { key: 'cpu_percent', label: 'CPU', fmt: (p) => fmtCPU(p.cpu_percent) },
+    { key: 'memory_bytes', label: 'Mem', fmt: (p) => fmtBytes(p.memory_bytes) },
+    { key: 'disk_read_bytes', label: 'Disk R', fmt: (p) => fmtBytes(p.disk_read_bytes) },
+    { key: 'disk_write_bytes', label: 'Disk W', fmt: (p) => fmtBytes(p.disk_write_bytes) },
+    { key: 'net_rx_bytes', label: 'Net RX', fmt: (p) => fmtBytes(p.net_rx_bytes) },
+    { key: 'net_tx_bytes', label: 'Net TX', fmt: (p) => fmtBytes(p.net_tx_bytes) },
+  ]
+
+  return (
+    <table className="tbl" aria-label="Processes">
+      <thead>
+        <tr>
+          {cols.map((col) => {
+            const active = sort.key === col.key
+            return (
+              <th
+                key={col.key}
+                className={`c-${col.key}${active ? ' sort' : ''}`}
+                aria-sort={
+                  active
+                    ? sort.direction > 0
+                      ? 'ascending'
+                      : 'descending'
+                    : undefined
+                }
+                onClick={() => onSort(col.key)}
+              >
+                {col.label}
+                <SortArrow active={active} direction={sort.direction} />
+              </th>
+            )
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((proc) => (
+          <tr key={`${proc.pid}-${proc.name}`}>
+            {cols.map((col) => (
+              <td key={col.key} className={`c-${col.key}`}>
+                <span className="mono2">{col.fmt(proc)}</span>
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function stateClass(s: string): string {
+  switch (s.toLowerCase()) {
+    case 'running':
+    case 'active':
+      return 'ok'
+    case 'stopped':
+    case 'inactive':
+    case 'dead':
+      return 'neutral'
+    case 'failed':
+    case 'error':
+      return 'crit'
+    default:
+      return 'neutral'
+  }
+}
+
+interface ServiceListProps {
+  services: ServiceSnapshot[]
+}
+
+function ServiceList({ services }: ServiceListProps) {
+  return (
+    <table className="tbl" aria-label="Services">
+      <thead>
+        <tr>
+          <th>Service</th>
+          <th>State</th>
+        </tr>
+      </thead>
+      <tbody>
+        {services.map((svc) => (
+          <tr key={svc.name}>
+            <td><span className="nm">{svc.name}</span></td>
+            <td>
+              <span className={`pill ${stateClass(svc.state)}`}>
+                <span className="dot" />
+                {svc.state}
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface LiveActivityTabProps {
+  stewardId: string
+}
+
+export default function LiveActivityTab({ stewardId }: LiveActivityTabProps) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const wsRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const url = `${proto}//${location.host}/api/v1/telemetry/ws/${encodeURIComponent(stewardId)}`
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onmessage = (ev) => {
+      let msg: TelemetryMessage
+      try {
+        msg = JSON.parse(ev.data as string) as TelemetryMessage
+      } catch {
+        return
+      }
+      if (msg.type === 'snapshot') {
+        dispatch({ type: 'snapshot', processes: msg.processes, services: msg.services })
+      } else if (msg.type === 'disconnect') {
+        dispatch({ type: 'disconnect' })
+      }
+    }
+
+    ws.onclose = (ev) => {
+      if (ev.code === 4403) {
+        dispatch({ type: 'denied', detail: ev.reason })
+      } else if (ev.code !== 1000 && ev.code !== 1001) {
+        dispatch({ type: 'connection-error' })
+      }
+    }
+
+    return () => {
+      wsRef.current = null
+      ws.close()
+    }
+  }, [stewardId])
+
+  function onSort(key: string) {
+    dispatch({ type: 'sort', key })
+  }
+
+  if (state.error) {
+    const { kind } = state.error
+    let message: string
+    if (kind === 'denied') {
+      message = 'Permission denied. You do not have access to live telemetry for this device.'
+    } else if (kind === 'offline') {
+      message = 'Steward offline. The device disconnected from the controller.'
+    } else {
+      message = 'Connection lost. Unable to reach the telemetry stream.'
+    }
+    return (
+      <div role="alert" className="notice notice-error">
+        <p>{message}</p>
+      </div>
+    )
+  }
+
+  if (state.loading) {
+    return <div data-testid="live-loading" className="loading-skeleton">Loading live activity…</div>
+  }
+
+  return (
+    <div className="live-activity">
+      <section>
+        <h2>Processes</h2>
+        <ProcessTable processes={state.processes} sort={state.sort} onSort={onSort} />
+      </section>
+      <section>
+        <h2>Services</h2>
+        <ServiceList services={state.services} />
+      </section>
+    </div>
+  )
+}

--- a/web/src/fleet/StewardAssetPage.test.tsx
+++ b/web/src/fleet/StewardAssetPage.test.tsx
@@ -2,12 +2,15 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * StewardAssetPage suite (Story #2723): tab switching, inert-placeholder
- * rendering for Config/Shell/Live Activity, and DNA-tab content parity
- * with the pre-router DnaDrawer behavior.
+ * StewardAssetPage suite (Story #2723 + #2766): tab switching, inert-placeholder
+ * rendering for Config/Shell, DNA-tab content parity with the pre-router
+ * DnaDrawer behavior, and live tab mounts LiveActivityTab (Story #2766).
  *
  * The component reads :id from the route param; tests use MemoryRouter to
  * provide the steward ID without a real browser.
+ *
+ * WebSocket is stubbed so the LiveActivityTab panel does not attempt real
+ * network connections when the live tab is activated in tests.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
@@ -16,9 +19,24 @@ import StewardAssetPage, { PanelContent, TABS } from './StewardAssetPage.tsx'
 
 const fetchMock = vi.fn<typeof fetch>()
 
+// Minimal WebSocket stub — keeps LiveActivityPanel from throwing when the
+// live tab mounts during StewardAssetPage tests.
+class StubWebSocket {
+  readyState: number = WebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onclose: ((ev: { code: number }) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  close() {
+    this.readyState = WebSocket.CLOSED
+  }
+}
+
 beforeEach(() => {
   fetchMock.mockReset()
   vi.stubGlobal('fetch', fetchMock)
+  // @ts-expect-error intentional stub
+  vi.stubGlobal('WebSocket', StubWebSocket)
 })
 
 afterEach(() => {
@@ -87,7 +105,7 @@ describe('tab strip', () => {
     )
   })
 
-  it('inert tabs (Config, Shell, Live Activity) carry the soon badge text', () => {
+  it('inert tabs (Config, Shell) carry the soon badge text', () => {
     fetchMock.mockReturnValue(new Promise(() => {}))
     renderAssetPage()
 
@@ -122,12 +140,23 @@ describe('tab strip', () => {
     expect(screen.getByRole('tabpanel').textContent).toContain('Shell')
   })
 
-  it('clicking Live Activity shows a coming-soon placeholder', () => {
+  it('clicking Live Activity mounts LiveActivityTab (not a SoonPanel)', () => {
     fetchMock.mockReturnValue(new Promise(() => {}))
     renderAssetPage()
 
     fireEvent.click(screen.getByRole('tab', { name: /^Live Activity/i }))
-    expect(screen.getByRole('tabpanel').textContent).toContain('Live Activity')
+
+    // LiveActivityTab renders a loading indicator, not the "soon" placeholder.
+    expect(screen.getByTestId('live-loading')).toBeInTheDocument()
+    expect(screen.queryByText(/Live Activity is not yet available/i)).not.toBeInTheDocument()
+  })
+
+  it('Live Activity tab has no soon badge', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderAssetPage()
+
+    const liveTab = screen.getByRole('tab', { name: /^Live Activity/i })
+    expect(within(liveTab).queryByText(/soon/i)).not.toBeInTheDocument()
   })
 
   it('clicking back to DNA after an inert tab restores DNA content', async () => {

--- a/web/src/fleet/StewardAssetPage.test.tsx
+++ b/web/src/fleet/StewardAssetPage.test.tsx
@@ -35,7 +35,6 @@ class StubWebSocket {
 beforeEach(() => {
   fetchMock.mockReset()
   vi.stubGlobal('fetch', fetchMock)
-  // @ts-expect-error intentional stub
   vi.stubGlobal('WebSocket', StubWebSocket)
 })
 

--- a/web/src/fleet/StewardAssetPage.tsx
+++ b/web/src/fleet/StewardAssetPage.tsx
@@ -21,6 +21,7 @@
 import { type ComponentType, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import DnaDrawer from './DnaDrawer.tsx'
+import LiveActivityTab from './LiveActivityTab.tsx'
 
 type TabKey = 'dna' | 'config' | 'shell' | 'live'
 
@@ -31,11 +32,16 @@ interface TabSpec {
   Panel?: ComponentType
 }
 
+function LiveActivityPanel() {
+  const { id: stewardId = '' } = useParams<{ id: string }>()
+  return <LiveActivityTab stewardId={stewardId} />
+}
+
 export const TABS: readonly TabSpec[] = [
   { key: 'dna', label: 'DNA', soon: false, Panel: DnaDrawer },
   { key: 'config', label: 'Config', soon: true },
   { key: 'shell', label: 'Shell', soon: true },
-  { key: 'live', label: 'Live Activity', soon: true },
+  { key: 'live', label: 'Live Activity', soon: false, Panel: LiveActivityPanel },
 ]
 
 function SoonPanel({ label }: { label: string }) {


### PR DESCRIPTION
## Summary

- Implements the Live Activity tab on the steward asset page, replacing the `soon` placeholder with a real-time process table + service list streaming from the #2765 telemetry WebSocket endpoint (`/api/v1/telemetry/ws/{id}`)
- New `LiveActivityTab` component: opens WebSocket on mount, closes on unmount; sortable process table (CPU/mem/disk/net) using `SortState` convention from `FleetTable.tsx`; service list with state pills; loading/denied/offline/connection-error states
- `StewardAssetPage` flips `live` tab's `soon: false`, adds thin `LiveActivityPanel` wrapper (reads `stewardId` from `useParams`, same pattern as `DnaDrawer`)
- 17 new tests in `LiveActivityTab.test.tsx` cover lifecycle, sort, service list, and all error states; `StewardAssetPage.test.tsx` updated to verify live tab is no longer `soon` and mounts `LiveActivityTab`
- `docs/design/web-ui-design-system.md` §4 updated with sortable-table pattern documentation

Fixes #2766

## Specialist Review Results

- **Code Review**: PASS (0 findings)
- **Test Quality**: PASS (0 findings)
- **Security**: PASS (0 findings)

All three lenses passed in round 1 with no fix rounds required.

## Test plan

- [ ] `make test-agent-complete` passes locally (all 434 web tests pass, all Go tests pass, lint clean)
- [ ] CI required checks pass: `unit-tests`, `integration-tests`, `Build Gate`, `security-deployment-gate`
- [ ] Live Activity tab opens with a loading skeleton, then shows process/service tables once WebSocket delivers a snapshot
- [ ] Clicking a column header sorts; second click reverses; `aria-sort` attribute updates correctly
- [ ] Navigating away from the Live Activity tab closes the WebSocket (verified via test suite)
- [ ] Network column renders but shows 0 (expected per collector limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)