### PR TITLE
workflow/siem: fix SIEMProcessor Start/Stop data race + broken restart (#2864)

### DIFF
--- a/features/workflow/trigger/siem.go
+++ b/features/workflow/trigger/siem.go
@@ -87,14 +87,24 @@ func (sp *SIEMProcessor) Start(ctx context.Context) error {
 		"buffer_size", sp.bufferSize,
 		"cleanup_interval", sp.cleanupInterval.String())
 
+	// Recreate stopChan so that a processor which was previously stopped (which
+	// closes stopChan) can be started again with a fresh signal channel.
+	sp.stopChan = make(chan struct{})
 	sp.logBuffer = make(chan LogEntry, sp.bufferSize)
 	sp.running = true
 
+	// Capture the freshly created channels as locals and hand them to the
+	// worker goroutines. The goroutines must not read sp.logBuffer / sp.stopChan
+	// directly: a subsequent Start would reassign those fields under the mutex
+	// while these goroutines read them without the lock, which is a data race.
+	logBuffer := sp.logBuffer
+	stopChan := sp.stopChan
+
 	// Start log processing goroutine
-	go sp.processLogEntries(ctx)
+	go sp.processLogEntries(ctx, logBuffer, stopChan)
 
 	// Start cleanup goroutine
-	go sp.cleanupAggregationData(ctx)
+	go sp.cleanupAggregationData(ctx, stopChan)
 
 	logger.InfoCtx(ctx, "SIEM processor started successfully")
 	return nil
@@ -237,8 +247,10 @@ func (sp *SIEMProcessor) ProcessLogEntry(ctx context.Context, logEntry map[strin
 	}
 }
 
-// processLogEntries processes log entries from the buffer
-func (sp *SIEMProcessor) processLogEntries(ctx context.Context) {
+// processLogEntries processes log entries from the buffer. The logBuffer and stopChan
+// channels are passed in by Start rather than read from the receiver so that a subsequent
+// Start reassigning sp.logBuffer / sp.stopChan cannot race with this goroutine.
+func (sp *SIEMProcessor) processLogEntries(ctx context.Context, logBuffer <-chan LogEntry, stopChan <-chan struct{}) {
 	tenantID := logging.ExtractTenantFromContext(ctx)
 	logger := sp.logger.WithTenant(tenantID)
 
@@ -249,10 +261,10 @@ func (sp *SIEMProcessor) processLogEntries(ctx context.Context) {
 		case <-ctx.Done():
 			logger.InfoCtx(ctx, "Log entry processing stopped due to context cancellation")
 			return
-		case <-sp.stopChan:
+		case <-stopChan:
 			logger.InfoCtx(ctx, "Log entry processing stopped due to stop signal")
 			return
-		case entry, ok := <-sp.logBuffer:
+		case entry, ok := <-logBuffer:
 			if !ok {
 				logger.InfoCtx(ctx, "Log buffer closed, stopping processing")
 				return
@@ -743,8 +755,10 @@ func (sp *SIEMProcessor) resetAggregationWindow(triggerID string) {
 	aggData.LastUpdated = time.Now()
 }
 
-// cleanupAggregationData periodically cleans up old aggregation data
-func (sp *SIEMProcessor) cleanupAggregationData(ctx context.Context) {
+// cleanupAggregationData periodically cleans up old aggregation data. stopChan is passed
+// in by Start rather than read from the receiver so a subsequent Start reassigning
+// sp.stopChan cannot race with this goroutine.
+func (sp *SIEMProcessor) cleanupAggregationData(ctx context.Context, stopChan <-chan struct{}) {
 	ticker := time.NewTicker(sp.cleanupInterval)
 	defer ticker.Stop()
 
@@ -755,7 +769,7 @@ func (sp *SIEMProcessor) cleanupAggregationData(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-sp.stopChan:
+		case <-stopChan:
 			return
 		case <-ticker.C:
 			sp.performCleanup(ctx, logger)

--- a/features/workflow/trigger/siem_test.go
+++ b/features/workflow/trigger/siem_test.go
@@ -58,6 +58,49 @@ func TestSIEMProcessor_StartStop(t *testing.T) {
 	assert.Contains(t, err.Error(), "SIEM processor is not running")
 }
 
+// TestSIEMProcessor_RestartRecreatesStopChan proves Start installs a fresh stopChan on
+// every start, so a processor that was stopped (which closes stopChan) can be started
+// again with worker goroutines that do NOT immediately exit on a stale, already-closed
+// stopChan. Without the recreate, a restarted processor's workers select the closed
+// stopChan on their first loop and return, silently doing no work.
+//
+// Regression guard salvaged from closed PR #2849 (the header work there duplicated #2836,
+// but this SIEM fix was unique and unmerged).
+func TestSIEMProcessor_RestartRecreatesStopChan(t *testing.T) {
+	processor := NewSIEMProcessor(&MockTriggerManager{}, &MockWorkflowTrigger{})
+	ctx := context.Background()
+
+	require.NoError(t, processor.Start(ctx))
+	require.NoError(t, processor.Stop(ctx))
+
+	// Restart: Start must install a fresh, open stopChan.
+	require.NoError(t, processor.Start(ctx))
+	select {
+	case <-processor.stopChan:
+		t.Fatal("stopChan is closed after restart; Start must recreate it so restarted workers do not exit immediately")
+	default:
+		// open, as required
+	}
+	require.NoError(t, processor.Stop(ctx))
+}
+
+// TestSIEMProcessor_StartStopRestartRaceFree exercises repeated start/stop restart cycles
+// so the -race detector catches any lock-free read of sp.logBuffer / sp.stopChan by the
+// worker goroutines while a subsequent Start reassigns those fields under the mutex. The
+// fix hands the freshly created channels to the goroutines as locals; the worker loops
+// must never read the receiver fields. Run with `-race` for this to have teeth.
+func TestSIEMProcessor_StartStopRestartRaceFree(t *testing.T) {
+	processor := NewSIEMProcessor(&MockTriggerManager{}, &MockWorkflowTrigger{})
+	processor.cleanupInterval = time.Millisecond // frequent cleanup ticks widen the race window
+	ctx := context.Background()
+
+	for i := 0; i < 8; i++ {
+		require.NoError(t, processor.Start(ctx))
+		time.Sleep(2 * time.Millisecond) // let both worker goroutines enter their select loops
+		require.NoError(t, processor.Stop(ctx))
+	}
+}
+
 func TestSIEMProcessor_RegisterSIEMTrigger(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	mockWorkflowTrigger := &MockWorkflowTrigger{}


### PR DESCRIPTION
## Summary

Fixes a data race and a broken-restart bug in `SIEMProcessor` (`features/workflow/trigger/siem.go`).

**Salvaged from closed PR #2849.** That PR was a parallel implementation of #2836 whose publisher-header work landed via #2856 (so #2849 was closed as a duplicate), but it also carried this unrelated SIEM fix — which was unmerged and untested. This PR preserves just the fix and adds the regression test #2849 lacked.

## The bugs

1. **Data race on restart.** `Start` reassigns `sp.logBuffer` / `sp.stopChan` under `sp.mutex`, but the worker goroutines (`processLogEntries`, `cleanupAggregationData`) read those fields from the receiver **lock-free**. A later `Start` reassigns them while lingering workers from a prior cycle still read them → data race (confirmed by `-race`).
2. **Restart silently does nothing.** `Start` never recreated `stopChan` while `Stop` closes it. A restarted processor's workers select the already-closed `stopChan` on their first loop iteration and return immediately.

## The fix

- `Start` recreates `stopChan` on each start.
- `Start` captures the fresh `logBuffer` / `stopChan` as locals and passes them to the workers as parameters; the workers no longer read the receiver fields, so a later `Start` cannot race with them.

## Testing

- `TestSIEMProcessor_RestartRecreatesStopChan` — after a restart, `stopChan` must be open (fails on pre-fix code: "stopChan is closed after restart").
- `TestSIEMProcessor_StartStopRestartRaceFree` — repeated start/stop cycles; under `-race` this fires `WARNING: DATA RACE` on pre-fix code.
- Verified both tests **fail on develop's unfixed `siem.go`** and **pass on the fix**; full `features/workflow/trigger` package green under `-race`.

Fixes #2864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>