### PR TITLE
telemetry: suppress in-flight snapshot after unsubscribe on slow platforms (Issue #2825)

### DIFF
--- a/features/steward/client/telemetry_stream.go
+++ b/features/steward/client/telemetry_stream.go
@@ -227,6 +227,23 @@ func (t *TelemetryStream) runStream(ctx context.Context, stop <-chan struct{}) e
 				t.logger.Warn("TelemetryStream: Snapshot failed", "error", err)
 				continue
 			}
+			// Check again for a control message that arrived while Snapshot()
+			// was in flight. On slow platforms (e.g. cold Windows CI), Snapshot()
+			// can take hundreds of milliseconds — long enough for the controller's
+			// unsubscribe to arrive and be queued in recvCh during the collection.
+			// If unsubscribe arrived, suppress this result; the controller has
+			// signalled it no longer wants snapshots. This is a production-contract
+			// fix: "stop" means stop, even for an already-started collection.
+			select {
+			case req := <-recvCh:
+				ticker, tickCh = applyTelemetryControl(req, ticker, tickCh)
+				if ticker == nil {
+					// Unsubscribe arrived during collection: drop the stale result.
+					continue
+				}
+				// Re-subscribe arrived during collection: fall through to send.
+			default:
+			}
 			pb := telemetryToProto(snap, t.stewardID)
 			if sendErr := stream.Send(pb); sendErr != nil {
 				return sendErr


### PR DESCRIPTION
## Summary

Fixes `TestTelemetryStream_NoSnapshotAfterUnsubscribe` flaking on `windows-latest`
in merge groups. Root cause is a second race distinct from the one fixed by PR #2778.

## Root cause analysis

**PR #2778's fix** added a pre-collection priority check: before calling `Snapshot()`,
the send loop non-blocking-reads `recvCh` to detect an unsubscribe that arrived in the
same scheduling window as the tick. That fix is correct and complete for its scope.

**The second race (in-flight collection):**

1. Tick fires; pre-check finds `recvCh` empty — the unsubscribe hasn't arrived yet.
2. `Snapshot()` begins. On cold Windows CI (first COM/WMI/SCM call), this takes
   800 ms or more.
3. While `Snapshot()` is blocked: the server receives frame N, sends `subscribe=false`,
   and the network delivers it to `recvCh`.
4. `Snapshot()` returns. The old code proceeds directly to `stream.Send(pb)` — sending
   a stale snapshot after the controller already signalled "stop".
5. Server counts the frame in `snapshotsSentAfterUnsub` → assertion fires.

**Conclusion: #2778's fix was not incomplete — this is a second, independent race.**

## Fix

Added a non-blocking `recvCh` check *after* `Snapshot()` returns but *before*
`stream.Send()`. If unsubscribe arrived during the collection, the result is suppressed.
A re-subscribe during collection falls through to send (controller has re-opted-in).

This is a **production-contract fix**: unsubscribe means "send no more snapshots", even
for an already-started collection. Enforcing this at the production layer keeps the
test assertion strict at zero.

## Test assertion preserved

- 500 ms window: unchanged.
- No `t.Skip`, no build tag, no platform guard.
- No loosened assertion (`snapshotsSentAfterUnsub == 0` remains).
- Adversarial check: if `applyTelemetryControl` is a no-op for `subscribe=false`, the
  ticker never stops and frames accumulate past the window → test goes red.

## Specialist review results

- **Security review**: PASS — no central-provider violations, no unsanitized log inputs,
  no insecure defaults, no secrets. gosec/staticcheck/secret-scan all clean for the
  reviewed file.
- **QA/test quality review**: PASS — no mocks of CFGMS components, no unjustified
  `t.Skip`, no empty assertions, no `time.Sleep` synchronization, all production symbols
  exercised with substantive assertions.
- **Test suite** (`go test ./features/steward/client/...`): PASS (26.7 s on Linux).
- `make test-agent-complete`: exit 0.

Fixes #2825