### PR TITLE
entitygraph: edges, placeholder nodes, depth-bounded neighborhood (Issue #2873)

### DIFF
--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -52,6 +52,12 @@ func RunEntityGraphContractTests(t *testing.T, factory EntityGraphProviderFactor
 	t.Run("ResolveIdentity", func(t *testing.T) { testEGResolveIdentity(t, factory) })        // AC 8
 	t.Run("EmptyProjectionTables", func(t *testing.T) { testEGEmptyProjections(t, factory) }) // AC 9
 	t.Run("GetEntityOptsNoOp", func(t *testing.T) { testEGOptsNoOp(t, factory) })             // opts pass-through
+	// Story-3: edges, placeholder nodes, depth-bounded neighborhood (Issue #2873)
+	t.Run("EdgeRoundTrip", func(t *testing.T) { testEGEdgeRoundTrip(t, factory) })                       // AC 1
+	t.Run("PlaceholderNode", func(t *testing.T) { testEGPlaceholderNode(t, factory) })                   // AC 2
+	t.Run("NeighborhoodDepthCap", func(t *testing.T) { testEGNeighborhoodDepthCap(t, factory) })         // AC 3
+	t.Run("NeighborhoodTenantPerHop", func(t *testing.T) { testEGNeighborhoodTenantPerHop(t, factory) }) // AC 4
+	t.Run("GetEdgesTenantFilter", func(t *testing.T) { testEGGetEdgesTenantFilter(t, factory) })         // AC 5
 }
 
 // --- Contract test helpers ---
@@ -409,6 +415,285 @@ func testEGOptsNoOp(t *testing.T, factory EntityGraphProviderFactory) {
 	require.NoError(t, err)
 	require.NotNil(t, view)
 	assert.Nil(t, view.CollapseGroup, "CollapseGroup opt is a pass-through no-op in this round")
+}
+
+// egReportEdge ingests a single-observation edge batch, failing on error.
+// Subject format: "edge_type|from_eid|to_eid".
+func egReportEdge(ctx context.Context, t *testing.T, p interfaces.EntityGraphProvider, source, fromEIDStr, toEIDStr, edgeType string) {
+	t.Helper()
+	subject := edgeType + "|" + fromEIDStr + "|" + toEIDStr
+	batch := interfaces.ObservationBatch{
+		Source: source,
+		Observations: []types.Observation{
+			egObservation(subject, source, time.Now().UTC(), map[string]interface{}{}),
+		},
+	}
+	require.NoError(t, p.ReportObservations(ctx, batch), "report edge %s", subject)
+}
+
+// testEGEdgeRoundTrip verifies that an edge asserted via ReportObservations is
+// readable via GetEdges by endpoint, type, and source (Story-3 AC 1).
+func testEGEdgeRoundTrip(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	fromEID := egEID(t, "host:er-auth/from1")
+	toEID := egEID(t, "host:er-auth/to1")
+	egReport(ctx, t, p, "observer:scan", fromEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/er-tenant",
+	})
+	egReport(ctx, t, p, "observer:scan", toEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/er-tenant",
+	})
+	egReportEdge(ctx, t, p, "observer:scan", fromEID.String(), toEID.String(), "contains")
+
+	// Filter by FromEID.
+	fromRef := fromEID
+	edges, err := p.GetEdges(ctx, interfaces.EdgeFilter{
+		FromEID:      &fromRef,
+		TenantFilter: "root/er-tenant",
+	})
+	require.NoError(t, err)
+	require.Len(t, edges, 1, "edge must be readable by FromEID")
+	assert.Equal(t, "contains", edges[0].Edge.Type)
+	assert.Equal(t, fromEID.String(), edges[0].Edge.From.String())
+	assert.Equal(t, toEID.String(), edges[0].Edge.To.String())
+
+	// Filter by ToEID.
+	toRef := toEID
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{
+		ToEID:        &toRef,
+		TenantFilter: "root/er-tenant",
+	})
+	require.NoError(t, err)
+	require.Len(t, edges, 1, "edge must be readable by ToEID")
+
+	// Filter by source.
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{
+		FromEID:      &fromRef,
+		Source:       "observer:scan",
+		TenantFilter: "root/er-tenant",
+	})
+	require.NoError(t, err)
+	require.Len(t, edges, 1, "edge must be readable by source")
+
+	// Wrong source returns nothing.
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{
+		FromEID:      &fromRef,
+		Source:       "observer:other",
+		TenantFilter: "root/er-tenant",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, edges, "filter by wrong source must return nothing")
+
+	// Filter by edge type.
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{
+		FromEID:      &fromRef,
+		Types:        []string{"contains"},
+		TenantFilter: "root/er-tenant",
+	})
+	require.NoError(t, err)
+	require.Len(t, edges, 1, "edge must be readable by type")
+
+	// Wrong type returns nothing.
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{
+		FromEID:      &fromRef,
+		Types:        []string{"runs-on"},
+		TenantFilter: "root/er-tenant",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, edges, "filter by wrong type must return nothing")
+}
+
+// testEGPlaceholderNode verifies that an edge referencing an unseen EID creates a
+// placeholder node, and a later observation of that EID enriches it without
+// creating a duplicate (Story-3 AC 2).
+func testEGPlaceholderNode(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	fromEID := egEID(t, "host:ph-auth/from1")
+	toEID := egEID(t, "host:ph-auth/to1") // not yet observed
+	egReport(ctx, t, p, "observer:scan", fromEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/ph-tenant",
+	})
+
+	// Edge references toEID which has no prior observation — placeholder created.
+	egReportEdge(ctx, t, p, "observer:scan", fromEID.String(), toEID.String(), "contains")
+
+	// Edge is readable via GetEdges (no tenant filter so placeholder's empty owning_tenant passes).
+	fromRef := fromEID
+	edges, err := p.GetEdges(ctx, interfaces.EdgeFilter{FromEID: &fromRef})
+	require.NoError(t, err)
+	require.Len(t, edges, 1, "edge referencing placeholder node must be readable")
+	assert.Equal(t, toEID.String(), edges[0].Edge.To.String())
+
+	// Now enrich the placeholder with a real observation.
+	egReport(ctx, t, p, "observer:scan", toEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/ph-tenant", "hostname": "enriched-host",
+	})
+
+	// Entity is retrievable and carries the enriched data.
+	view, err := p.GetEntity(ctx, toEID, interfaces.GetEntityOpts{TenantFilter: "root/ph-tenant"})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	assert.Equal(t, "enriched-host", view.Entity.Attributes["hostname"], "placeholder must be enriched, not duplicated")
+
+	// Edge still has exactly one entry (no orphan or duplicate).
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{FromEID: &fromRef})
+	require.NoError(t, err)
+	require.Len(t, edges, 1, "enriching placeholder must not duplicate the edge")
+}
+
+// testEGNeighborhoodDepthCap verifies that GetNeighborhood enforces the contract
+// maximum depth of 3 and uses depth 2 when depth ≤ 0 (Story-3 AC 3).
+func testEGNeighborhoodDepthCap(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	eid := egEID(t, "host:ndep-auth/root1")
+	egReport(ctx, t, p, "observer:scan", eid.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/ndep-tenant",
+	})
+
+	// depth ≤ 0 → default depth 2: must not error.
+	n, err := p.GetNeighborhood(ctx, eid, nil, types.TraversalBoth, 0)
+	require.NoError(t, err, "depth=0 (default) must not error")
+	require.NotNil(t, n)
+	assert.Equal(t, eid.String(), n.Root.String())
+
+	// depth=3 (maximum): must not error.
+	n, err = p.GetNeighborhood(ctx, eid, nil, types.TraversalBoth, 3)
+	require.NoError(t, err, "depth=3 (contract max) must not error")
+	require.NotNil(t, n)
+
+	// depth=4 (exceeds maximum): must be rejected with an error.
+	_, err = p.GetNeighborhood(ctx, eid, nil, types.TraversalBoth, 4)
+	require.Error(t, err, "depth=4 must be rejected")
+}
+
+// testEGNeighborhoodTenantPerHop verifies that GetNeighborhood excludes edges to
+// out-of-subtree entities at every hop, resolved through current endpoint ownership,
+// not any cached edge-row tenant field (Story-3 AC 4).
+//
+// Covers the static case (endpoint always out-of-subtree) and the moved-endpoint
+// case (endpoint was in-subtree when the edge was first observed, then moved).
+func testEGNeighborhoodTenantPerHop(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	rootEID := egEID(t, "host:nhop-auth/root1")
+	inEID := egEID(t, "host:nhop-auth/in1")
+	outEID := egEID(t, "host:nhop-auth/out1")
+
+	egReport(ctx, t, p, "observer:scan", rootEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/nhop-tenant",
+	})
+	egReport(ctx, t, p, "observer:scan", inEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/nhop-tenant",
+	})
+	egReport(ctx, t, p, "observer:scan", outEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/other-tenant",
+	})
+
+	// Static cross-tenant edge: root → outEID (always out-of-subtree).
+	egReportEdge(ctx, t, p, "observer:scan", rootEID.String(), outEID.String(), "contains")
+	// Same-tenant edge: root → inEID.
+	egReportEdge(ctx, t, p, "observer:scan", rootEID.String(), inEID.String(), "contains")
+
+	n, err := p.GetNeighborhood(ctx, rootEID, nil, types.TraversalOutbound, 1)
+	require.NoError(t, err)
+	require.NotNil(t, n)
+
+	// Cross-tenant edge must be absent.
+	for _, e := range n.Edges {
+		assert.NotEqual(t, outEID.String(), e.To.String(),
+			"static cross-tenant edge endpoint must be excluded")
+	}
+	// Same-tenant edge must be present.
+	var foundIn bool
+	for _, e := range n.Edges {
+		if e.To.String() == inEID.String() {
+			foundIn = true
+		}
+	}
+	assert.True(t, foundIn, "same-tenant edge must be included in neighborhood")
+
+	// Moved-endpoint case: movedEID starts in nhop-tenant, then moves to other-tenant.
+	movedEID := egEID(t, "host:nhop-auth/moved1")
+	egReport(ctx, t, p, "enforcing-module:mover", movedEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/nhop-tenant",
+	})
+	egReportEdge(ctx, t, p, "observer:scan", rootEID.String(), movedEID.String(), "contains")
+
+	// Before move: edge is visible (movedEID is in-subtree).
+	n, err = p.GetNeighborhood(ctx, rootEID, nil, types.TraversalOutbound, 1)
+	require.NoError(t, err)
+	var movedVisible bool
+	for _, e := range n.Edges {
+		if e.To.String() == movedEID.String() {
+			movedVisible = true
+		}
+	}
+	assert.True(t, movedVisible, "edge to in-subtree entity must be visible before endpoint moves")
+
+	// Move movedEID to other-tenant.
+	egReport(ctx, t, p, "enforcing-module:mover", movedEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/other-tenant",
+	})
+
+	// After move: edge must be excluded via current-ownership check.
+	n, err = p.GetNeighborhood(ctx, rootEID, nil, types.TraversalOutbound, 1)
+	require.NoError(t, err)
+	for _, e := range n.Edges {
+		assert.NotEqual(t, movedEID.String(), e.To.String(),
+			"moved-out endpoint must be excluded from neighborhood after move")
+	}
+}
+
+// testEGGetEdgesTenantFilter verifies that GetEdges applies the same tenant-subtree
+// filter as GetNeighborhood's hop-0 case, and that a cross-tenant edge query
+// returns nothing (Story-3 AC 5).
+func testEGGetEdgesTenantFilter(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	fromEID := egEID(t, "host:getef-auth/from1")
+	toEID := egEID(t, "host:getef-auth/to1")
+	egReport(ctx, t, p, "observer:scan", fromEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/tenant-a",
+	})
+	egReport(ctx, t, p, "observer:scan", toEID.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/tenant-b",
+	})
+	egReportEdge(ctx, t, p, "observer:scan", fromEID.String(), toEID.String(), "contains")
+
+	// Scoped to tenant-a: to-endpoint is in tenant-b → cross-tenant → excluded.
+	fromRef := fromEID
+	edges, err := p.GetEdges(ctx, interfaces.EdgeFilter{
+		FromEID:      &fromRef,
+		TenantFilter: "root/tenant-a",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, edges, "cross-tenant edge must not be returned when tenant filter is set")
+
+	// Scoped to tenant-b: from-endpoint is in tenant-a → cross-tenant → excluded.
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{
+		ToEID:        &toEID,
+		TenantFilter: "root/tenant-b",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, edges, "cross-tenant edge must not be returned from the other side's tenant filter")
+
+	// No tenant filter: edge is returned.
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{FromEID: &fromRef})
+	require.NoError(t, err)
+	assert.Len(t, edges, 1, "edge must be returned when no tenant filter is applied")
 }
 
 func testEGProviderIdentity(t *testing.T, factory EntityGraphProviderFactory) {

--- a/pkg/entitygraph/providers/database/contract_test.go
+++ b/pkg/entitygraph/providers/database/contract_test.go
@@ -105,3 +105,25 @@ func TestSubjectKind_Database(t *testing.T) {
 	assert.Equal(t, "edge", subjectKind("contains|host:a|host:b"))
 	assert.Equal(t, "edge", subjectKind("arbitrary-edge-string"))
 }
+
+func TestParseEdgeSubject_Database(t *testing.T) {
+	edgeType, from, to, err := parseEdgeSubject("contains|host:a|host:b")
+	require.NoError(t, err)
+	assert.Equal(t, "contains", edgeType)
+	assert.Equal(t, "host:a", from)
+	assert.Equal(t, "host:b", to)
+
+	// to_subject may contain slashes (local_id component of EID).
+	edgeType, from, to, err = parseEdgeSubject("runs-on|cluster:cl1|host:cl1/vm1")
+	require.NoError(t, err)
+	assert.Equal(t, "runs-on", edgeType)
+	assert.Equal(t, "cluster:cl1", from)
+	assert.Equal(t, "host:cl1/vm1", to)
+
+	// Missing components must error.
+	_, _, _, err = parseEdgeSubject("only-one-part")
+	require.Error(t, err)
+
+	_, _, _, err = parseEdgeSubject("two|parts")
+	require.Error(t, err)
+}

--- a/pkg/entitygraph/providers/database/edges.go
+++ b/pkg/entitygraph/providers/database/edges.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+func init() {
+	RegisterProjectionUpdater("edge", updateEdgeProjection)
+}
+
+// parseEdgeSubject parses an edge subject string into its constituent parts.
+// The expected format is "edge_type|from_eid|to_eid".
+func parseEdgeSubject(subject string) (edgeType, fromSubject, toSubject string, err error) {
+	parts := strings.SplitN(subject, "|", 3)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("entitygraph/database: invalid edge subject %q: expected edge_type|from|to", subject)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+// updateEdgeProjection is the "edge" subject-kind projection updater. It upserts
+// the per-source edge projection row and materializes placeholder nodes for any
+// referenced EID not yet in eg_entity_index (ADR-022 §2).
+func updateEdgeProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, _ int64) error {
+	edgeType, fromSubject, toSubject, err := parseEdgeSubject(obs.Subject)
+	if err != nil {
+		return err
+	}
+
+	hash, err := payloadHash(obs.Payload)
+	if err != nil {
+		return err
+	}
+	sc := string(resolveSourceClass(obs.Source))
+	observedAt := obs.ObservedAt.UTC().Format(time.RFC3339Nano)
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO eg_edge_projection
+			(from_subject, to_subject, edge_type, source, source_class, observed_at, payload_hash)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 ON CONFLICT (from_subject, to_subject, edge_type, source) DO UPDATE SET
+			source_class = EXCLUDED.source_class,
+			observed_at  = EXCLUDED.observed_at,
+			payload_hash = EXCLUDED.payload_hash`,
+		fromSubject, toSubject, edgeType, obs.Source, sc, observedAt, hash,
+	); err != nil {
+		return fmt.Errorf("entitygraph/database: upsert edge projection: %w", err)
+	}
+
+	// Materialize placeholder nodes for endpoint EIDs not yet in eg_entity_index.
+	for _, subject := range []string{fromSubject, toSubject} {
+		if err := materializePlaceholderNode(ctx, tx, subject); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// materializePlaceholderNode ensures eg_entity_index has an entry for subject.
+// If the subject is not a valid EID, it is silently skipped. If the entry already
+// exists, the INSERT ... ON CONFLICT DO NOTHING is a no-op.
+func materializePlaceholderNode(ctx context.Context, tx *sql.Tx, subject string) error {
+	eid, err := types.ParseEID(subject)
+	if err != nil {
+		return nil // non-EID endpoint — no placeholder
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO eg_entity_index
+			(subject, entity_kind, owning_tenant, hostname, mac_addrs, machine_sid, dir_object_guid, serial_number, cloud_object_id)
+		 VALUES ($1, $2, '', '', '', '', '', '', '')
+		 ON CONFLICT (subject) DO NOTHING`,
+		subject, eid.AuthorityType(),
+	); err != nil {
+		return fmt.Errorf("entitygraph/database: materialize placeholder for %s: %w", subject, err)
+	}
+	return nil
+}
+
+// GetEdges returns edges matching the filter. Tenant filtering is applied via a
+// JOIN against eg_entity_index (current endpoint ownership), never via any
+// tenant column on the edge row itself (ADR-023 §4 / Story-3 AC 5).
+func (p *DatabaseEntityGraphProvider) GetEdges(ctx context.Context, filter interfaces.EdgeFilter) ([]*interfaces.EdgeView, error) {
+	var conds []string
+	var args []interface{}
+	n := 1
+
+	addArg := func(v interface{}) string {
+		args = append(args, v)
+		s := fmt.Sprintf("$%d", n)
+		n++
+		return s
+	}
+
+	if filter.FromEID != nil {
+		conds = append(conds, "ep.from_subject = "+addArg(filter.FromEID.String()))
+	}
+	if filter.ToEID != nil {
+		conds = append(conds, "ep.to_subject = "+addArg(filter.ToEID.String()))
+	}
+	if len(filter.Types) > 0 {
+		phs := make([]string, len(filter.Types))
+		for i, et := range filter.Types {
+			phs[i] = addArg(et)
+		}
+		conds = append(conds, "ep.edge_type IN ("+strings.Join(phs, ",")+")")
+	}
+	if filter.Source != "" {
+		conds = append(conds, "ep.source = "+addArg(filter.Source))
+	}
+	if filter.TenantFilter != "" {
+		tf, tfLike := addArg(filter.TenantFilter), addArg(filter.TenantFilter+"/%")
+		conds = append(conds, "(fi.owning_tenant = "+tf+" OR fi.owning_tenant LIKE "+tfLike+")")
+		tf2, tfLike2 := addArg(filter.TenantFilter), addArg(filter.TenantFilter+"/%")
+		conds = append(conds, "(ti.owning_tenant = "+tf2+" OR ti.owning_tenant LIKE "+tfLike2+")")
+	}
+
+	where := ""
+	if len(conds) > 0 {
+		where = " WHERE " + strings.Join(conds, " AND ")
+	}
+
+	q := `SELECT ep.from_subject, ep.to_subject, ep.edge_type, ep.source, ep.observed_at, ep.payload_hash, pc.payload_json
+		  FROM eg_edge_projection ep
+		  LEFT JOIN eg_entity_index fi ON fi.subject = ep.from_subject
+		  LEFT JOIN eg_entity_index ti ON ti.subject = ep.to_subject
+		  LEFT JOIN eg_payload_content pc ON pc.content_hash = ep.payload_hash` + where
+
+	rows, err := p.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: get edges: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var views []*interfaces.EdgeView
+	for rows.Next() {
+		var fromSubj, toSubj, edgeType, source, observedAt, payloadHash string
+		var payloadJSON sql.NullString
+		if err := rows.Scan(&fromSubj, &toSubj, &edgeType, &source, &observedAt, &payloadHash, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/database: scan edge row: %w", err)
+		}
+
+		fromEID, err := types.ParseEID(fromSubj)
+		if err != nil {
+			continue
+		}
+		toEID, err := types.ParseEID(toSubj)
+		if err != nil {
+			continue
+		}
+
+		var attrs map[string]interface{}
+		if payloadJSON.Valid && payloadJSON.String != "" {
+			if err := json.Unmarshal([]byte(payloadJSON.String), &attrs); err != nil {
+				attrs = map[string]interface{}{}
+			}
+		} else {
+			attrs = map[string]interface{}{}
+		}
+
+		oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+		obs := types.Observation{
+			Source:     source,
+			Subject:    edgeType + "|" + fromSubj + "|" + toSubj,
+			ObservedAt: oa,
+			RecordedAt: oa,
+			Kind:       types.ObservationKindState,
+			Confidence: types.ConfidenceHigh,
+			Payload:    attrs,
+		}
+		edge := &types.Edge{
+			Type:       edgeType,
+			From:       fromEID,
+			To:         toEID,
+			Attributes: attrs,
+			Sources:    []types.Observation{obs},
+		}
+		views = append(views, &interfaces.EdgeView{
+			Edge:      edge,
+			Freshness: types.Freshness{ObservedAt: oa, RecordedAt: oa},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: iterate edge rows: %w", err)
+	}
+	return views, nil
+}

--- a/pkg/entitygraph/providers/database/entity_reads.go
+++ b/pkg/entitygraph/providers/database/entity_reads.go
@@ -446,16 +446,6 @@ func (p *DatabaseEntityGraphProvider) GetDriftState(_ context.Context, _ interfa
 	return nil, interfaces.ErrNotImplemented
 }
 
-// GetEdges returns edges matching the filter.
-func (p *DatabaseEntityGraphProvider) GetEdges(_ context.Context, _ interfaces.EdgeFilter) ([]*interfaces.EdgeView, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
-// GetNeighborhood returns a depth-bounded connected subgraph starting at eid.
-func (p *DatabaseEntityGraphProvider) GetNeighborhood(_ context.Context, _ interfaces.EIDRef, _ []string, _ types.TraversalDirection, _ int) (*types.Neighborhood, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
 // GetHistory returns the versioned observation log for a subject over a range.
 func (p *DatabaseEntityGraphProvider) GetHistory(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
 	return nil, interfaces.ErrNotImplemented

--- a/pkg/entitygraph/providers/database/migrations.sql
+++ b/pkg/entitygraph/providers/database/migrations.sql
@@ -68,10 +68,16 @@ CREATE TABLE IF NOT EXISTS eg_edge_projection (
     edge_type    TEXT NOT NULL,
     source       TEXT NOT NULL,
     source_class TEXT NOT NULL DEFAULT '',
-    tenant_path  TEXT NOT NULL DEFAULT '',
+    observed_at  TEXT NOT NULL DEFAULT '',
     payload_hash TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (from_subject, to_subject, edge_type, source)
 );
+
+-- Story-3: add observed_at to databases created before it existed.
+ALTER TABLE eg_edge_projection ADD COLUMN IF NOT EXISTS observed_at TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_eg_edge_from ON eg_edge_projection(from_subject);
+CREATE INDEX IF NOT EXISTS idx_eg_edge_to   ON eg_edge_projection(to_subject);
 
 CREATE TABLE IF NOT EXISTS eg_drift_projection (
     subject          TEXT PRIMARY KEY,

--- a/pkg/entitygraph/providers/database/neighborhood.go
+++ b/pkg/entitygraph/providers/database/neighborhood.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+const (
+	neighborhoodMaxDepth     = 3
+	neighborhoodDefaultDepth = 2
+)
+
+// GetNeighborhood returns a depth-bounded connected subgraph starting at eid.
+// The implicit tenant filter is derived from the root entity's current owning_tenant:
+// at every hop, both edge endpoints must be within that subtree (ADR-023 §4).
+//
+// depth ≤ 0 is treated as the contract default (2).
+// depth > 3 is rejected with an error per the access contract.
+func (p *DatabaseEntityGraphProvider) GetNeighborhood(
+	ctx context.Context,
+	eid interfaces.EIDRef,
+	edgeTypes []string,
+	direction types.TraversalDirection,
+	depth int,
+) (*types.Neighborhood, error) {
+	if depth > neighborhoodMaxDepth {
+		return nil, fmt.Errorf("entitygraph/database: depth %d exceeds maximum %d", depth, neighborhoodMaxDepth)
+	}
+	if depth <= 0 {
+		depth = neighborhoodDefaultDepth
+	}
+
+	// Derive implicit tenant filter from the root entity's current owning_tenant.
+	var tenantFilter string
+	_ = p.db.QueryRowContext(ctx,
+		`SELECT owning_tenant FROM eg_entity_index WHERE subject = $1`, eid.String(),
+	).Scan(&tenantFilter)
+
+	type edgeKey struct{ from, to, edgeType string }
+	edgeMap := make(map[edgeKey]*types.Edge)
+	visited := map[string]bool{eid.String(): true}
+	frontier := []string{eid.String()}
+
+	for hop := 0; hop < depth && len(frontier) > 0; hop++ {
+		hopEdges, err := p.queryNeighborhoodEdges(ctx, frontier, edgeTypes, direction, tenantFilter)
+		if err != nil {
+			return nil, err
+		}
+
+		var nextFrontier []string
+		for _, e := range hopEdges {
+			k := edgeKey{from: e.From.String(), to: e.To.String(), edgeType: e.Type}
+			if existing, ok := edgeMap[k]; ok {
+				existing.Sources = append(existing.Sources, e.Sources...)
+			} else {
+				edgeMap[k] = e
+			}
+
+			peer := peerSubject(e, frontier, direction)
+			if peer != "" && !visited[peer] {
+				visited[peer] = true
+				nextFrontier = append(nextFrontier, peer)
+			}
+		}
+		frontier = nextFrontier
+	}
+
+	edges := make([]*types.Edge, 0, len(edgeMap))
+	for _, e := range edgeMap {
+		edges = append(edges, e)
+	}
+
+	nodes := make([]*types.Entity, 0, len(visited))
+	for subject := range visited {
+		entityEID, err := types.ParseEID(subject)
+		if err != nil {
+			continue
+		}
+		var kind, tenant string
+		err = p.db.QueryRowContext(ctx,
+			`SELECT entity_kind, owning_tenant FROM eg_entity_index WHERE subject = $1`, subject,
+		).Scan(&kind, &tenant)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, fmt.Errorf("entitygraph/database: load node %s: %w", subject, err)
+		}
+		if kind == "" {
+			kind = entityEID.AuthorityType()
+		}
+		nodes = append(nodes, &types.Entity{
+			EID:          entityEID,
+			Kind:         kind,
+			Attributes:   map[string]interface{}{},
+			OwningTenant: tenant,
+		})
+	}
+
+	return &types.Neighborhood{Root: eid, Nodes: nodes, Edges: edges}, nil
+}
+
+// queryNeighborhoodEdges returns edges connected to any subject in the frontier
+// in a single SQL round-trip. Both endpoints must satisfy the tenant filter so
+// cross-tenant edges are excluded at the hop level (ADR-023 §4 / Story-3 AC 4).
+func (p *DatabaseEntityGraphProvider) queryNeighborhoodEdges(
+	ctx context.Context,
+	frontier []string,
+	edgeTypes []string,
+	direction types.TraversalDirection,
+	tenantFilter string,
+) ([]*types.Edge, error) {
+	if len(frontier) == 0 {
+		return nil, nil
+	}
+
+	var args []interface{}
+	n := 1
+
+	addArg := func(v interface{}) string {
+		args = append(args, v)
+		s := fmt.Sprintf("$%d", n)
+		n++
+		return s
+	}
+
+	// Build frontier placeholders.
+	fph := make([]string, len(frontier))
+	for i, s := range frontier {
+		fph[i] = addArg(s)
+	}
+	frontierIn := "(" + strings.Join(fph, ",") + ")"
+
+	var dirCond string
+	switch direction {
+	case types.TraversalOutbound:
+		dirCond = "ep.from_subject IN " + frontierIn
+	case types.TraversalInbound:
+		dirCond = "ep.to_subject IN " + frontierIn
+	default: // TraversalBoth
+		// Build a second set of placeholders for the to_subject IN clause.
+		fph2 := make([]string, len(frontier))
+		for i, s := range frontier {
+			fph2[i] = addArg(s)
+		}
+		frontierIn2 := "(" + strings.Join(fph2, ",") + ")"
+		dirCond = "(ep.from_subject IN " + frontierIn + " OR ep.to_subject IN " + frontierIn2 + ")"
+	}
+
+	var conds []string
+	conds = append(conds, dirCond)
+
+	if len(edgeTypes) > 0 {
+		ephs := make([]string, len(edgeTypes))
+		for i, et := range edgeTypes {
+			ephs[i] = addArg(et)
+		}
+		conds = append(conds, "ep.edge_type IN ("+strings.Join(ephs, ",")+")")
+	}
+
+	if tenantFilter != "" {
+		tf, tfLike := addArg(tenantFilter), addArg(tenantFilter+"/%")
+		conds = append(conds, "(fi.owning_tenant = "+tf+" OR fi.owning_tenant LIKE "+tfLike+")")
+		tf2, tfLike2 := addArg(tenantFilter), addArg(tenantFilter+"/%")
+		conds = append(conds, "(ti.owning_tenant = "+tf2+" OR ti.owning_tenant LIKE "+tfLike2+")")
+	}
+
+	q := `SELECT ep.from_subject, ep.to_subject, ep.edge_type, ep.source
+		  FROM eg_edge_projection ep
+		  LEFT JOIN eg_entity_index fi ON fi.subject = ep.from_subject
+		  LEFT JOIN eg_entity_index ti ON ti.subject = ep.to_subject
+		  WHERE ` + strings.Join(conds, " AND ")
+
+	rows, err := p.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: neighborhood hop query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var edges []*types.Edge
+	for rows.Next() {
+		var fromSubj, toSubj, edgeType, source string
+		if err := rows.Scan(&fromSubj, &toSubj, &edgeType, &source); err != nil {
+			return nil, fmt.Errorf("entitygraph/database: scan neighborhood edge: %w", err)
+		}
+		fromEID, err := types.ParseEID(fromSubj)
+		if err != nil {
+			continue
+		}
+		toEID, err := types.ParseEID(toSubj)
+		if err != nil {
+			continue
+		}
+		edges = append(edges, &types.Edge{
+			Type:       edgeType,
+			From:       fromEID,
+			To:         toEID,
+			Attributes: map[string]interface{}{},
+			Sources: []types.Observation{{
+				Source:  source,
+				Subject: edgeType + "|" + fromSubj + "|" + toSubj,
+				Kind:    types.ObservationKindState,
+			}},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: iterate neighborhood edges: %w", err)
+	}
+	return edges, nil
+}
+
+// peerSubject returns the "other end" of an edge relative to the frontier subjects.
+func peerSubject(e *types.Edge, frontier []string, direction types.TraversalDirection) string {
+	frontierSet := make(map[string]bool, len(frontier))
+	for _, s := range frontier {
+		frontierSet[s] = true
+	}
+	switch direction {
+	case types.TraversalOutbound:
+		return e.To.String()
+	case types.TraversalInbound:
+		return e.From.String()
+	default: // Both
+		fromIn, toIn := frontierSet[e.From.String()], frontierSet[e.To.String()]
+		if fromIn && !toIn {
+			return e.To.String()
+		}
+		if toIn && !fromIn {
+			return e.From.String()
+		}
+		return ""
+	}
+}

--- a/pkg/entitygraph/providers/sqlite/edges.go
+++ b/pkg/entitygraph/providers/sqlite/edges.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+func init() {
+	RegisterProjectionUpdater("edge", updateEdgeProjection)
+}
+
+// edgeKeySep is the unit-separator (ASCII 0x1F) used to join the four components
+// of an edge_key. None of the component fields (EID strings, edge type names,
+// source identifiers) contain control characters, so 0x1F is an unambiguous
+// delimiter.
+const edgeKeySep = "\x1f"
+
+// edgeProjectionKey builds the PRIMARY KEY for an eg_edge_projection row.
+// Uniqueness: one row per (from, edge_type, to, source).
+func edgeProjectionKey(fromSubject, edgeType, toSubject, source string) string {
+	return fromSubject + edgeKeySep + edgeType + edgeKeySep + toSubject + edgeKeySep + source
+}
+
+// parseEdgeSubject parses an edge subject string into its constituent parts.
+// The expected format is "edge_type|from_eid|to_eid" (pipe-delimited, three fields).
+func parseEdgeSubject(subject string) (edgeType, fromSubject, toSubject string, err error) {
+	parts := strings.SplitN(subject, "|", 3)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("entitygraph/sqlite: invalid edge subject %q: expected edge_type|from|to", subject)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+// updateEdgeProjection is the "edge" subject-kind projection updater registered
+// via init(). It upserts the per-source edge projection row and materializes
+// placeholder nodes in eg_entity_index for any referenced EID that has no
+// prior observation (ADR-022 §2).
+func updateEdgeProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, logSeq int64) error {
+	edgeType, fromSubject, toSubject, err := parseEdgeSubject(obs.Subject)
+	if err != nil {
+		return err
+	}
+
+	hash, err := payloadHash(obs.Payload)
+	if err != nil {
+		return err
+	}
+	sc := resolveSourceClass(obs.Source)
+	key := edgeProjectionKey(fromSubject, edgeType, toSubject, obs.Source)
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO eg_edge_projection
+			(edge_key, edge_type, from_subject, to_subject, source, source_class, observed_at, payload_hash, log_seq)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(edge_key) DO UPDATE SET
+			source_class = excluded.source_class,
+			observed_at  = excluded.observed_at,
+			payload_hash = excluded.payload_hash,
+			log_seq      = excluded.log_seq`,
+		key, edgeType, fromSubject, toSubject, obs.Source, string(sc),
+		rfc3339(obs.ObservedAt), hash, logSeq,
+	); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: upsert edge projection: %w", err)
+	}
+
+	// Materialize placeholder nodes for endpoint EIDs not yet in eg_entity_index.
+	for _, subject := range []string{fromSubject, toSubject} {
+		if err := materializePlaceholderNode(ctx, tx, subject); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// materializePlaceholderNode inserts a stub eg_entity_index row for subject if
+// one does not already exist. The placeholder has empty owning_tenant and
+// identity fields; a later observation enriches the same row (no duplicates).
+// Subjects that are not valid EIDs are silently skipped.
+func materializePlaceholderNode(ctx context.Context, tx *sql.Tx, subject string) error {
+	eid, err := types.ParseEID(subject)
+	if err != nil {
+		return nil // non-EID endpoint — no placeholder
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO eg_entity_index
+			(subject, entity_kind, owning_tenant, hostname, mac_addrs, machine_sid, dir_object_guid, serial_number, cloud_object_id)
+		 VALUES(?, ?, '', '', '', '', '', '', '')`,
+		subject, eid.AuthorityType(),
+	); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: materialize placeholder for %s: %w", subject, err)
+	}
+	return nil
+}
+
+// GetEdges returns edges matching the filter. Tenant filtering is applied via a
+// JOIN against eg_entity_index (current endpoint ownership), never via any
+// tenant column on the edge row itself (ADR-023 §4 / Story-3 AC 5).
+//
+// One EdgeView is returned per eg_edge_projection row (per source). Multiple
+// sources asserting the same (from, to, type) edge produce multiple EdgeViews.
+func (p *SQLiteEntityGraphProvider) GetEdges(ctx context.Context, filter interfaces.EdgeFilter) ([]*interfaces.EdgeView, error) {
+	var conds []string
+	var args []interface{}
+
+	if filter.FromEID != nil {
+		conds = append(conds, "ep.from_subject = ?")
+		args = append(args, filter.FromEID.String())
+	}
+	if filter.ToEID != nil {
+		conds = append(conds, "ep.to_subject = ?")
+		args = append(args, filter.ToEID.String())
+	}
+	if len(filter.Types) > 0 {
+		ph := strings.Repeat("?,", len(filter.Types))
+		ph = ph[:len(ph)-1] // strip trailing comma
+		conds = append(conds, "ep.edge_type IN ("+ph+")")
+		for _, et := range filter.Types {
+			args = append(args, et)
+		}
+	}
+	if filter.Source != "" {
+		conds = append(conds, "ep.source = ?")
+		args = append(args, filter.Source)
+	}
+	if filter.TenantFilter != "" {
+		conds = append(conds,
+			"(fi.owning_tenant = ? OR fi.owning_tenant LIKE ?)",
+			"(ti.owning_tenant = ? OR ti.owning_tenant LIKE ?)",
+		)
+		args = append(args, filter.TenantFilter, filter.TenantFilter+"/%")
+		args = append(args, filter.TenantFilter, filter.TenantFilter+"/%")
+	}
+
+	where := ""
+	if len(conds) > 0 {
+		where = " WHERE " + strings.Join(conds, " AND ")
+	}
+
+	q := `SELECT ep.from_subject, ep.to_subject, ep.edge_type, ep.source, ep.observed_at, ep.payload_hash, pc.payload
+		  FROM eg_edge_projection ep
+		  LEFT JOIN eg_entity_index fi ON fi.subject = ep.from_subject
+		  LEFT JOIN eg_entity_index ti ON ti.subject = ep.to_subject
+		  LEFT JOIN eg_payload_content pc ON pc.payload_hash = ep.payload_hash` + where
+
+	rows, err := p.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: get edges: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var views []*interfaces.EdgeView
+	for rows.Next() {
+		var fromSubj, toSubj, edgeType, source, observedAt, payloadHash string
+		var payloadJSON sql.NullString
+		if err := rows.Scan(&fromSubj, &toSubj, &edgeType, &source, &observedAt, &payloadHash, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan edge row: %w", err)
+		}
+
+		fromEID, err := types.ParseEID(fromSubj)
+		if err != nil {
+			continue
+		}
+		toEID, err := types.ParseEID(toSubj)
+		if err != nil {
+			continue
+		}
+
+		var attrs map[string]interface{}
+		if payloadJSON.Valid && payloadJSON.String != "" {
+			if err := json.Unmarshal([]byte(payloadJSON.String), &attrs); err != nil {
+				attrs = map[string]interface{}{}
+			}
+		} else {
+			attrs = map[string]interface{}{}
+		}
+
+		oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+		obs := types.Observation{
+			Source:     source,
+			Subject:    edgeType + "|" + fromSubj + "|" + toSubj,
+			ObservedAt: oa,
+			RecordedAt: oa,
+			Kind:       types.ObservationKindState,
+			Confidence: types.ConfidenceHigh,
+			Payload:    attrs,
+		}
+		edge := &types.Edge{
+			Type:       edgeType,
+			From:       fromEID,
+			To:         toEID,
+			Attributes: attrs,
+			Sources:    []types.Observation{obs},
+		}
+		views = append(views, &interfaces.EdgeView{
+			Edge:      edge,
+			Freshness: types.Freshness{ObservedAt: oa, RecordedAt: oa},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate edge rows: %w", err)
+	}
+	return views, nil
+}

--- a/pkg/entitygraph/providers/sqlite/entity_reads.go
+++ b/pkg/entitygraph/providers/sqlite/entity_reads.go
@@ -384,16 +384,6 @@ func (p *SQLiteEntityGraphProvider) GetDriftState(_ context.Context, _ interface
 	return nil, interfaces.ErrNotImplemented
 }
 
-// GetEdges is implemented by STORY-3.
-func (p *SQLiteEntityGraphProvider) GetEdges(_ context.Context, _ interfaces.EdgeFilter) ([]*interfaces.EdgeView, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
-// GetNeighborhood is implemented by STORY-3.
-func (p *SQLiteEntityGraphProvider) GetNeighborhood(_ context.Context, _ interfaces.EIDRef, _ []string, _ types.TraversalDirection, _ int) (*types.Neighborhood, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
 // GetHistory is implemented by a later story.
 func (p *SQLiteEntityGraphProvider) GetHistory(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
 	return nil, interfaces.ErrNotImplemented

--- a/pkg/entitygraph/providers/sqlite/neighborhood.go
+++ b/pkg/entitygraph/providers/sqlite/neighborhood.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+const (
+	neighborhoodMaxDepth     = 3
+	neighborhoodDefaultDepth = 2
+)
+
+// GetNeighborhood returns a depth-bounded connected subgraph starting at eid.
+// The implicit tenant filter is the root entity's current owning_tenant: at every
+// hop, both edge endpoints must be in the root entity's tenant subtree (ADR-023 §4).
+//
+// depth ≤ 0 is treated as the contract default (2).
+// depth > 3 is rejected with an error per the access contract.
+func (p *SQLiteEntityGraphProvider) GetNeighborhood(
+	ctx context.Context,
+	eid interfaces.EIDRef,
+	edgeTypes []string,
+	direction types.TraversalDirection,
+	depth int,
+) (*types.Neighborhood, error) {
+	if depth > neighborhoodMaxDepth {
+		return nil, fmt.Errorf("entitygraph/sqlite: depth %d exceeds maximum %d", depth, neighborhoodMaxDepth)
+	}
+	if depth <= 0 {
+		depth = neighborhoodDefaultDepth
+	}
+
+	// Derive implicit tenant filter from the root entity's current owning_tenant.
+	var tenantFilter string
+	_ = p.db.QueryRowContext(ctx,
+		`SELECT owning_tenant FROM eg_entity_index WHERE subject = ?`, eid.String(),
+	).Scan(&tenantFilter)
+
+	// BFS over the edge projection.
+	type edgeKey struct{ from, to, edgeType string }
+	edgeMap := make(map[edgeKey]*types.Edge)
+	visited := map[string]bool{eid.String(): true}
+	frontier := []string{eid.String()}
+
+	for hop := 0; hop < depth && len(frontier) > 0; hop++ {
+		hopEdges, err := p.queryNeighborhoodEdges(ctx, frontier, edgeTypes, direction, tenantFilter)
+		if err != nil {
+			return nil, err
+		}
+
+		var nextFrontier []string
+		for _, e := range hopEdges {
+			k := edgeKey{from: e.From.String(), to: e.To.String(), edgeType: e.Type}
+			if existing, ok := edgeMap[k]; ok {
+				existing.Sources = append(existing.Sources, e.Sources...)
+			} else {
+				edgeMap[k] = e
+			}
+
+			// Determine the peer node relative to what we traversed from.
+			peer := peerSubject(e, frontier, direction)
+			if peer != "" && !visited[peer] {
+				visited[peer] = true
+				nextFrontier = append(nextFrontier, peer)
+			}
+		}
+		frontier = nextFrontier
+	}
+
+	// Collect unique edges.
+	edges := make([]*types.Edge, 0, len(edgeMap))
+	for _, e := range edgeMap {
+		edges = append(edges, e)
+	}
+
+	// Collect node entities for all visited subjects.
+	nodes := make([]*types.Entity, 0, len(visited))
+	for subject := range visited {
+		entityEID, err := types.ParseEID(subject)
+		if err != nil {
+			continue
+		}
+		var kind, tenant string
+		err = p.db.QueryRowContext(ctx,
+			`SELECT entity_kind, owning_tenant FROM eg_entity_index WHERE subject = ?`, subject,
+		).Scan(&kind, &tenant)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, fmt.Errorf("entitygraph/sqlite: load node %s: %w", subject, err)
+		}
+		if kind == "" {
+			kind = entityEID.AuthorityType()
+		}
+		nodes = append(nodes, &types.Entity{
+			EID:          entityEID,
+			Kind:         kind,
+			Attributes:   map[string]interface{}{},
+			OwningTenant: tenant,
+		})
+	}
+
+	return &types.Neighborhood{Root: eid, Nodes: nodes, Edges: edges}, nil
+}
+
+// queryNeighborhoodEdges returns all edges connected to any entity in the
+// frontier (one SQL round-trip per hop). Both edge endpoints must satisfy the
+// tenant filter so that cross-tenant edges are excluded at the hop level, not
+// post-filtered from the final result set (ADR-023 §4 / Story-3 AC 4).
+func (p *SQLiteEntityGraphProvider) queryNeighborhoodEdges(
+	ctx context.Context,
+	frontier []string,
+	edgeTypes []string,
+	direction types.TraversalDirection,
+	tenantFilter string,
+) ([]*types.Edge, error) {
+	if len(frontier) == 0 {
+		return nil, nil
+	}
+
+	ph := inPlaceholders(len(frontier))
+	var args []interface{}
+	for _, s := range frontier {
+		args = append(args, s)
+	}
+
+	var dirCond string
+	switch direction {
+	case types.TraversalOutbound:
+		dirCond = "ep.from_subject IN " + ph
+	case types.TraversalInbound:
+		dirCond = "ep.to_subject IN " + ph
+	default: // TraversalBoth
+		dirCond = "(ep.from_subject IN " + ph + " OR ep.to_subject IN " + ph + ")"
+		// For TraversalBoth the frontier args are used twice (in and out).
+		extra := make([]interface{}, len(frontier))
+		for i, s := range frontier {
+			extra[i] = s
+		}
+		args = append(args, extra...)
+	}
+
+	var conds []string
+	conds = append(conds, dirCond)
+
+	if len(edgeTypes) > 0 {
+		eph := inPlaceholders(len(edgeTypes))
+		conds = append(conds, "ep.edge_type IN "+eph)
+		for _, et := range edgeTypes {
+			args = append(args, et)
+		}
+	}
+	if tenantFilter != "" {
+		conds = append(conds,
+			"(fi.owning_tenant = ? OR fi.owning_tenant LIKE ?)",
+			"(ti.owning_tenant = ? OR ti.owning_tenant LIKE ?)",
+		)
+		args = append(args, tenantFilter, tenantFilter+"/%")
+		args = append(args, tenantFilter, tenantFilter+"/%")
+	}
+
+	q := `SELECT ep.from_subject, ep.to_subject, ep.edge_type, ep.source
+		  FROM eg_edge_projection ep
+		  LEFT JOIN eg_entity_index fi ON fi.subject = ep.from_subject
+		  LEFT JOIN eg_entity_index ti ON ti.subject = ep.to_subject
+		  WHERE ` + strings.Join(conds, " AND ")
+
+	rows, err := p.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: neighborhood hop query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var edges []*types.Edge
+	for rows.Next() {
+		var fromSubj, toSubj, edgeType, source string
+		if err := rows.Scan(&fromSubj, &toSubj, &edgeType, &source); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan neighborhood edge: %w", err)
+		}
+		fromEID, err := types.ParseEID(fromSubj)
+		if err != nil {
+			continue
+		}
+		toEID, err := types.ParseEID(toSubj)
+		if err != nil {
+			continue
+		}
+		edges = append(edges, &types.Edge{
+			Type:       edgeType,
+			From:       fromEID,
+			To:         toEID,
+			Attributes: map[string]interface{}{},
+			Sources: []types.Observation{{
+				Source:  source,
+				Subject: edgeType + "|" + fromSubj + "|" + toSubj,
+				Kind:    types.ObservationKindState,
+			}},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate neighborhood edges: %w", err)
+	}
+	return edges, nil
+}
+
+// peerSubject returns the "other end" of an edge relative to the entities in
+// the current frontier and traversal direction. Returns "" when the peer cannot
+// be determined (e.g., both endpoints are in the frontier).
+func peerSubject(e *types.Edge, frontier []string, direction types.TraversalDirection) string {
+	frontierSet := make(map[string]bool, len(frontier))
+	for _, s := range frontier {
+		frontierSet[s] = true
+	}
+	switch direction {
+	case types.TraversalOutbound:
+		return e.To.String()
+	case types.TraversalInbound:
+		return e.From.String()
+	default: // Both
+		fromIn, toIn := frontierSet[e.From.String()], frontierSet[e.To.String()]
+		if fromIn && !toIn {
+			return e.To.String()
+		}
+		if toIn && !fromIn {
+			return e.From.String()
+		}
+		return ""
+	}
+}
+
+// inPlaceholders returns a parenthesised SQLite ? placeholder list of length n.
+func inPlaceholders(n int) string {
+	if n == 0 {
+		return "(NULL)"
+	}
+	return "(" + strings.Repeat("?,", n-1) + "?)"
+}

--- a/pkg/entitygraph/providers/sqlite/provider_test.go
+++ b/pkg/entitygraph/providers/sqlite/provider_test.go
@@ -262,15 +262,42 @@ func TestUnimplementedReturnsErrNotImplemented(t *testing.T) {
 
 	_, err := p.GetDesiredState(ctx, eid)
 	require.ErrorIs(t, err, interfaces.ErrNotImplemented)
-	_, err = p.GetEdges(ctx, interfaces.EdgeFilter{})
-	require.ErrorIs(t, err, interfaces.ErrNotImplemented)
 	err = p.UpdateDriftLifecycle(ctx, interfaces.DriftLifecycleUpdate{})
 	require.ErrorIs(t, err, interfaces.ErrNotImplemented)
+}
+
+func TestGetEdgesEmpty(t *testing.T) {
+	// GetEdges on an empty provider returns empty slice, not ErrNotImplemented.
+	p := newTestProvider(t)
+	edges, err := p.GetEdges(context.Background(), interfaces.EdgeFilter{})
+	require.NoError(t, err)
+	require.Empty(t, edges)
 }
 
 func TestSubjectKind(t *testing.T) {
 	require.Equal(t, "entity", subjectKind("host:abc"))
 	require.Equal(t, "edge", subjectKind("contains|host:a|host:b"))
+}
+
+func TestParseEdgeSubject(t *testing.T) {
+	edgeType, from, to, err := parseEdgeSubject("contains|host:a|host:b")
+	require.NoError(t, err)
+	require.Equal(t, "contains", edgeType)
+	require.Equal(t, "host:a", from)
+	require.Equal(t, "host:b", to)
+
+	// to_subject may include a local_id with slashes.
+	edgeType, from, to, err = parseEdgeSubject("runs-on|cluster:cl1|host:cl1/vm1")
+	require.NoError(t, err)
+	require.Equal(t, "runs-on", edgeType)
+	require.Equal(t, "cluster:cl1", from)
+	require.Equal(t, "host:cl1/vm1", to)
+
+	_, _, _, err = parseEdgeSubject("bad")
+	require.Error(t, err, "missing components must error")
+
+	_, _, _, err = parseEdgeSubject("two|parts")
+	require.Error(t, err)
 }
 
 func TestSourceClassPrecedence(t *testing.T) {

--- a/pkg/entitygraph/providers/sqlite/schema.go
+++ b/pkg/entitygraph/providers/sqlite/schema.go
@@ -186,16 +186,21 @@ var schemaStatements = []string{
 	`CREATE INDEX IF NOT EXISTS eg_entity_index_serial ON eg_entity_index(serial_number)`,
 	`CREATE INDEX IF NOT EXISTS eg_entity_index_cloud_id ON eg_entity_index(cloud_object_id)`,
 
-	// Edge projection — populated by STORY-3. Created now (empty) so the
-	// schema is forward-stable and RebuildProjections has a place to write.
+	// Edge projection — populated by STORY-3. edge_key encodes uniqueness as
+	// from_subject + "\x1f" + edge_type + "\x1f" + to_subject + "\x1f" + source.
 	`CREATE TABLE IF NOT EXISTS eg_edge_projection (
 		edge_key     TEXT PRIMARY KEY,
 		edge_type    TEXT NOT NULL DEFAULT '',
 		from_subject TEXT NOT NULL DEFAULT '',
 		to_subject   TEXT NOT NULL DEFAULT '',
+		source       TEXT NOT NULL DEFAULT '',
+		source_class TEXT NOT NULL DEFAULT '',
+		observed_at  TEXT NOT NULL DEFAULT '',
 		payload_hash TEXT NOT NULL DEFAULT '',
 		log_seq      INTEGER NOT NULL DEFAULT 0
 	)`,
+	`CREATE INDEX IF NOT EXISTS eg_edge_proj_from ON eg_edge_projection(from_subject)`,
+	`CREATE INDEX IF NOT EXISTS eg_edge_proj_to   ON eg_edge_projection(to_subject)`,
 
 	// Drift projection — populated by a later story. Created now (empty).
 	`CREATE TABLE IF NOT EXISTS eg_drift_projection (
@@ -215,9 +220,100 @@ var schemaStatements = []string{
 	)`,
 }
 
+// egTableExists reports whether the named table is present in the SQLite schema catalog.
+func egTableExists(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name,
+	).Scan(&count)
+	return count > 0, err
+}
+
+// egColumnExists reports whether the named column is present in the given table.
+// SQLite PRAGMA does not support ? binding, so only literal table/column names
+// from trusted call-sites may be passed.
+func egColumnExists(ctx context.Context, db *sql.DB, table, column string) (found bool, retErr error) {
+	// #nosec G202 -- PRAGMA does not support ? binding; caller passes only literals.
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")")
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+	for rows.Next() {
+		var cid, notNull, pk int
+		var colName, colType string
+		var dfltValue sql.NullString
+		if err := rows.Scan(&cid, &colName, &colType, &notNull, &dfltValue, &pk); err != nil {
+			return false, err
+		}
+		if colName == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// backfillEdgeProjection adds the source, source_class, and observed_at columns
+// to an eg_edge_projection table created by STORY-2 before those columns existed,
+// and creates the from/to indexes. It is idempotent: presence of each column is
+// checked via PRAGMA before ALTER TABLE is attempted.
+func backfillEdgeProjection(ctx context.Context, db *sql.DB) error {
+	exists, err := egTableExists(ctx, db, "eg_edge_projection")
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: probe eg_edge_projection: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+
+	type colDef struct {
+		name string
+		ddl  string
+	}
+	for _, c := range []colDef{
+		{"source", `ALTER TABLE eg_edge_projection ADD COLUMN source TEXT NOT NULL DEFAULT ''`},
+		{"source_class", `ALTER TABLE eg_edge_projection ADD COLUMN source_class TEXT NOT NULL DEFAULT ''`},
+		{"observed_at", `ALTER TABLE eg_edge_projection ADD COLUMN observed_at TEXT NOT NULL DEFAULT ''`},
+	} {
+		present, err := egColumnExists(ctx, db, "eg_edge_projection", c.name)
+		if err != nil {
+			return fmt.Errorf("entitygraph/sqlite: probe column %s: %w", c.name, err)
+		}
+		if present {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, c.ddl); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: add column %s: %w", c.name, err)
+		}
+	}
+
+	// Indexes are idempotent due to IF NOT EXISTS.
+	for _, idx := range []string{
+		`CREATE INDEX IF NOT EXISTS eg_edge_proj_from ON eg_edge_projection(from_subject)`,
+		`CREATE INDEX IF NOT EXISTS eg_edge_proj_to   ON eg_edge_projection(to_subject)`,
+	} {
+		if _, err := db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: create index: %w", err)
+		}
+	}
+	return nil
+}
+
 // initializeSchema creates all entity-graph tables and indexes in a single
 // transaction. It is idempotent (every statement uses IF NOT EXISTS).
+// After the DDL pass, it runs backfill migrations for databases created by
+// earlier story revisions that may be missing columns.
 func initializeSchema(ctx context.Context, db *sql.DB) error {
+	// Backfill before the DDL pass so that ALTER TABLE runs on the old schema
+	// before CREATE TABLE IF NOT EXISTS is a no-op for existing tables.
+	if err := backfillEdgeProjection(ctx, db); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: backfill edge projection: %w", err)
+	}
+
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("entitygraph/sqlite: begin schema tx: %w", err)


### PR DESCRIPTION
## Summary

Implements Story-3 of the entity graph foundation (epic #2851 / Issue #2873).

- **Edge ingestion**: `ReportObservations` handles `edge_type|from_eid|to_eid` subjects via a registered "edge" projection updater; upserts `eg_edge_projection` on both SQLite and PostgreSQL providers.
- **Placeholder nodes**: When an edge references an unseen EID, `INSERT OR IGNORE` materializes a skeleton row in `eg_entity_index` (empty `owning_tenant`). Later entity observations enrich the same row without conflict.
- **GetEdges with tenant filtering**: LEFT JOINs `eg_entity_index` to resolve ownership; only edges whose `from_subject` falls within the requested tenant subtree are returned.
- **GetNeighborhood (depth ≤ 3, default 2)**: Frontier-based BFS with one SQL query per hop. Implicit tenant filter derived from root entity's `owning_tenant` so cross-tenant edges are excluded at every hop (ADR-023 §4).
- **Schema evolution**: SQLite uses `egColumnExists` (PRAGMA table_info) + `ALTER TABLE ADD COLUMN`; PostgreSQL uses `ADD COLUMN IF NOT EXISTS`.
- **Contract suite**: 5 new subtests (`EdgeRoundTrip`, `PlaceholderNode`, `NeighborhoodDepthCap`, `NeighborhoodTenantPerHop`, `GetEdgesTenantFilter`) added to `RunEntityGraphContractTests`; all pass against both providers.

## Specialist Review Results

- **Code Review**: PASS — architecture sound, no central provider violations, pluggable design maintained
- **Test Quality**: PASS — TDD, real components (no mocks), all 5 new contract subtests pass, edge cases covered
- **Security**: PASS — parameterized queries throughout, no injection surfaces, tenant filtering enforced at SQL layer

## Test Plan

- [x] `go test ./pkg/entitygraph/... -count=1` — 4 packages, all pass (18 SQLite contract subtests + 5 new Story-3 subtests)
- [x] `golangci-lint run ./pkg/entitygraph/...` — 0 issues
- [x] `make check-architecture` — no central provider violations
- [x] `gofmt -l` — clean
- [x] PostgreSQL contract suite runs via `pkg/entitygraph/interfaces/providers_test.go`

Fixes #2873

🤖 Generated with [Claude Code](https://claude.com/claude-code)