### PR TITLE
agent-container: derive Node from web/.nvmrc and warm the npm cache

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,10 +48,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsmasq \
     && rm -rf /var/lib/apt/lists/*
 
-# Node.js 22 (required by Claude Code — Debian Bookworm ships Node 18 which
-# lacks Array.with() and other APIs used since Claude Code 2.1.79)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+# Node.js — major version tracks web/.nvmrc, the same file frontend-ci.yml reads
+# via node-version-file, so the container, CI, and the web toolchain never drift.
+# (Debian Bookworm ships Node 18, too old for both the web build and Claude Code,
+# which needs >=22 — a web/.nvmrc bump past Claude Code's supported range would
+# need checking here since this Node also runs Claude Code.)
+COPY web/.nvmrc /tmp/nvmrc
+RUN NODE_MAJOR="$(tr -dc '0-9' < /tmp/nvmrc)" \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
+    && rm -f /tmp/nvmrc \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI
@@ -132,6 +138,18 @@ RUN go mod download \
     && chown -R agent:agent /home/agent/go/pkg/mod \
     && rm go.mod go.sum
 WORKDIR /
+
+# Pre-warm the npm cache so per-agent `npm ci` in web/ resolves tarballs from the
+# warm cache instead of a cold registry pull each dispatch — same rationale as the
+# Go module / Trivy DB pre-caches above. We keep the CACHE (~/.npm), not
+# node_modules: /workspace is bind-mounted at runtime and the checked-out lockfile
+# may differ, so `npm ci` must re-resolve — but it pulls unchanged tarballs from
+# the integrity-hash-keyed cache offline and only fetches genuinely-new deps from
+# the registry (npmjs.org is allowlisted in dnsmasq-allowlist.conf).
+COPY web/package.json web/package-lock.json /tmp/webcache/
+RUN chown -R agent:agent /tmp/webcache \
+    && su agent -c 'cd /tmp/webcache && npm ci --no-audit --no-fund' \
+    && rm -rf /tmp/webcache
 
 # CLI_BINARY=cfg — install cfg CLI built in the builder stage above.
 # The builder stage is discarded; only the binary is copied to this layer.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # which needs >=22 — a web/.nvmrc bump past Claude Code's supported range would
 # need checking here since this Node also runs Claude Code.)
 COPY web/.nvmrc /tmp/nvmrc
-RUN NODE_MAJOR="$(tr -dc '0-9' < /tmp/nvmrc)" \
+RUN NODE_MAJOR="$(cut -d. -f1 < /tmp/nvmrc)" \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -f /tmp/nvmrc \


### PR DESCRIPTION
## Problem

The agent dispatch container hardcoded **Node 22** (`.devcontainer/Dockerfile`), while the web toolchain and CI both target **Node 26** (`web/.nvmrc`; `frontend-ci.yml` reads it via `node-version-file`). Agents therefore could not faithfully reproduce the required `frontend-checks` / `make test-frontend` gate on the correct runtime — the "green locally, red in CI" divergence the frontend gate exists to prevent.

Additionally, the container pre-caches Go modules and the Trivy DB "to minimize per-agent startup time" but had **no npm equivalent**, so every web dispatch ran a cold `npm ci` over the firewall.

## Changes

- **Node tracks `web/.nvmrc` (single source of truth).** The Node install parses the major from `web/.nvmrc` (`COPY` + `tr`) and feeds it to the nodesource setup script. The container, CI, and the web build now derive from one file — nothing to drift. An unpublished major fails the build loudly (correct failure mode), never silently wrong. This Node also runs Claude Code (needs ≥22, satisfied by 26); a comment flags that a future `.nvmrc` bump should be checked against Claude Code's supported range.
- **Warm the npm cache.** A build-time `npm ci` over `web/`'s `package.json` + lockfile populates `~/.npm`, mirroring the existing Go module / Trivy DB pre-caches. We keep the **cache**, not `node_modules`: `/workspace` is bind-mounted at runtime and the checked-out lockfile may differ, so `npm ci` must re-resolve — but it pulls unchanged tarballs from the integrity-hash-keyed cache offline and only fetches genuinely-new deps from the already-allowlisted `npmjs.org`.

## Not in scope
- No browser/Playwright tooling — web tests are vitest + jsdom (headless in Node). A browser-e2e tier is a separate decision.
- Go is already aligned (`go.mod toolchain go1.26.5` == `golang:1.26.5` image) — untouched.

## Validation
Minimal reproduction build of the two changed steps on the same base image:
- `node=v26.5.0` — correctly derived from `web/.nvmrc` (26)
- `npm=11.17.0` (bundled)
- `/home/agent/.npm` = **52 MB** warm cache, `npm ci` succeeds against the real lockfile

Pre-push `make test` passed. The image itself is refreshed by the existing weekly `--no-cache` rebuild, which also re-warms the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)