### PR TITLE
chore: make develop gofmt-clean to close an agent contamination path

### DIFF
--- a/features/modules/extended/acme/storage_windows.go
+++ b/features/modules/extended/acme/storage_windows.go
@@ -21,16 +21,16 @@ import (
 
 // Windows CryptoAPI constants
 const (
-	certStoreProvSystem        = 10         // CERT_STORE_PROV_SYSTEM_W
+	certStoreProvSystem         = 10         // CERT_STORE_PROV_SYSTEM_W
 	certSystemStoreLocalMachine = 0x00020000 // CERT_SYSTEM_STORE_LOCAL_MACHINE
 	certSystemStoreCurrentUser  = 0x00010000 // CERT_SYSTEM_STORE_CURRENT_USER
-	certFindSubjectStr         = 0x00080007 // CERT_FIND_SUBJECT_STR_W
+	certFindSubjectStr          = 0x00080007 // CERT_FIND_SUBJECT_STR_W
 	certStoreAddReplaceExisting = 3          // CERT_STORE_ADD_REPLACE_EXISTING
-	cryptExportable            = 0x00000001  // CRYPT_EXPORTABLE
-	cryptMachineKeyset         = 0x00000020  // CRYPT_MACHINE_KEYSET
-	pkcs12AllowOverwriteKey    = 0x00004000  // PKCS12_ALLOW_OVERWRITE_KEY
+	cryptExportable             = 0x00000001 // CRYPT_EXPORTABLE
+	cryptMachineKeyset          = 0x00000020 // CRYPT_MACHINE_KEYSET
+	pkcs12AllowOverwriteKey     = 0x00004000 // PKCS12_ALLOW_OVERWRITE_KEY
 
-	x509ASNEncoding = 0x00000001 // X509_ASN_ENCODING
+	x509ASNEncoding  = 0x00000001 // X509_ASN_ENCODING
 	pkcs7ASNEncoding = 0x00010000 // PKCS_7_ASN_ENCODING
 	encodingType     = x509ASNEncoding | pkcs7ASNEncoding
 )

--- a/features/modules/stdlib/file/acl_windows_test.go
+++ b/features/modules/stdlib/file/acl_windows_test.go
@@ -30,7 +30,7 @@ func TestMaskToAccessString(t *testing.T) {
 		{windows.GENERIC_WRITE, "Write"},
 		{windows.GENERIC_READ, "Read"},
 		// File-specific expanded constants — stored by Windows, returned by GetNamedSecurityInfo
-		{fileACLFullControl, "FullControl"},      // 0x001F01FF (FILE_ALL_ACCESS)
+		{fileACLFullControl, "FullControl"},       // 0x001F01FF (FILE_ALL_ACCESS)
 		{fileACLReadAndExecute, "ReadAndExecute"}, // 0x001200A9
 		{fileACLModify, "Modify"},                 // 0x001201BF
 		{fileACLWrite, "Write"},                   // 0x00120116

--- a/features/modules/stdlib/patch/windows_update.go
+++ b/features/modules/stdlib/patch/windows_update.go
@@ -1,8 +1,8 @@
 //go:build windows
+// +build windows
 
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// +build windows
 
 package patch
 

--- a/features/modules/stdlib/patch/windows_update_test.go
+++ b/features/modules/stdlib/patch/windows_update_test.go
@@ -1,8 +1,8 @@
 //go:build windows
+// +build windows
 
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// +build windows
 
 package patch_test
 

--- a/features/steward/dex/collector_linux_spike.go
+++ b/features/steward/dex/collector_linux_spike.go
@@ -134,7 +134,9 @@ type cnMsg struct {
 }
 
 // procEventHdr mirrors the fixed header of struct proc_event:
-//   what(4) + cpu(4) + timestamp_ns(8, aligned to 8)
+//
+//	what(4) + cpu(4) + timestamp_ns(8, aligned to 8)
+//
 // Total: 16 bytes.
 type procEventHdr struct {
 	What        uint32
@@ -217,11 +219,11 @@ type LinuxSpikeReport struct {
 type LinuxCollector struct {
 	cfg        LinuxSpikeConfig
 	sink       *Sink
-	total      atomic.Int64  // events successfully written to sink
-	dropped    atomic.Int64  // events dropped (ENOBUFS / ring exhaustion)
-	sinkErrors atomic.Int64  // sink write failures
+	total      atomic.Int64 // events successfully written to sink
+	dropped    atomic.Int64 // events dropped (ENOBUFS / ring exhaustion)
+	sinkErrors atomic.Int64 // sink write failures
 
-	mu           sync.Mutex
+	mu            sync.Mutex
 	sourcesActive []string
 
 	// started is closed by Run once all collection goroutines have been
@@ -677,10 +679,10 @@ func (c *LinuxCollector) decodeProcEvent(buf []byte) {
 		}
 		attr := attributePID(int(fi.ChildPid))
 		fields = map[string]any{
-			"event":       "fork",
-			"parent_pid":  fi.ParentPid,
-			"child_pid":   fi.ChildPid,
-			"ts_ns":       hdr.TimestampNs,
+			"event":      "fork",
+			"parent_pid": fi.ParentPid,
+			"child_pid":  fi.ChildPid,
+			"ts_ns":      hdr.TimestampNs,
 		}
 		mergeAttribution(fields, attr)
 
@@ -694,9 +696,9 @@ func (c *LinuxCollector) decodeProcEvent(buf []byte) {
 		}
 		attr := attributePID(int(ei.ProcessPid))
 		fields = map[string]any{
-			"event":   "exec",
-			"pid":     ei.ProcessPid,
-			"ts_ns":   hdr.TimestampNs,
+			"event": "exec",
+			"pid":   ei.ProcessPid,
+			"ts_ns": hdr.TimestampNs,
 		}
 		mergeAttribution(fields, attr)
 
@@ -899,11 +901,11 @@ func (c *LinuxCollector) runDiskStatsReader(ctx context.Context) {
 					continue
 				}
 				fields := map[string]any{
-					"dev":            dev,
-					"read_sectors":   deltaReadSec,
-					"write_sectors":  deltaWriteSec,
-					"read_ms":        deltaReadMs,
-					"write_ms":       deltaWriteMs,
+					"dev":           dev,
+					"read_sectors":  deltaReadSec,
+					"write_sectors": deltaWriteSec,
+					"read_ms":       deltaReadMs,
+					"write_ms":      deltaWriteMs,
 				}
 				if err := c.sink.WriteEvent(SignalLinuxDiskIO, fields); err != nil {
 					c.sinkErrors.Add(1)
@@ -918,8 +920,9 @@ func (c *LinuxCollector) runDiskStatsReader(ctx context.Context) {
 
 // readDiskStats parses /proc/diskstats into a map keyed by device name.
 // Field layout (1-indexed in kernel docs, 0-indexed here after major/minor/name):
-//   0=reads_completed, 1=reads_merged, 2=sectors_read, 3=time_reading_ms,
-//   4=writes_completed, 5=writes_merged, 6=sectors_written, 7=time_writing_ms, ...
+//
+//	0=reads_completed, 1=reads_merged, 2=sectors_read, 3=time_reading_ms,
+//	4=writes_completed, 5=writes_merged, 6=sectors_written, 7=time_writing_ms, ...
 func readDiskStats() map[string]diskStatRow {
 	data, err := os.ReadFile("/proc/diskstats")
 	if err != nil {
@@ -1076,10 +1079,10 @@ func (c *LinuxCollector) runThermalReader(ctx context.Context) {
 			}
 
 			fields := map[string]any{
-				"zone":       zone,
-				"type":       zoneType,
-				"temp_mc":    milliC,      // milli-Celsius
-				"temp_c":     float64(milliC) / 1000.0,
+				"zone":    zone,
+				"type":    zoneType,
+				"temp_mc": milliC, // milli-Celsius
+				"temp_c":  float64(milliC) / 1000.0,
 			}
 			if err := c.sink.WriteEvent(SignalLinuxThermal, fields); err != nil {
 				c.sinkErrors.Add(1)
@@ -1155,9 +1158,10 @@ func attributePID(pid int) procAttribution {
 // extractContainerID parses a cgroup v2 path for a Docker/containerd container ID.
 // Returns "" for host or non-container paths.
 // Example paths:
-//   /docker/abc123def456...   → "abc123def456..."
-//   /system.slice/docker-abc123.scope → "abc123"
-//   /                          → ""
+//
+//	/docker/abc123def456...   → "abc123def456..."
+//	/system.slice/docker-abc123.scope → "abc123"
+//	/                          → ""
 func extractContainerID(cgroupPath string) string {
 	parts := strings.Split(strings.Trim(cgroupPath, "/"), "/")
 	for _, part := range parts {

--- a/features/steward/dex/collector_linux_spike_test.go
+++ b/features/steward/dex/collector_linux_spike_test.go
@@ -418,8 +418,9 @@ func TestLinuxSpikeReportJSONRoundtrip(t *testing.T) {
 //
 // Gated on LINUX_SPIKE_LONGRUN=1 so it doesn't run in standard CI
 // (which times out after 30s). Run explicitly for the feasibility report:
-//   LINUX_SPIKE_LONGRUN=1 go test -tags spike -v -run TestLinuxCollectorStability \
-//     -timeout 900s ./features/steward/dex/
+//
+//	LINUX_SPIKE_LONGRUN=1 go test -tags spike -v -run TestLinuxCollectorStability \
+//	  -timeout 900s ./features/steward/dex/
 func TestLinuxCollectorStability(t *testing.T) {
 	if os.Getenv("LINUX_SPIKE_LONGRUN") != "1" {
 		t.Skip("set LINUX_SPIKE_LONGRUN=1 to run the sustained stability window (10 min)")

--- a/pkg/migrate/secrets/migrate_test.go
+++ b/pkg/migrate/secrets/migrate_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	migratesecrets "github.com/cfgis/cfgms/pkg/migrate/secrets"
 	"github.com/cfgis/cfgms/pkg/cert"
+	migratesecrets "github.com/cfgis/cfgms/pkg/migrate/secrets"
 	secretsinterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 

--- a/pkg/secrets/providers/steward/crypto_windows.go
+++ b/pkg/secrets/providers/steward/crypto_windows.go
@@ -15,7 +15,7 @@ import (
 
 // DPAPI flags
 const (
-	cryptprotectUIForbidden = 0x1
+	cryptprotectUIForbidden  = 0x1
 	cryptprotectLocalMachine = 0x4
 )
 

--- a/pkg/testing/storage/integration_test.go
+++ b/pkg/testing/storage/integration_test.go
@@ -1,8 +1,8 @@
 //go:build integration
+// +build integration
 
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// +build integration
 
 // Package storage provides comprehensive integration testing for storage providers
 // Tests storage providers against real backends for Epic 6 validation

--- a/test/e2e/hyperv/provision_windows_test.go
+++ b/test/e2e/hyperv/provision_windows_test.go
@@ -69,11 +69,11 @@ const (
 // type, not a mock.
 type e2eConfig struct{ m map[string]interface{} }
 
-func (c e2eConfig) AsMap() map[string]interface{}     { return c.m }
-func (c e2eConfig) ToYAML() ([]byte, error)           { return nil, nil }
-func (c e2eConfig) FromYAML([]byte) error             { return nil }
-func (c e2eConfig) Validate() error                   { return nil }
-func (c e2eConfig) GetManagedFields() []string        { return nil }
+func (c e2eConfig) AsMap() map[string]interface{} { return c.m }
+func (c e2eConfig) ToYAML() ([]byte, error)       { return nil, nil }
+func (c e2eConfig) FromYAML([]byte) error         { return nil }
+func (c e2eConfig) Validate() error               { return nil }
+func (c e2eConfig) GetManagedFields() []string    { return nil }
 
 // The e2eSecretStore type used here is the shared in-memory SecretStore double
 // defined in provision_debian_test.go (#2046); both the Linux preseed and the

--- a/test/integration/logging/central_logging_integration_test.go
+++ b/test/integration/logging/central_logging_integration_test.go
@@ -1,8 +1,8 @@
 //go:build integration
+// +build integration
 
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// +build integration
 
 package logging_test
 

--- a/test/integration/logging/file_integration_test.go
+++ b/test/integration/logging/file_integration_test.go
@@ -1,8 +1,8 @@
 //go:build integration
+// +build integration
 
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// +build integration
 
 package logging_test
 

--- a/test/integration/session_store_test.go
+++ b/test/integration/session_store_test.go
@@ -108,10 +108,10 @@ func newTestCertManager(t *testing.T, certPath string) *cert.Manager {
 	mgr, err := cert.NewManager(&cert.ManagerConfig{
 		StoragePath: certPath,
 		CAConfig: &cert.CAConfig{
-			Organization:       "CFGMS Session Store Integration Test CA",
-			Country:            "US",
-			ValidityDays:       1,
-			KeySize:            2048,
+			Organization: "CFGMS Session Store Integration Test CA",
+			Country:      "US",
+			ValidityDays: 1,
+			KeySize:      2048,
 		},
 		LoadExistingCA:       false,
 		RenewalThresholdDays: 1,


### PR DESCRIPTION
## Summary

Thirteen files on develop were gofmt-dirty. That is not merely untidy — it is an **active contamination path for agent PRs**, and it has already reached develop once.

## Mechanism

`.golangci.yml` sets `formatters.enable: [gofmt, goimports]` with `gofmt.simplify: true`, and **`issues.new: false`** — so golangci-lint reports findings **tree-wide**, not just on lines the PR changed. `make lint` runs bare `golangci-lint run`.

So **any agent running the lint gate is handed formatting findings for files it never touched**, and formats them to get green.

## Observed three times; the most recent landed

PR #2824 was a telemetry test fix touching only `features/steward/client/` — yet it committed and merged a gofmt realignment of `features/controller/api/handlers_webauthn_test.go` in merge commit `212ccb36`. Its own commit message says so:

> "Also fix a pre-existing gofmt alignment issue in handlers_webauthn_test.go (const block at line 352) caught by the CI lint gate during review."

The file had nothing to do with webauthn. It simply happened to be the dirty file at the time. Two earlier instances were caught before commit (a stray `handlers_webauthn_test.go` in #2826's worktree, an unstaged `publisher.go` in `pr-fix-2810`).

## Changes

`gofmt -w` over the 13 dirty files. **Formatting only** — no logic, no exported surface, no behavioural change. The diff is whitespace alignment plus gofmt's normalisation of the legacy `// +build` constraint blocks (it inserts the required blank line after the constraint).

## Testing

| Check | Result |
|---|---|
| `gofmt -l` over the tree (excl. `.cache`, vendor) | **0 files** |
| `go build ./...` | pass |
| `go vet` | pass |
| `GOOS=windows go build ./...` | pass |
| `GOOS=windows go vet` | pass |
| `//go:build windows` / `// +build windows` pairs | intact |

The Windows configuration was verified **explicitly** rather than assumed: gofmt rewrote build-constraint blocks, and **seven of these files are `//go:build windows`**, which a Linux build silently skips. A broken constraint would not have surfaced until a merge-group Windows job — exactly the failure class this repo has been fighting.

## Follow-up (not in this PR)

Setting `issues.new-from-rev` in `.golangci.yml` would stop this class recurring even if develop drifts dirty again. Worth its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5e2oETfBbpBFadKkjY8B