### PR TITLE
agent-container: run Dockerfile RUN steps under bash pipefail

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,6 +33,15 @@ FROM golang:1.26.5-bookworm
 # expands to empty and silently breaks all architecture mappings below.
 ARG TARGETARCH
 
+# Run every RUN step in this stage under bash with pipefail, so a failure on the
+# LEFT side of a pipe (a curl download feeding `| bash -` / `| sh` / `| gpg`)
+# aborts the build instead of being masked by the default /bin/sh (dash has no
+# pipefail) — which would silently proceed with an empty/partial download (e.g.
+# a 404 on an unpublished Node major would otherwise let apt install Debian's
+# stock Node 18). truffleHog below keeps its explicit `|| true` to stay
+# best-effort by design.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # System dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \


### PR DESCRIPTION
## Problem

The runtime stage of `.devcontainer/Dockerfile` runs its `RUN` steps under the default `/bin/sh` (dash on bookworm), which has **no `pipefail`**. Several install steps pipe a download straight into a shell/tool:

- Node: `curl … setup_${NODE_MAJOR}.x | bash -`
- gh keyring: `curl … githubcli-archive-keyring.gpg | gpg --dearmor …`
- golangci-lint: `curl … install.sh | sh -s -- …`

Without `pipefail`, a failure on the **left** side of the pipe is masked — the pipe takes the exit status of its last command, so a failed/partial `curl` proceeds silently. Concretely: a 404 on an unpublished Node major would let `apt-get install nodejs` fall back to Debian's stock **Node 18** instead of failing the build (which undercuts the "fails loudly" guarantee of the `.nvmrc`-derived Node install). Surfaced as review finding #2 on PR #2841 — pre-existing, not introduced there.

## Fix

Add one directive to the runtime stage:

```dockerfile
SHELL ["/bin/bash", "-o", "pipefail", "-c"]
```

Every subsequent `RUN` now runs under bash with `pipefail`, so a left-of-pipe failure aborts the build. This is the idiomatic, comprehensive fix (hadolint DL4006) — it covers all three pipes at once and future-proofs any new one. truffleHog keeps its explicit `|| true` and stays best-effort by design.

## Validation
- **Behavioral proof:** a minimal build reproducing the directive with a 404 `curl` into `| bash -` now **aborts** (`curl: (22) … 404` propagated, `exit code 22`), where the same pipe under dash exits 0.
- **No regression:** the **full real `cfg-agent` image builds green** under the new bash `SHELL` (`node v26.5.0`) — every existing RUN step (all POSIX-compatible) runs fine under bash.
- Pre-push `make test` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)