### PR TITLE
entitygraph: Core: schema, append primitive, generic precedence resolver, core reads (sqlite + da...

### DIFF
--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -19,6 +19,7 @@ package interfaces_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
 	"github.com/cfgis/cfgms/pkg/entitygraph/types"
@@ -41,6 +42,348 @@ func RunEntityGraphContractTests(t *testing.T, factory EntityGraphProviderFactor
 	t.Run("ProviderAvailable", func(t *testing.T) {
 		testEGProviderAvailable(t, factory)
 	})
+	t.Run("RoundTrip", func(t *testing.T) { testEGRoundTrip(t, factory) })                    // AC 1
+	t.Run("ContentHashDedup", func(t *testing.T) { testEGContentHashDedup(t, factory) })      // AC 2
+	t.Run("PrecedenceResolution", func(t *testing.T) { testEGPrecedence(t, factory) })        // AC 3
+	t.Run("QueryEntities", func(t *testing.T) { testEGQueryEntities(t, factory) })            // AC 4
+	t.Run("CrossTenantNotFound", func(t *testing.T) { testEGCrossTenant(t, factory) })        // AC 5
+	t.Run("MovedEntityVisibility", func(t *testing.T) { testEGMovedEntity(t, factory) })      // AC 6
+	t.Run("ProjectionRebuild", func(t *testing.T) { testEGRebuild(t, factory) })              // AC 7
+	t.Run("ResolveIdentity", func(t *testing.T) { testEGResolveIdentity(t, factory) })        // AC 8
+	t.Run("EmptyProjectionTables", func(t *testing.T) { testEGEmptyProjections(t, factory) }) // AC 9
+	t.Run("GetEntityOptsNoOp", func(t *testing.T) { testEGOptsNoOp(t, factory) })             // opts pass-through
+}
+
+// --- Contract test helpers ---
+
+// egEID parses a canonical EID string, failing the test on error.
+func egEID(t *testing.T, s string) interfaces.EIDRef {
+	t.Helper()
+	eid, err := types.ParseEID(s)
+	require.NoError(t, err, "parse eid %q", s)
+	return eid
+}
+
+// egObservation builds a single state observation with a fixed timestamp so that
+// repeated calls with the same arguments are bit-identical (content-hash dedup).
+func egObservation(subject, source string, observedAt time.Time, payload map[string]interface{}) types.Observation {
+	return types.Observation{
+		Source:     source,
+		ObservedAt: observedAt,
+		RecordedAt: observedAt,
+		Subject:    subject,
+		Kind:       types.ObservationKindState,
+		Confidence: types.ConfidenceHigh,
+		Payload:    payload,
+	}
+}
+
+// egReport ingests a single-observation batch from source, failing on error.
+func egReport(ctx context.Context, t *testing.T, p interfaces.EntityGraphProvider, source, subject string, payload map[string]interface{}) {
+	t.Helper()
+	batch := interfaces.ObservationBatch{
+		Source:       source,
+		Observations: []types.Observation{egObservation(subject, source, time.Now().UTC(), payload)},
+	}
+	require.NoError(t, p.ReportObservations(ctx, batch), "report observation for %q", subject)
+}
+
+// testEGRoundTrip verifies a reported observation is retrievable via GetEntity
+// and QueryEntities under the owning tenant (AC 1).
+func testEGRoundTrip(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject = "host:test-host/server1"
+	egReport(ctx, t, p, "observer:test", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "server1",
+		"owning_tenant": "root/test-tenant",
+	})
+
+	view, err := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{TenantFilter: "root/test-tenant"})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	require.NotNil(t, view.Entity)
+	assert.Equal(t, "server1", view.Entity.Attributes["hostname"])
+
+	page, err := p.QueryEntities(ctx, interfaces.EntityFilter{Kind: "host", TenantFilter: "root/test-tenant"}, interfaces.PageToken{})
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.GreaterOrEqual(t, len(page.Entities), 1)
+}
+
+// testEGContentHashDedup verifies that reporting a bit-identical observation
+// twice is idempotent: no error, and the entity view stays consistent (AC 2).
+// The provider-level test asserts the underlying log-row count.
+func testEGContentHashDedup(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject = "host:dedup-auth/dedup1"
+	payload := map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "dedup-host",
+		"owning_tenant": "root/dedup-tenant",
+	}
+	// Build one observation and report it twice — bit-identical (same timestamp).
+	obs := egObservation(subject, "observer:test", time.Now().UTC(), payload)
+	batch := interfaces.ObservationBatch{Source: "observer:test", Observations: []types.Observation{obs}}
+
+	require.NoError(t, p.ReportObservations(ctx, batch))
+	view1, err := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{TenantFilter: "root/dedup-tenant"})
+	require.NoError(t, err)
+	require.NotNil(t, view1)
+	require.NotNil(t, view1.Entity)
+
+	// Second identical report must not error and must not change the view.
+	require.NoError(t, p.ReportObservations(ctx, batch))
+	view2, err := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{TenantFilter: "root/dedup-tenant"})
+	require.NoError(t, err)
+	require.NotNil(t, view2)
+	require.NotNil(t, view2.Entity)
+	assert.Equal(t, view1.Entity.Attributes["hostname"], view2.Entity.Attributes["hostname"])
+}
+
+// testEGPrecedence verifies that the higher-precedence source class wins when
+// two sources assert conflicting values for the same subject (AC 3).
+func testEGPrecedence(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject = "host:precedence-auth/host1"
+
+	// Report the lower-precedence source (correlator inference) first.
+	egReport(ctx, t, p, "correlator-inference:ml", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "wrong-name",
+		"owning_tenant": "root/t1",
+	})
+	// Then the higher-precedence source (enforcing module).
+	egReport(ctx, t, p, "enforcing-module:hyperv", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "correct-name",
+		"owning_tenant": "root/t1",
+	})
+
+	view, err := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{TenantFilter: "root/t1"})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	require.NotNil(t, view.Entity)
+	assert.Equal(t, "correct-name", view.Entity.Attributes["hostname"], "enforcing-module must win over correlator-inference")
+}
+
+// testEGQueryEntities verifies kind and tenant filtering in QueryEntities (AC 4).
+func testEGQueryEntities(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const hostSubject = "host:provider-qe/host1"
+	const userSubject = "m365:provider-qe/user1"
+
+	egReport(ctx, t, p, "observer:test", hostSubject, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "test-host",
+		"owning_tenant": "root/msp-a",
+	})
+	egReport(ctx, t, p, "observer:test", userSubject, map[string]interface{}{
+		"entity_kind":   "user",
+		"hostname":      "",
+		"owning_tenant": "root/msp-b",
+	})
+
+	hostPage, err := p.QueryEntities(ctx, interfaces.EntityFilter{Kind: "host", TenantFilter: "root/msp-a"}, interfaces.PageToken{})
+	require.NoError(t, err)
+	require.NotNil(t, hostPage)
+	require.Len(t, hostPage.Entities, 1)
+	require.NotNil(t, hostPage.Entities[0].Entity)
+	assert.Equal(t, "host", hostPage.Entities[0].Entity.Kind)
+
+	userPage, err := p.QueryEntities(ctx, interfaces.EntityFilter{TenantFilter: "root/msp-b"}, interfaces.PageToken{})
+	require.NoError(t, err)
+	require.NotNil(t, userPage)
+	require.Len(t, userPage.Entities, 1)
+	require.NotNil(t, userPage.Entities[0].Entity)
+	assert.Equal(t, "user", userPage.Entities[0].Entity.Kind)
+
+	emptyPage, err := p.QueryEntities(ctx, interfaces.EntityFilter{TenantFilter: "root/msp-c"}, interfaces.PageToken{})
+	require.NoError(t, err)
+	require.NotNil(t, emptyPage)
+	assert.Empty(t, emptyPage.Entities)
+}
+
+// testEGCrossTenant verifies that a read scoped to a non-owning tenant returns
+// not-found (nil entity or ErrNotFound), never another tenant's data (AC 5).
+func testEGCrossTenant(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject = "host:xtenant-auth/host1"
+	egReport(ctx, t, p, "observer:test", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "tenant-a-secret",
+		"owning_tenant": "root/tenant-a",
+	})
+
+	view, err := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{TenantFilter: "root/tenant-b"})
+	// The AC accepts either an error or a nil entity — but never tenant-a's data.
+	if err == nil {
+		assert.Nil(t, view, "cross-tenant read must not return the owning tenant's entity")
+	}
+}
+
+// testEGMovedEntity verifies current-ownership semantics in both directions when
+// an entity's owning_tenant changes (AC 6).
+func testEGMovedEntity(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject = "host:moved-auth/host1"
+
+	// Initial ownership: tenant-a.
+	egReport(ctx, t, p, "enforcing-module:mover", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"owning_tenant": "root/tenant-a",
+		"hostname":      "moved-host",
+	})
+	// Same subject, same source, moved to tenant-b.
+	egReport(ctx, t, p, "enforcing-module:mover", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"owning_tenant": "root/tenant-b",
+		"hostname":      "moved-host",
+	})
+
+	// Now visible under the new owning tenant.
+	viewB, err := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{TenantFilter: "root/tenant-b"})
+	require.NoError(t, err)
+	require.NotNil(t, viewB)
+	require.NotNil(t, viewB.Entity)
+	assert.Equal(t, "moved-host", viewB.Entity.Attributes["hostname"])
+
+	// No longer visible under the old owning tenant.
+	viewA, errA := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{TenantFilter: "root/tenant-a"})
+	if errA == nil {
+		assert.Nil(t, viewA, "moved entity must not remain visible to its former owning tenant")
+	}
+}
+
+// testEGRebuild verifies that RebuildProjections leaves entity reads unchanged
+// (AC 7). Providers that do not implement RebuildProjections are skipped via the
+// type assertion so the shared harness stays provider-agnostic.
+func testEGRebuild(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject1 = "host:rebuild-auth/host1"
+	const subject2 = "host:rebuild-auth/host2"
+	egReport(ctx, t, p, "observer:test", subject1, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "rebuild-1",
+		"owning_tenant": "root/rb-tenant",
+	})
+	egReport(ctx, t, p, "observer:test", subject2, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "rebuild-2",
+		"owning_tenant": "root/rb-tenant",
+	})
+
+	opts := interfaces.GetEntityOpts{TenantFilter: "root/rb-tenant"}
+	before1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
+	require.NoError(t, err)
+	require.NotNil(t, before1)
+	before2, err := p.GetEntity(ctx, egEID(t, subject2), opts)
+	require.NoError(t, err)
+	require.NotNil(t, before2)
+
+	rebuilder, ok := p.(interface {
+		RebuildProjections(ctx context.Context) error
+	})
+	if !ok {
+		t.Skip("provider does not implement RebuildProjections")
+	}
+	require.NoError(t, rebuilder.RebuildProjections(ctx))
+
+	after1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
+	require.NoError(t, err)
+	require.NotNil(t, after1)
+	after2, err := p.GetEntity(ctx, egEID(t, subject2), opts)
+	require.NoError(t, err)
+	require.NotNil(t, after2)
+
+	assert.Equal(t, before1.Entity.Attributes["hostname"], after1.Entity.Attributes["hostname"])
+	assert.Equal(t, before2.Entity.Attributes["hostname"], after2.Entity.Attributes["hostname"])
+}
+
+// testEGResolveIdentity verifies identity-claim resolution to EIDs (AC 8).
+func testEGResolveIdentity(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject = "host:ri-auth/resolve1"
+	egReport(ctx, t, p, "observer:test", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "resolve-host",
+		"machine_sid":   "S-1-5-21-xyz",
+		"owning_tenant": "root/ri-tenant",
+	})
+	eid := egEID(t, subject)
+
+	byHostname, err := p.ResolveIdentity(ctx, interfaces.IdentityClaims{Hostname: "resolve-host"})
+	require.NoError(t, err)
+	assert.Contains(t, byHostname, eid)
+
+	byMissing, err := p.ResolveIdentity(ctx, interfaces.IdentityClaims{Hostname: "nonexistent"})
+	require.NoError(t, err, "resolving an unknown identity must not error")
+	assert.Empty(t, byMissing)
+
+	bySID, err := p.ResolveIdentity(ctx, interfaces.IdentityClaims{MachineSID: "S-1-5-21-xyz"})
+	require.NoError(t, err)
+	assert.Contains(t, bySID, eid)
+}
+
+// testEGEmptyProjections verifies that the forward-declared edge and drift
+// projections are queryable without panicking before their populating stories
+// land (AC 9). The provider-level test asserts the schema tables exist.
+func testEGEmptyProjections(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	// GetEdges over an empty projection returns either ErrNotImplemented or an
+	// empty result — never a table-missing error and never a panic.
+	edges, edgeErr := p.GetEdges(ctx, interfaces.EdgeFilter{})
+	if edgeErr != nil {
+		assert.ErrorIs(t, edgeErr, interfaces.ErrNotImplemented)
+	} else {
+		assert.Empty(t, edges)
+	}
+
+	// GetDriftState over an unmanaged entity returns an error (ErrNotImplemented
+	// or not-found), never a panic.
+	_, driftErr := p.GetDriftState(ctx, egEID(t, "host:empty-auth/host1"))
+	assert.Error(t, driftErr)
+}
+
+// testEGOptsNoOp verifies that setting CollapseGroup on GetEntityOpts is a
+// pass-through no-op: the read still succeeds and CollapseGroup is not populated.
+func testEGOptsNoOp(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	const subject = "host:opts-auth/host1"
+	egReport(ctx, t, p, "observer:test", subject, map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "opts-host",
+		"owning_tenant": "root/opts-tenant",
+	})
+
+	view, err := p.GetEntity(ctx, egEID(t, subject), interfaces.GetEntityOpts{
+		CollapseGroup: true,
+		TenantFilter:  "root/opts-tenant",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	assert.Nil(t, view.CollapseGroup, "CollapseGroup opt is a pass-through no-op in this round")
 }
 
 func testEGProviderIdentity(t *testing.T, factory EntityGraphProviderFactory) {
@@ -157,5 +500,8 @@ func (n *noopProvider) ReportObservations(_ context.Context, _ interfaces.Observ
 	return interfaces.ErrNotImplemented
 }
 func (n *noopProvider) UpdateDriftLifecycle(_ context.Context, _ interfaces.DriftLifecycleUpdate) error {
+	return interfaces.ErrNotImplemented
+}
+func (n *noopProvider) RebuildProjections(_ context.Context) error {
 	return interfaces.ErrNotImplemented
 }

--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -267,9 +267,18 @@ func testEGMovedEntity(t *testing.T, factory EntityGraphProviderFactory) {
 	}
 }
 
-// testEGRebuild verifies that RebuildProjections leaves entity reads unchanged
-// (AC 7). RebuildProjections is part of the EntityGraphProvider interface, so
-// every provider has the method and the test always runs.
+// corruptibleProvider is satisfied by providers that expose a test-only
+// corruption hook. The interface is used by testEGRebuild to verify the
+// corruption-recovery path of RebuildProjections (AC 7, tested directly).
+type corruptibleProvider interface {
+	CorruptProjectionsForTesting(ctx context.Context) error
+}
+
+// testEGRebuild verifies that RebuildProjections reconstructs projections from
+// the observation log (AC 7). When the provider implements corruptibleProvider,
+// the test verifies the full corruption-recovery path: delete both projection
+// tables and confirm that reads recover after rebuild. When the provider does
+// not expose a corruption hook, the test verifies idempotency instead.
 func testEGRebuild(t *testing.T, factory EntityGraphProviderFactory) {
 	t.Helper()
 	p := factory(t)
@@ -288,24 +297,46 @@ func testEGRebuild(t *testing.T, factory EntityGraphProviderFactory) {
 	})
 
 	opts := interfaces.GetEntityOpts{TenantFilter: "root/rb-tenant"}
-	before1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
-	require.NoError(t, err)
-	require.NotNil(t, before1)
-	before2, err := p.GetEntity(ctx, egEID(t, subject2), opts)
-	require.NoError(t, err)
-	require.NotNil(t, before2)
 
-	require.NoError(t, p.RebuildProjections(ctx))
+	if c, ok := p.(corruptibleProvider); ok {
+		// Corruption-recovery path: delete both projection tables, confirm reads
+		// fail, rebuild, confirm reads recover with the correct values.
+		require.NoError(t, c.CorruptProjectionsForTesting(ctx))
 
-	after1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
-	require.NoError(t, err)
-	require.NotNil(t, after1)
-	after2, err := p.GetEntity(ctx, egEID(t, subject2), opts)
-	require.NoError(t, err)
-	require.NotNil(t, after2)
+		_, err := p.GetEntity(ctx, egEID(t, subject1), opts)
+		require.Error(t, err, "entity must be unreachable after projection corruption")
 
-	assert.Equal(t, before1.Entity.Attributes["hostname"], after1.Entity.Attributes["hostname"])
-	assert.Equal(t, before2.Entity.Attributes["hostname"], after2.Entity.Attributes["hostname"])
+		require.NoError(t, p.RebuildProjections(ctx))
+
+		after1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
+		require.NoError(t, err, "entity must be readable after rebuild")
+		require.NotNil(t, after1)
+		after2, err := p.GetEntity(ctx, egEID(t, subject2), opts)
+		require.NoError(t, err, "entity must be readable after rebuild")
+		require.NotNil(t, after2)
+		assert.Equal(t, "rebuild-1", after1.Entity.Attributes["hostname"])
+		assert.Equal(t, "rebuild-2", after2.Entity.Attributes["hostname"])
+	} else {
+		// Idempotency path: rebuild leaves entity reads unchanged.
+		before1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
+		require.NoError(t, err)
+		require.NotNil(t, before1)
+		before2, err := p.GetEntity(ctx, egEID(t, subject2), opts)
+		require.NoError(t, err)
+		require.NotNil(t, before2)
+
+		require.NoError(t, p.RebuildProjections(ctx))
+
+		after1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
+		require.NoError(t, err)
+		require.NotNil(t, after1)
+		after2, err := p.GetEntity(ctx, egEID(t, subject2), opts)
+		require.NoError(t, err)
+		require.NotNil(t, after2)
+
+		assert.Equal(t, before1.Entity.Attributes["hostname"], after1.Entity.Attributes["hostname"])
+		assert.Equal(t, before2.Entity.Attributes["hostname"], after2.Entity.Attributes["hostname"])
+	}
 }
 
 // testEGResolveIdentity verifies identity-claim resolution to EIDs (AC 8).

--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -268,8 +268,8 @@ func testEGMovedEntity(t *testing.T, factory EntityGraphProviderFactory) {
 }
 
 // testEGRebuild verifies that RebuildProjections leaves entity reads unchanged
-// (AC 7). Providers that do not implement RebuildProjections are skipped via the
-// type assertion so the shared harness stays provider-agnostic.
+// (AC 7). RebuildProjections is part of the EntityGraphProvider interface, so
+// every provider has the method and the test always runs.
 func testEGRebuild(t *testing.T, factory EntityGraphProviderFactory) {
 	t.Helper()
 	p := factory(t)
@@ -295,13 +295,7 @@ func testEGRebuild(t *testing.T, factory EntityGraphProviderFactory) {
 	require.NoError(t, err)
 	require.NotNil(t, before2)
 
-	rebuilder, ok := p.(interface {
-		RebuildProjections(ctx context.Context) error
-	})
-	if !ok {
-		t.Skip("provider does not implement RebuildProjections")
-	}
-	require.NoError(t, rebuilder.RebuildProjections(ctx))
+	require.NoError(t, p.RebuildProjections(ctx))
 
 	after1, err := p.GetEntity(ctx, egEID(t, subject1), opts)
 	require.NoError(t, err)

--- a/pkg/entitygraph/interfaces/provider.go
+++ b/pkg/entitygraph/interfaces/provider.go
@@ -252,6 +252,12 @@ type EntityGraphProvider interface {
 
 	// UpdateDriftLifecycle records a workflow annotation on a drift record.
 	UpdateDriftLifecycle(ctx context.Context, update DriftLifecycleUpdate) error
+
+	// RebuildProjections rebuilds all derived projection tables (entity index,
+	// edge, and drift projections) from the observation log and current-state
+	// tables. Used after a projection-logic change or schema migration so that
+	// derived views reflect the full accumulated observation history (ADR-022 §6).
+	RebuildProjections(ctx context.Context) error
 }
 
 // --- Provider Registry ---

--- a/pkg/entitygraph/interfaces/providers_test.go
+++ b/pkg/entitygraph/interfaces/providers_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package interfaces_test — provider contract-suite wiring.
+//
+// This file runs each real EntityGraphProvider implementation through the shared
+// RunEntityGraphContractTests harness (see contract_test.go). It is deliberately
+// named providers_test.go so the check-providers.sh architecture script permits
+// the direct sqlite/database provider imports (the */providers_test.go
+// exception); every other file in this package imports only the interface.
+package interfaces_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/providers/database"
+	"github.com/cfgis/cfgms/pkg/entitygraph/providers/sqlite"
+	"github.com/cfgis/cfgms/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLiteEntityGraphProvider_ContractSuite runs the shared contract suite
+// against a real, file-backed SQLite provider. A fresh database per subtest
+// keeps each acceptance criterion isolated; file-backed (not :memory:) exercises
+// the real WAL path that RebuildProjections depends on.
+func TestSQLiteEntityGraphProvider_ContractSuite(t *testing.T) {
+	RunEntityGraphContractTests(t, func(t *testing.T) interfaces.EntityGraphProvider {
+		p, err := sqlite.NewSQLiteEntityGraphProvider(filepath.Join(t.TempDir(), "eg.db"))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = p.Close() })
+		return p
+	})
+}
+
+// TestDatabaseEntityGraphProvider_ContractSuite runs the shared contract suite
+// against a real PostgreSQL provider. It is skipped in -short mode and when no
+// test Postgres is reachable. Subtests share one database; the suite's ACs are
+// tenant- and subject-scoped (stable subjects upsert, tenant cuts isolate
+// reads), so they stay correct without per-subtest teardown.
+func TestDatabaseEntityGraphProvider_ContractSuite(t *testing.T) {
+	dsn := skipIfNoTestPostgres(t)
+	RunEntityGraphContractTests(t, func(t *testing.T) interfaces.EntityGraphProvider {
+		p, err := database.NewDatabaseEntityGraphProvider(dsn)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = p.Close() })
+		return p
+	})
+}
+
+// testPostgresDSN builds a Postgres DSN from the standard CFGMS test environment
+// variables, matching the storage database provider tests.
+func testPostgresDSN() string {
+	pw := testutil.GetTestDBPassword()
+	port := 5432
+	if p := os.Getenv("CFGMS_TEST_DB_PORT"); p != "" {
+		if pi, err := strconv.Atoi(p); err == nil {
+			port = pi
+		}
+	}
+	dbName := "cfgms_test"
+	if v := os.Getenv("CFGMS_TEST_DB_NAME"); v != "" {
+		dbName = v
+	}
+	dbUser := "cfgms_test"
+	if v := os.Getenv("CFGMS_TEST_DB_USER"); v != "" {
+		dbUser = v
+	}
+	return fmt.Sprintf("host=localhost port=%d dbname=%s user=%s password=%s sslmode=disable",
+		port, dbName, dbUser, pw)
+}
+
+// skipIfNoTestPostgres skips the calling test when running with -short or when
+// the test Postgres instance is not reachable, returning the DSN otherwise. The
+// "postgres" driver is registered transitively via the database provider import.
+func skipIfNoTestPostgres(t *testing.T) string {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping Postgres entity-graph contract suite in short mode")
+	}
+	dsn := testPostgresDSN()
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Skip("Postgres not available:", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		t.Skip("Postgres not reachable:", err)
+	}
+	return dsn
+}

--- a/pkg/entitygraph/providers/database/contract_test.go
+++ b/pkg/entitygraph/providers/database/contract_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package database contains unit tests for the PostgreSQL entity graph
+// provider helpers. The full contract suite (interfaces.RunEntityGraphContractTests)
+// runs against a live PostgreSQL instance in
+// pkg/entitygraph/interfaces/providers_test.go, which uses the
+// */providers_test.go architecture exception to import the provider directly.
+// Tests here cover the pure-function helpers that do not require a connection.
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+func TestResolveSourceClass_Database(t *testing.T) {
+	tests := []struct {
+		source string
+		want   types.SourceClass
+	}{
+		{"enforcing-module:hyperv", types.SourceClassEnforcingModule},
+		{"managing-integration:m365", types.SourceClassManagingIntegration},
+		{"observer:network-scan", types.SourceClassObserver},
+		{"operator-assertion:manual", types.SourceClassOperatorAssertion},
+		{"correlator-inference:ml", types.SourceClassCorrelatorInference},
+		{"unknown-source:anything", types.SourceClassObserver},
+		{"nocoion", types.SourceClassObserver},
+	}
+	for _, tc := range tests {
+		t.Run(tc.source, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveSourceClass(tc.source))
+		})
+	}
+}
+
+func TestTenantVisible_Database(t *testing.T) {
+	tests := []struct {
+		owning string
+		filter string
+		want   bool
+	}{
+		{"root/msp-a", "", true},                    // empty filter sees everything
+		{"root/msp-a", "root/msp-a", true},          // exact match
+		{"root/msp-a/client-1", "root/msp-a", true}, // subtree match
+		{"root/msp-ab", "root/msp-a", false},        // prefix but not a child path
+		{"root/msp-b", "root/msp-a", false},         // sibling
+		{"root/msp-a", "root/msp-b", false},         // wrong root
+	}
+	for _, tc := range tests {
+		t.Run(tc.owning+"|"+tc.filter, func(t *testing.T) {
+			assert.Equal(t, tc.want, tenantVisible(tc.owning, tc.filter))
+		})
+	}
+}
+
+func TestSourceClassRank_Ordering(t *testing.T) {
+	// enforcing-module must rank strictly lower (higher precedence) than all others.
+	enfRank := sourceClassRank(types.SourceClassEnforcingModule)
+	for _, sc := range []types.SourceClass{
+		types.SourceClassManagingIntegration,
+		types.SourceClassObserver,
+		types.SourceClassOperatorAssertion,
+		types.SourceClassCorrelatorInference,
+	} {
+		assert.Less(t, enfRank, sourceClassRank(sc), "enforcing-module must outrank %s", sc)
+	}
+}
+
+func TestMergeAttributes_Database(t *testing.T) {
+	low := sourceEntry{
+		source:      "observer:scan",
+		sourceClass: string(types.SourceClassObserver),
+		observedAt:  time.Now(),
+		payload:     map[string]interface{}{"color": "blue", "only_low": "x"},
+	}
+	high := sourceEntry{
+		source:      "enforcing-module:paint",
+		sourceClass: string(types.SourceClassEnforcingModule),
+		observedAt:  time.Now(),
+		payload:     map[string]interface{}{"color": "red"},
+	}
+	merged := mergeAttributes([]sourceEntry{low, high})
+	require.Equal(t, "red", merged["color"], "high-precedence source must win")
+	assert.Equal(t, "x", merged["only_low"], "low-precedence-only keys survive in merged view")
+}
+
+func TestBetterSource_TieBreak(t *testing.T) {
+	ts := time.Now()
+	a := sourceEntry{sourceClass: string(types.SourceClassObserver), observedAt: ts, payloadHash: "aaa"}
+	b := sourceEntry{sourceClass: string(types.SourceClassObserver), observedAt: ts, payloadHash: "bbb"}
+	// Same rank, same time: hash tie-break (lower hash wins).
+	assert.True(t, betterSource(a, b), "lower payload hash must win tie-break")
+	assert.False(t, betterSource(b, a))
+}
+
+func TestSubjectKind_Database(t *testing.T) {
+	assert.Equal(t, "entity", subjectKind("host:abc123"))
+	assert.Equal(t, "entity", subjectKind("m365:tenant-x/user1"))
+	assert.Equal(t, "edge", subjectKind("contains|host:a|host:b"))
+	assert.Equal(t, "edge", subjectKind("arbitrary-edge-string"))
+}

--- a/pkg/entitygraph/providers/database/entity_reads.go
+++ b/pkg/entitygraph/providers/database/entity_reads.go
@@ -327,10 +327,10 @@ func (p *DatabaseEntityGraphProvider) ResolveIdentity(ctx context.Context, claim
 	return eids, nil
 }
 
-// RebuildProjections rebuilds the entity index projection from the durable
-// current-state table. It clears the index and replays every distinct subject
-// through the same projection logic used during ingestion, all within one
-// transaction.
+// RebuildProjections deletes the current-state and index projections, then
+// replays every row in the observation log (ascending sequence order) to
+// reconstruct an identical state. The log is the authoritative source of truth;
+// projections are derived — this is the ADR-023 §3 corruption-recovery path.
 func (p *DatabaseEntityGraphProvider) RebuildProjections(ctx context.Context) error {
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -338,42 +338,93 @@ func (p *DatabaseEntityGraphProvider) RebuildProjections(ctx context.Context) er
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if _, err := tx.ExecContext(ctx, `DELETE FROM eg_entity_current`); err != nil {
+		return fmt.Errorf("entitygraph/database: clear current: %w", err)
+	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM eg_entity_index`); err != nil {
 		return fmt.Errorf("entitygraph/database: clear entity index: %w", err)
 	}
 
-	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT subject FROM eg_entity_current`)
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id, subject, source, source_class, observed_at, recorded_at,
+		        kind, confidence, payload_hash, tenant_path
+		 FROM eg_observation_log
+		 ORDER BY id ASC`,
+	)
 	if err != nil {
-		return fmt.Errorf("entitygraph/database: list subjects for rebuild: %w", err)
+		return fmt.Errorf("entitygraph/database: read observation log: %w", err)
 	}
-	var subjects []string
+
+	type logRow struct {
+		id                                       int64
+		subject, source, sourceClass, observedAt string
+		recordedAt, kind, confidence             string
+		payloadHash, tenantPath                  string
+	}
+	var logRows []logRow
 	for rows.Next() {
-		var s string
-		if err := rows.Scan(&s); err != nil {
+		var lr logRow
+		if err := rows.Scan(&lr.id, &lr.subject, &lr.source, &lr.sourceClass,
+			&lr.observedAt, &lr.recordedAt, &lr.kind, &lr.confidence,
+			&lr.payloadHash, &lr.tenantPath); err != nil {
 			_ = rows.Close()
-			return fmt.Errorf("entitygraph/database: scan rebuild subject: %w", err)
+			return fmt.Errorf("entitygraph/database: scan log row: %w", err)
 		}
-		subjects = append(subjects, s)
+		logRows = append(logRows, lr)
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
-		return fmt.Errorf("entitygraph/database: iterate rebuild subjects: %w", err)
+		return fmt.Errorf("entitygraph/database: iterate log: %w", err)
 	}
 	if err := rows.Close(); err != nil {
-		return fmt.Errorf("entitygraph/database: close rebuild subjects: %w", err)
+		return fmt.Errorf("entitygraph/database: close log rows: %w", err)
 	}
 
-	for _, s := range subjects {
-		if subjectKind(s) != "entity" {
+	for _, lr := range logRows {
+		if subjectKind(lr.subject) != "entity" {
 			continue
 		}
-		if err := rebuildEntityIndex(ctx, tx, s); err != nil {
-			return err
+		// Replay: fold the log row into eg_entity_current (same supersede logic as
+		// ReportObservations) then rebuild the index from the accumulated state.
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO eg_entity_current
+				(subject, source, source_class, kind, confidence, observed_at, recorded_at, payload_hash, tenant_path, log_seq)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			 ON CONFLICT (subject, source) DO UPDATE SET
+				source_class = EXCLUDED.source_class,
+				kind         = EXCLUDED.kind,
+				confidence   = EXCLUDED.confidence,
+				observed_at  = EXCLUDED.observed_at,
+				recorded_at  = EXCLUDED.recorded_at,
+				payload_hash = EXCLUDED.payload_hash,
+				tenant_path  = EXCLUDED.tenant_path,
+				log_seq      = EXCLUDED.log_seq`,
+			lr.subject, lr.source, lr.sourceClass, lr.kind, lr.confidence,
+			lr.observedAt, lr.recordedAt, lr.payloadHash, lr.tenantPath, lr.id,
+		); err != nil {
+			return fmt.Errorf("entitygraph/database: replay current state seq %d: %w", lr.id, err)
+		}
+		if err := rebuildEntityIndex(ctx, tx, lr.subject); err != nil {
+			return fmt.Errorf("entitygraph/database: rebuild index seq %d: %w", lr.id, err)
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("entitygraph/database: commit rebuild: %w", err)
+	}
+	return nil
+}
+
+// CorruptProjectionsForTesting deletes both projection tables while leaving the
+// observation log intact. Used by contract tests to verify that
+// RebuildProjections genuinely recovers from corruption rather than only testing
+// the idempotent no-op path.
+func (p *DatabaseEntityGraphProvider) CorruptProjectionsForTesting(ctx context.Context) error {
+	if _, err := p.db.ExecContext(ctx, `DELETE FROM eg_entity_current`); err != nil {
+		return fmt.Errorf("entitygraph/database: corrupt current: %w", err)
+	}
+	if _, err := p.db.ExecContext(ctx, `DELETE FROM eg_entity_index`); err != nil {
+		return fmt.Errorf("entitygraph/database: corrupt index: %w", err)
 	}
 	return nil
 }

--- a/pkg/entitygraph/providers/database/entity_reads.go
+++ b/pkg/entitygraph/providers/database/entity_reads.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,13 +30,35 @@ type currentRow struct {
 }
 
 // GetEntity returns the merged current state, provenance, and freshness for an
-// entity. The mandatory tenant filter in opts restricts visible source rows to
-// the caller's tenant subtree. Returns errNotFound when the entity has no
-// visible current state.
+// entity. Visibility is governed by eg_entity_index.owning_tenant (the
+// current-ownership projection), not by the ingest-time tenant_path columns
+// on individual source rows (ADR-023 §111-119).
 func (p *DatabaseEntityGraphProvider) GetEntity(ctx context.Context, eid interfaces.EIDRef, opts interfaces.GetEntityOpts) (*types.EntityView, error) {
 	subject := eid.String()
 
-	rows, err := p.queryCurrentRows(ctx, subject, opts.TenantFilter, opts.AsOf)
+	// Apply the tenant cut via the current-ownership index — the only
+	// access-control axis. A filtered-out entity is indistinguishable from a
+	// missing one to the caller, regardless of ingest-time tenant_path values.
+	if opts.TenantFilter != "" {
+		var owningTenant string
+		err := p.db.QueryRowContext(ctx,
+			`SELECT owning_tenant FROM eg_entity_index WHERE subject = $1`, subject,
+		).Scan(&owningTenant)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errNotFound
+		}
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/database: lookup entity index: %w", err)
+		}
+		if !tenantVisible(owningTenant, opts.TenantFilter) {
+			return nil, errNotFound
+		}
+	}
+
+	// Fetch all per-source current rows without tenant filtering — visibility
+	// has already been confirmed via the index lookup above, so all source
+	// rows for the subject are accessible to the authorized caller.
+	rows, err := p.queryCurrentRows(ctx, subject, "", opts.AsOf)
 	if err != nil {
 		return nil, err
 	}
@@ -265,9 +288,14 @@ func (p *DatabaseEntityGraphProvider) ResolveIdentity(ctx context.Context, claim
 		if mac == "" {
 			continue
 		}
-		conds = append(conds, fmt.Sprintf("mac_addrs LIKE $%d", n))
-		args = append(args, "%"+mac+"%")
-		n++
+		// mac_addrs is a comma-joined list; match as a delimited token to avoid
+		// unanchored substring collisions (e.g. "00:11" matching "00:11:22:33:44:55").
+		conds = append(conds, fmt.Sprintf(
+			"(mac_addrs = $%d OR mac_addrs LIKE $%d OR mac_addrs LIKE $%d OR mac_addrs LIKE $%d)",
+			n, n+1, n+2, n+3,
+		))
+		args = append(args, mac, mac+",%", "%,"+mac, "%,"+mac+",%")
+		n += 4
 	}
 
 	if len(conds) == 0 {

--- a/pkg/entitygraph/providers/database/entity_reads.go
+++ b/pkg/entitygraph/providers/database/entity_reads.go
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// currentRow is a scanned per-source current-state row joined with its payload.
+type currentRow struct {
+	source      string
+	sourceClass string
+	kind        string
+	confidence  string
+	observedAt  time.Time
+	recordedAt  time.Time
+	payloadHash string
+	payload     map[string]interface{}
+}
+
+// GetEntity returns the merged current state, provenance, and freshness for an
+// entity. The mandatory tenant filter in opts restricts visible source rows to
+// the caller's tenant subtree. Returns errNotFound when the entity has no
+// visible current state.
+func (p *DatabaseEntityGraphProvider) GetEntity(ctx context.Context, eid interfaces.EIDRef, opts interfaces.GetEntityOpts) (*types.EntityView, error) {
+	subject := eid.String()
+
+	rows, err := p.queryCurrentRows(ctx, subject, opts.TenantFilter, opts.AsOf)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, errNotFound
+	}
+
+	entries := make([]sourceEntry, len(rows))
+	sources := make([]types.Observation, len(rows))
+	for i, r := range rows {
+		entries[i] = sourceEntry{
+			source:      r.source,
+			sourceClass: r.sourceClass,
+			observedAt:  r.observedAt,
+			payloadHash: r.payloadHash,
+			payload:     r.payload,
+		}
+		sources[i] = types.Observation{
+			Source:     r.source,
+			ObservedAt: r.observedAt,
+			RecordedAt: r.recordedAt,
+			Subject:    subject,
+			Kind:       types.ObservationKind(r.kind),
+			Confidence: types.Confidence(r.confidence),
+			Payload:    r.payload,
+		}
+	}
+
+	merged := mergeAttributes(entries)
+	win := winningSourceIdx(entries)
+
+	entityKind := stringAttr(merged, "entity_kind", "kind")
+	if entityKind == "" {
+		entityKind = subjectEntityKind(subject)
+	}
+
+	entity := &types.Entity{
+		EID:          eid,
+		Kind:         entityKind,
+		Attributes:   merged,
+		OwningTenant: stringAttr(merged, "owning_tenant", "tenant_path"),
+	}
+
+	view := &types.EntityView{
+		Entity:  entity,
+		Sources: sources,
+		Freshness: types.Freshness{
+			ObservedAt: rows[win].observedAt,
+			RecordedAt: rows[win].recordedAt,
+		},
+	}
+	return view, nil
+}
+
+// queryCurrentRows returns the per-source current-state rows for a subject.
+// When asOf is nil it reads the eg_entity_current projection; when asOf is set
+// it reconstructs the latest observation per source at or before asOf from the
+// immutable log. The tenant filter, when non-empty, restricts rows to the
+// tenant path or its subtree.
+func (p *DatabaseEntityGraphProvider) queryCurrentRows(ctx context.Context, subject, tenantFilter string, asOf *time.Time) ([]currentRow, error) {
+	var query string
+	args := []interface{}{subject}
+
+	if asOf == nil {
+		query = `SELECT c.source, c.source_class, c.kind, c.confidence, c.observed_at, c.recorded_at, c.payload_hash, p.payload_json
+			 FROM eg_entity_current c
+			 JOIN eg_payload_content p ON p.content_hash = c.payload_hash
+			 WHERE c.subject = $1`
+		if tenantFilter != "" {
+			query += ` AND (c.tenant_path = $2 OR c.tenant_path LIKE $3)`
+			args = append(args, tenantFilter, tenantFilter+"/%")
+		}
+	} else {
+		// DISTINCT ON keeps the newest log row per source at or before asOf.
+		query = `SELECT DISTINCT ON (l.source) l.source, l.source_class, l.kind, l.confidence, l.observed_at, l.recorded_at, l.payload_hash, p.payload_json
+			 FROM eg_observation_log l
+			 JOIN eg_payload_content p ON p.content_hash = l.payload_hash
+			 WHERE l.subject = $1 AND l.observed_at <= $2`
+		args = append(args, asOf.UTC().Format(time.RFC3339Nano))
+		if tenantFilter != "" {
+			query += ` AND (l.tenant_path = $3 OR l.tenant_path LIKE $4)`
+			args = append(args, tenantFilter, tenantFilter+"/%")
+		}
+		query += ` ORDER BY l.source, l.observed_at DESC, l.id DESC`
+	}
+
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: query current rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []currentRow
+	for rows.Next() {
+		var (
+			r                      currentRow
+			observedAt, recordedAt string
+			pjson                  string
+		)
+		if err := rows.Scan(&r.source, &r.sourceClass, &r.kind, &r.confidence, &observedAt, &recordedAt, &r.payloadHash, &pjson); err != nil {
+			return nil, fmt.Errorf("entitygraph/database: scan current row: %w", err)
+		}
+		r.observedAt, _ = time.Parse(time.RFC3339Nano, observedAt)
+		r.recordedAt, _ = time.Parse(time.RFC3339Nano, recordedAt)
+		if pjson != "" {
+			if err := json.Unmarshal([]byte(pjson), &r.payload); err != nil {
+				return nil, fmt.Errorf("entitygraph/database: unmarshal current payload: %w", err)
+			}
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: iterate current rows: %w", err)
+	}
+	return out, nil
+}
+
+// QueryEntities returns entities matching the filter, paged. The page token is
+// an integer offset; NextToken is empty on the final page. Kind and tenant
+// filters are applied against the entity index; the tenant filter matches the
+// exact tenant path or any descendant.
+func (p *DatabaseEntityGraphProvider) QueryEntities(ctx context.Context, filter interfaces.EntityFilter, page interfaces.PageToken) (*interfaces.EntityPage, error) {
+	pageSize := page.PageSize
+	if pageSize <= 0 {
+		pageSize = 50
+	}
+	offset := 0
+	if page.Token != "" {
+		v, err := strconv.Atoi(page.Token)
+		if err != nil || v < 0 {
+			return nil, fmt.Errorf("entitygraph/database: invalid page token %q", page.Token)
+		}
+		offset = v
+	}
+
+	var conds []string
+	var args []interface{}
+	n := 1
+	if filter.Kind != "" {
+		conds = append(conds, fmt.Sprintf("entity_kind = $%d", n))
+		args = append(args, filter.Kind)
+		n++
+	}
+	if filter.TenantFilter != "" {
+		conds = append(conds, fmt.Sprintf("(owning_tenant = $%d OR owning_tenant LIKE $%d)", n, n+1))
+		args = append(args, filter.TenantFilter, filter.TenantFilter+"/%")
+		n += 2
+	}
+
+	query := "SELECT subject FROM eg_entity_index"
+	if len(conds) > 0 {
+		query += " WHERE " + strings.Join(conds, " AND ")
+	}
+	query += fmt.Sprintf(" ORDER BY subject LIMIT $%d OFFSET $%d", n, n+1)
+	args = append(args, pageSize+1, offset)
+
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: query entities: %w", err)
+	}
+	subjects := make([]string, 0, pageSize+1)
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("entitygraph/database: scan subject: %w", err)
+		}
+		subjects = append(subjects, s)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("entitygraph/database: iterate subjects: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: close subjects rows: %w", err)
+	}
+
+	nextToken := ""
+	if len(subjects) > pageSize {
+		subjects = subjects[:pageSize]
+		nextToken = strconv.Itoa(offset + pageSize)
+	}
+
+	entities := make([]*types.EntityView, 0, len(subjects))
+	for _, s := range subjects {
+		eid, err := types.ParseEID(s)
+		if err != nil {
+			continue
+		}
+		ev, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{
+			TenantFilter: filter.TenantFilter,
+			AsOf:         filter.AsOf,
+		})
+		if err != nil {
+			if errors.Is(err, errNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		entities = append(entities, ev)
+	}
+
+	return &interfaces.EntityPage{Entities: entities, NextToken: nextToken}, nil
+}
+
+// ResolveIdentity returns the best-known EIDs for the supplied device/object
+// identity claims by matching the entity index. Any claim that matches is
+// sufficient (OR semantics); results are de-duplicated by the index.
+func (p *DatabaseEntityGraphProvider) ResolveIdentity(ctx context.Context, claims interfaces.IdentityClaims) ([]interfaces.EIDRef, error) {
+	var conds []string
+	var args []interface{}
+	n := 1
+
+	addEq := func(col, val string) {
+		if val != "" {
+			conds = append(conds, fmt.Sprintf("%s = $%d", col, n))
+			args = append(args, val)
+			n++
+		}
+	}
+	addEq("hostname", claims.Hostname)
+	addEq("machine_sid", claims.MachineSID)
+	addEq("dir_object_guid", claims.DirectoryObjectGUID)
+	addEq("serial_number", claims.SerialNumber)
+	addEq("cloud_object_id", claims.CloudObjectID)
+	for _, mac := range claims.MACAddrs {
+		if mac == "" {
+			continue
+		}
+		conds = append(conds, fmt.Sprintf("mac_addrs LIKE $%d", n))
+		args = append(args, "%"+mac+"%")
+		n++
+	}
+
+	if len(conds) == 0 {
+		return nil, nil
+	}
+
+	query := "SELECT DISTINCT subject FROM eg_entity_index WHERE " + strings.Join(conds, " OR ")
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: resolve identity: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var eids []interfaces.EIDRef
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("entitygraph/database: scan identity subject: %w", err)
+		}
+		eid, err := types.ParseEID(s)
+		if err != nil {
+			continue
+		}
+		eids = append(eids, eid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: iterate identity subjects: %w", err)
+	}
+	return eids, nil
+}
+
+// RebuildProjections rebuilds the entity index projection from the durable
+// current-state table. It clears the index and replays every distinct subject
+// through the same projection logic used during ingestion, all within one
+// transaction.
+func (p *DatabaseEntityGraphProvider) RebuildProjections(ctx context.Context) error {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("entitygraph/database: begin rebuild tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM eg_entity_index`); err != nil {
+		return fmt.Errorf("entitygraph/database: clear entity index: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT subject FROM eg_entity_current`)
+	if err != nil {
+		return fmt.Errorf("entitygraph/database: list subjects for rebuild: %w", err)
+	}
+	var subjects []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("entitygraph/database: scan rebuild subject: %w", err)
+		}
+		subjects = append(subjects, s)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("entitygraph/database: iterate rebuild subjects: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("entitygraph/database: close rebuild subjects: %w", err)
+	}
+
+	for _, s := range subjects {
+		if subjectKind(s) != "entity" {
+			continue
+		}
+		if err := rebuildEntityIndex(ctx, tx, s); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("entitygraph/database: commit rebuild: %w", err)
+	}
+	return nil
+}
+
+// --- Deferred read operations ---
+//
+// The following reads share the observation-log / projection substrate above
+// but are scheduled in later rounds of the entity graph epic. They satisfy the
+// EntityGraphProvider contract at compile time and return ErrNotImplemented
+// until their round lands.
+
+// GetDesiredState returns the desired state and originating config revision.
+func (p *DatabaseEntityGraphProvider) GetDesiredState(_ context.Context, _ interfaces.EIDRef) (*types.DesiredStateView, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetDriftState returns the persisted drift-diff for a managed entity.
+func (p *DatabaseEntityGraphProvider) GetDriftState(_ context.Context, _ interfaces.EIDRef) (*interfaces.DriftState, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetEdges returns edges matching the filter.
+func (p *DatabaseEntityGraphProvider) GetEdges(_ context.Context, _ interfaces.EdgeFilter) ([]*interfaces.EdgeView, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetNeighborhood returns a depth-bounded connected subgraph starting at eid.
+func (p *DatabaseEntityGraphProvider) GetNeighborhood(_ context.Context, _ interfaces.EIDRef, _ []string, _ types.TraversalDirection, _ int) (*types.Neighborhood, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetHistory returns the versioned observation log for a subject over a range.
+func (p *DatabaseEntityGraphProvider) GetHistory(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// Diff returns the attribute delta between two points in time for a subject.
+func (p *DatabaseEntityGraphProvider) Diff(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) (*interfaces.StateDiff, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetTimeline returns a merged change-event stream for the given subjects.
+func (p *DatabaseEntityGraphProvider) GetTimeline(_ context.Context, _ []interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.TimelineEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// ListDrifted returns entities with active drift matching the filter.
+func (p *DatabaseEntityGraphProvider) ListDrifted(_ context.Context, _ interfaces.DriftFilter) ([]*interfaces.DriftState, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// Watch returns a durable, cursor-replayable change feed.
+func (p *DatabaseEntityGraphProvider) Watch(_ context.Context, _ interfaces.WatchFilter, _ string) (<-chan interfaces.WatchEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// UpdateDriftLifecycle records a workflow annotation on a drift record.
+func (p *DatabaseEntityGraphProvider) UpdateDriftLifecycle(_ context.Context, _ interfaces.DriftLifecycleUpdate) error {
+	return interfaces.ErrNotImplemented
+}

--- a/pkg/entitygraph/providers/database/migrations.sql
+++ b/pkg/entitygraph/providers/database/migrations.sql
@@ -1,0 +1,89 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright 2026 Jordan Ritz
+--
+-- PostgreSQL schema for the CFGMS entity graph database provider (ADR-022).
+-- Mirrors the SQLite provider tables (eg_ prefix) using PostgreSQL syntax:
+-- BIGSERIAL primary keys, $N placeholders (in Go), TEXT RFC3339 timestamps for
+-- cross-provider portability, and ON CONFLICT upserts.
+
+CREATE TABLE IF NOT EXISTS eg_payload_content (
+    content_hash TEXT PRIMARY KEY,
+    payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS eg_observation_log (
+    id              BIGSERIAL PRIMARY KEY,
+    subject         TEXT NOT NULL,
+    source          TEXT NOT NULL,
+    source_class    TEXT NOT NULL DEFAULT '',
+    observed_at     TEXT NOT NULL,
+    recorded_at     TEXT NOT NULL,
+    kind            TEXT NOT NULL,
+    confidence      TEXT NOT NULL DEFAULT '',
+    claim_scope_key TEXT NOT NULL DEFAULT '',
+    payload_hash    TEXT NOT NULL,
+    tenant_path     TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_eg_log_subject  ON eg_observation_log(subject);
+CREATE INDEX IF NOT EXISTS idx_eg_log_source   ON eg_observation_log(source);
+CREATE INDEX IF NOT EXISTS idx_eg_log_tenant   ON eg_observation_log(tenant_path);
+CREATE INDEX IF NOT EXISTS idx_eg_log_subj_src ON eg_observation_log(subject, source);
+
+CREATE TABLE IF NOT EXISTS eg_entity_current (
+    subject         TEXT NOT NULL,
+    source          TEXT NOT NULL,
+    source_class    TEXT NOT NULL DEFAULT '',
+    kind            TEXT NOT NULL,
+    confidence      TEXT NOT NULL DEFAULT '',
+    observed_at     TEXT NOT NULL,
+    recorded_at     TEXT NOT NULL,
+    payload_hash    TEXT NOT NULL,
+    tenant_path     TEXT NOT NULL DEFAULT '',
+    log_seq         BIGINT NOT NULL,
+    PRIMARY KEY (subject, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eg_cur_subject ON eg_entity_current(subject);
+CREATE INDEX IF NOT EXISTS idx_eg_cur_tenant  ON eg_entity_current(tenant_path);
+
+CREATE TABLE IF NOT EXISTS eg_entity_index (
+    subject          TEXT PRIMARY KEY,
+    entity_kind      TEXT NOT NULL DEFAULT '',
+    owning_tenant    TEXT NOT NULL DEFAULT '',
+    hostname         TEXT NOT NULL DEFAULT '',
+    mac_addrs        TEXT NOT NULL DEFAULT '',
+    machine_sid      TEXT NOT NULL DEFAULT '',
+    dir_object_guid  TEXT NOT NULL DEFAULT '',
+    serial_number    TEXT NOT NULL DEFAULT '',
+    cloud_object_id  TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_eg_idx_kind   ON eg_entity_index(entity_kind);
+CREATE INDEX IF NOT EXISTS idx_eg_idx_tenant ON eg_entity_index(owning_tenant);
+
+CREATE TABLE IF NOT EXISTS eg_edge_projection (
+    from_subject TEXT NOT NULL,
+    to_subject   TEXT NOT NULL,
+    edge_type    TEXT NOT NULL,
+    source       TEXT NOT NULL,
+    source_class TEXT NOT NULL DEFAULT '',
+    tenant_path  TEXT NOT NULL DEFAULT '',
+    payload_hash TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (from_subject, to_subject, edge_type, source)
+);
+
+CREATE TABLE IF NOT EXISTS eg_drift_projection (
+    subject          TEXT PRIMARY KEY,
+    detected_at      TEXT NOT NULL,
+    fields_json      TEXT NOT NULL DEFAULT '[]',
+    config_revision  TEXT NOT NULL DEFAULT '',
+    lifecycle_status TEXT NOT NULL DEFAULT 'detected'
+);
+
+CREATE TABLE IF NOT EXISTS eg_claim_scope_prior (
+    source          TEXT NOT NULL,
+    claim_scope_key TEXT NOT NULL,
+    subject         TEXT NOT NULL,
+    PRIMARY KEY (source, claim_scope_key, subject)
+);

--- a/pkg/entitygraph/providers/database/observations.go
+++ b/pkg/entitygraph/providers/database/observations.go
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+func init() {
+	RegisterProjectionUpdater("entity", updateEntityProjection)
+}
+
+// canonicalJSON marshals a payload to a canonical JSON encoding. Go's
+// encoding/json sorts map keys, so the output is stable for a given payload and
+// suitable for content-addressed storage and hashing. A nil payload encodes as
+// an empty object.
+func canonicalJSON(payload map[string]interface{}) ([]byte, error) {
+	if payload == nil {
+		payload = map[string]interface{}{}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: marshal payload: %w", err)
+	}
+	return data, nil
+}
+
+// payloadHash returns the SHA-256 hex digest of the canonical JSON encoding of
+// a payload. Identical payloads always hash to the same value.
+func payloadHash(payload map[string]interface{}) (string, error) {
+	data, err := canonicalJSON(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// subjectKind classifies an observation subject as "entity" or "edge". Entity
+// subjects parse as valid EIDs; anything else (an edge identity string) is
+// treated as an edge.
+func subjectKind(subject string) string {
+	if _, err := types.ParseEID(subject); err == nil {
+		return "entity"
+	}
+	return "edge"
+}
+
+// subjectEntityKind derives the entity kind for an EID subject from its
+// authority type. Returns "" for non-EID subjects.
+func subjectEntityKind(subject string) string {
+	eid, err := types.ParseEID(subject)
+	if err != nil {
+		return ""
+	}
+	return eid.AuthorityType()
+}
+
+// tenantPathOf extracts the owning tenant path from an observation payload,
+// checking the conventional attribute keys. Returns "" when absent.
+func tenantPathOf(obs types.Observation) string {
+	if obs.Payload == nil {
+		return ""
+	}
+	for _, k := range []string{"tenant_path", "owning_tenant"} {
+		if v, ok := obs.Payload[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// ReportObservations ingests a batch of observations from one source. Each
+// observation is appended to the immutable observation log, folded into the
+// per-source current-state table, and dispatched to the registered projection
+// updater — all inside a single transaction so partial batches never persist.
+func (p *DatabaseEntityGraphProvider) ReportObservations(ctx context.Context, batch interfaces.ObservationBatch) error {
+	if len(batch.Observations) == 0 {
+		return nil
+	}
+
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("entitygraph/database: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i := range batch.Observations {
+		obs := batch.Observations[i]
+		if obs.Source == "" {
+			obs.Source = batch.Source
+		}
+		if obs.Subject == "" {
+			return fmt.Errorf("entitygraph/database: observation %d has empty subject", i)
+		}
+
+		sourceClass := string(resolveSourceClass(obs.Source))
+
+		hash, err := payloadHash(obs.Payload)
+		if err != nil {
+			return err
+		}
+
+		// Content-hash dedup: a bit-identical re-observation from the same
+		// source appends no new log row. The current-state row already carries
+		// the winning hash for (subject, source).
+		var existing string
+		err = tx.QueryRowContext(ctx,
+			`SELECT payload_hash FROM eg_entity_current WHERE subject = $1 AND source = $2`,
+			obs.Subject, obs.Source).Scan(&existing)
+		switch {
+		case err == nil:
+			if existing == hash {
+				continue
+			}
+		case errors.Is(err, sql.ErrNoRows):
+			// First observation for this (subject, source) — fall through.
+		default:
+			return fmt.Errorf("entitygraph/database: dedup lookup: %w", err)
+		}
+
+		payloadJSON, err := canonicalJSON(obs.Payload)
+		if err != nil {
+			return err
+		}
+
+		// Content-addressed payload: store once, dedup by hash.
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO eg_payload_content (content_hash, payload_json)
+			 VALUES ($1, $2)
+			 ON CONFLICT (content_hash) DO NOTHING`,
+			hash, string(payloadJSON)); err != nil {
+			return fmt.Errorf("entitygraph/database: insert payload content: %w", err)
+		}
+
+		observedAt := obs.ObservedAt.UTC().Format(time.RFC3339Nano)
+		recordedAt := obs.RecordedAt
+		if recordedAt.IsZero() {
+			recordedAt = time.Now()
+		}
+		recordedAtStr := recordedAt.UTC().Format(time.RFC3339Nano)
+		tenantPath := tenantPathOf(obs)
+
+		// Append to the immutable log and capture the assigned sequence id.
+		var logSeq int64
+		err = tx.QueryRowContext(ctx,
+			`INSERT INTO eg_observation_log
+				(subject, source, source_class, observed_at, recorded_at, kind, confidence, claim_scope_key, payload_hash, tenant_path)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			 RETURNING id`,
+			obs.Subject, obs.Source, sourceClass, observedAt, recordedAtStr,
+			string(obs.Kind), string(obs.Confidence), "", hash, tenantPath).Scan(&logSeq)
+		if err != nil {
+			return fmt.Errorf("entitygraph/database: append observation log: %w", err)
+		}
+
+		// Fold into per-source current state. The latest observation for the
+		// same (subject, source) supersedes the prior one.
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO eg_entity_current
+				(subject, source, source_class, kind, confidence, observed_at, recorded_at, payload_hash, tenant_path, log_seq)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			 ON CONFLICT (subject, source) DO UPDATE SET
+				source_class = EXCLUDED.source_class,
+				kind         = EXCLUDED.kind,
+				confidence   = EXCLUDED.confidence,
+				observed_at  = EXCLUDED.observed_at,
+				recorded_at  = EXCLUDED.recorded_at,
+				payload_hash = EXCLUDED.payload_hash,
+				tenant_path  = EXCLUDED.tenant_path,
+				log_seq      = EXCLUDED.log_seq`,
+			obs.Subject, obs.Source, sourceClass, string(obs.Kind), string(obs.Confidence),
+			observedAt, recordedAtStr, hash, tenantPath, logSeq); err != nil {
+			return fmt.Errorf("entitygraph/database: upsert current state: %w", err)
+		}
+
+		if err := dispatchProjectionUpdate(ctx, tx, subjectKind(obs.Subject), obs, logSeq); err != nil {
+			return fmt.Errorf("entitygraph/database: projection update: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("entitygraph/database: commit: %w", err)
+	}
+	return nil
+}
+
+// updateEntityProjection rebuilds the entity index row for the observation's
+// subject from the merged current state. Registered for the "entity" subject
+// kind.
+func updateEntityProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, _ int64) error {
+	return rebuildEntityIndex(ctx, tx, obs.Subject)
+}
+
+// rebuildEntityIndex recomputes the eg_entity_index row for subject by merging
+// all per-source current-state payloads under the precedence rules and
+// projecting the identity/lookup columns. When no current rows remain the index
+// row is deleted.
+func rebuildEntityIndex(ctx context.Context, tx *sql.Tx, subject string) error {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT c.source, c.source_class, c.observed_at, c.payload_hash, p.payload_json
+		 FROM eg_entity_current c
+		 JOIN eg_payload_content p ON p.content_hash = c.payload_hash
+		 WHERE c.subject = $1`, subject)
+	if err != nil {
+		return fmt.Errorf("entitygraph/database: read current state: %w", err)
+	}
+
+	var entries []sourceEntry
+	for rows.Next() {
+		var src, sclass, observedAt, phash, pjson string
+		if err := rows.Scan(&src, &sclass, &observedAt, &phash, &pjson); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("entitygraph/database: scan current state: %w", err)
+		}
+		var payload map[string]interface{}
+		if pjson != "" {
+			if err := json.Unmarshal([]byte(pjson), &payload); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("entitygraph/database: unmarshal payload: %w", err)
+			}
+		}
+		t, _ := time.Parse(time.RFC3339Nano, observedAt)
+		entries = append(entries, sourceEntry{
+			source:      src,
+			sourceClass: sclass,
+			observedAt:  t,
+			payloadHash: phash,
+			payload:     payload,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("entitygraph/database: iterate current state: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("entitygraph/database: close current state rows: %w", err)
+	}
+
+	if len(entries) == 0 {
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM eg_entity_index WHERE subject = $1`, subject); err != nil {
+			return fmt.Errorf("entitygraph/database: delete stale index: %w", err)
+		}
+		return nil
+	}
+
+	merged := mergeAttributes(entries)
+
+	entityKind := stringAttr(merged, "entity_kind", "kind")
+	if entityKind == "" {
+		entityKind = subjectEntityKind(subject)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO eg_entity_index
+			(subject, entity_kind, owning_tenant, hostname, mac_addrs, machine_sid, dir_object_guid, serial_number, cloud_object_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (subject) DO UPDATE SET
+			entity_kind     = EXCLUDED.entity_kind,
+			owning_tenant   = EXCLUDED.owning_tenant,
+			hostname        = EXCLUDED.hostname,
+			mac_addrs       = EXCLUDED.mac_addrs,
+			machine_sid     = EXCLUDED.machine_sid,
+			dir_object_guid = EXCLUDED.dir_object_guid,
+			serial_number   = EXCLUDED.serial_number,
+			cloud_object_id = EXCLUDED.cloud_object_id`,
+		subject,
+		entityKind,
+		stringAttr(merged, "owning_tenant", "tenant_path"),
+		stringAttr(merged, "hostname"),
+		joinStrAttr(merged, "mac_addrs", "mac_addresses"),
+		stringAttr(merged, "machine_sid"),
+		stringAttr(merged, "dir_object_guid", "directory_object_guid"),
+		stringAttr(merged, "serial_number"),
+		stringAttr(merged, "cloud_object_id"),
+	); err != nil {
+		return fmt.Errorf("entitygraph/database: upsert entity index: %w", err)
+	}
+	return nil
+}
+
+// stringAttr returns the first non-empty string value found among the given
+// attribute keys.
+func stringAttr(m map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// joinStrAttr returns the first present attribute among keys as a comma-joined
+// string, accepting a scalar string or a string/interface slice.
+func joinStrAttr(m map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		v, ok := m[k]
+		if !ok {
+			continue
+		}
+		switch t := v.(type) {
+		case string:
+			if t != "" {
+				return t
+			}
+		case []string:
+			if len(t) > 0 {
+				return strings.Join(t, ",")
+			}
+		case []interface{}:
+			parts := make([]string, 0, len(t))
+			for _, e := range t {
+				if s, ok := e.(string); ok && s != "" {
+					parts = append(parts, s)
+				}
+			}
+			if len(parts) > 0 {
+				return strings.Join(parts, ",")
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/entitygraph/providers/database/precedence.go
+++ b/pkg/entitygraph/providers/database/precedence.go
@@ -11,6 +11,17 @@ import (
 	"github.com/cfgis/cfgms/pkg/entitygraph/types"
 )
 
+// tenantVisible reports whether an entity currently owned by owningTenant is
+// visible to a caller scoped to tenantFilter. An empty filter sees everything;
+// otherwise the owning tenant must equal the filter or be nested under it.
+// This is the sole access-control axis (ADR-023 §111-119).
+func tenantVisible(owningTenant, tenantFilter string) bool {
+	if tenantFilter == "" {
+		return true
+	}
+	return owningTenant == tenantFilter || strings.HasPrefix(owningTenant, tenantFilter+"/")
+}
+
 // resolveSourceClass derives the source class from a source identity string.
 // Sources are conventionally "<class>:<name>" (e.g. "enforcing-module:hyperv");
 // the prefix before the first ':' is matched against the known source classes.

--- a/pkg/entitygraph/providers/database/precedence.go
+++ b/pkg/entitygraph/providers/database/precedence.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// resolveSourceClass derives the source class from a source identity string.
+// Sources are conventionally "<class>:<name>" (e.g. "enforcing-module:hyperv");
+// the prefix before the first ':' is matched against the known source classes.
+// Unrecognized sources default to the observer class per ADR-022 §4.
+func resolveSourceClass(source string) types.SourceClass {
+	prefix := source
+	if i := strings.Index(source, ":"); i >= 0 {
+		prefix = source[:i]
+	}
+	switch types.SourceClass(prefix) {
+	case types.SourceClassEnforcingModule,
+		types.SourceClassManagingIntegration,
+		types.SourceClassObserver,
+		types.SourceClassOperatorAssertion,
+		types.SourceClassCorrelatorInference:
+		return types.SourceClass(prefix)
+	default:
+		return types.SourceClassObserver
+	}
+}
+
+// sourceClassRank returns the precedence rank of a source class: lower rank is
+// higher precedence. Unknown classes rank after all known classes.
+func sourceClassRank(sc types.SourceClass) int {
+	for i, c := range types.DefaultPrecedenceOrder {
+		if c == sc {
+			return i
+		}
+	}
+	return len(types.DefaultPrecedenceOrder)
+}
+
+// sourceEntry is one source's assertion about an entity, used for precedence
+// resolution and attribute merging.
+type sourceEntry struct {
+	source      string
+	sourceClass string
+	observedAt  time.Time
+	payloadHash string
+	payload     map[string]interface{}
+}
+
+// entryRank returns the precedence rank of an entry, preferring its recorded
+// sourceClass and falling back to deriving it from the source identity.
+func entryRank(e sourceEntry) int {
+	sc := types.SourceClass(e.sourceClass)
+	if sc == "" {
+		sc = resolveSourceClass(e.source)
+	}
+	return sourceClassRank(sc)
+}
+
+// betterSource reports whether a should win over b. Precedence is decided first
+// by source-class rank, then by most-recent observation, and finally by payload
+// hash for a stable, deterministic tie-break.
+func betterSource(a, b sourceEntry) bool {
+	ra, rb := entryRank(a), entryRank(b)
+	if ra != rb {
+		return ra < rb
+	}
+	if !a.observedAt.Equal(b.observedAt) {
+		return a.observedAt.After(b.observedAt)
+	}
+	return a.payloadHash < b.payloadHash
+}
+
+// winningSourceIdx returns the index of the highest-precedence entry, or -1 for
+// an empty slice.
+func winningSourceIdx(sources []sourceEntry) int {
+	if len(sources) == 0 {
+		return -1
+	}
+	best := 0
+	for i := 1; i < len(sources); i++ {
+		if betterSource(sources[i], sources[best]) {
+			best = i
+		}
+	}
+	return best
+}
+
+// mergeAttributes merges attribute payloads across sources. For each attribute
+// key the value from the highest-precedence source that supplies it wins; lower
+// precedence sources fill only keys the winners do not provide.
+func mergeAttributes(sources []sourceEntry) map[string]interface{} {
+	merged := map[string]interface{}{}
+	if len(sources) == 0 {
+		return merged
+	}
+
+	order := make([]int, len(sources))
+	for i := range order {
+		order[i] = i
+	}
+	// Best-first ordering.
+	sort.SliceStable(order, func(a, b int) bool {
+		return betterSource(sources[order[a]], sources[order[b]])
+	})
+
+	// Apply worst-first so the best source's values overwrite lower ones.
+	for i := len(order) - 1; i >= 0; i-- {
+		for k, v := range sources[order[i]].payload {
+			merged[k] = v
+		}
+	}
+	return merged
+}

--- a/pkg/entitygraph/providers/database/provider_test.go
+++ b/pkg/entitygraph/providers/database/provider_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// provider_test.go contains database-provider integration tests that require a
+// live PostgreSQL connection. These mirror the SQLite provider_test.go tests and
+// verify the same invariants on the Postgres backend.
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/cfgis/cfgms/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// skipIfNoPostgres skips the calling test when running with -short or when the
+// test Postgres instance is not reachable, returning the DSN otherwise.
+func skipIfNoPostgres(t *testing.T) string {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping Postgres integration test in short mode")
+	}
+	dsn := testPostgresDSN()
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Skip("Postgres not available:", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		t.Skip("Postgres not reachable:", err)
+	}
+	return dsn
+}
+
+func testPostgresDSN() string {
+	pw := testutil.GetTestDBPassword()
+	port := 5432
+	if p := os.Getenv("CFGMS_TEST_DB_PORT"); p != "" {
+		if pi, err := strconv.Atoi(p); err == nil {
+			port = pi
+		}
+	}
+	dbName := "cfgms_test"
+	if v := os.Getenv("CFGMS_TEST_DB_NAME"); v != "" {
+		dbName = v
+	}
+	dbUser := "cfgms_test"
+	if v := os.Getenv("CFGMS_TEST_DB_USER"); v != "" {
+		dbUser = v
+	}
+	return fmt.Sprintf("host=localhost port=%d dbname=%s user=%s password=%s sslmode=disable",
+		port, dbName, dbUser, pw)
+}
+
+func newTestDBProvider(t *testing.T, dsn string) *DatabaseEntityGraphProvider {
+	t.Helper()
+	p, err := NewDatabaseEntityGraphProvider(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func dbObs(subject, source string, kind types.ObservationKind, at time.Time, payload map[string]interface{}) types.Observation {
+	return types.Observation{
+		Source:     source,
+		ObservedAt: at,
+		RecordedAt: at,
+		Subject:    subject,
+		Kind:       kind,
+		Confidence: types.ConfidenceHigh,
+		Payload:    payload,
+	}
+}
+
+func dbMustEID(t *testing.T, s string) types.EID {
+	t.Helper()
+	eid, err := types.ParseEID(s)
+	require.NoError(t, err)
+	return eid
+}
+
+// TestRebuildProjections_Database verifies the corruption-recovery path on the
+// PostgreSQL provider: delete both projection tables, confirm reads fail, call
+// RebuildProjections, confirm reads recover with correct values. Mirrors
+// sqlite/provider_test.go:TestRebuildProjections.
+func TestRebuildProjections_Database(t *testing.T) {
+	dsn := skipIfNoPostgres(t)
+	p := newTestDBProvider(t, dsn)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := dbMustEID(t, "host:db-rebuild")
+
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "enforcing-module:file",
+		Observations: []types.Observation{
+			dbObs(eid.String(), "enforcing-module:file", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind": "host", "hostname": "db-rb01", "owning_tenant": "root/msp-rebuild",
+			}),
+		},
+	}))
+
+	// Corrupt the projections; the log remains the source of truth.
+	_, err := p.db.ExecContext(ctx, `DELETE FROM eg_entity_current WHERE subject = $1`, eid.String())
+	require.NoError(t, err)
+	_, err = p.db.ExecContext(ctx, `DELETE FROM eg_entity_index WHERE subject = $1`, eid.String())
+	require.NoError(t, err)
+
+	_, err = p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.Error(t, err, "entity must not be found after corruption")
+
+	require.NoError(t, p.RebuildProjections(ctx))
+
+	view, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.NoError(t, err)
+	require.Equal(t, "db-rb01", view.Entity.Attributes["hostname"])
+}
+
+// TestContentHashDedup_Database verifies that a bit-identical re-observation
+// from the same source appends no new log row on the PostgreSQL provider.
+// Mirrors sqlite/provider_test.go:TestContentHashDedup. AC 2 requires this
+// row-count assertion on both providers.
+func TestContentHashDedup_Database(t *testing.T) {
+	dsn := skipIfNoPostgres(t)
+	p := newTestDBProvider(t, dsn)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := dbMustEID(t, "host:db-dedup")
+	payload := map[string]interface{}{"entity_kind": "host", "hostname": "db-h1", "owning_tenant": "root/dedup-db"}
+
+	batch := interfaces.ObservationBatch{
+		Source: "observer:scan",
+		Observations: []types.Observation{
+			dbObs(eid.String(), "observer:scan", types.ObservationKindState, now, payload),
+		},
+	}
+	require.NoError(t, p.ReportObservations(ctx, batch))
+	require.NoError(t, p.ReportObservations(ctx, batch)) // identical — must not append
+
+	var count int
+	require.NoError(t, p.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM eg_observation_log WHERE subject = $1`, eid.String()).Scan(&count))
+	require.Equal(t, 1, count, "bit-identical re-observation must not append a log row")
+}

--- a/pkg/entitygraph/providers/database/registry.go
+++ b/pkg/entitygraph/providers/database/registry.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// ProjectionUpdaterFunc incrementally updates the derived projections for one
+// observation inside the ingesting transaction. It runs after the observation
+// log row and current-state row for obs have been written; logSeq is the
+// eg_observation_log id assigned to that row.
+type ProjectionUpdaterFunc func(ctx context.Context, tx *sql.Tx, obs types.Observation, logSeq int64) error
+
+var (
+	mu                 sync.RWMutex
+	projectionUpdaters = map[string]ProjectionUpdaterFunc{}
+)
+
+// RegisterProjectionUpdater registers a projection updater for a subject kind
+// (e.g. "entity", "edge"). Called from init() in the same package. Registering
+// the same kind twice replaces the prior updater.
+func RegisterProjectionUpdater(subjectKind string, fn ProjectionUpdaterFunc) {
+	mu.Lock()
+	defer mu.Unlock()
+	projectionUpdaters[subjectKind] = fn
+}
+
+// dispatchProjectionUpdate invokes the registered updater for subjectKind, if
+// any. Subject kinds without a registered updater are a no-op (nil error).
+func dispatchProjectionUpdate(ctx context.Context, tx *sql.Tx, subjectKind string, obs types.Observation, logSeq int64) error {
+	mu.RLock()
+	fn, ok := projectionUpdaters[subjectKind]
+	mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return fn(ctx, tx, obs, logSeq)
+}

--- a/pkg/entitygraph/providers/database/schema.go
+++ b/pkg/entitygraph/providers/database/schema.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package database implements the PostgreSQL entity graph provider for CFGMS.
+//
+// It is the production backend for clustered controller deployments and mirrors
+// the SQLite entity graph provider's projection model (observation log →
+// current-state → derived index/edge/drift projections) using PostgreSQL syntax:
+// BIGSERIAL identities, $N placeholders, ON CONFLICT upserts, and INSERT ...
+// RETURNING for log sequence assignment (ADR-022).
+package database
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"errors"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+)
+
+//go:embed migrations.sql
+var migrationsSQL string
+
+// Compile-time assertion that the provider satisfies the central contract.
+var _ interfaces.EntityGraphProvider = (*DatabaseEntityGraphProvider)(nil)
+
+// errNotFound is the provider-local not-found sentinel. The interfaces package
+// intentionally does not export a not-found error, so reads that miss return
+// this value for callers to test with errors.Is.
+var errNotFound = errors.New("entitygraph/database: not found")
+
+// DatabaseEntityGraphProvider is the PostgreSQL-backed EntityGraphProvider.
+// It is safe for concurrent use: all state lives in the connection-pooled
+// *sql.DB, and per-observation ingestion is transactional.
+type DatabaseEntityGraphProvider struct {
+	db *sql.DB
+}
+
+// NewDatabaseEntityGraphProvider opens a PostgreSQL connection using dsn,
+// initializes the entity graph schema, and returns a ready provider. The caller
+// owns the returned provider and must call Close when done.
+func NewDatabaseEntityGraphProvider(dsn string) (*DatabaseEntityGraphProvider, error) {
+	db, err := openPGDB(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := initializeSchema(context.Background(), db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("entitygraph/database: initialize schema: %w", err)
+	}
+
+	return &DatabaseEntityGraphProvider{db: db}, nil
+}
+
+// Name returns the provider registry name.
+func (p *DatabaseEntityGraphProvider) Name() string { return "database" }
+
+// Description returns a human-readable description of the provider.
+func (p *DatabaseEntityGraphProvider) Description() string {
+	return "PostgreSQL entity graph provider — production backend for clustered deployments"
+}
+
+// Available reports whether the provider is usable. A live connection ping is
+// deferred to first use, matching the storage database provider convention.
+func (p *DatabaseEntityGraphProvider) Available() (bool, error) {
+	return true, nil
+}
+
+// Close releases the underlying connection pool.
+func (p *DatabaseEntityGraphProvider) Close() error {
+	if p.db != nil {
+		return p.db.Close()
+	}
+	return nil
+}
+
+// openPGDB opens a PostgreSQL database handle and configures the connection
+// pool for controller-scale concurrency.
+func openPGDB(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: open connection: %w", err)
+	}
+
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(30 * time.Minute)
+
+	return db, nil
+}
+
+// initializeSchema executes the embedded migrations.sql DDL. The DDL is
+// idempotent (CREATE TABLE/INDEX IF NOT EXISTS), so repeated invocation across
+// controller nodes is safe.
+func initializeSchema(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx, migrationsSQL); err != nil {
+		return fmt.Errorf("entitygraph/database: exec migrations: %w", err)
+	}
+	return nil
+}

--- a/pkg/entitygraph/providers/sqlite/entity_reads.go
+++ b/pkg/entitygraph/providers/sqlite/entity_reads.go
@@ -22,13 +22,15 @@ const defaultPageSize = 100
 
 // tenantVisible reports whether an entity owned by owningTenant is visible to a
 // caller scoped to tenantFilter. An empty filter sees everything; otherwise the
-// owning tenant must equal the filter or be nested under it (prefix match).
-// This is the sole access-control axis (ADR-023 §111-119).
+// owning tenant must equal the filter or be a strict descendant separated by
+// '/'. The separator is required to avoid matching a sibling tenant whose name
+// merely shares a common prefix (e.g. filter "root/msp-a" must NOT match
+// owningTenant "root/msp-ab"). This is the sole access-control axis (ADR-023 §111-119).
 func tenantVisible(owningTenant, tenantFilter string) bool {
 	if tenantFilter == "" {
 		return true
 	}
-	return owningTenant == tenantFilter || strings.HasPrefix(owningTenant, tenantFilter)
+	return owningTenant == tenantFilter || strings.HasPrefix(owningTenant, tenantFilter+"/")
 }
 
 // GetEntity returns the current entity state, provenance, and freshness,
@@ -141,8 +143,9 @@ func (p *SQLiteEntityGraphProvider) QueryEntities(ctx context.Context, filter in
 		args = append(args, filter.Kind)
 	}
 	if filter.TenantFilter != "" {
+		// Use filter+"/" to avoid matching sibling tenants that share a name prefix.
 		conds = append(conds, "(owning_tenant = ? OR owning_tenant LIKE ?)")
-		args = append(args, filter.TenantFilter, filter.TenantFilter+"%")
+		args = append(args, filter.TenantFilter, filter.TenantFilter+"/%")
 	}
 
 	where := ""

--- a/pkg/entitygraph/providers/sqlite/entity_reads.go
+++ b/pkg/entitygraph/providers/sqlite/entity_reads.go
@@ -358,6 +358,20 @@ func (p *SQLiteEntityGraphProvider) RebuildProjections(ctx context.Context) erro
 	return nil
 }
 
+// CorruptProjectionsForTesting deletes both projection tables while leaving the
+// observation log intact. Used by contract tests to verify that
+// RebuildProjections genuinely recovers from corruption rather than only testing
+// the idempotent no-op path.
+func (p *SQLiteEntityGraphProvider) CorruptProjectionsForTesting(ctx context.Context) error {
+	if _, err := p.db.ExecContext(ctx, `DELETE FROM eg_entity_current`); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: corrupt current: %w", err)
+	}
+	if _, err := p.db.ExecContext(ctx, `DELETE FROM eg_entity_index`); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: corrupt index: %w", err)
+	}
+	return nil
+}
+
 // --- Unimplemented methods (owned by later stories) -------------------------
 
 // GetDesiredState is implemented by a later story.

--- a/pkg/entitygraph/providers/sqlite/entity_reads.go
+++ b/pkg/entitygraph/providers/sqlite/entity_reads.go
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// defaultPageSize bounds QueryEntities when the caller supplies no page size.
+const defaultPageSize = 100
+
+// tenantVisible reports whether an entity owned by owningTenant is visible to a
+// caller scoped to tenantFilter. An empty filter sees everything; otherwise the
+// owning tenant must equal the filter or be nested under it (prefix match).
+// This is the sole access-control axis (ADR-023 §111-119).
+func tenantVisible(owningTenant, tenantFilter string) bool {
+	if tenantFilter == "" {
+		return true
+	}
+	return owningTenant == tenantFilter || strings.HasPrefix(owningTenant, tenantFilter)
+}
+
+// GetEntity returns the current entity state, provenance, and freshness,
+// applying the caller's tenant cut and source-precedence attribute merge.
+func (p *SQLiteEntityGraphProvider) GetEntity(ctx context.Context, eid interfaces.EIDRef, opts interfaces.GetEntityOpts) (*types.EntityView, error) {
+	subject := eid.String()
+
+	var entityKind, owningTenant string
+	err := p.db.QueryRowContext(ctx,
+		`SELECT entity_kind, owning_tenant FROM eg_entity_index WHERE subject = ?`,
+		subject,
+	).Scan(&entityKind, &owningTenant)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("entitygraph/sqlite: entity %s: %w", subject, ErrNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: lookup index: %w", err)
+	}
+
+	// Apply the tenant cut. A filtered-out entity is indistinguishable from a
+	// missing one to the caller.
+	if !tenantVisible(owningTenant, opts.TenantFilter) {
+		return nil, fmt.Errorf("entitygraph/sqlite: entity %s: %w", subject, ErrNotFound)
+	}
+
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT c.source, c.source_class, c.kind, c.confidence, c.observed_at, c.recorded_at, c.payload_hash, p.payload
+		 FROM eg_entity_current c
+		 JOIN eg_payload_content p ON p.payload_hash = c.payload_hash
+		 WHERE c.subject = ?`,
+		subject,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: load sources: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var (
+		entries      []sourceEntry
+		observations []types.Observation
+	)
+	for rows.Next() {
+		var source, sourceClass, kind, confidence, observedAt, recordedAt, hash, payloadJSON string
+		if err := rows.Scan(&source, &sourceClass, &kind, &confidence, &observedAt, &recordedAt, &hash, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan source: %w", err)
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: decode payload: %w", err)
+		}
+		oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+		ra, _ := time.Parse(time.RFC3339Nano, recordedAt)
+		entries = append(entries, sourceEntry{
+			source:      source,
+			sourceClass: sourceClass,
+			observedAt:  oa,
+			payloadHash: hash,
+			payload:     payload,
+		})
+		observations = append(observations, types.Observation{
+			Source:     source,
+			ObservedAt: oa,
+			RecordedAt: ra,
+			Subject:    subject,
+			Kind:       types.ObservationKind(kind),
+			Confidence: types.Confidence(confidence),
+			Payload:    payload,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate sources: %w", err)
+	}
+
+	// The index row exists, so there must be at least one current source; guard
+	// defensively rather than index into an empty slice.
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("entitygraph/sqlite: entity %s: %w", subject, ErrNotFound)
+	}
+
+	winIdx := winningSourceIdx(entries)
+	merged := mergeAttributes(entries)
+
+	view := &types.EntityView{
+		Entity: &types.Entity{
+			EID:          eid,
+			Kind:         entityKind,
+			Attributes:   merged,
+			OwningTenant: owningTenant,
+		},
+		Sources: observations,
+		Freshness: types.Freshness{
+			ObservedAt: observations[winIdx].ObservedAt,
+			RecordedAt: observations[winIdx].RecordedAt,
+		},
+		// CollapseGroup is wired by STORY-6; a pass-through no-op here.
+		CollapseGroup: nil,
+	}
+	return view, nil
+}
+
+// QueryEntities returns entities matching the filter, paged via an integer
+// offset encoded in the page token.
+func (p *SQLiteEntityGraphProvider) QueryEntities(ctx context.Context, filter interfaces.EntityFilter, page interfaces.PageToken) (*interfaces.EntityPage, error) {
+	var (
+		conds []string
+		args  []interface{}
+	)
+	if filter.Kind != "" {
+		conds = append(conds, "entity_kind = ?")
+		args = append(args, filter.Kind)
+	}
+	if filter.TenantFilter != "" {
+		conds = append(conds, "(owning_tenant = ? OR owning_tenant LIKE ?)")
+		args = append(args, filter.TenantFilter, filter.TenantFilter+"%")
+	}
+
+	where := ""
+	if len(conds) > 0 {
+		where = " WHERE " + strings.Join(conds, " AND ")
+	}
+
+	pageSize := page.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	offset := 0
+	if page.Token != "" {
+		v, err := strconv.Atoi(page.Token)
+		if err != nil || v < 0 {
+			return nil, fmt.Errorf("entitygraph/sqlite: invalid page token %q", page.Token)
+		}
+		offset = v
+	}
+
+	// Fetch one extra row to detect whether a further page exists.
+	query := "SELECT subject, entity_kind, owning_tenant FROM eg_entity_index" + where + " ORDER BY subject LIMIT ? OFFSET ?"
+	args = append(args, pageSize+1, offset)
+
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: query entities: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entities []*types.EntityView
+	for rows.Next() {
+		var subject, kind, tenant string
+		if err := rows.Scan(&subject, &kind, &tenant); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan entity: %w", err)
+		}
+		eid, err := types.ParseEID(subject)
+		if err != nil {
+			// Non-EID subjects should not appear in the entity index; skip
+			// rather than fail the whole page.
+			continue
+		}
+		entities = append(entities, &types.EntityView{
+			Entity: &types.Entity{
+				EID:          eid,
+				Kind:         kind,
+				Attributes:   map[string]interface{}{},
+				OwningTenant: tenant,
+			},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate entities: %w", err)
+	}
+
+	nextToken := ""
+	if len(entities) > pageSize {
+		entities = entities[:pageSize]
+		nextToken = strconv.Itoa(offset + pageSize)
+	}
+
+	return &interfaces.EntityPage{Entities: entities, NextToken: nextToken}, nil
+}
+
+// ResolveIdentity returns the EIDs whose index entry matches any of the
+// supplied device/object identity claims. An empty claim set returns an empty
+// result (not an error).
+func (p *SQLiteEntityGraphProvider) ResolveIdentity(ctx context.Context, claims interfaces.IdentityClaims) ([]interfaces.EIDRef, error) {
+	var (
+		conds []string
+		args  []interface{}
+	)
+	if claims.Hostname != "" {
+		conds = append(conds, "hostname = ?")
+		args = append(args, claims.Hostname)
+	}
+	if claims.MachineSID != "" {
+		conds = append(conds, "machine_sid = ?")
+		args = append(args, claims.MachineSID)
+	}
+	if claims.DirectoryObjectGUID != "" {
+		conds = append(conds, "dir_object_guid = ?")
+		args = append(args, claims.DirectoryObjectGUID)
+	}
+	if claims.SerialNumber != "" {
+		conds = append(conds, "serial_number = ?")
+		args = append(args, claims.SerialNumber)
+	}
+	if claims.CloudObjectID != "" {
+		conds = append(conds, "cloud_object_id = ?")
+		args = append(args, claims.CloudObjectID)
+	}
+	for _, mac := range claims.MACAddrs {
+		if mac == "" {
+			continue
+		}
+		// mac_addrs is a comma-joined list; match the MAC as a delimited token.
+		conds = append(conds,
+			"(mac_addrs = ? OR mac_addrs LIKE ? OR mac_addrs LIKE ? OR mac_addrs LIKE ?)")
+		args = append(args, mac, mac+",%", "%,"+mac, "%,"+mac+",%")
+	}
+
+	if len(conds) == 0 {
+		return nil, nil
+	}
+
+	query := "SELECT DISTINCT subject FROM eg_entity_index WHERE " + strings.Join(conds, " OR ")
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: resolve identity: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []interfaces.EIDRef
+	for rows.Next() {
+		var subject string
+		if err := rows.Scan(&subject); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan identity match: %w", err)
+		}
+		eid, err := types.ParseEID(subject)
+		if err != nil {
+			continue
+		}
+		result = append(result, eid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate identity matches: %w", err)
+	}
+	return result, nil
+}
+
+// RebuildProjections drops and rebuilds the current-state and index projections
+// by replaying the observation log in sequence order. This is the recovery path
+// that proves the log is the source of truth.
+func (p *SQLiteEntityGraphProvider) RebuildProjections(ctx context.Context) error {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: begin rebuild tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM eg_entity_current`); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: clear current: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM eg_entity_index`); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: clear index: %w", err)
+	}
+
+	// Collect the full log first: modernc/sqlite cannot interleave writes on a
+	// transaction while a result-set cursor from the same tx is still open.
+	rows, err := tx.QueryContext(ctx,
+		`SELECT l.id, l.subject, l.source, l.observed_at, l.recorded_at, l.kind, l.confidence, p.payload
+		 FROM eg_observation_log l
+		 JOIN eg_payload_content p ON p.payload_hash = l.payload_hash
+		 ORDER BY l.id ASC`,
+	)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: read log: %w", err)
+	}
+
+	type logRow struct {
+		id  int64
+		obs types.Observation
+	}
+	var logs []logRow
+	for rows.Next() {
+		var (
+			id                                                                     int64
+			subject, source, observedAt, recordedAt, kind, confidence, payloadJSON string
+		)
+		if err := rows.Scan(&id, &subject, &source, &observedAt, &recordedAt, &kind, &confidence, &payloadJSON); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("entitygraph/sqlite: scan log row: %w", err)
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("entitygraph/sqlite: decode log payload: %w", err)
+		}
+		oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+		ra, _ := time.Parse(time.RFC3339Nano, recordedAt)
+		logs = append(logs, logRow{
+			id: id,
+			obs: types.Observation{
+				Source:     source,
+				ObservedAt: oa,
+				RecordedAt: ra,
+				Subject:    subject,
+				Kind:       types.ObservationKind(kind),
+				Confidence: types.Confidence(confidence),
+				Payload:    payload,
+			},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("entitygraph/sqlite: iterate log: %w", err)
+	}
+	_ = rows.Close()
+
+	for _, lr := range logs {
+		if err := dispatchProjectionUpdate(ctx, tx, subjectKind(lr.obs.Subject), lr.obs, lr.id); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: replay log seq %d: %w", lr.id, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: commit rebuild: %w", err)
+	}
+	return nil
+}
+
+// --- Unimplemented methods (owned by later stories) -------------------------
+
+// GetDesiredState is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) GetDesiredState(_ context.Context, _ interfaces.EIDRef) (*types.DesiredStateView, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetDriftState is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) GetDriftState(_ context.Context, _ interfaces.EIDRef) (*interfaces.DriftState, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetEdges is implemented by STORY-3.
+func (p *SQLiteEntityGraphProvider) GetEdges(_ context.Context, _ interfaces.EdgeFilter) ([]*interfaces.EdgeView, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetNeighborhood is implemented by STORY-3.
+func (p *SQLiteEntityGraphProvider) GetNeighborhood(_ context.Context, _ interfaces.EIDRef, _ []string, _ types.TraversalDirection, _ int) (*types.Neighborhood, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetHistory is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) GetHistory(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// Diff is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) Diff(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) (*interfaces.StateDiff, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// GetTimeline is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) GetTimeline(_ context.Context, _ []interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.TimelineEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// ListDrifted is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) ListDrifted(_ context.Context, _ interfaces.DriftFilter) ([]*interfaces.DriftState, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// Watch is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) Watch(_ context.Context, _ interfaces.WatchFilter, _ string) (<-chan interfaces.WatchEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}
+
+// UpdateDriftLifecycle is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) UpdateDriftLifecycle(_ context.Context, _ interfaces.DriftLifecycleUpdate) error {
+	return interfaces.ErrNotImplemented
+}

--- a/pkg/entitygraph/providers/sqlite/observations.go
+++ b/pkg/entitygraph/providers/sqlite/observations.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// init wires the entity projection updater. Edge and other subject kinds are
+// registered by their own stories; a missing registration is a no-op.
+func init() {
+	RegisterProjectionUpdater("entity", updateEntityProjection)
+}
+
+// payloadHash returns the hex-encoded SHA-256 of the canonical JSON encoding of
+// payload. Go's encoding/json marshals map keys in sorted order, so the
+// encoding — and therefore the hash — is deterministic for a given payload.
+// This is what makes a bit-identical re-observation produce the same hash and
+// thus append no new log row.
+func payloadHash(payload map[string]interface{}) (string, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("entitygraph/sqlite: hash payload: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// subjectKind classifies an observation subject: "entity" if it parses as an
+// EID, otherwise "edge".
+func subjectKind(subject string) string {
+	if _, err := types.ParseEID(subject); err == nil {
+		return "entity"
+	}
+	return "edge"
+}
+
+// rfc3339 formats a timestamp for storage as a sortable TEXT column value.
+func rfc3339(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }
+
+// ReportObservations ingests a batch of observations from one source. Each
+// observation is content-hash-deduped, appended to the observation log, and
+// projected into the current-state and index tables — all within a single
+// transaction so a partial batch never leaves torn projections.
+func (p *SQLiteEntityGraphProvider) ReportObservations(ctx context.Context, batch interfaces.ObservationBatch) error {
+	if len(batch.Observations) == 0 {
+		return nil
+	}
+
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i := range batch.Observations {
+		obs := batch.Observations[i]
+		if obs.Source == "" {
+			obs.Source = batch.Source
+		}
+		if obs.Subject == "" {
+			return fmt.Errorf("entitygraph/sqlite: observation %d has empty subject", i)
+		}
+
+		hash, err := payloadHash(obs.Payload)
+		if err != nil {
+			return err
+		}
+
+		// Content-hash dedup: a bit-identical re-observation from the same
+		// source appends no new log row. The current-state row already
+		// carries the winning hash for (subject, source).
+		var existing string
+		err = tx.QueryRowContext(ctx,
+			`SELECT payload_hash FROM eg_entity_current WHERE subject = ? AND source = ?`,
+			obs.Subject, obs.Source,
+		).Scan(&existing)
+		switch {
+		case err == nil:
+			if existing == hash {
+				continue
+			}
+		case errors.Is(err, sql.ErrNoRows):
+			// first observation for this (subject, source) — fall through
+		default:
+			return fmt.Errorf("entitygraph/sqlite: dedup lookup: %w", err)
+		}
+
+		payloadJSON, err := json.Marshal(obs.Payload)
+		if err != nil {
+			return fmt.Errorf("entitygraph/sqlite: marshal payload: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO eg_payload_content(payload_hash, payload) VALUES(?, ?)`,
+			hash, string(payloadJSON),
+		); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: insert payload: %w", err)
+		}
+
+		sc := resolveSourceClass(obs.Source)
+		tenantPath := extractString(obs.Payload, "tenant_path")
+
+		res, err := tx.ExecContext(ctx,
+			`INSERT INTO eg_observation_log
+				(subject, source, source_class, observed_at, recorded_at, kind, confidence, claim_scope_key, payload_hash, tenant_path)
+			 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			obs.Subject, obs.Source, string(sc),
+			rfc3339(obs.ObservedAt), rfc3339(obs.RecordedAt),
+			string(obs.Kind), string(obs.Confidence), "", hash, tenantPath,
+		)
+		if err != nil {
+			return fmt.Errorf("entitygraph/sqlite: append log: %w", err)
+		}
+		logSeq, err := res.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("entitygraph/sqlite: log seq: %w", err)
+		}
+
+		if err := dispatchProjectionUpdate(ctx, tx, subjectKind(obs.Subject), obs, logSeq); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: projection update: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: commit: %w", err)
+	}
+	return nil
+}
+
+// updateEntityProjection is the "entity" subject-kind projection updater. It
+// upserts the current-state row for (subject, source) with the new log
+// sequence and rebuilds the entity index from all current sources.
+func updateEntityProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, logSeq int64) error {
+	hash, err := payloadHash(obs.Payload)
+	if err != nil {
+		return err
+	}
+	sc := resolveSourceClass(obs.Source)
+	tenantPath := extractString(obs.Payload, "tenant_path")
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO eg_entity_current
+			(subject, source, source_class, kind, confidence, observed_at, recorded_at, payload_hash, tenant_path, log_seq)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(subject, source) DO UPDATE SET
+			source_class = excluded.source_class,
+			kind         = excluded.kind,
+			confidence   = excluded.confidence,
+			observed_at  = excluded.observed_at,
+			recorded_at  = excluded.recorded_at,
+			payload_hash = excluded.payload_hash,
+			tenant_path  = excluded.tenant_path,
+			log_seq      = excluded.log_seq`,
+		obs.Subject, obs.Source, string(sc), string(obs.Kind), string(obs.Confidence),
+		rfc3339(obs.ObservedAt), rfc3339(obs.RecordedAt), hash, tenantPath, logSeq,
+	); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: upsert current: %w", err)
+	}
+
+	return rebuildEntityIndex(ctx, tx, obs.Subject)
+}
+
+// rebuildEntityIndex recomputes the eg_entity_index row for subject from all of
+// its current sources, applying source precedence. Kind and owning tenant are
+// taken from the winning (highest-precedence) source; identity fields are taken
+// from the precedence-merged attribute set so a lower-precedence source can
+// still contribute an identity claim the winner omitted.
+func rebuildEntityIndex(ctx context.Context, tx *sql.Tx, subject string) error {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT c.source, c.source_class, c.observed_at, c.payload_hash, p.payload
+		 FROM eg_entity_current c
+		 JOIN eg_payload_content p ON p.payload_hash = c.payload_hash
+		 WHERE c.subject = ?`,
+		subject,
+	)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: load current sources: %w", err)
+	}
+
+	var entries []sourceEntry
+	for rows.Next() {
+		var source, sourceClass, observedAt, hash, payloadJSON string
+		if err := rows.Scan(&source, &sourceClass, &observedAt, &hash, &payloadJSON); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("entitygraph/sqlite: scan current source: %w", err)
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("entitygraph/sqlite: decode payload: %w", err)
+		}
+		t, _ := time.Parse(time.RFC3339Nano, observedAt)
+		entries = append(entries, sourceEntry{
+			source:      source,
+			sourceClass: sourceClass,
+			observedAt:  t,
+			payloadHash: hash,
+			payload:     payload,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("entitygraph/sqlite: iterate current sources: %w", err)
+	}
+	_ = rows.Close()
+
+	// No live sources (e.g. after a retraction): remove the index entry.
+	if len(entries) == 0 {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM eg_entity_index WHERE subject = ?`, subject); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: clear index: %w", err)
+		}
+		return nil
+	}
+
+	win := entries[winningSourceIdx(entries)].payload
+	merged := mergeAttributes(entries)
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO eg_entity_index
+			(subject, entity_kind, owning_tenant, hostname, mac_addrs, machine_sid, dir_object_guid, serial_number, cloud_object_id)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(subject) DO UPDATE SET
+			entity_kind     = excluded.entity_kind,
+			owning_tenant   = excluded.owning_tenant,
+			hostname        = excluded.hostname,
+			mac_addrs       = excluded.mac_addrs,
+			machine_sid     = excluded.machine_sid,
+			dir_object_guid = excluded.dir_object_guid,
+			serial_number   = excluded.serial_number,
+			cloud_object_id = excluded.cloud_object_id`,
+		subject,
+		extractString(win, "entity_kind"),
+		extractString(win, "owning_tenant"),
+		extractString(merged, "hostname"),
+		extractStringList(merged, "mac_addrs"),
+		extractString(merged, "machine_sid"),
+		extractString(merged, "dir_object_guid"),
+		extractString(merged, "serial_number"),
+		extractString(merged, "cloud_object_id"),
+	); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: upsert index: %w", err)
+	}
+	return nil
+}
+
+// extractString returns m[key] as a string, or "" if absent or not a string.
+func extractString(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// extractStringList returns m[key] as a comma-joined string, accepting a
+// []string, a []interface{} of strings, or a bare string.
+func extractStringList(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	switch vv := v.(type) {
+	case []string:
+		return strings.Join(vv, ",")
+	case []interface{}:
+		parts := make([]string, 0, len(vv))
+		for _, e := range vv {
+			if s, ok := e.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, ",")
+	case string:
+		return vv
+	default:
+		return ""
+	}
+}

--- a/pkg/entitygraph/providers/sqlite/precedence.go
+++ b/pkg/entitygraph/providers/sqlite/precedence.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// resolveSourceClass extracts the source class from a source identity string.
+// The class is the segment before the first ':' (e.g. "enforcing-module:hyperv"
+// → "enforcing-module"). Unrecognised prefixes fall back to the observer class,
+// which sits mid-precedence and never wins over an enforcing module.
+func resolveSourceClass(source string) types.SourceClass {
+	prefix := source
+	if idx := strings.IndexByte(source, ':'); idx >= 0 {
+		prefix = source[:idx]
+	}
+	sc := types.SourceClass(prefix)
+	for _, known := range types.DefaultPrecedenceOrder {
+		if known == sc {
+			return sc
+		}
+	}
+	return types.SourceClassObserver
+}
+
+// sourceClassRank returns the precedence rank of a source class: the index in
+// DefaultPrecedenceOrder, where a lower rank means higher precedence. Unknown
+// classes rank last (lowest precedence).
+func sourceClassRank(sc types.SourceClass) int {
+	for i, known := range types.DefaultPrecedenceOrder {
+		if known == sc {
+			return i
+		}
+	}
+	return len(types.DefaultPrecedenceOrder)
+}
+
+// sourceEntry is one current-state source contributing to an entity's merged
+// view. It carries the decoded payload plus the metadata needed for precedence
+// and tie-breaking.
+type sourceEntry struct {
+	source      string
+	sourceClass string
+	observedAt  time.Time
+	payloadHash string
+	payload     map[string]interface{}
+}
+
+// winningSourceIdx returns the index of the highest-precedence source: lowest
+// class rank wins, ties broken by newest observedAt. Returns -1 for an empty
+// slice.
+func winningSourceIdx(sources []sourceEntry) int {
+	if len(sources) == 0 {
+		return -1
+	}
+	best := 0
+	bestRank := sourceClassRank(types.SourceClass(sources[0].sourceClass))
+	for i := 1; i < len(sources); i++ {
+		r := sourceClassRank(types.SourceClass(sources[i].sourceClass))
+		switch {
+		case r < bestRank:
+			best, bestRank = i, r
+		case r == bestRank && sources[i].observedAt.After(sources[best].observedAt):
+			best = i
+		}
+	}
+	return best
+}
+
+// mergeAttributes merges the payloads of all sources into a single attribute
+// map, applying source precedence: lower-precedence values are written first
+// and higher-precedence values override them per key. Within one class the
+// newer observation overrides the older.
+func mergeAttributes(sources []sourceEntry) map[string]interface{} {
+	ordered := make([]sourceEntry, len(sources))
+	copy(ordered, sources)
+
+	// Sort so that the winning source is applied last: higher rank (lower
+	// precedence) first, and within equal rank, older observations first.
+	sort.SliceStable(ordered, func(i, j int) bool {
+		ri := sourceClassRank(types.SourceClass(ordered[i].sourceClass))
+		rj := sourceClassRank(types.SourceClass(ordered[j].sourceClass))
+		if ri != rj {
+			return ri > rj
+		}
+		return ordered[i].observedAt.Before(ordered[j].observedAt)
+	})
+
+	merged := make(map[string]interface{})
+	for _, s := range ordered {
+		for k, v := range s.payload {
+			merged[k] = v
+		}
+	}
+	return merged
+}

--- a/pkg/entitygraph/providers/sqlite/provider_test.go
+++ b/pkg/entitygraph/providers/sqlite/provider_test.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// newTestProvider returns a file-backed provider in a temp dir. File-backed
+// (not :memory:) so RebuildProjections and multi-statement flows exercise the
+// real WAL path.
+func newTestProvider(t *testing.T) *SQLiteEntityGraphProvider {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "eg.db")
+	p, err := NewSQLiteEntityGraphProvider(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func mustEID(t *testing.T, s string) types.EID {
+	t.Helper()
+	eid, err := types.ParseEID(s)
+	require.NoError(t, err)
+	return eid
+}
+
+func obs(subject, source string, kind types.ObservationKind, at time.Time, payload map[string]interface{}) types.Observation {
+	return types.Observation{
+		Source:     source,
+		ObservedAt: at,
+		RecordedAt: at,
+		Subject:    subject,
+		Kind:       kind,
+		Confidence: types.ConfidenceHigh,
+		Payload:    payload,
+	}
+}
+
+func TestReportAndGetEntity(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := mustEID(t, "host:abc123")
+
+	err := p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "enforcing-module:file",
+		Observations: []types.Observation{
+			obs(eid.String(), "enforcing-module:file", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind":   "host",
+				"owning_tenant": "root/msp-a/client-1",
+				"hostname":      "web01",
+				"cpu_count":     float64(8),
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	view, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.NoError(t, err)
+	require.Equal(t, "host", view.Entity.Kind)
+	require.Equal(t, "root/msp-a/client-1", view.Entity.OwningTenant)
+	require.Equal(t, "web01", view.Entity.Attributes["hostname"])
+	require.Equal(t, float64(8), view.Entity.Attributes["cpu_count"])
+	require.Len(t, view.Sources, 1)
+}
+
+func TestGetEntityNotFound(t *testing.T) {
+	p := newTestProvider(t)
+	_, err := p.GetEntity(context.Background(), mustEID(t, "host:nope"), interfaces.GetEntityOpts{})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestContentHashDedup(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := mustEID(t, "host:dedup")
+	payload := map[string]interface{}{"entity_kind": "host", "hostname": "h1"}
+
+	batch := interfaces.ObservationBatch{
+		Source:       "observer:scan",
+		Observations: []types.Observation{obs(eid.String(), "observer:scan", types.ObservationKindState, now, payload)},
+	}
+	require.NoError(t, p.ReportObservations(ctx, batch))
+	require.NoError(t, p.ReportObservations(ctx, batch)) // identical → no new log row
+
+	var count int
+	require.NoError(t, p.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM eg_observation_log WHERE subject = ?`, eid.String()).Scan(&count))
+	require.Equal(t, 1, count, "bit-identical re-observation must not append a log row")
+}
+
+func TestPrecedenceMerge(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := mustEID(t, "host:prec")
+
+	// Observer says color=blue; enforcing module says color=red. Enforcing wins.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "observer:scan",
+		Observations: []types.Observation{
+			obs(eid.String(), "observer:scan", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind": "host", "color": "blue", "only_observer": "x",
+			}),
+		},
+	}))
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "enforcing-module:paint",
+		Observations: []types.Observation{
+			obs(eid.String(), "enforcing-module:paint", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind": "host", "color": "red",
+			}),
+		},
+	}))
+
+	view, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.NoError(t, err)
+	require.Equal(t, "red", view.Entity.Attributes["color"], "enforcing module overrides observer")
+	require.Equal(t, "x", view.Entity.Attributes["only_observer"], "lower-precedence-only keys survive")
+}
+
+func TestTenantFilter(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := mustEID(t, "host:tenant")
+
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "observer:scan",
+		Observations: []types.Observation{
+			obs(eid.String(), "observer:scan", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind": "host", "owning_tenant": "root/msp-a/client-1",
+			}),
+		},
+	}))
+
+	_, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{TenantFilter: "root/msp-a"})
+	require.NoError(t, err, "matching tenant subtree is visible")
+
+	_, err = p.GetEntity(ctx, eid, interfaces.GetEntityOpts{TenantFilter: "root/msp-b"})
+	require.ErrorIs(t, err, ErrNotFound, "other tenant subtree is invisible")
+}
+
+func TestQueryEntitiesPaging(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for _, name := range []string{"a", "b", "c"} {
+		eid := mustEID(t, "host:"+name)
+		require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+			Source: "observer:scan",
+			Observations: []types.Observation{
+				obs(eid.String(), "observer:scan", types.ObservationKindState, now, map[string]interface{}{
+					"entity_kind": "host", "owning_tenant": "root/t",
+				}),
+			},
+		}))
+	}
+
+	page1, err := p.QueryEntities(ctx, interfaces.EntityFilter{Kind: "host"}, interfaces.PageToken{PageSize: 2})
+	require.NoError(t, err)
+	require.Len(t, page1.Entities, 2)
+	require.NotEmpty(t, page1.NextToken)
+
+	page2, err := p.QueryEntities(ctx, interfaces.EntityFilter{Kind: "host"}, interfaces.PageToken{PageSize: 2, Token: page1.NextToken})
+	require.NoError(t, err)
+	require.Len(t, page2.Entities, 1)
+	require.Empty(t, page2.NextToken)
+}
+
+func TestResolveIdentity(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := mustEID(t, "host:ident")
+
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "observer:scan",
+		Observations: []types.Observation{
+			obs(eid.String(), "observer:scan", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind": "host",
+				"machine_sid": "S-1-5-21-XYZ",
+				"mac_addrs":   []interface{}{"00:11:22:33:44:55", "aa:bb:cc:dd:ee:ff"},
+			}),
+		},
+	}))
+
+	got, err := p.ResolveIdentity(ctx, interfaces.IdentityClaims{MachineSID: "S-1-5-21-XYZ"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, eid.String(), got[0].String())
+
+	got, err = p.ResolveIdentity(ctx, interfaces.IdentityClaims{MACAddrs: []string{"aa:bb:cc:dd:ee:ff"}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	// Empty claims → empty result, not an error.
+	got, err = p.ResolveIdentity(ctx, interfaces.IdentityClaims{})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestRebuildProjections(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	eid := mustEID(t, "host:rebuild")
+
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "enforcing-module:file",
+		Observations: []types.Observation{
+			obs(eid.String(), "enforcing-module:file", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind": "host", "hostname": "rb01",
+			}),
+		},
+	}))
+
+	// Corrupt the projections; the log remains the source of truth.
+	_, err := p.db.ExecContext(ctx, `DELETE FROM eg_entity_current`)
+	require.NoError(t, err)
+	_, err = p.db.ExecContext(ctx, `DELETE FROM eg_entity_index`)
+	require.NoError(t, err)
+
+	_, err = p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.ErrorIs(t, err, ErrNotFound)
+
+	require.NoError(t, p.RebuildProjections(ctx))
+
+	view, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.NoError(t, err)
+	require.Equal(t, "rb01", view.Entity.Attributes["hostname"])
+}
+
+func TestUnimplementedReturnsErrNotImplemented(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	eid := mustEID(t, "host:x")
+
+	_, err := p.GetDesiredState(ctx, eid)
+	require.ErrorIs(t, err, interfaces.ErrNotImplemented)
+	_, err = p.GetEdges(ctx, interfaces.EdgeFilter{})
+	require.ErrorIs(t, err, interfaces.ErrNotImplemented)
+	err = p.UpdateDriftLifecycle(ctx, interfaces.DriftLifecycleUpdate{})
+	require.ErrorIs(t, err, interfaces.ErrNotImplemented)
+}
+
+func TestSubjectKind(t *testing.T) {
+	require.Equal(t, "entity", subjectKind("host:abc"))
+	require.Equal(t, "edge", subjectKind("contains|host:a|host:b"))
+}
+
+func TestSourceClassPrecedence(t *testing.T) {
+	require.Equal(t, types.SourceClassEnforcingModule, resolveSourceClass("enforcing-module:hyperv"))
+	require.Equal(t, types.SourceClassObserver, resolveSourceClass("mystery:thing"))
+	require.Less(t, sourceClassRank(types.SourceClassEnforcingModule), sourceClassRank(types.SourceClassObserver))
+}
+
+func TestProviderSatisfiesInterface(t *testing.T) {
+	var _ interfaces.EntityGraphProvider = (*SQLiteEntityGraphProvider)(nil)
+	require.NotEqual(t, "", (&SQLiteEntityGraphProvider{}).Name())
+}
+
+func TestDedupErrorPathIsClean(t *testing.T) {
+	// Guard: an empty batch is a no-op, not an error.
+	p := newTestProvider(t)
+	require.NoError(t, p.ReportObservations(context.Background(), interfaces.ObservationBatch{}))
+	require.False(t, errors.Is(nil, ErrNotFound))
+}

--- a/pkg/entitygraph/providers/sqlite/provider_test.go
+++ b/pkg/entitygraph/providers/sqlite/provider_test.go
@@ -5,7 +5,6 @@ package sqlite
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -151,6 +150,19 @@ func TestTenantFilter(t *testing.T) {
 
 	_, err = p.GetEntity(ctx, eid, interfaces.GetEntityOpts{TenantFilter: "root/msp-b"})
 	require.ErrorIs(t, err, ErrNotFound, "other tenant subtree is invisible")
+
+	// Prefix-collision guard: "root/msp-a" must not match "root/msp-a-other" or "root/msp-ab".
+	eid2 := mustEID(t, "host:prefix-tenant")
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "observer:scan",
+		Observations: []types.Observation{
+			obs(eid2.String(), "observer:scan", types.ObservationKindState, now, map[string]interface{}{
+				"entity_kind": "host", "owning_tenant": "root/msp-ab",
+			}),
+		},
+	}))
+	_, err = p.GetEntity(ctx, eid2, interfaces.GetEntityOpts{TenantFilter: "root/msp-a"})
+	require.ErrorIs(t, err, ErrNotFound, "sibling tenant sharing a name prefix must not be visible")
 }
 
 func TestQueryEntitiesPaging(t *testing.T) {
@@ -276,5 +288,6 @@ func TestDedupErrorPathIsClean(t *testing.T) {
 	// Guard: an empty batch is a no-op, not an error.
 	p := newTestProvider(t)
 	require.NoError(t, p.ReportObservations(context.Background(), interfaces.ObservationBatch{}))
-	require.False(t, errors.Is(nil, ErrNotFound))
+	// ErrNotFound is a valid non-nil sentinel; confirm it is not accidentally nil.
+	require.NotNil(t, ErrNotFound, "ErrNotFound must be a non-nil sentinel error")
 }

--- a/pkg/entitygraph/providers/sqlite/registry.go
+++ b/pkg/entitygraph/providers/sqlite/registry.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// ProjectionUpdaterFunc applies the projection-specific side effects of a newly
+// appended observation. It runs inside the same write transaction as the log
+// append, so it must only touch the provided *sql.Tx and must not commit.
+//
+// logSeq is the eg_observation_log.id of the row that triggered this update.
+type ProjectionUpdaterFunc func(ctx context.Context, tx *sql.Tx, obs types.Observation, logSeq int64) error
+
+var (
+	mu                 sync.RWMutex
+	projectionUpdaters = map[string]ProjectionUpdaterFunc{}
+)
+
+// RegisterProjectionUpdater registers a projection updater for a subject kind
+// ("entity" or "edge"). It is intended to be called from package init()
+// functions. A later registration for the same subject kind replaces the
+// previous one.
+func RegisterProjectionUpdater(subjectKind string, fn ProjectionUpdaterFunc) {
+	mu.Lock()
+	defer mu.Unlock()
+	projectionUpdaters[subjectKind] = fn
+}
+
+// dispatchProjectionUpdate invokes the registered updater for subjectKind, if
+// any. A missing registration is not an error — the observation log row has
+// already been written and the projection simply has no consumer yet (e.g.
+// edges before STORY-3).
+func dispatchProjectionUpdate(ctx context.Context, tx *sql.Tx, subjectKind string, obs types.Observation, logSeq int64) error {
+	mu.RLock()
+	fn, ok := projectionUpdaters[subjectKind]
+	mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return fn(ctx, tx, obs, logSeq)
+}

--- a/pkg/entitygraph/providers/sqlite/schema.go
+++ b/pkg/entitygraph/providers/sqlite/schema.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package sqlite implements the SQLite entity graph provider for CFGMS.
+//
+// This is the OSS default entity-graph backend for single-instance
+// deployments (ADR-022/ADR-023). It uses modernc.org/sqlite, a pure-Go port
+// of SQLite that builds with CGO_ENABLED=0 and cross-compiles cleanly to all
+// controller platforms.
+//
+// The store is observation-first: every write is an append to an
+// observation log (eg_observation_log). Current-state and index projections
+// are derived from that log and can always be rebuilt via RebuildProjections.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	_ "modernc.org/sqlite" // Pure-Go SQLite driver (CGO-free)
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+)
+
+// Compile-time assertion that SQLiteEntityGraphProvider satisfies the contract.
+var _ interfaces.EntityGraphProvider = (*SQLiteEntityGraphProvider)(nil)
+
+// ErrNotFound is returned when a requested entity has no current-state
+// projection (or is filtered out by the caller's tenant cut).
+var ErrNotFound = errors.New("entitygraph: not found")
+
+// SQLiteEntityGraphProvider is the SQLite-backed EntityGraphProvider.
+// It is safe for concurrent use: all writes go through short transactions and
+// SQLite (WAL mode) serialises writers while permitting concurrent readers.
+type SQLiteEntityGraphProvider struct {
+	db *sql.DB
+}
+
+// NewSQLiteEntityGraphProvider opens (or creates) the entity-graph database at
+// path, runs schema initialisation, and returns a ready provider.
+//
+// path may be ":memory:", a "file:" DSN, or a plain filesystem path.
+func NewSQLiteEntityGraphProvider(path string) (*SQLiteEntityGraphProvider, error) {
+	db, err := openDB(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := initializeSchema(context.Background(), db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("entitygraph/sqlite: schema initialisation failed: %w", err)
+	}
+	return &SQLiteEntityGraphProvider{db: db}, nil
+}
+
+// Name returns the provider name used for registration and lookup.
+func (p *SQLiteEntityGraphProvider) Name() string { return "sqlite" }
+
+// Description returns a human-readable description of the provider.
+func (p *SQLiteEntityGraphProvider) Description() string {
+	return "SQLite entity graph provider — OSS default for single-instance deployments"
+}
+
+// Available reports whether the provider is usable. The pure-Go SQLite driver
+// is always linked in, so this is always true.
+func (p *SQLiteEntityGraphProvider) Available() (bool, error) { return true, nil }
+
+// Close closes the underlying database connection pool.
+func (p *SQLiteEntityGraphProvider) Close() error {
+	if p.db == nil {
+		return nil
+	}
+	return p.db.Close()
+}
+
+// openDB opens (or creates) a SQLite database at path and enables WAL mode and
+// foreign keys. Pragmas are passed via DSN _pragma= tokens so every pooled
+// connection applies them (see pkg/storage/providers/sqlite for the rationale).
+func openDB(path string) (*sql.DB, error) {
+	const pragmas = "_pragma=busy_timeout(15000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)"
+
+	var dsn string
+	switch {
+	case path == ":memory:":
+		dsn = "file::memory:?cache=shared&" + pragmas
+	case strings.HasPrefix(path, "file:"):
+		sep := "?"
+		if strings.Contains(path, "?") {
+			sep = "&"
+		}
+		dsn = path + sep + pragmas
+	default:
+		dsn = "file:" + path + "?" + pragmas
+	}
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: open %s: %w", path, err)
+	}
+
+	// Pin single-connection in-memory databases so the backing store lives for
+	// the pool's entire lifetime (a shared-cache in-memory DB is freed the
+	// instant the last connection closes).
+	if path == ":memory:" || strings.Contains(dsn, "mode=memory") {
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		db.SetConnMaxLifetime(0)
+		db.SetConnMaxIdleTime(0)
+	}
+
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("entitygraph/sqlite: ping %s: %w", path, err)
+	}
+	return db, nil
+}
+
+// schemaStatements is the ordered DDL that establishes the entity-graph schema.
+//
+// All tables are prefixed eg_ to avoid collisions with the business-data
+// schema when both share a database file. The observation log uses
+// INTEGER PRIMARY KEY AUTOINCREMENT (never a bare rowid) so log sequence
+// numbers are monotonic and never reused after deletion (ADR-023 §5).
+var schemaStatements = []string{
+	// Content-hash-deduped payload blobs. payload_hash is SHA-256(json) hex.
+	`CREATE TABLE IF NOT EXISTS eg_payload_content (
+		payload_hash TEXT PRIMARY KEY,
+		payload      TEXT NOT NULL
+	)`,
+
+	// Append-only observation log — the source of truth. Projections derive
+	// from it and can be rebuilt at any time.
+	`CREATE TABLE IF NOT EXISTS eg_observation_log (
+		id              INTEGER PRIMARY KEY AUTOINCREMENT,
+		subject         TEXT NOT NULL,
+		source          TEXT NOT NULL,
+		source_class    TEXT NOT NULL,
+		observed_at     TEXT NOT NULL,
+		recorded_at     TEXT NOT NULL,
+		kind            TEXT NOT NULL,
+		confidence      TEXT NOT NULL,
+		claim_scope_key TEXT NOT NULL DEFAULT '',
+		payload_hash    TEXT NOT NULL,
+		tenant_path     TEXT NOT NULL DEFAULT ''
+	)`,
+	`CREATE INDEX IF NOT EXISTS eg_observation_log_subject ON eg_observation_log(subject)`,
+	`CREATE INDEX IF NOT EXISTS eg_observation_log_subject_source ON eg_observation_log(subject, source)`,
+
+	// Current-state projection: highest-seq observation per (subject, source).
+	`CREATE TABLE IF NOT EXISTS eg_entity_current (
+		subject      TEXT NOT NULL,
+		source       TEXT NOT NULL,
+		source_class TEXT NOT NULL,
+		kind         TEXT NOT NULL,
+		confidence   TEXT NOT NULL,
+		observed_at  TEXT NOT NULL,
+		recorded_at  TEXT NOT NULL,
+		payload_hash TEXT NOT NULL,
+		tenant_path  TEXT NOT NULL DEFAULT '',
+		log_seq      INTEGER NOT NULL,
+		PRIMARY KEY (subject, source)
+	)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_current_subject ON eg_entity_current(subject)`,
+
+	// Entity type/tenant/identity index for QueryEntities and ResolveIdentity.
+	// owning_tenant is the ONLY access-control axis (ADR-023 §111-119); the
+	// tenant_path columns elsewhere are ingest-time provenance only.
+	`CREATE TABLE IF NOT EXISTS eg_entity_index (
+		subject         TEXT PRIMARY KEY,
+		entity_kind     TEXT NOT NULL DEFAULT '',
+		owning_tenant   TEXT NOT NULL DEFAULT '',
+		hostname        TEXT NOT NULL DEFAULT '',
+		mac_addrs       TEXT NOT NULL DEFAULT '',
+		machine_sid     TEXT NOT NULL DEFAULT '',
+		dir_object_guid TEXT NOT NULL DEFAULT '',
+		serial_number   TEXT NOT NULL DEFAULT '',
+		cloud_object_id TEXT NOT NULL DEFAULT ''
+	)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_index_kind ON eg_entity_index(entity_kind)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_index_tenant ON eg_entity_index(owning_tenant)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_index_hostname ON eg_entity_index(hostname)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_index_machine_sid ON eg_entity_index(machine_sid)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_index_dir_guid ON eg_entity_index(dir_object_guid)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_index_serial ON eg_entity_index(serial_number)`,
+	`CREATE INDEX IF NOT EXISTS eg_entity_index_cloud_id ON eg_entity_index(cloud_object_id)`,
+
+	// Edge projection — populated by STORY-3. Created now (empty) so the
+	// schema is forward-stable and RebuildProjections has a place to write.
+	`CREATE TABLE IF NOT EXISTS eg_edge_projection (
+		edge_key     TEXT PRIMARY KEY,
+		edge_type    TEXT NOT NULL DEFAULT '',
+		from_subject TEXT NOT NULL DEFAULT '',
+		to_subject   TEXT NOT NULL DEFAULT '',
+		payload_hash TEXT NOT NULL DEFAULT '',
+		log_seq      INTEGER NOT NULL DEFAULT 0
+	)`,
+
+	// Drift projection — populated by a later story. Created now (empty).
+	`CREATE TABLE IF NOT EXISTS eg_drift_projection (
+		subject          TEXT PRIMARY KEY,
+		detected_at      TEXT NOT NULL DEFAULT '',
+		config_revision  TEXT NOT NULL DEFAULT '',
+		lifecycle_status TEXT NOT NULL DEFAULT '',
+		fields           TEXT NOT NULL DEFAULT ''
+	)`,
+
+	// Claim-scope prior-assertion tracking — populated by STORY-4. Empty now.
+	`CREATE TABLE IF NOT EXISTS eg_claim_scope_prior (
+		scope_key TEXT PRIMARY KEY,
+		source    TEXT NOT NULL DEFAULT '',
+		as_of     TEXT NOT NULL DEFAULT '',
+		subjects  TEXT NOT NULL DEFAULT ''
+	)`,
+}
+
+// initializeSchema creates all entity-graph tables and indexes in a single
+// transaction. It is idempotent (every statement uses IF NOT EXISTS).
+func initializeSchema(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: begin schema tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, stmt := range schemaStatements {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: schema statement failed: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: commit schema tx: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
WIP salvage of a dev-agent session that stalled (ended turn on background `make test-commit`, killed, exited 0 with empty PR). `make test` had passed in-container before the stall. Staged provider work committed and pushed for fix-cycle resume; the agent's unstaged Makefile/.serena drift was deliberately excluded.

Draft — not for review. The fix cycle (dispatch-fix / resume_failed_session) should finish validation and mark ready.

Fixes #2872