### PR TITLE
test: tolerate extra tick in TestTelemetryStream_IntervalClamping (Issue #2835)

### DIFF
--- a/features/modules/stdlib/package/choco_bootstrap.go
+++ b/features/modules/stdlib/package/choco_bootstrap.go
@@ -91,7 +91,7 @@ func fetchBytes(ctx context.Context, src string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to download bootstrap package from %s: %w", src, err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("failed to download bootstrap package from %s: HTTP %d", src, resp.StatusCode)
 		}
@@ -143,16 +143,20 @@ func extractZipFile(f *zip.File, destPath string) error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
-	_, err = io.Copy(out, rc)
-	return err
+	if _, err := io.Copy(out, rc); err != nil {
+		_ = out.Close()
+		return err
+	}
+	// Return the Close error so a failed flush of the extracted file surfaces
+	// rather than being silently dropped by a deferred close.
+	return out.Close()
 }
 
 // runner returns the commandRunner this module uses: the injected test seam
@@ -258,7 +262,7 @@ func (m *PackageModule) bootstrapChocoReal(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp dir for chocolatey bootstrap: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	if err := extractZip(data, tmpDir); err != nil {
 		return fmt.Errorf("failed to extract chocolatey bootstrap package: %w", err)

--- a/features/modules/stdlib/package/windows.go
+++ b/features/modules/stdlib/package/windows.go
@@ -94,10 +94,6 @@ type wingetManager struct {
 	env []string
 }
 
-func newWingetManager() PackageManager {
-	return &wingetManager{bin: "winget", env: wingetAugmentedEnv("winget")}
-}
-
 // newWingetManagerWithPath returns a wingetManager that invokes the given
 // fully qualified winget.exe (see resolveWingetFullPath in factory.go).
 func newWingetManagerWithPath(bin string) PackageManager {

--- a/features/steward/client/telemetry_stream_test.go
+++ b/features/steward/client/telemetry_stream_test.go
@@ -521,7 +521,7 @@ func TestTelemetryStream_IntervalClamping(t *testing.T) {
 	}
 
 	times := timingCol.snapTimes()
-	require.Len(t, times, 2, "must have recorded 2 Snapshot invocations")
+	require.GreaterOrEqual(t, len(times), 2, "must have recorded at least 2 Snapshot invocations")
 	gap := times[1].Sub(times[0])
 	// The gap between tick-fire instants must be ≥ 900 ms (10% slack for
 	// scheduling jitter). This is the ticker cadence directly — collection


### PR DESCRIPTION
## Summary

- Replaces `require.Len(t, times, 2)` with `require.GreaterOrEqual(t, len(times), 2)` so a third tick firing inside the observation window on cold Windows runners no longer evicts the merge queue entry
- The clamp property (first inter-tick gap ≥ 900 ms) is fully preserved — a broken clamp fires many sub-second ticks, failing the `assert.GreaterOrEqual` on `gap`
- Also fixes pre-existing `errcheck` violations in `choco_bootstrap.go` and removes a dead function in `windows.go`, both surfaced by the code-review lens during validation

Fixes #2835

## Root Cause

`TestTelemetryStream_IntervalClamping` held the stream open under an 8 s ceiling and asserted exactly 2 tick-fire instants. On cold Windows CI runners in merge groups, a third tick fires before the server signals done, causing `require.Len` to fail with `"[...3 timestamps...] should have 2 item(s), but has 3"` — even though the cadence was correct. Five confirmed evictions since #2824 merged.

## Specialist Review Results

| Lens | Round 1 | Round 2 |
|------|---------|---------|
| Code Review (QA) | PASS | — |
| Security | PASS | — |
| Test Quality | FAIL (errcheck in choco_bootstrap.go) | PASS |

Workflow verdict: **passed: true**, `remainingFindings: []`