### PR TITLE
steward: self-fetch desired_version binary from controller + HTTPS base-URL plumbing (Issue #2833)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1275,8 +1275,15 @@ func connectWithApprovedRegistration(
 	// after InitializeConfigExecutor creates it (Issue #2435).
 	dnaAdapter := newDNACollectorAdapter(logger, nil)
 
+	// CFGMS_CONTROLLER_HTTPS_BASE_URL enables steward self-fetch upgrades (Issue #2833).
+	// When set, the steward pulls its own binary from the controller instead of waiting
+	// for a controller-initiated push_steward_binary command. Must use https scheme and
+	// match the controller endpoint hostname.
+	controllerHTTPSBaseURL := os.Getenv("CFGMS_CONTROLLER_HTTPS_BASE_URL")
+
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
 		ControllerURL:               reg.TransportAddress,
+		ControllerHTTPSBaseURL:      controllerHTTPSBaseURL,
 		RegistrationToken:           token,
 		CACertPEM:                   reg.CACert,
 		ClientCertPEM:               reg.ClientCert,
@@ -1424,6 +1431,7 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
 		ControllerURL:               id.TransportAddress,
+		ControllerHTTPSBaseURL:      os.Getenv("CFGMS_CONTROLLER_HTTPS_BASE_URL"),
 		RegistrationToken:           token,
 		CACertPEM:                   id.CACertPEM,
 		ServerCertPEM:               id.ServerCertPEM,

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -502,7 +502,7 @@ The controller can send commands to stewards over the gRPC control plane service
 
 Commands are fire-and-forget with completion tracking — the controller publishes the command and monitors for completion/failure events.
 
-### Steward Auto-Upgrade via `desired_version` (Issue #2260)
+### Steward Auto-Upgrade via `desired_version` (Issues #2260, #2833)
 
 Operators pin the steward version fleet-wide or per-tenant via the `steward.upgrade` cfg block:
 
@@ -517,9 +517,25 @@ steward:
 
 **How a steward converges to `desired_version`:**
 
-1. The controller pushes a new steward binary to the endpoint via the `push_steward_binary` data-plane command. The steward downloads, verifies, and stages the binary under `{Root}/versions/{version}/{binaryName}`, then invokes the launcher's `swap` sub-command. On success, the staged version and path are recorded internally (`lastStagedVersion` / `lastStagedBinaryPath`).
-2. On every cfg-convergence cycle (`TriggerConvergence`), the steward reads `desired_version` from its last received cfg. If it differs from the running version, the steward re-invokes the launcher swap against the already-staged binary without downloading again.
+1. On every cfg-convergence cycle (`TriggerConvergence`), the steward reads `desired_version` from its last received cfg. If it differs from the running version and the desired binary is **not already staged**, the steward self-fetches it from the controller (see Self-pull path below).
+2. If the desired binary **is already staged** (from a prior self-fetch or a controller `push_steward_binary` command), the steward re-invokes the launcher's `swap` sub-command against the staged binary without downloading again.
 3. If `allow_downgrade` is `false` (the default) and `desired_version` is older than the running version, the swap is blocked. Set `allow_downgrade: true` to permit explicit rollbacks.
+
+**Self-pull path (Issue #2833):**
+
+When `CFGMS_CONTROLLER_HTTPS_BASE_URL` is set on the steward, `TriggerConvergence` self-fetches the desired binary rather than waiting for a controller-initiated `push_steward_binary` command:
+
+1. The steward constructs the fetch URL: `{CFGMS_CONTROLLER_HTTPS_BASE_URL}/api/v1/public/steward-binaries/{version}/{platform}/{arch}?tenant={tenantID}`. Platform and arch are detected at runtime from `runtime.GOOS`/`runtime.GOARCH`.
+2. **Tenant resolution:** the steward tries its own registered tenant first; on HTTP 404 it retries under the `default` tenant. A root/MSP admin can publish a binary under `default` to update the whole fleet, while individual tenants can override for their own stewards only.
+3. **SHA-256 consistency check:** the recomputed digest of the downloaded bytes is compared against the `X-CFGMS-SHA256` response header. Security depends on the publisher signature below, not on this header value.
+4. **Independent publisher signature verify:** the steward verifies the `X-CFGMS-Signature` response header against the baked-in `CFGMSPublisherIdentity` (Ed25519 key injected at build time). The signed message is a **version-bound composite**: `sha256(content)|version|platform|arch`, where `version`/`platform`/`arch` come from the steward's own requested `desired_version` and detected runtime values — never from any controller-supplied header. This closes the rollback attack surface: a compromised controller that serves an old binary with its authentic old-version signature cannot forge a composite matching the steward's requested new version. `X-CFGMS-Publisher` is used only as a lookup key in the trust store; it is not a trust anchor.
+5. **Revocation check** and the downgrade guard apply exactly as on the push path.
+6. On success, the binary is staged at `{certStoreDir}/upgrades/upgrade-{seq}.bin` and the launcher swap is invoked immediately.
+7. **Degrade safe:** any failure (network error, SHA-256 mismatch, signature mismatch, version-binding mismatch, both tenants 404, revoked version) logs a warning and retries on the next convergence cycle. The steward never swaps an unverified binary.
+
+**Host-pin and HTTPS enforcement:** the fetch URL host must match the controller endpoint host (same hostname as the QUIC transport address). Non-HTTPS URLs and cross-host URLs are rejected before any download is attempted.
+
+**Controller-push fallback:** when `CFGMS_CONTROLLER_HTTPS_BASE_URL` is not configured, the steward falls back to the legacy model: it logs and waits for a `push_steward_binary` command. No self-fetch is attempted.
 
 **Downgrade guard:**
 - Blocked unless `allow_downgrade` is `true` in either the running cfg or the controller-synced config cache (`upgradeAllowDowngrade`).

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -187,6 +187,11 @@ type TransportClient struct {
 	// downloads binaries to a subdirectory here. (Issue #1943)
 	certStoreDir string
 
+	// controllerHTTPSBaseURL is the controller's HTTPS REST API base URL used
+	// for steward self-fetch upgrades (Issue #2833). Sourced from
+	// CFGMS_CONTROLLER_HTTPS_BASE_URL. When empty, self-fetch is disabled.
+	controllerHTTPSBaseURL string
+
 	// revokedVersions is the controller-supplied list of revoked steward versions.
 	// Protected by revokedVersionsMu. Updated via SetRevokedVersions. (Issue #1943)
 	revokedVersionsMu sync.RWMutex
@@ -383,6 +388,15 @@ type TransportConfig struct {
 	// handler returns an error. (Issue #1943)
 	CertStoreDir string
 
+	// ControllerHTTPSBaseURL is the controller's HTTPS base URL for the REST API
+	// (e.g., "https://controller.example.com"). Required for steward self-fetch
+	// upgrade (Issue #2833). When empty, self-fetch is disabled and the steward
+	// falls back to awaiting a controller-initiated push_steward_binary command.
+	// Sourced from the CFGMS_CONTROLLER_HTTPS_BASE_URL environment variable in
+	// cmd/steward/main.go. Must use the https scheme; the host must match the
+	// controller endpoint host (same as the QUIC transport address host).
+	ControllerHTTPSBaseURL string
+
 	// UpgradeAllowDowngrade, when true, permits the upgrade handler to install a
 	// steward version older than or equal to the currently running version.
 	// Mirrors steward.cfg upgrade.allow_downgrade. (Issue #1943)
@@ -472,6 +486,7 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 		identityPersistFunc:        cfg.IdentityPersistFunc,
 		secretStore:                cfg.SecretStore,
 		certStoreDir:               cfg.CertStoreDir,
+		controllerHTTPSBaseURL:     cfg.ControllerHTTPSBaseURL,
 		upgradeAllowDowngrade:      cfg.UpgradeAllowDowngrade,
 		upgradePublisherTrustStore: cfg.UpgradePublisherTrustStore,
 		// Self-exit after a pushed-upgrade swap only when a launcher is supervising
@@ -1529,11 +1544,34 @@ func (c *TransportClient) triggerVersionConvergence(ctx context.Context, desired
 	}
 
 	if stagedVersion != desiredVersion || stagedPath == "" {
-		c.logger.Info("Version convergence: desired_version differs from running; awaiting controller binary push",
+		// Attempt self-fetch when an HTTPS base URL is configured; otherwise fall
+		// back to the legacy model of awaiting a controller push_steward_binary.
+		c.mu.RLock()
+		httpsBase := c.controllerHTTPSBaseURL
+		tid := c.tenantID
+		c.mu.RUnlock()
+
+		if httpsBase == "" {
+			c.logger.Info("Version convergence: binary not staged; no HTTPS base URL configured; awaiting controller push",
+				"desired_version", logging.SanitizeLogValue(desiredVersion),
+				"running_version", runningVersion,
+				"staged_version", logging.SanitizeLogValue(stagedVersion))
+			return
+		}
+
+		c.logger.Info("Version convergence: binary not staged; attempting self-fetch from controller",
 			"desired_version", logging.SanitizeLogValue(desiredVersion),
-			"running_version", runningVersion,
-			"staged_version", logging.SanitizeLogValue(stagedVersion))
-		return
+			"running_version", runningVersion)
+
+		fetchedPath, fetchErr := c.selfFetchForUpgrade(ctx, desiredVersion, tid)
+		if fetchErr != nil {
+			c.logger.Warn("Version convergence: self-fetch failed; will retry next cycle",
+				"desired_version", logging.SanitizeLogValue(desiredVersion),
+				"error", fetchErr)
+			return
+		}
+		stagedPath = fetchedPath
+		// Fall through to launcher swap below.
 	}
 
 	lPath := lPathOverride

--- a/features/steward/client/client_transport_upgrade.go
+++ b/features/steward/client/client_transport_upgrade.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -615,4 +616,294 @@ func parseSemver(v string) []int {
 		nums[i] = n
 	}
 	return nums
+}
+
+// ---- Self-fetch upgrade (Issue #2833) ----------------------------------------
+
+// errSelfFetchBinaryNotFound is returned by selfFetchDownload when the controller
+// responds with HTTP 404. Callers use this to implement the own-tenant → default
+// tenant fallback without treating 404 as a hard error.
+var errSelfFetchBinaryNotFound = errors.New("binary not found on controller (404)")
+
+// mapRuntimePlatformArch maps runtime.GOOS and runtime.GOARCH to the controller's
+// vocabulary (matching validPlatforms/validArchs in handlers_installer.go: windows,
+// darwin, linux; amd64, arm64).
+func mapRuntimePlatformArch() (platform, arch string) {
+	switch runtime.GOOS {
+	case "windows":
+		platform = "windows"
+	case "darwin":
+		platform = "darwin"
+	default:
+		platform = "linux"
+	}
+	switch runtime.GOARCH {
+	case "arm64":
+		arch = "arm64"
+	default:
+		arch = "amd64"
+	}
+	return
+}
+
+// buildSelfFetchURL constructs the self-fetch URL for handleGetStewardBinaryPublic.
+// baseURL must have its trailing slash already trimmed.
+func buildSelfFetchURL(baseURL, ver, platform, arch, tenantID string) string {
+	return fmt.Sprintf("%s/api/v1/public/steward-binaries/%s/%s/%s?tenant=%s",
+		baseURL,
+		url.PathEscape(ver),
+		url.PathEscape(platform),
+		url.PathEscape(arch),
+		url.QueryEscape(tenantID),
+	)
+}
+
+// selfFetchDownload GETs rawURL, saves the body to dstPath, and returns:
+//   - recomputed hex SHA-256 of downloaded bytes (recomputedSHA256)
+//   - X-CFGMS-SHA256 response header value (serverSHA256; may be empty)
+//   - X-CFGMS-Publisher response header value (publisher; may be empty)
+//   - base64-decoded X-CFGMS-Signature response header bytes (bundleSig; nil if absent)
+//   - number of bytes written
+//
+// Returns errSelfFetchBinaryNotFound on HTTP 404.
+// rawURL must be host-pinned and scheme-validated by the caller.
+func (c *TransportClient) selfFetchDownload(ctx context.Context, rawURL, dstPath string) (
+	recomputedSHA256, serverSHA256, publisher string, bundleSig []byte, sizeBytes int64, err error,
+) {
+	httpClient, err := c.buildHTTPClientForUpgrade()
+	if err != nil {
+		return "", "", "", nil, 0, fmt.Errorf("build http client: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil) //#nosec G107 -- URL is host-pinned before this call
+	if err != nil {
+		return "", "", "", nil, 0, fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", "", "", nil, 0, fmt.Errorf("http get: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", "", "", nil, 0, errSelfFetchBinaryNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", "", "", nil, 0, fmt.Errorf("http get: unexpected status %d", resp.StatusCode)
+	}
+
+	// Read security-relevant response headers.
+	serverSHA256 = resp.Header.Get("X-CFGMS-SHA256")
+	publisher = resp.Header.Get("X-CFGMS-Publisher")
+	if sigB64 := resp.Header.Get("X-CFGMS-Signature"); sigB64 != "" {
+		decoded, decErr := base64.StdEncoding.DecodeString(sigB64)
+		if decErr != nil {
+			return "", "", "", nil, 0, fmt.Errorf("decode X-CFGMS-Signature header: %w", decErr)
+		}
+		bundleSig = decoded
+	}
+
+	// Size cap via Content-Length header.
+	if cl := resp.ContentLength; cl > MaxBinarySizeBytes {
+		return "", "", "", nil, 0, fmt.Errorf("Content-Length %d exceeds MaxBinarySizeBytes %d", cl, MaxBinarySizeBytes)
+	}
+
+	f, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //#nosec G304 -- dstPath is built from certStoreDir+seq
+	if err != nil {
+		return "", "", "", nil, 0, fmt.Errorf("create temp file: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	hasher := sha256.New()
+	limited := &io.LimitedReader{R: resp.Body, N: MaxBinarySizeBytes + 1}
+	tee := io.TeeReader(limited, hasher)
+
+	written, copyErr := io.Copy(f, tee)
+	if copyErr != nil {
+		return "", "", "", nil, 0, fmt.Errorf("write temp file: %w", copyErr)
+	}
+	if limited.N == 0 {
+		return "", "", "", nil, 0, fmt.Errorf("body exceeds MaxBinarySizeBytes %d; download aborted", MaxBinarySizeBytes)
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), serverSHA256, publisher, bundleSig, written, nil
+}
+
+// verifyBinarySignatureForSelfFetch verifies the Ed25519 publisher signature for the
+// self-fetch path using a version-bound composite message.
+//
+// Composite: recomputedSHA256 + "|" + version + "|" + platform + "|" + arch
+//
+// The composite values (version, platform, arch) are the steward's own requested
+// desired_version and detected runtime.GOOS/GOARCH — never any controller-supplied field.
+// This is the rollback defence from Issue #2834: a compromised controller that serves an
+// old binary cannot reuse the old version's authentic signature because the steward
+// composes the verify message from the NEW requested version, not from any header.
+//
+// The trust anchor is always the baked-in CFGMSPublisherIdentity() (or the test-only
+// upgradePublisherTrustStore override). The publisher header value is used solely as a
+// lookup key; if it does not match the baked-in identity name the lookup returns
+// ErrPublisherNotTrusted, proving the header is not a trust anchor.
+func (c *TransportClient) verifyBinarySignatureForSelfFetch(
+	recomputedSHA256, ver, platform, arch, publisher string, bundleSig []byte,
+) error {
+	if publisher == "" {
+		return fmt.Errorf("self-fetch: X-CFGMS-Publisher response header is absent")
+	}
+	if len(bundleSig) == 0 {
+		return fmt.Errorf("self-fetch: X-CFGMS-Signature response header is absent")
+	}
+
+	c.mu.RLock()
+	overrideStore := c.upgradePublisherTrustStore
+	c.mu.RUnlock()
+
+	var store trust.TrustStore
+	if overrideStore != nil {
+		store = overrideStore
+	} else {
+		ts := trust.NewInMemoryTrustStore()
+		_ = ts.AddPublisher(trust.CFGMSPublisherIdentity())
+		store = ts
+	}
+
+	// Version-bound composite: Version/Platform/Arch are the steward's own values.
+	composite := recomputedSHA256 + "|" + ver + "|" + platform + "|" + arch
+
+	b := bundle.Bundle{ContentHash: composite}
+	sig := bundle.BundleSignature{
+		Publisher: publisher,
+		Algorithm: "ed25519",
+		Signature: bundleSig,
+	}
+	return trust.VerifyBundleSignature(&b, sig, store)
+}
+
+// selfFetchForUpgrade downloads, verifies, and stages the desired steward binary
+// from the controller. It tries tenantID first, then "default" on 404.
+//
+// On success it updates c.lastStagedVersion / c.lastStagedBinaryPath and returns
+// the staged binary path. On any failure it removes the temp file and returns an
+// error; the caller logs and retries on the next convergence cycle.
+func (c *TransportClient) selfFetchForUpgrade(ctx context.Context, desiredVersion, tenantID string) (string, error) {
+	c.mu.RLock()
+	certStoreDir := c.certStoreDir
+	httpsBase := c.controllerHTTPSBaseURL
+	c.mu.RUnlock()
+
+	if certStoreDir == "" {
+		return "", fmt.Errorf("self-fetch: cert store dir not configured")
+	}
+
+	// Validate HTTPS base URL: scheme and host-pin.
+	baseURL, err := url.Parse(httpsBase)
+	if err != nil {
+		return "", fmt.Errorf("self-fetch: cannot parse HTTPS base URL: %w", err)
+	}
+	if baseURL.Scheme != "https" {
+		return "", fmt.Errorf("self-fetch: HTTPS base URL scheme must be https, got %q", baseURL.Scheme)
+	}
+	controllerHost := c.controllerEndpointHost()
+	fetchHost := baseURL.Hostname()
+	if fetchHost != controllerHost {
+		return "", fmt.Errorf("self-fetch: HTTPS base URL host %q does not match controller endpoint host %q",
+			fetchHost, controllerHost)
+	}
+
+	platform, arch := mapRuntimePlatformArch()
+
+	upgradesDir := filepath.Join(certStoreDir, "upgrades")
+	if mkErr := os.MkdirAll(upgradesDir, 0o700); mkErr != nil {
+		return "", fmt.Errorf("self-fetch: create upgrades dir: %w", mkErr)
+	}
+
+	seq := upgradeSeq.Add(1)
+	tmpPath := filepath.Join(upgradesDir, fmt.Sprintf("upgrade-%d.bin", seq))
+
+	// Try own tenant, then "default" on 404.
+	tenants := []string{tenantID}
+	if tenantID != "default" {
+		tenants = append(tenants, "default")
+	}
+
+	trimmedBase := strings.TrimRight(httpsBase, "/")
+	var lastErr error
+	for _, tenant := range tenants {
+		fetchURL := buildSelfFetchURL(trimmedBase, desiredVersion, platform, arch, tenant)
+
+		c.logger.Info("Version convergence: self-fetch: trying tenant",
+			"desired_version", logging.SanitizeLogValue(desiredVersion),
+			"tenant", logging.SanitizeLogValue(tenant))
+
+		hexSHA256, serverSHA256, publisher, bundleSig, sizeBytes, dlErr := c.selfFetchDownload(ctx, fetchURL, tmpPath)
+		if dlErr != nil {
+			if errors.Is(dlErr, errSelfFetchBinaryNotFound) {
+				c.logger.Info("Version convergence: self-fetch: binary not found for tenant; trying next",
+					"desired_version", logging.SanitizeLogValue(desiredVersion),
+					"tenant", logging.SanitizeLogValue(tenant))
+				lastErr = dlErr
+				_ = os.Remove(tmpPath)
+				continue
+			}
+			lastErr = fmt.Errorf("download: %w", dlErr)
+			_ = os.Remove(tmpPath)
+			break
+		}
+
+		// SHA-256 consistency check. The recomputed digest is the authoritative value;
+		// the header is informational. Security comes from the publisher signature below.
+		if serverSHA256 != "" && !strings.EqualFold(hexSHA256, serverSHA256) {
+			lastErr = fmt.Errorf("self-fetch: sha256 mismatch: server header %q vs recomputed %q",
+				serverSHA256, hexSHA256)
+			_ = os.Remove(tmpPath)
+			break
+		}
+
+		// Publisher signature verify (version-bound composite). The trust anchor is the
+		// baked-in CFGMSPublisherIdentity(); X-CFGMS-Publisher is only a lookup key.
+		if verErr := c.verifyBinarySignatureForSelfFetch(hexSHA256, desiredVersion, platform, arch, publisher, bundleSig); verErr != nil {
+			c.logger.Warn("Version convergence: self-fetch: signature verification failed",
+				"desired_version", logging.SanitizeLogValue(desiredVersion),
+				"publisher", logging.SanitizeLogValue(publisher),
+				"error", verErr)
+			lastErr = fmt.Errorf("self-fetch: signature verification failed: %w", verErr)
+			_ = os.Remove(tmpPath)
+			break
+		}
+
+		// Revocation check.
+		if c.isVersionRevoked(desiredVersion) {
+			c.logger.Warn("Version convergence: self-fetch: version is revoked",
+				"desired_version", logging.SanitizeLogValue(desiredVersion))
+			lastErr = fmt.Errorf("self-fetch: version %q is in the revoked list", desiredVersion)
+			_ = os.Remove(tmpPath)
+			break
+		}
+
+		// Stage the verified binary.
+		c.mu.Lock()
+		c.lastStagedVersion = desiredVersion
+		c.lastStagedBinaryPath = tmpPath
+		c.mu.Unlock()
+
+		c.logger.Info("Version convergence: self-fetch: binary staged",
+			"desired_version", logging.SanitizeLogValue(desiredVersion),
+			"size_bytes", sizeBytes,
+			"tenant", logging.SanitizeLogValue(tenant))
+		return tmpPath, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("self-fetch: all tenants returned 404")
+	}
+	return "", lastErr
 }

--- a/features/steward/client/client_transport_upgrade_test.go
+++ b/features/steward/client/client_transport_upgrade_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -105,6 +106,11 @@ func computeSHA256(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
 }
+
+// roundTripFunc is an http.RoundTripper backed by a function literal.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 // noopSwap is a launcherSwapFunc that always succeeds.
 func noopSwap(_ context.Context, _, _, _ string) error { return nil }
@@ -1352,4 +1358,227 @@ func TestUpgradeCommandRegistered(t *testing.T) {
 	assert.Equal(t, cpTypes.EventType("steward.upgrade.swapped"), cpTypes.EventStewardUpgradeSwapped)
 	assert.Equal(t, cpTypes.EventType("steward.upgrade.committed"), cpTypes.EventStewardUpgradeCommitted)
 	assert.Equal(t, cpTypes.EventType("steward.upgrade.rolled_back"), cpTypes.EventStewardUpgradeRolledBack)
+}
+
+// ---- Self-fetch fail-closed matrix (AC 6, Issue #2833) ---------------------
+
+// selfFetchTestClient builds a TransportClient wired for selfFetchForUpgrade tests.
+func selfFetchTestClient(
+	t *testing.T,
+	httpsBase string,
+	controllerHost string,
+	trustStore trust.TrustStore,
+) *TransportClient {
+	t.Helper()
+	c := &TransportClient{
+		stewardID:                  "test-steward",
+		tenantID:                   "test-tenant",
+		transportAddress:           controllerHost + ":4433",
+		controllerHTTPSBaseURL:     httpsBase,
+		certStoreDir:               t.TempDir(),
+		upgradePublisherTrustStore: trustStore,
+		heartbeatStop:              make(chan struct{}),
+		convergenceStop:            make(chan struct{}),
+		logger:                     newTestLogger(t),
+		launcherManaged:            false,
+	}
+	return c
+}
+
+// selfFetchComposite returns the version-bound composite string that must be signed.
+func selfFetchComposite(hexSHA256, ver, platform, arch string) string {
+	return hexSHA256 + "|" + ver + "|" + platform + "|" + arch
+}
+
+// TestSelfFetch_FailClosedMatrix is a table-driven test verifying that
+// selfFetchForUpgrade rejects every unsafe download and never stages an
+// unverified binary. (AC 6, Issue #2833)
+func TestSelfFetch_FailClosedMatrix(t *testing.T) {
+	const desiredVersion = "v99.20.0"
+	const oldVersion = "v1.0.0"
+
+	content := []byte("steward binary for fail-closed matrix")
+	hexSHA256 := computeSHA256(content)
+
+	platform, arch := runtime.GOOS, runtime.GOARCH
+	if platform != "windows" && platform != "darwin" {
+		platform = "linux"
+	}
+	if arch != "arm64" {
+		arch = "amd64"
+	}
+
+	correctComposite := selfFetchComposite(hexSHA256, desiredVersion, platform, arch)
+
+	// Build a legitimate publisher for cases that need a valid key.
+	ts, sign := testPublisher(t, "cfgms")
+	validSig := sign(correctComposite)
+	validSigB64 := base64.StdEncoding.EncodeToString(validSig)
+
+	// Old-version signature (authentic, but for oldVersion not desiredVersion).
+	oldComposite := selfFetchComposite(hexSHA256, oldVersion, platform, arch)
+	oldVersionSig := sign(oldComposite)
+	oldVersionSigB64 := base64.StdEncoding.EncodeToString(oldVersionSig)
+
+	// Tampered: sign a different hash so the signature won't verify against the real content.
+	tamperedSig := sign(selfFetchComposite("deadbeef00000000", desiredVersion, platform, arch))
+	tamperedSigB64 := base64.StdEncoding.EncodeToString(tamperedSig)
+
+	type testCase struct {
+		name          string
+		setupServer   func(t *testing.T) *httptest.Server
+		setupClient   func(t *testing.T, c *TransportClient, srv *httptest.Server)
+		trustStore    trust.TrustStore // nil → use baked-in (placeholder key in dev builds)
+		wantErrSubstr string
+	}
+
+	cases := []testCase{
+		{
+			name: "tampered_binary_wrong_signature",
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("X-CFGMS-SHA256", hexSHA256)
+					w.Header().Set("X-CFGMS-Publisher", "cfgms")
+					w.Header().Set("X-CFGMS-Signature", tamperedSigB64)
+					w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(content)
+				}))
+			},
+			setupClient: func(t *testing.T, c *TransportClient, srv *httptest.Server) {
+				c.mu.Lock()
+				c.upgradeHTTPClient = srv.Client()
+				c.mu.Unlock()
+			},
+			trustStore:    ts,
+			wantErrSubstr: "signature verification failed",
+		},
+		{
+			name: "valid_signature_attacker_publisher_header",
+			// Server returns the correct binary + correct signature, but lies about publisher.
+			// The header X-CFGMS-Publisher: attacker must NOT select a verification key —
+			// the baked-in identity is the only trust anchor.
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("X-CFGMS-SHA256", hexSHA256)
+					w.Header().Set("X-CFGMS-Publisher", "attacker")  // wrong publisher name
+					w.Header().Set("X-CFGMS-Signature", validSigB64) // valid sig but for "cfgms"
+					w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(content)
+				}))
+			},
+			setupClient: func(t *testing.T, c *TransportClient, srv *httptest.Server) {
+				c.mu.Lock()
+				c.upgradeHTTPClient = srv.Client()
+				c.mu.Unlock()
+			},
+			trustStore:    ts,
+			wantErrSubstr: "signature verification failed",
+		},
+		{
+			name: "placeholder_key_build_rejects_all",
+			// No override trust store → uses CFGMSPublisherIdentity() (all-zero placeholder in dev builds).
+			// isUnsafePublisherKey rejects the all-zero key → ErrUntrustedPublisherKey.
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("X-CFGMS-SHA256", hexSHA256)
+					w.Header().Set("X-CFGMS-Publisher", "cfgms")
+					w.Header().Set("X-CFGMS-Signature", validSigB64)
+					w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(content)
+				}))
+			},
+			setupClient: func(t *testing.T, c *TransportClient, srv *httptest.Server) {
+				c.mu.Lock()
+				c.upgradeHTTPClient = srv.Client()
+				c.upgradePublisherTrustStore = nil // use baked-in placeholder
+				c.mu.Unlock()
+			},
+			trustStore:    nil,
+			wantErrSubstr: "signature verification failed",
+		},
+		{
+			name: "non_https_url",
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(content)
+				}))
+			},
+			setupClient: func(t *testing.T, c *TransportClient, srv *httptest.Server) {
+				// Override base URL to use http (non-TLS).
+				c.mu.Lock()
+				c.controllerHTTPSBaseURL = srv.URL // srv.URL starts with "http://"
+				c.mu.Unlock()
+			},
+			trustStore:    ts,
+			wantErrSubstr: "https",
+		},
+		{
+			name: "off_host_https_url",
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			setupClient: func(t *testing.T, c *TransportClient, srv *httptest.Server) {
+				// HTTPS base URL points to a different host than the QUIC transport address.
+				c.mu.Lock()
+				c.controllerHTTPSBaseURL = "https://evil.example.com"
+				c.mu.Unlock()
+			},
+			trustStore:    ts,
+			wantErrSubstr: "does not match controller endpoint host",
+		},
+		{
+			name: "compromised_controller_rollback",
+			// A compromised controller serves oldVersion binary + authentic old-version signature
+			// at the desiredVersion (v99.20.0) URL. Every controller-supplied field (headers,
+			// body) claims this is an old binary — but the steward composes the verify message
+			// from its own requested desiredVersion, so the sig is invalid and it rejects.
+			setupServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Server lies: claims oldVersion's SHA256 in the header (same content
+					// hash since content is unchanged, but the composite includes oldVersion).
+					w.Header().Set("X-CFGMS-SHA256", hexSHA256)
+					w.Header().Set("X-CFGMS-Publisher", "cfgms")
+					// Signature was made for composite(hexSHA256|oldVersion|platform|arch), NOT for desiredVersion.
+					w.Header().Set("X-CFGMS-Signature", oldVersionSigB64)
+					w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(content) // same binary bytes (old version)
+				}))
+			},
+			setupClient: func(t *testing.T, c *TransportClient, srv *httptest.Server) {
+				c.mu.Lock()
+				c.upgradeHTTPClient = srv.Client()
+				c.mu.Unlock()
+			},
+			trustStore:    ts,
+			wantErrSubstr: "signature verification failed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := tc.setupServer(t)
+			defer srv.Close()
+
+			c := selfFetchTestClient(t, srv.URL, "127.0.0.1", tc.trustStore)
+			tc.setupClient(t, c, srv)
+
+			_, err := c.selfFetchForUpgrade(context.Background(), desiredVersion, "test-tenant")
+			require.Error(t, err, "selfFetchForUpgrade must return an error for case %q", tc.name)
+			assert.Contains(t, err.Error(), tc.wantErrSubstr,
+				"error must mention %q for case %q", tc.wantErrSubstr, tc.name)
+
+			// Binary must NOT be staged.
+			c.mu.RLock()
+			staged := c.lastStagedVersion
+			c.mu.RUnlock()
+			assert.Empty(t, staged, "lastStagedVersion must remain empty after rejection for case %q", tc.name)
+		})
+	}
 }

--- a/features/steward/client/version_convergence_test.go
+++ b/features/steward/client/version_convergence_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-// Tests for desired_version auto-convergence in TriggerConvergence. (Issue #2260)
+// Tests for desired_version auto-convergence in TriggerConvergence. (Issue #2260, #2833)
 //
 // Tests:
 //   - TestTriggerConvergence_VersionConvergence_InvokesSwapWhenVersionDiffers
@@ -8,11 +8,19 @@
 //   - TestTriggerConvergence_VersionConvergence_NoOpWhenDesiredVersionAbsent
 //   - TestTriggerConvergence_VersionConvergence_DowngradeGuardBlocksOlderVersion
 //   - TestTriggerConvergence_VersionConvergence_AllowDowngradeInCfgPermitsOlderVersion
+//   - TestTriggerConvergence_SelfFetch_HappyPath
+//   - TestTriggerConvergence_SelfFetch_OwnTenant404FallsBackToDefault
+//   - TestTriggerConvergence_SelfFetch_NoHTTPSBase_DoesNotFetch
 package client
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +29,7 @@ import (
 
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/execution"
+	"github.com/cfgis/cfgms/pkg/modules/trust"
 	"github.com/cfgis/cfgms/pkg/version"
 )
 
@@ -184,4 +193,197 @@ func TestTriggerConvergence_VersionConvergence_AllowDowngradeInCfgPermitsOlderVe
 
 	assert.True(t, swapCalled, "swap MUST be called when AllowDowngrade is enabled in cfg")
 	assert.Equal(t, olderVersion, swappedVersion)
+}
+
+// ---- Self-fetch tests (Issue #2833) ----------------------------------------
+
+// newSelfFetchTestServer returns a TLS test server that serves a steward binary
+// with the correct version-bound signature headers. tenantFilter, when non-empty,
+// makes the server return 404 for that tenant and 200 for all others — used to
+// test the own-tenant-404 → default fallback.
+func newSelfFetchTestServer(
+	t *testing.T,
+	content []byte,
+	hexSHA256 string,
+	publisherName string,
+	sigB64 string,
+	tenantFilter string, // return 404 for this tenant; empty = always 200
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tenantFilter != "" && r.URL.Query().Get("tenant") == tenantFilter {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("X-CFGMS-SHA256", hexSHA256)
+		w.Header().Set("X-CFGMS-Publisher", publisherName)
+		w.Header().Set("X-CFGMS-Signature", sigB64)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+}
+
+// newClientForSelfFetchTest returns a TransportClient wired for self-fetch tests.
+// The configExecutor is real so TriggerConvergence does not short-circuit.
+func newClientForSelfFetchTest(
+	t *testing.T,
+	httpsBaseURL string,
+	httpClient *http.Client,
+	ts trust.TrustStore,
+	swapFn func(ctx context.Context, lPath, ver, bin string) error,
+) *TransportClient {
+	t.Helper()
+	exec, err := execution.NewExecutor(&execution.ExecutorConfig{Logger: newTestLogger(t)})
+	require.NoError(t, err)
+
+	c := &TransportClient{
+		stewardID:                  "test-steward",
+		tenantID:                   "test-tenant",
+		transportAddress:           "127.0.0.1:4433",
+		controllerHTTPSBaseURL:     httpsBaseURL,
+		certStoreDir:               t.TempDir(),
+		upgradePublisherTrustStore: ts,
+		upgradeHTTPClient:          httpClient,
+		launcherSwapFunc:           swapFn,
+		heartbeatStop:              make(chan struct{}),
+		convergenceStop:            make(chan struct{}),
+		logger:                     newTestLogger(t),
+		configExecutor:             exec,
+		launcherManaged:            false,
+	}
+	return c
+}
+
+// TestTriggerConvergence_SelfFetch_HappyPath proves AC 1 and AC 5: when
+// desired_version is set and the binary is NOT pre-staged, TriggerConvergence
+// self-fetches from the controller (own tenant), verifies the version-bound
+// publisher signature, stages the binary, and invokes the launcher swap — with
+// zero controller-initiated push. (Issue #2833)
+func TestTriggerConvergence_SelfFetch_HappyPath(t *testing.T) {
+	const desiredVersion = "v99.10.0"
+	content := []byte("self-fetch steward binary for happy-path test")
+	hexSHA256 := computeSHA256(content)
+
+	// Build the version-bound composite for signing. Version/Platform/Arch are the
+	// steward's own values (same as mapRuntimePlatformArch() will produce at runtime).
+	platform, arch := runtime.GOOS, runtime.GOARCH
+	if platform != "windows" && platform != "darwin" {
+		platform = "linux"
+	}
+	if arch != "arm64" {
+		arch = "amd64"
+	}
+	composite := hexSHA256 + "|" + desiredVersion + "|" + platform + "|" + arch
+
+	ts, sign := testPublisher(t, "cfgms")
+	sig := sign(composite)
+	sigB64 := base64.StdEncoding.EncodeToString(sig)
+
+	srv := newSelfFetchTestServer(t, content, hexSHA256, "cfgms", sigB64, "")
+	defer srv.Close()
+
+	var swapCalled bool
+	var swappedVersion string
+	swapFn := func(_ context.Context, _, ver, _ string) error {
+		swapCalled = true
+		swappedVersion = ver
+		return nil
+	}
+
+	c := newClientForSelfFetchTest(t, srv.URL, srv.Client(), ts, swapFn)
+	c.lastConfigYAML = makeVersionCfgYAML(t, desiredVersion, false)
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, swapCalled, "launcher swap must be called after self-fetch succeeds")
+	assert.Equal(t, desiredVersion, swappedVersion, "swap must target the desired version")
+
+	c.mu.RLock()
+	staged := c.lastStagedVersion
+	c.mu.RUnlock()
+	assert.Equal(t, desiredVersion, staged, "lastStagedVersion must be recorded after self-fetch")
+}
+
+// TestTriggerConvergence_SelfFetch_OwnTenant404FallsBackToDefault proves that
+// when the steward's own tenant returns 404, TriggerConvergence retries under
+// the "default" tenant and successfully stages and swaps. (AC 1, AC 5)
+func TestTriggerConvergence_SelfFetch_OwnTenant404FallsBackToDefault(t *testing.T) {
+	const desiredVersion = "v99.11.0"
+	content := []byte("self-fetch binary for tenant fallback test")
+	hexSHA256 := computeSHA256(content)
+
+	platform, arch := runtime.GOOS, runtime.GOARCH
+	if platform != "windows" && platform != "darwin" {
+		platform = "linux"
+	}
+	if arch != "arm64" {
+		arch = "amd64"
+	}
+	composite := hexSHA256 + "|" + desiredVersion + "|" + platform + "|" + arch
+
+	ts, sign := testPublisher(t, "cfgms")
+	sig := sign(composite)
+	sigB64 := base64.StdEncoding.EncodeToString(sig)
+
+	// Server returns 404 for the steward's own tenant ("test-tenant") and 200 for "default".
+	srv := newSelfFetchTestServer(t, content, hexSHA256, "cfgms", sigB64, "test-tenant")
+	defer srv.Close()
+
+	var swapCalled bool
+	swapFn := func(_ context.Context, _, _, _ string) error {
+		swapCalled = true
+		return nil
+	}
+
+	c := newClientForSelfFetchTest(t, srv.URL, srv.Client(), ts, swapFn)
+	c.lastConfigYAML = makeVersionCfgYAML(t, desiredVersion, false)
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, swapCalled, "launcher swap must succeed via the default-tenant fallback")
+
+	c.mu.RLock()
+	staged := c.lastStagedVersion
+	c.mu.RUnlock()
+	assert.Equal(t, desiredVersion, staged, "binary must be staged after fallback to default tenant")
+}
+
+// TestTriggerConvergence_SelfFetch_NoHTTPSBase_DoesNotFetch proves that when
+// ControllerHTTPSBaseURL is not configured, TriggerConvergence does NOT attempt
+// a self-fetch and instead returns without error — preserving backward compat
+// with controller-push-only deployments. (Issue #2833)
+func TestTriggerConvergence_SelfFetch_NoHTTPSBase_DoesNotFetch(t *testing.T) {
+	const desiredVersion = "v99.12.0"
+
+	fetchAttempted := false
+	swapCalled := false
+
+	// Sentinel transport: if selfFetchForUpgrade ever calls the HTTP client it records the attempt.
+	sentinelClient := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			fetchAttempted = true
+			return nil, fmt.Errorf("sentinel: unexpected fetch attempt")
+		}),
+	}
+
+	swapFn := func(_ context.Context, _, _, _ string) error {
+		swapCalled = true
+		return nil
+	}
+
+	// controllerHTTPSBaseURL is "" — self-fetch must not be attempted.
+	c := newClientForSelfFetchTest(t, "", sentinelClient, nil, swapFn)
+	c.lastConfigYAML = makeVersionCfgYAML(t, desiredVersion, false)
+	c.lastConfigVersion = "v1"
+
+	err := c.TriggerConvergence(context.Background())
+	require.NoError(t, err)
+
+	assert.False(t, fetchAttempted, "HTTP client must NOT be called when no HTTPS base URL is configured")
+	assert.False(t, swapCalled, "swap must NOT be called when no HTTPS base URL is configured")
 }


### PR DESCRIPTION
## Summary

- **HTTPS base-URL plumbing**: new `ControllerHTTPSBaseURL` field threaded through `TransportConfig` → `TransportClient`, sourced from `CFGMS_CONTROLLER_HTTPS_BASE_URL` env var in both `NewTransportClient` call sites
- **Self-fetch path** (`selfFetchForUpgrade`): when `desired_version` is set and the binary is not staged, the steward pulls it from the controller via HTTPS, verifies a version-bound Ed25519 publisher signature (`sha256|version|platform|arch`), checks revocation, and stages — then falls through to the existing launcher swap path
- **Tenant fallback**: tries own registered tenant first; on 404, retries under "default" tenant
- **Degrade-safe**: any failure (bad sig, network error, revoked) logs a warning and returns; steward retries next convergence cycle; zero impact when env var is unset (falls back to controller-push-only behavior)

## Security invariants

The trust anchor is the baked-in `CFGMSPublisherIdentity()` Ed25519 key only. `X-CFGMS-Publisher` is a lookup key, never a trust anchor. Version/Platform/Arch come from the steward's own values, never from response headers. The host-pin check ensures downloads only come from the configured controller. Placeholder-key dev builds fail closed via `isUnsafePublisherKey`.

## Test coverage

- `TestSelfFetch_FailClosedMatrix` (6 cases): tampered binary, attacker publisher header, placeholder-key build, non-HTTPS URL, off-host URL, compromised-controller rollback
- `TestTriggerConvergence_SelfFetch_HappyPath`: full end-to-end with real TLS server
- `TestTriggerConvergence_SelfFetch_OwnTenant404FallsBackToDefault`: tenant fallback
- `TestTriggerConvergence_SelfFetch_NoHTTPSBase_DoesNotFetch`: backward compat (sentinel HTTP client proves no fetch attempted)

## Dependencies

- Story #2836 (controller `X-CFGMS-Signature`/`X-CFGMS-Publisher` response headers): client reads these headers; when absent the verify step fails safely and the steward retries next cycle — no blocking dependency
- Story #2834 (version-bound verify scheme): implemented client-side directly in this PR

## Test plan

- [ ] `make test-agent-complete` passes (verified locally)
- [ ] `make lint` passes (0 issues)
- [ ] `make check-architecture` passes
- [ ] All 6 fail-closed matrix cases pass
- [ ] All 3 convergence integration tests pass

Fixes #2833

🤖 Generated with [Claude Code](https://claude.com/claude-code)