### PR TITLE
deps: bump straggler Dockerfiles golang:1.26.4 -> 1.26.5 (CVE-2026-39822, Issue #2899)

### DIFF
--- a/Dockerfile.test-runner
+++ b/Dockerfile.test-runner
@@ -1,4 +1,4 @@
-FROM golang:1.26.4
+FROM golang:1.26.5
 WORKDIR /workspace
 
 # Install dependencies needed by tests

--- a/cmd/steward/Dockerfile.debian
+++ b/cmd/steward/Dockerfile.debian
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM golang:1.26.4-alpine3.23 AS builder
+FROM golang:1.26.5-alpine3.23 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates


### PR DESCRIPTION
## Summary

Two Dockerfiles pinned `golang:1.26.4`, which carries **CVE-2026-39822** (HIGH) — `os.Root` symlink-following directory traversal in the Go stdlib, fixed in 1.26.5.

| File | Change |
|------|--------|
| `Dockerfile.test-runner:1` | `golang:1.26.4` → `golang:1.26.5` |
| `cmd/steward/Dockerfile.debian:3` | `golang:1.26.4-alpine3.23` → `golang:1.26.5-alpine3.23` |

**Drift correction, not a version advance** — `cmd/controller/Dockerfile`, `cmd/steward/Dockerfile`, and `.devcontainer/Dockerfile` are already on 1.26.5. These two were missed.

## Why no gate caught it

`Scan Controller Image` / `Scan Steward Image` build and scan only `cmd/controller/Dockerfile` and `cmd/steward/Dockerfile` (both already 1.26.5). Neither `Dockerfile.test-runner` nor `cmd/steward/Dockerfile.debian` is built or scanned by any gate, so this HIGH was invisible to CI.

## Verification (ran, not inferred)

```
trivy image golang:1.26.4-alpine3.23 --severity HIGH,CRITICAL
  -> Total: 1 (HIGH: 1)  stdlib CVE-2026-39822 (fixed: 1.25.12, 1.26.5, 1.27.0-rc.2)
trivy image golang:1.26.5-alpine3.23 --severity HIGH,CRITICAL
  -> no HIGH/CRITICAL findings

docker build -f cmd/steward/Dockerfile.debian --target builder
  -> exit 0, both steward binaries (steward + cfgms-launcher) compiled on the new base
```

Fixes #2899