### PR TITLE
web: WebAuthn step-up re-authentication modal (Issue #2786)

### DIFF
--- a/features/controller/fleet/storage/storage.go
+++ b/features/controller/fleet/storage/storage.go
@@ -25,6 +25,7 @@ package storage
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -47,10 +48,11 @@ type Manager struct {
 	storage    Backend
 	compressor Compressor
 	indexer    Indexer
-	pruneWg    sync.WaitGroup
-	doneCh     chan struct{}
-	closeOnce  sync.Once
-	closeErr   error
+	pruneWg       sync.WaitGroup
+	maintenanceWg sync.WaitGroup
+	doneCh        chan struct{}
+	closeOnce     sync.Once
+	closeErr      error
 }
 
 // Config defines the configuration for DNA storage management.
@@ -190,6 +192,7 @@ func NewManager(config *Config, logger logging.Logger) (*Manager, error) {
 	}
 
 	// Start background maintenance tasks
+	manager.maintenanceWg.Add(1)
 	go manager.startMaintenanceTasks()
 
 	logger.Info("DNA storage manager initialized",
@@ -468,25 +471,29 @@ func (m *Manager) Close() error {
 	m.closeOnce.Do(func() {
 		m.logger.Info("Shutting down DNA storage manager")
 
-		// Signal the maintenance goroutine to stop.
+		// Signal the maintenance goroutine to stop, then wait for it to exit so
+		// that runMaintenance cannot access the storage after we close it below.
 		close(m.doneCh)
+		m.maintenanceWg.Wait()
 
 		// Wait for any in-flight per-device prune goroutines so that all database
 		// transactions are committed before we tear down the connection pool.
 		m.pruneWg.Wait()
 
-		// Close components in order
+		var errs []error
 		if err := m.indexer.Close(); err != nil {
 			m.logger.Error("Failed to close indexer", "error", err)
+			errs = append(errs, err)
 		}
-
 		if err := m.compressor.Close(); err != nil {
 			m.logger.Error("Failed to close compressor", "error", err)
+			errs = append(errs, err)
 		}
-
 		if err := m.storage.Close(); err != nil {
 			m.logger.Error("Failed to close storage backend", "error", err)
+			errs = append(errs, err)
 		}
+		m.closeErr = errors.Join(errs...)
 	})
 
 	return m.closeErr
@@ -656,6 +663,7 @@ func (m *Manager) filterAttributes(dna *commonpb.DNA, attributes []string) *comm
 }
 
 func (m *Manager) startMaintenanceTasks() {
+	defer m.maintenanceWg.Done()
 	ticker := time.NewTicker(m.config.FlushInterval)
 	defer ticker.Stop()
 

--- a/features/controller/fleet/storage/storage.go
+++ b/features/controller/fleet/storage/storage.go
@@ -43,11 +43,11 @@ import (
 // - Retention policy enforcement
 // - Storage optimization
 type Manager struct {
-	logger     logging.Logger
-	config     *Config
-	storage    Backend
-	compressor Compressor
-	indexer    Indexer
+	logger        logging.Logger
+	config        *Config
+	storage       Backend
+	compressor    Compressor
+	indexer       Indexer
 	pruneWg       sync.WaitGroup
 	maintenanceWg sync.WaitGroup
 	doneCh        chan struct{}

--- a/features/controller/fleet/storage/storage.go
+++ b/features/controller/fleet/storage/storage.go
@@ -48,6 +48,9 @@ type Manager struct {
 	compressor Compressor
 	indexer    Indexer
 	pruneWg    sync.WaitGroup
+	doneCh     chan struct{}
+	closeOnce  sync.Once
+	closeErr   error
 }
 
 // Config defines the configuration for DNA storage management.
@@ -183,6 +186,7 @@ func NewManager(config *Config, logger logging.Logger) (*Manager, error) {
 		storage:    backend,
 		compressor: compressor,
 		indexer:    indexer,
+		doneCh:     make(chan struct{}),
 	}
 
 	// Start background maintenance tasks
@@ -455,27 +459,37 @@ func (m *Manager) GetStorageStats(ctx context.Context) (*StorageStats, error) {
 }
 
 // Close gracefully shuts down the storage manager and flushes pending operations.
+//
+// Close is safe to call multiple times: the shutdown sequence runs exactly once
+// (guarded by closeOnce) so that concurrent callers and duplicate cleanup
+// registrations (e.g. an explicit Close() plus a t.Cleanup) cannot double-close
+// doneCh. Subsequent calls return the result of the first shutdown.
 func (m *Manager) Close() error {
-	m.logger.Info("Shutting down DNA storage manager")
+	m.closeOnce.Do(func() {
+		m.logger.Info("Shutting down DNA storage manager")
 
-	// Wait for any in-flight per-device prune goroutines so that all database
-	// transactions are committed before we tear down the connection pool.
-	m.pruneWg.Wait()
+		// Signal the maintenance goroutine to stop.
+		close(m.doneCh)
 
-	// Close components in order
-	if err := m.indexer.Close(); err != nil {
-		m.logger.Error("Failed to close indexer", "error", err)
-	}
+		// Wait for any in-flight per-device prune goroutines so that all database
+		// transactions are committed before we tear down the connection pool.
+		m.pruneWg.Wait()
 
-	if err := m.compressor.Close(); err != nil {
-		m.logger.Error("Failed to close compressor", "error", err)
-	}
+		// Close components in order
+		if err := m.indexer.Close(); err != nil {
+			m.logger.Error("Failed to close indexer", "error", err)
+		}
 
-	if err := m.storage.Close(); err != nil {
-		m.logger.Error("Failed to close storage backend", "error", err)
-	}
+		if err := m.compressor.Close(); err != nil {
+			m.logger.Error("Failed to close compressor", "error", err)
+		}
 
-	return nil
+		if err := m.storage.Close(); err != nil {
+			m.logger.Error("Failed to close storage backend", "error", err)
+		}
+	})
+
+	return m.closeErr
 }
 
 // DefaultConfig returns a default configuration for DNA storage
@@ -645,9 +659,13 @@ func (m *Manager) startMaintenanceTasks() {
 	ticker := time.NewTicker(m.config.FlushInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		// Run periodic maintenance
-		m.runMaintenance()
+	for {
+		select {
+		case <-m.doneCh:
+			return
+		case <-ticker.C:
+			m.runMaintenance()
+		}
 	}
 }
 

--- a/features/controller/fleet/storage/storage.go
+++ b/features/controller/fleet/storage/storage.go
@@ -25,7 +25,6 @@ package storage
 import (
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -43,16 +42,12 @@ import (
 // - Retention policy enforcement
 // - Storage optimization
 type Manager struct {
-	logger        logging.Logger
-	config        *Config
-	storage       Backend
-	compressor    Compressor
-	indexer       Indexer
-	pruneWg       sync.WaitGroup
-	maintenanceWg sync.WaitGroup
-	doneCh        chan struct{}
-	closeOnce     sync.Once
-	closeErr      error
+	logger     logging.Logger
+	config     *Config
+	storage    Backend
+	compressor Compressor
+	indexer    Indexer
+	pruneWg    sync.WaitGroup
 }
 
 // Config defines the configuration for DNA storage management.
@@ -188,11 +183,9 @@ func NewManager(config *Config, logger logging.Logger) (*Manager, error) {
 		storage:    backend,
 		compressor: compressor,
 		indexer:    indexer,
-		doneCh:     make(chan struct{}),
 	}
 
 	// Start background maintenance tasks
-	manager.maintenanceWg.Add(1)
 	go manager.startMaintenanceTasks()
 
 	logger.Info("DNA storage manager initialized",
@@ -462,41 +455,27 @@ func (m *Manager) GetStorageStats(ctx context.Context) (*StorageStats, error) {
 }
 
 // Close gracefully shuts down the storage manager and flushes pending operations.
-//
-// Close is safe to call multiple times: the shutdown sequence runs exactly once
-// (guarded by closeOnce) so that concurrent callers and duplicate cleanup
-// registrations (e.g. an explicit Close() plus a t.Cleanup) cannot double-close
-// doneCh. Subsequent calls return the result of the first shutdown.
 func (m *Manager) Close() error {
-	m.closeOnce.Do(func() {
-		m.logger.Info("Shutting down DNA storage manager")
+	m.logger.Info("Shutting down DNA storage manager")
 
-		// Signal the maintenance goroutine to stop, then wait for it to exit so
-		// that runMaintenance cannot access the storage after we close it below.
-		close(m.doneCh)
-		m.maintenanceWg.Wait()
+	// Wait for any in-flight per-device prune goroutines so that all database
+	// transactions are committed before we tear down the connection pool.
+	m.pruneWg.Wait()
 
-		// Wait for any in-flight per-device prune goroutines so that all database
-		// transactions are committed before we tear down the connection pool.
-		m.pruneWg.Wait()
+	// Close components in order
+	if err := m.indexer.Close(); err != nil {
+		m.logger.Error("Failed to close indexer", "error", err)
+	}
 
-		var errs []error
-		if err := m.indexer.Close(); err != nil {
-			m.logger.Error("Failed to close indexer", "error", err)
-			errs = append(errs, err)
-		}
-		if err := m.compressor.Close(); err != nil {
-			m.logger.Error("Failed to close compressor", "error", err)
-			errs = append(errs, err)
-		}
-		if err := m.storage.Close(); err != nil {
-			m.logger.Error("Failed to close storage backend", "error", err)
-			errs = append(errs, err)
-		}
-		m.closeErr = errors.Join(errs...)
-	})
+	if err := m.compressor.Close(); err != nil {
+		m.logger.Error("Failed to close compressor", "error", err)
+	}
 
-	return m.closeErr
+	if err := m.storage.Close(); err != nil {
+		m.logger.Error("Failed to close storage backend", "error", err)
+	}
+
+	return nil
 }
 
 // DefaultConfig returns a default configuration for DNA storage
@@ -663,17 +642,12 @@ func (m *Manager) filterAttributes(dna *commonpb.DNA, attributes []string) *comm
 }
 
 func (m *Manager) startMaintenanceTasks() {
-	defer m.maintenanceWg.Done()
 	ticker := time.NewTicker(m.config.FlushInterval)
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-m.doneCh:
-			return
-		case <-ticker.C:
-			m.runMaintenance()
-		}
+	for range ticker.C {
+		// Run periodic maintenance
+		m.runMaintenance()
 	}
 }
 

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -6,6 +6,7 @@ import {
   loginRequest,
   logoutRequest,
   onSessionExpired,
+  onStepUpRequired,
 } from './client.ts'
 
 function clearCookies() {
@@ -32,6 +33,7 @@ describe('apiFetch', () => {
     fetchMock.mockReset()
     vi.stubGlobal('fetch', fetchMock)
     onSessionExpired(null)
+    onStepUpRequired(null)
   })
 
   afterEach(() => {
@@ -87,6 +89,129 @@ describe('apiFetch', () => {
     await apiFetch('/api/v1/stewards')
     fetchMock.mockResolvedValueOnce(jsonResponse(403))
     await apiFetch('/api/v1/things', { method: 'POST' })
+    expect(expired).not.toHaveBeenCalled()
+  })
+
+  // ── Step-up detection (Story #2786) ──────────────────────────────────────
+
+  it('CFGMS-StepUp 401 fires onStepUpRequired, not onSessionExpired', async () => {
+    const expired = vi.fn()
+    const stepUp = vi.fn(async () => null)
+    onSessionExpired(expired)
+    onStepUpRequired(stepUp)
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'step_up_required' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+          'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"',
+        },
+      }),
+    )
+    await apiFetch('/api/v1/stewards')
+    expect(stepUp).toHaveBeenCalledTimes(1)
+    expect(expired).not.toHaveBeenCalled()
+  })
+
+  it('CFGMS-StepUp with presence="required" sets presenceRequired=true in the payload', async () => {
+    const stepUp = vi.fn(async () => null)
+    onStepUpRequired(stepUp)
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: {
+          'WWW-Authenticate':
+            'CFGMS-StepUp realm="cfgms", required="strong", presence="required"',
+        },
+      }),
+    )
+    await apiFetch('/api/v1/modules/approvals/cfgms:test:1.0.0:AAAA/approve', {
+      method: 'POST',
+    })
+    expect(stepUp).toHaveBeenCalledWith(
+      expect.objectContaining({ presenceRequired: true }),
+    )
+  })
+
+  it('CFGMS-StepUp without presence="required" sets presenceRequired=false', async () => {
+    const stepUp = vi.fn(async () => null)
+    onStepUpRequired(stepUp)
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: {
+          'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"',
+        },
+      }),
+    )
+    await apiFetch('/api/v1/stewards')
+    expect(stepUp).toHaveBeenCalledWith(
+      expect.objectContaining({ presenceRequired: false }),
+    )
+  })
+
+  it('step-up listener receives the original path and init', async () => {
+    const stepUp = vi.fn(async () => null)
+    onStepUpRequired(stepUp)
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: {
+          'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"',
+        },
+      }),
+    )
+    await apiFetch('/api/v1/stewards', { method: 'GET' })
+    const [req] = stepUp.mock.calls[0] as [{ path: string; init: RequestInit }]
+    expect(req.path).toBe('/api/v1/stewards')
+    expect(req.init).toEqual({ method: 'GET' })
+  })
+
+  it('when step-up listener returns a Response, apiFetch returns it', async () => {
+    const successResponse = jsonResponse(200, { ok: true })
+    onStepUpRequired(async () => successResponse)
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: {
+          'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"',
+        },
+      }),
+    )
+    const result = await apiFetch('/api/v1/stewards')
+    expect(result.status).toBe(200)
+  })
+
+  it('when step-up listener returns null, apiFetch returns the original 401 without session-expired', async () => {
+    const expired = vi.fn()
+    onSessionExpired(expired)
+    onStepUpRequired(async () => null)
+    const original401 = new Response(JSON.stringify({}), {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"',
+      },
+    })
+    fetchMock.mockResolvedValue(original401)
+    const result = await apiFetch('/api/v1/stewards')
+    expect(result.status).toBe(401)
+    expect(expired).not.toHaveBeenCalled()
+  })
+
+  it('CFGMS-StepUp 401 with no step-up listener does NOT fire session-expired', async () => {
+    const expired = vi.fn()
+    onSessionExpired(expired)
+    // No step-up listener registered (onStepUpRequired(null) from beforeEach).
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: {
+          'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"',
+        },
+      }),
+    )
+    const result = await apiFetch('/api/v1/stewards')
+    expect(result.status).toBe(401)
     expect(expired).not.toHaveBeenCalled()
   })
 })

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -162,7 +162,7 @@ describe('apiFetch', () => {
       }),
     )
     await apiFetch('/api/v1/stewards', { method: 'GET' })
-    const [req] = stepUp.mock.calls[0] as [{ path: string; init: RequestInit }]
+    const [req] = stepUp.mock.calls[0]! as unknown as [{ path: string; init: RequestInit }]
     expect(req.path).toBe('/api/v1/stewards')
     expect(req.init).toEqual({ method: 'GET' })
   })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -16,6 +16,9 @@
  *    expiry or revocation) — a central listener drops the app to the login
  *    screen in its "session expired" state (ADR-018 §4). Login and logout
  *    requests are exempt: a 401 there is not an expired session.
+ *  - A 401 with WWW-Authenticate: CFGMS-StepUp is NOT a session expiry —
+ *    it is a step-up challenge (ADR-021 Decision 6). The onStepUpRequired
+ *    listener handles it; the session-expired listener is NOT fired.
  */
 
 const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
@@ -41,16 +44,49 @@ let sessionExpiredListener: SessionExpiredListener | null = null
 
 /**
  * Register the central session-expired handler (or clear it with null).
- * The AuthProvider owns this; it fires on any 401 from apiFetch.
+ * The AuthProvider owns this; it fires on any plain 401 from apiFetch
+ * (i.e. a 401 without WWW-Authenticate: CFGMS-StepUp).
  */
 export function onSessionExpired(listener: SessionExpiredListener | null): void {
   sessionExpiredListener = listener
 }
 
 /**
+ * Context carried to the step-up listener on a CFGMS-StepUp 401.
+ * Includes the original request so the modal can retry it after a successful
+ * assertion ceremony (ADR-021 Decision 6).
+ */
+export interface StepUpRequest {
+  /** Original fetch path. */
+  path: string
+  /** Original fetch init (method, headers, body). */
+  init: RequestInit
+  /** True when WWW-Authenticate: CFGMS-StepUp includes presence="required". */
+  presenceRequired: boolean
+}
+
+/**
+ * The listener receives the original request and returns a Promise that resolves
+ * with the retry Response on success, or null on cancel / assertion failure.
+ * Returning null causes apiFetch to return the original 401 response without
+ * firing the session-expired listener (the operator stays signed in).
+ */
+type StepUpRequiredListener = (req: StepUpRequest) => Promise<Response | null>
+let stepUpRequiredListener: StepUpRequiredListener | null = null
+
+/**
+ * Register the central step-up handler (or clear it with null).
+ * The AuthProvider owns this (Story #2786).
+ */
+export function onStepUpRequired(listener: StepUpRequiredListener | null): void {
+  stepUpRequiredListener = listener
+}
+
+/**
  * Fetch wrapper for all cookie-authenticated API calls.
  * Same-origin credentials, automatic CSRF header on unsafe methods,
- * central 401 → session-expired handling.
+ * central 401 → session-expired handling, and CFGMS-StepUp 401 → step-up
+ * listener dispatch (Story #2786, ADR-021 Decision 6).
  */
 export async function apiFetch(
   path: string,
@@ -70,6 +106,25 @@ export async function apiFetch(
     credentials: 'same-origin',
   })
   if (response.status === 401) {
+    const wwwAuth = response.headers.get('WWW-Authenticate') ?? ''
+    if (wwwAuth.startsWith('CFGMS-StepUp')) {
+      // Step-up challenge: NEVER fire session-expired regardless of listener state.
+      // A CFGMS-StepUp 401 means the operator's session is intact but needs a
+      // higher assurance proof — the operator is NOT signed out (ADR-021 Decision 6).
+      if (stepUpRequiredListener !== null) {
+        const retryResponse = await stepUpRequiredListener({
+          path,
+          init,
+          presenceRequired: wwwAuth.includes('presence="required"'),
+        })
+        // Listener resolves with the retry response (success) or null (cancel/failure).
+        // On null: return the original 401 — caller sees the failure; session stays intact.
+        return retryResponse ?? response
+      }
+      // No listener registered: return the 401 without firing session-expired.
+      return response
+    }
+    // Plain 401 (no step-up header): session is gone.
     sessionExpiredListener?.()
   }
   return response

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -4,10 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import { AuthProvider, RequireAuth, useAuth } from './AuthContext.tsx'
 
-function jsonResponse(status: number, body: unknown = {}): Response {
+function jsonResponse(
+  status: number,
+  body: unknown = {},
+  headers: Record<string, string> = {},
+): Response {
   return new Response(status === 204 ? null : JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
   })
 }
 
@@ -95,7 +99,7 @@ describe('AuthProvider state transitions', () => {
     expect(screen.getByTestId('principal')).toHaveTextContent('')
   })
 
-  it('a 401 on any API call after sign-in → expired', async () => {
+  it('a plain 401 (no step-up header) after sign-in → expired', async () => {
     mockLoginEndpoints(200)
     render(
       <AuthProvider>
@@ -154,6 +158,152 @@ describe('AuthProvider state transitions', () => {
     )
     expect(window.localStorage.length).toBe(0)
     expect(window.sessionStorage.length).toBe(0)
+  })
+})
+
+describe('AuthProvider — step-up (Story #2786)', () => {
+  const MOCK_BEGIN_OPTIONS = {
+    publicKey: {
+      challenge: 'Y2hhbGxlbmdlLWJ5dGVz',
+      timeout: 60000,
+      rpId: 'localhost',
+      allowCredentials: [],
+      userVerification: 'required' as const,
+    },
+  }
+
+  it('CFGMS-StepUp 401 shows the step-up modal, NOT the sign-in screen', async () => {
+    mockLoginEndpoints(200)
+    // presence/begin returns valid options so the modal reaches 'waiting' state.
+    fetchMock.mockImplementation((input) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/web/csrf')) {
+        document.cookie = 'cfgms_csrf_pre=pre-tok; path=/'
+        return Promise.resolve(jsonResponse(204))
+      }
+      if (url.endsWith('/api/v1/web/login')) return Promise.resolve(jsonResponse(200))
+      if (url.includes('presence/begin')) {
+        return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      }
+      // The API call that triggers step-up.
+      return Promise.resolve(
+        jsonResponse(401, { error: 'step_up_required' }, {
+          'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong", presence="required"',
+        }),
+      )
+    })
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+
+    act(() => screen.getByText('do-login').click())
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('signedIn'),
+    )
+
+    const { apiFetch } = await import('../api/client.ts')
+    // Fire the step-up 401 without awaiting — the listener promise holds it
+    // open until the modal is dismissed. Do NOT use void act(async () => ...)
+    // here: calling act() without await defers React state updates until after
+    // the test frame, so waitFor never sees setStepUpState flush.
+    void apiFetch('/api/v1/modules/approvals/cfgms:test:1.0.0:AAAA/approve', {
+      method: 'POST',
+    })
+
+    // Modal overlay must appear; waitFor flushes state updates on each retry.
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-overlay')).toBeInTheDocument(),
+    )
+    // Auth status must remain signedIn (not expired, not signedOut).
+    expect(screen.getByTestId('status')).toHaveTextContent('signedIn')
+    // No "Sign in" button — the login screen must NOT be shown.
+    expect(screen.queryByRole('button', { name: /sign in/i })).not.toBeInTheDocument()
+
+    // Dismiss the modal to resolve the listener promise and prevent a dangling
+    // Promise from contaminating later tests in this file.
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-cancel-btn').click())
+    await waitFor(() =>
+      expect(screen.queryByTestId('step-up-overlay')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('plain 401 (no CFGMS-StepUp header) still triggers session-expired — regression', async () => {
+    mockLoginEndpoints(200)
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+    act(() => screen.getByText('do-login').click())
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('signedIn'),
+    )
+
+    fetchMock.mockResolvedValue(jsonResponse(401))
+    const { apiFetch } = await import('../api/client.ts')
+    await act(async () => {
+      await apiFetch('/api/v1/stewards')
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('expired'),
+    )
+    // No step-up modal should appear.
+    expect(screen.queryByTestId('step-up-overlay')).not.toBeInTheDocument()
+  })
+
+  it('cancelling the step-up modal leaves auth status signedIn', async () => {
+    mockLoginEndpoints(200)
+    fetchMock.mockImplementation((input) => {
+      const url = String(input)
+      if (url.endsWith('/api/v1/web/csrf')) {
+        document.cookie = 'cfgms_csrf_pre=pre-tok; path=/'
+        return Promise.resolve(jsonResponse(204))
+      }
+      if (url.endsWith('/api/v1/web/login')) return Promise.resolve(jsonResponse(200))
+      if (url.includes('presence/begin')) {
+        return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      }
+      return Promise.resolve(
+        jsonResponse(401, { error: 'step_up_required' }, {
+          'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong", presence="required"',
+        }),
+      )
+    })
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+
+    act(() => screen.getByText('do-login').click())
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('signedIn'),
+    )
+
+    const { apiFetch } = await import('../api/client.ts')
+    void apiFetch('/api/v1/modules/approvals/cfgms:test:1.0.0:AAAA/approve', {
+      method: 'POST',
+    })
+
+    // Wait for modal with Cancel button enabled (waiting state).
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+
+    // Click Cancel.
+    act(() => screen.getByTestId('step-up-cancel-btn').click())
+
+    // Modal must close.
+    await waitFor(() =>
+      expect(screen.queryByTestId('step-up-overlay')).not.toBeInTheDocument(),
+    )
+    // Auth must stay signedIn.
+    expect(screen.getByTestId('status')).toHaveTextContent('signedIn')
+    expect(screen.getByTestId('principal')).toHaveTextContent('admin@msp-a')
   })
 })
 

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -6,10 +6,16 @@
  *
  * The signed-in principal lives in React context ONLY — never in web
  * storage (enforced by a source-scan test), never in a cookie readable by
- * JS. Session
- * presence is inferred from API responses; a page reload starts signedOut
- * and the first authenticated screen's data call re-establishes or expires
- * the session naturally.
+ * JS. Session presence is inferred from API responses; a page reload starts
+ * signedOut and the first authenticated screen's data call re-establishes
+ * or expires the session naturally.
+ *
+ * Step-up (Story #2786, ADR-021 Decision 6): when apiFetch receives a 401 +
+ * WWW-Authenticate: CFGMS-StepUp, the onStepUpRequired listener fires and
+ * the AuthProvider renders a StepUpModal over the current view. The operator's
+ * AuthStatus stays 'signedIn' throughout — this is not a session expiry.
+ * On successful assertion the original request is retried; on cancel/failure
+ * the operator returns to the prior view still signed in.
  */
 import {
   createContext,
@@ -20,8 +26,15 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import { loginRequest, logoutRequest, onSessionExpired } from '../api/client.ts'
+import {
+  loginRequest,
+  logoutRequest,
+  onSessionExpired,
+  onStepUpRequired,
+  type StepUpRequest,
+} from '../api/client.ts'
 import Login from '../pages/Login.tsx'
+import StepUpModal from './StepUpModal.tsx'
 
 export interface Principal {
   username: string
@@ -30,8 +43,11 @@ export interface Principal {
 /**
  * signedOut — fresh visit (mockup "signin" state)
  * invalid   — last login attempt was rejected (mockup "invalid" state)
- * expired   — a 401 dropped the session (mockup "expired" state)
+ * expired   — a plain 401 dropped the session (mockup "expired" state)
  * signedIn  — authenticated
+ *
+ * Step-up is NOT a new AuthStatus value: the operator remains 'signedIn'
+ * while the step-up modal is visible, because their existing session is intact.
  */
 export type AuthStatus = 'signedOut' | 'invalid' | 'expired' | 'signedIn'
 
@@ -45,16 +61,31 @@ export interface AuthValue {
 
 const AuthContext = createContext<AuthValue | null>(null)
 
+interface StepUpState {
+  request: StepUpRequest
+  resolve: (response: Response | null) => void
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<AuthStatus>('signedOut')
   const [principal, setPrincipal] = useState<Principal | null>(null)
+  const [stepUpState, setStepUpState] = useState<StepUpState | null>(null)
 
   useEffect(() => {
     onSessionExpired(() => {
       setPrincipal(null)
       setStatus('expired')
     })
-    return () => onSessionExpired(null)
+    onStepUpRequired(
+      (req) =>
+        new Promise<Response | null>((resolve) => {
+          setStepUpState({ request: req, resolve })
+        }),
+    )
+    return () => {
+      onSessionExpired(null)
+      onStepUpRequired(null)
+    }
   }, [])
 
   const login = useCallback(async (username: string, password: string) => {
@@ -80,7 +111,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [status, principal, login, logout],
   )
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  function handleStepUpSuccess(response: Response) {
+    const state = stepUpState
+    setStepUpState(null)
+    state?.resolve(response)
+  }
+
+  function handleStepUpCancel() {
+    const state = stepUpState
+    setStepUpState(null)
+    state?.resolve(null)
+  }
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+      {stepUpState !== null && (
+        <StepUpModal
+          request={stepUpState.request}
+          principalUsername={principal?.username ?? null}
+          onSuccess={handleStepUpSuccess}
+          onCancel={handleStepUpCancel}
+        />
+      )}
+    </AuthContext.Provider>
+  )
 }
 
 export function useAuth(): AuthValue {

--- a/web/src/auth/StepUpModal.css
+++ b/web/src/auth/StepUpModal.css
@@ -1,0 +1,188 @@
+/* SPDX-License-Identifier: AGPL-3.0-only */
+/* Copyright 2026 Jordan Ritz */
+
+/*
+ * Step-up re-authentication modal (Story #2786, ADR-021 Decision 6).
+ *
+ * Overlay and card styles following the terminal-window design language
+ * (docs/design/web-ui-design-tokens.css). Inner layout matches the mockup's
+ * mfa state (docs/design/mockups/login.html). All color values are token vars.
+ *
+ * The overlay uses z-index 200 (above the app-shell drawer at z-index 40 and
+ * popovers at z-index 60) to ensure the modal always appears on top.
+ */
+
+.step-up-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: grid;
+  place-items: center;
+  z-index: 200;
+  padding: var(--space-4) 18px;
+}
+
+/* terminal-window modal card (design-system §5.1 shape) */
+.step-up-modal {
+  width: 100%;
+  max-width: 400px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.step-up-titlebar {
+  display: flex;
+  align-items: center;
+  padding: 10px 13px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+}
+
+.step-up-title {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-faint);
+  margin: 0 auto;
+  letter-spacing: 0.02em;
+}
+
+.step-up-body {
+  padding: 26px 26px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  align-items: center;
+  text-align: center;
+}
+
+/* Passkey icon tile (matches mfa .mic in the mockup) */
+.step-up-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: var(--bg-sunk);
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+
+.step-up-heading {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.step-up-desc {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  max-width: 290px;
+  line-height: 1.5;
+}
+
+.step-up-error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  font-size: 12.5px;
+  color: var(--state-crit);
+  background: var(--state-crit-bg);
+  border: 1px solid var(--state-crit);
+  border-radius: var(--radius);
+  padding: 9px 12px;
+  width: 100%;
+  text-align: left;
+}
+
+.step-up-err-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+  margin-top: 4px;
+}
+
+.step-up-actions {
+  width: 100%;
+}
+
+/* Primary action button (matches .mbtn in the mockup) */
+.step-up-btn {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  padding: var(--space-3);
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font: inherit;
+  font-size: var(--text-md);
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+}
+
+.step-up-btn:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.step-up-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.step-up-spin {
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: step-up-sp 0.7s linear infinite;
+  flex: none;
+}
+
+@keyframes step-up-sp {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step-up-spin {
+    animation: none;
+  }
+}
+
+/* Cancel link (matches .alt in the mockup) */
+.step-up-cancel {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.step-up-cancel:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.step-up-cancel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/web/src/auth/StepUpModal.test.tsx
+++ b/web/src/auth/StepUpModal.test.tsx
@@ -46,7 +46,7 @@ function makePublicKeyCredential(id = 'cred-id-b64u'): PublicKeyCredential {
     } as AuthenticatorAssertionResponse,
     getClientExtensionResults: () => ({} as AuthenticationExtensionsClientOutputs),
     authenticatorAttachment: null,
-    toJSON: () => ({}) as PublicKeyCredentialJSON,
+    toJSON: () => ({}),
   } as unknown as PublicKeyCredential
 }
 

--- a/web/src/auth/StepUpModal.test.tsx
+++ b/web/src/auth/StepUpModal.test.tsx
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import StepUpModal from './StepUpModal.tsx'
+import type { StepUpRequest } from '../api/client.ts'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(status === 204 ? null : JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/** Minimal presence/begin options JSON (matches go-webauthn CredentialAssertion shape). */
+const MOCK_BEGIN_OPTIONS = {
+  publicKey: {
+    challenge: 'Y2hhbGxlbmdlLWJ5dGVz',
+    timeout: 60000,
+    rpId: 'localhost',
+    allowCredentials: [
+      {
+        type: 'public-key' as const,
+        id: 'Y3JlZGVudGlhbC1pZA',
+        transports: ['internal'],
+      },
+    ],
+    userVerification: 'required' as const,
+  },
+}
+
+/** Minimal PublicKeyCredential stub matching the shape StepUpModal expects. */
+function makePublicKeyCredential(id = 'cred-id-b64u'): PublicKeyCredential {
+  const toArrayBuffer = (s: string) => new TextEncoder().encode(s).buffer as ArrayBuffer
+  return {
+    id,
+    type: 'public-key',
+    rawId: toArrayBuffer(id),
+    response: {
+      clientDataJSON: toArrayBuffer('{"type":"webauthn.get"}'),
+      authenticatorData: toArrayBuffer('authenticator-data'),
+      signature: toArrayBuffer('signature'),
+      userHandle: null,
+    } as AuthenticatorAssertionResponse,
+    getClientExtensionResults: () => ({} as AuthenticationExtensionsClientOutputs),
+    authenticatorAttachment: null,
+    toJSON: () => ({}) as PublicKeyCredentialJSON,
+  } as unknown as PublicKeyCredential
+}
+
+const defaultRequest: StepUpRequest = {
+  path: '/api/v1/modules/approvals/cfgms:test:1.0.0:AAAA/approve',
+  init: { method: 'POST', body: JSON.stringify({ note: 'lgtm' }) },
+  presenceRequired: true,
+}
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ── Loading and waiting states ────────────────────────────────────────────────
+
+describe('StepUpModal — initial states', () => {
+  it('shows a disabled "Preparing…" button while fetching the challenge', () => {
+    // Presence/begin never resolves so the modal stays in loading state.
+    fetchMock.mockReturnValue(new Promise(() => undefined))
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername="admin@msp-a"
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /preparing/i })).toBeDisabled()
+  })
+
+  it('shows "Verify with passkey" button after challenge arrives', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername="admin@msp-a"
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('step-up-verify-btn'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('shows the principal username in the description', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername="admin@msp-a"
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    await waitFor(() =>
+      expect(screen.getByText(/admin@msp-a/)).toBeInTheDocument(),
+    )
+  })
+
+  it('shows error state when presence/begin fails', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(403, { error: 'forbidden' }))
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-error')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('step-up-retry-btn')).toBeInTheDocument()
+  })
+})
+
+// ── Cancel ───────────────────────────────────────────────────────────────────
+
+describe('StepUpModal — cancel', () => {
+  it('calls onCancel when the cancel button is clicked', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    const onCancel = vi.fn()
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername="admin@msp-a"
+        onSuccess={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+    // Wait for waiting state so Cancel is enabled.
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-cancel-btn').click())
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancel button is disabled while ceremony is in progress', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    // credentials.get never resolves → keeps modal in 'running' phase.
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn(() => new Promise(() => undefined)) },
+    })
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-cancel-btn')).toBeDisabled(),
+    )
+  })
+})
+
+// ── Successful ceremony ───────────────────────────────────────────────────────
+
+describe('StepUpModal — successful assertion', () => {
+  it('calls onSuccess with the retry response after full ceremony', async () => {
+    const mockCred = makePublicKeyCredential()
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn().mockResolvedValue(mockCred) },
+    })
+
+    const retryResponse = jsonResponse(200, { ok: true })
+    fetchMock.mockImplementation((url) => {
+      const u = String(url)
+      if (u.includes('presence/begin')) return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      if (u.includes('presence/finish')) {
+        return Promise.resolve(
+          jsonResponse(200, { presence_token: 'tok-abc123', expires_in: 30 }),
+        )
+      }
+      // retry of the original request
+      return Promise.resolve(retryResponse)
+    })
+
+    const onSuccess = vi.fn()
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername="admin@msp-a"
+        onSuccess={onSuccess}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
+    const [response] = onSuccess.mock.calls[0] as [Response]
+    expect(response.status).toBe(200)
+  })
+
+  it('sends X-Presence-Token header on the retry request', async () => {
+    const mockCred = makePublicKeyCredential()
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn().mockResolvedValue(mockCred) },
+    })
+
+    fetchMock.mockImplementation((url) => {
+      const u = String(url)
+      if (u.includes('presence/begin')) return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      if (u.includes('presence/finish')) {
+        return Promise.resolve(
+          jsonResponse(200, { presence_token: 'test-presence-token', expires_in: 30 }),
+        )
+      }
+      return Promise.resolve(jsonResponse(200, {}))
+    })
+
+    const onSuccess = vi.fn()
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={onSuccess}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
+
+    // Find the retry call (the one that's not begin or finish).
+    const retryCalls = fetchMock.mock.calls.filter(
+      ([u]) =>
+        !String(u).includes('presence/begin') && !String(u).includes('presence/finish'),
+    )
+    expect(retryCalls.length).toBe(1)
+    const retryHeaders = new Headers(retryCalls[0]?.[1]?.headers)
+    expect(retryHeaders.get('X-Presence-Token')).toBe('test-presence-token')
+  })
+})
+
+// ── Assertion failure / cancel ────────────────────────────────────────────────
+
+describe('StepUpModal — assertion failure', () => {
+  it('shows error when credentials.get() throws NotAllowedError (user cancelled)', async () => {
+    vi.stubGlobal('navigator', {
+      credentials: {
+        get: vi.fn().mockRejectedValue(
+          new DOMException('User cancelled', 'NotAllowedError'),
+        ),
+      },
+    })
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-error')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('step-up-error').textContent).toMatch(/cancelled/i)
+  })
+
+  it('shows error when presence/finish fails', async () => {
+    const mockCred = makePublicKeyCredential()
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn().mockResolvedValue(mockCred) },
+    })
+
+    fetchMock.mockImplementation((url) => {
+      const u = String(url)
+      if (u.includes('presence/begin')) return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      if (u.includes('presence/finish')) return Promise.resolve(jsonResponse(400, { error: 'WEBAUTHN_VERIFY_ERROR' }))
+      return Promise.resolve(jsonResponse(200, {}))
+    })
+
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-error')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('step-up-retry-btn')).toBeInTheDocument()
+  })
+
+  it('does not call onSuccess or onCancel after assertion failure', async () => {
+    vi.stubGlobal('navigator', {
+      credentials: {
+        get: vi.fn().mockRejectedValue(new DOMException('fail', 'NotAllowedError')),
+      },
+    })
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    const onSuccess = vi.fn()
+    const onCancel = vi.fn()
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={onSuccess}
+        onCancel={onCancel}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+    await waitFor(() => screen.getByTestId('step-up-error'))
+
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+})
+
+// ── Retry ─────────────────────────────────────────────────────────────────────
+
+describe('StepUpModal — retry', () => {
+  it('calls presence/begin again when Try again is clicked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(403, { error: 'forbidden' }))
+      .mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    // First begin fails → error state.
+    await waitFor(() => screen.getByTestId('step-up-retry-btn'))
+    act(() => screen.getByTestId('step-up-retry-btn').click())
+
+    // Second begin succeeds → waiting state.
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    const beginCalls = fetchMock.mock.calls.filter(([u]) =>
+      String(u).includes('presence/begin'),
+    )
+    expect(beginCalls.length).toBe(2)
+  })
+})
+
+// ── Accessibility: no click-outside dismissal ─────────────────────────────────
+
+describe('StepUpModal — security constraints', () => {
+  it('clicking the backdrop does NOT call onCancel', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    const onCancel = vi.fn()
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    // Click directly on the overlay element (not a button inside).
+    act(() => screen.getByTestId('step-up-overlay').click())
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('renders with role=dialog and aria-modal=true', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    render(
+      <StepUpModal
+        request={defaultRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+})

--- a/web/src/auth/StepUpModal.tsx
+++ b/web/src/auth/StepUpModal.tsx
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * WebAuthn re-authentication modal (Story #2786, ADR-021 Decision 6).
+ *
+ * Renders as a focus-trapped overlay over the current view when apiFetch
+ * detects a 401 + WWW-Authenticate: CFGMS-StepUp response. Performs the
+ * WebAuthn presence ceremony:
+ *
+ *   1. POST /api/v1/webauthn/presence/begin  → server-side challenge
+ *   2. navigator.credentials.get()           → authenticator gesture
+ *   3. POST /api/v1/webauthn/presence/finish → presence token
+ *   4. Retry original request with X-Presence-Token
+ *
+ * Security properties:
+ *  - No click-outside-to-dismiss: the backdrop intercepts pointer events but
+ *    does not call onCancel. Cancel requires the explicit button.
+ *  - No Escape dismissal: intentionally not handled — this is a security gate.
+ *  - Focus-trapped: Tab cycles only within the modal; focus is restored on unmount.
+ *  - Ceremony calls use raw fetch (not apiFetch) to avoid re-triggering the
+ *    step-up listener; CSRF is applied manually via the session cookie.
+ *  - On cancel or failure: onSuccess is NOT called; the original mutation
+ *    receives null (its 401) and the operator stays signed-in at their prior
+ *    assurance level.
+ *
+ * Design: docs/design/mockups/login.html `mfa` state, rendered as a modal.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { StepUpRequest } from '../api/client.ts'
+import './StepUpModal.css'
+
+// ── CSRF cookie helper (session token only; pre-session is for login) ────────
+
+function readSessionCsrf(): string | null {
+  for (const pair of document.cookie.split(';')) {
+    const eq = pair.indexOf('=')
+    if (eq === -1) continue
+    if (pair.slice(0, eq).trim() === 'cfgms_csrf') {
+      return decodeURIComponent(pair.slice(eq + 1).trim())
+    }
+  }
+  return null
+}
+
+// ── base64url helpers ────────────────────────────────────────────────────────
+
+function b64uToBytes(b64u: string): Uint8Array {
+  const padded = b64u + '='.repeat((4 - (b64u.length % 4)) % 4)
+  const base64 = padded.replace(/-/g, '+').replace(/_/g, '/')
+  return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
+}
+
+function bytesToB64u(buf: ArrayBuffer | ArrayBufferLike): string {
+  const bytes = new Uint8Array(buf)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+// ── WebAuthn JSON ↔ browser type adapters ────────────────────────────────────
+//
+// go-webauthn/webauthn serialises challenge + credential IDs as raw base64url
+// strings. The browser's PublicKeyCredential API requires ArrayBuffer. These
+// adapters convert between the two representations without an external library.
+
+interface PresenceOptions {
+  publicKey: {
+    challenge: string
+    timeout?: number
+    rpId?: string
+    allowCredentials?: Array<{
+      type: 'public-key'
+      id: string
+      transports?: string[]
+    }>
+    userVerification?: UserVerificationRequirement
+  }
+}
+
+function toBrowserOptions(opts: PresenceOptions): PublicKeyCredentialRequestOptions {
+  const pk = opts.publicKey
+  return {
+    challenge: b64uToBytes(pk.challenge),
+    timeout: pk.timeout,
+    rpId: pk.rpId,
+    userVerification: pk.userVerification,
+    allowCredentials: pk.allowCredentials?.map((c) => ({
+      type: 'public-key' as const,
+      id: b64uToBytes(c.id),
+      transports: c.transports as AuthenticatorTransport[] | undefined,
+    })),
+  }
+}
+
+interface AssertionJSON {
+  id: string
+  rawId: string
+  response: {
+    authenticatorData: string
+    clientDataJSON: string
+    signature: string
+    userHandle: string | null
+  }
+  type: 'public-key'
+  clientExtensionResults: Record<string, unknown>
+}
+
+function toAssertionJSON(cred: PublicKeyCredential): AssertionJSON {
+  const resp = cred.response as AuthenticatorAssertionResponse
+  return {
+    id: cred.id,
+    rawId: bytesToB64u(cred.rawId),
+    response: {
+      authenticatorData: bytesToB64u(resp.authenticatorData),
+      clientDataJSON: bytesToB64u(resp.clientDataJSON),
+      signature: bytesToB64u(resp.signature),
+      userHandle: resp.userHandle !== null ? bytesToB64u(resp.userHandle) : null,
+    },
+    type: 'public-key',
+    clientExtensionResults: {},
+  }
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export interface StepUpModalProps {
+  request: StepUpRequest
+  principalUsername: string | null
+  onSuccess: (response: Response) => void
+  onCancel: () => void
+}
+
+type Phase = 'loading' | 'waiting' | 'running' | 'error'
+
+const UNSAFE = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+export default function StepUpModal({
+  request,
+  principalUsername,
+  onSuccess,
+  onCancel,
+}: StepUpModalProps) {
+  const [phase, setPhase] = useState<Phase>('loading')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const optsRef = useRef<PresenceOptions | null>(null)
+  const modalRef = useRef<HTMLDivElement>(null)
+  // Incrementing this triggers the presence/begin effect to re-run on retry.
+  const [beginKey, setBeginKey] = useState(0)
+
+  // Focus trap: move focus into modal on mount; restore previous focus on unmount.
+  useEffect(() => {
+    const prevFocus = document.activeElement as HTMLElement | null
+
+    function trapFocus(e: KeyboardEvent) {
+      if (e.key !== 'Tab' || modalRef.current === null) return
+      const btns = [
+        ...modalRef.current.querySelectorAll<HTMLElement>('button:not([disabled])'),
+      ]
+      if (btns.length === 0) {
+        e.preventDefault()
+        return
+      }
+      const first = btns[0]
+      const last = btns[btns.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', trapFocus)
+
+    // Defer focus so the browser has painted the modal buttons.
+    const timer = setTimeout(() => {
+      modalRef.current?.querySelector<HTMLElement>('button:not([disabled])')?.focus()
+    }, 0)
+
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('keydown', trapFocus)
+      prevFocus?.focus()
+    }
+  }, [])
+
+  // Fetch a fresh presence challenge on mount and on each retry.
+  useEffect(() => {
+    let aborted = false
+
+    async function beginPresence() {
+      setPhase('loading')
+      setErrorMsg(null)
+      optsRef.current = null
+
+      try {
+        const csrf = readSessionCsrf()
+        const headers = new Headers()
+        if (csrf !== null) headers.set('X-CSRF-Token', csrf)
+
+        const resp = await fetch('/api/v1/webauthn/presence/begin', {
+          method: 'POST',
+          headers,
+          credentials: 'same-origin',
+        })
+        if (aborted) return
+
+        if (!resp.ok) {
+          setPhase('error')
+          setErrorMsg(
+            'Unable to start verification. Sign in again if the issue persists.',
+          )
+          return
+        }
+
+        const opts = (await resp.json()) as PresenceOptions
+        if (aborted) return
+        optsRef.current = opts
+        setPhase('waiting')
+      } catch {
+        if (!aborted) {
+          setPhase('error')
+          setErrorMsg('Network error — check your connection and try again.')
+        }
+      }
+    }
+
+    void beginPresence()
+    return () => {
+      aborted = true
+    }
+  }, [beginKey])
+
+  const handleVerify = useCallback(async () => {
+    const opts = optsRef.current
+    if (opts === null) return
+
+    setPhase('running')
+
+    try {
+      const publicKey = toBrowserOptions(opts)
+      const rawCred = await navigator.credentials.get({ publicKey })
+
+      // navigator.credentials.get({ publicKey }) should always return a
+      // PublicKeyCredential, but the return type is Credential | null.
+      // Duck-type check avoids a hard instanceof dependency on the class
+      // (which is unavailable in test environments that don't support WebAuthn).
+      if (rawCred === null || rawCred.type !== 'public-key') {
+        throw new DOMException('Expected a public-key credential', 'NotAllowedError')
+      }
+      const cred = rawCred as PublicKeyCredential
+
+      // Finish the ceremony: send the assertion to the server and get the token.
+      const csrf = readSessionCsrf()
+      const finishHeaders = new Headers({ 'Content-Type': 'application/json' })
+      if (csrf !== null) finishHeaders.set('X-CSRF-Token', csrf)
+
+      const finishResp = await fetch('/api/v1/webauthn/presence/finish', {
+        method: 'POST',
+        headers: finishHeaders,
+        credentials: 'same-origin',
+        body: JSON.stringify(toAssertionJSON(cred)),
+      })
+
+      if (!finishResp.ok) {
+        setPhase('error')
+        setErrorMsg('Verification failed — please try again.')
+        return
+      }
+
+      const finishData = (await finishResp.json()) as { presence_token: string }
+      const presenceToken = finishData.presence_token
+
+      // Retry the original request with the minted presence token.
+      // Raw fetch avoids re-triggering the step-up listener in apiFetch.
+      const method = (request.init.method ?? 'GET').toUpperCase()
+      const retryHeaders = new Headers(request.init.headers)
+      retryHeaders.set('X-Presence-Token', presenceToken)
+      if (UNSAFE.has(method) && csrf !== null) {
+        retryHeaders.set('X-CSRF-Token', csrf)
+      }
+
+      const retryResp = await fetch(request.path, {
+        ...request.init,
+        headers: retryHeaders,
+        credentials: 'same-origin',
+      })
+
+      onSuccess(retryResp)
+    } catch (err) {
+      const isCancelled =
+        err instanceof DOMException && err.name === 'NotAllowedError'
+      setPhase('error')
+      setErrorMsg(
+        isCancelled
+          ? 'Verification cancelled — click Cancel to go back, or try again.'
+          : 'An unexpected error occurred — please try again.',
+      )
+    }
+  }, [request, onSuccess])
+
+  function handleRetry() {
+    setBeginKey((k) => k + 1)
+  }
+
+  const username = principalUsername ?? 'your account'
+
+  return (
+    <div className="step-up-overlay" data-testid="step-up-overlay">
+      <div
+        className="step-up-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="step-up-title"
+        ref={modalRef}
+      >
+        <div className="step-up-titlebar">
+          <span className="step-up-title">cfgms · secure session</span>
+        </div>
+
+        <div className="step-up-body">
+          <div className="step-up-icon" aria-hidden="true">
+            {/* Passkey / key icon (matches mockup .mic) */}
+            <svg width="26" height="26" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M7.5 13.5a3.5 3.5 0 113.5-3.5M11 10h9l-2 2 2 2-3 3"
+                stroke="currentColor"
+                strokeWidth="1.7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+
+          <h3 id="step-up-title" className="step-up-heading">
+            Verify it&rsquo;s you
+          </h3>
+
+          <p className="step-up-desc">
+            Action requires verification as{' '}
+            <b className="step-up-title">{username}</b>. Use your passkey or
+            security key to continue.
+          </p>
+
+          {phase === 'error' && errorMsg !== null && (
+            <div
+              className="step-up-error"
+              role="alert"
+              data-testid="step-up-error"
+            >
+              <span className="step-up-err-dot" aria-hidden="true" />
+              {errorMsg}
+            </div>
+          )}
+
+          <div className="step-up-actions">
+            {(phase === 'loading') && (
+              <button type="button" className="step-up-btn" disabled>
+                <span className="step-up-spin" aria-hidden="true" />
+                <span>Preparing…</span>
+              </button>
+            )}
+
+            {phase === 'waiting' && (
+              <button
+                type="button"
+                className="step-up-btn"
+                onClick={() => void handleVerify()}
+                data-testid="step-up-verify-btn"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M7.5 13.5a3.5 3.5 0 113.5-3.5M11 10h9l-2 2 2 2-3 3"
+                    stroke="currentColor"
+                    strokeWidth="1.7"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                Verify with passkey
+              </button>
+            )}
+
+            {phase === 'running' && (
+              <button type="button" className="step-up-btn" disabled>
+                <span className="step-up-spin" aria-hidden="true" />
+                <span>Waiting for gesture…</span>
+              </button>
+            )}
+
+            {phase === 'error' && (
+              <button
+                type="button"
+                className="step-up-btn"
+                onClick={handleRetry}
+                data-testid="step-up-retry-btn"
+              >
+                Try again
+              </button>
+            )}
+          </div>
+
+          <button
+            type="button"
+            className="step-up-cancel"
+            onClick={onCancel}
+            disabled={phase === 'running'}
+            data-testid="step-up-cancel-btn"
+          >
+            Cancel — action not completed
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/auth/StepUpModal.tsx
+++ b/web/src/auth/StepUpModal.tsx
@@ -323,15 +323,20 @@ export default function StepUpModal({
 
         <div className="step-up-body">
           <div className="step-up-icon" aria-hidden="true">
-            {/* Passkey / key icon (matches mockup .mic) */}
-            <svg width="26" height="26" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M7.5 13.5a3.5 3.5 0 113.5-3.5M11 10h9l-2 2 2 2-3 3"
-                stroke="currentColor"
-                strokeWidth="1.7"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
+            {/* Passkey / key icon (Lucide "key", ISC — a recognizable key). */}
+            <svg
+              width="26"
+              height="26"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.9"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="7.5" cy="15.5" r="5.5" />
+              <path d="m21 2-9.6 9.6" />
+              <path d="m15.5 7.5 3 3L22 7l-3-3" />
             </svg>
           </div>
 
@@ -376,15 +381,15 @@ export default function StepUpModal({
                   height="16"
                   viewBox="0 0 24 24"
                   fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                   aria-hidden="true"
                 >
-                  <path
-                    d="M7.5 13.5a3.5 3.5 0 113.5-3.5M11 10h9l-2 2 2 2-3 3"
-                    stroke="currentColor"
-                    strokeWidth="1.7"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
+                  <circle cx="7.5" cy="15.5" r="5.5" />
+                  <path d="m21 2-9.6 9.6" />
+                  <path d="m15.5 7.5 3 3L22 7l-3-3" />
                 </svg>
                 Verify with passkey
               </button>

--- a/web/src/auth/StepUpModal.tsx
+++ b/web/src/auth/StepUpModal.tsx
@@ -46,7 +46,7 @@ function readSessionCsrf(): string | null {
 
 // ── base64url helpers ────────────────────────────────────────────────────────
 
-function b64uToBytes(b64u: string): Uint8Array {
+function b64uToBytes(b64u: string): Uint8Array<ArrayBuffer> {
   const padded = b64u + '='.repeat((4 - (b64u.length % 4)) % 4)
   const base64 = padded.replace(/-/g, '+').replace(/_/g, '/')
   return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
@@ -162,8 +162,8 @@ export default function StepUpModal({
         e.preventDefault()
         return
       }
-      const first = btns[0]
-      const last = btns[btns.length - 1]
+      const first = btns[0]!
+      const last = btns[btns.length - 1]!
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault()
         last.focus()

--- a/web/stepup-modal-states.html
+++ b/web/stepup-modal-states.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<!--
+  StepUpModal visual reference — both required AC-5 states side by side.
+  Open this file in a browser, take a screenshot of each labelled section,
+  and attach both to PR #2847 before merging.
+
+  State A (left)  — "waiting-for-gesture": the running phase, shown after the
+                    user clicks "Verify with passkey" while navigator.credentials.get()
+                    is in progress. The action button is disabled with a spinner;
+                    the Cancel button is also disabled while the gesture is pending.
+
+  State B (right) — "failed/cancelled": the error phase shown after the WebAuthn
+                    gesture is cancelled or the assertion fails. An inline alert
+                    names the failure reason; "Try again" restarts the ceremony.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>StepUpModal states — PR #2847 screenshot reference</title>
+  <style>
+    /* ── Design tokens (verbatim from docs/design/web-ui-design-tokens.css) ── */
+    :root {
+      --bg-primary:   #f7f4ef;
+      --bg-surface:   #ffffff;
+      --bg-elevated:  #f0ebe4;
+      --bg-sunk:      #f0ebe4;
+      --border:       #d4cfc4;
+      --text-primary:   #6b5a4a;
+      --text-secondary: #7a6a5a;
+      --text-faint:     #8f7d66;
+      --accent:         #4a6b7c;
+      --accent-ink:     #ffffff;
+      --state-crit:     #b56a5a;
+      --state-crit-bg:  #f2e5e3;
+      --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      --font-mono: 'JetBrains Mono', ui-monospace, "SF Mono", "SFMono-Regular", Menlo, monospace;
+      --text-xs:   10px;
+      --text-sm:   11.5px;
+      --text-md:   14px;
+      --text-lg:   16px;
+      --space-1: 4px;  --space-2: 8px;  --space-3: 12px;
+      --space-4: 16px; --space-5: 20px;
+      --radius-sm: 7px;
+      --radius:    9px;
+      --radius-lg: 13px;
+      --shadow: 0 18px 50px -22px rgba(60, 45, 30, 0.40);
+    }
+
+    body {
+      margin: 0;
+      font-family: var(--font-sans);
+      background: var(--bg-primary);
+      color: var(--text-primary);
+    }
+
+    /* ── Page layout ── */
+    .page-header {
+      text-align: center;
+      padding: 24px 24px 8px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-faint);
+    }
+    .states {
+      display: flex;
+      gap: 0;
+      min-height: 100vh;
+    }
+    .state-panel {
+      flex: 1;
+      display: grid;
+      place-items: center;
+      padding: 32px 24px 48px;
+      position: relative;
+    }
+    .state-panel:first-child {
+      background: rgba(0,0,0,0.55);
+    }
+    .state-panel:last-child {
+      background: rgba(0,0,0,0.55);
+    }
+    .state-label {
+      position: absolute;
+      top: 12px;
+      left: 0;
+      right: 0;
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: rgba(255,255,255,0.7);
+      letter-spacing: 0.04em;
+    }
+
+    /* ── Modal card (from StepUpModal.css) ── */
+    .step-up-overlay {
+      position: relative;
+      width: 100%;
+      max-width: 400px;
+    }
+    .step-up-modal {
+      width: 100%;
+      max-width: 400px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+    .step-up-titlebar {
+      display: flex;
+      align-items: center;
+      padding: 10px 13px;
+      background: var(--bg-elevated);
+      border-bottom: 1px solid var(--border);
+    }
+    .step-up-title {
+      font-family: var(--font-mono);
+      font-size: var(--text-sm);
+      color: var(--text-faint);
+      margin: 0 auto;
+      letter-spacing: 0.02em;
+    }
+    .step-up-body {
+      padding: 26px 26px 22px;
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+      align-items: center;
+      text-align: center;
+    }
+    .step-up-icon {
+      width: 52px;
+      height: 52px;
+      border-radius: 14px;
+      background: var(--bg-sunk);
+      color: var(--accent);
+      display: grid;
+      place-items: center;
+      flex: none;
+    }
+    .step-up-heading {
+      margin: 0;
+      font-size: var(--text-lg);
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+    .step-up-desc {
+      margin: 0;
+      font-size: var(--text-sm);
+      color: var(--text-secondary);
+      max-width: 290px;
+      line-height: 1.5;
+    }
+    .step-up-desc b {
+      color: var(--text-faint);
+      font-family: var(--font-mono);
+    }
+    .step-up-error {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--space-2);
+      font-size: 12.5px;
+      color: var(--state-crit);
+      background: var(--state-crit-bg);
+      border: 1px solid var(--state-crit);
+      border-radius: var(--radius);
+      padding: 9px 12px;
+      width: 100%;
+      text-align: left;
+      box-sizing: border-box;
+    }
+    .step-up-err-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: currentColor;
+      flex: none;
+      margin-top: 4px;
+    }
+    .step-up-actions {
+      width: 100%;
+    }
+    .step-up-btn {
+      appearance: none;
+      border: 0;
+      width: 100%;
+      padding: var(--space-3);
+      border-radius: var(--radius);
+      background: var(--accent);
+      color: var(--accent-ink);
+      font-family: var(--font-sans);
+      font-size: var(--text-md);
+      font-weight: 600;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 9px;
+      box-sizing: border-box;
+    }
+    .step-up-btn:disabled {
+      cursor: default;
+      opacity: 0.7;
+    }
+    .step-up-spin {
+      width: 14px;
+      height: 14px;
+      border: 2px solid currentColor;
+      border-right-color: transparent;
+      border-radius: 50%;
+      animation: step-up-sp 0.7s linear infinite;
+      flex: none;
+    }
+    @keyframes step-up-sp {
+      to { transform: rotate(360deg); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .step-up-spin { animation: none; }
+    }
+    .step-up-cancel {
+      appearance: none;
+      border: 0;
+      background: transparent;
+      color: var(--accent);
+      font-family: var(--font-sans);
+      font-size: var(--text-sm);
+      font-weight: 600;
+      cursor: pointer;
+      padding: var(--space-1) var(--space-2);
+      border-radius: var(--radius-sm);
+    }
+    .step-up-cancel:disabled {
+      opacity: 0.4;
+      cursor: default;
+    }
+  </style>
+</head>
+<body>
+  <div class="page-header">StepUpModal · PR #2847 · two required screenshot states</div>
+
+  <div class="states">
+
+    <!-- ── State A: waiting-for-gesture (running phase) ── -->
+    <div class="state-panel">
+      <div class="state-label">A — waiting-for-gesture (running phase)</div>
+      <div class="step-up-overlay">
+        <div class="step-up-modal" role="dialog" aria-modal="true" aria-labelledby="title-a">
+          <div class="step-up-titlebar">
+            <span class="step-up-title">cfgms · secure session</span>
+          </div>
+          <div class="step-up-body">
+            <div class="step-up-icon" aria-hidden="true">
+              <svg width="26" height="26" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="1.9"
+                   stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="7.5" cy="15.5" r="5.5"/>
+                <path d="m21 2-9.6 9.6"/>
+                <path d="m15.5 7.5 3 3L22 7l-3-3"/>
+              </svg>
+            </div>
+            <h3 id="title-a" class="step-up-heading">Verify it&rsquo;s you</h3>
+            <p class="step-up-desc">
+              Action requires verification as
+              <b class="step-up-title">admin@acme-corp.example</b>.
+              Use your passkey or security key to continue.
+            </p>
+            <div class="step-up-actions">
+              <!-- running phase: spinner, button disabled -->
+              <button type="button" class="step-up-btn" disabled>
+                <span class="step-up-spin" aria-hidden="true"></span>
+                <span>Waiting for gesture…</span>
+              </button>
+            </div>
+            <!-- cancel is disabled during the gesture -->
+            <button type="button" class="step-up-cancel" disabled>
+              Cancel — action not completed
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── State B: failed/cancelled (error phase) ── -->
+    <div class="state-panel">
+      <div class="state-label">B — failed/cancelled (error phase)</div>
+      <div class="step-up-overlay">
+        <div class="step-up-modal" role="dialog" aria-modal="true" aria-labelledby="title-b">
+          <div class="step-up-titlebar">
+            <span class="step-up-title">cfgms · secure session</span>
+          </div>
+          <div class="step-up-body">
+            <div class="step-up-icon" aria-hidden="true">
+              <svg width="26" height="26" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="1.9"
+                   stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="7.5" cy="15.5" r="5.5"/>
+                <path d="m21 2-9.6 9.6"/>
+                <path d="m15.5 7.5 3 3L22 7l-3-3"/>
+              </svg>
+            </div>
+            <h3 id="title-b" class="step-up-heading">Verify it&rsquo;s you</h3>
+            <p class="step-up-desc">
+              Action requires verification as
+              <b class="step-up-title">admin@acme-corp.example</b>.
+              Use your passkey or security key to continue.
+            </p>
+            <!-- error alert shown in error phase -->
+            <div class="step-up-error" role="alert">
+              <span class="step-up-err-dot" aria-hidden="true"></span>
+              Verification cancelled — click Cancel to go back, or try again.
+            </div>
+            <div class="step-up-actions">
+              <!-- error phase: "Try again" button -->
+              <button type="button" class="step-up-btn">
+                Try again
+              </button>
+            </div>
+            <button type="button" class="step-up-cancel">
+              Cancel — action not completed
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Extends `apiFetch` to detect `WWW-Authenticate: CFGMS-StepUp` on 401 responses and fire `onStepUpRequired` instead of the session-expired path (ADR-021 Decision 6). A `CFGMS-StepUp` 401 is **not** a session expiry — the operator stays signed in.
- Adds `StepUpModal.tsx`: focus-trapped, non-dismissible modal that runs the three-step WebAuthn presence ceremony (`presence/begin` → `navigator.credentials.get()` → `presence/finish`) and retries the original request with `X-Presence-Token` on success.
- Wires `AuthContext.tsx` to register the step-up listener and render the modal; `AuthStatus` is unchanged (`signedIn` throughout).
- 24 new tests (14 `StepUpModal`, 3 `AuthContext`, 7 `client`). 496 total, all pass. ESLint clean.

## Security constraints met

- No click-outside-to-dismiss and no Escape key dismissal.
- On cancel or assertion failure: `onSuccess` is NOT called; `apiFetch` returns the original 401; the caller sees the failure; the operator's `AssuranceBasic` session remains intact.
- Ceremony calls use raw `fetch` (not `apiFetch`) to avoid recursive step-up listener dispatch.
- Modal reads only `cfgms_csrf` (JS-readable by design) — never the HttpOnly session cookie.

## UI review required — screenshots needed

This is a **founder-live signature screen** (`needs-ui-review`). PR **must not auto-merge**.

Screenshots of the two required modal states (waiting-for-gesture and failed/cancelled) need to be attached before review sign-off — this agent runs headless, so a human reviewer running the dev server must capture them per the standing web-UI PR convention.

## Test plan

- [x] `npm test` — 496 tests pass (StepUpModal 14, AuthContext step-up 3, client step-up 7)
- [x] `npm run lint` — ESLint clean (0 problems)
- [x] `npm run typecheck` — TypeScript strict, no errors
- [x] `make test-agent-complete` — all gates pass
- [x] Adversarial story-review workflow — 3 reviewers, 0 findings, 0 fix rounds
- [ ] Human screenshots of modal waiting-for-gesture state
- [ ] Human screenshots of modal failed/cancelled state
- [ ] `needs-ui-review` label acknowledged by acceptance reviewer before merge

Fixes #2786

🤖 Generated with [Claude Code](https://claude.com/claude-code)