### PR TITLE
storage: add business.AssurancePolicyStore with database and sqlite providers (Issue #2845)

### DIFF
--- a/docs/architecture/decisions/021-identity-assurance-levels.md
+++ b/docs/architecture/decisions/021-identity-assurance-levels.md
@@ -486,3 +486,29 @@ These do not block decomposition and are config, not design:
    is invisible to the operator, so it can be aggressive at no UX cost. When silent
    proof is impossible (no credential available on this device), fall back to
    `AssuranceBasic` and step up on the next sensitive action.
+
+---
+
+## Per-tenant tightening of `permissionAssurance` (Issue #2845)
+
+The `permissionAssurance` map in `features/controller/api` is a global registry —
+the same floor applies to every tenant. Operators may need stricter floors for
+specific tenants (e.g. a managed tenant with elevated security requirements).
+
+**Storage substrate (Issue #2845):** `business.AssurancePolicyStore`, defined in
+`pkg/storage/interfaces/business`, stores a set of `AssurancePolicyOverride`
+entries per tenant. Each entry carries a `PermissionID`, an optional `MinOverride`
+(`*int`, mirroring `session.AssuranceLevel` values: 0=Machine, 1=Basic, 2=Strong),
+and a `RequireUserPresence` flag. The store is wired for the `database`
+(PostgreSQL) and `sqlite` providers only — the `git`/SOPS config-storage path is
+untouched, matching the precedent set by `RefreshPolicyStore`.
+
+`SetPolicy` replaces the tenant's **entire** override set in one call (full-replace
+/ PUT semantics). `GetPolicy` returns `{TenantID: id, Overrides: nil}` without
+error when no record exists — absence and "no override" are equivalent.
+
+**Resolution (follow-on story):** A follow-on story resolves the per-tenant
+overrides root→leaf against the global `permissionAssurance` map so that
+`requirePermission` and `scanAPIKeysForPrivilegedAccess` enforce the stricter of
+the global floor and any ancestor-chain override. Until that story lands,
+`permissionAssurance` is the sole source of truth.

--- a/pkg/storage/interfaces/business/assurance_policy_store.go
+++ b/pkg/storage/interfaces/business/assurance_policy_store.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package business defines the AssurancePolicyStore interface for per-tenant
+// identity-assurance policy overrides (ADR-021, Issue #2845).
+package business
+
+import "context"
+
+// AssurancePolicyOverride configures a per-permission assurance floor override
+// for a given tenant.
+//
+// MinOverride mirrors the underlying integer values of session.AssuranceLevel
+// (0=Machine, 1=Basic, 2=Strong). Callers in features/controller/api are
+// responsible for converting between the two; this package does not import
+// pkg/session to avoid adding a cross-package dependency for a single int type.
+type AssurancePolicyOverride struct {
+	// PermissionID is the RBAC permission identifier this override applies to.
+	PermissionID string
+
+	// MinOverride, when non-nil, replaces the global permissionAssurance floor
+	// for PermissionID within this tenant. Values mirror session.AssuranceLevel
+	// (0=Machine, 1=Basic, 2=Strong); callers convert before storage.
+	MinOverride *int
+
+	// RequireUserPresence, when true, mandates user-presence verification for
+	// PermissionID within this tenant regardless of the assurance level.
+	RequireUserPresence bool
+}
+
+// AssurancePolicy is the full set of per-permission overrides for a single tenant.
+type AssurancePolicy struct {
+	// TenantID identifies the tenant this policy applies to.
+	TenantID string
+
+	// Overrides is the list of per-permission overrides. A nil or empty slice
+	// means no overrides are in effect for this tenant (global defaults apply).
+	Overrides []AssurancePolicyOverride
+}
+
+// AssurancePolicyStore defines the storage interface for per-tenant assurance-policy
+// overrides (ADR-021, Issue #2845).
+type AssurancePolicyStore interface {
+	// GetPolicy returns the assurance-policy overrides for the given tenant.
+	// When no record exists, it returns {TenantID: tenantID, Overrides: nil}
+	// without error — "no override" and "no data" are equivalent here.
+	GetPolicy(ctx context.Context, tenantID string) (*AssurancePolicy, error)
+
+	// SetPolicy replaces the tenant's full override set in one call.
+	// A nil policy or empty TenantID returns an error.
+	// A SetPolicy call with an empty Overrides slice clears all overrides for
+	// the tenant (full-replace semantics).
+	SetPolicy(ctx context.Context, policy *AssurancePolicy) error
+}

--- a/pkg/storage/interfaces/business/assurance_policy_store_test.go
+++ b/pkg/storage/interfaces/business/assurance_policy_store_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package business_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemAssurancePolicyStore is a minimal in-memory AssurancePolicyStore for
+// contract tests.
+type inMemAssurancePolicyStore struct {
+	mu       sync.RWMutex
+	policies map[string]*business.AssurancePolicy
+}
+
+func newInMemAssurancePolicyStore() business.AssurancePolicyStore {
+	return &inMemAssurancePolicyStore{policies: make(map[string]*business.AssurancePolicy)}
+}
+
+func (s *inMemAssurancePolicyStore) GetPolicy(_ context.Context, tenantID string) (*business.AssurancePolicy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.policies[tenantID]
+	if !ok {
+		return &business.AssurancePolicy{TenantID: tenantID, Overrides: nil}, nil
+	}
+	cp := business.AssurancePolicy{TenantID: p.TenantID}
+	if len(p.Overrides) > 0 {
+		cp.Overrides = make([]business.AssurancePolicyOverride, len(p.Overrides))
+		for i, o := range p.Overrides {
+			cp.Overrides[i] = o
+			if o.MinOverride != nil {
+				v := *o.MinOverride
+				cp.Overrides[i].MinOverride = &v
+			}
+		}
+	}
+	return &cp, nil
+}
+
+func (s *inMemAssurancePolicyStore) SetPolicy(_ context.Context, policy *business.AssurancePolicy) error {
+	if policy == nil {
+		return errStr("nil policy")
+	}
+	if policy.TenantID == "" {
+		return errStr("empty tenant_id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := business.AssurancePolicy{TenantID: policy.TenantID}
+	if len(policy.Overrides) > 0 {
+		cp.Overrides = make([]business.AssurancePolicyOverride, len(policy.Overrides))
+		for i, o := range policy.Overrides {
+			cp.Overrides[i] = o
+			if o.MinOverride != nil {
+				v := *o.MinOverride
+				cp.Overrides[i].MinOverride = &v
+			}
+		}
+	}
+	s.policies[policy.TenantID] = &cp
+	return nil
+}
+
+// Compile-time assertion.
+var _ business.AssurancePolicyStore = (*inMemAssurancePolicyStore)(nil)
+
+// --- Contract tests ---
+
+func TestAssurancePolicyStore_DefaultEmpty_Contract(t *testing.T) {
+	store := newInMemAssurancePolicyStore()
+
+	got, err := store.GetPolicy(context.Background(), "tenant-absent")
+	require.NoError(t, err, "absent record must not be an error")
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-absent", got.TenantID)
+	assert.Nil(t, got.Overrides, "Overrides must default to nil when no record exists")
+}
+
+func TestAssurancePolicyStore_SetAndGet_Contract(t *testing.T) {
+	store := newInMemAssurancePolicyStore()
+	ctx := context.Background()
+
+	min1 := 2 // Strong
+	require.NoError(t, store.SetPolicy(ctx, &business.AssurancePolicy{
+		TenantID: "tenant-ap-1",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:write", MinOverride: &min1, RequireUserPresence: true},
+			{PermissionID: "perm:read"},
+		},
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-ap-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-ap-1", got.TenantID)
+	require.Len(t, got.Overrides, 2)
+	assert.Equal(t, "perm:write", got.Overrides[0].PermissionID)
+	require.NotNil(t, got.Overrides[0].MinOverride)
+	assert.Equal(t, 2, *got.Overrides[0].MinOverride)
+	assert.True(t, got.Overrides[0].RequireUserPresence)
+	assert.Equal(t, "perm:read", got.Overrides[1].PermissionID)
+}
+
+func TestAssurancePolicyStore_SetReplacesExisting_Contract(t *testing.T) {
+	store := newInMemAssurancePolicyStore()
+	ctx := context.Background()
+
+	min1 := 1
+	require.NoError(t, store.SetPolicy(ctx, &business.AssurancePolicy{
+		TenantID: "tenant-ap-upd",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:admin", MinOverride: &min1},
+			{PermissionID: "perm:read"},
+		},
+	}))
+
+	// Second call drops perm:admin and perm:read, replaces with perm:write.
+	min2 := 2
+	require.NoError(t, store.SetPolicy(ctx, &business.AssurancePolicy{
+		TenantID: "tenant-ap-upd",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:write", MinOverride: &min2},
+		},
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-ap-upd")
+	require.NoError(t, err)
+	require.Len(t, got.Overrides, 1, "second SetPolicy must fully replace first")
+	assert.Equal(t, "perm:write", got.Overrides[0].PermissionID)
+	require.NotNil(t, got.Overrides[0].MinOverride)
+	assert.Equal(t, 2, *got.Overrides[0].MinOverride)
+}
+
+func TestAssurancePolicyStore_SetNilPolicy_Contract(t *testing.T) {
+	store := newInMemAssurancePolicyStore()
+	err := store.SetPolicy(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestAssurancePolicyStore_SetEmptyTenantID_Contract(t *testing.T) {
+	store := newInMemAssurancePolicyStore()
+	err := store.SetPolicy(context.Background(), &business.AssurancePolicy{
+		Overrides: []business.AssurancePolicyOverride{{PermissionID: "perm:read"}},
+	})
+	require.Error(t, err)
+}

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -48,8 +48,9 @@ type BusinessStoreBundle struct {
 	Push                business.PushStore
 	PendingRegistration business.PendingRegistrationStore
 	IPTrust             business.IPTrustStore
-	PendingRefresh      business.PendingRefreshStore // Issue #2098: registration-refresh approval queue
-	RefreshPolicy       business.RefreshPolicyStore  // Issue #2098: per-tenant refresh policy
+	PendingRefresh      business.PendingRefreshStore  // Issue #2098: registration-refresh approval queue
+	RefreshPolicy       business.RefreshPolicyStore   // Issue #2098: per-tenant refresh policy
+	AssurancePolicy     business.AssurancePolicyStore // Issue #2845: per-tenant assurance-policy overrides
 }
 
 // BusinessStoreOpener is an optional StorageProvider extension. A provider that
@@ -66,6 +67,13 @@ type BusinessStoreOpener interface {
 type RefreshStoreCreator interface {
 	CreateRefreshPolicyStore(config map[string]interface{}) (business.RefreshPolicyStore, error)
 	CreatePendingRefreshStore(config map[string]interface{}) (business.PendingRefreshStore, error)
+}
+
+// AssuranceStoreCreator is an optional StorageProvider extension for backends that
+// support per-tenant assurance-policy overrides (Issue #2845, ADR-021).
+// Backends that do not implement this interface leave the store nil in the manager.
+type AssuranceStoreCreator interface {
+	CreateAssurancePolicyStore(config map[string]interface{}) (business.AssurancePolicyStore, error)
 }
 
 // StorageProvider defines the interface that all storage backends must implement.
@@ -542,8 +550,9 @@ type StorageManager struct {
 	pushStore                business.PushStore
 	pendingRegistrationStore business.PendingRegistrationStore
 	ipTrustStore             business.IPTrustStore
-	pendingRefreshStore      business.PendingRefreshStore // Issue #2098: registration-refresh approval queue
-	refreshPolicyStore       business.RefreshPolicyStore  // Issue #2098: per-tenant refresh policy
+	pendingRefreshStore      business.PendingRefreshStore  // Issue #2098: registration-refresh approval queue
+	refreshPolicyStore       business.RefreshPolicyStore   // Issue #2098: per-tenant refresh policy
+	assurancePolicyStore     business.AssurancePolicyStore // Issue #2845: per-tenant assurance-policy overrides
 }
 
 // GetProviderName returns the name of the storage provider.
@@ -658,6 +667,17 @@ func (sm *StorageManager) SetRefreshPolicyStore(s business.RefreshPolicyStore) {
 	sm.refreshPolicyStore = s
 }
 
+// GetAssurancePolicyStore returns the per-tenant assurance-policy override store (Issue #2845).
+// Returns nil when not yet wired; callers must nil-check before use.
+func (sm *StorageManager) GetAssurancePolicyStore() business.AssurancePolicyStore {
+	return sm.assurancePolicyStore
+}
+
+// SetAssurancePolicyStore wires the per-tenant assurance-policy store after construction.
+func (sm *StorageManager) SetAssurancePolicyStore(s business.AssurancePolicyStore) {
+	sm.assurancePolicyStore = s
+}
+
 // GetCapabilities returns the provider's capabilities.
 // Returns a zero-value ProviderCapabilities when the manager has no backing provider
 // (e.g. a composite manager created with NewStorageManagerFromStores).
@@ -704,6 +724,7 @@ func (sm *StorageManager) Close() error {
 		sm.ipTrustStore,
 		sm.refreshPolicyStore,
 		sm.pendingRefreshStore,
+		sm.assurancePolicyStore,
 	}
 	var firstErr error
 	for _, s := range slots {
@@ -907,6 +928,16 @@ func CreateClusterStorageManager(pgConnStr string, _ map[string]interface{}) (*S
 			sm.SetPendingRefreshStore(pendingRefreshStore)
 		}
 	}
+	// Wire assurance policy store if the provider implements AssuranceStoreCreator (Issue #2845).
+	if asc, ok := provider.(AssuranceStoreCreator); ok {
+		assurancePolicyStore, err := asc.CreateAssurancePolicyStore(dbCfg)
+		if err != nil && !errors.Is(err, business.ErrNotSupported) {
+			return nil, fmt.Errorf("cluster storage: failed to create assurance policy store: %w", err)
+		}
+		if assurancePolicyStore != nil {
+			sm.SetAssurancePolicyStore(assurancePolicyStore)
+		}
+	}
 	return sm, nil
 }
 
@@ -971,6 +1002,7 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 		sm.SetIPTrustStore(ipTrustStore)
 		sm.SetPendingRefreshStore(bundle.PendingRefresh)
 		sm.SetRefreshPolicyStore(bundle.RefreshPolicy)
+		sm.SetAssurancePolicyStore(bundle.AssurancePolicy)
 		return sm, nil
 	}
 

--- a/pkg/storage/providers/database/assurance_policy_store.go
+++ b/pkg/storage/providers/database/assurance_policy_store.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package database implements AssurancePolicyStore using PostgreSQL (Issue #2845).
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.AssurancePolicyStore = (*DatabaseAssurancePolicyStore)(nil)
+
+// DatabaseAssurancePolicyStore implements business.AssurancePolicyStore using PostgreSQL.
+type DatabaseAssurancePolicyStore struct {
+	db *sql.DB
+}
+
+// NewDatabaseAssurancePolicyStore opens a pooled Postgres connection, initialises
+// the schema, and returns a ready-to-use AssurancePolicyStore.
+func NewDatabaseAssurancePolicyStore(dsn string, config map[string]interface{}) (*DatabaseAssurancePolicyStore, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to open assurance policy store connection: %w", err)
+	}
+	db.SetMaxOpenConns(getIntFromConfig(config, "max_open_connections", 25))
+	db.SetMaxIdleConns(getIntFromConfig(config, "max_idle_connections", 5))
+	db.SetConnMaxLifetime(time.Duration(getIntFromConfig(config, "connection_max_lifetime_minutes", 30)) * time.Minute)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("database: failed to ping assurance policy store: %w", err)
+	}
+	store := &DatabaseAssurancePolicyStore{db: db}
+	if err := store.initSchema(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("database: failed to initialise assurance policy schema: %w", err)
+	}
+	return store, nil
+}
+
+func (s *DatabaseAssurancePolicyStore) initSchema() error {
+	ctx := context.Background()
+	const lockID = 53781295 // advisory lock ID unique to assurance_policy_overrides schema
+	if _, err := s.db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", lockID); err != nil {
+		return fmt.Errorf("database: failed to acquire assurance policy schema lock: %w", err)
+	}
+	defer func() { _, _ = s.db.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", lockID) }()
+	return NewDatabaseSchemas().CreateAssurancePolicyOverridesTable(ctx, s.db)
+}
+
+// Close releases the database connection.
+func (s *DatabaseAssurancePolicyStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// GetPolicy returns the assurance-policy overrides for the given tenant. When no
+// rows exist for the tenant, it returns {TenantID: tenantID, Overrides: nil}
+// without error — "no override" and "no data" are equivalent (ADR-021, Issue #2845).
+func (s *DatabaseAssurancePolicyStore) GetPolicy(ctx context.Context, tenantID string) (*business.AssurancePolicy, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT permission_id, min_override, require_user_presence
+		FROM assurance_policy_overrides
+		WHERE tenant_id = $1`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to get assurance policy for tenant %s: %w", tenantID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var overrides []business.AssurancePolicyOverride
+	for rows.Next() {
+		var o business.AssurancePolicyOverride
+		var minOverride sql.NullInt64
+		if err := rows.Scan(&o.PermissionID, &minOverride, &o.RequireUserPresence); err != nil {
+			return nil, fmt.Errorf("database: failed to scan assurance policy row for tenant %s: %w", tenantID, err)
+		}
+		if minOverride.Valid {
+			v := int(minOverride.Int64)
+			o.MinOverride = &v
+		}
+		overrides = append(overrides, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("database: failed to iterate assurance policy rows for tenant %s: %w", tenantID, err)
+	}
+
+	return &business.AssurancePolicy{TenantID: tenantID, Overrides: overrides}, nil
+}
+
+// SetPolicy replaces the tenant's full assurance-policy override set in one
+// transaction (delete all existing rows for the tenant, then insert the new set).
+func (s *DatabaseAssurancePolicyStore) SetPolicy(ctx context.Context, policy *business.AssurancePolicy) error {
+	if policy == nil {
+		return fmt.Errorf("database: assurance policy cannot be nil")
+	}
+	if policy.TenantID == "" {
+		return fmt.Errorf("database: assurance policy tenant_id cannot be empty")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("database: failed to begin assurance policy transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM assurance_policy_overrides WHERE tenant_id = $1`,
+		policy.TenantID,
+	); err != nil {
+		return fmt.Errorf("database: failed to delete existing assurance policy overrides for tenant %s: %w", policy.TenantID, err)
+	}
+
+	for _, o := range policy.Overrides {
+		var minOverride interface{}
+		if o.MinOverride != nil {
+			minOverride = *o.MinOverride
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO assurance_policy_overrides (tenant_id, permission_id, min_override, require_user_presence)
+			VALUES ($1, $2, $3, $4)`,
+			policy.TenantID, o.PermissionID, minOverride, o.RequireUserPresence,
+		); err != nil {
+			return fmt.Errorf("database: failed to insert assurance policy override for tenant %s permission %s: %w",
+				policy.TenantID, o.PermissionID, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("database: failed to commit assurance policy transaction for tenant %s: %w", policy.TenantID, err)
+	}
+	return nil
+}

--- a/pkg/storage/providers/database/assurance_policy_store_test.go
+++ b/pkg/storage/providers/database/assurance_policy_store_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package database provides unit tests for the PostgreSQL AssurancePolicyStore (Issue #2845).
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestAssurancePolicyStore creates an AssurancePolicyStore backed by the test
+// Postgres database. The schema is initialised fresh via the store constructor;
+// the test is skipped when Postgres is unavailable.
+func newTestAssurancePolicyStore(t *testing.T) *DatabaseAssurancePolicyStore {
+	t.Helper()
+	db := setupTestDatabase(t)
+	t.Cleanup(func() { _ = db.Close() })
+	schemas := NewDatabaseSchemas()
+	ctx := context.Background()
+	require.NoError(t, schemas.CreateAssurancePolicyOverridesTable(ctx, db))
+
+	store, err := NewDatabaseAssurancePolicyStore(buildTestDSN(), getTestConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestDatabaseAssurancePolicyStore_GetDefault verifies that GetPolicy returns an
+// empty override set (Overrides: nil) when no record exists for the tenant.
+func TestDatabaseAssurancePolicyStore_GetDefault(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+
+	p, err := store.GetPolicy(ctx, "tenant-ap-default")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "tenant-ap-default", p.TenantID)
+	assert.Nil(t, p.Overrides)
+}
+
+// TestDatabaseAssurancePolicyStore_SetAndGet verifies that SetPolicy persists a
+// multi-entry override set and GetPolicy retrieves it correctly.
+func TestDatabaseAssurancePolicyStore_SetAndGet(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+
+	minVal := 2 // Strong
+	policy := &business.AssurancePolicy{
+		TenantID: "tenant-ap-set",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:write", MinOverride: &minVal, RequireUserPresence: true},
+			{PermissionID: "perm:read"},
+		},
+	}
+	require.NoError(t, store.SetPolicy(ctx, policy))
+
+	got, err := store.GetPolicy(ctx, "tenant-ap-set")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-ap-set", got.TenantID)
+	require.Len(t, got.Overrides, 2)
+
+	// Find and verify each override (order is not guaranteed).
+	byPerm := make(map[string]business.AssurancePolicyOverride, len(got.Overrides))
+	for _, o := range got.Overrides {
+		byPerm[o.PermissionID] = o
+	}
+
+	write, ok := byPerm["perm:write"]
+	require.True(t, ok, "perm:write must be present")
+	require.NotNil(t, write.MinOverride)
+	assert.Equal(t, 2, *write.MinOverride)
+	assert.True(t, write.RequireUserPresence)
+
+	read, ok := byPerm["perm:read"]
+	require.True(t, ok, "perm:read must be present")
+	assert.Nil(t, read.MinOverride)
+	assert.False(t, read.RequireUserPresence)
+}
+
+// TestDatabaseAssurancePolicyStore_SetReplaces verifies that a second SetPolicy
+// call fully replaces the first: a permission dropped from the second call is
+// absent from the next GetPolicy.
+func TestDatabaseAssurancePolicyStore_SetReplaces(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+
+	min1 := 1
+	require.NoError(t, store.SetPolicy(ctx, &business.AssurancePolicy{
+		TenantID: "tenant-ap-replace",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:admin", MinOverride: &min1},
+			{PermissionID: "perm:read"},
+		},
+	}))
+
+	min2 := 2
+	require.NoError(t, store.SetPolicy(ctx, &business.AssurancePolicy{
+		TenantID: "tenant-ap-replace",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:write", MinOverride: &min2},
+		},
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-ap-replace")
+	require.NoError(t, err)
+	require.Len(t, got.Overrides, 1, "second SetPolicy must fully replace the first")
+	assert.Equal(t, "perm:write", got.Overrides[0].PermissionID)
+	require.NotNil(t, got.Overrides[0].MinOverride)
+	assert.Equal(t, 2, *got.Overrides[0].MinOverride)
+}
+
+// TestDatabaseAssurancePolicyStore_NilPolicyError verifies that SetPolicy
+// rejects a nil policy.
+func TestDatabaseAssurancePolicyStore_NilPolicyError(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+	err := store.SetPolicy(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+// TestDatabaseAssurancePolicyStore_EmptyTenantError verifies that SetPolicy
+// rejects a policy with an empty TenantID.
+func TestDatabaseAssurancePolicyStore_EmptyTenantError(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+	err := store.SetPolicy(ctx, &business.AssurancePolicy{
+		Overrides: []business.AssurancePolicyOverride{{PermissionID: "perm:read"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenant_id")
+}

--- a/pkg/storage/providers/database/plugin.go
+++ b/pkg/storage/providers/database/plugin.go
@@ -234,6 +234,19 @@ func (p *DatabaseProvider) CreateRefreshPolicyStore(config map[string]interface{
 	return store, nil
 }
 
+// CreateAssurancePolicyStore creates a PostgreSQL-backed AssurancePolicyStore (Issue #2845).
+func (p *DatabaseProvider) CreateAssurancePolicyStore(config map[string]interface{}) (business.AssurancePolicyStore, error) {
+	dsn, err := p.getDSN(config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid database configuration: %w", err)
+	}
+	store, err := NewDatabaseAssurancePolicyStore(dsn, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create database assurance policy store: %w", err)
+	}
+	return store, nil
+}
+
 // CreatePendingRefreshStore creates a PostgreSQL-backed PendingRefreshStore (Issue #2329).
 func (p *DatabaseProvider) CreatePendingRefreshStore(config map[string]interface{}) (business.PendingRefreshStore, error) {
 	dsn, err := p.getDSN(config)

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -741,6 +741,33 @@ func (s DatabaseSchemas) CreateAllTables(ctx context.Context, db *sql.DB) error 
 		return err
 	}
 
+	if err := s.CreateAssurancePolicyOverridesTable(ctx, db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateAssurancePolicyOverridesTable creates the assurance_policy_overrides table (Issue #2845).
+// Each row holds one per-permission override for a tenant. SetPolicy replaces
+// the full set for a tenant transactionally (delete-then-insert).
+func (s DatabaseSchemas) CreateAssurancePolicyOverridesTable(ctx context.Context, db *sql.DB) error {
+	ddl := `
+		CREATE TABLE IF NOT EXISTS assurance_policy_overrides (
+			tenant_id             TEXT NOT NULL,
+			permission_id         TEXT NOT NULL,
+			min_override          INTEGER,
+			require_user_presence BOOLEAN NOT NULL DEFAULT FALSE,
+			PRIMARY KEY (tenant_id, permission_id)
+		);`
+	if _, err := db.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("failed to create assurance_policy_overrides table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"CREATE INDEX IF NOT EXISTS idx_assurance_policy_overrides_tenant_id ON assurance_policy_overrides(tenant_id);",
+	); err != nil {
+		return fmt.Errorf("failed to create assurance_policy_overrides index: %w", err)
+	}
 	return nil
 }
 
@@ -1098,6 +1125,7 @@ func (s DatabaseSchemas) DropAllTables(ctx context.Context, db *sql.DB) error {
 		"DROP TABLE IF EXISTS rbac_subjects;",
 		"DROP TABLE IF EXISTS rbac_roles;", // Has self-reference foreign key
 		"DROP TABLE IF EXISTS rbac_permissions;",
+		"DROP TABLE IF EXISTS assurance_policy_overrides;",
 		"DROP TABLE IF EXISTS pending_refresh_requests;",
 		"DROP TABLE IF EXISTS refresh_policies;",
 		"DROP TABLE IF EXISTS command_transitions;",

--- a/pkg/storage/providers/sqlite/assurance_policy_store.go
+++ b/pkg/storage/providers/sqlite/assurance_policy_store.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements AssurancePolicyStore using the assurance_policy_overrides
+// table (ADR-021, Issue #2845).
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.AssurancePolicyStore = (*SQLiteAssurancePolicyStore)(nil)
+
+// SQLiteAssurancePolicyStore implements business.AssurancePolicyStore using a
+// SQLite database backed by the assurance_policy_overrides table.
+type SQLiteAssurancePolicyStore struct {
+	db *sql.DB
+}
+
+// Close closes the underlying database connection.
+func (s *SQLiteAssurancePolicyStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// GetPolicy returns the assurance-policy overrides for the given tenant. When no
+// rows exist, it returns {TenantID: tenantID, Overrides: nil} without error —
+// "no override" and "no data" are equivalent (ADR-021, Issue #2845).
+func (s *SQLiteAssurancePolicyStore) GetPolicy(ctx context.Context, tenantID string) (*business.AssurancePolicy, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT permission_id, min_override, require_user_presence
+		FROM assurance_policy_overrides
+		WHERE tenant_id = ?`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to get assurance policy for tenant %s: %w", tenantID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var overrides []business.AssurancePolicyOverride
+	for rows.Next() {
+		var o business.AssurancePolicyOverride
+		var minOverride sql.NullInt64
+		if err := rows.Scan(&o.PermissionID, &minOverride, &o.RequireUserPresence); err != nil {
+			return nil, fmt.Errorf("sqlite: failed to scan assurance policy row for tenant %s: %w", tenantID, err)
+		}
+		if minOverride.Valid {
+			v := int(minOverride.Int64)
+			o.MinOverride = &v
+		}
+		overrides = append(overrides, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: failed to iterate assurance policy rows for tenant %s: %w", tenantID, err)
+	}
+
+	return &business.AssurancePolicy{TenantID: tenantID, Overrides: overrides}, nil
+}
+
+// SetPolicy replaces the tenant's full assurance-policy override set in one
+// transaction (delete all existing rows for the tenant, then insert the new set).
+func (s *SQLiteAssurancePolicyStore) SetPolicy(ctx context.Context, policy *business.AssurancePolicy) error {
+	if policy == nil {
+		return fmt.Errorf("sqlite: assurance policy cannot be nil")
+	}
+	if policy.TenantID == "" {
+		return fmt.Errorf("sqlite: assurance policy tenant_id cannot be empty")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to begin assurance policy transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM assurance_policy_overrides WHERE tenant_id = ?`,
+		policy.TenantID,
+	); err != nil {
+		return fmt.Errorf("sqlite: failed to delete existing assurance policy overrides for tenant %s: %w", policy.TenantID, err)
+	}
+
+	for _, o := range policy.Overrides {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO assurance_policy_overrides (tenant_id, permission_id, min_override, require_user_presence)
+			VALUES (?, ?, ?, ?)`,
+			policy.TenantID, o.PermissionID, nullableInt(o.MinOverride), o.RequireUserPresence,
+		); err != nil {
+			return fmt.Errorf("sqlite: failed to insert assurance policy override for tenant %s permission %s: %w",
+				policy.TenantID, o.PermissionID, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlite: failed to commit assurance policy transaction for tenant %s: %w", policy.TenantID, err)
+	}
+	return nil
+}

--- a/pkg/storage/providers/sqlite/assurance_policy_store_test.go
+++ b/pkg/storage/providers/sqlite/assurance_policy_store_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestAssurancePolicyStore opens an in-memory SQLite store for testing.
+func newTestAssurancePolicyStore(t *testing.T) *SQLiteAssurancePolicyStore {
+	t.Helper()
+	db, err := openAndInit(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return &SQLiteAssurancePolicyStore{db: db}
+}
+
+// TestAssurancePolicyStore_DefaultEmpty verifies that GetPolicy returns an empty
+// override set when no record exists for the tenant (ADR-021, Issue #2845 AC).
+func TestAssurancePolicyStore_DefaultEmpty(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+
+	got, err := store.GetPolicy(ctx, "tenant-ap-absent")
+	require.NoError(t, err, "absent record must not be an error")
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-ap-absent", got.TenantID)
+	assert.Nil(t, got.Overrides, "Overrides must default to nil when no record exists")
+}
+
+func TestAssurancePolicyStore_SetAndGet(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+
+	minVal := 2 // Strong
+	policy := &business.AssurancePolicy{
+		TenantID: "tenant-ap-1",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:write", MinOverride: &minVal, RequireUserPresence: true},
+			{PermissionID: "perm:read"},
+		},
+	}
+	require.NoError(t, store.SetPolicy(ctx, policy))
+
+	got, err := store.GetPolicy(ctx, "tenant-ap-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-ap-1", got.TenantID)
+	require.Len(t, got.Overrides, 2)
+
+	// Find and verify each override (order is not guaranteed by SQLite).
+	byPerm := make(map[string]business.AssurancePolicyOverride, len(got.Overrides))
+	for _, o := range got.Overrides {
+		byPerm[o.PermissionID] = o
+	}
+
+	write, ok := byPerm["perm:write"]
+	require.True(t, ok, "perm:write must be present")
+	require.NotNil(t, write.MinOverride)
+	assert.Equal(t, 2, *write.MinOverride)
+	assert.True(t, write.RequireUserPresence)
+
+	read, ok := byPerm["perm:read"]
+	require.True(t, ok, "perm:read must be present")
+	assert.Nil(t, read.MinOverride)
+	assert.False(t, read.RequireUserPresence)
+}
+
+func TestAssurancePolicyStore_SetReplaces(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	ctx := context.Background()
+
+	min1 := 1
+	require.NoError(t, store.SetPolicy(ctx, &business.AssurancePolicy{
+		TenantID: "tenant-ap-replace",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:admin", MinOverride: &min1},
+			{PermissionID: "perm:read"},
+		},
+	}))
+
+	// Second call fully replaces; perm:admin and perm:read are dropped.
+	min2 := 2
+	require.NoError(t, store.SetPolicy(ctx, &business.AssurancePolicy{
+		TenantID: "tenant-ap-replace",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "perm:write", MinOverride: &min2},
+		},
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-ap-replace")
+	require.NoError(t, err)
+	require.Len(t, got.Overrides, 1, "second SetPolicy must fully replace first")
+	assert.Equal(t, "perm:write", got.Overrides[0].PermissionID)
+	require.NotNil(t, got.Overrides[0].MinOverride)
+	assert.Equal(t, 2, *got.Overrides[0].MinOverride)
+}
+
+func TestAssurancePolicyStore_SetNilPolicy(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	err := store.SetPolicy(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestAssurancePolicyStore_SetEmptyTenantID(t *testing.T) {
+	store := newTestAssurancePolicyStore(t)
+	err := store.SetPolicy(context.Background(), &business.AssurancePolicy{
+		Overrides: []business.AssurancePolicyOverride{{PermissionID: "perm:read"}},
+	})
+	require.Error(t, err)
+}

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -361,6 +361,7 @@ func (p *SQLiteProvider) OpenBusinessStores(path string) (*interfaces.BusinessSt
 		PendingRegistration: &SQLitePendingRegistrationStore{db: db},
 		PendingRefresh:      &SQLitePendingRefreshStore{db: db},
 		RefreshPolicy:       &SQLiteRefreshPolicyStore{db: db},
+		AssurancePolicy:     &SQLiteAssurancePolicyStore{db: db},
 	}, nil
 }
 

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -515,6 +515,17 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 			max_dormancy_days INTEGER
 		)`,
 
+		// Per-tenant assurance-policy overrides (ADR-021, Issue #2845).
+		// Each row holds one per-permission override. Absent rows mean global defaults apply.
+		`CREATE TABLE IF NOT EXISTS assurance_policy_overrides (
+			tenant_id             TEXT NOT NULL,
+			permission_id         TEXT NOT NULL,
+			min_override          INTEGER,
+			require_user_presence INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (tenant_id, permission_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_assurance_policy_overrides_tenant_id ON assurance_policy_overrides(tenant_id)`,
+
 		// Durable sessions (Persistent=true only)
 		`CREATE TABLE IF NOT EXISTS sessions (
 			session_id       TEXT PRIMARY KEY,

--- a/scripts/sign-steward-binary/main.go
+++ b/scripts/sign-steward-binary/main.go
@@ -78,12 +78,17 @@ func run(args []string, out io.Writer) error {
 		return fmt.Errorf("write signature: %w", err)
 	}
 
-	fmt.Fprintf(out, "pub=%s\n", base64.StdEncoding.EncodeToString(pub))
-	fmt.Fprintf(out, "sha256=%s\n", contentHash)
-	fmt.Fprintf(out, "message=%s\n", message)
 	// URL-safe base64 is what `cfg installer publish --signature` expects.
-	fmt.Fprintf(out, "signature=%s\n", base64.RawURLEncoding.EncodeToString(sig))
-	fmt.Fprintf(out, "wrote %s (%d bytes)\n", sigPath, len(sig))
+	if _, err := fmt.Fprintf(out,
+		"pub=%s\nsha256=%s\nmessage=%s\nsignature=%s\nwrote %s (%d bytes)\n",
+		base64.StdEncoding.EncodeToString(pub),
+		contentHash,
+		message,
+		base64.RawURLEncoding.EncodeToString(sig),
+		sigPath, len(sig),
+	); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Adds `business.AssurancePolicyStore` interface with `GetPolicy`/`SetPolicy` for per-tenant assurance-policy overrides (ADR-021)
- Implements the store over PostgreSQL (`DatabaseAssurancePolicyStore`, normalized `assurance_policy_overrides` table, transactional delete+insert) and SQLite (`SQLiteAssurancePolicyStore`, same approach)
- Wires the store into `StorageManager` via `AssuranceStoreCreator` extension (cluster path) and `BusinessStoreBundle.AssurancePolicy` (OSS SQLite bundle path); non-bundle fallback leaves it nil, matching `RefreshPolicyStore` precedent
- Updates ADR-021 with a "Per-tenant tightening of permissionAssurance" subsection documenting the shipped mechanism
- Also fixes a pre-existing `errcheck` lint violation in `scripts/sign-steward-binary/main.go` (5 unchecked `fmt.Fprintf` returns) that blocked `make test-agent-complete`

## Specialist Review Results

| Reviewer | Round 1 | Round 2 |
|----------|---------|---------|
| Code Review | PASS | — |
| Security Review | PASS | — |
| QA / Test Quality | FAIL (pre-existing errcheck in sign-steward-binary) | PASS |

All three reviewers passed after a single fix round. No remaining findings.

## Test plan

- [ ] `pkg/storage/interfaces/business/assurance_policy_store_test.go` — contract tests (5 cases): default-empty on first get, set-and-get round-trip, full-replace semantics, nil-policy error, empty-tenant-id error
- [ ] `pkg/storage/providers/sqlite/assurance_policy_store_test.go` — in-memory SQLite (5 cases matching above)
- [ ] `pkg/storage/providers/database/assurance_policy_store_test.go` — PostgreSQL (5 cases matching above; auto-skipped when Postgres unavailable)
- [ ] `make test-agent-complete` passes

Fixes #2845

🤖 Generated with [Claude Code](https://claude.com/claude-code)