### PR TITLE
entitygraph: extend taxonomy with DNA fragment kinds (Issue #2904)

### DIFF
--- a/pkg/entitygraph/types/taxonomy.go
+++ b/pkg/entitygraph/types/taxonomy.go
@@ -102,16 +102,22 @@ func (tx *Taxonomy) EffectivePrecedenceOrder(desc *EntityTypeDescriptor) []Sourc
 	return DefaultPrecedenceOrder
 }
 
-// DefaultTaxonomy returns the canonical seed taxonomy (version 1).
+// DefaultTaxonomy returns the canonical seed taxonomy (version 2).
 // Seed entity kinds and edge kinds are per ADR-022 §1/§2.
+// Version 2 adds DNA fragment kinds per ADR-017/A1.2.
 func DefaultTaxonomy() *Taxonomy {
 	tx := &Taxonomy{
-		Version:     1,
+		// Version 2: added DNA fragment kinds (ADR-017/A1.2) and host:* observe-only kinds.
+		Version:     2,
 		entityTypes: make(map[string]*EntityTypeDescriptor),
 		edgeTypes:   make(map[string]*EdgeTypeDescriptor),
 	}
 
 	// Seed entity kinds per ADR-022 §1.
+	// user carries directory/m365/host — the host class is added here (ADR-017/A1.2)
+	// to merge with the pre-existing directory/m365 authority for local-account fragments
+	// from the stdlib user module; a second descriptor would silently overwrite via map
+	// assignment, so the merge is done in-place on this single entry.
 	entitySeeds := []*EntityTypeDescriptor{
 		{Kind: "host", AuthorityClasses: []string{"host"}},
 		{Kind: "cluster", AuthorityClasses: []string{"cluster"}},
@@ -119,12 +125,43 @@ func DefaultTaxonomy() *Taxonomy {
 		{Kind: "vswitch", AuthorityClasses: []string{"cluster", "host"}},
 		{Kind: "device", AuthorityClasses: []string{"host"}},
 		{Kind: "application", AuthorityClasses: []string{"host"}},
-		{Kind: "user", AuthorityClasses: []string{"directory", "m365"}},
+		{Kind: "user", AuthorityClasses: []string{"directory", "m365", "host"}},
 		{Kind: "group", AuthorityClasses: []string{"directory", "m365"}},
 		{Kind: "tenant", AuthorityClasses: []string{"cfgms"}},
 		{Kind: "directory", AuthorityClasses: []string{"directory", "m365"}},
 	}
 	for _, d := range entitySeeds {
+		tx.entityTypes[d.Kind] = d
+	}
+
+	// DNA fragment kinds per ADR-017/A1.2 — one entry per stdlib module that declares
+	// owns: in features/modules/stdlib/*/module.yaml (re-grepped at story-2904 authoring
+	// time: file, package, script, firewall, service, patch, hostname, cert_trust, time).
+	// All are host-scoped; the user collision is handled above via the merged entry.
+	dnaFragmentSeeds := []*EntityTypeDescriptor{
+		{Kind: "file", AuthorityClasses: []string{"host"}},
+		{Kind: "package", AuthorityClasses: []string{"host"}},
+		{Kind: "script", AuthorityClasses: []string{"host"}},
+		{Kind: "firewall", AuthorityClasses: []string{"host"}},
+		{Kind: "service", AuthorityClasses: []string{"host"}},
+		{Kind: "patch", AuthorityClasses: []string{"host"}},
+		{Kind: "hostname", AuthorityClasses: []string{"host"}},
+		{Kind: "cert_trust", AuthorityClasses: []string{"host"}},
+		{Kind: "time", AuthorityClasses: []string{"host"}},
+	}
+	for _, d := range dnaFragmentSeeds {
+		tx.entityTypes[d.Kind] = d
+	}
+
+	// host:* observe-only kinds per ADR-017 §8 fixed contract — hardware and OS facts
+	// observed by the steward but not enforced by any module.
+	hostObserveSeeds := []*EntityTypeDescriptor{
+		{Kind: "host:cpu", AuthorityClasses: []string{"host"}},
+		{Kind: "host:memory", AuthorityClasses: []string{"host"}},
+		{Kind: "host:os", AuthorityClasses: []string{"host"}},
+		{Kind: "host:bios", AuthorityClasses: []string{"host"}},
+	}
+	for _, d := range hostObserveSeeds {
 		tx.entityTypes[d.Kind] = d
 	}
 

--- a/pkg/entitygraph/types/taxonomy_test.go
+++ b/pkg/entitygraph/types/taxonomy_test.go
@@ -76,6 +76,30 @@ func TestTaxonomy_UnrecognizedEdgeRoundTrip(t *testing.T) {
 	}
 }
 
+// TestTaxonomy_ParseRelatedEscapeError verifies that ParseRelatedEscape returns a
+// non-nil, meaningful error for inputs that are not related:<discriminator> escapes.
+// This exercises the error-return branch (taxonomy.go) that the round-trip test never hits.
+func TestTaxonomy_ParseRelatedEscapeError(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	// Ordinary strings, a seed edge kind, and the bare prefix (no discriminator) must all
+	// be rejected — IsRelatedEscape requires the prefix AND a non-empty discriminator.
+	cases := []string{"widget", "same-as", "related:", "", "notrelated:x"}
+
+	for _, kind := range cases {
+		t.Run(kind, func(t *testing.T) {
+			require.False(t, tx.IsRelatedEscape(kind),
+				"test case %q must not be a related: escape", kind)
+
+			discriminator, err := tx.ParseRelatedEscape(kind)
+			require.Error(t, err, "ParseRelatedEscape(%q) must return an error", kind)
+			assert.Empty(t, discriminator, "discriminator must be empty on error")
+			assert.Contains(t, err.Error(), "is not a related: escape",
+				"error message must explain why the input was rejected")
+		})
+	}
+}
+
 func TestTaxonomy_PrecedenceOverrideField(t *testing.T) {
 	tx := types.DefaultTaxonomy()
 
@@ -94,4 +118,91 @@ func TestTaxonomy_PrecedenceOverrideField(t *testing.T) {
 func TestTaxonomy_Version(t *testing.T) {
 	tx := types.DefaultTaxonomy()
 	assert.Greater(t, tx.Version, 0, "taxonomy must have a positive version")
+}
+
+// TestTaxonomy_DNAFragmentKinds verifies that all stdlib owns: kinds (except user, which
+// is a merge case) are registered with AuthorityClasses == []string{"host"} per ADR-017/A1.2.
+func TestTaxonomy_DNAFragmentKinds(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	// These 9 kinds come from the 10 stdlib modules with owns: declarations; user is handled
+	// separately because it requires merging with the pre-existing directory/m365 entry.
+	hostKinds := []string{
+		"file", "package", "script", "firewall", "service",
+		"patch", "hostname", "cert_trust", "time",
+	}
+
+	for _, kind := range hostKinds {
+		t.Run(kind, func(t *testing.T) {
+			desc, ok := tx.LookupEntityType(kind)
+			require.True(t, ok, "DNA fragment kind %q must be registered in taxonomy", kind)
+			assert.Equal(t, kind, desc.Kind)
+			assert.Equal(t, []string{"host"}, desc.AuthorityClasses,
+				"DNA fragment kind %q must have AuthorityClasses == [\"host\"]", kind)
+		})
+	}
+}
+
+// TestTaxonomy_HostObserveOnlyKinds verifies the four fixed host:* observe-only kinds
+// from ADR-017 §8 are registered per ADR-017/A1.2.
+func TestTaxonomy_HostObserveOnlyKinds(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	observeKinds := []string{"host:cpu", "host:memory", "host:os", "host:bios"}
+
+	for _, kind := range observeKinds {
+		t.Run(kind, func(t *testing.T) {
+			desc, ok := tx.LookupEntityType(kind)
+			require.True(t, ok, "observe-only kind %q must be registered in taxonomy", kind)
+			assert.Equal(t, kind, desc.Kind)
+			assert.Equal(t, []string{"host"}, desc.AuthorityClasses,
+				"observe-only kind %q must have AuthorityClasses == [\"host\"]", kind)
+		})
+	}
+}
+
+// TestTaxonomy_UserMergedAuthorityClasses verifies that the user kind carries all three
+// authority classes after the ADR-017/A1.2 merge — the pre-existing directory/m365 entries
+// must not be dropped.
+func TestTaxonomy_UserMergedAuthorityClasses(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	desc, ok := tx.LookupEntityType("user")
+	require.True(t, ok, "user kind must be registered in taxonomy")
+
+	classes := desc.AuthorityClasses
+	assert.Contains(t, classes, "directory", "user must retain directory authority class")
+	assert.Contains(t, classes, "m365", "user must retain m365 authority class")
+	assert.Contains(t, classes, "host", "user must gain host authority class from stdlib user module")
+}
+
+// TestTaxonomy_UnregisteredKindReturnsFalse verifies that unknown kinds return ok=false
+// with no accidental wildcard match.
+func TestTaxonomy_UnregisteredKindReturnsFalse(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	unknown := []string{"widget", "foo", "host:", "related:", "host:unknown"}
+	for _, kind := range unknown {
+		t.Run(kind, func(t *testing.T) {
+			_, ok := tx.LookupEntityType(kind)
+			assert.False(t, ok, "unregistered kind %q must return ok=false", kind)
+		})
+	}
+}
+
+// TestTaxonomy_VersionTwo verifies the taxonomy version is bumped to 2 per ADR-017/A1.2.
+func TestTaxonomy_VersionTwo(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+	assert.Equal(t, 2, tx.Version, "taxonomy must be at version 2 after ADR-017/A1.2 additions")
+}
+
+// TestTaxonomy_ClusterUntouched verifies that the cluster kind retains its
+// pre-existing AuthorityClasses and is not modified by this story's additions.
+func TestTaxonomy_ClusterUntouched(t *testing.T) {
+	tx := types.DefaultTaxonomy()
+
+	desc, ok := tx.LookupEntityType("cluster")
+	require.True(t, ok, "cluster kind must remain in taxonomy")
+	assert.Equal(t, []string{"cluster"}, desc.AuthorityClasses,
+		"cluster AuthorityClasses must be unchanged by ADR-017/A1.2 additions")
 }


### PR DESCRIPTION
## Summary

- Extends `DefaultTaxonomy()` in `pkg/entitygraph/types/taxonomy.go` with 13 new entity-type descriptors: 9 from stdlib module `owns:` declarations (`file`, `package`, `script`, `firewall`, `service`, `patch`, `hostname`, `cert_trust`, `time`) and 4 `host:*` observe-only kinds (`host:cpu`, `host:memory`, `host:os`, `host:bios`) per ADR-017 §8.
- Merges `"host"` into the pre-existing `user` entry's `AuthorityClasses` rather than adding a colliding second descriptor (which would have silently overwritten `"directory"`/`"m365"` via map assignment).
- Bumps `Taxonomy.Version` from 1 to 2 per ADR-017/A1.2.

Fixes #2904

## Adversarial Review Results

- **Code review**: PASS (2 rounds — round 1 flagged missing `ParseRelatedEscape` error-path coverage; fix agent added `TestTaxonomy_ParseRelatedEscapeError`; round 2 clean)
- **Test quality**: PASS
- **Security**: PASS

## Test plan

- [ ] `go test ./pkg/entitygraph/types/...` — all 40 tests pass
- [ ] `make test-agent-complete` — full CI gate passes
- [ ] `LookupEntityType("service")` returns `ok=true`, `AuthorityClasses == ["host"]`
- [ ] `LookupEntityType("user")` returns `AuthorityClasses` containing `"directory"`, `"m365"`, `"host"`
- [ ] `LookupEntityType("widget")` returns `ok=false`
- [ ] `LookupEntityType("cluster")` returns `AuthorityClasses == ["cluster"]` (unchanged)
- [ ] `Taxonomy.Version == 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)