### PR TITLE
design: asset-page Shell (remote terminal) reference mockup (#2762)

### DIFF
--- a/docs/design/mockups/asset-shell.html
+++ b/docs/design/mockups/asset-shell.html
@@ -1,0 +1,443 @@
+<style>
+  /* ============================================================================
+     CFGMS — Asset drawer · Shell tab (interactive remote terminal) mockup
+     Same verified device-frame harness as asset-live-activity.html (no iframe,
+     no @container, class-based .md/.mt/.mm modes, namespaced .droot state classes
+     so nothing collides with element selectors like .asset). Story #2762.
+     Tokens from docs/design/web-ui-design-tokens.css (source of truth).
+     ========================================================================== */
+  :root{
+    --bg:#f7f4ef; --panel:#ffffff; --elev:#f0ebe4; --sunk:#f0ebe4; --border:#d4cfc4;
+    --text:#6b5a4a; --dim:#7a6a5a; --faint:#8f7d66;
+    --accent:#4a6b7c; --accent-ink:#ffffff; --accent-weak:#e6eef2;
+    --ok:#507055; --ok-bg:#e8f0e9; --warn:#a05a35; --warn-bg:#f7e8db; --crit:#b56a5a; --crit-bg:#f2e5e3;
+    --neu:#7a6a5a; --neu-bg:#e8e0d8; --pop-sh:0 16px 44px -20px rgba(50,40,25,.4); --track:#ece5db; --hbar:#f0ebe4;
+    --term-bg:#f4efe7; --term-fg:#5a4a3a;
+    --font-sans:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
+    --font-mono:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace;
+  }
+  @media (prefers-color-scheme:dark){ :root{
+    --bg:#1e1e1e; --panel:#252526; --elev:#2d2d2d; --sunk:#1a1a1a; --border:#3c3c3c;
+    --text:#c4b4a4; --dim:#a89888; --faint:#8a7a68;
+    --accent:#7b9fb0; --accent-ink:#16202a; --accent-weak:#1e2528;
+    --ok:#6d9472; --ok-bg:#1a2e1d; --warn:#d4864f; --warn-bg:#332518; --crit:#c97a6a; --crit-bg:#2d1f1c;
+    --neu:#a89888; --neu-bg:#2a2520; --pop-sh:0 16px 44px -18px rgba(0,0,0,.7); --track:#332f29; --hbar:#181817;
+    --term-bg:#141414; --term-fg:#cbbaa8;
+  } }
+  :root[data-theme="light"]{ --bg:#f7f4ef; --panel:#ffffff; --elev:#f0ebe4; --sunk:#f0ebe4; --border:#d4cfc4;
+    --text:#6b5a4a; --dim:#7a6a5a; --faint:#8f7d66; --accent:#4a6b7c; --accent-ink:#ffffff; --accent-weak:#e6eef2;
+    --ok:#507055; --ok-bg:#e8f0e9; --warn:#a05a35; --warn-bg:#f7e8db; --crit:#b56a5a; --crit-bg:#f2e5e3;
+    --neu:#7a6a5a; --neu-bg:#e8e0d8; --pop-sh:0 16px 44px -20px rgba(50,40,25,.4); --track:#ece5db; --hbar:#f0ebe4; --term-bg:#f4efe7; --term-fg:#5a4a3a; }
+  :root[data-theme="dark"]{ --bg:#1e1e1e; --panel:#252526; --elev:#2d2d2d; --sunk:#1a1a1a; --border:#3c3c3c;
+    --text:#c4b4a4; --dim:#a89888; --faint:#8a7a68; --accent:#7b9fb0; --accent-ink:#16202a; --accent-weak:#1e2528;
+    --ok:#6d9472; --ok-bg:#1a2e1d; --warn:#d4864f; --warn-bg:#332518; --crit:#c97a6a; --crit-bg:#2d1f1c;
+    --neu:#a89888; --neu-bg:#2a2520; --pop-sh:0 16px 44px -18px rgba(0,0,0,.7); --track:#332f29; --hbar:#181817; --term-bg:#141414; --term-fg:#cbbaa8; }
+
+  *{box-sizing:border-box;}
+  body{margin:0; min-height:100dvh; background:var(--bg); color:var(--text); display:flex; flex-direction:column;
+    font-family:var(--font-sans); -webkit-font-smoothing:antialiased;}
+  .mono{font-family:var(--font-mono); font-variant-numeric:tabular-nums;}
+  svg{display:block;}
+
+  .hbar{display:flex; align-items:center; gap:14px; flex-wrap:wrap; padding:11px 16px; background:var(--hbar);
+    border-bottom:1px solid var(--border); position:sticky; top:0; z-index:5;}
+  .hbrand{display:flex; align-items:baseline; gap:8px; margin-right:auto;}
+  .hbrand b{font-size:14px; letter-spacing:.13em; text-transform:uppercase; font-weight:700;}
+  .hbrand span{font-size:11px; color:var(--dim); letter-spacing:.04em;}
+  .seg{display:inline-flex; position:relative; background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:3px;}
+  .seg button{position:relative; z-index:1; appearance:none; border:0; background:transparent; color:var(--dim);
+    font:inherit; font-size:12.5px; font-weight:600; padding:6px 13px; border-radius:7px; cursor:pointer; transition:color .18s ease;}
+  .seg button[aria-pressed="true"]{color:var(--accent-ink);}
+  .seg .thumb{position:absolute; top:3px; left:3px; height:calc(100% - 6px); background:var(--accent); border-radius:7px;
+    transition:transform .22s cubic-bezier(.4,.9,.3,1), width .22s cubic-bezier(.4,.9,.3,1); z-index:0;}
+  .seg button:focus-visible{outline:2px solid var(--accent); outline-offset:2px;}
+  .dims{font-family:var(--font-mono); font-size:12px; color:var(--dim); font-variant-numeric:tabular-nums; white-space:nowrap;}
+
+  .stage{flex:1; display:flex; align-items:flex-start; justify-content:center; padding:22px 16px 30px; overflow:auto;}
+  .wrap{position:relative; margin:0 auto; border-radius:14px; overflow:hidden; box-shadow:var(--pop-sh); border:1px solid var(--border); background:var(--bg);}
+  .device{position:relative; overflow:hidden; transform-origin:0 0; background:var(--bg);}
+  .hint{text-align:center; color:var(--dim); font-size:12.5px; line-height:1.6; padding:0 20px 30px; max-width:700px; margin:0 auto;}
+  .hint b{color:var(--text);}
+
+  /* ===== APP ============================================================== */
+  .droot{height:100%; font-size:13.5px; line-height:1.45; color:var(--text);}
+  .lbl{font-size:10px; letter-spacing:.09em; text-transform:uppercase; color:var(--faint); font-weight:600;}
+  .dot{width:7px; height:7px; border-radius:50%; background:currentColor; flex:none;}
+  .pill{display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:20px; font-size:11.5px; font-weight:600; white-space:nowrap;}
+  .pill.ok{background:var(--ok-bg); color:var(--ok);} .pill.warn{background:var(--warn-bg); color:var(--warn);}
+  .pill.crit{background:var(--crit-bg); color:var(--crit);} .pill.neu{background:var(--neu-bg); color:var(--neu);}
+  .icobtn{appearance:none; border:1px solid var(--border); background:var(--panel); color:var(--dim); border-radius:9px; width:34px; height:34px; display:grid; place-items:center; cursor:pointer; position:relative; flex:none;}
+  .icobtn:hover{color:var(--text);}
+
+  .shell{display:grid; grid-template-columns:1fr; height:100%;}
+  .side{display:flex; flex-direction:column; background:var(--panel); border-right:1px solid var(--border);
+    position:absolute; top:0; bottom:0; left:0; width:250px; z-index:40; transform:translateX(-105%); transition:transform .22s ease;}
+  .droot.drawer .side{transform:translateX(0);}
+  .scrim{position:absolute; inset:0; background:rgba(30,22,14,.42); z-index:44; opacity:0; pointer-events:none; transition:opacity .2s;}
+  .droot.drawer .scrim, .droot.detail .scrim{opacity:1; pointer-events:auto;}
+  .side .logo{display:flex; align-items:center; justify-content:space-between; padding:16px 16px 12px;}
+  .side .logo .l{display:flex; align-items:baseline; gap:7px;}
+  .side .logo b{font-size:15px; letter-spacing:.13em; text-transform:uppercase;} .side .logo i{font-style:normal; font-size:10px; color:var(--faint); letter-spacing:.05em;}
+  nav{display:flex; flex-direction:column; gap:2px; padding:6px 10px;}
+  nav a{display:flex; align-items:center; gap:11px; padding:9px 11px; border-radius:8px; color:var(--dim); text-decoration:none; font-weight:500; font-size:13.5px; cursor:pointer;}
+  nav a .ico{width:16px; height:16px; flex:none; opacity:.8;}
+  nav a.active{background:var(--accent-weak); color:var(--accent); font-weight:600;} nav a.active .ico{opacity:1;}
+  nav a.soon{opacity:.5;} nav a.soon .tag{margin-left:auto; font-size:9px; letter-spacing:.06em; text-transform:uppercase; color:var(--faint);}
+  .side .cfoot{margin-top:auto; padding:12px 14px; border-top:1px solid var(--border); display:flex; align-items:center; gap:9px; font-size:12px; color:var(--dim);}
+  .side .cfoot .cn{font-weight:600; color:var(--text); font-family:var(--font-mono); font-size:12px;} .side .cfoot small{display:block; color:var(--faint); font-size:10.5px;}
+
+  .main{display:flex; flex-direction:column; min-width:0; height:100%; overflow:auto;}
+  .appbar{position:sticky; top:0; z-index:20; display:flex; align-items:center; gap:10px; padding:10px 14px; background:var(--bg); border-bottom:1px solid var(--border);}
+  .scope{display:flex; align-items:center; gap:8px; padding:7px 10px; background:var(--panel); border:1px solid var(--border); border-radius:9px; cursor:pointer; font-size:12.5px; white-space:nowrap;}
+  .scope .path{font-family:var(--font-mono); color:var(--dim);} .scope .path b{color:var(--text);} .scope .cv{color:var(--faint);}
+  .searchbox{flex:1; min-width:0; display:flex; align-items:center; gap:9px; padding:0 12px; background:var(--panel); border:1px solid var(--border); border-radius:9px; max-width:440px;}
+  .searchbox svg{color:var(--faint); flex:none;}
+  .searchbox input{flex:1; min-width:0; border:0; background:transparent; color:var(--text); font:inherit; font-size:13px; padding:9px 0; outline:none;}
+  .searchbox input::placeholder{color:var(--faint);}
+  .abspacer{flex:1;}
+  .badge{position:absolute; top:-5px; right:-5px; min-width:16px; height:16px; padding:0 4px; border-radius:9px; background:var(--crit); color:#fff; font-size:9.5px; font-weight:700; display:grid; place-items:center;}
+  .uav{width:34px; height:34px; border-radius:50%; background:var(--accent); color:var(--accent-ink); display:grid; place-items:center; font-size:12px; font-weight:700; cursor:pointer; flex:none;}
+
+  .pop{position:absolute; z-index:60; background:var(--panel); border:1px solid var(--border); border-radius:12px; box-shadow:var(--pop-sh); padding:6px; min-width:230px; display:none;}
+  .pop.open{display:block;}
+  .pop h4{margin:2px 8px 6px; font-size:10px; letter-spacing:.08em; text-transform:uppercase; color:var(--faint);}
+  .pop .row{display:flex; align-items:center; gap:10px; padding:8px 9px; border-radius:8px; font-size:13px; cursor:pointer; color:var(--text);}
+  .pop .row:hover{background:var(--elev);} .pop .row .sub{color:var(--faint); font-size:11px;}
+  .pop .sep{height:1px; background:var(--border); margin:5px 4px;} .pop .row .r{margin-left:auto; font-size:11px; color:var(--faint); font-family:var(--font-mono);}
+  .pop.right{right:14px;}
+  .miniseg{display:flex; gap:3px; margin:2px 8px 6px;}
+  .miniseg button{flex:1; font:inherit; font-size:11px; font-weight:600; border:1px solid var(--border); background:var(--panel); color:var(--dim); border-radius:6px; padding:5px; cursor:pointer;}
+  .miniseg button.on{background:var(--accent); color:var(--accent-ink); border-color:var(--accent);}
+
+  .content{padding:18px; display:flex; flex-direction:column; gap:14px;}
+  .htitle h1{margin:0; font-size:20px; font-weight:700; letter-spacing:-.01em;}
+  .htitle p{margin:3px 0 0; color:var(--dim); font-size:13px;}
+  .flist{background:var(--panel); border:1px solid var(--border); border-radius:13px; overflow:hidden;}
+  .flist table{width:100%; border-collapse:collapse; font-size:13px;}
+  .flist th{text-align:left; font-size:10.5px; letter-spacing:.05em; text-transform:uppercase; color:var(--faint); font-weight:600; padding:10px 14px; border-bottom:1px solid var(--border); white-space:nowrap;}
+  .flist td{padding:11px 14px; border-bottom:1px solid var(--border); white-space:nowrap;}
+  .flist tbody tr:last-child td{border-bottom:0;}
+  .flist tbody tr{cursor:pointer;} .flist tbody tr:hover td{background:var(--elev);}
+  .flist tbody tr.sel td{background:var(--accent-weak);} .flist tbody tr.sel td:first-child{box-shadow:inset 3px 0 0 var(--accent);}
+  .flist .nm{font-family:var(--font-mono); font-size:12.5px; font-weight:600;}
+  .flist .mut{color:var(--dim);} .flist .seen{color:var(--faint); font-size:12px; font-variant-numeric:tabular-nums;}
+  .flist .cta{font-size:11px; color:var(--accent); font-weight:600;}
+
+  /* ===== asset drawer ===== */
+  .asset{position:absolute; top:0; right:0; bottom:0; width:min(920px,96%); background:var(--panel); border-left:1px solid var(--border);
+    z-index:46; transform:translateX(103%); transition:transform .26s cubic-bezier(.4,.9,.3,1); display:flex; flex-direction:column; box-shadow:var(--pop-sh);}
+  .droot.detail .asset{transform:translateX(0);}
+  .ahead{display:flex; align-items:flex-start; gap:13px; padding:16px 18px 12px; border-bottom:1px solid var(--border);}
+  .ahead .pico{width:40px; height:40px; border-radius:10px; font-size:14px; background:var(--elev); color:var(--dim); display:grid; place-items:center; font-family:var(--font-mono); font-weight:700; flex:none;}
+  .ahead .bc{font-size:11.5px; color:var(--dim); margin:0 0 2px;} .ahead .bc a{color:var(--accent); text-decoration:none; cursor:pointer;} .ahead .bc .mono{color:var(--dim); font-size:11px;}
+  .ahead .h1row{display:flex; align-items:center; gap:10px; flex-wrap:wrap;}
+  .ahead h1{margin:0; font-size:19px; font-weight:700; letter-spacing:-.01em; font-family:var(--font-mono);}
+  .ahead .meta{margin:4px 0 0; font-size:12px; color:var(--faint); font-family:var(--font-mono);}
+  .ahead .x{margin-left:auto;}
+  .atabs{display:flex; gap:2px; padding:0 18px; border-bottom:1px solid var(--border); overflow-x:auto;}
+  .atabs button{appearance:none; border:0; background:transparent; font:inherit; font-size:13px; font-weight:500; color:var(--dim);
+    padding:11px 13px; cursor:pointer; border-bottom:2px solid transparent; margin-bottom:-1px; white-space:nowrap; display:flex; align-items:center; gap:7px;}
+  .atabs button:hover{color:var(--text);}
+  .atabs button.active{color:var(--accent); font-weight:600; border-bottom-color:var(--accent);}
+  .atabs button.soon{opacity:.5; cursor:not-allowed;}
+  .atabs button.soon .tag{font-size:9px; letter-spacing:.06em; text-transform:uppercase; color:var(--faint);}
+  .abody{flex:1; min-height:0; overflow:auto; display:flex; flex-direction:column; gap:13px; padding:14px 18px 20px;}
+
+  .demobar{display:flex; align-items:center; gap:10px; padding:6px 11px; background:var(--sunk); border:1px dashed var(--border); border-radius:10px; flex-wrap:wrap; flex:none;}
+  .demobar .dlbl{font-size:10px; text-transform:uppercase; letter-spacing:.08em; color:var(--faint); font-weight:700;}
+  .demobar .dhint{margin-left:auto; font-size:10.5px; color:var(--faint);}
+  .sw2{display:inline-flex; gap:2px; flex-wrap:wrap;} .sw2 button{appearance:none;border:0;background:transparent;font:inherit;font-size:11px;font-weight:600;color:var(--dim);padding:5px 9px;border-radius:6px;cursor:pointer;} .sw2 button.on{background:var(--accent);color:var(--accent-ink);}
+
+  /* ===== terminal ===== */
+  .term{flex:1; min-height:0; display:flex; flex-direction:column; border:1px solid var(--border); border-radius:13px; overflow:hidden; background:var(--term-bg);}
+  .termhead{display:flex; align-items:center; gap:10px; padding:8px 12px; background:var(--panel); border-bottom:1px solid var(--border); flex-wrap:wrap; flex:none;}
+  .conn{display:inline-flex; align-items:center; gap:6px; font-size:11.5px; font-weight:600; padding:3px 9px; border-radius:20px;}
+  .conn.ok{background:var(--ok-bg); color:var(--ok);} .conn.warn{background:var(--warn-bg); color:var(--warn);} .conn.crit{background:var(--crit-bg); color:var(--crit);}
+  .conn .dot{width:7px;height:7px;border-radius:50%;background:currentColor;}
+  .termhead .tmeta{font-family:var(--font-mono); font-size:11px; color:var(--faint); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
+  .termhead .tacts{margin-left:auto; display:flex; gap:6px;}
+  .termhead .tbtn{appearance:none; border:1px solid var(--border); background:var(--panel); color:var(--dim); border-radius:8px; font:inherit; font-size:11.5px; font-weight:600; padding:5px 10px; cursor:pointer; display:inline-flex; align-items:center; gap:6px;}
+  .termhead .tbtn:hover{color:var(--text); border-color:var(--accent);} .termhead .tbtn.danger:hover{color:var(--crit); border-color:var(--crit);}
+  .termbody{flex:1; min-height:0; overflow:auto; padding:12px 14px; font-family:var(--font-mono); font-size:12.5px; line-height:1.55; color:var(--term-fg); white-space:pre-wrap; word-break:break-word; position:relative;}
+  .termbody .prompt{color:var(--accent); font-weight:600;}
+  .termbody .out{color:var(--term-fg); opacity:.82;}
+  .termbody .cmt{color:var(--faint); font-style:italic;}
+  .termbody .warnv{color:var(--warn); font-weight:600;}
+  .termbody .head{color:var(--faint);}
+  .caret{display:inline-block; width:7px; height:14px; background:var(--accent); vertical-align:-2px; margin-left:1px; animation:blink 1.1s step-end infinite;}
+  @keyframes blink{50%{opacity:0;}}
+  @media (prefers-reduced-motion:reduce){.caret{animation:none;}}
+  .tnotice{position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:10px; text-align:center; padding:30px; background:color-mix(in srgb,var(--term-bg) 88%, transparent); font-family:var(--font-sans);}
+  .tnotice .ic{width:44px;height:44px;border-radius:12px;display:grid;place-items:center;font-size:20px;}
+  .tnotice.conn-i .ic{background:var(--warn-bg);color:var(--warn);} .tnotice.ended .ic{background:var(--crit-bg);color:var(--crit);} .tnotice.denied .ic{background:var(--crit-bg);color:var(--crit);}
+  .tnotice h3{margin:0;font-size:15px;font-weight:700;color:var(--text);} .tnotice p{margin:0;font-size:12.5px;color:var(--dim);max-width:320px;} .tnotice .mono{font-size:11px;color:var(--faint);}
+  .tnotice .btn{margin-top:4px;appearance:none;border:1px solid var(--accent);background:var(--accent);color:var(--accent-ink);font:inherit;font-size:12.5px;font-weight:600;padding:8px 16px;border-radius:9px;cursor:pointer;}
+  .spin{width:26px;height:26px;border-radius:50%;border:2.5px solid var(--border);border-top-color:var(--warn);animation:sp .8s linear infinite;}
+  @keyframes sp{to{transform:rotate(360deg);}} @media (prefers-reduced-motion:reduce){.spin{animation:none;}}
+  .terminput{display:flex; align-items:center; gap:8px; padding:8px 12px; border-top:1px solid var(--border); background:var(--panel); flex:none;}
+  .terminput .pr{font-family:var(--font-mono); font-size:12px; color:var(--accent); font-weight:600; white-space:nowrap;}
+  .terminput input{flex:1; border:0; background:transparent; color:var(--text); font-family:var(--font-mono); font-size:12.5px; outline:none; min-width:0;}
+  .terminput input::placeholder{color:var(--faint);}
+  .terminput .hintk{font-size:10px; color:var(--faint); font-family:var(--font-mono); white-space:nowrap;}
+
+  /* state visibility */
+  .conn-live,.conn-connecting,.conn-ended,.conn-denied{display:none;}
+  .droot[data-state="ready"] .conn-live{display:inline-flex;}
+  .droot[data-state="loading"] .conn-connecting{display:inline-flex;}
+  .droot[data-state="error"] .conn-ended{display:inline-flex;}
+  .droot[data-state="empty"] .conn-denied{display:inline-flex;}
+  .tnotice.conn-i,.tnotice.ended,.tnotice.denied{display:none;}
+  .droot[data-state="loading"] .tnotice.conn-i{display:flex;}
+  .droot[data-state="error"] .tnotice.ended{display:flex;}
+  .droot[data-state="empty"] .tnotice.denied{display:flex;}
+  .droot[data-state="empty"] .session, .droot[data-state="loading"] .session{visibility:hidden;}
+  .droot:not([data-state="ready"]) .terminput{opacity:.5; pointer-events:none;}
+  .droot:not([data-state="ready"]) .caret{display:none;}
+
+  /* ---- viewport modes ---- */
+  .device.md .shell{grid-template-columns:250px 1fr;}
+  .device.md .side{position:static; transform:none;}
+  .device.md [data-drawer-close]{display:none;}
+  .device.md .ham{display:none;}
+  .device.mt .ham{display:grid;}
+  .device.mm .ham{display:grid;}
+  .device.mm .flist td:nth-child(3),.device.mm .flist th:nth-child(3){display:none;}
+  .device.mm .appbar{flex-wrap:wrap; row-gap:10px;} .device.mm .searchbox{order:6; flex-basis:100%; max-width:none;} .device.mm .searchbox input{padding:11px 0; font-size:15px;}
+  .device.mm .termhead .tmeta{display:none;}
+</style>
+
+<div class="hbar">
+  <div class="hbrand"><b>CFGMS</b><span>asset · shell (remote terminal)</span></div>
+  <div class="seg" role="group" aria-label="Preview viewport">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-dev="desktop" aria-pressed="true">Desktop</button>
+    <button data-dev="tablet" aria-pressed="false">Tablet</button>
+    <button data-dev="mobile" aria-pressed="false">Mobile</button>
+  </div>
+  <div class="seg themeseg" role="group" aria-label="Theme">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-theme-mode="auto" aria-pressed="true">Auto</button>
+    <button data-theme-mode="light" aria-pressed="false">Light</button>
+    <button data-theme-mode="dark" aria-pressed="false">Dark</button>
+  </div>
+  <div class="dims" id="dims">—</div>
+</div>
+
+<div class="stage">
+  <div class="wrap" id="wrap">
+    <div class="device droot" id="device">
+      <div class="scrim" data-close></div>
+      <div class="shell">
+        <aside class="side">
+          <div class="logo"><div class="l"><b>CFGMS</b><i>controller</i></div><button class="icobtn" data-drawer-close style="width:30px;height:30px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></button></div>
+          <nav>
+            <a class="active"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M3 4h18M3 10h18M3 16h18" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>Fleet</a>
+            <a class="soon"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>Modules<span class="tag">soon</span></a>
+            <a class="soon"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M4 6h16M4 12h10M4 18h16" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>Config<span class="tag">soon</span></a>
+            <a class="soon"><svg class="ico" viewBox="0 0 24 24" fill="none"><path d="M6 3h9l4 4v14H6V3z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>Audit<span class="tag">soon</span></a>
+          </nav>
+          <div class="cfoot"><span class="dot" style="color:var(--ok)"></span><div><span class="cn">controller-01</span><small>healthy · v0.42</small></div></div>
+        </aside>
+
+        <div class="main">
+          <div class="appbar">
+            <button class="icobtn ham" data-drawer-open><svg width="17" height="17" viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></button>
+            <button class="scope" data-pop="pop-tenant"><span class="cv">scope</span><span class="path">root / <b>acme-corp</b></span><svg width="13" height="13" viewBox="0 0 24 24" fill="none"><path d="M8 10l4 4 4-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+            <div class="searchbox"><svg width="15" height="15" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="1.7"/><path d="M20 20l-3-3" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg><input type="text" placeholder="Search stewards, config, audit…"></div>
+            <div class="abspacer"></div>
+            <button class="icobtn" data-pop="pop-notif"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M6 9a6 6 0 1112 0c0 5 2 6 2 6H4s2-1 2-6z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M10 20a2 2 0 004 0" stroke="currentColor" stroke-width="1.6"/></svg><span class="badge">2</span></button>
+            <button class="uav" data-pop="pop-user">AD</button>
+          </div>
+
+          <div class="pop" id="pop-tenant" style="left:14px; top:52px;"><h4>Switch scope</h4><div class="row"><span class="mono">root / acme-corp</span><span class="r">1,204</span></div><div class="row"><span class="mono">root / msp-a</span><span class="r">1,652</span></div></div>
+          <div class="pop right" id="pop-notif" style="top:52px; min-width:300px;"><h4>Notifications · 2</h4><div class="row"><span class="dot" style="color:var(--crit)"></span><div><div>W3SVC stopped — drift on dc-01</div><div class="sub">acme-corp · 40s ago</div></div></div><div class="row"><span class="dot" style="color:var(--ok)"></span><div><div>Config r2291 rolled out</div><div class="sub">ring: broad · 12m ago</div></div></div></div>
+          <div class="pop right" id="pop-user" style="top:52px; min-width:240px;"><div class="row" style="cursor:default"><div class="uav" style="width:30px;height:30px;font-size:11px">AD</div><div><div>admin@msp-a</div><div class="sub">operator · msp-a</div></div></div><div class="sep"></div><h4>Theme</h4><div class="miniseg" id="themeseg"><button data-theme="light">Light</button><button data-theme="auto" class="on">Auto</button><button data-theme="dark">Dark</button></div><div class="sep"></div><div class="row" style="color:var(--crit)">Sign out</div></div>
+
+          <div class="content">
+            <div class="htitle"><h1>Fleet</h1><p>Stewards enrolled to this controller. Tap a steward to open its asset drawer.</p></div>
+            <div class="flist"><table><thead><tr><th>Name</th><th>Company</th><th>OS</th><th>Health</th><th>Last check-in</th><th></th></tr></thead><tbody id="fleet-body"></tbody></table></div>
+          </div>
+        </div>
+      </div>
+
+      <aside class="asset" aria-label="Asset detail">
+        <div class="ahead">
+          <span class="pico" id="a-ico">DC</span>
+          <div style="min-width:0">
+            <p class="bc"><a data-close>Fleet</a> / <span class="mono" id="a-bc">dc-01</span></p>
+            <div class="h1row"><h1 id="a-name">dc-01</h1><span class="pill ok" id="a-health"><span class="dot"></span>Healthy</span></div>
+            <p class="meta" id="a-meta">acme-corp · 10.20.1.5 · Win Server 2022</p>
+          </div>
+          <button class="icobtn x" data-close style="width:30px;height:30px;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></button>
+        </div>
+        <div class="atabs" role="tablist" aria-label="Asset sections">
+          <button role="tab">DNA</button>
+          <button role="tab" class="soon" aria-disabled="true">Config<span class="tag">soon</span></button>
+          <button role="tab" class="active" aria-selected="true">Shell</button>
+          <button role="tab" class="soon" aria-disabled="true">Live Activity<span class="tag">soon</span></button>
+        </div>
+        <div class="abody">
+          <div class="demobar" role="group" aria-label="Mockup preview state — harness control, not part of the product UI">
+            <span class="dlbl">preview state</span>
+            <div class="sw2"><button data-state="ready" class="on">Connected</button><button data-state="loading">Connecting</button><button data-state="error">Disconnected</button><button data-state="empty">Denied</button></div>
+            <span class="dhint">harness only</span>
+          </div>
+
+          <div class="term">
+            <div class="termhead">
+              <span class="conn ok conn-live"><span class="dot"></span>Connected</span>
+              <span class="conn warn conn-connecting"><span class="dot"></span>Connecting…</span>
+              <span class="conn crit conn-ended"><span class="dot"></span>Disconnected</span>
+              <span class="conn crit conn-denied"><span class="dot"></span>Denied</span>
+              <span class="tmeta">pts/0 · mTLS · <span id="t-host">dc-01</span> · admin@msp-a</span>
+              <div class="tacts">
+                <button class="tbtn">Clear</button>
+                <button class="tbtn">Copy</button>
+                <button class="tbtn danger">Disconnect</button>
+              </div>
+            </div>
+            <div class="termbody" id="termbody">
+              <div class="session" id="session"></div>
+              <div class="tnotice conn-i"><div class="spin"></div><h3>Opening remote shell…</h3><p>Establishing an encrypted PTY to <span class="mono" id="ci-host">dc-01</span> through the controller relay.</p><span class="mono">terminal: dial-out PTY · awaiting steward accept</span></div>
+              <div class="tnotice ended"><div class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M12 3v8" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/><path d="M6.6 6.6a8 8 0 1 0 10.8 0" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/></svg></div><h3>Session closed</h3><p>The remote shell to this steward ended. Live Activity and DNA remain available from the other tabs.</p><span class="mono">terminal: peer closed — code 1000</span><button class="btn">Reconnect</button></div>
+              <div class="tnotice denied"><div class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none"><rect x="5" y="10.5" width="14" height="9.5" rx="2" stroke="currentColor" stroke-width="1.8"/><path d="M8 10.5V8a4 4 0 0 1 8 0v2.5" stroke="currentColor" stroke-width="1.8"/></svg></div><h3>Remote shell denied</h3><p>You don't have permission to open a shell on this steward. Ask an operator with remote-shell rights, or use read-only DNA / Live Activity.</p><span class="mono" id="denied-mono">GET /terminal/ws/dc-01 — 403 Forbidden</span></div>
+            </div>
+            <div class="terminput">
+              <span class="pr" id="t-prompt">PS C:\Users\administrator&gt;</span>
+              <input type="text" placeholder="type a command… (mockup — not wired)" aria-label="Terminal input">
+              <span class="hintk">↵ send</span>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+  </div>
+</div>
+
+<p class="hint">
+  <b>Tap a steward</b> (start with <b>dc-01</b>) to open its asset drawer on the <b>Shell</b> tab — an interactive remote
+  terminal over an encrypted mTLS relay, connecting on open and disconnecting on close. Switch <b>Desktop / Tablet / Mobile</b>
+  and <b>Connected / Connecting / Disconnected / Denied</b> above. The demo session surfaces the same W3SVC drift flagged in Live Activity.
+</p>
+
+<script>
+(function(){
+  "use strict";
+  var DEVICES={desktop:{w:1440,h:900,cls:'md'}, tablet:{w:900,h:1120,cls:'mt'}, mobile:{w:390,h:820,cls:'mm'}};
+  var current=(window.innerWidth<820?'mobile':'desktop'), themeMode='auto', scale=1;
+  var wrap=document.getElementById('wrap'), device=document.getElementById('device');
+  var stage=document.querySelector('.stage'), dims=document.getElementById('dims');
+  var devSeg=document.querySelector('.seg:not(.themeseg)'), themeSeg=document.querySelector('.themeseg');
+  var devBtns=[].slice.call(devSeg.querySelectorAll('button')), themeBtns=[].slice.call(themeSeg.querySelectorAll('button'));
+  devBtns.forEach(function(b){ b.setAttribute('aria-pressed', b.dataset.dev===current?'true':'false'); });
+  function posThumb(seg){ var t=seg.querySelector('.thumb'); var a=seg.querySelector('button[aria-pressed="true"]')||seg.querySelector('button'); t.style.width=a.offsetWidth+'px'; t.style.transform='translateX('+(a.offsetLeft-3)+'px)'; }
+  function layout(){ var d=DEVICES[current];
+    device.classList.remove('md','mt','mm'); device.classList.add(d.cls);
+    device.style.width=d.w+'px'; device.style.height=d.h+'px';
+    var avail=stage.clientWidth-32; scale=Math.min(1, avail/d.w);
+    device.style.transform='scale('+scale+')';
+    wrap.style.width=(d.w*scale)+'px'; wrap.style.height=(d.h*scale)+'px';
+    dims.textContent=d.w+' × '+d.h+' · '+Math.round(scale*100)+'%'; }
+  devBtns.forEach(function(b){ b.addEventListener('click',function(){ current=b.dataset.dev; devBtns.forEach(function(x){x.setAttribute('aria-pressed',x===b?'true':'false');}); posThumb(devSeg); layout(); }); });
+  themeBtns.forEach(function(b){ b.addEventListener('click',function(){ themeMode=b.dataset.themeMode; themeBtns.forEach(function(x){x.setAttribute('aria-pressed',x===b?'true':'false');}); posThumb(themeSeg);
+    if(themeMode==='auto') document.documentElement.removeAttribute('data-theme'); else document.documentElement.setAttribute('data-theme',themeMode); }); });
+  window.addEventListener('resize',function(){ layout(); posThumb(devSeg); posThumb(themeSeg); });
+
+  var FLEET=[
+    {name:'dc-01', company:'acme-corp', os:'Win Server 2022', ip:'10.20.1.5', st:'Healthy', cls:'ok', seen:'40s ago', shell:'ps', user:'administrator'},
+    {name:'sql-primary', company:'acme-corp', os:'Win Server 2019', ip:'10.20.1.9', st:'Degraded', cls:'warn', seen:'2m ago', shell:'ps', user:'svc_sql'},
+    {name:'web-ingest-04', company:'acme-corp', os:'Ubuntu 24.04', ip:'10.20.4.14', st:'Healthy', cls:'ok', seen:'12s ago', shell:'sh', user:'svc_deploy'},
+    {name:'reception-07', company:'client-1', os:'Windows 11', ip:'192.168.1.42', st:'Healthy', cls:'ok', seen:'18s ago', shell:'ps', user:'jdoe'},
+    {name:'build-mac-11', company:'globex', os:'macOS 14.5', ip:'10.30.9.11', st:'Healthy', cls:'ok', seen:'51s ago', shell:'sh', user:'ci-runner'},
+    {name:'edge-fw-02', company:'initech', os:'Debian 12', ip:'10.40.0.2', st:'Healthy', cls:'ok', seen:'22s ago', shell:'sh', user:'root'}
+  ];
+  var D=device;
+  function esc(x){return String(x).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+
+  var fbody=document.getElementById('fleet-body');
+  fbody.innerHTML=FLEET.map(function(s,i){ return '<tr data-f="'+i+'"><td><span class="nm">'+esc(s.name)+'</span></td><td><span class="mut">'+esc(s.company)+'</span></td><td><span class="mut">'+esc(s.os)+'</span></td><td><span class="pill '+s.cls+'"><span class="dot"></span>'+esc(s.st)+'</span></td><td><span class="seen">'+esc(s.seen)+'</span></td><td><span class="cta">Open ›</span></td></tr>'; }).join('');
+
+  function L(cls,txt){ return '<div class="'+(cls||'')+'">'+txt+'</div>'; }
+  function psSession(host){
+    var HN=host.toUpperCase();
+    var P='<span class="prompt">PS C:\\Users\\administrator&gt;</span> ';
+    return [
+      L('','CFGMS remote shell — encrypted mTLS relay via controller-01'),
+      L('cmt','# audited session · admin@msp-a → '+esc(host)),
+      L('',''),
+      L('',P+'hostname'),
+      L('out',HN),
+      L('',P+'Get-Service W3SVC | Format-Table -Auto Status,Name,DisplayName'),
+      L('out',''),
+      L('head','Status   Name    DisplayName'),
+      L('head','------   ----    -----------'),
+      L('','<span class="warnv">Stopped</span>  W3SVC   World Wide Web Publishing Service'),
+      L('out',''),
+      L('cmt','# cfg already flagged this as drift — desired state is Running'),
+      L('',P+'Get-Process sqlservr | Format-Table -Auto Id,CPU,WS'),
+      L('out',''),
+      L('head','  Id     CPU           WS'),
+      L('head','  --     ---           --'),
+      L('out','4120  1284.5  43210112512'),
+      L('out',''),
+      L('',P+'<span class="caret"></span>')
+    ].join('');
+  }
+  function shSession(host,user){
+    var P='<span class="prompt">'+esc(user)+'@'+esc(host)+':~$</span> ';
+    return [
+      L('','CFGMS remote shell — encrypted mTLS relay via controller-01'),
+      L('cmt','# audited session · admin@msp-a → '+esc(host)),
+      L('',''),
+      L('',P+'systemctl is-active cfgms-steward'),
+      L('out','active'),
+      L('',P+'uptime'),
+      L('out',' 06:58:12 up 23 days,  4:11,  1 user,  load average: 0.34, 0.22, 0.19'),
+      L('',P+'<span class="caret"></span>')
+    ].join('');
+  }
+  function renderTerm(s){
+    document.getElementById('t-host').textContent=s.name;
+    document.getElementById('ci-host').textContent=s.name;
+    document.getElementById('denied-mono').textContent='GET /terminal/ws/'+s.name+' — 403 Forbidden';
+    var isPs=(s.shell==='ps');
+    document.getElementById('t-prompt').innerHTML= isPs ? 'PS C:\\Users\\administrator&gt;' : esc(s.user)+'@'+esc(s.name)+':~$';
+    document.getElementById('session').innerHTML= isPs ? psSession(s.name) : shSession(s.name, s.user);
+  }
+
+  function selectSteward(i){
+    var s=FLEET[i];
+    [].forEach.call(fbody.querySelectorAll('tr'), function(tr,idx){ tr.classList.toggle('sel', idx===i); });
+    document.getElementById('a-name').textContent=s.name;
+    document.getElementById('a-bc').textContent=s.name;
+    document.getElementById('a-ico').textContent=s.name.slice(0,2).toUpperCase();
+    var hp=document.getElementById('a-health'); hp.className='pill '+s.cls; hp.innerHTML='<span class="dot"></span>'+s.st;
+    document.getElementById('a-meta').textContent=s.company+' · '+s.ip+' · '+s.os;
+    renderTerm(s);
+    D.classList.add('detail'); D.dataset.state='ready';
+    var tb=document.getElementById('termbody'); tb.scrollTop=tb.scrollHeight;
+  }
+  fbody.addEventListener('click', function(e){ var tr=e.target.closest('tr[data-f]'); if(tr) selectSteward(+tr.getAttribute('data-f')); });
+
+  function closeAllPops(){ [].forEach.call(document.querySelectorAll('.pop.open'), function(p){ p.classList.remove('open'); }); }
+  document.addEventListener('click', function(e){
+    if(e.target.closest('.tnotice.ended .btn')){ D.dataset.state='loading'; [].forEach.call(document.querySelectorAll('.sw2 button'),function(x){x.classList.toggle('on',x.getAttribute('data-state')==='loading');}); setTimeout(function(){ D.dataset.state='ready'; [].forEach.call(document.querySelectorAll('.sw2 button'),function(x){x.classList.toggle('on',x.getAttribute('data-state')==='ready');}); },1100); return; }
+    var th=e.target.closest('#themeseg button');
+    if(th){ e.stopPropagation(); var m=th.getAttribute('data-theme'); if(m==='auto') document.documentElement.removeAttribute('data-theme'); else document.documentElement.setAttribute('data-theme',m); [].forEach.call(document.querySelectorAll('#themeseg button'),function(x){x.classList.toggle('on',x===th);}); return; }
+    var t=e.target.closest('[data-pop]'); if(t){ var p=document.getElementById(t.getAttribute('data-pop')); var o=p.classList.contains('open'); closeAllPops(); if(!o) p.classList.add('open'); e.stopPropagation(); return; }
+    if(e.target.closest('[data-drawer-open]')){ D.classList.add('drawer'); return; }
+    if(e.target.closest('[data-drawer-close]')){ D.classList.remove('drawer'); return; }
+    if(e.target.closest('[data-close]')){ D.classList.remove('detail'); return; }
+    if(!e.target.closest('.pop')) closeAllPops();
+  });
+  document.addEventListener('keydown', function(e){ if(e.key==='Escape'){ closeAllPops(); D.classList.remove('detail','drawer'); } });
+  [].forEach.call(document.querySelectorAll('#pop-user .miniseg button'), function(btn){ btn.addEventListener('click', function(e){ e.stopPropagation(); [].forEach.call(document.querySelectorAll('#pop-user .miniseg button'), function(x){ x.classList.toggle('on', x===btn); }); }); });
+  [].forEach.call(document.querySelectorAll('.sw2 button'), function(btn){ btn.addEventListener('click', function(e){ e.stopPropagation(); D.dataset.state=btn.getAttribute('data-state'); [].forEach.call(document.querySelectorAll('.sw2 button'), function(x){ x.classList.toggle('on', x===btn); }); }); });
+
+  // Boot: render fleet + a default session; leave drawer CLOSED (first paint = list).
+  renderTerm(FLEET[0]);
+  document.getElementById('a-meta').textContent=FLEET[0].company+' · '+FLEET[0].ip+' · '+FLEET[0].os;
+  D.dataset.state='ready';
+  layout(); posThumb(devSeg); posThumb(themeSeg);
+})();
+</script>


### PR DESCRIPTION
## What

Adds `docs/design/mockups/asset-shell.html` — the design source for **story #2762** (web: shell tab on the asset page) under the design-control gate.

## The screen

The steward asset page's **Shell** tab: an interactive remote terminal in the right-side asset drawer, over an encrypted mTLS relay, connecting on tab-open and disconnecting on tab-close (the lifecycle the story requires).

- **Warm-terminal** session — PowerShell on Windows stewards, sh on Linux/macOS; the demo session surfaces the same **W3SVC drift** flagged in the Live Activity mockup, for continuity.
- **Header** — connection status pill, session meta (`pts/0 · mTLS · host · admin`), Clear / Copy / Disconnect.
- **States** — Connected / Connecting / Disconnected (Reconnect) / **Denied (403)** — the story's required denied state.

## Conventions

Same verified device-frame harness as `asset-live-activity.html` — no nested iframe, class-based responsive modes (no `@container`), namespaced state classes. Warm-terminal tokens from `web-ui-design-tokens.css` (source of truth), both themes, Desktop/Tablet/Mobile. Verified rendering headless at all three viewports and every connection state.

Docs/design only — no code or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)