### PR TITLE
steward-binary: bind publisher signature to (content_hash, version, platform, arch) — close rollback gap (#2834)

### DIFF
--- a/cmd/cfg/cmd/connection_registry_test.go
+++ b/cmd/cfg/cmd/connection_registry_test.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"encoding/json"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -95,6 +96,12 @@ func TestConnectionRegistry_FilePermissions(t *testing.T) {
 		ControllerURL: "https://ctrl.example.com:9090",
 		AdminIdentity: "admin@example.com",
 	}))
+
+	// POSIX permission bits are not meaningful on Windows (ACL-based); only
+	// assert the modes where the underlying filesystem honors 0700/0600.
+	if runtime.GOOS == "windows" {
+		return
+	}
 
 	// Config directory must be 0700
 	cfgmsDir := dir + "/cfgms"

--- a/cmd/cfg/cmd/credential_store_test.go
+++ b/cmd/cfg/cmd/credential_store_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -112,7 +113,9 @@ func TestCredentialStore_DirectoryCreatedAt0700(t *testing.T) {
 	info, err := os.Stat(credDir)
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
-	if os.Getenv("GOOS") != "windows" {
+	// POSIX permission bits are not meaningful on Windows (ACL-based); only
+	// assert the mode where the underlying filesystem honors 0700.
+	if runtime.GOOS != "windows" {
 		assert.Equal(t, os.FileMode(0700), info.Mode().Perm(),
 			"credentials directory must be created at mode 0700")
 	}
@@ -129,7 +132,9 @@ func TestCredentialStore_EncFileCreatedAt0600(t *testing.T) {
 
 	info, err := os.Stat(filepath.Join(tmpDir, "ctrl.enc"))
 	require.NoError(t, err)
-	if os.Getenv("GOOS") != "windows" {
+	// POSIX permission bits are not meaningful on Windows (ACL-based); only
+	// assert the mode where the underlying filesystem honors 0600.
+	if runtime.GOOS != "windows" {
 		assert.Equal(t, os.FileMode(0600), info.Mode().Perm(),
 			".enc file must be created at mode 0600")
 	}

--- a/cmd/cfgms-steward-launcher/lifecycle_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_test.go
@@ -60,20 +60,38 @@ func TestHelperProcess(t *testing.T) {
 	if mf := os.Getenv("FAKE_STEWARD_RECORD_MANAGED_FILE"); mf != "" {
 		_ = os.WriteFile(mf, []byte(os.Getenv(version.EnvStewardLauncherManaged)), 0o600)
 	}
-	// FAKE_STEWARD_STAGE_VERSION simulates StageBinary: "<root>:<version>:<binary_name>".
-	// When set, the fake-steward advances state.json to the given version before exiting,
-	// mimicking the steward's upgrade handler calling WriteCurrent after staging a binary.
-	// This is idempotent: WriteCurrent is a no-op when current already equals the target.
+	// FAKE_STEWARD_STAGE_VERSION advances state.json to the given version before
+	// exiting, mimicking the steward's upgrade handler calling WriteCurrent after
+	// staging a binary. The install root and binary name arrive in their own env
+	// vars (FAKE_STEWARD_STAGE_ROOT / FAKE_STEWARD_STAGE_BINARY) rather than being
+	// packed into one colon-delimited value: a Windows root such as
+	// "C:\\Program Files\\CFGMS" contains a colon, so a single-string ":"-split
+	// mis-parses the path and writes state.json to the wrong place. Separate vars
+	// are unambiguous on every platform. WriteCurrent is idempotent: a no-op when
+	// current already equals the target.
 	if sv := os.Getenv("FAKE_STEWARD_STAGE_VERSION"); sv != "" {
-		parts := strings.SplitN(sv, ":", 3)
-		if len(parts) == 3 {
-			wl := Layout{Root: parts[0], StewardBinaryName: parts[2]}
-			_ = wl.WriteCurrent(parts[1])
+		wl := Layout{
+			Root:              os.Getenv("FAKE_STEWARD_STAGE_ROOT"),
+			StewardBinaryName: os.Getenv("FAKE_STEWARD_STAGE_BINARY"),
 		}
+		_ = wl.WriteCurrent(sv)
 	}
 	if sleepMs := os.Getenv("FAKE_STEWARD_SLEEP_MS"); sleepMs != "" {
 		if n, err := strconv.Atoi(sleepMs); err == nil && n > 0 {
 			time.Sleep(time.Duration(n) * time.Millisecond)
+		}
+	}
+	// FAKE_STEWARD_RENAME_SELF makes the fake steward rename its own on-disk
+	// binary out of the way just before exiting, forcing the launcher's
+	// post-exec computeBinaryHash to fail (file not found) deterministically on
+	// every platform. This is the cross-platform stand-in for "the binary became
+	// unreadable after a successful exec": chmod-to-000 achieves that on POSIX
+	// but is a no-op on Windows (an exec'd image is always readable there).
+	// Renaming a running executable is permitted on both POSIX and Windows;
+	// deleting it is not (the image stays locked on Windows), so we rename.
+	if os.Getenv("FAKE_STEWARD_RENAME_SELF") == "1" {
+		if exe, err := os.Executable(); err == nil {
+			_ = os.Rename(exe, exe+".moved")
 		}
 	}
 	if exitMarker := os.Getenv("FAKE_STEWARD_EXIT_MARKER_FILE"); exitMarker != "" {
@@ -884,7 +902,9 @@ func TestSupervise_UpgradeSelfExit_AdvancesToNewVersion(t *testing.T) {
 	// All children run WriteCurrent("v2"): v1 advances state.json to v2; v2's
 	// call is a no-op (current already == v2). Both exit cleanly with code 0.
 	envForChild(t, map[string]string{
-		"FAKE_STEWARD_STAGE_VERSION": l.Root + ":v2:" + l.StewardBinaryName,
+		"FAKE_STEWARD_STAGE_ROOT":    l.Root,
+		"FAKE_STEWARD_STAGE_VERSION": "v2",
+		"FAKE_STEWARD_STAGE_BINARY":  l.StewardBinaryName,
 		"FAKE_STEWARD_SLEEP_MS":      "0",
 		"FAKE_STEWARD_EXIT_CODE":     "0",
 	})
@@ -1342,10 +1362,11 @@ func TestSupervise_HashFailureAfterCleanRun_SkipsKnownGoodUpdate(t *testing.T) {
 // launcher cannot confirm the binary is the proven one — isKnownGood stays false
 // and probation rules apply (rollback fires).
 //
-// Scenario: v1 is known-good; v1 starts, writes a marker, then sleeps. The test
-// goroutine chmod-s the binary to 0o000 after the child is running. When the child
-// exits with code 1 (failed startup), computeBinaryHash fails → isKnownGood=false
-// → rollback to v0 instead of restart-in-place.
+// Scenario: v1 is known-good; v1 starts, then renames its own binary out of the
+// way before exiting with code 1 (failed startup). When the launcher computes the
+// post-exec hash the binary is gone, so computeBinaryHash fails → isKnownGood=false
+// → rollback to v0 instead of restart-in-place. The self-rename forces the hash
+// failure deterministically on every platform (chmod-to-000 is a no-op on Windows).
 func TestSupervise_HashFailureAfterFailedStartup_TreatsAsNotKnownGood(t *testing.T) {
 	l := newLayout(t)
 	installFakeSteward(t, l, "v0")
@@ -1359,20 +1380,15 @@ func TestSupervise_HashFailureAfterFailedStartup_TreatsAsNotKnownGood(t *testing
 	// State: current=v1, previous=v0. Mark v1 known-good.
 	premarkKnownGood(t, l, "v1")
 
-	markerFile := filepath.Join(t.TempDir(), "started")
-	// Child sleeps long enough for the test to chmod the binary, then exits
-	// with code 1 (simulating a crashed steward). The clock will report 0 for
-	// ranFor (always inside startup window), making this look like a fast exit.
+	// Child renames its own binary away before exiting with code 1 (simulating a
+	// crashed steward whose binary is no longer where the launcher hashes it). The
+	// clock reports 0 for ranFor (always inside startup window), making this look
+	// like a fast exit.
 	envForChild(t, map[string]string{
 		"FAKE_STEWARD_EXIT_CODE":   "1",
-		"FAKE_STEWARD_SLEEP_MS":    "300",
-		"FAKE_STEWARD_MARKER_FILE": markerFile,
+		"FAKE_STEWARD_SLEEP_MS":    "0",
+		"FAKE_STEWARD_RENAME_SELF": "1",
 	})
-
-	exe, exeErr := l.StewardExeFor("v1")
-	if exeErr != nil {
-		t.Fatalf("StewardExeFor v1: %v", exeErr)
-	}
 
 	s := &Supervisor{
 		Layout:            l,
@@ -1388,15 +1404,6 @@ func TestSupervise_HashFailureAfterFailedStartup_TreatsAsNotKnownGood(t *testing
 	defer cancel()
 	done := make(chan error, 1)
 	go func() { done <- s.Supervise(ctx) }()
-
-	// Wait for v1 to start, then make its binary unreadable.
-	if !waitForFile(markerFile, 5*time.Second) {
-		t.Fatal("child never started (marker absent within 5s)")
-	}
-	if chErr := os.Chmod(exe, 0o000); chErr != nil {
-		t.Fatalf("chmod 000 v1 binary: %v", chErr)
-	}
-	t.Cleanup(func() { _ = os.Chmod(exe, 0o755) })
 
 	// Supervise must return an error: v1 rolls back to v0 (hash failure → not
 	// known-good → probation), then v0 also fails and budget is exhausted.

--- a/docs/deployment/fleet-upgrades.md
+++ b/docs/deployment/fleet-upgrades.md
@@ -4,36 +4,72 @@ This document describes the operator workflow for upgrading steward binaries acr
 
 ## Overview
 
-The upgrade workflow has four steps:
+The upgrade workflow has five steps:
 
-1. **Publish** — upload the steward binary to the controller's blob store.
-2. **Approve** — approve the published blob before dispatch (separate approval step).
-3. **Dispatch** — send the upgrade command to matching stewards.
-4. **Monitor or rollback** — check per-steward status, and roll back if needed.
+1. **Sign** — produce the publisher signature over the binary.
+2. **Publish** — upload the steward binary and its signature to the controller's blob store.
+3. **Approve** — approve the published blob before dispatch (separate approval step).
+4. **Dispatch** — send the upgrade command to matching stewards.
+5. **Monitor or rollback** — check per-steward status, and roll back if needed.
 
-## Step 1: Publish the steward binary
+## Step 1: Sign the steward binary
 
-Use `cfg installer publish` to upload a new steward binary to the controller:
+Unsigned uploads are rejected. The publisher signature covers a canonical
+`content_hash|version|platform|arch` message, so a signature is valid **only** for the
+exact version, platform, and arch it was minted for:
 
 ```
-cfg installer publish steward \
+go run ./scripts/sign-steward-binary /path/to/steward-linux-amd64 v0.5.12 linux amd64
+```
+
+This writes `<binary>.sig` and prints the content hash and the URL-safe base64 signature.
+
+By default it signs with the zero-seed **dev** publisher key, which only dev/lab
+controllers trust. To sign for a fleet that trusts a real publisher identity, supply the
+32-byte Ed25519 seed as standard base64 in `CFGMS_PUBLISHER_SEED`.
+
+> **Why the coordinates are signed.** A content-hash-only signature lets a compromised
+> controller serve a genuinely signed *older, vulnerable* binary at a *newer* version's
+> URL: the signature verifies, the SHA-256 matches, and the downgrade guard is bypassed
+> because the version is controller-attested rather than signed. Binding the coordinates
+> closes that rollback path (Issue #2834).
+
+## Step 2: Publish the steward binary
+
+Use `cfg installer publish` to upload the binary and its signature:
+
+```
+cfg installer publish \
+  --kind steward \
   --version v0.5.12 \
   --platform linux \
   --arch amd64 \
-  --file /path/to/steward-linux-amd64
+  --binary /path/to/steward-linux-amd64 \
+  --signature /path/to/steward-linux-amd64.sig
 ```
+
+The version, platform, and arch **must** match the values the binary was signed for, or
+the controller rejects the upload with `SIGNATURE_VERIFICATION_FAILED`. Add `--force` to
+overwrite an existing binary at the same coordinates.
 
 The command prints the blob ID on success. The blob starts in `published` state
 and must be approved before it can be dispatched.
 
-## Step 2: Approve the binary (separate approval step)
+### Migrating binaries signed before coordinate binding
+
+Binaries signed under the previous content-hash-only scheme no longer verify. Re-sign and
+re-publish (with `--force`) every steward binary the fleet may still converge to **before**
+rolling out a controller/steward build that enforces the new scheme — otherwise every
+upgrade fails closed until the re-publish completes.
+
+## Step 3: Approve the binary (separate approval step)
 
 Approval is performed via the controller API or admin tooling. A blob in
 `published` state cannot be dispatched — dispatch returns 403 until the blob
 transitions to `approved`. See the controller administration guide for the
 approval workflow.
 
-## Step 3: Dispatch the upgrade
+## Step 4: Dispatch the upgrade
 
 Use `cfg steward upgrade` to dispatch the upgrade to stewards matching a selector:
 
@@ -92,7 +128,7 @@ steward-3901879957445270929           committed
 
 Exit code is 1 if any steward reaches `failed` or `rolled_back` state.
 
-## Step 4a: Check upgrade status
+## Step 5a: Check upgrade status
 
 Use `cfg steward upgrade status` to check per-steward upgrade progress:
 
@@ -135,7 +171,7 @@ steward-1780659937223058807            v0.5.12   committed  2026-06-09T10:00:00Z
 steward-2890769947334169918            v0.5.11   committed  2026-06-08T14:30:00Z
 ```
 
-## Step 4b: Roll back an upgrade
+## Step 5b: Roll back an upgrade
 
 Use `cfg steward upgrade rollback` to roll back a dispatched upgrade:
 

--- a/features/controller/api/handlers_steward_binary.go
+++ b/features/controller/api/handlers_steward_binary.go
@@ -148,14 +148,18 @@ func (s *Server) handlePublishStewardBinary(w http.ResponseWriter, r *http.Reque
 	sum := sha256.Sum256(body)
 	contentHash := hex.EncodeToString(sum[:])
 
-	// Verify the publisher signature. The Ed25519 message is the UTF-8 bytes of contentHash.
-	b := bundle.Bundle{ContentHash: contentHash}
+	// Verify the publisher signature over the canonical (content hash, version,
+	// platform, arch) message. Binding the release coordinates means a signature
+	// issued for one version/platform/arch cannot be replayed to publish a
+	// different one (Issue #2834). version/platform/arch are the route vars
+	// validated above, so the stored signature always covers the key it lands under.
 	sig := bundle.BundleSignature{
 		Publisher: "cfgms",
 		Algorithm: "ed25519",
 		Signature: sigBytes,
 	}
-	if verifyErr := trust.VerifyBundleSignature(&b, sig, s.stewardBinaryTrust()); verifyErr != nil {
+	if verifyErr := trust.VerifyStewardBinarySignature(
+		contentHash, version, platform, arch, sig, s.stewardBinaryTrust()); verifyErr != nil {
 		s.writeErrorResponse(w, http.StatusBadRequest,
 			"Signature verification failed: "+verifyErr.Error(),
 			"SIGNATURE_VERIFICATION_FAILED")

--- a/features/controller/api/handlers_steward_binary_test.go
+++ b/features/controller/api/handlers_steward_binary_test.go
@@ -62,12 +62,18 @@ func setupStewardBinaryServer(t *testing.T) (*Server, stewardBinaryTestFixture) 
 	return server, fix
 }
 
-// signContent signs the SHA-256 hex of content with the fixture private key and returns
-// URL-safe base64 (no padding) signature bytes, as expected by the endpoint.
-func (f stewardBinaryTestFixture) signContent(content []byte) string {
+// signContent signs the canonical (contentHash, version, platform, arch) composite with
+// the fixture private key and returns URL-safe base64 (no padding) signature bytes, as
+// expected by the endpoint. Binding the release coordinates means a signature minted for
+// one version/platform/arch cannot be replayed to publish another (Issue #2834).
+func (f stewardBinaryTestFixture) signContent(content []byte, version, platform, arch string) string {
 	sum := sha256.Sum256(content)
 	hash := hex.EncodeToString(sum[:])
-	sig := ed25519.Sign(f.priv, []byte(hash))
+	msg, err := trust.StewardBinaryMessage(hash, version, platform, arch)
+	if err != nil {
+		panic(err)
+	}
+	sig := ed25519.Sign(f.priv, []byte(msg))
 	return base64.RawURLEncoding.EncodeToString(sig)
 }
 
@@ -157,6 +163,34 @@ func TestPublishEndpoint_RejectsInvalidSignature(t *testing.T) {
 	assert.Contains(t, body, "SIGNATURE_VERIFICATION_FAILED")
 }
 
+// TestPublishEndpoint_RejectsVersionBindingMismatch verifies that a signature minted for
+// one set of release coordinates cannot be replayed to publish a different version,
+// platform, or arch. This is the publish-side half of the rollback defense (Issue #2834):
+// the stored signature always covers the key the blob lands under, so a later GET cannot
+// serve bytes whose signature was issued for some other release.
+func TestPublishEndpoint_RejectsVersionBindingMismatch(t *testing.T) {
+	content := []byte("steward binary signed for v1.0.0/linux/amd64")
+
+	cases := map[string][3]string{
+		"version substituted":  {"v2.0.0", "linux", "amd64"},
+		"platform substituted": {"v1.0.0", "darwin", "amd64"},
+		"arch substituted":     {"v1.0.0", "linux", "arm64"},
+	}
+	for name, coords := range cases {
+		t.Run(name, func(t *testing.T) {
+			server, fix := setupStewardBinaryServer(t)
+			// Authentic signature, but bound to v1.0.0/linux/amd64.
+			sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
+
+			rec := doPublish(server, coords[0], coords[1], coords[2], "test-tenant", sigBase64, content)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code,
+				"signature bound to different coordinates must be rejected")
+			assert.Contains(t, rec.Body.String(), "SIGNATURE_VERIFICATION_FAILED")
+		})
+	}
+}
+
 // TestPublishEndpoint_RejectsCrossTenantPublish verifies that a caller without
 // installer:publish:steward permission receives 403. This demonstrates tenant-namespace
 // isolation: a key scoped to tenant-b (without the required permission) cannot publish
@@ -176,7 +210,7 @@ func TestPublishEndpoint_RejectsCrossTenantPublish(t *testing.T) {
 	defer ts.Close()
 
 	content := []byte("steward binary content for tenant-b test")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
 
 	q := url.Values{}
 	q.Set("signature", sigBase64)
@@ -198,7 +232,7 @@ func TestPublishEndpoint_DuplicatePublishReturns409(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 
 	content := []byte("steward binary content")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
 
 	// First publish — must succeed.
 	rec1 := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
@@ -216,7 +250,7 @@ func TestPublishEndpoint_DuplicatePublishReturns409(t *testing.T) {
 func TestPublishEndpoint_ValidatesPlatformAndArch(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 	content := []byte("binary")
-	sig := fix.signContent(content)
+	sig := fix.signContent(content, "v1.0.0", "solaris", "amd64")
 
 	t.Run("rejects unknown platform", func(t *testing.T) {
 		rec := doPublish(server, "v1.0.0", "solaris", "amd64", "test-tenant", sig, content)
@@ -238,7 +272,7 @@ func TestHandlePublishStewardBinary_ValidInput(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 
 	content := []byte("cfgms-steward binary content")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v0.5.12", "linux", "amd64")
 
 	rec := doPublish(server, "v0.5.12", "linux", "amd64", "test-tenant", sigBase64, content)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -264,14 +298,14 @@ func TestHandlePublishStewardBinary_ForceOverwrite(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 
 	content := []byte("original binary")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
 
 	rec := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
 	require.Equal(t, http.StatusOK, rec.Code, "first publish must succeed")
 
 	// Overwrite with --force.
 	newContent := []byte("updated binary")
-	newSig := fix.signContent(newContent)
+	newSig := fix.signContent(newContent, "v1.0.0", "linux", "amd64")
 	q := url.Values{}
 	q.Set("signature", newSig)
 	q.Set("force", "true")
@@ -290,7 +324,7 @@ func TestHandlePublishStewardBinary_ForceOverwrite(t *testing.T) {
 func TestHandlePublishStewardBinary_InvalidVersion(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 	content := []byte("binary")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "1.0.0", "linux", "amd64")
 
 	rec := doPublish(server, "1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -301,7 +335,7 @@ func TestHandlePublishStewardBinary_InvalidVersion(t *testing.T) {
 func TestHandlePublishStewardBinary_InvalidPlatform(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 	content := []byte("binary")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "solaris", "amd64")
 
 	rec := doPublish(server, "v1.0.0", "solaris", "amd64", "test-tenant", sigBase64, content)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -312,7 +346,7 @@ func TestHandlePublishStewardBinary_InvalidPlatform(t *testing.T) {
 func TestHandlePublishStewardBinary_NoTenant(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 	content := []byte("binary")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/api/v1/installer/steward-binaries/v1.0.0/linux/amd64?signature="+sigBase64,
@@ -346,7 +380,7 @@ func TestHandleGetStewardBinary_ReturnsStream(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 
 	content := []byte("cfgms-steward-binary-content-for-get-test")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.2.3", "darwin", "arm64")
 
 	// Publish first.
 	rec := doPublish(server, "v1.2.3", "darwin", "arm64", "get-tenant", sigBase64, content)
@@ -374,7 +408,7 @@ func TestHandleGetStewardBinary_TenantIsolation(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 
 	content := []byte("tenant-a binary")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
 
 	// Publish under tenant-a.
 	rec := doPublish(server, "v1.0.0", "linux", "amd64", "tenant-a", sigBase64, content)
@@ -437,7 +471,7 @@ func TestHandlePublishStewardBinary_LabelsStoredCorrectly(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 
 	content := []byte("binary for label test")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v2.0.0", "windows", "amd64")
 
 	// Inject an operator identity so published_by is non-empty.
 	q2 := url.Values{}
@@ -523,7 +557,7 @@ func getWithPrincipal(server *Server, principalReq func(*http.Request) *http.Req
 func TestPublish_AdminEmptyTenant_NotUnauthorized(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 	content := []byte("admin-published steward binary")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
 
 	rec := publishWithPrincipal(server, withAdminPrincipal, "v1.0.0", "linux", "amd64", sigBase64, content)
 
@@ -537,7 +571,7 @@ func TestPublish_AdminEmptyTenant_NotUnauthorized(t *testing.T) {
 func TestPublish_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 	content := []byte("scoped-but-tenantless binary")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
 
 	emptyScoped := func(req *http.Request) *http.Request { return withScopedPrincipal(req, "") }
 	rec := publishWithPrincipal(server, emptyScoped, "v1.0.0", "linux", "amd64", sigBase64, content)
@@ -551,7 +585,7 @@ func TestPublish_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
 func TestGetStewardBinary_AdminEmptyTenant_NotUnauthorized(t *testing.T) {
 	server, fix := setupStewardBinaryServer(t)
 	content := []byte("admin binary for get")
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v1.2.3", "darwin", "arm64")
 
 	pubRec := publishWithPrincipal(server, withAdminPrincipal, "v1.2.3", "darwin", "arm64", sigBase64, content)
 	require.Equal(t, http.StatusOK, pubRec.Code, "admin publish must succeed: %s", pubRec.Body.String())

--- a/features/controller/api/handlers_upgrade_test.go
+++ b/features/controller/api/handlers_upgrade_test.go
@@ -1163,7 +1163,7 @@ func TestAdminDispatch_EndToEndDeliveryPath_DefaultNamespace(t *testing.T) {
 	content := []byte("cfgms-steward-binary-e2e-admin")
 	fix := newStewardBinaryFixture(t)
 	server.stewardBinaryTrustStore = fix.store
-	sigBase64 := fix.signContent(content)
+	sigBase64 := fix.signContent(content, "v0.5.12", "linux", "amd64")
 	pubRec := publishWithPrincipal(server, withAdminPrincipal, "v0.5.12", "linux", "amd64", sigBase64, content)
 	require.Equal(t, http.StatusOK, pubRec.Code, "admin publish must succeed: %s", pubRec.Body.String())
 

--- a/features/steward/client/client_transport_upgrade.go
+++ b/features/steward/client/client_transport_upgrade.go
@@ -509,8 +509,13 @@ func (c *TransportClient) buildHTTPClientForUpgrade() (*http.Client, error) {
 }
 
 // verifyBinarySignature constructs an ephemeral trust store and calls
-// trust.VerifyBundleSignature. In tests, c.upgradePublisherTrustStore may
+// trust.VerifyStewardBinarySignature. In tests, c.upgradePublisherTrustStore may
 // override the default CFGMSPublisherIdentity() store.
+//
+// The signature is verified over the canonical (content hash, version, platform, arch)
+// message, so a genuinely signed binary for one release cannot be replayed as another
+// (Issue #2834). hexSHA256 MUST be the digest recomputed locally over the received
+// bytes — never a value echoed by the serving controller.
 func (c *TransportClient) verifyBinarySignature(hexSHA256 string, params *pushStewardBinaryParams) error {
 	c.mu.RLock()
 	overrideStore := c.upgradePublisherTrustStore
@@ -525,13 +530,12 @@ func (c *TransportClient) verifyBinarySignature(hexSHA256 string, params *pushSt
 		store = ts
 	}
 
-	b := bundle.Bundle{ContentHash: hexSHA256}
 	sig := bundle.BundleSignature{
 		Publisher: params.Publisher,
 		Algorithm: "ed25519",
 		Signature: params.BundleSignature,
 	}
-	return trust.VerifyBundleSignature(&b, sig, store)
+	return trust.VerifyStewardBinarySignature(hexSHA256, params.Version, params.Platform, params.Arch, sig, store)
 }
 
 // isVersionRevoked checks whether v is in the cached revoked versions list.

--- a/features/steward/client/client_transport_upgrade_test.go
+++ b/features/steward/client/client_transport_upgrade_test.go
@@ -43,7 +43,11 @@ import (
 // testPublisher creates a new Ed25519 key pair and returns a trust store
 // seeded with the public key, plus a sign function that produces valid
 // BundleSignature bytes using the private key.
-func testPublisher(t *testing.T, name string) (store trust.TrustStore, sign func(contentHash string) []byte) {
+// The signature covers the canonical (contentHash, version, platform, arch) composite
+// (Issue #2834), so a signature minted for one release cannot be replayed as another.
+// platformArch optionally overrides the host's runtime.GOOS/GOARCH, which is what
+// almost every upgrade test dispatches.
+func testPublisher(t *testing.T, name string) (store trust.TrustStore, sign func(contentHash, version string, platformArch ...string) []byte) {
 	t.Helper()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
@@ -54,8 +58,14 @@ func testPublisher(t *testing.T, name string) (store trust.TrustStore, sign func
 		PublicKey: []byte(pub),
 		Algorithm: "ed25519",
 	}))
-	sign = func(contentHash string) []byte {
-		return ed25519.Sign(priv, []byte(contentHash))
+	sign = func(contentHash, version string, platformArch ...string) []byte {
+		platform, arch := runtime.GOOS, runtime.GOARCH
+		if len(platformArch) == 2 {
+			platform, arch = platformArch[0], platformArch[1]
+		}
+		msg, err := trust.StewardBinaryMessage(contentHash, version, platform, arch)
+		require.NoError(t, err)
+		return ed25519.Sign(priv, []byte(msg))
 	}
 	return ts, sign
 }
@@ -110,7 +120,7 @@ func TestHandlePushStewardBinary_RejectsInvalidSignature(t *testing.T) {
 
 	ts, sign := testPublisher(t, "cfgms")
 	// Tamper: sign the WRONG content hash.
-	tamperedSig := sign("wrong-content-hash-that-does-not-match")
+	tamperedSig := sign("wrong-content-hash-that-does-not-match", "v2.0.0")
 
 	// Use an HTTPS test server; inject its transport so the download proceeds.
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -164,7 +174,7 @@ func TestHandlePushStewardBinary_RejectsDowngrade(t *testing.T) {
 
 	ts, sign := testPublisher(t, "cfgms")
 	// Use a valid signature so the rejection happens specifically at the version check.
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v0.1.0")
 
 	// Serve via HTTPS test server with injected transport.
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -217,8 +227,10 @@ func TestHandlePushStewardBinary_RejectsRevokedVersion(t *testing.T) {
 	content := []byte("revoked version binary")
 	sha256Hex := computeSHA256(content)
 
+	revokedVer := "v9.9.9"
+
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, revokedVer)
 
 	// Serve via HTTPS; the binary must be downloaded before revocation is checked.
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -242,7 +254,6 @@ func TestHandlePushStewardBinary_RejectsRevokedVersion(t *testing.T) {
 	c.upgradeHTTPClient = srv.Client()
 	c.mu.Unlock()
 
-	revokedVer := "v9.9.9"
 	c.SetRevokedVersions([]string{"v1.0.0-bad", revokedVer, "v2.0.0-bad"})
 
 	cmd := &cpTypes.Command{
@@ -308,7 +319,7 @@ func TestHandlePushStewardBinary_RejectsCrossHostDownloadURL(t *testing.T) {
 	sha256Hex := computeSHA256(content)
 
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v2.0.0")
 
 	certStoreDir := t.TempDir()
 	// Controller is at "controller.example.com"; download URL points elsewhere.
@@ -423,7 +434,7 @@ func TestHandlePushStewardBinary_RejectsNonHTTPS(t *testing.T) {
 	content := []byte("test content")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v2.0.0")
 
 	certStoreDir := t.TempDir()
 	c := minimalClientForUpgradeTest(t, certStoreDir, "127.0.0.1", ts, noopSwap)
@@ -496,17 +507,52 @@ func TestVerifyBinarySignature_ValidKey(t *testing.T) {
 	sha256Hex := computeSHA256(content)
 
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v2.0.0")
 
 	certStoreDir := t.TempDir()
 	c := minimalClientForUpgradeTest(t, certStoreDir, "127.0.0.1", ts, noopSwap)
 
 	params := &pushStewardBinaryParams{
+		Version:         "v2.0.0",
+		Platform:        runtime.GOOS,
+		Arch:            runtime.GOARCH,
 		Publisher:       "cfgms",
 		BundleSignature: sig,
 	}
 	err := c.verifyBinarySignature(sha256Hex, params)
 	require.NoError(t, err, "valid signature must pass verification")
+}
+
+// TestVerifyBinarySignature_RejectsVersionBindingMismatch proves the steward rejects a
+// binary that carries a genuine publisher signature issued for DIFFERENT release
+// coordinates. This is the rollback defense (Issue #2834): without it, a compromised
+// controller could serve a legitimately signed older binary at a newer version's
+// coordinates and bypass the downgrade guard, since the version is controller-attested
+// rather than signed.
+func TestVerifyBinarySignature_RejectsVersionBindingMismatch(t *testing.T) {
+	content := []byte("valid binary content")
+	sha256Hex := computeSHA256(content)
+
+	ts, sign := testPublisher(t, "cfgms")
+	// Authentic signature, but minted for v1.0.0 on this platform.
+	sig := sign(sha256Hex, "v1.0.0")
+
+	certStoreDir := t.TempDir()
+	c := minimalClientForUpgradeTest(t, certStoreDir, "127.0.0.1", ts, noopSwap)
+
+	cases := map[string]*pushStewardBinaryParams{
+		"version substituted":  {Version: "v2.0.0", Platform: runtime.GOOS, Arch: runtime.GOARCH},
+		"platform substituted": {Version: "v1.0.0", Platform: "plan9", Arch: runtime.GOARCH},
+		"arch substituted":     {Version: "v1.0.0", Platform: runtime.GOOS, Arch: "riscv64"},
+	}
+	for name, params := range cases {
+		t.Run(name, func(t *testing.T) {
+			params.Publisher = "cfgms"
+			params.BundleSignature = sig
+			err := c.verifyBinarySignature(sha256Hex, params)
+			require.Error(t, err, "signature bound to different coordinates must be rejected")
+		})
+	}
 }
 
 // TestIsNewerVersion exercises the version comparison helper.
@@ -594,7 +640,7 @@ func TestUpgradeEventsEmitted(t *testing.T) {
 	sha256Hex := computeSHA256(content)
 
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.0.0")
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
@@ -664,8 +710,10 @@ func TestHandlePushStewardBinary_HappyPath(t *testing.T) {
 	content := []byte("a valid steward binary for the happy path test")
 	sha256Hex := computeSHA256(content)
 
+	const upgradeVer = "v99.1.0"
+
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, upgradeVer)
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
@@ -706,7 +754,6 @@ func TestHandlePushStewardBinary_HappyPath(t *testing.T) {
 	c.offlineQueue = queue
 	c.mu.Unlock()
 
-	const upgradeVer = "v99.1.0"
 	cmd := &cpTypes.Command{
 		ID:        "cmd-happy-path",
 		Type:      cpTypes.CommandPushStewardBinary,
@@ -786,7 +833,7 @@ func TestHandlePushStewardBinary_SuccessSchedulesGracefulShutdown(t *testing.T) 
 	content := []byte("a valid steward binary that auto-applies")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.2.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()
@@ -834,7 +881,7 @@ func TestHandlePushStewardBinary_FailedSwapDoesNotScheduleShutdown(t *testing.T)
 	content := []byte("binary whose swap fails")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.3.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()
@@ -874,7 +921,7 @@ func TestHandlePushStewardBinary_NilShutdownFuncIsSafe(t *testing.T) {
 	content := []byte("binary with no shutdown wired")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.4.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()
@@ -909,7 +956,7 @@ func TestHandlePushStewardBinary_DeferredSelfExitFiresWhenTriggerWired(t *testin
 	content := []byte("binary staged before shutdown trigger wired")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.5.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()
@@ -976,7 +1023,7 @@ func TestHandlePushStewardBinary_LauncherManagedGatesSelfExit(t *testing.T) {
 			content := []byte("launcher-managed gate steward binary " + tc.name)
 			sha256Hex := computeSHA256(content)
 			ts, sign := testPublisher(t, "cfgms")
-			sig := sign(sha256Hex)
+			sig := sign(sha256Hex, "v99.9.0")
 			srv := newUpgradeTestServer(t, content)
 
 			certStoreDir := t.TempDir()
@@ -1047,7 +1094,7 @@ func TestPushStewardBinary_CompletionAckBeforeShutdown(t *testing.T) {
 	content := []byte("ordering test steward binary")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.5.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()
@@ -1124,7 +1171,7 @@ func TestPushStewardBinary_DefaultTimerInvokesShutdown(t *testing.T) {
 	content := []byte("default timer path steward binary")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.6.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()
@@ -1164,7 +1211,7 @@ func TestPushStewardBinary_DefaultTimerExitsOnContextCancel(t *testing.T) {
 	content := []byte("ctx cancel path steward binary")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.7.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()
@@ -1226,7 +1273,7 @@ func TestPushStewardBinary_FiresWhenCommandCtxCancelledImmediately(t *testing.T)
 	content := []byte("regression 2003 steward binary")
 	sha256Hex := computeSHA256(content)
 	ts, sign := testPublisher(t, "cfgms")
-	sig := sign(sha256Hex)
+	sig := sign(sha256Hex, "v99.8.0")
 	srv := newUpgradeTestServer(t, content)
 
 	certStoreDir := t.TempDir()

--- a/pkg/modules/trust/steward_binary.go
+++ b/pkg/modules/trust/steward_binary.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+// ErrInvalidSignatureMessage is returned when steward-binary signature coordinates
+// cannot form a canonical message — an empty field, or a field containing the
+// reserved separator. It is deliberately a hard error rather than a sanitization:
+// stripping the separator would let two distinct coordinate sets collide on one
+// message, which is exactly the ambiguity the binding exists to remove.
+var ErrInvalidSignatureMessage = errors.New("invalid steward binary signature message")
+
+// stewardBinaryMessageSep separates the coordinates in the canonical message. It is
+// absent from every legitimate field: content hashes are hex, versions match
+// ^v\d+\.\d+\.\d+(-[a-zA-Z0-9][a-zA-Z0-9.-]*)?$, and platform/arch come from fixed
+// allow-lists. Fields carrying it are rejected rather than escaped.
+const stewardBinaryMessageSep = "|"
+
+// StewardBinaryMessage returns the canonical Ed25519 message for a steward-binary
+// publisher signature: contentHash|version|platform|arch.
+//
+// Binding the release coordinates — not just the content hash — is what closes the
+// rollback gap (Issue #2834). With a content-hash-only signature, a compromised
+// controller could serve a genuinely signed OLDER binary at a NEWER version's URL:
+// the signature would verify, the SHA-256 would match, and the downgrade guard would
+// be bypassed because the version is controller-attested rather than signed.
+//
+// The ONLY normalization applied is the leading "v" on the version. Anything that
+// collapsed semantically distinct versions — lowercasing, stripping build metadata,
+// treating v1.2.3-rc1 as v1.2.3 — would let one signature cover two releases and
+// partially reopen the gap this function exists to close.
+//
+// All three steward-binary touch points (the publish signer, the controller's
+// verify-on-upload, and the steward's verify) must derive their message from this
+// single helper so the signed and verified bytes match exactly.
+func StewardBinaryMessage(contentHash, version, platform, arch string) (string, error) {
+	for _, f := range []struct{ name, value string }{
+		{"content hash", contentHash},
+		{"version", version},
+		{"platform", platform},
+		{"arch", arch},
+	} {
+		if f.value == "" {
+			return "", fmt.Errorf("%w: %s is empty", ErrInvalidSignatureMessage, f.name)
+		}
+		if strings.Contains(f.value, stewardBinaryMessageSep) {
+			return "", fmt.Errorf("%w: %s contains the reserved %q separator",
+				ErrInvalidSignatureMessage, f.name, stewardBinaryMessageSep)
+		}
+	}
+
+	return strings.Join([]string{
+		contentHash,
+		canonicalStewardBinaryVersion(version),
+		platform,
+		arch,
+	}, stewardBinaryMessageSep), nil
+}
+
+// canonicalStewardBinaryVersion normalizes the leading "v" and nothing else, so that
+// "0.9.41" and "v0.9.41" produce an identical message while every other distinction
+// in the version string is preserved.
+func canonicalStewardBinaryVersion(version string) string {
+	if strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
+}
+
+// VerifyStewardBinarySignature verifies a steward-binary publisher signature over the
+// canonical (contentHash, version, platform, arch) message.
+//
+// The caller MUST pass coordinates it derived itself — the locally recomputed digest
+// of the downloaded bytes and its own requested version / detected platform+arch —
+// never values echoed back by the serving controller. Sourcing any coordinate from a
+// controller-supplied header would let a compromised controller name the coordinates
+// its old signature already covers, reopening the rollback path.
+//
+// The composite is carried in bundle.Bundle.ContentHash because VerifyBundleSignature
+// signs that field verbatim. That shared primitive is intentionally left untouched: it
+// also gates module auto-approval and steward module-execution trust, where bundles are
+// multi-platform and sign the bare content hash. Confining the composite to this
+// wrapper keeps already-published module bundles verifying.
+func VerifyStewardBinarySignature(contentHash, version, platform, arch string, sig bundle.BundleSignature, store TrustStore) error {
+	message, err := StewardBinaryMessage(contentHash, version, platform, arch)
+	if err != nil {
+		return err
+	}
+	return VerifyBundleSignature(&bundle.Bundle{ContentHash: message}, sig, store)
+}

--- a/pkg/modules/trust/steward_binary_test.go
+++ b/pkg/modules/trust/steward_binary_test.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust_test
+
+import (
+	"crypto/ed25519"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+// testContentHash is a well-formed hex SHA-256 (the digest of the empty input).
+const testContentHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+// stewardBinaryStore returns a trust store holding pub under the "cfgms" publisher.
+func stewardBinaryStore(t *testing.T, pub ed25519.PublicKey) trust.TrustStore {
+	t.Helper()
+	store := trust.NewInMemoryTrustStore()
+	require.NoError(t, store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: []byte(pub),
+		Algorithm: "ed25519",
+	}))
+	return store
+}
+
+// signStewardBinary signs the canonical composite message for the given coordinates.
+func signStewardBinary(t *testing.T, priv ed25519.PrivateKey, contentHash, version, platform, arch string) bundle.BundleSignature {
+	t.Helper()
+	msg, err := trust.StewardBinaryMessage(contentHash, version, platform, arch)
+	require.NoError(t, err)
+	return bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: ed25519.Sign(priv, []byte(msg)),
+	}
+}
+
+// TestStewardBinaryMessage_BindsAllCoordinates proves the signed message covers the
+// release coordinates, not just the content hash — the basis of the rollback defense.
+func TestStewardBinaryMessage_BindsAllCoordinates(t *testing.T) {
+	msg, err := trust.StewardBinaryMessage(testContentHash, "v0.9.41", "windows", "amd64")
+	require.NoError(t, err)
+
+	assert.Contains(t, msg, testContentHash)
+	assert.Contains(t, msg, "v0.9.41")
+	assert.Contains(t, msg, "windows")
+	assert.Contains(t, msg, "amd64")
+
+	// Changing any single coordinate must change the message.
+	for _, other := range []struct{ hash, version, platform, arch string }{
+		{"aaaa", "v0.9.41", "windows", "amd64"},
+		{testContentHash, "v0.9.42", "windows", "amd64"},
+		{testContentHash, "v0.9.41", "linux", "amd64"},
+		{testContentHash, "v0.9.41", "windows", "arm64"},
+	} {
+		got, err := trust.StewardBinaryMessage(other.hash, other.version, other.platform, other.arch)
+		require.NoError(t, err)
+		assert.NotEqual(t, msg, got)
+	}
+}
+
+// TestStewardBinaryMessage_CanonicalizesLeadingV proves the only permitted
+// normalization — a missing "v" prefix — yields a byte-identical message.
+func TestStewardBinaryMessage_CanonicalizesLeadingV(t *testing.T) {
+	withV, err := trust.StewardBinaryMessage(testContentHash, "v0.9.41", "windows", "amd64")
+	require.NoError(t, err)
+	withoutV, err := trust.StewardBinaryMessage(testContentHash, "0.9.41", "windows", "amd64")
+	require.NoError(t, err)
+
+	assert.Equal(t, withV, withoutV, "v-prefix normalization must produce an identical message")
+}
+
+// TestStewardBinaryMessage_DoesNotCollapseDistinctVersions proves normalization is
+// strictly limited to the leading "v". Collapsing pre-release or build metadata would
+// let one signature cover two releases and partially reopen the rollback gap.
+func TestStewardBinaryMessage_DoesNotCollapseDistinctVersions(t *testing.T) {
+	base, err := trust.StewardBinaryMessage(testContentHash, "v1.2.3", "windows", "amd64")
+	require.NoError(t, err)
+
+	for _, distinct := range []string{"v1.2.3-rc1", "v1.2.3+build5", "v1.2.30", "v1.2.3-RC1"} {
+		got, err := trust.StewardBinaryMessage(testContentHash, distinct, "windows", "amd64")
+		require.NoError(t, err)
+		assert.NotEqual(t, base, got, "%q must not collapse to v1.2.3", distinct)
+	}
+}
+
+// TestStewardBinaryMessage_RejectsSeparatorInField proves the separator is hard-rejected
+// rather than sanitized — stripping it would let two distinct inputs collide.
+func TestStewardBinaryMessage_RejectsSeparatorInField(t *testing.T) {
+	cases := map[string][4]string{
+		"content hash": {"abc|def", "v0.9.41", "windows", "amd64"},
+		"version":      {testContentHash, "v0.9|41", "windows", "amd64"},
+		"platform":     {testContentHash, "v0.9.41", "win|dows", "amd64"},
+		"arch":         {testContentHash, "v0.9.41", "windows", "amd|64"},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := trust.StewardBinaryMessage(c[0], c[1], c[2], c[3])
+			require.Error(t, err)
+			assert.ErrorIs(t, err, trust.ErrInvalidSignatureMessage)
+		})
+	}
+}
+
+// TestStewardBinaryMessage_RejectsEmptyField proves an unbound coordinate cannot be
+// signed — an empty version would defeat the binding entirely.
+func TestStewardBinaryMessage_RejectsEmptyField(t *testing.T) {
+	cases := map[string][4]string{
+		"content hash": {"", "v0.9.41", "windows", "amd64"},
+		"version":      {testContentHash, "", "windows", "amd64"},
+		"platform":     {testContentHash, "v0.9.41", "", "amd64"},
+		"arch":         {testContentHash, "v0.9.41", "windows", ""},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := trust.StewardBinaryMessage(c[0], c[1], c[2], c[3])
+			require.Error(t, err)
+			assert.ErrorIs(t, err, trust.ErrInvalidSignatureMessage)
+		})
+	}
+}
+
+// TestVerifyStewardBinarySignature_ValidRoundTrip proves signer and verifier agree
+// byte-for-byte on the canonical message.
+func TestVerifyStewardBinarySignature_ValidRoundTrip(t *testing.T) {
+	pub, priv := makeKeypair(t)
+	store := stewardBinaryStore(t, pub)
+	sig := signStewardBinary(t, priv, testContentHash, "v0.9.41", "windows", "amd64")
+
+	err := trust.VerifyStewardBinarySignature(testContentHash, "v0.9.41", "windows", "amd64", sig, store)
+	assert.NoError(t, err)
+}
+
+// TestVerifyStewardBinarySignature_RejectsRollback is the core security test: a binary
+// validly signed for an OLDER version, served at a NEWER version's coordinates, must be
+// rejected. Without version binding the signature would verify and the downgrade guard
+// would be bypassed, because the version is controller-attested rather than signed.
+func TestVerifyStewardBinarySignature_RejectsRollback(t *testing.T) {
+	pub, priv := makeKeypair(t)
+	store := stewardBinaryStore(t, pub)
+
+	// Authentic signature over the OLD version.
+	sig := signStewardBinary(t, priv, testContentHash, "v0.9.40", "windows", "amd64")
+
+	// Presented as the NEW version, with its genuine content hash and signature.
+	err := trust.VerifyStewardBinarySignature(testContentHash, "v0.9.41", "windows", "amd64", sig, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, trust.ErrInvalidSignature)
+}
+
+// TestVerifyStewardBinarySignature_RejectsCoordinateMismatch proves platform/arch and
+// content-hash substitution are rejected alongside version.
+func TestVerifyStewardBinarySignature_RejectsCoordinateMismatch(t *testing.T) {
+	pub, priv := makeKeypair(t)
+	store := stewardBinaryStore(t, pub)
+	sig := signStewardBinary(t, priv, testContentHash, "v0.9.41", "windows", "amd64")
+
+	cases := map[string][4]string{
+		"tampered binary": {strings.Repeat("a", 64), "v0.9.41", "windows", "amd64"},
+		"platform swap":   {testContentHash, "v0.9.41", "linux", "amd64"},
+		"arch swap":       {testContentHash, "v0.9.41", "windows", "arm64"},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := trust.VerifyStewardBinarySignature(c[0], c[1], c[2], c[3], sig, store)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, trust.ErrInvalidSignature)
+		})
+	}
+}
+
+// TestVerifyStewardBinarySignature_RejectsUntrustedPublisher proves a controller-supplied
+// publisher name cannot select a key outside the store.
+func TestVerifyStewardBinarySignature_RejectsUntrustedPublisher(t *testing.T) {
+	pub, priv := makeKeypair(t)
+	store := stewardBinaryStore(t, pub)
+
+	sig := signStewardBinary(t, priv, testContentHash, "v0.9.41", "windows", "amd64")
+	sig.Publisher = "attacker"
+
+	err := trust.VerifyStewardBinarySignature(testContentHash, "v0.9.41", "windows", "amd64", sig, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, trust.ErrPublisherNotTrusted)
+}
+
+// TestVerifyStewardBinarySignature_PlaceholderKeyFailsClosed proves an unconfigured
+// (all-zero identity) build rejects every binary rather than accepting forgeries.
+func TestVerifyStewardBinarySignature_PlaceholderKeyFailsClosed(t *testing.T) {
+	store := trust.NewInMemoryTrustStore()
+	require.NoError(t, store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: make([]byte, ed25519.PublicKeySize), // all-zero placeholder
+		Algorithm: "ed25519",
+	}))
+
+	_, priv := makeKeypair(t)
+	sig := signStewardBinary(t, priv, testContentHash, "v0.9.41", "windows", "amd64")
+
+	err := trust.VerifyStewardBinarySignature(testContentHash, "v0.9.41", "windows", "amd64", sig, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, trust.ErrUntrustedPublisherKey)
+}
+
+// TestVerifyStewardBinarySignature_RejectsMalformedCoordinates proves message-construction
+// failures surface as verification failures rather than being silently signed over.
+func TestVerifyStewardBinarySignature_RejectsMalformedCoordinates(t *testing.T) {
+	pub, priv := makeKeypair(t)
+	store := stewardBinaryStore(t, pub)
+	sig := signStewardBinary(t, priv, testContentHash, "v0.9.41", "windows", "amd64")
+
+	err := trust.VerifyStewardBinarySignature(testContentHash, "v0.9|41", "windows", "amd64", sig, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, trust.ErrInvalidSignatureMessage)
+}
+
+// TestVerifyBundleSignature_ModuleBundlePathUnaffected is a regression guard for the
+// #2834 constraint: module-bundle verification still signs the bare content hash, so
+// already-published module bundles keep verifying. If this breaks, the shared primitive
+// was altered and module auto-approval / steward module trust would fail fleet-wide.
+func TestVerifyBundleSignature_ModuleBundlePathUnaffected(t *testing.T) {
+	pub, priv := makeKeypair(t)
+	store := stewardBinaryStore(t, pub)
+
+	b := makeBundle("modulebundlecontenthash")
+	sig := bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: signHash(t, priv, b.ContentHash),
+	}
+
+	assert.NoError(t, trust.VerifyBundleSignature(b, sig, store))
+}

--- a/scripts/sign-steward-binary/main.go
+++ b/scripts/sign-steward-binary/main.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Command sign-steward-binary produces the detached publisher signature consumed by
+// `cfg installer publish --binary <file> --signature <base64>`.
+//
+// The signed message is the canonical contentHash|version|platform|arch composite from
+// trust.StewardBinaryMessage — the same helper the controller's verify-on-upload and the
+// steward's verify use, so signer and verifier cannot drift (Issue #2834). This program
+// previously lived at bin/publish/sign.go, which is gitignored; a signer that must stay in
+// lockstep with the verify path cannot live in an untracked directory.
+//
+// Key material: by default this signs with the well-known ZERO-SEED DEV key
+// (pub O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=), which is not a secret and is only
+// trusted by dev/lab controllers. To sign for a fleet that trusts a real publisher
+// identity, supply the seed via the CFGMS_PUBLISHER_SEED environment variable
+// (standard base64 of the 32-byte Ed25519 seed). The seed is never written to disk or
+// echoed to stdout.
+//
+// Usage:
+//
+//	go run ./scripts/sign-steward-binary <binary> <version> <platform> <arch>
+//	go run ./scripts/sign-steward-binary cfgms-steward.exe v0.9.41 windows amd64
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+// publisherSeedEnv optionally supplies the 32-byte Ed25519 seed (standard base64).
+const publisherSeedEnv = "CFGMS_PUBLISHER_SEED"
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, out *os.File) error {
+	if len(args) != 4 {
+		return fmt.Errorf("usage: sign-steward-binary <binary> <version> <platform> <arch>\n" +
+			"  e.g. sign-steward-binary cfgms-steward.exe v0.9.41 windows amd64")
+	}
+	path, version, platform, arch := args[0], args[1], args[2], args[3]
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read binary: %w", err)
+	}
+	sum := sha256.Sum256(content)
+	contentHash := hex.EncodeToString(sum[:])
+
+	// Build the canonical message through the shared helper so the bytes signed here
+	// are exactly the bytes the controller and steward verify.
+	message, err := trust.StewardBinaryMessage(contentHash, version, platform, arch)
+	if err != nil {
+		return err
+	}
+
+	priv, err := publisherKey()
+	if err != nil {
+		return err
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	sig := ed25519.Sign(priv, []byte(message))
+
+	sigPath := path + ".sig"
+	if err := os.WriteFile(sigPath, sig, 0o600); err != nil {
+		return fmt.Errorf("write signature: %w", err)
+	}
+
+	fmt.Fprintf(out, "pub=%s\n", base64.StdEncoding.EncodeToString(pub))
+	fmt.Fprintf(out, "sha256=%s\n", contentHash)
+	fmt.Fprintf(out, "message=%s\n", message)
+	// URL-safe base64 is what `cfg installer publish --signature` expects.
+	fmt.Fprintf(out, "signature=%s\n", base64.RawURLEncoding.EncodeToString(sig))
+	fmt.Fprintf(out, "wrote %s (%d bytes)\n", sigPath, len(sig))
+	return nil
+}
+
+// publisherKey returns the signing key: the CFGMS_PUBLISHER_SEED-derived key when set,
+// otherwise the zero-seed dev key.
+func publisherKey() (ed25519.PrivateKey, error) {
+	encoded := os.Getenv(publisherSeedEnv)
+	if encoded == "" {
+		return ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize)), nil
+	}
+	seed, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", publisherSeedEnv, err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("%s must decode to %d bytes, got %d", publisherSeedEnv, ed25519.SeedSize, len(seed))
+	}
+	return ed25519.NewKeyFromSeed(seed), nil
+}

--- a/scripts/sign-steward-binary/main.go
+++ b/scripts/sign-steward-binary/main.go
@@ -29,6 +29,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/cfgis/cfgms/pkg/modules/trust"
@@ -44,7 +45,7 @@ func main() {
 	}
 }
 
-func run(args []string, out *os.File) error {
+func run(args []string, out io.Writer) error {
 	if len(args) != 4 {
 		return fmt.Errorf("usage: sign-steward-binary <binary> <version> <platform> <arch>\n" +
 			"  e.g. sign-steward-binary cfgms-steward.exe v0.9.41 windows amd64")

--- a/scripts/sign-steward-binary/main_test.go
+++ b/scripts/sign-steward-binary/main_test.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// devPublicKey is the well-known zero-seed dev publisher identity. It is not a secret:
+// it is documented in the command header and trusted only by dev/lab controllers. If
+// this constant ever changes, every dev/lab controller trust store silently stops
+// verifying binaries this tool signs, so it is asserted explicitly.
+const devPublicKey = "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik="
+
+// writeBinary creates a stand-in "steward binary" and returns its path.
+func writeBinary(t *testing.T, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cfgms-steward.exe")
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+	return path
+}
+
+// parseOutput turns the key=value report into a map so assertions do not depend on
+// line ordering.
+func parseOutput(t *testing.T, out string) map[string]string {
+	t.Helper()
+	fields := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if key, value, found := strings.Cut(line, "="); found {
+			fields[key] = value
+		}
+	}
+	return fields
+}
+
+func TestPublisherKey_DefaultsToZeroSeedDevKey(t *testing.T) {
+	// An empty value is how the program sees an unset variable.
+	t.Setenv(publisherSeedEnv, "")
+
+	priv, err := publisherKey()
+	require.NoError(t, err)
+
+	pub := priv.Public().(ed25519.PublicKey)
+	assert.Equal(t, devPublicKey, base64.StdEncoding.EncodeToString(pub),
+		"default signing identity must remain the documented zero-seed dev key")
+}
+
+func TestPublisherKey_UsesSuppliedSeed(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	t.Setenv(publisherSeedEnv, base64.StdEncoding.EncodeToString(seed))
+
+	priv, err := publisherKey()
+	require.NoError(t, err)
+
+	assert.Equal(t, ed25519.NewKeyFromSeed(seed), priv)
+	assert.NotEqual(t, devPublicKey,
+		base64.StdEncoding.EncodeToString(priv.Public().(ed25519.PublicKey)),
+		"a supplied seed must not silently fall back to the dev key")
+}
+
+func TestPublisherKey_RejectsMalformedSeed(t *testing.T) {
+	tests := []struct {
+		name        string
+		seed        string
+		wantMessage string
+	}{
+		{
+			name:        "not base64",
+			seed:        "this is not base64!!",
+			wantMessage: "decode " + publisherSeedEnv,
+		},
+		{
+			name:        "too short",
+			seed:        base64.StdEncoding.EncodeToString(make([]byte, ed25519.SeedSize-1)),
+			wantMessage: "must decode to 32 bytes, got 31",
+		},
+		{
+			name:        "too long",
+			seed:        base64.StdEncoding.EncodeToString(make([]byte, ed25519.SeedSize+1)),
+			wantMessage: "must decode to 32 bytes, got 33",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(publisherSeedEnv, tc.seed)
+
+			priv, err := publisherKey()
+			require.Error(t, err, "malformed seed must not yield a signing key")
+			assert.Nil(t, priv)
+			assert.Contains(t, err.Error(), tc.wantMessage)
+		})
+	}
+}
+
+func TestRun_SignsWithCanonicalMessage(t *testing.T) {
+	t.Setenv(publisherSeedEnv, "")
+
+	content := []byte("steward binary bytes")
+	path := writeBinary(t, content)
+
+	var out bytes.Buffer
+	require.NoError(t, run([]string{path, "v0.9.41", "windows", "amd64"}, &out))
+
+	fields := parseOutput(t, out.String())
+
+	sum := sha256.Sum256(content)
+	wantHash := hex.EncodeToString(sum[:])
+	assert.Equal(t, wantHash, fields["sha256"])
+
+	wantMessage, err := trust.StewardBinaryMessage(wantHash, "v0.9.41", "windows", "amd64")
+	require.NoError(t, err)
+	assert.Equal(t, wantMessage, fields["message"],
+		"signed message must come from the shared canonical helper so signer and verifier cannot drift")
+
+	assert.Equal(t, devPublicKey, fields["pub"])
+
+	// The reported signature is URL-safe base64 because that is what
+	// `cfg installer publish --signature` accepts.
+	sig, err := base64.RawURLEncoding.DecodeString(fields["signature"])
+	require.NoError(t, err, "signature must be raw URL-safe base64")
+
+	pub, err := base64.StdEncoding.DecodeString(fields["pub"])
+	require.NoError(t, err)
+	assert.True(t, ed25519.Verify(ed25519.PublicKey(pub), []byte(wantMessage), sig),
+		"emitted signature must verify against the emitted public key and canonical message")
+
+	// The detached .sig file must hold the same raw signature bytes.
+	onDisk, err := os.ReadFile(path + ".sig")
+	require.NoError(t, err)
+	assert.Equal(t, sig, onDisk)
+
+	assert.Contains(t, out.String(), "wrote "+path+".sig")
+}
+
+func TestRun_NormalizesVersionPrefix(t *testing.T) {
+	t.Setenv(publisherSeedEnv, "")
+
+	path := writeBinary(t, []byte("steward binary bytes"))
+
+	var withPrefix, withoutPrefix bytes.Buffer
+	require.NoError(t, run([]string{path, "v0.9.41", "linux", "arm64"}, &withPrefix))
+	require.NoError(t, run([]string{path, "0.9.41", "linux", "arm64"}, &withoutPrefix))
+
+	assert.Equal(t, parseOutput(t, withPrefix.String())["signature"],
+		parseOutput(t, withoutPrefix.String())["signature"],
+		"only the leading v is normalized, so both spellings must sign identical bytes")
+}
+
+func TestRun_RejectsWrongArgumentCount(t *testing.T) {
+	path := writeBinary(t, []byte("steward binary bytes"))
+
+	tests := map[string][]string{
+		"none":     {},
+		"too few":  {path, "v0.9.41", "windows"},
+		"too many": {path, "v0.9.41", "windows", "amd64", "extra"},
+	}
+
+	for name, args := range tests {
+		t.Run(name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := run(args, &out)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "usage: sign-steward-binary")
+			assert.Empty(t, out.String(), "usage failures must not emit a report")
+			assert.NoFileExists(t, path+".sig")
+		})
+	}
+}
+
+func TestRun_ReportsUnreadableBinary(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.exe")
+
+	var out bytes.Buffer
+	err := run([]string{missing, "v0.9.41", "windows", "amd64"}, &out)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read binary")
+	assert.Empty(t, out.String())
+	assert.NoFileExists(t, missing+".sig")
+}
+
+func TestRun_RejectsUnsignableCoordinates(t *testing.T) {
+	t.Setenv(publisherSeedEnv, "")
+
+	tests := map[string][]string{
+		"empty version":         {"", "windows", "amd64"},
+		"empty platform":        {"v0.9.41", "", "amd64"},
+		"empty arch":            {"v0.9.41", "windows", ""},
+		"separator in version":  {"v0.9.41|v0.9.40", "windows", "amd64"},
+		"separator in platform": {"v0.9.41", "windows|linux", "amd64"},
+	}
+
+	for name, coords := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := writeBinary(t, []byte("steward binary bytes"))
+
+			var out bytes.Buffer
+			err := run(append([]string{path}, coords...), &out)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, trust.ErrInvalidSignatureMessage)
+			assert.Empty(t, out.String())
+			assert.NoFileExists(t, path+".sig",
+				"no signature may be written for coordinates that cannot form a canonical message")
+		})
+	}
+}
+
+func TestRun_MalformedSeedDoesNotWriteSignature(t *testing.T) {
+	t.Setenv(publisherSeedEnv, "not base64!!")
+
+	path := writeBinary(t, []byte("steward binary bytes"))
+
+	var out bytes.Buffer
+	err := run([]string{path, "v0.9.41", "windows", "amd64"}, &out)
+
+	require.Error(t, err)
+	assert.Empty(t, out.String())
+	assert.NoFileExists(t, path+".sig")
+}
+
+func TestRun_NeverEchoesSeed(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(0xA0 + i)
+	}
+	encoded := base64.StdEncoding.EncodeToString(seed)
+	t.Setenv(publisherSeedEnv, encoded)
+
+	path := writeBinary(t, []byte("steward binary bytes"))
+
+	var out bytes.Buffer
+	require.NoError(t, run([]string{path, "v0.9.41", "windows", "amd64"}, &out))
+
+	assert.NotContains(t, out.String(), encoded, "the private seed must never reach stdout")
+	assert.False(t, bytes.Contains(out.Bytes(), seed))
+
+	sigBytes, err := os.ReadFile(path + ".sig")
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(sigBytes, seed), "the private seed must never reach disk")
+}
+
+func TestRun_ErrInvalidSignatureMessageIsSentinel(t *testing.T) {
+	// Guards the wrapping in run(): callers (and this test suite) rely on errors.Is
+	// rather than string matching to identify unsignable coordinates.
+	_, err := trust.StewardBinaryMessage("hash", "", "windows", "amd64")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrInvalidSignatureMessage))
+}

--- a/test/e2e/fleet/upgrade_test.go
+++ b/test/e2e/fleet/upgrade_test.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/modules/trust"
 )
 
 // testUpgradePrivKey returns the zero-seed Ed25519 private key for E2E upgrade signing.
@@ -28,13 +30,16 @@ func testUpgradePrivKey() ed25519.PrivateKey {
 }
 
 // signUploadContent signs binary content using the test Ed25519 key.
-// The message is the UTF-8 encoding of the SHA-256 hex digest, matching
-// trust.VerifyBundleSignature's message derivation. Returns a URL-safe base64
-// (no padding) encoded signature suitable for the ?signature= query parameter.
-func signUploadContent(content []byte) string {
+// The message is the canonical (contentHash, version, platform, arch) composite from
+// trust.StewardBinaryMessage, matching trust.VerifyStewardBinarySignature's derivation
+// (Issue #2834). Returns a URL-safe base64 (no padding) encoded signature suitable for
+// the ?signature= query parameter.
+func signUploadContent(t *testing.T, content []byte, version, platform, arch string) string {
+	t.Helper()
 	sum := sha256.Sum256(content)
-	msg := []byte(hex.EncodeToString(sum[:]))
-	sig := ed25519.Sign(testUpgradePrivKey(), msg)
+	msg, err := trust.StewardBinaryMessage(hex.EncodeToString(sum[:]), version, platform, arch)
+	require.NoError(t, err)
+	sig := ed25519.Sign(testUpgradePrivKey(), []byte(msg))
 	return base64.RawURLEncoding.EncodeToString(sig)
 }
 
@@ -43,7 +48,7 @@ func signUploadContent(content []byte) string {
 // Set force=true to overwrite an existing entry without 409. Returns HTTP status code.
 func publishStewardBin(t *testing.T, client *http.Client, version string, content []byte, force bool) int {
 	t.Helper()
-	sig := signUploadContent(content)
+	sig := signUploadContent(t, content, version, "linux", "amd64")
 	u := fmt.Sprintf("%s/api/v1/installer/steward-binaries/%s/linux/amd64?signature=%s",
 		fleetControllerHTTP, version, sig)
 	if force {


### PR DESCRIPTION
## Summary

Closes the steward-binary **rollback gap**: the publisher signature covered only the content hash, so a compromised controller could serve a genuinely cfgms-signed *older, vulnerable* binary at a *newer* version's URL — the signature verified, the SHA-256 matched, and the downgrade guard was bypassed because the version is controller-attested, not signed. This binds the release coordinates into the signed message.

Story #2834 (split from #2833 per PO-team + security review). Dependency root of the #2834 → #2836 → #2833 chain.

## Changes

- **`trust.StewardBinaryMessage`** builds the canonical `contentHash|version|platform|arch` message; **`trust.VerifyStewardBinarySignature`** wraps `VerifyBundleSignature` with it. Normalization is limited to the leading `v`; separator/empty fields are hard-rejected (stripping would let distinct inputs collide).
- **`pkg/modules/trust/verify.go` / `VerifyBundleSignature` / `bundle.Bundle` are unchanged** — they are the shared module-bundle primitive (module auto-approval + steward module trust), where bundles are multi-platform and sign the bare hash. A regression test guards that boundary.
- All three steward-binary touch points use the one helper: the controller verify-on-upload (`handlePublishStewardBinary`), the steward verify (`verifyBinarySignature`), and the signer.
- **Signer moved** `bin/publish/sign.go` → **`scripts/sign-steward-binary/`**: `bin/` is gitignored, and a signer that must stay byte-for-byte in lockstep with the verifier cannot live untracked. It imports the shared helper (compiled by `go build ./...`, so CI catches drift) and takes an optional `CFGMS_PUBLISHER_SEED` for real-key fleets. Old path left as a panicking stub.
- **Docs:** `fleet-upgrades.md` gains the missing signing step, the corrected publish flags (the documented `--file`/positional form never matched the real `--kind`/`--binary`/`--signature` flags), and the re-sign rollout sequencing.
- **Follow-up commit** (review team): tested the signer (`main_test.go` + `run()` takes `io.Writer`); root-caused and fixed three pre-existing Windows test failures (`os.Getenv("GOOS")`→`runtime.GOOS`; a Windows drive-letter colon mis-split in the launcher test).

## Rollout ordering (operator action — read before deploying)

Binaries signed under the old content-hash-only scheme no longer verify, and the **same** verify call gates the existing push path. **Re-sign and re-publish** every steward binary the fleet may converge to **before** shipping this verify-side change, or every `desired_version` convergence fails closed fleet-wide. Documented in `fleet-upgrades.md`.

## Test results

- **Go unit suite + race: green** — the review workflow ran `make test-quality`; all ~185 Go packages (incl. race detection) passed. New tests: composite round-trip, coordinate-substitution rejection on **both** the controller publish path and the steward verify path (incl. a compromised-controller rollback case), separator/empty rejection, canonicalization bounds, untrusted-publisher + placeholder-key fail-closed, module-bundle regression guard, and the signer suite.
- **Known-environment note:** the review's `test-quality` gate reported `passed:false` solely from `scripts/test-scripts.sh` on the Windows dev host — `rev: command not found` (Git-for-Windows ships no `rev`) and a `python3` extensionless-mock quirk, in files this PR does not touch. Both pass under Linux CI. The reviewer classified them "a Windows-specific test-harness limitation rather than a regression."

## Review

Adversarial team review (acceptance / QA-code / security) **PASSED**; security review 0 blocking, 3 advisory warnings. Round-1 code/test findings were fixed in the follow-up commit and verified.

## Live validation (lab controller ctrl-01)

Deployed this controller and exercised verify-on-upload against real infrastructure:

| Test | Signature | Coordinates | Result |
|---|---|---|---|
| Baseline (old controller) | composite | correct | REJECTED (proves schemes differ) |
| Accept | composite | correct | **ACCEPTED** |
| Version bind | composite (v0.9.42) | published as v0.9.99 | REJECTED |
| Platform bind | composite (windows) | published as linux | REJECTED |
| Migration guard | old-scheme (bare hash) | correct | REJECTED |

Fleet healthy throughout. The steward-side push verify + the full self-fetch e2e are validated in #2833 (the marquee "no push" convergence needs all three stories deployed together).

Fixes #2834

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
