### PR TITLE
entitygraph: Entity Graph contract package — types, eid, taxonomy, provider interface (Issue #2871)

### DIFF
--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package interfaces_test contains contract tests for the EntityGraphProvider.
+//
+// RunEntityGraphContractTests is the shared harness; each round story adds
+// subtests here. Parallel stories may produce rebase conflicts on this file —
+// resolve by merging both diffs, never by re-serializing the rounds.
+//
+// Usage:
+//
+//	func TestMyProvider_ContractSuite(t *testing.T) {
+//		interfaces.RunEntityGraphContractTests(t, func(t *testing.T) interfaces.EntityGraphProvider {
+//			return myProvider
+//		})
+//	}
+package interfaces_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// EntityGraphProviderFactory creates an EntityGraphProvider under test.
+type EntityGraphProviderFactory func(t *testing.T) interfaces.EntityGraphProvider
+
+// RunEntityGraphContractTests runs the full EntityGraphProvider contract test suite.
+// Each contract is a subtest for granular reporting. Grown incrementally as each
+// round story lands.
+func RunEntityGraphContractTests(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+
+	t.Run("ProviderIdentity", func(t *testing.T) {
+		testEGProviderIdentity(t, factory)
+	})
+	t.Run("ProviderAvailable", func(t *testing.T) {
+		testEGProviderAvailable(t, factory)
+	})
+}
+
+func testEGProviderIdentity(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	assert.NotEmpty(t, p.Name(), "provider name must not be empty")
+	assert.NotEmpty(t, p.Description(), "provider description must not be empty")
+}
+
+func testEGProviderAvailable(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	// Available must not error — the noop provider is always available.
+	ok, err := p.Available()
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}
+
+// --- Registry tests ---
+
+func TestRegistry_RegisterAndLookup(t *testing.T) {
+	// Use unique names to avoid collisions with other tests.
+	p1 := &noopProvider{name: "reg-test-alpha"}
+	p2 := &noopProvider{name: "reg-test-beta"}
+
+	require.NoError(t, interfaces.RegisterEntityGraphProvider(p1))
+	require.NoError(t, interfaces.RegisterEntityGraphProvider(p2))
+
+	got1, err := interfaces.GetEntityGraphProvider("reg-test-alpha")
+	require.NoError(t, err)
+	assert.Equal(t, p1.Name(), got1.Name())
+
+	got2, err := interfaces.GetEntityGraphProvider("reg-test-beta")
+	require.NoError(t, err)
+	assert.Equal(t, p2.Name(), got2.Name())
+
+	t.Cleanup(func() {
+		interfaces.UnregisterEntityGraphProvider("reg-test-alpha")
+		interfaces.UnregisterEntityGraphProvider("reg-test-beta")
+	})
+}
+
+func TestRegistry_DuplicateNameRejected(t *testing.T) {
+	p := &noopProvider{name: "reg-test-dup"}
+	require.NoError(t, interfaces.RegisterEntityGraphProvider(p))
+	t.Cleanup(func() { interfaces.UnregisterEntityGraphProvider("reg-test-dup") })
+
+	dup := &noopProvider{name: "reg-test-dup"}
+	err := interfaces.RegisterEntityGraphProvider(dup)
+	require.Error(t, err, "registering a duplicate name must return an error")
+}
+
+func TestRegistry_LookupMissing(t *testing.T) {
+	_, err := interfaces.GetEntityGraphProvider("no-such-provider-xyzzy")
+	require.Error(t, err)
+}
+
+// --- Compile-time assertion ---
+
+// Verify that noopProvider satisfies the full EntityGraphProvider interface.
+// This is not a real provider — house rule: no memory-only storage for durable
+// features. It exists only to enforce the interface at compile time.
+var _ interfaces.EntityGraphProvider = (*noopProvider)(nil)
+
+// noopProvider is a minimal stub that satisfies EntityGraphProvider at compile
+// time. All methods return zero values or ErrNotImplemented.
+type noopProvider struct {
+	name string
+}
+
+func (n *noopProvider) Name() string        { return n.name }
+func (n *noopProvider) Description() string { return "noop provider for compile-time assertion" }
+func (n *noopProvider) Available() (bool, error) {
+	return true, nil
+}
+
+func (n *noopProvider) GetEntity(_ context.Context, _ interfaces.EIDRef, _ interfaces.GetEntityOpts) (*types.EntityView, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) GetDesiredState(_ context.Context, _ interfaces.EIDRef) (*types.DesiredStateView, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) GetDriftState(_ context.Context, _ interfaces.EIDRef) (*interfaces.DriftState, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) QueryEntities(_ context.Context, _ interfaces.EntityFilter, _ interfaces.PageToken) (*interfaces.EntityPage, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) GetEdges(_ context.Context, _ interfaces.EdgeFilter) ([]*interfaces.EdgeView, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) GetNeighborhood(_ context.Context, _ interfaces.EIDRef, _ []string, _ types.TraversalDirection, _ int) (*types.Neighborhood, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) GetHistory(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) Diff(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) (*interfaces.StateDiff, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) GetTimeline(_ context.Context, _ []interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.TimelineEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) ListDrifted(_ context.Context, _ interfaces.DriftFilter) ([]*interfaces.DriftState, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) Watch(_ context.Context, _ interfaces.WatchFilter, _ string) (<-chan interfaces.WatchEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) ResolveIdentity(_ context.Context, _ interfaces.IdentityClaims) ([]interfaces.EIDRef, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+func (n *noopProvider) ReportObservations(_ context.Context, _ interfaces.ObservationBatch) error {
+	return interfaces.ErrNotImplemented
+}
+func (n *noopProvider) UpdateDriftLifecycle(_ context.Context, _ interfaces.DriftLifecycleUpdate) error {
+	return interfaces.ErrNotImplemented
+}

--- a/pkg/entitygraph/interfaces/provider.go
+++ b/pkg/entitygraph/interfaces/provider.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package interfaces defines the EntityGraph pluggable central provider for CFGMS.
+//
+// The entity graph is the product-wide accumulation point for everything CFGMS
+// knows about a deployment: typed entities, typed relationships, their state,
+// provenance, and history (ADR-022).
+package interfaces
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// ErrNotImplemented is returned by stub implementations that satisfy the
+// interface at compile time but are not backed by real storage.
+var ErrNotImplemented = errors.New("entitygraph: not implemented")
+
+// EIDRef is an alias for types.EID so callers can import only this package.
+type EIDRef = types.EID
+
+// --- Request / Response types ---
+
+// GetEntityOpts carries the optional collapse-group and temporal parameters for
+// GetEntity (ADR-022 §9 table; §5 scopes collapse to GetEntity + temporal reads).
+type GetEntityOpts struct {
+	// AsOf, when non-nil, projects state as of this timestamp.
+	AsOf *time.Time
+
+	// CollapseGroup, when true, returns the merged same-as group view (§3).
+	// The provider applies the tenant-cut before merging.
+	CollapseGroup bool
+
+	// TenantFilter is the mandatory caller-tenant-subtree filter (§7).
+	TenantFilter string
+}
+
+// EntityFilter selects entities for QueryEntities.
+type EntityFilter struct {
+	Kind         string
+	TenantFilter string
+	AsOf         *time.Time
+	TextQuery    string
+	Attributes   map[string]interface{}
+}
+
+// PageToken is a cursor for paginated queries.
+type PageToken struct {
+	Token    string
+	PageSize int
+}
+
+// EntityPage is the paginated result of QueryEntities.
+type EntityPage struct {
+	Entities  []*types.EntityView
+	NextToken string
+}
+
+// EdgeFilter selects edges for GetEdges.
+type EdgeFilter struct {
+	// At least one of FromEID or ToEID must be set.
+	FromEID      *EIDRef
+	ToEID        *EIDRef
+	Types        []string
+	Source       string
+	TenantFilter string
+}
+
+// EdgeView wraps an Edge with freshness metadata.
+type EdgeView struct {
+	Edge      *types.Edge
+	Freshness types.Freshness
+}
+
+// TimeRange is an inclusive time interval for history and diff operations.
+type TimeRange struct {
+	From time.Time
+	To   time.Time
+}
+
+// ObservationRecord is a historical observation entry returned by GetHistory.
+type ObservationRecord struct {
+	Observation types.Observation
+	Version     int64
+}
+
+// StateDiff is the result of a two-point diff between entity states (ADR-022 §5).
+type StateDiff struct {
+	Subject EIDRef
+	T1      time.Time
+	T2      time.Time
+	Changes []AttributeChange
+}
+
+// AttributeChange records one attribute's before/after in a StateDiff.
+type AttributeChange struct {
+	Attribute string
+	Before    interface{}
+	After     interface{}
+	Source    string
+}
+
+// TimelineEvent is one entry in a merged change-event stream (ADR-022 §5).
+type TimelineEvent struct {
+	Subject    EIDRef
+	OccurredAt time.Time
+	Kind       string // "state-change" | "drift-detected" | "apply-outcome"
+	Detail     map[string]interface{}
+}
+
+// DriftState holds the persisted desired-vs-actual delta for one entity (ADR-022 §6).
+type DriftState struct {
+	EID             EIDRef
+	DetectedAt      time.Time
+	Fields          []DriftField
+	ConfigRevision  string
+	LifecycleStatus string // "detected" | "acknowledged" | "resolved" | "ignored"
+}
+
+// DriftField is one attribute in a DriftState comparison.
+type DriftField struct {
+	Attribute string
+	Desired   interface{}
+	Actual    interface{}
+	Matching  bool
+}
+
+// DriftFilter selects entities for ListDrifted.
+type DriftFilter struct {
+	TenantFilter    string
+	LifecycleStatus string
+	Kind            string
+}
+
+// WatchFilter selects the subjects for a Watch subscription.
+type WatchFilter struct {
+	TenantFilter string
+	Kinds        []string
+	EIDs         []EIDRef
+}
+
+// WatchEvent is one event delivered by the Watch cursor feed (ADR-022 §9).
+type WatchEvent struct {
+	Subject   EIDRef
+	EventKind string // "entity-updated" | "edge-updated" | "drift-updated"
+	Version   int64
+	At        time.Time
+}
+
+// IdentityClaims carries device/object identity claims for ResolveIdentity (ADR-022 §9).
+// This covers device claims only — not PSA/CRM contacts.
+type IdentityClaims struct {
+	Hostname            string
+	MACAddrs            []string
+	MachineSID          string
+	DirectoryObjectGUID string
+	SerialNumber        string
+	CloudObjectID       string
+}
+
+// ObservationBatch groups observations under one source identity (ADR-022 §4/§9).
+type ObservationBatch struct {
+	// Source is the identity of the reporting collector.
+	Source string
+
+	// Observations is the batch of observations to ingest.
+	Observations []types.Observation
+
+	// ClaimScopes, when non-empty, declares snapshot scopes that trigger
+	// implicit retraction of prior assertions outside this batch.
+	ClaimScopes []types.ClaimScope
+}
+
+// DriftLifecycleUpdate carries a single drift lifecycle transition (ADR-022 §6/§9).
+type DriftLifecycleUpdate struct {
+	EID        EIDRef
+	Transition string // "acknowledge" | "resolve" | "ignore"
+	Actor      string // identity of the technician or automation
+	At         time.Time
+	Note       string
+}
+
+// --- Provider Interface ---
+
+// EntityGraphProvider is the pluggable central provider contract for the entity
+// graph (ADR-022 §9/§10). All read operations accept the mandatory tenant filter
+// embedded in their opts/filter arguments. GetEntity is the only read that takes
+// the collapse-group opts; GetDesiredState and GetDriftState take no opts.
+//
+// Implementations must be safe for concurrent use.
+type EntityGraphProvider interface {
+	// Identification.
+	Name() string
+	Description() string
+	Available() (bool, error)
+
+	// --- Read operations (ADR-022 §9 table) ---
+
+	// GetEntity returns the current entity state, provenance, and freshness.
+	// opts carries the mandatory tenant filter, optional as-of timestamp, and
+	// collapse-group flag.
+	GetEntity(ctx context.Context, eid EIDRef, opts GetEntityOpts) (*types.EntityView, error)
+
+	// GetDesiredState returns the desired state and originating config revision.
+	// Takes no opts parameter per ADR-022 §9.
+	GetDesiredState(ctx context.Context, eid EIDRef) (*types.DesiredStateView, error)
+
+	// GetDriftState returns the persisted drift-diff for a managed entity.
+	// Takes no opts parameter per ADR-022 §9.
+	GetDriftState(ctx context.Context, eid EIDRef) (*DriftState, error)
+
+	// QueryEntities returns entities matching the filter, paged.
+	QueryEntities(ctx context.Context, filter EntityFilter, page PageToken) (*EntityPage, error)
+
+	// GetEdges returns edges matching the filter.
+	GetEdges(ctx context.Context, filter EdgeFilter) ([]*EdgeView, error)
+
+	// GetNeighborhood returns a depth-bounded connected subgraph starting at eid.
+	// depth must be ≤3 per the access contract.
+	GetNeighborhood(ctx context.Context, eid EIDRef, edgeTypes []string, direction types.TraversalDirection, depth int) (*types.Neighborhood, error)
+
+	// GetHistory returns the versioned observation log for a subject over a time range.
+	GetHistory(ctx context.Context, eid EIDRef, r TimeRange) ([]*ObservationRecord, error)
+
+	// Diff returns the attribute delta between two points in time for a subject.
+	Diff(ctx context.Context, eid EIDRef, r TimeRange) (*StateDiff, error)
+
+	// GetTimeline returns a merged change-event stream for the given subjects.
+	GetTimeline(ctx context.Context, eids []EIDRef, r TimeRange) ([]*TimelineEvent, error)
+
+	// ListDrifted returns entities with active drift matching the filter.
+	ListDrifted(ctx context.Context, filter DriftFilter) ([]*DriftState, error)
+
+	// Watch returns a durable, cursor-replayable change feed.
+	// cursor is the last-seen cursor position; empty starts from now.
+	// The returned channel is closed when the context is cancelled.
+	Watch(ctx context.Context, filter WatchFilter, cursor string) (<-chan WatchEvent, error)
+
+	// ResolveIdentity returns the best-known EIDs for the given device/object
+	// identity claims. Not a PSA/CRM contact lookup.
+	ResolveIdentity(ctx context.Context, claims IdentityClaims) ([]EIDRef, error)
+
+	// --- Write contract (collectors only, ADR-022 §9) ---
+
+	// ReportObservations ingests a batch of observations from one source.
+	ReportObservations(ctx context.Context, batch ObservationBatch) error
+
+	// UpdateDriftLifecycle records a workflow annotation on a drift record.
+	UpdateDriftLifecycle(ctx context.Context, update DriftLifecycleUpdate) error
+}
+
+// --- Provider Registry ---
+
+var (
+	egRegistry = &entityGraphRegistry{providers: make(map[string]EntityGraphProvider)}
+)
+
+type entityGraphRegistry struct {
+	mu        sync.RWMutex
+	providers map[string]EntityGraphProvider
+}
+
+// RegisterEntityGraphProvider registers an EntityGraphProvider.
+// Returns an error if a provider with the same name is already registered.
+// Call from init() functions in provider packages.
+func RegisterEntityGraphProvider(p EntityGraphProvider) error {
+	if p == nil {
+		return fmt.Errorf("entitygraph: cannot register nil provider")
+	}
+	name := p.Name()
+	if name == "" {
+		return fmt.Errorf("entitygraph: provider name must not be empty")
+	}
+
+	egRegistry.mu.Lock()
+	defer egRegistry.mu.Unlock()
+
+	if _, exists := egRegistry.providers[name]; exists {
+		return fmt.Errorf("entitygraph: provider %q already registered", name)
+	}
+	egRegistry.providers[name] = p
+	return nil
+}
+
+// GetEntityGraphProvider retrieves a registered provider by name.
+// Returns an error if no provider with that name is registered.
+func GetEntityGraphProvider(name string) (EntityGraphProvider, error) {
+	egRegistry.mu.RLock()
+	defer egRegistry.mu.RUnlock()
+
+	p, ok := egRegistry.providers[name]
+	if !ok {
+		return nil, fmt.Errorf("entitygraph: provider %q not registered", name)
+	}
+	return p, nil
+}
+
+// ListEntityGraphProviders returns all registered provider names.
+func ListEntityGraphProviders() []string {
+	egRegistry.mu.RLock()
+	defer egRegistry.mu.RUnlock()
+
+	names := make([]string, 0, len(egRegistry.providers))
+	for name := range egRegistry.providers {
+		names = append(names, name)
+	}
+	return names
+}
+
+// UnregisterEntityGraphProvider removes a provider from the registry.
+// Primarily for testing; returns true if the provider was found and removed.
+func UnregisterEntityGraphProvider(name string) bool {
+	egRegistry.mu.Lock()
+	defer egRegistry.mu.Unlock()
+
+	if _, ok := egRegistry.providers[name]; ok {
+		delete(egRegistry.providers, name)
+		return true
+	}
+	return false
+}

--- a/pkg/entitygraph/types/edge.go
+++ b/pkg/entitygraph/types/edge.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package types
+
+// Edge is a directed, typed relationship between two entities (ADR-022 §2).
+type Edge struct {
+	// Type is the edge kind (e.g. "contains", "runs-on", "related:custom").
+	Type string
+	From EID
+	To   EID
+
+	// Attributes are optional typed metadata for this edge.
+	Attributes map[string]interface{}
+
+	// Sources holds the per-source observations asserting this edge.
+	Sources []Observation
+}
+
+// TraversalDirection controls the direction of neighborhood traversal.
+type TraversalDirection string
+
+const (
+	TraversalOutbound TraversalDirection = "outbound"
+	TraversalInbound  TraversalDirection = "inbound"
+	TraversalBoth     TraversalDirection = "both"
+)
+
+// Neighborhood is the result of a depth-bounded subgraph traversal (ADR-022 §9).
+// Depth is bounded at ≤3 per the access contract.
+type Neighborhood struct {
+	Root  EID
+	Nodes []*Entity
+	Edges []*Edge
+}

--- a/pkg/entitygraph/types/eid.go
+++ b/pkg/entitygraph/types/eid.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package types defines the foundational types for the CFGMS entity graph.
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// registeredAuthorityTypes is the closed set of authority types for this version
+// of the taxonomy. Authority types are the named things that mint stable local IDs
+// for entities (ADR-022 §1).
+var registeredAuthorityTypes = map[string]struct{}{
+	"host":      {},
+	"cluster":   {},
+	"directory": {},
+	"m365":      {},
+	"cfgms":     {},
+}
+
+// EID is a fleet-global entity identifier with the form:
+//
+//	authority_type:authority_name[/local_id]
+//
+// authority_type must be a registered authority type.
+// authority_name must not contain '/'.
+// local_id, when present, is the ADR-017 fragment_id and may contain '/'.
+//
+// Parsing is unambiguous at the first '/': everything left is the authority
+// segment; everything right is the local_id.
+type EID struct {
+	authorityType string
+	authorityName string
+	localID       string
+}
+
+// NewEID constructs a validated EID from its constituent parts.
+// localID may be empty (produces a bare-authority EID) or may contain '/'.
+func NewEID(authorityType, authorityName, localID string) (EID, error) {
+	if authorityType == "" {
+		return EID{}, fmt.Errorf("entitygraph/eid: authority type must not be empty")
+	}
+	if _, ok := registeredAuthorityTypes[authorityType]; !ok {
+		return EID{}, fmt.Errorf("entitygraph/eid: unregistered authority type %q", authorityType)
+	}
+	if authorityName == "" {
+		return EID{}, fmt.Errorf("entitygraph/eid: authority name must not be empty")
+	}
+	if strings.Contains(authorityName, "/") {
+		return EID{}, fmt.Errorf("entitygraph/eid: authority name must not contain '/': %q", authorityName)
+	}
+	return EID{authorityType: authorityType, authorityName: authorityName, localID: localID}, nil
+}
+
+// ParseEID parses a string EID.
+//
+// The string is split at the first '/' to obtain the authority segment and
+// optional local_id. The authority segment must be 'type:name' where type is
+// a registered authority type and name contains no '/'.
+func ParseEID(s string) (EID, error) {
+	if s == "" {
+		return EID{}, fmt.Errorf("entitygraph/eid: empty string is not a valid eid")
+	}
+
+	var authSeg, localID string
+	if idx := strings.Index(s, "/"); idx >= 0 {
+		authSeg = s[:idx]
+		localID = s[idx+1:]
+	} else {
+		authSeg = s
+	}
+
+	colonIdx := strings.Index(authSeg, ":")
+	if colonIdx < 0 {
+		return EID{}, fmt.Errorf("entitygraph/eid: malformed authority segment %q: expected 'type:name'", authSeg)
+	}
+
+	authType := authSeg[:colonIdx]
+	authName := authSeg[colonIdx+1:]
+
+	if authType == "" {
+		return EID{}, fmt.Errorf("entitygraph/eid: authority type must not be empty")
+	}
+	if authName == "" {
+		return EID{}, fmt.Errorf("entitygraph/eid: authority name must not be empty in segment %q", authSeg)
+	}
+	if strings.Contains(authName, "/") {
+		return EID{}, fmt.Errorf("entitygraph/eid: authority name must not contain '/': %q", authName)
+	}
+	if _, ok := registeredAuthorityTypes[authType]; !ok {
+		return EID{}, fmt.Errorf("entitygraph/eid: unregistered authority type %q", authType)
+	}
+
+	return EID{authorityType: authType, authorityName: authName, localID: localID}, nil
+}
+
+// AuthorityType returns the authority type portion (e.g. "host", "cluster").
+func (e EID) AuthorityType() string { return e.authorityType }
+
+// AuthorityName returns the authority name portion (e.g. "a1b2c3").
+func (e EID) AuthorityName() string { return e.authorityName }
+
+// LocalID returns the local_id portion. Empty string means this is a bare
+// authority-level EID naming the asset as a whole.
+func (e EID) LocalID() string { return e.localID }
+
+// AuthoritySegment returns "authority_type:authority_name".
+func (e EID) AuthoritySegment() string { return e.authorityType + ":" + e.authorityName }
+
+// HasLocalID reports whether the EID names a fragment within an authority.
+func (e EID) HasLocalID() bool { return e.localID != "" }
+
+// String returns the canonical string form of the EID.
+func (e EID) String() string {
+	if e.localID == "" {
+		return e.authorityType + ":" + e.authorityName
+	}
+	return e.authorityType + ":" + e.authorityName + "/" + e.localID
+}
+
+// IsZero reports whether the EID is the zero value (not yet set).
+func (e EID) IsZero() bool { return e.authorityType == "" }

--- a/pkg/entitygraph/types/eid_test.go
+++ b/pkg/entitygraph/types/eid_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package types_test
+
+import (
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEID_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantAuth string
+		wantName string
+		wantLID  string
+	}{
+		{
+			name:     "bare authority",
+			input:    "host:a1b2c3",
+			wantAuth: "host",
+			wantName: "a1b2c3",
+			wantLID:  "",
+		},
+		{
+			name:     "authority with service local id",
+			input:    "host:a1b2c3/service:sshd",
+			wantAuth: "host",
+			wantName: "a1b2c3",
+			wantLID:  "service:sshd",
+		},
+		{
+			name:     "authority with file local id containing slash",
+			input:    "host:a1b2/file:/etc/hosts",
+			wantAuth: "host",
+			wantName: "a1b2",
+			wantLID:  "file:/etc/hosts",
+		},
+		{
+			name:     "cluster authority",
+			input:    "cluster:hv-east-guid",
+			wantAuth: "cluster",
+			wantName: "hv-east-guid",
+			wantLID:  "",
+		},
+		{
+			name:     "directory authority with local id",
+			input:    "directory:inst-42/user:alice",
+			wantAuth: "directory",
+			wantName: "inst-42",
+			wantLID:  "user:alice",
+		},
+		{
+			name:     "m365 authority",
+			input:    "m365:tenant-guid",
+			wantAuth: "m365",
+			wantName: "tenant-guid",
+			wantLID:  "",
+		},
+		{
+			name:     "cfgms authority",
+			input:    "cfgms:deploy-1",
+			wantAuth: "cfgms",
+			wantName: "deploy-1",
+			wantLID:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eid, err := types.ParseEID(tc.input)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantAuth, eid.AuthorityType())
+			assert.Equal(t, tc.wantName, eid.AuthorityName())
+			assert.Equal(t, tc.wantLID, eid.LocalID())
+			assert.Equal(t, tc.input, eid.String(), "round-trip must match input")
+		})
+	}
+}
+
+func TestNewEID_RoundTrip(t *testing.T) {
+	eid, err := types.NewEID("host", "a1b2c3", "service:sshd")
+	require.NoError(t, err)
+	assert.Equal(t, "host:a1b2c3/service:sshd", eid.String())
+
+	eid2, err := types.NewEID("host", "a1b2c3", "")
+	require.NoError(t, err)
+	assert.Equal(t, "host:a1b2c3", eid2.String())
+	assert.False(t, eid2.HasLocalID())
+
+	eid3, err := types.NewEID("host", "a1b2", "file:/etc/hosts")
+	require.NoError(t, err)
+	assert.Equal(t, "host:a1b2/file:/etc/hosts", eid3.String())
+	assert.True(t, eid3.HasLocalID())
+}
+
+func TestParseEID_RejectMalformed(t *testing.T) {
+	// Note: "slash in authority name" cannot be tested via ParseEID because the
+	// format splits unambiguously at the first '/'. A slash would end the authority
+	// segment, not embed in the authority name. NewEID rejects slash-in-name
+	// directly (see TestNewEID_RejectMalformed).
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "unregistered authority type",
+			input: "bogus:a1b2c3",
+		},
+		{
+			name:  "empty authority type",
+			input: ":a1b2c3",
+		},
+		{
+			name:  "empty authority name",
+			input: "host:",
+		},
+		{
+			name:  "missing colon in authority segment",
+			input: "hosta1b2c3",
+		},
+		{
+			name:  "empty string",
+			input: "",
+		},
+		{
+			name:  "only slash",
+			input: "/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := types.ParseEID(tc.input)
+			assert.Error(t, err, "expected error for input %q", tc.input)
+		})
+	}
+}
+
+func TestNewEID_RejectMalformed(t *testing.T) {
+	_, err := types.NewEID("host", "a1/b2", "")
+	assert.Error(t, err, "authority name with slash must be rejected")
+
+	_, err = types.NewEID("bogus", "a1b2c3", "")
+	assert.Error(t, err, "unregistered authority type must be rejected")
+
+	_, err = types.NewEID("host", "", "")
+	assert.Error(t, err, "empty authority name must be rejected")
+
+	_, err = types.NewEID("", "a1b2c3", "")
+	assert.Error(t, err, "empty authority type must be rejected")
+}
+
+func TestEID_AuthoritySegment(t *testing.T) {
+	eid, err := types.ParseEID("host:a1b2c3/service:sshd")
+	require.NoError(t, err)
+	assert.Equal(t, "host:a1b2c3", eid.AuthoritySegment())
+}
+
+func TestEID_IsZero(t *testing.T) {
+	var zero types.EID
+	assert.True(t, zero.IsZero())
+
+	eid, err := types.ParseEID("host:a1b2c3")
+	require.NoError(t, err)
+	assert.False(t, eid.IsZero())
+}

--- a/pkg/entitygraph/types/entity.go
+++ b/pkg/entitygraph/types/entity.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package types
+
+import "time"
+
+// Entity is a node in the entity graph: a typed asset known to CFGMS.
+// Current state is a projection over accumulated observations (ADR-022 §4).
+type Entity struct {
+	EID          EID
+	Kind         string
+	Attributes   map[string]interface{}
+	OwningTenant string
+}
+
+// Freshness captures how current a piece of knowledge is (ADR-022 §4).
+type Freshness struct {
+	// ObservedAt is when the source observed this value.
+	ObservedAt time.Time
+	// RecordedAt is when the controller ingested this value.
+	RecordedAt time.Time
+	// Stale reports whether the observation is past its declared cadence.
+	Stale bool
+}
+
+// EntityView is the read-projected view returned by GetEntity.
+// It includes the current state, provenance summary, freshness, and an
+// optional collapsed same-as group view (ADR-022 §3/§9).
+type EntityView struct {
+	Entity    *Entity
+	Sources   []Observation
+	Freshness Freshness
+
+	// CollapseGroup, when non-nil, is the merged view of the same-as group
+	// after the tenant-cut and source-precedence rules are applied (§3).
+	CollapseGroup *CollapseGroupView
+}
+
+// CollapseGroupView is the merged entity view across a same-as group (ADR-022 §3).
+type CollapseGroupView struct {
+	Members   []EID
+	Merged    map[string]interface{} // attribute key → winning value
+	Conflicts map[string][]AttributeConflict
+}
+
+// AttributeConflict holds the competing values for one attribute in a collapse group.
+type AttributeConflict struct {
+	Source string
+	Value  interface{}
+}
+
+// DesiredStateView is the return type for GetDesiredState (ADR-022 §6/§9).
+type DesiredStateView struct {
+	EID            EID
+	State          map[string]interface{}
+	ConfigRevision string
+	ObservedAt     time.Time
+}

--- a/pkg/entitygraph/types/observation.go
+++ b/pkg/entitygraph/types/observation.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package types
+
+import "time"
+
+// ObservationKind classifies the intent of an observation (ADR-022 §4).
+type ObservationKind string
+
+const (
+	ObservationKindState    ObservationKind = "state"
+	ObservationKindPresence ObservationKind = "presence"
+	ObservationKindAbsence  ObservationKind = "absence"
+)
+
+// Confidence is the producer-declared confidence level for an observation.
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "high"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceLow    Confidence = "low"
+)
+
+// Observation is the single write primitive for entities, attributes, and edges
+// alike (ADR-022 §4). Subject is either an EID or an edge identity string.
+type Observation struct {
+	Source     string          // source identity (e.g. "enforcing-module:hyperv")
+	ObservedAt time.Time       // when true in the world, per the source
+	RecordedAt time.Time       // when the controller ingested this observation
+	Subject    string          // eid.String() or edge identity
+	Kind       ObservationKind // state | presence | absence
+	Confidence Confidence
+	Payload    map[string]interface{} // typed, optional
+}
+
+// EdgeScopePattern is the edge-addressed variant of a claim scope pattern.
+type EdgeScopePattern struct {
+	EdgeType  string
+	AnchorEID EID
+	Direction TraversalDirection
+}
+
+// EntityScopePattern is the entity-addressed variant of a claim scope pattern.
+type EntityScopePattern struct {
+	EntityType      string
+	AuthorityPrefix string
+}
+
+// ClaimScopePattern is a discriminated union of the two pattern kinds.
+// Exactly one of Edge or Entity must be non-nil.
+type ClaimScopePattern struct {
+	Edge   *EdgeScopePattern
+	Entity *EntityScopePattern
+}
+
+// ClaimScope declares the scope of a snapshot-style collector's assertion set
+// per ADR-022 §4. An enumeration under a claim scope implicitly retracts any
+// prior assertion by the same source inside that scope.
+type ClaimScope struct {
+	Source  string
+	Pattern ClaimScopePattern
+	AsOf    time.Time
+}

--- a/pkg/entitygraph/types/taxonomy.go
+++ b/pkg/entitygraph/types/taxonomy.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SourceClass identifies the class of a knowledge source for precedence ordering
+// per ADR-022 §4. Higher index = lower precedence in DefaultPrecedenceOrder.
+type SourceClass string
+
+const (
+	SourceClassEnforcingModule     SourceClass = "enforcing-module"
+	SourceClassManagingIntegration SourceClass = "managing-integration"
+	SourceClassObserver            SourceClass = "observer"
+	SourceClassOperatorAssertion   SourceClass = "operator-assertion"
+	SourceClassCorrelatorInference SourceClass = "correlator-inference"
+)
+
+// DefaultPrecedenceOrder is the default source class ordering per ADR-022 §4:
+// enforcing module > managing integration > observer > operator assertion > correlator inference.
+var DefaultPrecedenceOrder = []SourceClass{
+	SourceClassEnforcingModule,
+	SourceClassManagingIntegration,
+	SourceClassObserver,
+	SourceClassOperatorAssertion,
+	SourceClassCorrelatorInference,
+}
+
+// EntityTypeDescriptor describes a known entity kind in the taxonomy.
+type EntityTypeDescriptor struct {
+	// Kind is the entity type name (e.g. "host", "user").
+	Kind string
+
+	// AuthorityClasses lists the authority types that can name this entity kind.
+	AuthorityClasses []string
+
+	// PrecedenceOrder overrides DefaultPrecedenceOrder for this entity type.
+	// nil means use DefaultPrecedenceOrder. No entity type in this epic sets
+	// a non-default value; wiring a consumer is a named follow-on.
+	PrecedenceOrder []SourceClass
+}
+
+// EdgeTypeDescriptor describes a known edge kind in the taxonomy.
+type EdgeTypeDescriptor struct {
+	// Kind is the edge type name (e.g. "contains", "runs-on").
+	Kind string
+}
+
+// relatedPrefix is the open-subtype escape prefix per ADR-022 §2.
+const relatedPrefix = "related:"
+
+// Taxonomy is the versioned entity and edge type registry per ADR-022 §1/§2.
+type Taxonomy struct {
+	// Version is the registry version; bumped on each taxonomy change.
+	Version int
+
+	entityTypes map[string]*EntityTypeDescriptor
+	edgeTypes   map[string]*EdgeTypeDescriptor
+}
+
+// LookupEntityType returns the descriptor for a known entity kind.
+// The second return value is false for unrecognized kinds.
+func (tx *Taxonomy) LookupEntityType(kind string) (*EntityTypeDescriptor, bool) {
+	d, ok := tx.entityTypes[kind]
+	return d, ok
+}
+
+// LookupEdgeType returns the descriptor for a known edge kind.
+// Returns false for unrecognized kinds that are not the related: escape.
+func (tx *Taxonomy) LookupEdgeType(kind string) (*EdgeTypeDescriptor, bool) {
+	d, ok := tx.edgeTypes[kind]
+	return d, ok
+}
+
+// IsRelatedEscape reports whether kind is a related:<discriminator> open-subtype.
+func (tx *Taxonomy) IsRelatedEscape(kind string) bool {
+	return strings.HasPrefix(kind, relatedPrefix) && len(kind) > len(relatedPrefix)
+}
+
+// ParseRelatedEscape extracts the discriminator from a related:<discriminator> kind.
+func (tx *Taxonomy) ParseRelatedEscape(kind string) (string, error) {
+	if !tx.IsRelatedEscape(kind) {
+		return "", fmt.Errorf("entitygraph/taxonomy: %q is not a related: escape", kind)
+	}
+	return kind[len(relatedPrefix):], nil
+}
+
+// FormatRelatedEscape formats a discriminator into a related:<discriminator> kind.
+func (tx *Taxonomy) FormatRelatedEscape(discriminator string) string {
+	return relatedPrefix + discriminator
+}
+
+// EffectivePrecedenceOrder returns the precedence order for the given entity type,
+// falling back to DefaultPrecedenceOrder when the descriptor carries no override.
+func (tx *Taxonomy) EffectivePrecedenceOrder(desc *EntityTypeDescriptor) []SourceClass {
+	if desc != nil && len(desc.PrecedenceOrder) > 0 {
+		return desc.PrecedenceOrder
+	}
+	return DefaultPrecedenceOrder
+}
+
+// DefaultTaxonomy returns the canonical seed taxonomy (version 1).
+// Seed entity kinds and edge kinds are per ADR-022 §1/§2.
+func DefaultTaxonomy() *Taxonomy {
+	tx := &Taxonomy{
+		Version:     1,
+		entityTypes: make(map[string]*EntityTypeDescriptor),
+		edgeTypes:   make(map[string]*EdgeTypeDescriptor),
+	}
+
+	// Seed entity kinds per ADR-022 §1.
+	entitySeeds := []*EntityTypeDescriptor{
+		{Kind: "host", AuthorityClasses: []string{"host"}},
+		{Kind: "cluster", AuthorityClasses: []string{"cluster"}},
+		{Kind: "vm", AuthorityClasses: []string{"cluster", "host"}},
+		{Kind: "vswitch", AuthorityClasses: []string{"cluster", "host"}},
+		{Kind: "device", AuthorityClasses: []string{"host"}},
+		{Kind: "application", AuthorityClasses: []string{"host"}},
+		{Kind: "user", AuthorityClasses: []string{"directory", "m365"}},
+		{Kind: "group", AuthorityClasses: []string{"directory", "m365"}},
+		{Kind: "tenant", AuthorityClasses: []string{"cfgms"}},
+		{Kind: "directory", AuthorityClasses: []string{"directory", "m365"}},
+	}
+	for _, d := range entitySeeds {
+		tx.entityTypes[d.Kind] = d
+	}
+
+	// Seed edge kinds per ADR-022 §2.
+	edgeSeeds := []string{
+		"contains",
+		"runs-on",
+		"member-of",
+		"depends-on",
+		"serves",
+		"connects-to",
+		"manages",
+		"managed-by",
+		"assigned-to",
+		"delegated-access",
+		"reports-to",
+		"same-as",
+	}
+	for _, kind := range edgeSeeds {
+		tx.edgeTypes[kind] = &EdgeTypeDescriptor{Kind: kind}
+	}
+
+	return tx
+}

--- a/pkg/entitygraph/types/taxonomy_test.go
+++ b/pkg/entitygraph/types/taxonomy_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package types_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaxonomy_SeedEntityTypes(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	seedKinds := []string{
+		"application", "device", "user", "group", "tenant",
+		"vm", "vswitch", "host", "cluster", "directory",
+	}
+
+	for _, kind := range seedKinds {
+		t.Run(kind, func(t *testing.T) {
+			desc, ok := tx.LookupEntityType(kind)
+			require.True(t, ok, "seed entity kind %q must be in taxonomy", kind)
+			assert.Equal(t, kind, desc.Kind)
+			assert.NotEmpty(t, desc.AuthorityClasses, "entity type must have at least one authority class")
+		})
+	}
+}
+
+func TestTaxonomy_SeedEdgeTypes(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	seedEdges := []string{
+		"contains", "runs-on", "member-of", "depends-on", "serves",
+		"connects-to", "manages", "managed-by", "assigned-to",
+		"delegated-access", "reports-to", "same-as",
+	}
+
+	for _, kind := range seedEdges {
+		t.Run(kind, func(t *testing.T) {
+			desc, ok := tx.LookupEdgeType(kind)
+			require.True(t, ok, "seed edge kind %q must be in taxonomy", kind)
+			assert.Equal(t, kind, desc.Kind)
+		})
+	}
+}
+
+func TestTaxonomy_UnrecognizedEdgeRoundTrip(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	cases := []string{
+		"related:custom-link",
+		"related:hyperv-move",
+		"related:arbitrary-discriminator",
+	}
+
+	for _, edgeKind := range cases {
+		t.Run(edgeKind, func(t *testing.T) {
+			require.True(t, strings.HasPrefix(edgeKind, "related:"),
+				"test case should use the related: prefix")
+
+			ok := tx.IsRelatedEscape(edgeKind)
+			assert.True(t, ok, "related: edge must be recognized as escape")
+
+			// Must parse without error and round-trip the discriminator.
+			discriminator, err := tx.ParseRelatedEscape(edgeKind)
+			require.NoError(t, err)
+			assert.NotEmpty(t, discriminator)
+
+			// Re-encoding must round-trip.
+			roundTripped := tx.FormatRelatedEscape(discriminator)
+			assert.Equal(t, edgeKind, roundTripped)
+		})
+	}
+}
+
+func TestTaxonomy_PrecedenceOverrideField(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	// Every seed entity type must carry the PrecedenceOrder field (may be nil = default).
+	// This epic populates no non-default values, but the field must exist on the descriptor.
+	desc, ok := tx.LookupEntityType("host")
+	require.True(t, ok)
+
+	// Field exists and nil signals "use default order" — that is correct for this epic.
+	// A consumer that needs the order calls tx.EffectivePrecedenceOrder(desc).
+	order := tx.EffectivePrecedenceOrder(desc)
+	assert.Equal(t, types.DefaultPrecedenceOrder, order,
+		"host with nil override must return DefaultPrecedenceOrder")
+}
+
+func TestTaxonomy_Version(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+	assert.Greater(t, tx.Version, 0, "taxonomy must have a positive version")
+}


### PR DESCRIPTION
## Summary

- Introduces `pkg/entitygraph/types` and `pkg/entitygraph/interfaces` as the foundational contract layer for the CFGMS Entity Graph (ADR-022, epic #2851).
- Pure Go, no storage backend. Patterns follow `pkg/dataplane/interfaces` (registry) and `pkg/storage/interfaces` (auto-registration).
- All five acceptance criteria verified: EID round-trip + rejection, taxonomy seed types + related: escape + precedence-override field, EntityGraphProvider interface compile assertion, registry registration + duplicate rejection + lookup, architecture checks clean.

Fixes #2871

## What changed

**`pkg/entitygraph/types/eid.go`** — `EID` type with `NewEID` / `ParseEID`. Splits at first `/`; validates authority type against closed registered set (`host`, `cluster`, `directory`, `m365`, `cfgms`); rejects malformed ids.

**`pkg/entitygraph/types/taxonomy.go`** — Versioned entity/edge type registry v1. Seed entity kinds: `application`, `device`, `user`, `group`, `tenant`, `vm`, `vswitch`, `host`, `cluster`, `directory`. Seed edge kinds: 12 first-class types from ADR-022 §2. `related:<discriminator>` open-subtype escape. `PrecedenceOrder` override field on `EntityTypeDescriptor` (nil = default; no override set in this epic per story spec).

**`pkg/entitygraph/types/{entity,edge,observation}.go`** — `Entity`, `EntityView`, `CollapseGroupView`, `DesiredStateView`, `Edge`, `Neighborhood`, `Observation`, `ClaimScope`, and supporting enumerations per ADR-022 §3/§4.

**`pkg/entitygraph/interfaces/provider.go`** — `EntityGraphProvider` interface with all ADR-022 §9 operations. `GetEntity(eid, opts)` takes collapse-group opts; `GetDesiredState` and `GetDriftState` take no opts. Provider registry mirroring `pkg/storage/interfaces`.

**`pkg/entitygraph/interfaces/contract_test.go`** — `RunEntityGraphContractTests` harness (grown incrementally by follow-on round stories), registry tests, and compile-time `var _ EntityGraphProvider = (*noopProvider)(nil)` assertion.

## Specialist review results

| Lens | Round 1 | Round 2 |
|------|---------|---------|
| Code review | PASS | — |
| Test quality | FAIL (test suite run) | PASS (fixed) |
| Security | PASS | — |

**Aggregate: PASS** (`passed: true`, 2 review rounds, 1 fix round, 0 remaining findings)

## Test plan

- [ ] `go test ./pkg/entitygraph/...` — all subtests pass
- [ ] `make check-architecture` — no central provider violations
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate