### PR TITLE
controller/api: enforce caller tenant subtree on steward get-one endpoint (Issue #2869)

### DIFF
--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -390,6 +390,23 @@ func (s *Server) handleGetSteward(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cross-tenant scope check: API-key principals carry a non-empty TenantID; admin mTLS
+	// principals have TenantID="" meaning no scope restriction.
+	// Use path-separator-aware prefix matching so "root/msp-a" cannot match "root/msp-alpha".
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := stewardInfo.TenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(stewardInfo.TenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			// 404 instead of 403 to avoid disclosing steward existence across tenants.
+			s.logger.Info("Cross-tenant steward get refused",
+				"steward_tenant", logging.SanitizeLogValue(stewardInfo.TenantID),
+				"caller_tenant", logging.SanitizeLogValue(callerTenant))
+			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+			return
+		}
+	}
+
 	activeSessions := 0
 	connectionState := "disconnected"
 	s.mu.RLock()

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -803,6 +803,142 @@ func TestHandleGetSteward_NilRegistry(t *testing.T) {
 	assert.Equal(t, "disconnected", resp.Data.ConnectionState)
 }
 
+// TestHandleGetSteward_CrossTenant_Returns404 verifies that a principal scoped to one
+// tenant receives 404 (not 403) for a steward in an unrelated tenant, so the response
+// is indistinguishable from a nonexistent steward ID (AC1, AC5).
+func TestHandleGetSteward_CrossTenant_Returns404(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Steward lives in "root/msp-b"; caller is scoped to "root/msp-a".
+	stewardID := registerTestStewardWithDNA(t, server, map[string]string{
+		"hostname": "msp-b-host", "os": "linux",
+	}, "root/msp-b")
+
+	callerKey := NewEphemeralTestKey(t, server, []string{"steward:read"}, "root/msp-a", 5*time.Minute)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req.Header.Set("X-API-Key", callerKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	// AC5: must be identical to a nonexistent steward — same status, message, and code.
+	reqNonexistent := httptest.NewRequest("GET", "/api/v1/stewards/this-id-does-not-exist", nil)
+	reqNonexistent.Header.Set("X-API-Key", callerKey)
+	recNonexistent := httptest.NewRecorder()
+	server.router.ServeHTTP(recNonexistent, reqNonexistent)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant get must return 404, not 403")
+	assert.Equal(t, recNonexistent.Code, rec.Code, "status must match nonexistent-ID response")
+
+	var errResp, errRespNonexistent ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	require.NoError(t, json.NewDecoder(recNonexistent.Body).Decode(&errRespNonexistent))
+	assert.Equal(t, "STEWARD_NOT_FOUND", errResp.Error.Code)
+	assert.Equal(t, errRespNonexistent.Error.Code, errResp.Error.Code,
+		"error code must match nonexistent-ID response")
+	assert.Equal(t, errRespNonexistent.Error.Message, errResp.Error.Message,
+		"error message must match nonexistent-ID response")
+}
+
+// TestHandleGetSteward_SameTenant_Returns200 verifies that a principal scoped to a
+// tenant can read a steward belonging to that same tenant (AC2).
+func TestHandleGetSteward_SameTenant_Returns200(t *testing.T) {
+	server := setupTestServer(t)
+
+	stewardID := registerTestStewardWithDNA(t, server, map[string]string{
+		"hostname": "msp-a-host", "os": "linux",
+	}, "root/msp-a")
+
+	callerKey := NewEphemeralTestKey(t, server, []string{"steward:read"}, "root/msp-a", 5*time.Minute)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req.Header.Set("X-API-Key", callerKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.ID)
+}
+
+// TestHandleGetSteward_DescendantTenant_Returns200 verifies that a principal scoped to
+// a parent tenant can read a steward in a descendant tenant (AC2).
+func TestHandleGetSteward_DescendantTenant_Returns200(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Steward is in "root/msp-a/client-1"; caller is scoped to "root/msp-a".
+	stewardID := registerTestStewardWithDNA(t, server, map[string]string{
+		"hostname": "client-1-host", "os": "linux",
+	}, "root/msp-a/client-1")
+
+	callerKey := NewEphemeralTestKey(t, server, []string{"steward:read"}, "root/msp-a", 5*time.Minute)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req.Header.Set("X-API-Key", callerKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.ID)
+}
+
+// TestHandleGetSteward_UnscopedAdmin_Returns200 verifies that a principal with an empty
+// tenant context (unscoped / root admin) receives 200 for a steward in any tenant (AC3).
+func TestHandleGetSteward_UnscopedAdmin_Returns200(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Register steward under an arbitrary tenant.
+	stewardID := registerTestStewardWithDNA(t, server, map[string]string{
+		"hostname": "any-tenant-host", "os": "linux",
+	}, "some-tenant")
+
+	// Call handler directly with empty TenantID — the unscoped admin path.
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req = withTenant(req, "")
+	req = withVars(req, map[string]string{"id": stewardID})
+	rec := httptest.NewRecorder()
+	server.handleGetSteward(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.ID)
+}
+
+// TestHandleGetSteward_SiblingPrefixTenant_Returns404 verifies that a principal scoped
+// to "root/msp-a" cannot read a steward in "root/msp-alpha" (AC4). A bare HasPrefix
+// check without the "/" separator would incorrectly allow this.
+func TestHandleGetSteward_SiblingPrefixTenant_Returns404(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Steward lives in "root/msp-alpha"; caller is scoped to "root/msp-a".
+	stewardID := registerTestStewardWithDNA(t, server, map[string]string{
+		"hostname": "msp-alpha-host", "os": "linux",
+	}, "root/msp-alpha")
+
+	callerKey := NewEphemeralTestKey(t, server, []string{"steward:read"}, "root/msp-a", 5*time.Minute)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req.Header.Set("X-API-Key", callerKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"sibling-prefix tenant must return 404 (AC4: root/msp-a must not match root/msp-alpha)")
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "STEWARD_NOT_FOUND", errResp.Error.Code)
+}
+
 // TestHandleStewardAuthRefresh_UnknownSteward_Returns404 verifies that POSTing to
 // /api/v1/stewards/{id}/auth/refresh with an unregistered steward ID returns 404.
 func TestHandleStewardAuthRefresh_UnknownSteward_Returns404(t *testing.T) {

--- a/scripts/sign-steward-binary/main.go
+++ b/scripts/sign-steward-binary/main.go
@@ -78,12 +78,17 @@ func run(args []string, out io.Writer) error {
 		return fmt.Errorf("write signature: %w", err)
 	}
 
-	fmt.Fprintf(out, "pub=%s\n", base64.StdEncoding.EncodeToString(pub))
-	fmt.Fprintf(out, "sha256=%s\n", contentHash)
-	fmt.Fprintf(out, "message=%s\n", message)
 	// URL-safe base64 is what `cfg installer publish --signature` expects.
-	fmt.Fprintf(out, "signature=%s\n", base64.RawURLEncoding.EncodeToString(sig))
-	fmt.Fprintf(out, "wrote %s (%d bytes)\n", sigPath, len(sig))
+	if _, err := fmt.Fprintf(out,
+		"pub=%s\nsha256=%s\nmessage=%s\nsignature=%s\nwrote %s (%d bytes)\n",
+		base64.StdEncoding.EncodeToString(pub),
+		contentHash,
+		message,
+		base64.RawURLEncoding.EncodeToString(sig),
+		sigPath, len(sig),
+	); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `GET /api/v1/stewards/{id}` previously returned steward identity, status, and DNA-derived attributes to any principal holding `steward:read`, with no tenant scoping — a principal scoped to `root/msp-a` could read stewards belonging to `root/msp-b`
- Added the same subtree enforcement `handleListStewards` already applies: caller tenant must equal or be a hierarchical ancestor of the steward's tenant
- Cross-tenant refusals return 404 `STEWARD_NOT_FOUND` (identical to a genuinely nonexistent ID) to avoid existence disclosure; both tenant values are sanitized before logging

Fixes #2869

## Changes

**`features/controller/api/handlers_stewards.go`** — `handleGetSteward`: after the `GetStewardInfo` lookup, read `ctxkeys.TenantID` from context. If non-empty, require `stewardInfo.TenantID == callerTenant || strings.HasPrefix(stewardInfo.TenantID, callerTenant+"/")`. The `"/"` separator boundary prevents `root/msp-a` from matching `root/msp-alpha`. Empty caller tenant (unscoped mTLS admin) retains full access.

**`features/controller/api/handlers_stewards_test.go`** — 5 new tests covering all ACs:
- `TestHandleGetSteward_CrossTenant_Returns404` (AC1, AC5)
- `TestHandleGetSteward_SameTenant_Returns200` (AC2)
- `TestHandleGetSteward_DescendantTenant_Returns200` (AC2 — descendant)
- `TestHandleGetSteward_UnscopedAdmin_Returns200` (AC3)
- `TestHandleGetSteward_SiblingPrefixTenant_Returns404` (AC4)

**`scripts/sign-steward-binary/main.go`** — incidental fix found during review: consolidated 5 separate `fmt.Fprintf` calls into one and added missing error handling on the return value (previously silently dropped).

## Out of scope (follow-on)

The sub-routes `/dna`, `/logs`, `/config`, `/connection`, `/compliance`, and `/modules` share the same latent cross-tenant gap. `/dna`, `/logs`, and `/modules` already have their own tenant enforcement; `/config`, `/connection`, and `/compliance` do not. These are addressed by a follow-on sweep story per the issue spec.

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS (round 2) |
| Test quality | PASS (round 2) |
| Security | PASS (round 2) |

story-review workflow: `passed: true`, `reviewRounds: 2`, `fixRounds: 1`, `remainingFindings: []`

## Test plan

- [ ] `make test-agent-complete` green
- [ ] `TestHandleGetSteward_CrossTenant_Returns404` — 404 with identical body to nonexistent ID
- [ ] `TestHandleGetSteward_SameTenant_Returns200` — 200 for same-tenant read
- [ ] `TestHandleGetSteward_DescendantTenant_Returns200` — 200 for ancestor reading descendant
- [ ] `TestHandleGetSteward_UnscopedAdmin_Returns200` — 200 for empty-tenant admin
- [ ] `TestHandleGetSteward_SiblingPrefixTenant_Returns404` — 404 for `root/msp-a` vs `root/msp-alpha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)