### PR TITLE
test: restore -timeout to Go default 10m — it is a hang detector, not a performance budget (Issue #2887)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,16 @@ test: fix-git-bare
 	@if [ "$$GITHUB_ACTIONS" != "true" ]; then go clean -testcache; fi
 	@echo "🧪 Testing OSS Build..."
 	@echo "  Testing framework (excluding modules and long-running tests)..."
-	@go test -race -short -timeout=5m $$(go list ./... | grep -v '/features/modules/' | grep -v '/test/integration' | grep -v '/test/e2e')
+#	-timeout is a HANG DETECTOR, not a performance budget (Issue #2887). It applies
+#	per test binary (per package), so it scales with package size, not test health:
+#	when it fires, Go panics and dumps every goroutine stack so a deadlocked test is
+#	diagnosable instead of hanging CI forever. 10m is Go's own default. The outer
+#	bound on a genuine hang is `timeout-minutes: 15` on the unit-tests job in
+#	.github/workflows/test-suite.yml. Do not tighten this to track how long the
+#	suite currently takes — that turns a hang detector into a false ceiling that
+#	any growing package eventually crosses (features/controller/api did, at 863
+#	tests, with a 2.46s slowest test and a 0.130s median).
+	@go test -race -short -timeout=10m $$(go list ./... | grep -v '/features/modules/' | grep -v '/test/integration' | grep -v '/test/e2e')
 	@echo "  Testing core modules (smoke test)..."
 	@for module in $(CORE_MODULES); do \
 		echo "  Testing $$module..."; \


### PR DESCRIPTION
## Summary

`Makefile:389` → `-timeout=5m` becomes `-timeout=10m`, with a comment recording why so it doesn't get re-tightened.

## What `-timeout` actually is

`go test -timeout d` is a **hang detector**, not a performance budget. When it fires, Go panics and dumps every goroutine's stack so a deadlocked test is diagnosable instead of hanging CI forever. Go's own default is **10m**. It applies **per test binary** (per package), so it scales with package size rather than with test health — which means a tight value is guaranteed to become a false ceiling as any package grows.

`features/controller/api` reached that point:

| Context | Duration |
|---|---|
| Local, package alone | 142.6s / 160.3s |
| Local, under `make test` (parallel CPU contention) | 211.0s |
| CI, 2-core runner with `-race` | **>300s — killed** |

CI record today: **1 pass, 3 failures** across #2884 and #2886 — plus a fourth occurrence misattributed to #2881, which caused a fix agent to be dispatched against a PR that had nothing wrong with it.

## Nothing is hanging

```
panic: test timed out after 5m0s
  running tests:
    TestSeedTestAPIKeys (0s)
```

That `(0s)` is the elapsed time of the test in flight when the alarm fired — it had just *started*. The binary accumulated 300s across 863 sequential tests; the hang detector fired with no hang to report.

Measured distribution (863 top-level tests): 142.2s total, slowest single test **2.46s**, median **0.130s**, only 5 tests over 1s. No hotspot, no pathological test.

## Why raising it is safe, not papering over

The outer bound already exists — `.github/workflows/test-suite.yml` sets `timeout-minutes: 15` on the `unit-tests` job. A genuine hang is caught there regardless. The 5m value was *both* tighter than Go's default *and* redundant with a guard already in place.

## Considered and rejected

- **Splitting `features/controller/api`.** Go package boundaries are driven by cohesion and API surface, not test runtime. No Go guidance supports splitting a package to avoid a timeout, and the standard library contains packages with far larger test suites. Rejected as cargo-culting.
- **A per-test slow-test check** (parse `go test -json`, fail on any single test over N seconds). This is the instrument that would actually catch a degrading test — it's size-independent, unlike `-timeout`. Deferred deliberately: the slowest test today is 2.46s, so there's nothing live for it to catch.

Both are recorded in #2887 so they aren't relitigated later.

## Verification

- `make -n test` — recipe parses, `-timeout=10m` present, no comment lines leak into the shell
- `make test` — **exit 0**, 163 packages ok, `features/controller/api` **160.344s**, 211 script tests passed / 0 failed

## Sequencing

This is self-applying: the PR's own `unit-tests` run uses the updated Makefile, so it should pass first time despite being the fix for the check that's failing. Once merged, **#2886** (the `x/net` + `x/text` CVE bumps, currently blocked on exactly this) re-runs and passes.

Fixes #2887