### PR TITLE
session/middleware: silent WebAuthn continuity + IP-change downgrade (Issue #2788)

### DIFF
--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"sort"
@@ -305,7 +306,11 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 				// base64.RawURLEncoding of 32 bytes = 43 chars (no padding).
 				const sessionTokenLen = 43
 				if len(bearerToken) == sessionTokenLen {
-					sess, err := s.sessionManager.Validate(r.Context(), bearerToken)
+					// Pass source IP to Validate for IP-change detection (ADR-021 Decision 5).
+					// SplitHostPort extracts just the host; errors are ignored (empty host → no detection).
+					sourceIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+					validateCtx := session.WithSourceIP(r.Context(), sourceIP)
+					sess, err := s.sessionManager.Validate(validateCtx, bearerToken)
 					if err != nil {
 						switch {
 						case errors.Is(err, session.ErrSessionRevoked):
@@ -320,16 +325,19 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 					// Renew the session to reset idle TTL; set X-Session-Token when
 					// a new token is issued (empty string = prior-token grace path,
 					// no new token to publish). The raw new token is never logged.
-					_, newToken, renewErr := s.sessionManager.Renew(r.Context(), bearerToken)
+					_, newToken, renewErr := s.sessionManager.Renew(validateCtx, bearerToken)
 					if renewErr == nil && newToken != "" {
 						w.Header().Set("X-Session-Token", newToken)
 					}
-					// Build a Principal from session state.
+					// Build a Principal from session state. Assurance is read directly from
+					// the session so that IP-change downgrades (ADR-021 Decision 5) and future
+					// WebAuthn upgrades are reflected on every request rather than fixed at issuance.
 					sessionPrincipal := &Principal{
-						ID:          sess.PrincipalID,
-						Name:        "session:" + logging.SanitizeLogValue(sess.PrincipalID),
-						Assurance:   session.AssuranceBasic,
-						GlobalScope: true,
+						ID:           sess.PrincipalID,
+						Name:         "session:" + logging.SanitizeLogValue(sess.PrincipalID),
+						Assurance:    sess.Assurance,
+						LastProvenAt: sess.LastProvenAt,
+						GlobalScope:  true,
 						// TenantID mirrors the issuing admin cert; "" means no tenant scope
 						// (same semantics as extractAdminPrincipal for mTLS admin certs).
 						TenantID: sess.TenantID,
@@ -351,7 +359,10 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 		// is present, ensuring existing Bearer/API-key/mTLS clients are byte-identical.
 		if s.webSessionManager != nil && !hasHeaderCredentials(r) {
 			if cookie, cookieErr := r.Cookie("cfgms_session"); cookieErr == nil {
-				webSess, webErr := s.webSessionManager.Validate(r.Context(), cookie.Value)
+				// Pass source IP to Validate for IP-change detection (ADR-021 Decision 5).
+				webSourceIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+				webValidateCtx := session.WithSourceIP(r.Context(), webSourceIP)
+				webSess, webErr := s.webSessionManager.Validate(webValidateCtx, cookie.Value)
 				if webErr != nil {
 					switch {
 					case errors.Is(webErr, session.ErrSessionRevoked):
@@ -372,7 +383,7 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 				// If revocation races Validate→Renew within nanoseconds, the request still
 				// proceeds; the next request will be rejected by Validate. If stricter
 				// atomicity is needed, merge Validate and Renew into a single operation.
-				_, newToken, renewErr := s.webSessionManager.Renew(r.Context(), cookie.Value)
+				_, newToken, renewErr := s.webSessionManager.Renew(webValidateCtx, cookie.Value)
 				if renewErr == nil && newToken != "" {
 					http.SetCookie(w, &http.Cookie{
 						Name:     "cfgms_session",
@@ -384,12 +395,15 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 					})
 				}
 				// Build Principal mirroring the Bearer session path (the sessionPrincipal block above).
+				// Assurance and LastProvenAt are read from session state so that IP-change downgrades
+				// and future WebAuthn upgrades are reflected on every request (ADR-021 Decision 3/5).
 				webPrincipal := &Principal{
-					ID:          webSess.PrincipalID,
-					Name:        "web-session:" + logging.SanitizeLogValue(webSess.PrincipalID),
-					Assurance:   session.AssuranceBasic,
-					GlobalScope: true,
-					TenantID:    webSess.TenantID,
+					ID:           webSess.PrincipalID,
+					Name:         "web-session:" + logging.SanitizeLogValue(webSess.PrincipalID),
+					Assurance:    webSess.Assurance,
+					LastProvenAt: webSess.LastProvenAt,
+					GlobalScope:  true,
+					TenantID:     webSess.TenantID,
 				}
 				ctx := context.WithValue(r.Context(), principalContextKey, webPrincipal)
 				ctx = context.WithValue(ctx, ctxkeys.UserIDKey, logging.SanitizeLogValue(webSess.PrincipalID))

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -1383,3 +1383,186 @@ func TestWebSessionCookie_InvalidToken_Returns401(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code, "unknown cookie token must return 401")
 	assert.Contains(t, rec.Body.String(), "INVALID_SESSION_TOKEN")
 }
+
+// --- Session assurance propagation tests (ADR-021 Decision 3/5, Issue #2788) ---
+// The Bearer and cookie paths read sess.Assurance from the session returned by Manager.Validate
+// instead of hardcoding AssuranceBasic. These tests verify that both the upgrade path
+// (AssuranceStrong propagated to Principal) and the downgrade path (IP-change downgrade
+// reflected in Principal) are correctly wired through the middleware.
+
+// setupBearerSessionWithAssurance issues a session via mgrWrite, writes AssuranceStrong state
+// directly to the shared store (simulating a WebAuthn assertion handler), and returns the token.
+// mgrRead (cold cache) must be set as the server's sessionManager before making requests.
+func setupBearerSessionWithAssurance(t *testing.T, store *session.MemStore, mgrWrite session.Manager, boundIP string) string {
+	t.Helper()
+	sess, token, err := mgrWrite.Issue(context.Background(), "admin", "cfg-cli", "tenant-1")
+	require.NoError(t, err)
+	sess.Assurance = session.AssuranceStrong
+	sess.BoundIP = boundIP
+	sess.LastProvenAt = time.Now()
+	require.NoError(t, store.Set(context.Background(), session.HashToken(token), sess))
+	return token
+}
+
+// TestBearerSession_AssurancePropagatedToPrincipal verifies that authenticationMiddleware reads
+// sess.Assurance from Manager.Validate (ADR-021 Decision 3/5) and not a hardcoded value.
+//
+// (a) An AssuranceStrong session with a matching source IP must yield a Principal
+// with Assurance == AssuranceStrong.
+// (b) An AssuranceStrong session whose BoundIP differs from the request source IP is
+// downgraded by Manager.Validate to AssuranceBasic; the Principal must reflect that downgrade.
+func TestBearerSession_AssurancePropagatedToPrincipal(t *testing.T) {
+	// httptest.NewRequest sets RemoteAddr = "192.0.2.1:1234"; SplitHostPort → "192.0.2.1".
+	const httptestIP = "192.0.2.1"
+
+	t.Run("AssuranceStrong propagated when source IP matches bound IP", func(t *testing.T) {
+		cfg := session.DefaultConfig()
+		store := session.NewMemStore(cfg, time.Now)
+		t.Cleanup(store.Close)
+		mgrWrite := session.NewManager(cfg, store, time.Now)
+		mgrRead := session.NewManager(cfg, store, time.Now)
+
+		srv := setupTestServer(t)
+		srv.SetSessionManager(mgrRead)
+
+		token := setupBearerSessionWithAssurance(t, store, mgrWrite, httptestIP)
+
+		var capturedPrincipal *Principal
+		handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, capturedPrincipal)
+		assert.Equal(t, session.AssuranceStrong, capturedPrincipal.Assurance,
+			"AssuranceStrong session with matching IP must yield Principal with AssuranceStrong")
+	})
+
+	t.Run("IP-change downgrade reflected as AssuranceBasic in Principal", func(t *testing.T) {
+		cfg := session.DefaultConfig()
+		store := session.NewMemStore(cfg, time.Now)
+		t.Cleanup(store.Close)
+		mgrWrite := session.NewManager(cfg, store, time.Now)
+		mgrRead := session.NewManager(cfg, store, time.Now)
+
+		srv := setupTestServer(t)
+		srv.SetSessionManager(mgrRead)
+
+		// BoundIP differs from httptest.NewRequest RemoteAddr so Manager.Validate downgrades.
+		token := setupBearerSessionWithAssurance(t, store, mgrWrite, "10.0.0.1")
+
+		var capturedPrincipal *Principal
+		handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		// RemoteAddr = "192.0.2.1:1234" → sourceIP "192.0.2.1" ≠ BoundIP "10.0.0.1"
+		// → Manager.Validate downgrades session to AssuranceBasic (ADR-021 Decision 5).
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code,
+			"downgraded session must remain valid — not killed (ADR-021 Decision 5)")
+		require.NotNil(t, capturedPrincipal)
+		assert.Equal(t, session.AssuranceBasic, capturedPrincipal.Assurance,
+			"IP-change downgrade must be reflected in Principal Assurance")
+	})
+}
+
+// TestWebSessionCookie_AssurancePropagatedToPrincipal verifies that the cookie auth path
+// reads sess.Assurance from Manager.Validate (ADR-021 Decision 3/5) and not a hardcoded value.
+//
+// (a) An AssuranceStrong web session with matching source IP must yield a Principal
+// with Assurance == AssuranceStrong.
+// (b) An AssuranceStrong web session whose BoundIP differs from the request source IP is
+// downgraded by Manager.Validate; the Principal must reflect AssuranceBasic.
+func TestWebSessionCookie_AssurancePropagatedToPrincipal(t *testing.T) {
+	const httptestIP = "192.0.2.1"
+
+	webCfg := session.Config{
+		IdleTimeout:           60 * time.Minute,
+		AbsoluteTimeout:       12 * time.Hour,
+		GraceWindow:           30 * time.Second,
+		SilentReproofInterval: 5 * time.Minute,
+	}
+
+	t.Run("AssuranceStrong propagated when source IP matches bound IP", func(t *testing.T) {
+		store := session.NewMemStore(webCfg, time.Now)
+		t.Cleanup(store.Close)
+		mgrWrite := session.NewManager(webCfg, store, time.Now)
+		mgrRead := session.NewManager(webCfg, store, time.Now)
+
+		srv := setupTestServer(t)
+		srv.SetWebSessionManager(mgrRead)
+
+		// Issue via mgrWrite and elevate to AssuranceStrong in the shared store.
+		webSess, token, err := mgrWrite.Issue(context.Background(), "alice", "web-login", "tenant-a")
+		require.NoError(t, err)
+		webSess.Assurance = session.AssuranceStrong
+		webSess.BoundIP = httptestIP
+		webSess.LastProvenAt = time.Now()
+		require.NoError(t, store.Set(context.Background(), session.HashToken(token), webSess))
+
+		var capturedPrincipal *Principal
+		handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+		req.AddCookie(&http.Cookie{Name: "cfgms_session", Value: token})
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, capturedPrincipal)
+		assert.Equal(t, session.AssuranceStrong, capturedPrincipal.Assurance,
+			"AssuranceStrong web session with matching IP must yield Principal with AssuranceStrong")
+	})
+
+	t.Run("IP-change downgrade reflected as AssuranceBasic in Principal", func(t *testing.T) {
+		store := session.NewMemStore(webCfg, time.Now)
+		t.Cleanup(store.Close)
+		mgrWrite := session.NewManager(webCfg, store, time.Now)
+		mgrRead := session.NewManager(webCfg, store, time.Now)
+
+		srv := setupTestServer(t)
+		srv.SetWebSessionManager(mgrRead)
+
+		// BoundIP differs from httptest RemoteAddr so Validate downgrades.
+		webSess, token, err := mgrWrite.Issue(context.Background(), "alice", "web-login", "tenant-a")
+		require.NoError(t, err)
+		webSess.Assurance = session.AssuranceStrong
+		webSess.BoundIP = "10.0.0.1"
+		webSess.LastProvenAt = time.Now()
+		require.NoError(t, store.Set(context.Background(), session.HashToken(token), webSess))
+
+		var capturedPrincipal *Principal
+		handler := srv.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+		req.AddCookie(&http.Cookie{Name: "cfgms_session", Value: token})
+		// RemoteAddr "192.0.2.1:1234" → sourceIP "192.0.2.1" ≠ BoundIP "10.0.0.1"
+		// → Manager.Validate downgrades web session to AssuranceBasic.
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code,
+			"downgraded web session must remain valid (ADR-021 Decision 5)")
+		require.NotNil(t, capturedPrincipal)
+		assert.Equal(t, session.AssuranceBasic, capturedPrincipal.Assurance,
+			"IP-change downgrade must be reflected in web session Principal Assurance")
+	})
+}

--- a/pkg/session/continuity_test.go
+++ b/pkg/session/continuity_test.go
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session_test
+
+// Tests for ADR-021 device-continuity behaviour (Issue #2788):
+//   - IP-change-triggered downgrade (required test)
+//   - Two-node simulation via shared Store (required test)
+//   - Silent-proof failure falls back to AssuranceBasic (required test)
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// testContinuityConfig returns a Config tuned for continuity tests:
+// short SilentReproofInterval so timer-based tests don't need large clock advances.
+func testContinuityConfig() session.Config {
+	return session.Config{
+		IdleTimeout:           10 * time.Minute,
+		AbsoluteTimeout:       1 * time.Hour,
+		GraceWindow:           30 * time.Second,
+		SilentReproofInterval: 5 * time.Minute,
+	}
+}
+
+// issueAndElevate issues a session on mgr, persists an AssuranceStrong record to store
+// (simulating a WebAuthn assertion handler that ran between the Issue and the next Validate),
+// and returns the token and hash.
+//
+// Because Manager caches sessions in memory (in-process), a direct store.Set does not
+// update the issuing Manager's in-memory copy — it is visible only to a fresh Manager
+// or via loadFromStore on a cold-cache lookup. All continuity tests that need to start
+// from AssuranceStrong therefore issue on mgrWrite and validate on mgrRead, matching
+// the real-world pattern where a WebAuthn handler on one path updates the store and the
+// next authenticated request arrives on a potentially-different node.
+func issueAndElevate(t *testing.T, mgr session.Manager, store session.Store, clock *fakeClock,
+	principalID, connName, tenantID, boundIP string) (token, hash string) {
+	t.Helper()
+	ctx := context.Background()
+
+	sess, tok, err := mgr.Issue(ctx, principalID, connName, tenantID)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	h := session.HashToken(tok)
+
+	// Simulate the WebAuthn assertion handler writing AssuranceStrong to the durable store.
+	sess.Assurance = session.AssuranceStrong
+	sess.BoundIP = boundIP
+	sess.LastProvenAt = clock.Now()
+	if err := store.Set(ctx, h, sess); err != nil {
+		t.Fatalf("store.Set (elevate): %v", err)
+	}
+	return tok, h
+}
+
+// TestIPChangeDowngradesAssurance verifies ADR-021 Decision 5:
+// a source-IP change on an AssuranceStrong session immediately downgrades it to
+// AssuranceBasic and clears LastProvenAt. The session must remain valid (not killed),
+// and the next sensitive-action check would see AssuranceBasic → 401 step-up (not 403).
+//
+// [REQUIRED TEST]
+func TestIPChangeDowngradesAssurance(t *testing.T) {
+	cfg := testContinuityConfig()
+	clock := &fakeClock{t: time.Now()}
+	sharedStore := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(sharedStore.Close)
+
+	// mgrWrite issues the session; mgrRead validates (cold cache → loads from store,
+	// seeing the AssuranceStrong state written by issueAndElevate).
+	mgrWrite := session.NewManager(cfg, sharedStore, clock.Now)
+	mgrRead := session.NewManager(cfg, sharedStore, clock.Now)
+	ctx := context.Background()
+
+	token, hash := issueAndElevate(t, mgrWrite, sharedStore, clock, "alice", "ctrl", "tenant-1", "192.0.2.1")
+
+	// Request from the SAME IP → Assurance stays Strong.
+	sameIPCtx := session.WithSourceIP(ctx, "192.0.2.1")
+	got, err := mgrRead.Validate(sameIPCtx, token)
+	if err != nil {
+		t.Fatalf("Validate (same IP): %v", err)
+	}
+	if got.Assurance != session.AssuranceStrong {
+		t.Errorf("same-IP Validate: Assurance = %v, want AssuranceStrong", got.Assurance)
+	}
+
+	// Request arrives from a DIFFERENT IP → Assurance must downgrade.
+	newIPCtx := session.WithSourceIP(ctx, "10.0.0.1")
+	got, err = mgrRead.Validate(newIPCtx, token)
+	if err != nil {
+		t.Fatalf("Validate (new IP): unexpected error %v", err)
+	}
+
+	// Session must remain valid (not killed — ADR Decision 5 says "never hard-lock").
+	if got == nil {
+		t.Fatal("Validate (new IP): session was killed (got nil), want valid session")
+	}
+
+	// Assurance must be downgraded to Basic.
+	if got.Assurance != session.AssuranceBasic {
+		t.Errorf("new-IP Validate: Assurance = %v, want AssuranceBasic", got.Assurance)
+	}
+
+	// LastProvenAt must be cleared.
+	if !got.LastProvenAt.IsZero() {
+		t.Errorf("new-IP Validate: LastProvenAt = %v, want zero", got.LastProvenAt)
+	}
+
+	// The downgrade must be visible in the store (other nodes + subsequent requests).
+	stored, err := sharedStore.Get(ctx, hash)
+	if err != nil {
+		t.Fatalf("store.Get after downgrade: %v", err)
+	}
+	if stored.Assurance != session.AssuranceBasic {
+		t.Errorf("store after downgrade: Assurance = %v, want AssuranceBasic", stored.Assurance)
+	}
+	if !stored.LastProvenAt.IsZero() {
+		t.Errorf("store after downgrade: LastProvenAt = %v, want zero", stored.LastProvenAt)
+	}
+}
+
+// TestTwoNodeSessionContinuity verifies that assurance state written by "node A" is
+// correctly read and evaluated by "node B" (failover / rolling-restart scenario).
+// Both nodes share the same Store; each has its own Manager instance (separate in-memory
+// caches), simulating two independent controller processes sharing a durable store.
+//
+// [REQUIRED TEST]
+func TestTwoNodeSessionContinuity(t *testing.T) {
+	cfg := testContinuityConfig()
+	clock := &fakeClock{t: time.Now()}
+
+	// Shared store simulates the durable Postgres/SQLite store in a multi-node deployment.
+	sharedStore := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(sharedStore.Close)
+
+	// Node A and Node B each have their own Manager (independent in-memory index).
+	mgrA := session.NewManager(cfg, sharedStore, clock.Now)
+	mgrB := session.NewManager(cfg, sharedStore, clock.Now)
+
+	ctx := context.Background()
+
+	// Node A issues a session and a WebAuthn assertion sets AssuranceStrong in the store.
+	token, _ := issueAndElevate(t, mgrA, sharedStore, clock, "bob", "ctrl-a", "tenant-2", "198.51.100.5")
+
+	// Node B validates the token (cold cache — never saw this session).
+	// The Manager falls back to the durable store (loadFromStore).
+	sameIPCtx := session.WithSourceIP(ctx, "198.51.100.5")
+	gotB, err := mgrB.Validate(sameIPCtx, token)
+	if err != nil {
+		t.Fatalf("Node B Validate: %v", err)
+	}
+
+	// Node B must see the AssuranceStrong state set by the WebAuthn handler on Node A.
+	if gotB.Assurance != session.AssuranceStrong {
+		t.Errorf("Node B Validate: Assurance = %v, want AssuranceStrong", gotB.Assurance)
+	}
+	if gotB.LastProvenAt.IsZero() {
+		t.Error("Node B Validate: LastProvenAt is zero, want non-zero (cross-node visibility)")
+	}
+
+	// Simulate the client's next request going to Node B from a new IP (failover scenario).
+	// Node B must downgrade based on the BoundIP loaded from the shared store.
+	newIPCtx := session.WithSourceIP(ctx, "203.0.113.99")
+	gotB2, err := mgrB.Validate(newIPCtx, token)
+	if err != nil {
+		t.Fatalf("Node B Validate (new IP): %v", err)
+	}
+	if gotB2.Assurance != session.AssuranceBasic {
+		t.Errorf("Node B Validate (new IP): Assurance = %v, want AssuranceBasic", gotB2.Assurance)
+	}
+
+	// The downgrade must also be visible to any reader (written to shared store by Node B).
+	storedAfterDowngrade, err := sharedStore.Get(ctx, session.HashToken(token))
+	if err != nil {
+		t.Fatalf("shared store Get after Node-B downgrade: %v", err)
+	}
+	if storedAfterDowngrade.Assurance != session.AssuranceBasic {
+		t.Errorf("shared store after Node-B downgrade: Assurance = %v, want AssuranceBasic",
+			storedAfterDowngrade.Assurance)
+	}
+}
+
+// TestSilentProofFailureFallsBackToBasic verifies that when a session holds
+// AssuranceStrong but silent re-proof is impossible (CredentialID is nil — no device
+// binding, so there is nothing to prove with), the session falls back to AssuranceBasic
+// without returning an error. The in-flight request must not be rejected outright.
+//
+// [REQUIRED TEST]
+func TestSilentProofFailureFallsBackToBasic(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:           10 * time.Minute,
+		AbsoluteTimeout:       1 * time.Hour,
+		GraceWindow:           30 * time.Second,
+		SilentReproofInterval: 5 * time.Minute,
+	}
+	clock := &fakeClock{t: time.Now()}
+	sharedStore := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(sharedStore.Close)
+
+	mgrWrite := session.NewManager(cfg, sharedStore, clock.Now)
+	mgrRead := session.NewManager(cfg, sharedStore, clock.Now)
+	ctx := context.Background()
+
+	// Issue and elevate to AssuranceStrong with NO CredentialID.
+	// Simulates a session where the authenticator device is no longer available.
+	sess, token, err := mgrWrite.Issue(ctx, "carol", "ctrl", "tenant-3")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	hash := session.HashToken(token)
+	sess.Assurance = session.AssuranceStrong
+	sess.LastProvenAt = clock.Now()
+	sess.CredentialID = nil // explicitly: no credential — silent proof is impossible
+	if err := sharedStore.Set(ctx, hash, sess); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	// Advance past the SilentReproofInterval so a time-based re-proof is triggered.
+	clock.advance(6 * time.Minute)
+
+	// mgrRead has a cold cache → loads from store → sees AssuranceStrong with elapsed interval.
+	// Validate: silent re-proof is triggered but impossible (no credential) → fall back.
+	// Must NOT return an error — the request must proceed with AssuranceBasic.
+	got, err := mgrRead.Validate(ctx, token)
+	if err != nil {
+		t.Fatalf("Validate after proof interval elapsed: unexpected error %v", err)
+	}
+	if got == nil {
+		t.Fatal("Validate: got nil session, want valid session")
+	}
+
+	// Must fall back to AssuranceBasic (not an error, not a hard rejection).
+	if got.Assurance != session.AssuranceBasic {
+		t.Errorf("Assurance = %v, want AssuranceBasic (graceful fallback)", got.Assurance)
+	}
+	// LastProvenAt must be cleared.
+	if !got.LastProvenAt.IsZero() {
+		t.Errorf("LastProvenAt = %v, want zero after fallback", got.LastProvenAt)
+	}
+}
+
+// TestDefaultConfigSilentReproofInterval locks the SilentReproofInterval default so
+// implementation stories cannot silently drift it (complements TestDefaultConfig in
+// contract_test.go which locks the other three tunables).
+func TestDefaultConfigSilentReproofInterval(t *testing.T) {
+	cfg := session.DefaultConfig()
+	if cfg.SilentReproofInterval != 5*time.Minute {
+		t.Errorf("SilentReproofInterval = %v, want 5m", cfg.SilentReproofInterval)
+	}
+}
+
+// TestIPChangeDowngradeNotFiredWhenBoundIPEmpty verifies that IP-change detection does
+// NOT fire when BoundIP is empty (session has never been proved from an IP). Only a
+// non-empty BoundIP constitutes a "bound" location to compare against.
+func TestIPChangeDowngradeNotFiredWhenBoundIPEmpty(t *testing.T) {
+	cfg := testContinuityConfig()
+	clock := &fakeClock{t: time.Now()}
+	sharedStore := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(sharedStore.Close)
+
+	mgrWrite := session.NewManager(cfg, sharedStore, clock.Now)
+	mgrRead := session.NewManager(cfg, sharedStore, clock.Now)
+	ctx := context.Background()
+
+	sess, token, err := mgrWrite.Issue(ctx, "dave", "ctrl", "tenant-4")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Elevate to AssuranceStrong with an empty BoundIP — IP detection should be skipped.
+	hash := session.HashToken(token)
+	sess.Assurance = session.AssuranceStrong
+	sess.BoundIP = "" // not yet bound to any IP
+	sess.LastProvenAt = clock.Now()
+	if err := sharedStore.Set(ctx, hash, sess); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	// Request from any IP must NOT downgrade because BoundIP is empty.
+	someIPCtx := session.WithSourceIP(ctx, "10.255.0.1")
+	got, err := mgrRead.Validate(someIPCtx, token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got.Assurance != session.AssuranceStrong {
+		t.Errorf("Assurance = %v, want AssuranceStrong (no BoundIP → no detection)", got.Assurance)
+	}
+}
+
+// TestAssuranceLevelPersistedAcrossRenew verifies that the session's Assurance level
+// is preserved through token rotation (Manager.Renew). A downgrade recorded before
+// Renew must be visible on the new token as well.
+func TestAssuranceLevelPersistedAcrossRenew(t *testing.T) {
+	cfg := testContinuityConfig()
+	clock := &fakeClock{t: time.Now()}
+	sharedStore := session.NewMemStore(cfg, clock.Now)
+	t.Cleanup(sharedStore.Close)
+
+	mgrWrite := session.NewManager(cfg, sharedStore, clock.Now)
+	mgrRead := session.NewManager(cfg, sharedStore, clock.Now)
+	ctx := context.Background()
+
+	// Elevate to AssuranceStrong on mgrWrite.
+	token, _ := issueAndElevate(t, mgrWrite, sharedStore, clock, "eve", "ctrl", "tenant-5", "172.16.0.1")
+
+	// Trigger IP-change downgrade via mgrRead (cold cache → loads from store).
+	got, err := mgrRead.Validate(session.WithSourceIP(ctx, "172.16.0.2"), token)
+	if err != nil {
+		t.Fatalf("Validate (IP change): %v", err)
+	}
+	if got.Assurance != session.AssuranceBasic {
+		t.Errorf("post-downgrade Assurance = %v, want AssuranceBasic", got.Assurance)
+	}
+
+	// Renew: new token issued; Assurance should still be AssuranceBasic on the new token.
+	_, newToken, err := mgrRead.Renew(ctx, token)
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if newToken == "" {
+		t.Fatal("Renew: expected new token, got empty string")
+	}
+
+	gotAfterRenew, err := mgrRead.Validate(ctx, newToken)
+	if err != nil {
+		t.Fatalf("Validate (new token): %v", err)
+	}
+	if gotAfterRenew.Assurance != session.AssuranceBasic {
+		t.Errorf("post-Renew Assurance = %v, want AssuranceBasic", gotAfterRenew.Assurance)
+	}
+}

--- a/pkg/session/contract.go
+++ b/pkg/session/contract.go
@@ -28,6 +28,12 @@ var ErrSessionNotFound = errors.New("session: session not found")
 // Session is the runtime record for a cfg admin session (ADR-014 §2).
 // ID holds the opaque session identifier (not the bearer token; that is never stored).
 // AbsoluteExpiresAt is measured from the original connect, capping even continuously-active sessions.
+//
+// Device-continuity fields (ADR-021 Decision 3, Issue #2788) are additive: they are
+// zero-valued for sessions that predate this story and for sessions that have never
+// undergone a strong-factor proof. Middleware reads Assurance from this struct rather
+// than hardcoding AssuranceBasic so that upgrades (WebAuthn assertion — later story)
+// and downgrades (IP change, proof expiry) are reflected on every request.
 type Session struct {
 	ID                string
 	ConnectionName    string
@@ -36,6 +42,22 @@ type Session struct {
 	IssuedAt          time.Time
 	LastActivity      time.Time
 	AbsoluteExpiresAt time.Time
+
+	// Assurance is the current identity assurance level. Set to AssuranceBasic for
+	// newly issued sessions; upgraded to AssuranceStrong by a successful WebAuthn
+	// assertion (later story); downgraded back to AssuranceBasic on IP change or
+	// when the silent-proof interval has elapsed without a fresh proof.
+	Assurance AssuranceLevel
+	// CredentialID is the WebAuthn credential ID that established AssuranceStrong.
+	// Nil/empty when no device-bound proof has been recorded for this session.
+	CredentialID []byte
+	// BoundIP is the source IP at the last successful strong-factor proof.
+	// Empty until the first proof. IP-change detection compares the current request
+	// IP against this value — not the IP at original session issuance.
+	BoundIP string
+	// LastProvenAt is the wall-clock time of the last successful strong-factor proof.
+	// Zero until the first proof. Used to enforce the SilentReproofInterval cadence.
+	LastProvenAt time.Time
 }
 
 // Config holds the lifecycle tunables for cfg admin sessions (ADR-014 §3).
@@ -48,16 +70,46 @@ type Config struct {
 	// GraceWindow is the time-only window during which the prior token remains valid
 	// after a renewal (tolerates racing requests from a stateless CLI; see ADR-014 §3).
 	GraceWindow time.Duration
+	// SilentReproofInterval is the maximum duration AssuranceStrong can be held without
+	// a fresh device proof. After this interval, the session is downgraded to
+	// AssuranceBasic unless a valid WebAuthn assertion is provided (ADR-021 Decision 3,
+	// "Remaining tunables"). Zero disables the interval check.
+	SilentReproofInterval time.Duration
 }
 
 // DefaultConfig returns the ratified ADR-014 tunables: idle 15m, absolute 8h, grace 30s.
+// SilentReproofInterval defaults to 5 minutes per ADR-021 "Remaining tunables" (PO-set).
 // Tests lock these values so implementation stories cannot silently drift them.
 func DefaultConfig() Config {
 	return Config{
-		IdleTimeout:     15 * time.Minute,
-		AbsoluteTimeout: 8 * time.Hour,
-		GraceWindow:     30 * time.Second,
+		IdleTimeout:           15 * time.Minute,
+		AbsoluteTimeout:       8 * time.Hour,
+		GraceWindow:           30 * time.Second,
+		SilentReproofInterval: 5 * time.Minute,
 	}
+}
+
+// sourceIPKeyType is unexported so no external package can construct a value of this type,
+// preventing context-key aliasing across package boundaries (the standard Go opaque-key idiom).
+type sourceIPKeyType struct{}
+
+var sourceIPKey = sourceIPKeyType{}
+
+// WithSourceIP returns a context carrying the client's source IP address.
+// Called by the authentication middleware before Manager.Validate to enable
+// IP-change detection (ADR-021 Decision 5, Issue #2788).
+// Pass only the host portion — not "host:port".
+func WithSourceIP(ctx context.Context, ip string) context.Context {
+	return context.WithValue(ctx, sourceIPKey, ip)
+}
+
+// SourceIPFromContext returns the source IP stored by WithSourceIP.
+// Returns "" when no IP has been set (Validate skips IP-change detection in that case).
+func SourceIPFromContext(ctx context.Context) string {
+	if ip, ok := ctx.Value(sourceIPKey).(string); ok {
+		return ip
+	}
+	return ""
 }
 
 // Manager is the runtime interface for cfg admin session lifecycle (ADR-014 §2).

--- a/pkg/session/contract_test.go
+++ b/pkg/session/contract_test.go
@@ -304,6 +304,92 @@ func RunStoreContractSuite(t *testing.T, store session.Store) {
 			t.Errorf("after Delete, Get hashNew: got %v, want ErrSessionNotFound", err)
 		}
 	})
+
+	// ContinuityFieldsRoundTrip verifies that all four device-continuity fields
+	// (Assurance, CredentialID, BoundIP, LastProvenAt) survive a Set → Get round-trip
+	// with non-zero / non-nil values. This exercises the nullable-column deserialization
+	// branches in SQLite and Postgres stores that are never reached by makeTestSession
+	// (which always leaves these fields at their zero defaults).
+	t.Run("ContinuityFieldsRoundTrip", func(t *testing.T) {
+		tok, err := session.GenerateToken()
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+		hash := session.HashToken(tok)
+		now := time.Now().UTC().Truncate(time.Second)
+		credID := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04}
+
+		sess := &session.Session{
+			ID:                "sc-continuity",
+			PrincipalID:       "carol",
+			ConnectionName:    "ctrl",
+			TenantID:          "tenant-continuity",
+			IssuedAt:          now,
+			LastActivity:      now,
+			AbsoluteExpiresAt: now.Add(cfg.AbsoluteTimeout),
+			Assurance:         session.AssuranceStrong,
+			CredentialID:      credID,
+			BoundIP:           "198.51.100.42",
+			LastProvenAt:      now,
+		}
+
+		if err := store.Set(ctx, hash, sess); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		got, err := store.Get(ctx, hash)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Assurance != session.AssuranceStrong {
+			t.Errorf("Assurance: got %v, want AssuranceStrong", got.Assurance)
+		}
+		if got.BoundIP != "198.51.100.42" {
+			t.Errorf("BoundIP: got %q, want %q", got.BoundIP, "198.51.100.42")
+		}
+		if got.LastProvenAt.IsZero() {
+			t.Error("LastProvenAt: got zero, want non-zero")
+		}
+		if !got.LastProvenAt.Equal(now) {
+			t.Errorf("LastProvenAt: got %v, want %v", got.LastProvenAt, now)
+		}
+		if len(got.CredentialID) != len(credID) {
+			t.Errorf("CredentialID length: got %d, want %d", len(got.CredentialID), len(credID))
+		} else {
+			for i, b := range credID {
+				if got.CredentialID[i] != b {
+					t.Errorf("CredentialID[%d]: got 0x%02x, want 0x%02x", i, got.CredentialID[i], b)
+				}
+			}
+		}
+
+		// ListAll must also return the continuity fields intact.
+		all, err := store.ListAll(ctx)
+		if err != nil {
+			t.Fatalf("ListAll: %v", err)
+		}
+		var found *session.Session
+		for _, s := range all {
+			if s.ID == "sc-continuity" {
+				found = s
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("ListAll: sc-continuity session not found")
+		}
+		if found.Assurance != session.AssuranceStrong {
+			t.Errorf("ListAll Assurance: got %v, want AssuranceStrong", found.Assurance)
+		}
+		if found.BoundIP != "198.51.100.42" {
+			t.Errorf("ListAll BoundIP: got %q, want %q", found.BoundIP, "198.51.100.42")
+		}
+		if found.LastProvenAt.IsZero() {
+			t.Error("ListAll LastProvenAt: got zero, want non-zero")
+		}
+		if len(found.CredentialID) != len(credID) {
+			t.Errorf("ListAll CredentialID length: got %d, want %d", len(found.CredentialID), len(credID))
+		}
+	})
 }
 
 // TestStoreContract_MemStore runs the shared contract suite against the in-memory MemStore.

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -74,6 +74,9 @@ func (m *manager) Issue(ctx context.Context, principalID, connectionName, tenant
 		IssuedAt:          now,
 		LastActivity:      now,
 		AbsoluteExpiresAt: now.Add(m.cfg.AbsoluteTimeout),
+		// All Manager-issued sessions are human sessions. Assurance starts at Basic;
+		// it is upgraded to Strong by a successful WebAuthn assertion (later story).
+		Assurance: AssuranceBasic,
 	}
 	ms := &managedSession{
 		session:     sess,
@@ -165,6 +168,7 @@ func (m *manager) Validate(ctx context.Context, token string) (*Session, error) 
 	if now.After(ms.session.AbsoluteExpiresAt) {
 		return nil, ErrSessionExpired
 	}
+	needsSync := false
 	if hash == ms.prevHash {
 		// Prior-token path: only grace-window check; idle TTL is on the new token.
 		if !ms.prevExpiry.IsZero() && now.After(ms.prevExpiry) {
@@ -176,7 +180,43 @@ func (m *manager) Validate(ctx context.Context, token string) (*Session, error) 
 			return nil, ErrSessionExpired
 		}
 		ms.session.LastActivity = now
-		_ = m.store.Set(ctx, hash, ms.session) // best-effort sync to durable store
+		needsSync = true
+	}
+
+	// Device-continuity check (ADR-021 Decision 3/5, Issue #2788).
+	// Only AssuranceStrong sessions have continuity state to lose; AssuranceBasic
+	// sessions are never downgraded further by this logic.
+	if ms.session.Assurance == AssuranceStrong {
+		currentIP := SourceIPFromContext(ctx)
+		downgrade := false
+
+		// Decision 5: a source-IP change is an immediate downgrade — never hard-lock.
+		// Compare against BoundIP (last proof), not session issuance IP.
+		if currentIP != "" && ms.session.BoundIP != "" && currentIP != ms.session.BoundIP {
+			downgrade = true
+		}
+
+		// Re-proof cadence: if LastProvenAt is set and the silent-proof interval has
+		// elapsed, attempt silent re-proof. Since no WebAuthn assertion is present in
+		// this Validate call (the assertion path is a later story), the "attempt"
+		// always falls back to AssuranceBasic. When CredentialID is nil, proof is
+		// structurally impossible regardless of the timer.
+		if !downgrade && m.cfg.SilentReproofInterval > 0 && !ms.session.LastProvenAt.IsZero() {
+			if now.Sub(ms.session.LastProvenAt) > m.cfg.SilentReproofInterval {
+				downgrade = true
+			}
+		}
+
+		if downgrade {
+			ms.session.Assurance = AssuranceBasic
+			ms.session.LastProvenAt = time.Time{}
+			needsSync = true
+		}
+	}
+
+	if needsSync {
+		// best-effort sync to durable store (persists LastActivity and/or downgrade)
+		_ = m.store.Set(ctx, hash, ms.session)
 	}
 	out := *ms.session
 	return &out, nil

--- a/pkg/storage/providers/database/migrations/006_session_continuity.sql
+++ b/pkg/storage/providers/database/migrations/006_session_continuity.sql
@@ -1,0 +1,23 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Migration 006: Add device-continuity columns to session_token_store (Issue #2788).
+--
+-- ADR-021 Decision 3 (silent continuity) and Decision 5 (IP-change downgrade) require
+-- durable storage of per-session assurance state so that:
+--   - A session's AssuranceStrong survives rolling restarts and node failovers without
+--     downgrading every session on restart (the failover-looks-like-device-change problem
+--     that the ADR Sequencing section describes as the reason #2775 must precede this story).
+--   - The IP-change detection compares the stored BoundIP against the current request IP;
+--     the comparison must work on any node, so BoundIP must be in the shared store.
+--
+-- Column semantics:
+--   assurance:      AssuranceLevel numeric value (0=Machine, 1=Basic, 2=Strong).
+--                   Defaults to 1 (AssuranceBasic) — all pre-existing rows are human sessions.
+--   bound_ip:       Source IP at last successful strong-factor proof. Empty until first proof.
+--   last_proven_at: Wall-clock time of last proof. NULL until first proof.
+--   credential_id:  WebAuthn credential ID (BYTEA) that established AssuranceStrong.
+--                   NULL when no device-bound proof has been recorded.
+
+ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS assurance      INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS bound_ip       TEXT    NOT NULL DEFAULT '';
+ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS last_proven_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS credential_id  BYTEA;

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -1003,6 +1003,10 @@ func (s DatabaseSchemas) CreateCommandTransitionsTable(ctx context.Context, db *
 // CreateSessionTokenStoreTable creates the session_token_store table (Issue #2775).
 // This backs DatabaseSessionTokenStore (pkg/session.Store), not the business.SessionStore
 // that uses the `sessions` table.
+//
+// Device-continuity columns (Issue #2788) are included in the initial CREATE so that
+// fresh deployments get the full schema; the corresponding migration (006) uses
+// ADD COLUMN IF NOT EXISTS for rolling upgrades of existing deployments.
 func (s DatabaseSchemas) CreateSessionTokenStoreTable(ctx context.Context, db *sql.DB) error {
 	ddl := `
 		CREATE TABLE IF NOT EXISTS session_token_store (
@@ -1014,7 +1018,11 @@ func (s DatabaseSchemas) CreateSessionTokenStoreTable(ctx context.Context, db *s
 			issued_at           TIMESTAMP WITH TIME ZONE NOT NULL,
 			last_activity       TIMESTAMP WITH TIME ZONE NOT NULL,
 			absolute_expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
-			hash_expires_at     TIMESTAMP WITH TIME ZONE
+			hash_expires_at     TIMESTAMP WITH TIME ZONE,
+			assurance           INTEGER NOT NULL DEFAULT 1,
+			bound_ip            TEXT    NOT NULL DEFAULT '',
+			last_proven_at      TIMESTAMP WITH TIME ZONE,
+			credential_id       BYTEA
 		);`
 	if _, err := db.ExecContext(ctx, ddl); err != nil {
 		return fmt.Errorf("failed to create session_token_store table: %w", err)
@@ -1050,6 +1058,24 @@ func (s DatabaseSchemas) CreateSessionTokenStoreTable(ctx context.Context, db *s
 	for _, stmt := range rls {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("failed to configure session_token_store RLS: %w", err)
+		}
+	}
+	return nil
+}
+
+// BackfillSessionTokenStoreContinuity adds the device-continuity columns to an existing
+// session_token_store table (Issue #2788, migration 006). Safe to call on a table that
+// already has these columns — ADD COLUMN IF NOT EXISTS is idempotent on Postgres.
+func (s DatabaseSchemas) BackfillSessionTokenStoreContinuity(ctx context.Context, db *sql.DB) error {
+	alters := []string{
+		`ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS assurance      INTEGER NOT NULL DEFAULT 1`,
+		`ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS bound_ip       TEXT    NOT NULL DEFAULT ''`,
+		`ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS last_proven_at TIMESTAMP WITH TIME ZONE`,
+		`ALTER TABLE session_token_store ADD COLUMN IF NOT EXISTS credential_id  BYTEA`,
+	}
+	for _, stmt := range alters {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to backfill session_token_store continuity columns: %w", err)
 		}
 	}
 	return nil

--- a/pkg/storage/providers/database/session_token_store.go
+++ b/pkg/storage/providers/database/session_token_store.go
@@ -66,6 +66,8 @@ func NewDatabaseSessionTokenStore(dsn string, config map[string]interface{}) (*D
 
 // initializeSchema creates the session_token_store table under a Postgres advisory lock
 // so concurrent controller nodes starting in parallel do not race on DDL.
+// BackfillSessionTokenStoreContinuity is called after CREATE to add device-continuity
+// columns (Issue #2788) on existing deployments; ADD COLUMN IF NOT EXISTS makes it idempotent.
 func (s *DatabaseSessionTokenStore) initializeSchema() error {
 	ctx := context.Background()
 	const lockID = 12345678
@@ -73,7 +75,11 @@ func (s *DatabaseSessionTokenStore) initializeSchema() error {
 		return fmt.Errorf("failed to acquire session token store schema lock: %w", err)
 	}
 	defer func() { _, _ = s.db.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", lockID) }()
-	return NewDatabaseSchemas().CreateSessionTokenStoreTable(ctx, s.db)
+	schemas := NewDatabaseSchemas()
+	if err := schemas.CreateSessionTokenStoreTable(ctx, s.db); err != nil {
+		return err
+	}
+	return schemas.BackfillSessionTokenStoreContinuity(ctx, s.db)
 }
 
 // Close releases the database connection pool.
@@ -100,11 +106,21 @@ func (s *DatabaseSessionTokenStore) Set(ctx context.Context, tokenHash string, s
 		return fmt.Errorf("database: session token set: failed to set tenant context: %w", err)
 	}
 
+	var lastProvenAt interface{}
+	if !sess.LastProvenAt.IsZero() {
+		lastProvenAt = sess.LastProvenAt.UTC()
+	}
+	var credentialID interface{}
+	if len(sess.CredentialID) > 0 {
+		credentialID = sess.CredentialID
+	}
+
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO session_token_store
 			(token_hash, session_id, principal_id, connection_name, tenant_id,
-			 issued_at, last_activity, absolute_expires_at, hash_expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULL)
+			 issued_at, last_activity, absolute_expires_at, hash_expires_at,
+			 assurance, bound_ip, last_proven_at, credential_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULL, $9, $10, $11, $12)
 		ON CONFLICT(token_hash) DO UPDATE SET
 			session_id          = EXCLUDED.session_id,
 			principal_id        = EXCLUDED.principal_id,
@@ -112,7 +128,11 @@ func (s *DatabaseSessionTokenStore) Set(ctx context.Context, tokenHash string, s
 			tenant_id           = EXCLUDED.tenant_id,
 			issued_at           = EXCLUDED.issued_at,
 			last_activity       = EXCLUDED.last_activity,
-			absolute_expires_at = EXCLUDED.absolute_expires_at`,
+			absolute_expires_at = EXCLUDED.absolute_expires_at,
+			assurance           = EXCLUDED.assurance,
+			bound_ip            = EXCLUDED.bound_ip,
+			last_proven_at      = EXCLUDED.last_proven_at,
+			credential_id       = EXCLUDED.credential_id`,
 		tokenHash,
 		sess.ID,
 		sess.PrincipalID,
@@ -121,6 +141,10 @@ func (s *DatabaseSessionTokenStore) Set(ctx context.Context, tokenHash string, s
 		sess.IssuedAt.UTC(),
 		sess.LastActivity.UTC(),
 		sess.AbsoluteExpiresAt.UTC(),
+		int(sess.Assurance),
+		sess.BoundIP,
+		lastProvenAt,
+		credentialID,
 	)
 	if err != nil {
 		return fmt.Errorf("database: session token set failed: %w", err)
@@ -132,9 +156,13 @@ func (s *DatabaseSessionTokenStore) Set(ctx context.Context, tokenHash string, s
 // Returns ErrSessionNotFound when the hash is absent or when hash_expires_at has passed.
 func (s *DatabaseSessionTokenStore) Get(ctx context.Context, tokenHash string) (*session.Session, error) {
 	var sess session.Session
+	var assurance int
+	var lastProvenAt sql.NullTime
+	var credentialID []byte
 	err := s.db.QueryRowContext(ctx, `
 		SELECT session_id, principal_id, connection_name, tenant_id,
-		       issued_at, last_activity, absolute_expires_at
+		       issued_at, last_activity, absolute_expires_at,
+		       assurance, bound_ip, last_proven_at, credential_id
 		FROM session_token_store
 		WHERE token_hash = $1
 		  AND (hash_expires_at IS NULL OR hash_expires_at > NOW())`,
@@ -142,6 +170,7 @@ func (s *DatabaseSessionTokenStore) Get(ctx context.Context, tokenHash string) (
 	).Scan(
 		&sess.ID, &sess.PrincipalID, &sess.ConnectionName, &sess.TenantID,
 		&sess.IssuedAt, &sess.LastActivity, &sess.AbsoluteExpiresAt,
+		&assurance, &sess.BoundIP, &lastProvenAt, &credentialID,
 	)
 	if err == sql.ErrNoRows {
 		return nil, session.ErrSessionNotFound
@@ -152,6 +181,13 @@ func (s *DatabaseSessionTokenStore) Get(ctx context.Context, tokenHash string) (
 	sess.IssuedAt = sess.IssuedAt.UTC()
 	sess.LastActivity = sess.LastActivity.UTC()
 	sess.AbsoluteExpiresAt = sess.AbsoluteExpiresAt.UTC()
+	sess.Assurance = session.AssuranceLevel(assurance)
+	if lastProvenAt.Valid {
+		sess.LastProvenAt = lastProvenAt.Time.UTC()
+	}
+	if len(credentialID) > 0 {
+		sess.CredentialID = credentialID
+	}
 	return &sess, nil
 }
 
@@ -180,7 +216,8 @@ func (s *DatabaseSessionTokenStore) Delete(ctx context.Context, id string) error
 func (s *DatabaseSessionTokenStore) ListAll(ctx context.Context) ([]*session.Session, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token_hash, session_id, principal_id, connection_name, tenant_id,
-		       issued_at, last_activity, absolute_expires_at
+		       issued_at, last_activity, absolute_expires_at,
+		       assurance, bound_ip, last_proven_at, credential_id
 		FROM session_token_store
 		WHERE hash_expires_at IS NULL OR hash_expires_at > NOW()
 		ORDER BY issued_at`)
@@ -194,9 +231,13 @@ func (s *DatabaseSessionTokenStore) ListAll(ctx context.Context) ([]*session.Ses
 	for rows.Next() {
 		var tokenHash string
 		var sess session.Session
+		var assurance int
+		var lastProvenAt sql.NullTime
+		var credentialID []byte
 		if err := rows.Scan(
 			&tokenHash, &sess.ID, &sess.PrincipalID, &sess.ConnectionName, &sess.TenantID,
 			&sess.IssuedAt, &sess.LastActivity, &sess.AbsoluteExpiresAt,
+			&assurance, &sess.BoundIP, &lastProvenAt, &credentialID,
 		); err != nil {
 			return nil, fmt.Errorf("database: session token list scan failed: %w", err)
 		}
@@ -207,6 +248,13 @@ func (s *DatabaseSessionTokenStore) ListAll(ctx context.Context) ([]*session.Ses
 		sess.IssuedAt = sess.IssuedAt.UTC()
 		sess.LastActivity = sess.LastActivity.UTC()
 		sess.AbsoluteExpiresAt = sess.AbsoluteExpiresAt.UTC()
+		sess.Assurance = session.AssuranceLevel(assurance)
+		if lastProvenAt.Valid {
+			sess.LastProvenAt = lastProvenAt.Time.UTC()
+		}
+		if len(credentialID) > 0 {
+			sess.CredentialID = credentialID
+		}
 		cp := sess
 		sessions = append(sessions, &cp)
 	}

--- a/pkg/storage/providers/database/session_token_store_test.go
+++ b/pkg/storage/providers/database/session_token_store_test.go
@@ -4,6 +4,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -291,6 +292,103 @@ func TestDatabaseSessionTokenStore_NoRawTokenInStoredRows(t *testing.T) {
 		assert.Equal(t, expected, tokenHash, "stored hash must be SHA-256(token)")
 	}
 	require.NoError(t, rows.Err())
+}
+
+// legacySessionTokenStoreSchema is the session_token_store DDL from Issue #2775, before the
+// four device-continuity columns (Issue #2788) were added. Used to simulate a pre-#2788
+// deployment whose live table must be upgraded in place by BackfillSessionTokenStoreContinuity.
+const legacySessionTokenStoreSchema = `
+	CREATE TABLE session_token_store (
+		token_hash          TEXT NOT NULL PRIMARY KEY,
+		session_id          TEXT NOT NULL,
+		principal_id        TEXT NOT NULL,
+		connection_name     TEXT NOT NULL,
+		tenant_id           TEXT NOT NULL,
+		issued_at           TIMESTAMP WITH TIME ZONE NOT NULL,
+		last_activity       TIMESTAMP WITH TIME ZONE NOT NULL,
+		absolute_expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		hash_expires_at     TIMESTAMP WITH TIME ZONE
+	);`
+
+// pgColumnExists reports whether the named column is present on session_token_store.
+func pgColumnExists(ctx context.Context, t *testing.T, db *sql.DB, column string) bool {
+	t.Helper()
+	var exists bool
+	err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'session_token_store' AND column_name = $1
+		)`, column).Scan(&exists)
+	require.NoError(t, err)
+	return exists
+}
+
+// TestBackfillSessionTokenStoreContinuity_UpgradePath exercises the true pre-#2788 upgrade
+// scenario: a live session_token_store table created without the four continuity columns,
+// carrying an existing human-session row. BackfillSessionTokenStoreContinuity must add all
+// four columns, default the existing row to assurance=1 / empty bound_ip, leave the nullable
+// columns NULL, and be safe to run a second time.
+func TestBackfillSessionTokenStoreContinuity_UpgradePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database tests in short mode")
+	}
+	db := getTestDB(t) // skips if postgres not reachable
+	defer func() { _ = db.Close() }()
+	ctx := context.Background()
+
+	// Start from a clean slate, then create the legacy-shaped table.
+	_, err := db.ExecContext(ctx, "DROP TABLE IF EXISTS session_token_store")
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, "DROP TABLE IF EXISTS session_token_store") })
+
+	_, err = db.ExecContext(ctx, legacySessionTokenStoreSchema)
+	require.NoError(t, err, "create legacy session_token_store table")
+
+	// Seed a pre-#2788 human-session row.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO session_token_store
+			(token_hash, session_id, principal_id, connection_name, tenant_id,
+			 issued_at, last_activity, absolute_expires_at)
+		VALUES ('legacy-hash', 'legacy-sess', 'admin', 'ctrl', 'tenant-1',
+			now(), now(), now() + interval '8 hours')`)
+	require.NoError(t, err, "seed legacy row")
+
+	continuityCols := []string{"assurance", "bound_ip", "last_proven_at", "credential_id"}
+	for _, col := range continuityCols {
+		assert.False(t, pgColumnExists(ctx, t, db, col), "pre-condition: %s absent before back-fill", col)
+	}
+
+	schemas := NewDatabaseSchemas()
+
+	// First back-fill — must add all four columns.
+	require.NoError(t, schemas.BackfillSessionTokenStoreContinuity(ctx, db), "first back-fill")
+	for _, col := range continuityCols {
+		assert.True(t, pgColumnExists(ctx, t, db, col), "%s present after back-fill", col)
+	}
+
+	// The pre-existing human-session row must default to assurance=1 / empty bound_ip,
+	// with the nullable columns left NULL.
+	var assurance int
+	var boundIP string
+	var lastProven, credentialID sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT assurance, bound_ip, last_proven_at, credential_id::text
+		FROM session_token_store WHERE token_hash='legacy-hash'`).
+		Scan(&assurance, &boundIP, &lastProven, &credentialID))
+	assert.Equal(t, 1, assurance, "legacy row must default to assurance=1 (AssuranceBasic)")
+	assert.Equal(t, "", boundIP, "legacy row must default to empty bound_ip")
+	assert.False(t, lastProven.Valid, "legacy row last_proven_at must be NULL")
+	assert.False(t, credentialID.Valid, "legacy row credential_id must be NULL")
+
+	// Second back-fill must be a no-op and must not error (idempotency).
+	require.NoError(t, schemas.BackfillSessionTokenStoreContinuity(ctx, db), "second back-fill (idempotency)")
+	for _, col := range continuityCols {
+		assert.True(t, pgColumnExists(ctx, t, db, col), "%s still present after second back-fill", col)
+	}
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM session_token_store WHERE token_hash='legacy-hash'`).Scan(&count))
+	assert.Equal(t, 1, count, "legacy row must survive the idempotent second back-fill")
 }
 
 // TestDatabaseProvider_CreateSessionTokenStore verifies the plugin factory constructs

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -121,6 +121,45 @@ func backfillStewardColumns(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+// backfillSessionTokenRecords adds the device-continuity columns to a pre-existing
+// session_token_records table (Issue #2788). Fresh databases (table absent) are skipped.
+// Column-existence is checked via PRAGMA before each ALTER TABLE so the pass is idempotent.
+//
+// The assurance column defaults to 1 (AssuranceBasic) because every pre-existing row
+// in session_token_records belongs to a human session (mTLS admin or web session) —
+// API-key principals never write to this table.
+func backfillSessionTokenRecords(ctx context.Context, db *sql.DB) error {
+	exists, err := tableExists(ctx, db, "session_token_records")
+	if err != nil {
+		return fmt.Errorf("sqlite: session_token_records back-fill probe failed: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	type col struct {
+		name string
+		ddl  string
+	}
+	for _, c := range []col{
+		{"assurance", `ALTER TABLE session_token_records ADD COLUMN assurance      INTEGER NOT NULL DEFAULT 1`},
+		{"bound_ip", `ALTER TABLE session_token_records ADD COLUMN bound_ip       TEXT    NOT NULL DEFAULT ''`},
+		{"last_proven_at", `ALTER TABLE session_token_records ADD COLUMN last_proven_at TEXT`},
+		{"credential_id", `ALTER TABLE session_token_records ADD COLUMN credential_id  BLOB`},
+	} {
+		present, err := columnExists(ctx, db, "session_token_records", c.name)
+		if err != nil {
+			return fmt.Errorf("sqlite: session_token_records back-fill column probe failed (%s): %w", c.name, err)
+		}
+		if present {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, c.ddl); err != nil {
+			return fmt.Errorf("sqlite: session_token_records back-fill failed: %w\nSQL: %s", err, c.ddl)
+		}
+	}
+	return nil
+}
+
 // initializeSchema creates all tables and tracks schema version.
 // It is safe to call multiple times (all statements use IF NOT EXISTS).
 // All DDL statements are executed inside a single transaction to reduce WAL
@@ -131,6 +170,9 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		return err
 	}
 	if err := backfillStewardColumns(ctx, db); err != nil {
+		return err
+	}
+	if err := backfillSessionTokenRecords(ctx, db); err != nil {
 		return err
 	}
 
@@ -517,7 +559,11 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 			issued_at             TEXT NOT NULL,
 			last_activity         TEXT NOT NULL,
 			absolute_expires_at   TEXT NOT NULL,
-			hash_expires_at       TEXT
+			hash_expires_at       TEXT,
+			assurance             INTEGER NOT NULL DEFAULT 1,
+			bound_ip              TEXT    NOT NULL DEFAULT '',
+			last_proven_at        TEXT,
+			credential_id         BLOB
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_session_token_records_session_id ON session_token_records(session_id)`,
 	}

--- a/pkg/storage/providers/sqlite/schema_backfill_test.go
+++ b/pkg/storage/providers/sqlite/schema_backfill_test.go
@@ -261,3 +261,154 @@ func TestBackfillStewardColumns_FreshDB(t *testing.T) {
 	}
 	assert.True(t, hasIndex(t, db, "stewards", "idx_stewards_device_id"), "device_id index on fresh DB")
 }
+
+// sessionTokenContinuityColumns are the four device-continuity columns added in Issue #2788.
+var sessionTokenContinuityColumns = []string{"assurance", "bound_ip", "last_proven_at", "credential_id"}
+
+// legacySessionTokenRecordsSchema is the session_token_records DDL from Issue #2775, before
+// the four device-continuity columns (Issue #2788) were added. Used to simulate a
+// pre-#2788 deployment upgrading in place.
+const legacySessionTokenRecordsSchema = `CREATE TABLE IF NOT EXISTS session_token_records (
+	token_hash            TEXT PRIMARY KEY,
+	session_id            TEXT NOT NULL,
+	principal_id          TEXT NOT NULL,
+	connection_name       TEXT NOT NULL,
+	tenant_id             TEXT NOT NULL,
+	issued_at             TEXT NOT NULL,
+	last_activity         TEXT NOT NULL,
+	absolute_expires_at   TEXT NOT NULL,
+	hash_expires_at       TEXT
+)`
+
+// TestBackfillSessionTokenRecords_LegacyRecords verifies that initializeSchema adds the
+// four device-continuity columns to a pre-existing session_token_records table that lacks
+// them, and that a pre-existing human-session row receives assurance=1 (AssuranceBasic).
+func TestBackfillSessionTokenRecords_LegacyRecords(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	// Seed a legacy-shape table without the four continuity columns.
+	_, err := db.ExecContext(ctx, legacySessionTokenRecordsSchema)
+	require.NoError(t, err, "seed legacy session_token_records schema")
+
+	// Insert a pre-#2788 human-session row so we can prove the assurance default applies.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO session_token_records
+			(token_hash, session_id, principal_id, connection_name, tenant_id,
+			 issued_at, last_activity, absolute_expires_at)
+		VALUES ('legacy-hash', 'legacy-sess', 'admin', 'ctrl', 'tenant-1',
+			'2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T08:00:00Z')`)
+	require.NoError(t, err, "seed legacy row")
+
+	for _, col := range sessionTokenContinuityColumns {
+		assert.False(t, hasColumn(t, db, "session_token_records", col), "pre-condition: %s absent before back-fill", col)
+	}
+
+	// First invocation — should back-fill the four missing columns.
+	require.NoError(t, initializeSchema(ctx, db), "first initializeSchema call")
+
+	for _, col := range sessionTokenContinuityColumns {
+		assert.True(t, hasColumn(t, db, "session_token_records", col), "%s present after back-fill", col)
+	}
+
+	// The pre-existing human-session row must default to assurance=1 (AssuranceBasic)
+	// and empty bound_ip, with the nullable columns left NULL.
+	var assurance int
+	var boundIP string
+	var lastProven, credentialID sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT assurance, bound_ip, last_proven_at, credential_id
+		FROM session_token_records WHERE token_hash='legacy-hash'`).
+		Scan(&assurance, &boundIP, &lastProven, &credentialID))
+	assert.Equal(t, 1, assurance, "legacy row must default to assurance=1 (AssuranceBasic)")
+	assert.Equal(t, "", boundIP, "legacy row must default to empty bound_ip")
+	assert.False(t, lastProven.Valid, "legacy row last_proven_at must be NULL")
+	assert.False(t, credentialID.Valid, "legacy row credential_id must be NULL")
+}
+
+// TestBackfillSessionTokenRecords_Idempotent verifies that calling initializeSchema a second
+// time on an already-migrated session_token_records table succeeds and existing rows survive.
+func TestBackfillSessionTokenRecords_Idempotent(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	// Seed legacy table and migrate once.
+	_, err := db.ExecContext(ctx, legacySessionTokenRecordsSchema)
+	require.NoError(t, err, "seed legacy session_token_records schema")
+	require.NoError(t, initializeSchema(ctx, db), "first initializeSchema call")
+
+	// Insert a row to prove it survives the second pass.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO session_token_records
+			(token_hash, session_id, principal_id, connection_name, tenant_id,
+			 issued_at, last_activity, absolute_expires_at)
+		VALUES ('survive-hash', 'survive-sess', 'admin', 'ctrl', 'tenant-1',
+			'2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T08:00:00Z')`)
+	require.NoError(t, err, "insert test row")
+
+	// Second invocation must also succeed and leave rows intact.
+	require.NoError(t, initializeSchema(ctx, db), "second initializeSchema call (idempotency check)")
+
+	for _, col := range sessionTokenContinuityColumns {
+		assert.True(t, hasColumn(t, db, "session_token_records", col), "%s still present after second pass", col)
+	}
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM session_token_records WHERE token_hash='survive-hash'`).Scan(&count))
+	assert.Equal(t, 1, count, "row must survive second initializeSchema")
+}
+
+// TestBackfillSessionTokenRecords_FreshDB verifies that a fresh database initializes cleanly
+// with all four continuity columns present from the CREATE TABLE statement.
+func TestBackfillSessionTokenRecords_FreshDB(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, initializeSchema(ctx, db), "fresh DB initialization")
+
+	for _, col := range sessionTokenContinuityColumns {
+		assert.True(t, hasColumn(t, db, "session_token_records", col), "%s present on fresh DB", col)
+	}
+	assert.True(t, hasIndex(t, db, "session_token_records", "idx_session_token_records_session_id"),
+		"session_id index present on fresh DB")
+}
+
+// TestBackfillSessionTokenRecords_ProbeFailure verifies that a tableExists failure propagates
+// from backfillSessionTokenRecords rather than silently succeeding.
+func TestBackfillSessionTokenRecords_ProbeFailure(t *testing.T) {
+	ctx := context.Background()
+
+	// Open and immediately close the DB so all subsequent operations fail.
+	db, err := openDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	err = backfillSessionTokenRecords(ctx, db)
+	require.Error(t, err, "closed DB must return an error")
+	assert.Contains(t, err.Error(), "back-fill probe failed", "error must identify the probe stage")
+}
+
+// TestBackfillSessionTokenRecords_AlterFailure verifies that an ALTER TABLE failure on a
+// read-only database propagates instead of being silently ignored.
+func TestBackfillSessionTokenRecords_AlterFailure(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "readonly-sessiontokens.db")
+
+	// Create a file DB and seed the legacy table (no continuity columns).
+	setup, err := openDB(dbPath)
+	require.NoError(t, err)
+	_, err = setup.ExecContext(context.Background(), legacySessionTokenRecordsSchema)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close())
+
+	// Re-open in read-only mode — reads succeed but writes (ALTER) fail.
+	roDB, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = roDB.Close() })
+	require.NoError(t, roDB.Ping())
+
+	err = backfillSessionTokenRecords(context.Background(), roDB)
+	require.Error(t, err, "ALTER TABLE on read-only DB must return an error")
+	assert.Contains(t, err.Error(), "back-fill", "error must identify the back-fill stage")
+}

--- a/pkg/storage/providers/sqlite/session_token_store.go
+++ b/pkg/storage/providers/sqlite/session_token_store.go
@@ -45,11 +45,16 @@ func (s *SQLiteSessionTokenStore) Close() error {
 // session data is updated but hash_expires_at is left untouched so that a grace expiry
 // stamped by StampGraceExpiry is not erased by a subsequent LastActivity sync.
 func (s *SQLiteSessionTokenStore) Set(ctx context.Context, tokenHash string, sess *session.Session) error {
+	var lastProvenAt interface{}
+	if !sess.LastProvenAt.IsZero() {
+		lastProvenAt = formatTime(sess.LastProvenAt)
+	}
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO session_token_records
 			(token_hash, session_id, principal_id, connection_name, tenant_id,
-			 issued_at, last_activity, absolute_expires_at, hash_expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+			 issued_at, last_activity, absolute_expires_at, hash_expires_at,
+			 assurance, bound_ip, last_proven_at, credential_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
 		ON CONFLICT(token_hash) DO UPDATE SET
 			session_id          = excluded.session_id,
 			principal_id        = excluded.principal_id,
@@ -57,7 +62,11 @@ func (s *SQLiteSessionTokenStore) Set(ctx context.Context, tokenHash string, ses
 			tenant_id           = excluded.tenant_id,
 			issued_at           = excluded.issued_at,
 			last_activity       = excluded.last_activity,
-			absolute_expires_at = excluded.absolute_expires_at`,
+			absolute_expires_at = excluded.absolute_expires_at,
+			assurance           = excluded.assurance,
+			bound_ip            = excluded.bound_ip,
+			last_proven_at      = excluded.last_proven_at,
+			credential_id       = excluded.credential_id`,
 		tokenHash,
 		sess.ID,
 		sess.PrincipalID,
@@ -66,6 +75,10 @@ func (s *SQLiteSessionTokenStore) Set(ctx context.Context, tokenHash string, ses
 		formatTime(sess.IssuedAt),
 		formatTime(sess.LastActivity),
 		formatTime(sess.AbsoluteExpiresAt),
+		int(sess.Assurance),
+		sess.BoundIP,
+		lastProvenAt,
+		sess.CredentialID,
 	)
 	if err != nil {
 		return fmt.Errorf("sqlite: session token set failed: %w", err)
@@ -80,15 +93,20 @@ func (s *SQLiteSessionTokenStore) Get(ctx context.Context, tokenHash string) (*s
 	now := formatTime(time.Now().UTC())
 	var sess session.Session
 	var issuedAt, lastActivity, absoluteExpiresAt string
+	var assurance int
+	var lastProvenAt sql.NullString
+	var credentialID []byte
 	err := s.db.QueryRowContext(ctx, `
 		SELECT session_id, principal_id, connection_name, tenant_id,
-		       issued_at, last_activity, absolute_expires_at
+		       issued_at, last_activity, absolute_expires_at,
+		       assurance, bound_ip, last_proven_at, credential_id
 		FROM session_token_records
 		WHERE token_hash = ?
 		  AND (hash_expires_at IS NULL OR hash_expires_at > ?)`, tokenHash, now,
 	).Scan(
 		&sess.ID, &sess.PrincipalID, &sess.ConnectionName, &sess.TenantID,
 		&issuedAt, &lastActivity, &absoluteExpiresAt,
+		&assurance, &sess.BoundIP, &lastProvenAt, &credentialID,
 	)
 	if err == sql.ErrNoRows {
 		return nil, session.ErrSessionNotFound
@@ -99,6 +117,13 @@ func (s *SQLiteSessionTokenStore) Get(ctx context.Context, tokenHash string) (*s
 	sess.IssuedAt = parseTime(issuedAt)
 	sess.LastActivity = parseTime(lastActivity)
 	sess.AbsoluteExpiresAt = parseTime(absoluteExpiresAt)
+	sess.Assurance = session.AssuranceLevel(assurance)
+	if lastProvenAt.Valid && lastProvenAt.String != "" {
+		sess.LastProvenAt = parseTime(lastProvenAt.String)
+	}
+	if len(credentialID) > 0 {
+		sess.CredentialID = credentialID
+	}
 	return &sess, nil
 }
 
@@ -126,7 +151,8 @@ func (s *SQLiteSessionTokenStore) ListAll(ctx context.Context) ([]*session.Sessi
 	now := formatTime(time.Now().UTC())
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token_hash, session_id, principal_id, connection_name, tenant_id,
-		       issued_at, last_activity, absolute_expires_at
+		       issued_at, last_activity, absolute_expires_at,
+		       assurance, bound_ip, last_proven_at, credential_id
 		FROM session_token_records
 		WHERE hash_expires_at IS NULL OR hash_expires_at > ?
 		ORDER BY rowid`, now)
@@ -141,9 +167,13 @@ func (s *SQLiteSessionTokenStore) ListAll(ctx context.Context) ([]*session.Sessi
 		var tokenHash string
 		var sess session.Session
 		var issuedAt, lastActivity, absoluteExpiresAt string
+		var assurance int
+		var lastProvenAt sql.NullString
+		var credentialID []byte
 		if err := rows.Scan(
 			&tokenHash, &sess.ID, &sess.PrincipalID, &sess.ConnectionName, &sess.TenantID,
 			&issuedAt, &lastActivity, &absoluteExpiresAt,
+			&assurance, &sess.BoundIP, &lastProvenAt, &credentialID,
 		); err != nil {
 			return nil, fmt.Errorf("sqlite: session token list scan failed: %w", err)
 		}
@@ -154,6 +184,13 @@ func (s *SQLiteSessionTokenStore) ListAll(ctx context.Context) ([]*session.Sessi
 		sess.IssuedAt = parseTime(issuedAt)
 		sess.LastActivity = parseTime(lastActivity)
 		sess.AbsoluteExpiresAt = parseTime(absoluteExpiresAt)
+		sess.Assurance = session.AssuranceLevel(assurance)
+		if lastProvenAt.Valid && lastProvenAt.String != "" {
+			sess.LastProvenAt = parseTime(lastProvenAt.String)
+		}
+		if len(credentialID) > 0 {
+			sess.CredentialID = credentialID
+		}
 		cp := sess
 		sessions = append(sessions, &cp)
 	}


### PR DESCRIPTION
## Summary

- Extends `Session` struct with four device-continuity fields (`Assurance`, `CredentialID`, `BoundIP`, `LastProvenAt`) and adds `SilentReproofInterval` to `Config` (default 5 min), per ADR-021
- Source-IP change on `AssuranceStrong` session downgrades to `AssuranceBasic` + clears `LastProvenAt`; session is never hard-killed (ADR-021 Decision 5)
- Silent re-proof timer: when `SilentReproofInterval` elapses without a WebAuthn assertion the Manager falls back to `AssuranceBasic` gracefully; no error returned to the caller
- Middleware reads `sess.Assurance`/`sess.LastProvenAt` from live session state on both Bearer and cookie auth paths (previously hardcoded `AssuranceBasic`)
- Cross-node safety: continuity state persisted to durable store so failover nodes see correct assurance on first Validate call (loadFromStore path)
- SQLite: idempotent backfill via PRAGMA-guarded `ALTER TABLE`; Postgres: `006_session_continuity.sql` with `ADD COLUMN IF NOT EXISTS`

## Test plan

- [x] `TestIPChangeDowngradesAssurance` — same IP keeps Strong; different IP downgrades to Basic + clears LastProvenAt; store reflects downgrade
- [x] `TestTwoNodeSessionContinuity` — node A issues+elevates; node B cold-reads Strong from shared store; node B detects IP change → Basic; shared store updated
- [x] `TestSilentProofFailureFallsBackToBasic` — no CredentialID, 6 min elapsed, cold-read → Basic, no error
- [x] `TestBackfillSessionTokenRecords_*` (SQLite): legacy table upgrade, idempotency, probe-failure and alter-failure error propagation
- [x] `TestBackfillSessionTokenStoreContinuity_UpgradePath` (Postgres): legacy table upgrade with pre-existing row defaults to assurance=1
- [x] `make test` — 211 tests, 0 failures
- [x] `make check-architecture` — no central-provider violations
- [x] `go vet ./pkg/session/... ./pkg/storage/providers/... ./features/controller/api/...` — clean

## Specialist review results

**QA (qa-code-reviewer):** PASS — all three required tests present with real CFGMS components (no mocks), all four Session fields verified, middleware reads from session state, SQLite backfill called from `initializeSchema()`, Postgres migration correct. One non-blocking note: best-effort `store.Set()` during downgrade is untested in store-error scenarios (tracked for a future story).

**Security (security-engineer):** PASS — source IP never logged directly (context-only via `session.WithSourceIP()`), all SQL parameterized, no hardcoded secrets, IP comparison requires both `currentIP` and `BoundIP` non-empty, `make check-architecture` and `go vet` clean.

Fixes #2788

🤖 Generated with [Claude Code](https://claude.com/claude-code)