### PR TITLE
controller/api: serve publisher signature headers on public binary GET (Issue #2836)

### DIFF
--- a/features/controller/api/handlers_steward_binary.go
+++ b/features/controller/api/handlers_steward_binary.go
@@ -398,6 +398,15 @@ func (s *Server) handleGetStewardBinaryPublic(w http.ResponseWriter, r *http.Req
 	if meta.Checksum != "" {
 		w.Header().Set("X-CFGMS-SHA256", meta.Checksum)
 	}
+	// Read only the two safe-to-expose labels individually. Never range over meta.Labels
+	// to set headers — the same map holds published_by, publisher_tenant, and
+	// signature_digest which must not be served to unauthenticated callers.
+	if sig := meta.Labels["signature"]; sig != "" {
+		w.Header().Set("X-CFGMS-Signature", sig)
+	}
+	if pub := meta.Labels["publisher"]; pub != "" {
+		w.Header().Set("X-CFGMS-Publisher", pub)
+	}
 	w.WriteHeader(http.StatusOK)
 	if _, copyErr := io.Copy(w, rc); copyErr != nil {
 		s.logger.Warn("Failed to stream steward binary to client (public)", "error", copyErr)

--- a/features/controller/api/handlers_steward_binary_test.go
+++ b/features/controller/api/handlers_steward_binary_test.go
@@ -608,3 +608,201 @@ func TestGetStewardBinary_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, getRec.Code)
 	assert.Contains(t, getRec.Body.String(), "AUTHENTICATION_REQUIRED")
 }
+
+// --- Public endpoint tests (Issue #2836) ---
+
+// doGetPublic calls handleGetStewardBinaryPublic with the required tenant query parameter.
+// No authentication principal is set — the public endpoint is unauthenticated.
+func doGetPublic(server *Server, version, platform, arch, tenantID string) *httptest.ResponseRecorder {
+	q := url.Values{}
+	q.Set("tenant", tenantID)
+	rawURL := "/api/v1/public/steward-binaries/" + version + "/" + platform + "/" + arch + "?" + q.Encode()
+	req := httptest.NewRequest(http.MethodGet, rawURL, nil)
+	req = mux.SetURLVars(req, map[string]string{
+		"version":  version,
+		"platform": platform,
+		"arch":     arch,
+	})
+	rec := httptest.NewRecorder()
+	server.handleGetStewardBinaryPublic(rec, req)
+	return rec
+}
+
+// TestGetStewardBinaryPublic_SignatureRoundTrip publishes a binary, GETs it via the public
+// endpoint, and asserts that X-CFGMS-Signature/X-CFGMS-Publisher/X-CFGMS-SHA256 are all
+// present and equal to the values persisted during publish. (Issue #2836 AC)
+func TestGetStewardBinaryPublic_SignatureRoundTrip(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("steward binary for public endpoint round-trip test")
+	sigBase64 := fix.signContent(content)
+
+	pubRec := doPublish(server, "v1.2.3", "linux", "amd64", "round-trip-tenant", sigBase64, content)
+	require.Equal(t, http.StatusOK, pubRec.Code, "publish must succeed: %s", pubRec.Body.String())
+
+	// Fetch stored metadata to compare against response headers.
+	rc, storedMeta, err := server.blobStore.GetBlob(context.Background(), blob.BlobKey{
+		TenantID:  "round-trip-tenant",
+		Namespace: "steward-binaries",
+		Name:      "v1.2.3-linux-amd64",
+	})
+	require.NoError(t, err)
+	_, _ = io.ReadAll(rc)
+	_ = rc.Close()
+
+	getRec := doGetPublic(server, "v1.2.3", "linux", "amd64", "round-trip-tenant")
+	require.Equal(t, http.StatusOK, getRec.Code, "public GET must succeed: %s", getRec.Body.String())
+
+	h := getRec.Header()
+	assert.Equal(t, storedMeta.Checksum, h.Get("X-CFGMS-SHA256"), "X-CFGMS-SHA256 must match stored checksum")
+	assert.Equal(t, storedMeta.Labels["signature"], h.Get("X-CFGMS-Signature"), "X-CFGMS-Signature must match stored signature label")
+	assert.Equal(t, storedMeta.Labels["publisher"], h.Get("X-CFGMS-Publisher"), "X-CFGMS-Publisher must match stored publisher label")
+
+	// Sanity: all three values must be non-empty.
+	assert.NotEmpty(t, h.Get("X-CFGMS-SHA256"))
+	assert.NotEmpty(t, h.Get("X-CFGMS-Signature"))
+	assert.Equal(t, "cfgms", h.Get("X-CFGMS-Publisher"))
+}
+
+// TestGetStewardBinaryPublic_NoLabelLeakage verifies that the public GET response does not
+// expose the internal blob labels published_by, publisher_tenant, or signature_digest as
+// response headers. Guards against a range-over-Labels implementation leaking operator
+// identity and internal tenant IDs to unauthenticated callers. (Issue #2836 AC)
+func TestGetStewardBinaryPublic_NoLabelLeakage(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("steward binary for label leakage test")
+	sigBase64 := fix.signContent(content)
+
+	// Inject an operator identity so published_by is populated.
+	q := url.Values{}
+	q.Set("signature", sigBase64)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/installer/steward-binaries/v1.0.0/linux/amd64?"+q.Encode(),
+		bytes.NewReader(content))
+	req = withScopedPrincipal(req, "leak-test-tenant")
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.UserIDKey, "operator@example.com"))
+	req = mux.SetURLVars(req, map[string]string{"version": "v1.0.0", "platform": "linux", "arch": "amd64"})
+	pubRec := httptest.NewRecorder()
+	server.handlePublishStewardBinary(pubRec, req)
+	require.Equal(t, http.StatusOK, pubRec.Code, "publish must succeed: %s", pubRec.Body.String())
+
+	getRec := doGetPublic(server, "v1.0.0", "linux", "amd64", "leak-test-tenant")
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	// Internal labels must not appear as response headers.
+	h := getRec.Header()
+	assert.Empty(t, h.Get("X-CFGMS-Published-By"), "published_by must not leak as X-CFGMS-Published-By")
+	assert.Empty(t, h.Get("X-CFGMS-Publisher-Tenant"), "publisher_tenant must not leak as X-CFGMS-Publisher-Tenant")
+	assert.Empty(t, h.Get("X-CFGMS-Signature-Digest"), "signature_digest must not leak as X-CFGMS-Signature-Digest")
+}
+
+// TestGetStewardBinaryPublic_LabelsPreservation_Filesystem verifies that a GetBlob round-trip
+// through the filesystem blob provider preserves the signature and publisher labels that
+// handlePublishStewardBinary stores. (Issue #2836 AC)
+func TestGetStewardBinaryPublic_LabelsPreservation_Filesystem(t *testing.T) {
+	store := newFSBlobStore(t)
+	ctx := context.Background()
+
+	labels := map[string]string{
+		"signature":        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"publisher":        "cfgms",
+		"published_by":     "admin@example.com",
+		"publisher_tenant": "tenant-x",
+		"signature_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	}
+	key := blob.BlobKey{TenantID: "test-tenant", Namespace: "steward-binaries", Name: "v1.0.0-linux-amd64"}
+	err := store.PutBlob(ctx, key, bytes.NewReader([]byte("binary content")), blob.BlobMeta{
+		ContentType: "application/octet-stream",
+		Labels:      labels,
+	})
+	require.NoError(t, err)
+
+	rc, meta, err := store.GetBlob(ctx, key)
+	require.NoError(t, err)
+	_, _ = io.ReadAll(rc)
+	_ = rc.Close()
+
+	assert.Equal(t, labels["signature"], meta.Labels["signature"], "filesystem provider must preserve signature label through GetBlob")
+	assert.Equal(t, labels["publisher"], meta.Labels["publisher"], "filesystem provider must preserve publisher label through GetBlob")
+}
+
+// doGetPublicRaw calls handleGetStewardBinaryPublic without forcing a tenant query
+// parameter, so callers can exercise the MISSING_TENANT branch. When tenantID is empty
+// the tenant query parameter is omitted entirely.
+func doGetPublicRaw(server *Server, version, platform, arch, tenantID string) *httptest.ResponseRecorder {
+	rawURL := "/api/v1/public/steward-binaries/" + version + "/" + platform + "/" + arch
+	if tenantID != "" {
+		q := url.Values{}
+		q.Set("tenant", tenantID)
+		rawURL += "?" + q.Encode()
+	}
+	req := httptest.NewRequest(http.MethodGet, rawURL, nil)
+	req = mux.SetURLVars(req, map[string]string{
+		"version":  version,
+		"platform": platform,
+		"arch":     arch,
+	})
+	rec := httptest.NewRecorder()
+	server.handleGetStewardBinaryPublic(rec, req)
+	return rec
+}
+
+// TestHandleGetStewardBinaryPublic_NoBlobStore verifies the public GET handler returns
+// 503 SERVICE_UNAVAILABLE when no blob store is wired. Analog of
+// TestHandleGetStewardBinary_NoBlobStore for the unauthenticated endpoint. (Issue #2836)
+func TestHandleGetStewardBinaryPublic_NoBlobStore(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := doGetPublicRaw(server, "v1.0.0", "linux", "amd64", "test-tenant")
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), "SERVICE_UNAVAILABLE")
+}
+
+// TestHandleGetStewardBinaryPublic_MissingTenant verifies the public GET handler returns
+// 400 MISSING_TENANT when the required tenant query parameter is absent. This branch has
+// no analog on the authenticated endpoint (which derives tenant from the principal) and
+// must be covered directly. (Issue #2836)
+func TestHandleGetStewardBinaryPublic_MissingTenant(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	rec := doGetPublicRaw(server, "v1.0.0", "linux", "amd64", "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "MISSING_TENANT")
+}
+
+// TestHandleGetStewardBinaryPublic_ErrorPaths verifies the public GET handler validation
+// branches for version, platform, and arch. Analog of TestHandleGetStewardBinary_ErrorPaths
+// for the unauthenticated endpoint. (Issue #2836)
+func TestHandleGetStewardBinaryPublic_ErrorPaths(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	t.Run("invalid version returns 400", func(t *testing.T) {
+		rec := doGetPublicRaw(server, "1.0.0", "linux", "amd64", "test-tenant")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_VERSION")
+	})
+
+	t.Run("invalid platform returns 400", func(t *testing.T) {
+		rec := doGetPublicRaw(server, "v1.0.0", "solaris", "amd64", "test-tenant")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_PLATFORM")
+	})
+
+	t.Run("invalid arch returns 400", func(t *testing.T) {
+		rec := doGetPublicRaw(server, "v1.0.0", "linux", "ppc64", "test-tenant")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_ARCH")
+	})
+}
+
+// TestHandleGetStewardBinaryPublic_Returns404WhenAbsent verifies the public GET handler
+// returns 404 BINARY_NOT_FOUND for a missing binary. Analog of
+// TestHandleGetStewardBinary_Returns404WhenAbsent for the unauthenticated endpoint. (Issue #2836)
+func TestHandleGetStewardBinaryPublic_Returns404WhenAbsent(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	rec := doGetPublicRaw(server, "v9.9.9", "linux", "amd64", "test-tenant")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "BINARY_NOT_FOUND")
+}

--- a/features/workflow/trigger/siem.go
+++ b/features/workflow/trigger/siem.go
@@ -87,14 +87,24 @@ func (sp *SIEMProcessor) Start(ctx context.Context) error {
 		"buffer_size", sp.bufferSize,
 		"cleanup_interval", sp.cleanupInterval.String())
 
+	// Recreate stopChan so that a processor which was previously stopped (which
+	// closes stopChan) can be started again with a fresh signal channel.
+	sp.stopChan = make(chan struct{})
 	sp.logBuffer = make(chan LogEntry, sp.bufferSize)
 	sp.running = true
 
+	// Capture the freshly created channels as locals and hand them to the
+	// worker goroutines. The goroutines must not read sp.logBuffer / sp.stopChan
+	// directly: a subsequent Start would reassign those fields under the mutex
+	// while these goroutines read them without the lock, which is a data race.
+	logBuffer := sp.logBuffer
+	stopChan := sp.stopChan
+
 	// Start log processing goroutine
-	go sp.processLogEntries(ctx)
+	go sp.processLogEntries(ctx, logBuffer, stopChan)
 
 	// Start cleanup goroutine
-	go sp.cleanupAggregationData(ctx)
+	go sp.cleanupAggregationData(ctx, stopChan)
 
 	logger.InfoCtx(ctx, "SIEM processor started successfully")
 	return nil
@@ -237,8 +247,10 @@ func (sp *SIEMProcessor) ProcessLogEntry(ctx context.Context, logEntry map[strin
 	}
 }
 
-// processLogEntries processes log entries from the buffer
-func (sp *SIEMProcessor) processLogEntries(ctx context.Context) {
+// processLogEntries processes log entries from the buffer. The logBuffer and stopChan
+// channels are passed in by Start rather than read from the receiver so that a subsequent
+// Start reassigning sp.logBuffer / sp.stopChan cannot race with this goroutine.
+func (sp *SIEMProcessor) processLogEntries(ctx context.Context, logBuffer <-chan LogEntry, stopChan <-chan struct{}) {
 	tenantID := logging.ExtractTenantFromContext(ctx)
 	logger := sp.logger.WithTenant(tenantID)
 
@@ -249,10 +261,10 @@ func (sp *SIEMProcessor) processLogEntries(ctx context.Context) {
 		case <-ctx.Done():
 			logger.InfoCtx(ctx, "Log entry processing stopped due to context cancellation")
 			return
-		case <-sp.stopChan:
+		case <-stopChan:
 			logger.InfoCtx(ctx, "Log entry processing stopped due to stop signal")
 			return
-		case entry, ok := <-sp.logBuffer:
+		case entry, ok := <-logBuffer:
 			if !ok {
 				logger.InfoCtx(ctx, "Log buffer closed, stopping processing")
 				return
@@ -743,8 +755,10 @@ func (sp *SIEMProcessor) resetAggregationWindow(triggerID string) {
 	aggData.LastUpdated = time.Now()
 }
 
-// cleanupAggregationData periodically cleans up old aggregation data
-func (sp *SIEMProcessor) cleanupAggregationData(ctx context.Context) {
+// cleanupAggregationData periodically cleans up old aggregation data. stopChan is passed
+// in by Start rather than read from the receiver so a subsequent Start reassigning
+// sp.stopChan cannot race with this goroutine.
+func (sp *SIEMProcessor) cleanupAggregationData(ctx context.Context, stopChan <-chan struct{}) {
 	ticker := time.NewTicker(sp.cleanupInterval)
 	defer ticker.Stop()
 
@@ -755,7 +769,7 @@ func (sp *SIEMProcessor) cleanupAggregationData(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-sp.stopChan:
+		case <-stopChan:
 			return
 		case <-ticker.C:
 			sp.performCleanup(ctx, logger)

--- a/pkg/storage/providers/blobstore/s3/plugin_test.go
+++ b/pkg/storage/providers/blobstore/s3/plugin_test.go
@@ -521,6 +521,38 @@ func TestS3BlobStore_PathTraversal(t *testing.T) {
 	})
 }
 
+// TestS3BlobStore_LabelsPreservation_SignatureAndPublisher verifies that a GetBlob
+// round-trip through the S3 provider preserves the signature and publisher labels
+// that handlePublishStewardBinary stores. (Issue #2836 AC)
+func TestS3BlobStore_LabelsPreservation_SignatureAndPublisher(t *testing.T) {
+	store := newTestS3Store(t)
+	ctx := context.Background()
+
+	labels := map[string]string{
+		"signature":        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"publisher":        "cfgms",
+		"published_by":     "admin@example.com",
+		"publisher_tenant": "tenant-x",
+		"signature_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	}
+	key := blob.BlobKey{TenantID: "tenant-a", Namespace: "steward-binaries", Name: "v1.0.0-linux-amd64"}
+	err := store.PutBlob(ctx, key, bytes.NewReader([]byte("binary content")), blob.BlobMeta{
+		ContentType: "application/octet-stream",
+		Labels:      labels,
+	})
+	require.NoError(t, err)
+
+	rc, meta, err := store.GetBlob(ctx, key)
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	_, err = io.ReadAll(rc)
+	require.NoError(t, err)
+
+	assert.Equal(t, labels["signature"], meta.Labels["signature"], "S3 provider must preserve signature label through GetBlob")
+	assert.Equal(t, labels["publisher"], meta.Labels["publisher"], "S3 provider must preserve publisher label through GetBlob")
+	assert.Equal(t, labels, meta.Labels, "S3 provider must preserve all labels through GetBlob")
+}
+
 // TestS3BlobStore_ListBlobs_SidecarError verifies that ListBlobs returns an error
 // when fetchSidecar fails with a non-not-found error (e.g., parse failure).
 // Orphaned blobs (missing sidecar) are silently skipped; unexpected errors surface.


### PR DESCRIPTION
## Summary

- Adds `X-CFGMS-Signature` and `X-CFGMS-Publisher` response headers to `handleGetStewardBinaryPublic` (the unauthenticated steward-reachable endpoint), read from the already-persisted `BlobMeta.Labels` by exact key name — never by ranging over the map.
- Confirms the S3 blob provider already preserves `Labels` through `GetBlob` (via JSON sidecar); adds an explicit test covering both filesystem and S3 providers.
- Fixes a data race in `SIEMProcessor.Start` where goroutines were reading `sp.logBuffer`/`sp.stopChan` directly from the receiver while a subsequent `Start` could reassign those fields under the mutex.

Fixes #2836

## Review results

| Lens | Round 1 | Round 2 |
|------|---------|---------|
| Code review | FAIL | PASS |
| Test quality | FAIL | PASS |
| Security | PASS | — |

All lenses passed after 1 fix round. No remaining findings.

## Test plan

- [ ] `TestGetStewardBinaryPublic_SignatureRoundTrip` — publish → public GET → all three headers match persisted BlobMeta values
- [ ] `TestGetStewardBinaryPublic_NoLabelLeakage` — `published_by`/`publisher_tenant`/`signature_digest` absent from public response headers
- [ ] `TestGetStewardBinaryPublic_LabelsPreservation_Filesystem` — filesystem GetBlob round-trip preserves signature/publisher labels
- [ ] `TestS3BlobStore_LabelsPreservation_SignatureAndPublisher` — S3 GetBlob round-trip preserves all labels including signature/publisher
- [ ] `TestHandleGetStewardBinaryPublic_ErrorPaths` — validation branches on public endpoint
- [ ] `TestHandleGetStewardBinaryPublic_Returns404WhenAbsent` — 404 for missing binary on public endpoint
- [ ] All existing `handlers_steward_binary_test.go` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)