### PR TITLE
controller: serve publisher signature + publisher headers on public steward-binary GET (#2836)

### DIFF
--- a/features/controller/api/handlers_steward_binary.go
+++ b/features/controller/api/handlers_steward_binary.go
@@ -398,6 +398,18 @@ func (s *Server) handleGetStewardBinaryPublic(w http.ResponseWriter, r *http.Req
 	if meta.Checksum != "" {
 		w.Header().Set("X-CFGMS-SHA256", meta.Checksum)
 	}
+	// Serve the publisher signature so a self-fetching steward can verify the
+	// publisher identity independently of the controller-attested SHA-256 (#2836).
+	// Read the two keys individually by name — never range over meta.Labels: the
+	// same map also holds published_by (operator identity), publisher_tenant, and
+	// signature_digest, and this endpoint is unauthenticated, so a blanket
+	// label→header copy would leak operator/tenant identity to anonymous callers.
+	if sig := meta.Labels["signature"]; sig != "" {
+		w.Header().Set("X-CFGMS-Signature", sig)
+	}
+	if pub := meta.Labels["publisher"]; pub != "" {
+		w.Header().Set("X-CFGMS-Publisher", pub)
+	}
 	w.WriteHeader(http.StatusOK)
 	if _, copyErr := io.Copy(w, rc); copyErr != nil {
 		s.logger.Warn("Failed to stream steward binary to client (public)", "error", copyErr)

--- a/features/controller/api/handlers_steward_binary_test.go
+++ b/features/controller/api/handlers_steward_binary_test.go
@@ -191,6 +191,69 @@ func TestPublishEndpoint_RejectsVersionBindingMismatch(t *testing.T) {
 	}
 }
 
+// TestGetStewardBinaryPublic_ServesSignatureHeaders is the #2836 round-trip: publish a
+// binary, GET it via the public endpoint, and assert the publisher signature and identity
+// are served as headers alongside the SHA-256, equal to the persisted values — so a
+// self-fetching steward (#2833) can verify the publisher independently.
+func TestGetStewardBinaryPublic_ServesSignatureHeaders(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("steward binary for public-header round-trip")
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
+
+	pubRec := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
+	require.Equal(t, http.StatusOK, pubRec.Code, "publish must succeed: %s", pubRec.Body.String())
+
+	getRec := doGetStewardBinaryPublic(server, "v1.0.0", "linux", "amd64", "test-tenant")
+	require.Equal(t, http.StatusOK, getRec.Code, "public GET must succeed: %s", getRec.Body.String())
+
+	assert.Equal(t, sigBase64, getRec.Header().Get("X-CFGMS-Signature"),
+		"X-CFGMS-Signature must equal the persisted (base64url) publisher signature")
+	assert.Equal(t, "cfgms", getRec.Header().Get("X-CFGMS-Publisher"),
+		"X-CFGMS-Publisher must equal the persisted publisher identity")
+	assert.NotEmpty(t, getRec.Header().Get("X-CFGMS-SHA256"),
+		"existing X-CFGMS-SHA256 header must still be served")
+	assert.Equal(t, content, getRec.Body.Bytes(), "public GET must return the exact bytes")
+}
+
+// TestGetStewardBinaryPublic_DoesNotLeakSensitiveLabels guards the security invariant that
+// header emission reads the two signature keys individually and never ranges over the
+// blob's Labels map. The same map on this UNAUTHENTICATED endpoint also holds the operator
+// identity (published_by) and internal tenant IDs (publisher_tenant, signature_digest); a
+// blanket label→header copy would disclose them to any anonymous caller.
+func TestGetStewardBinaryPublic_DoesNotLeakSensitiveLabels(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("steward binary for label-leak guard")
+	sigBase64 := fix.signContent(content, "v1.0.0", "linux", "amd64")
+
+	pubRec := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
+	require.Equal(t, http.StatusOK, pubRec.Code, "publish must succeed: %s", pubRec.Body.String())
+
+	getRec := doGetStewardBinaryPublic(server, "v1.0.0", "linux", "amd64", "test-tenant")
+	require.Equal(t, http.StatusOK, getRec.Code, "public GET must succeed: %s", getRec.Body.String())
+
+	// None of the sensitive labels may surface as a response header, under any casing or the
+	// hypothetical X-CFGMS-<label> form a range-over-Labels implementation would produce.
+	for _, sensitive := range []string{"published_by", "publisher_tenant", "signature_digest"} {
+		for _, name := range []string{
+			sensitive,
+			"X-CFGMS-" + sensitive,
+			"X-Cfgms-" + sensitive,
+		} {
+			assert.Empty(t, getRec.Header().Get(name),
+				"sensitive label %q must not be served as header %q", sensitive, name)
+		}
+	}
+	// And the whole header set must not contain the operator identity value anywhere.
+	for k, vals := range getRec.Header() {
+		for _, v := range vals {
+			assert.NotContains(t, v, "cfgms-admin",
+				"operator identity must not leak via header %q", k)
+		}
+	}
+}
+
 // TestPublishEndpoint_RejectsCrossTenantPublish verifies that a caller without
 // installer:publish:steward permission receives 403. This demonstrates tenant-namespace
 // isolation: a key scoped to tenant-b (without the required permission) cannot publish

--- a/pkg/storage/providers/blobstore/filesystem/plugin_test.go
+++ b/pkg/storage/providers/blobstore/filesystem/plugin_test.go
@@ -30,6 +30,28 @@ func testKey(name string) blob.BlobKey {
 	}
 }
 
+// TestFilesystemBlobStore_PreservesSignatureLabels verifies the steward-binary
+// signature/publisher labels survive a GetBlob round-trip, so the public GET handler
+// can serve them as headers (#2836).
+func TestFilesystemBlobStore_PreservesSignatureLabels(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	labels := map[string]string{
+		"signature": "cVBzcy1zaWduYXR1cmUtYnl0ZXM",
+		"publisher": "cfgms",
+	}
+	key := testKey("steward.bin")
+	require.NoError(t, s.PutBlob(ctx, key, bytes.NewReader([]byte("bin")), blob.BlobMeta{Labels: labels}))
+
+	rc, gotMeta, err := s.GetBlob(ctx, key)
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	assert.Equal(t, "cVBzcy1zaWduYXR1cmUtYnl0ZXM", gotMeta.Labels["signature"])
+	assert.Equal(t, "cfgms", gotMeta.Labels["publisher"])
+}
+
 // TestFilesystemBlobStore_PutGetBlob verifies a basic roundtrip.
 func TestFilesystemBlobStore_PutGetBlob(t *testing.T) {
 	s := newTestStore(t)

--- a/pkg/storage/providers/blobstore/s3/plugin_test.go
+++ b/pkg/storage/providers/blobstore/s3/plugin_test.go
@@ -168,6 +168,28 @@ func testS3Key(name string) blob.BlobKey {
 	}
 }
 
+// TestS3BlobStore_PreservesSignatureLabels verifies the steward-binary signature/publisher
+// labels survive a GetBlob round-trip through the S3 sidecar, so the public GET handler can
+// serve them as headers in a production (non-filesystem) deployment (#2836).
+func TestS3BlobStore_PreservesSignatureLabels(t *testing.T) {
+	store := newTestS3Store(t)
+	ctx := context.Background()
+
+	labels := map[string]string{
+		"signature": "cVBzcy1zaWduYXR1cmUtYnl0ZXM",
+		"publisher": "cfgms",
+	}
+	key := testS3Key("steward.bin")
+	require.NoError(t, store.PutBlob(ctx, key, bytes.NewReader([]byte("bin")), blob.BlobMeta{Labels: labels}))
+
+	rc, gotMeta, err := store.GetBlob(ctx, key)
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	assert.Equal(t, "cVBzcy1zaWduYXR1cmUtYnl0ZXM", gotMeta.Labels["signature"])
+	assert.Equal(t, "cfgms", gotMeta.Labels["publisher"])
+}
+
 // TestS3BlobStore_PutGetBlob verifies a basic roundtrip.
 func TestS3BlobStore_PutGetBlob(t *testing.T) {
 	store := newTestS3Store(t)


### PR DESCRIPTION
## Summary

Serves the publisher Ed25519 signature and publisher identity as HTTP response headers on the public steward-binary GET endpoint, so a self-fetching steward (Issue #2833) can verify a downloaded binary without a second round-trip. Second story in the version-management stack (#2834 → #2836 → #2833).

## Changes

- `handleGetStewardBinaryPublic` now sets `X-CFGMS-Signature`, `X-CFGMS-Publisher`, and `X-CFGMS-SHA256` from the stored binary metadata. Headers are read individually from `meta.Labels` (never ranged over), so no internal-only label (`published_by`, `publisher_tenant`, `signature_digest`) can leak into the response.

## Testing

- Unit + handler tests for header presence and non-leak of internal labels.
- Live-proven on ctrl-01: public GET returns the three headers; no internal labels present in the response.
- Consumed end-to-end by the #2833 self-fetch live e2e on cluster node CFG-C3-02 (a steward downloaded and header-verified a self-fetched v0.9.46 binary).

Fixes #2836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>