### PR TITLE
web: add module review-queue UI (Issue #2732)

### DIFF
--- a/pkg/cache/runtime_test.go
+++ b/pkg/cache/runtime_test.go
@@ -474,8 +474,16 @@ func TestBackgroundCleanup(t *testing.T) {
 	err = rc.SetRuntimeState(ctx, "key1", "value1")
 	require.NoError(t, err)
 
-	// Wait for cleanup to run
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the background cleanup goroutine to actually run and record the
+	// expirations. Polling a condition (rather than reading once after a fixed
+	// sleep) avoids racing the cleanup goroutine's scheduling under CPU load:
+	// the sleep window elapsing does not guarantee the cleanup goroutine has
+	// been scheduled to process its ticks yet. Both the 30ms session and the
+	// 50ms runtime item must be expired and cleaned before the assertions
+	// below hold, so wait until both have been counted (ItemsExpired >= 2).
+	require.Eventually(t, func() bool {
+		return rc.GetCacheStats().ItemsExpired >= 2
+	}, 2*time.Second, 5*time.Millisecond, "background cleanup did not expire both items")
 
 	// Items should be cleaned up
 	_, err = rc.GetSession(ctx, "session1")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,11 +5,12 @@
  * App root: router + auth provider + route guard around the authenticated
  * app shell (Story #2496).
  *
- * Route table (Story #2723, #2727, #2730, #2731, Issue #2733):
+ * Route table (Story #2723, #2727, #2730, #2731, Issue #2732, #2733):
  *   /                → AppShell layout → FleetOverview
  *   /stewards/:id    → AppShell layout → StewardAssetPage
  *   /audit           → AppShell layout → AuditView
  *   /config          → AppShell layout → ConfigListView
+ *   /modules         → AppShell layout → ModuleReviewQueue
  *   /workflows       → AppShell layout → WorkflowListView
  *   /accounts        → AppShell layout → AccountsView
  *
@@ -28,6 +29,7 @@ import AuditView from './audit/AuditView.tsx'
 import ConfigListView from './config/ConfigListView.tsx'
 import WorkflowListView from './workflow/WorkflowListView.tsx'
 import AccountsView from './accounts/AccountsView.tsx'
+import ModuleReviewQueue from './modules/ModuleReviewQueue.tsx'
 
 function App() {
   return (
@@ -39,6 +41,7 @@ function App() {
             <Route path="stewards/:id" element={<StewardAssetPage />} />
             <Route path="audit" element={<AuditView />} />
             <Route path="config" element={<ConfigListView />} />
+            <Route path="modules" element={<ModuleReviewQueue />} />
             <Route path="workflows" element={<WorkflowListView />} />
             <Route path="accounts" element={<AccountsView />} />
           </Route>

--- a/web/src/modules/ModuleReviewQueue.test.tsx
+++ b/web/src/modules/ModuleReviewQueue.test.tsx
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * ModuleReviewQueue test suite (Issue #2732): list rendering, data states,
+ * approve-confirm-fire, and reject-confirm-fire.
+ *
+ * Security A9.1: bundle metadata is attacker-influenced. The tests verify
+ * that fields render as text content, not via dangerouslySetInnerHTML.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import ModuleReviewQueue from './ModuleReviewQueue.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+function makeBundle(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    address: 'vendor-a:file:1.0.0:abc123',
+    publisher: 'vendor-a',
+    name: 'file',
+    version: '1.0.0',
+    content_hash: 'abc123==',
+    ...overrides,
+  }
+}
+
+function makeListResponse(bundles: object[], status = 200) {
+  return new Response(
+    JSON.stringify({ data: { pending: bundles } }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeActionResponse(action: 'approved' | 'rejected' = 'approved', status = 200) {
+  return new Response(
+    JSON.stringify({ data: { status: action } }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function renderQueue() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <ModuleReviewQueue />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('ModuleReviewQueue — heading and list rendering', () => {
+  it('renders the Modules heading', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderQueue()
+    expect(screen.getByRole('heading', { name: /modules/i, level: 1 })).toBeInTheDocument()
+  })
+
+  it('shows loading rows while fetching', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderQueue()
+    expect(screen.getByTestId('modules-loading')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when no bundles are pending', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('modules-empty')).toBeInTheDocument())
+  })
+
+  it('renders a table with bundle rows when bundles are pending', async () => {
+    fetchMock.mockResolvedValue(
+      makeListResponse([
+        makeBundle(),
+        makeBundle({ address: 'vendor-b:patch:2.0.0:def456', name: 'patch', publisher: 'vendor-b' }),
+      ]),
+    )
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('modules-table')).toBeInTheDocument())
+    expect(screen.getAllByTestId('bundle-row')).toHaveLength(2)
+  })
+
+  it('renders bundle name, publisher, and version as text nodes', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('modules-table')).toBeInTheDocument())
+    expect(screen.getByText('file')).toBeInTheDocument()
+    expect(screen.getByText('vendor-a')).toBeInTheDocument()
+    expect(screen.getByText('1.0.0')).toBeInTheDocument()
+  })
+
+  it('shows Approve and Reject buttons for each bundle row', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('modules-table')).toBeInTheDocument())
+    expect(screen.getByTestId('bundle-approve-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('bundle-reject-btn')).toBeInTheDocument()
+  })
+
+  it('shows an error notice on fetch failure', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([], 500))
+    renderQueue()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('500')
+  })
+
+  it('retries the fetch when Retry is clicked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([], 500))
+      .mockResolvedValueOnce(makeListResponse([]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    await waitFor(() => expect(screen.getByTestId('modules-empty')).toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('ModuleReviewQueue — approve-confirm-fire', () => {
+  it('shows no confirm dialog before any action is triggered', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('modules-table')).toBeInTheDocument())
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens the approve confirm dialog showing publisher and content address', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-approve-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-approve-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /approve module bundle/i })).toBeInTheDocument()
+    expect(screen.getByTestId('confirm-publisher')).toHaveTextContent('vendor-a')
+    expect(screen.getByTestId('confirm-address')).toHaveTextContent('vendor-a:file:1.0.0:abc123')
+  })
+
+  it('cancel closes the approve dialog without firing any approve request', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-approve-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-approve-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('confirm-cancel-btn'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires the approve POST and refreshes the list when the confirm button is clicked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockResolvedValueOnce(makeActionResponse('approved'))
+      .mockResolvedValueOnce(makeListResponse([]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-approve-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-approve-btn'))
+    fireEvent.click(screen.getByTestId('confirm-approve-btn'))
+    await waitFor(() => expect(screen.getByTestId('modules-empty')).toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const approveCall = fetchMock.mock.calls[1]!
+    expect(String(approveCall[0])).toContain('/approve')
+  })
+
+  it('shows an action error banner when the approve request fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: 'Bundle not found' } }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-approve-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-approve-btn'))
+    fireEvent.click(screen.getByTestId('confirm-approve-btn'))
+    await waitFor(() => expect(screen.getByTestId('action-error')).toBeInTheDocument())
+    expect(screen.getByTestId('action-error')).toHaveTextContent('Bundle not found')
+  })
+})
+
+describe('ModuleReviewQueue — reject-confirm-fire', () => {
+  it('opens the reject confirm dialog showing publisher and content address', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-reject-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-reject-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /reject module bundle/i })).toBeInTheDocument()
+    expect(screen.getByTestId('confirm-publisher')).toHaveTextContent('vendor-a')
+    expect(screen.getByTestId('confirm-address')).toHaveTextContent('vendor-a:file:1.0.0:abc123')
+  })
+
+  it('cancel closes the reject dialog without firing any reject request', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-reject-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-reject-btn'))
+    fireEvent.click(screen.getByTestId('confirm-cancel-btn'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires the reject POST and refreshes the list when the confirm button is clicked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockResolvedValueOnce(makeActionResponse('rejected'))
+      .mockResolvedValueOnce(makeListResponse([]))
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-reject-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-reject-btn'))
+    fireEvent.click(screen.getByTestId('confirm-reject-btn'))
+    await waitFor(() => expect(screen.getByTestId('modules-empty')).toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const rejectCall = fetchMock.mock.calls[1]!
+    expect(String(rejectCall[0])).toContain('/reject')
+  })
+
+  it('shows an action error banner when the reject request fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: 'Not in pending state' } }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('bundle-reject-btn')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('bundle-reject-btn'))
+    fireEvent.click(screen.getByTestId('confirm-reject-btn'))
+    await waitFor(() => expect(screen.getByTestId('action-error')).toBeInTheDocument())
+    expect(screen.getByTestId('action-error')).toHaveTextContent('Not in pending state')
+  })
+})

--- a/web/src/modules/ModuleReviewQueue.tsx
+++ b/web/src/modules/ModuleReviewQueue.tsx
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Module review queue (Issue #2732). The /modules route page. Renders the
+ * module-bundle approval queue backed by:
+ *   GET  /api/v1/modules/approvals
+ *   POST /api/v1/modules/approvals/{address}/approve
+ *   POST /api/v1/modules/approvals/{address}/reject
+ *
+ * Security: bundle metadata (publisher, content address) is attacker-influenced
+ * — an unsigned or malicious bundle can carry arbitrary strings. All fields are
+ * rendered as JSX text nodes only, never via dangerouslySetInnerHTML.
+ *
+ * Approve and reject each require an explicit confirm step that shows the
+ * bundle's content address and publisher. Approving authorizes code execution
+ * on every managed endpoint that requires that bundle; the confirm step
+ * reflects that weight.
+ */
+import { useState } from 'react'
+import { useModuleQueue } from './useModuleQueue.ts'
+import type { ModuleApprovalEntry } from './useModuleQueue.ts'
+
+interface PendingAction {
+  bundle: ModuleApprovalEntry
+  action: 'approve' | 'reject'
+}
+
+function LoadingRows() {
+  return (
+    <div data-testid="modules-loading" aria-label="Loading module queue">
+      {Array.from({ length: 3 }, (_, i) => (
+        <div className="skrow" key={i}>
+          <span className="skel" style={{ width: '25%' }} />
+          <span className="skel" style={{ width: '15%' }} />
+          <span className="skel" style={{ width: '20%' }} />
+          <span className="skel" style={{ width: '55%' }} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ErrorNotice({ detail, onRetry }: { detail: string; onRetry: () => void }) {
+  return (
+    <div className="notice err" role="alert">
+      <div className="ic">!</div>
+      <h3>Couldn&apos;t load module queue</h3>
+      <p>The module approval list request failed. Check your connection and try again.</p>
+      <span className="mono2 detail">{detail}</span>
+      <button type="button" className="btn" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  )
+}
+
+function ModuleEmpty() {
+  return (
+    <div className="notice empty" data-testid="modules-empty">
+      <div className="ic">◍</div>
+      <h3>No modules pending review</h3>
+      <p>
+        All module bundles have been reviewed. New bundles will appear here when submitted for
+        approval.
+      </p>
+    </div>
+  )
+}
+
+function BundleRow({
+  bundle,
+  onApprove,
+  onReject,
+}: {
+  bundle: ModuleApprovalEntry
+  onApprove: () => void
+  onReject: () => void
+}) {
+  return (
+    <tr data-testid="bundle-row">
+      <td>
+        <span className="nm">{bundle.name}</span>
+      </td>
+      <td>
+        <span className="mono2">{bundle.version}</span>
+      </td>
+      <td>
+        <span className="mono2">{bundle.publisher}</span>
+      </td>
+      <td>
+        <span className="mono2">{bundle.address}</span>
+      </td>
+      <td onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          className="wf-btn-sm"
+          onClick={onApprove}
+          data-testid="bundle-approve-btn"
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          className="wf-btn-sm-danger"
+          onClick={onReject}
+          data-testid="bundle-reject-btn"
+          style={{ marginLeft: '6px' }}
+        >
+          Reject
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+export default function ModuleReviewQueue() {
+  const { bundles, loading, error, retry, approve, reject } = useModuleQueue()
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  async function handleConfirm() {
+    if (!pendingAction) return
+    const { bundle, action } = pendingAction
+    setActionError(null)
+    setPendingAction(null)
+    const result = action === 'approve'
+      ? await approve(bundle.address)
+      : await reject(bundle.address)
+    if (!result.ok) {
+      setActionError(result.error)
+    }
+  }
+
+  return (
+    <>
+      <div className="htitle">
+        <h1>Modules</h1>
+        <p>Review and approve or reject module bundles awaiting deployment authorization.</p>
+      </div>
+
+      <section className="panel">
+        {!loading && error === null && (
+          <div className="ptool">
+            <span className="cnt" data-testid="bundle-count">
+              {bundles.length} pending
+            </span>
+          </div>
+        )}
+
+        {actionError !== null && (
+          <div className="wf-form-error" style={{ padding: '8px 14px' }} data-testid="action-error">
+            {actionError}
+          </div>
+        )}
+
+        {loading ? (
+          <LoadingRows />
+        ) : error !== null ? (
+          <ErrorNotice detail={error} onRetry={retry} />
+        ) : bundles.length === 0 ? (
+          <ModuleEmpty />
+        ) : (
+          <table className="tbl" data-testid="modules-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Version</th>
+                <th>Publisher</th>
+                <th>Address</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bundles.map((bundle) => (
+                <BundleRow
+                  key={bundle.address}
+                  bundle={bundle}
+                  onApprove={() => {
+                    setActionError(null)
+                    setPendingAction({ bundle, action: 'approve' })
+                  }}
+                  onReject={() => {
+                    setActionError(null)
+                    setPendingAction({ bundle, action: 'reject' })
+                  }}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {pendingAction !== null && (
+        <div
+          className="wf-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="module-action-title"
+        >
+          <div className="wf-modal">
+            <h3 id="module-action-title">
+              {pendingAction.action === 'approve'
+                ? 'Approve module bundle?'
+                : 'Reject module bundle?'}
+            </h3>
+            <dl className="module-confirm-detail">
+              <dt>Publisher</dt>
+              <dd>
+                <span className="mono2" data-testid="confirm-publisher">
+                  {pendingAction.bundle.publisher}
+                </span>
+              </dd>
+              <dt>Content address</dt>
+              <dd>
+                <span className="mono2" data-testid="confirm-address">
+                  {pendingAction.bundle.address}
+                </span>
+              </dd>
+            </dl>
+            {pendingAction.action === 'approve' ? (
+              <p>
+                Approving this bundle authorizes it to execute on every managed endpoint that
+                requires it. This action is recorded in the audit log.
+              </p>
+            ) : (
+              <p>
+                Rejecting this bundle blocks it from deployment to managed endpoints.
+              </p>
+            )}
+            <div className="wf-modal-actions">
+              <button
+                type="button"
+                className="wf-btn-secondary"
+                onClick={() => setPendingAction(null)}
+                data-testid="confirm-cancel-btn"
+              >
+                Cancel
+              </button>
+              {pendingAction.action === 'approve' ? (
+                <button
+                  type="button"
+                  className="wf-btn"
+                  onClick={handleConfirm}
+                  data-testid="confirm-approve-btn"
+                >
+                  Approve bundle
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="wf-btn-danger"
+                  onClick={handleConfirm}
+                  data-testid="confirm-reject-btn"
+                >
+                  Reject bundle
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/web/src/modules/useModuleQueue.test.ts
+++ b/web/src/modules/useModuleQueue.test.ts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  useModuleQueue,
+  parseModuleApprovalEntry,
+  parseModuleApprovalList,
+} from './useModuleQueue.ts'
+import type { ActionResult } from './useModuleQueue.ts'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function makeBundle(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    address: 'vendor-a:file:1.0.0:abc123',
+    publisher: 'vendor-a',
+    name: 'file',
+    version: '1.0.0',
+    content_hash: 'abc123==',
+    ...overrides,
+  }
+}
+
+function makeListResponse(bundles: object[], status = 200) {
+  return new Response(
+    JSON.stringify({ data: { pending: bundles } }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeActionResponse(status = 200) {
+  return new Response(
+    JSON.stringify({ data: { status: 'approved' } }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+describe('parseModuleApprovalEntry', () => {
+  it('parses a valid bundle entry', () => {
+    const entry = parseModuleApprovalEntry(makeBundle())
+    expect(entry).not.toBeNull()
+    expect(entry!.address).toBe('vendor-a:file:1.0.0:abc123')
+    expect(entry!.publisher).toBe('vendor-a')
+    expect(entry!.name).toBe('file')
+    expect(entry!.version).toBe('1.0.0')
+    expect(entry!.content_hash).toBe('abc123==')
+  })
+
+  it('returns null when address is empty', () => {
+    expect(parseModuleApprovalEntry(makeBundle({ address: '' }))).toBeNull()
+  })
+
+  it('returns null when address is missing', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { address: _a, ...withoutAddress } = makeBundle()
+    expect(parseModuleApprovalEntry(withoutAddress)).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(parseModuleApprovalEntry(null)).toBeNull()
+    expect(parseModuleApprovalEntry('string')).toBeNull()
+    expect(parseModuleApprovalEntry(42)).toBeNull()
+  })
+
+  it('coerces non-string fields to empty string', () => {
+    const entry = parseModuleApprovalEntry(
+      makeBundle({ publisher: 42, name: null, version: true }),
+    )
+    expect(entry).not.toBeNull()
+    expect(entry!.publisher).toBe('')
+    expect(entry!.name).toBe('')
+    expect(entry!.version).toBe('')
+  })
+})
+
+describe('parseModuleApprovalList', () => {
+  it('parses a valid list', () => {
+    const list = parseModuleApprovalList({ pending: [makeBundle()] })
+    expect(list).toHaveLength(1)
+    expect(list[0]!.address).toBe('vendor-a:file:1.0.0:abc123')
+  })
+
+  it('returns empty list when pending is empty', () => {
+    expect(parseModuleApprovalList({ pending: [] })).toEqual([])
+  })
+
+  it('skips entries with empty address', () => {
+    const list = parseModuleApprovalList({ pending: [makeBundle({ address: '' })] })
+    expect(list).toHaveLength(0)
+  })
+
+  it('throws on null input', () => {
+    expect(() => parseModuleApprovalList(null)).toThrow('unexpected response shape')
+  })
+
+  it('throws when pending is missing', () => {
+    expect(() => parseModuleApprovalList({})).toThrow('unexpected response shape')
+  })
+
+  it('throws when input is not an object', () => {
+    expect(() => parseModuleApprovalList('string')).toThrow('unexpected response shape')
+    expect(() => parseModuleApprovalList(42)).toThrow('unexpected response shape')
+  })
+})
+
+describe('useModuleQueue', () => {
+  it('starts in loading state before the response arrives', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useModuleQueue())
+    expect(result.current.loading).toBe(true)
+    expect(result.current.bundles).toEqual([])
+    expect(result.current.error).toBeNull()
+  })
+
+  it('returns parsed bundles on success and clears loading', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([makeBundle()]))
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.bundles).toHaveLength(1)
+    expect(result.current.bundles[0]!.publisher).toBe('vendor-a')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces a user-presentable error on non-ok response', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([], 503))
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toContain('503')
+    expect(result.current.bundles).toEqual([])
+  })
+
+  it('surfaces a user-presentable error on network failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe('network down')
+  })
+
+  it('returns a fallback error string when the thrown error has no message', async () => {
+    fetchMock.mockRejectedValue({})
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toContain('request failed')
+  })
+
+  it('refetches when retry is called', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([]))
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.retry()
+    })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('approve POSTs to the correct endpoint and triggers a list refetch', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockResolvedValueOnce(makeActionResponse())
+      .mockResolvedValueOnce(makeListResponse([]))
+
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let actionResult!: ActionResult
+    await act(async () => {
+      actionResult = await result.current.approve('vendor-a:file:1.0.0:abc123')
+    })
+
+    expect(actionResult.ok).toBe(true)
+    const approveCall = fetchMock.mock.calls[1]!
+    expect(String(approveCall[0])).toContain('/approve')
+    expect(String(approveCall[0])).toContain('vendor-a')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+  })
+
+  it('reject POSTs to the correct endpoint and triggers a list refetch', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockResolvedValueOnce(makeActionResponse())
+      .mockResolvedValueOnce(makeListResponse([]))
+
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let actionResult!: ActionResult
+    await act(async () => {
+      actionResult = await result.current.reject('vendor-a:file:1.0.0:abc123')
+    })
+
+    expect(actionResult.ok).toBe(true)
+    const rejectCall = fetchMock.mock.calls[1]!
+    expect(String(rejectCall[0])).toContain('/reject')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+  })
+
+  it('approve returns an error result on non-ok response', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: 'Bundle not found' } }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let actionResult!: ActionResult
+    await act(async () => {
+      actionResult = await result.current.approve('vendor-a:file:1.0.0:abc123')
+    })
+
+    expect(actionResult.ok).toBe(false)
+    expect((actionResult as { ok: false; error: string }).error).toContain('Bundle not found')
+  })
+
+  it('reject returns an error result on network failure', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([makeBundle()]))
+      .mockRejectedValueOnce(new Error('network down'))
+
+    const { result } = renderHook(() => useModuleQueue())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let actionResult!: ActionResult
+    await act(async () => {
+      actionResult = await result.current.reject('vendor-a:file:1.0.0:abc123')
+    })
+
+    expect(actionResult.ok).toBe(false)
+    expect((actionResult as { ok: false; error: string }).error).toBe('network down')
+  })
+})

--- a/web/src/modules/useModuleQueue.ts
+++ b/web/src/modules/useModuleQueue.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Module review-queue hook (Issue #2732). Wraps:
+ *   GET  /api/v1/modules/approvals             → pending bundle list
+ *   POST /api/v1/modules/approvals/{address}/approve
+ *   POST /api/v1/modules/approvals/{address}/reject
+ *
+ * Security: bundle metadata (publisher, content address) originates from
+ * potentially untrusted sources — an unsigned bundle can carry arbitrary
+ * strings. All fields are coerced to plain strings. Callers must render as
+ * text nodes only, never via dangerouslySetInnerHTML.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface ModuleApprovalEntry {
+  address: string
+  publisher: string
+  name: string
+  version: string
+  content_hash: string
+}
+
+export type ActionResult = { ok: true } | { ok: false; error: string }
+
+export interface UseModuleQueueResult {
+  bundles: ModuleApprovalEntry[]
+  loading: boolean
+  error: string | null
+  retry: () => void
+  approve: (address: string) => Promise<ActionResult>
+  reject: (address: string) => Promise<ActionResult>
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+export function parseModuleApprovalEntry(value: unknown): ModuleApprovalEntry | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const address = str(r.address)
+  if (!address) return null
+  return {
+    address,
+    publisher: str(r.publisher),
+    name: str(r.name),
+    version: str(r.version),
+    content_hash: str(r.content_hash),
+  }
+}
+
+export function parseModuleApprovalList(data: unknown): ModuleApprovalEntry[] {
+  if (typeof data !== 'object' || data === null) throw new Error('unexpected response shape')
+  const obj = data as Record<string, unknown>
+  if (!Array.isArray(obj.pending)) throw new Error('unexpected response shape')
+  const list: ModuleApprovalEntry[] = []
+  for (const item of obj.pending) {
+    const entry = parseModuleApprovalEntry(item)
+    if (entry !== null) list.push(entry)
+  }
+  return list
+}
+
+// ── Action helper ─────────────────────────────────────────────────────────────
+
+async function postAction(path: string): Promise<ActionResult> {
+  try {
+    const response = await apiFetch(path, { method: 'POST' })
+    if (!response.ok) {
+      const errBody = (await response.json().catch(() => ({}))) as Record<string, unknown>
+      const errMsg =
+        ((errBody?.error as Record<string, unknown>)?.message as string) ||
+        `Request failed — ${response.status}`
+      return { ok: false, error: errMsg }
+    }
+    return { ok: true }
+  } catch (cause: unknown) {
+    return {
+      ok: false,
+      error: cause instanceof Error && cause.message ? cause.message : 'Request failed',
+    }
+  }
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+interface FetchOutcome {
+  key: string
+  bundles?: ModuleApprovalEntry[]
+  error?: string
+}
+
+export function useModuleQueue(): UseModuleQueueResult {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+  const key = `module-approvals:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/modules/approvals')
+      .then(async (response) => {
+        if (!response.ok)
+          throw new Error(`GET /api/v1/modules/approvals — ${response.status}`)
+        const body: unknown = await response.json()
+        const parsed = parseModuleApprovalList(
+          (body as Record<string, unknown> | null)?.data,
+        )
+        if (cancelled) return
+        setOutcome({ key, bundles: parsed })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/modules/approvals — request failed',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, attempt])
+
+  const approve = useCallback(
+    async (address: string): Promise<ActionResult> => {
+      const result = await postAction(
+        `/api/v1/modules/approvals/${encodeURIComponent(address)}/approve`,
+      )
+      if (result.ok) retry()
+      return result
+    },
+    [retry],
+  )
+
+  const reject = useCallback(
+    async (address: string): Promise<ActionResult> => {
+      const result = await postAction(
+        `/api/v1/modules/approvals/${encodeURIComponent(address)}/reject`,
+      )
+      if (result.ok) retry()
+      return result
+    },
+    [retry],
+  )
+
+  const current = outcome?.key === key ? outcome : null
+  return {
+    bundles: current?.bundles ?? [],
+    loading: current === null,
+    error: current?.error ?? null,
+    retry,
+    approve,
+    reject,
+  }
+}

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -55,21 +55,22 @@ function renderShell() {
 }
 
 describe('AppShell', () => {
-  it('renders sidebar navigation with Fleet, Config, Workflows, Audit, and Accounts as links', () => {
+  it('renders sidebar navigation with Fleet, Modules, Config, Workflows, Audit, and Accounts as links', () => {
     renderShell()
     expect(screen.getByRole('navigation')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /fleet/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /modules/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /config/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /workflows/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /audit/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
   })
 
-  it('marks only Modules as soon; Config, Fleet, Workflows, Audit, and Accounts are real links', () => {
+  it('all nav items are real links; no soon-tagged placeholders remain (Issue #2732)', () => {
     renderShell()
-    // Only 1 soon-tagged item remains (Modules); Config, Workflows, Audit, Accounts are real links
-    expect(screen.getAllByText(/soon/i)).toHaveLength(1)
-    // Config, Workflows, Audit, and Accounts are NavLinks, not soon anchors
+    expect(screen.queryAllByText(/soon/i)).toHaveLength(0)
+    expect(screen.getByRole('link', { name: /fleet/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /modules/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /config/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /workflows/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /audit/i })).toBeInTheDocument()

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -27,7 +27,7 @@ export interface AppShellContext {
 
 const NAV_ITEMS = [
   { label: 'Fleet', to: '/', soon: false },
-  { label: 'Modules', to: null, soon: true },
+  { label: 'Modules', to: '/modules', soon: false },
   { label: 'Config', to: '/config', soon: false },
   { label: 'Workflows', to: '/workflows', soon: false },
   { label: 'Audit', to: '/audit', soon: false },


### PR DESCRIPTION
## Summary

- Adds `/modules` route with `ModuleReviewQueue` component: table of pending bundles, approve/reject each behind a confirm dialog showing content address and publisher
- `useModuleQueue` hook wraps `GET /api/v1/modules/approvals`, `POST .../approve`, `POST .../reject` with auto-refresh on success
- Promotes the sidebar Modules nav item from `soon` placeholder to a real link
- Fixes `TestBackgroundCleanup` flaky test (timing race replaced with `require.Eventually`)

Fixes #2732

## Security

- Bundle metadata (publisher, content address) is attacker-influenced — all fields rendered as JSX text nodes only, never `dangerouslySetInnerHTML`
- Approve confirm step displays content address + publisher and explains the blast radius (code execution on all managed endpoints) before firing
- No client-side workaround for 403 — if a caller lacks `IsAdmin`, the error surfaces as-is; the `TierMTLSOnly` gate is preserved

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| Security | **PASS** — TypeScript-only changeset; check-architecture PASS; no hardcoded secrets |
| Test Quality | **PASS** — no mocks of CFGMS components; fetch stub is correct for browser boundary; all error paths covered |
| Code Review | **PASS after 1 fix** — pre-existing `TestBackgroundCleanup` flaky test fixed with `require.Eventually` |

## Test Plan

- [ ] `make test-agent-complete` passes (verified by story-review workflow, 2 rounds)
- [ ] `ModuleReviewQueue.test.tsx`: list rendering, approve-confirm-fire, reject-confirm-fire all covered
- [ ] `useModuleQueue.test.ts`: parse helpers, hook lifecycle, approve/reject POST targeting verified
- [ ] AppShell nav: no `soon` tags remain; Modules is a real link

🤖 Generated with [Claude Code](https://claude.com/claude-code)