### PR TITLE
entitygraph: claim-scoped ingest + source-closure retraction (Issue #2874)

### DIFF
--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -58,6 +58,11 @@ func RunEntityGraphContractTests(t *testing.T, factory EntityGraphProviderFactor
 	t.Run("NeighborhoodDepthCap", func(t *testing.T) { testEGNeighborhoodDepthCap(t, factory) })         // AC 3
 	t.Run("NeighborhoodTenantPerHop", func(t *testing.T) { testEGNeighborhoodTenantPerHop(t, factory) }) // AC 4
 	t.Run("GetEdgesTenantFilter", func(t *testing.T) { testEGGetEdgesTenantFilter(t, factory) })         // AC 5
+	// Story-4: claim-scoped ingest + source-closure retraction (Issue #2874)
+	t.Run("ClaimScopeEntityReplace", func(t *testing.T) { testEGClaimScopeEntityReplace(t, factory) })     // AC 1
+	t.Run("ClaimScopeEdgeReplace", func(t *testing.T) { testEGClaimScopeEdgeReplace(t, factory) })         // AC 2
+	t.Run("ClaimScopeOverlapRejected", func(t *testing.T) { testEGClaimScopeOverlapRejected(t, factory) }) // AC 3
+	t.Run("SourceClosure", func(t *testing.T) { testEGSourceClosure(t, factory) })                         // AC 4
 }
 
 // --- Contract test helpers ---
@@ -694,6 +699,225 @@ func testEGGetEdgesTenantFilter(t *testing.T, factory EntityGraphProviderFactory
 	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{FromEID: &fromRef})
 	require.NoError(t, err)
 	assert.Len(t, edges, 1, "edge must be returned when no tenant filter is applied")
+}
+
+// testEGClaimScopeEntityReplace verifies that a re-enumeration under an entity
+// claim scope retracts previously-asserted subjects that are absent from the new
+// set, while leaving assertions from other sources untouched (Story-4 AC1).
+func testEGClaimScopeEntityReplace(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	const (
+		sub1 = "host:csent-auth/host1"
+		sub2 = "host:csent-auth/host2"
+		sub3 = "host:csent-auth/host3"
+	)
+	const srcA = "enforcing-module:scanner-a"
+	const srcB = "enforcing-module:scanner-b"
+
+	now := time.Now().UTC()
+	scopePattern := types.ClaimScopePattern{
+		Entity: &types.EntityScopePattern{EntityType: "host", AuthorityPrefix: "host:csent-auth/"},
+	}
+
+	// Initial batch from source A: asserts host1, host2, host3 under a claim scope.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: srcA,
+		Observations: []types.Observation{
+			egObservation(sub1, srcA, now, map[string]interface{}{"entity_kind": "host", "owning_tenant": "root/csent-tenant", "hostname": "host1"}),
+			egObservation(sub2, srcA, now, map[string]interface{}{"entity_kind": "host", "owning_tenant": "root/csent-tenant", "hostname": "host2"}),
+			egObservation(sub3, srcA, now, map[string]interface{}{"entity_kind": "host", "owning_tenant": "root/csent-tenant", "hostname": "host3"}),
+		},
+		ClaimScopes: []types.ClaimScope{{Source: srcA, Pattern: scopePattern, AsOf: now}},
+	}))
+
+	// Source B also asserts host2 (different source, no claim scope).
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: srcB,
+		Observations: []types.Observation{
+			egObservation(sub2, srcB, now, map[string]interface{}{"entity_kind": "host", "owning_tenant": "root/csent-tenant", "hostname": "host2-from-b"}),
+		},
+	}))
+
+	// All three visible after initial assert.
+	for _, sub := range []string{sub1, sub2, sub3} {
+		_, err := p.GetEntity(ctx, egEID(t, sub), interfaces.GetEntityOpts{TenantFilter: "root/csent-tenant"})
+		require.NoError(t, err, "entity %s must be visible after initial assert", sub)
+	}
+
+	now2 := now.Add(time.Second)
+
+	// Re-enumeration from source A: only host1 now asserted.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: srcA,
+		Observations: []types.Observation{
+			egObservation(sub1, srcA, now2, map[string]interface{}{"entity_kind": "host", "owning_tenant": "root/csent-tenant", "hostname": "host1"}),
+		},
+		ClaimScopes: []types.ClaimScope{{Source: srcA, Pattern: scopePattern, AsOf: now2}},
+	}))
+
+	// host1 is still visible (not retracted by source A).
+	_, err := p.GetEntity(ctx, egEID(t, sub1), interfaces.GetEntityOpts{TenantFilter: "root/csent-tenant"})
+	require.NoError(t, err, "host1 must remain visible after re-enumeration that includes it")
+
+	// host3 must be retracted: source A no longer asserts it, no other source does.
+	_, err = p.GetEntity(ctx, egEID(t, sub3), interfaces.GetEntityOpts{TenantFilter: "root/csent-tenant"})
+	require.Error(t, err, "host3 must be retracted after source A omits it from re-enumeration")
+
+	// host2: source A's assertion is retracted, but source B's assertion survives.
+	view2, err := p.GetEntity(ctx, egEID(t, sub2), interfaces.GetEntityOpts{TenantFilter: "root/csent-tenant"})
+	require.NoError(t, err, "host2 must remain visible because source B still asserts it")
+	require.NotNil(t, view2)
+	require.NotNil(t, view2.Entity)
+	assert.Equal(t, "host2-from-b", view2.Entity.Attributes["hostname"],
+		"host2 must be served from source B's assertion after source A retracts")
+}
+
+// testEGClaimScopeEdgeReplace verifies that a re-enumeration under an edge
+// claim scope retracts edges that were present in the prior assertion set but
+// absent from the new enumeration (Story-4 AC2).
+func testEGClaimScopeEdgeReplace(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	anchor := egEID(t, "host:csedge-auth/anchor1")
+	peer1 := egEID(t, "host:csedge-auth/peer1")
+	peer2 := egEID(t, "host:csedge-auth/peer2")
+	const src = "enforcing-module:edge-scanner"
+
+	now := time.Now().UTC()
+	edgeScope := types.ClaimScopePattern{
+		Edge: &types.EdgeScopePattern{
+			EdgeType:  "contains",
+			AnchorEID: anchor,
+			Direction: types.TraversalOutbound,
+		},
+	}
+
+	mkEdgeObs := func(from, to interfaces.EIDRef, at time.Time) types.Observation {
+		return egObservation("contains|"+from.String()+"|"+to.String(), src, at, map[string]interface{}{})
+	}
+
+	// Initial batch: anchor → peer1, anchor → peer2.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source:       src,
+		Observations: []types.Observation{mkEdgeObs(anchor, peer1, now), mkEdgeObs(anchor, peer2, now)},
+		ClaimScopes:  []types.ClaimScope{{Source: src, Pattern: edgeScope, AsOf: now}},
+	}))
+
+	anchorRef := anchor
+	edges, err := p.GetEdges(ctx, interfaces.EdgeFilter{FromEID: &anchorRef, Source: src})
+	require.NoError(t, err)
+	require.Len(t, edges, 2, "both edges must be visible after initial assert")
+
+	now2 := now.Add(time.Second)
+
+	// Re-enumeration: only anchor → peer1 remains.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source:       src,
+		Observations: []types.Observation{mkEdgeObs(anchor, peer1, now2)},
+		ClaimScopes:  []types.ClaimScope{{Source: src, Pattern: edgeScope, AsOf: now2}},
+	}))
+
+	edges, err = p.GetEdges(ctx, interfaces.EdgeFilter{FromEID: &anchorRef, Source: src})
+	require.NoError(t, err)
+	require.Len(t, edges, 1, "edge to peer2 must be retracted after re-enumeration omits it")
+	assert.Equal(t, peer1.String(), edges[0].Edge.To.String(), "remaining edge must point to peer1")
+}
+
+// testEGClaimScopeOverlapRejected verifies that two claim scopes with the same
+// source and pattern key within a single batch are rejected (Story-4 AC3).
+func testEGClaimScopeOverlapRejected(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	const src = "enforcing-module:overlap-scanner"
+	now := time.Now().UTC()
+	pattern := types.ClaimScopePattern{
+		Entity: &types.EntityScopePattern{EntityType: "host", AuthorityPrefix: "host:csovlp-auth/"},
+	}
+
+	err := p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: src,
+		Observations: []types.Observation{
+			egObservation("host:csovlp-auth/host1", src, now, map[string]interface{}{
+				"entity_kind": "host", "owning_tenant": "root/ovlp-tenant",
+			}),
+		},
+		ClaimScopes: []types.ClaimScope{
+			{Source: src, Pattern: pattern, AsOf: now},
+			{Source: src, Pattern: pattern, AsOf: now.Add(time.Millisecond)},
+		},
+	})
+	require.Error(t, err, "two claim scopes with the same source+pattern in one batch must be rejected")
+}
+
+// testEGSourceClosure verifies that an empty re-enumeration retracts all prior
+// subjects under the scope and that the retraction is visible as an absence
+// observation in GetHistory (Story-4 AC4).
+func testEGSourceClosure(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	const (
+		sub1 = "host:csclo-auth/host1"
+		sub2 = "host:csclo-auth/host2"
+	)
+	const src = "enforcing-module:closure-scanner"
+
+	t0 := time.Now().UTC().Add(-time.Millisecond)
+	now := time.Now().UTC()
+	scopePattern := types.ClaimScopePattern{
+		Entity: &types.EntityScopePattern{EntityType: "host", AuthorityPrefix: "host:csclo-auth/"},
+	}
+
+	// Initial assertion: host1 and host2.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: src,
+		Observations: []types.Observation{
+			egObservation(sub1, src, now, map[string]interface{}{"entity_kind": "host", "owning_tenant": "root/clo-tenant"}),
+			egObservation(sub2, src, now, map[string]interface{}{"entity_kind": "host", "owning_tenant": "root/clo-tenant"}),
+		},
+		ClaimScopes: []types.ClaimScope{{Source: src, Pattern: scopePattern, AsOf: now}},
+	}))
+
+	for _, sub := range []string{sub1, sub2} {
+		_, err := p.GetEntity(ctx, egEID(t, sub), interfaces.GetEntityOpts{TenantFilter: "root/clo-tenant"})
+		require.NoError(t, err, "entity %s must be visible after initial assert", sub)
+	}
+
+	now2 := now.Add(time.Second)
+
+	// Source closure: empty re-enumeration retracts everything in scope.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source:       src,
+		Observations: nil,
+		ClaimScopes:  []types.ClaimScope{{Source: src, Pattern: scopePattern, AsOf: now2}},
+	}))
+
+	// Both entities must be gone.
+	for _, sub := range []string{sub1, sub2} {
+		_, err := p.GetEntity(ctx, egEID(t, sub), interfaces.GetEntityOpts{TenantFilter: "root/clo-tenant"})
+		require.Error(t, err, "entity %s must be retracted after source closure", sub)
+	}
+
+	// Absence must be visible in GetHistory for sub1.
+	t1 := now2.Add(time.Second)
+	history, err := p.GetHistory(ctx, egEID(t, sub1), interfaces.TimeRange{From: t0, To: t1})
+	require.NoError(t, err)
+	var hasAbsence bool
+	for _, rec := range history {
+		if rec.Observation.Kind == types.ObservationKindAbsence && rec.Observation.Source == src {
+			hasAbsence = true
+			break
+		}
+	}
+	assert.True(t, hasAbsence, "GetHistory must include an absence observation for the retracted entity")
 }
 
 func testEGProviderIdentity(t *testing.T, factory EntityGraphProviderFactory) {

--- a/pkg/entitygraph/providers/database/claimscope.go
+++ b/pkg/entitygraph/providers/database/claimscope.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// dbPatternKey derives a canonical storage key from a scope pattern alone
+// (without source). Source is a PK column in eg_claim_scope_prior, so it does
+// not need to be embedded in the key.
+func dbPatternKey(pattern types.ClaimScopePattern) string {
+	switch {
+	case pattern.Edge != nil:
+		e := pattern.Edge
+		return "edge\x1f" + e.EdgeType + "\x1f" + e.AnchorEID.String() + "\x1f" + string(e.Direction)
+	case pattern.Entity != nil:
+		en := pattern.Entity
+		return "entity\x1f" + en.EntityType + "\x1f" + en.AuthorityPrefix
+	default:
+		return "empty"
+	}
+}
+
+// subjectMatchesEntityScope reports whether a subject string falls within an
+// entity scope pattern. Empty EntityType or AuthorityPrefix match all values.
+func subjectMatchesEntityScope(subject string, p *types.EntityScopePattern) bool {
+	eid, err := types.ParseEID(subject)
+	if err != nil {
+		return false
+	}
+	if p.EntityType != "" && eid.AuthorityType() != p.EntityType {
+		return false
+	}
+	if p.AuthorityPrefix != "" && !strings.HasPrefix(subject, p.AuthorityPrefix) {
+		return false
+	}
+	return true
+}
+
+// subjectMatchesEdgeScope reports whether an edge subject string falls within an
+// edge scope pattern. The anchor EID and traversal direction determine which end
+// of the edge is fixed to the anchor.
+func subjectMatchesEdgeScope(subject string, p *types.EdgeScopePattern) bool {
+	edgeType, fromSubject, toSubject, err := parseEdgeSubject(subject)
+	if err != nil {
+		return false
+	}
+	if p.EdgeType != "" && edgeType != p.EdgeType {
+		return false
+	}
+	anchor := p.AnchorEID.String()
+	switch p.Direction {
+	case types.TraversalOutbound:
+		return fromSubject == anchor
+	case types.TraversalInbound:
+		return toSubject == anchor
+	default: // TraversalBoth
+		return fromSubject == anchor || toSubject == anchor
+	}
+}
+
+// collectScopeSubjects returns the set of subjects from observations that match
+// the given scope source and pattern. Per-observation source falls back to
+// batchSource when empty, mirroring ReportObservations behaviour.
+func collectScopeSubjects(batchSource, scopeSource string, pattern types.ClaimScopePattern, observations []types.Observation) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, obs := range observations {
+		src := obs.Source
+		if src == "" {
+			src = batchSource
+		}
+		if src != scopeSource {
+			continue
+		}
+		switch {
+		case pattern.Entity != nil && subjectMatchesEntityScope(obs.Subject, pattern.Entity):
+			result[obs.Subject] = struct{}{}
+		case pattern.Edge != nil && subjectMatchesEdgeScope(obs.Subject, pattern.Edge):
+			result[obs.Subject] = struct{}{}
+		}
+	}
+	return result
+}
+
+// processClaimScopes applies claim-scope diff-and-retract for every scope
+// declared in the batch. It runs inside the same write transaction as the
+// observation ingest so that partial retractions can never persist.
+//
+// Overlapping scopes (same source + pattern key) within one batch are rejected
+// immediately per ADR-022 §4.
+func processClaimScopes(ctx context.Context, tx *sql.Tx, batchSource string, scopes []types.ClaimScope, observations []types.Observation) error {
+	// Detect overlapping scopes before any writes.
+	seen := make(map[string]bool, len(scopes))
+	for _, cs := range scopes {
+		src := cs.Source
+		if src == "" {
+			src = batchSource
+		}
+		combined := src + "\x1f" + dbPatternKey(cs.Pattern)
+		if seen[combined] {
+			return fmt.Errorf("entitygraph/database: overlapping claim scope for source %q pattern key %q", src, dbPatternKey(cs.Pattern))
+		}
+		seen[combined] = true
+	}
+
+	for _, cs := range scopes {
+		src := cs.Source
+		if src == "" {
+			src = batchSource
+		}
+		scopeKey := dbPatternKey(cs.Pattern)
+		asOf := cs.AsOf
+		if asOf.IsZero() {
+			asOf = time.Now().UTC()
+		}
+
+		prior, err := loadPriorSubjects(ctx, tx, src, scopeKey)
+		if err != nil {
+			return err
+		}
+
+		current := collectScopeSubjects(batchSource, src, cs.Pattern, observations)
+
+		// Retract each subject present in the prior set but absent from the
+		// current enumeration.
+		for subject := range prior {
+			if _, ok := current[subject]; ok {
+				continue
+			}
+			if err := retractSubject(ctx, tx, subject, src, cs.Pattern, asOf); err != nil {
+				return fmt.Errorf("entitygraph/database: retract subject %q in scope %q: %w", subject, scopeKey, err)
+			}
+		}
+
+		// AC5: replace prior table in two statements (DELETE + batch INSERT),
+		// not an N+1-per-row loop.
+		if err := replacePriorSubjects(ctx, tx, src, scopeKey, current); err != nil {
+			return fmt.Errorf("entitygraph/database: replace prior subjects for scope %q: %w", scopeKey, err)
+		}
+	}
+	return nil
+}
+
+// loadPriorSubjects reads all subjects previously asserted under (source,
+// claim_scope_key) from eg_claim_scope_prior.
+func loadPriorSubjects(ctx context.Context, tx *sql.Tx, source, scopeKey string) (map[string]struct{}, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT subject FROM eg_claim_scope_prior WHERE source = $1 AND claim_scope_key = $2`,
+		source, scopeKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: load prior subjects for key %q: %w", scopeKey, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string]struct{})
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("entitygraph/database: scan prior subject: %w", err)
+		}
+		result[s] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: iterate prior subjects: %w", err)
+	}
+	return result, nil
+}
+
+// replacePriorSubjects replaces the prior subject set for a claim scope using
+// two SQL statements — a DELETE to clear the old set and a single multi-value
+// INSERT to write the new set. This satisfies AC5 (single indexed batch upsert,
+// not N+1 per row).
+func replacePriorSubjects(ctx context.Context, tx *sql.Tx, source, scopeKey string, subjects map[string]struct{}) error {
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM eg_claim_scope_prior WHERE source = $1 AND claim_scope_key = $2`,
+		source, scopeKey,
+	); err != nil {
+		return fmt.Errorf("entitygraph/database: delete prior subjects for scope %q: %w", scopeKey, err)
+	}
+	if len(subjects) == 0 {
+		return nil
+	}
+
+	list := make([]string, 0, len(subjects))
+	for s := range subjects {
+		list = append(list, s)
+	}
+
+	// Build a single multi-value INSERT: ($1, $2, $3), ($1, $2, $4), ...
+	// PostgreSQL permits re-referencing $1 and $2 across value groups.
+	args := make([]interface{}, 0, 2+len(list))
+	args = append(args, source, scopeKey)
+	phParts := make([]string, 0, len(list))
+	for i, s := range list {
+		phParts = append(phParts, fmt.Sprintf("($1, $2, $%d)", i+3))
+		args = append(args, s)
+	}
+	query := `INSERT INTO eg_claim_scope_prior (source, claim_scope_key, subject)
+              VALUES ` + strings.Join(phParts, ", ") + ` ON CONFLICT DO NOTHING`
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("entitygraph/database: batch insert prior subjects for scope %q: %w", scopeKey, err)
+	}
+	return nil
+}
+
+// retractSubject emits an absence observation into the log (making the
+// retraction permanently visible in the history stream per ADR-022 §4) and
+// removes the subject from its current-state projection.
+func retractSubject(ctx context.Context, tx *sql.Tx, subject, source string, pattern types.ClaimScopePattern, asOf time.Time) error {
+	if err := appendAbsenceLog(ctx, tx, subject, source, asOf); err != nil {
+		return err
+	}
+	if pattern.Entity != nil {
+		return retractEntityProjection(ctx, tx, subject, source)
+	}
+	return retractEdgeProjection(ctx, tx, subject, source)
+}
+
+// appendAbsenceLog writes a single absence observation to eg_observation_log so
+// that source-closure events are permanently visible in the history stream
+// (ADR-022 §4 / AC4).
+func appendAbsenceLog(ctx context.Context, tx *sql.Tx, subject, source string, asOf time.Time) error {
+	hash, err := payloadHash(nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO eg_payload_content (content_hash, payload_json)
+		 VALUES ($1, '{}')
+		 ON CONFLICT (content_hash) DO NOTHING`,
+		hash,
+	); err != nil {
+		return fmt.Errorf("entitygraph/database: insert absence payload: %w", err)
+	}
+	sc := string(resolveSourceClass(source))
+	asOfStr := asOf.UTC().Format("2006-01-02T15:04:05.999999999Z07:00")
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO eg_observation_log
+			(subject, source, source_class, observed_at, recorded_at, kind, confidence, claim_scope_key, payload_hash, tenant_path)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, '', $8, '')`,
+		subject, source, sc, asOfStr, asOfStr,
+		string(types.ObservationKindAbsence), string(types.ConfidenceHigh),
+		hash,
+	)
+	if err != nil {
+		return fmt.Errorf("entitygraph/database: append absence log for %q: %w", subject, err)
+	}
+	return nil
+}
+
+// retractEntityProjection removes a source's assertion of an entity from the
+// current-state table and rebuilds the entity index for the subject.
+func retractEntityProjection(ctx context.Context, tx *sql.Tx, subject, source string) error {
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM eg_entity_current WHERE subject = $1 AND source = $2`, subject, source,
+	); err != nil {
+		return fmt.Errorf("entitygraph/database: delete entity current for retraction: %w", err)
+	}
+	return rebuildEntityIndex(ctx, tx, subject)
+}
+
+// retractEdgeProjection removes an edge from eg_edge_projection.
+func retractEdgeProjection(ctx context.Context, tx *sql.Tx, subject, source string) error {
+	edgeType, fromSubject, toSubject, err := parseEdgeSubject(subject)
+	if err != nil {
+		return fmt.Errorf("entitygraph/database: parse edge subject for retraction: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM eg_edge_projection WHERE from_subject = $1 AND to_subject = $2 AND edge_type = $3 AND source = $4`,
+		fromSubject, toSubject, edgeType, source,
+	); err != nil {
+		return fmt.Errorf("entitygraph/database: delete edge projection for retraction: %w", err)
+	}
+	return nil
+}

--- a/pkg/entitygraph/providers/database/edges.go
+++ b/pkg/entitygraph/providers/database/edges.go
@@ -33,6 +33,19 @@ func parseEdgeSubject(subject string) (edgeType, fromSubject, toSubject string, 
 // the per-source edge projection row and materializes placeholder nodes for any
 // referenced EID not yet in eg_entity_index (ADR-022 §2).
 func updateEdgeProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, _ int64) error {
+	if obs.Kind == types.ObservationKindAbsence {
+		edgeType, fromSubject, toSubject, err := parseEdgeSubject(obs.Subject)
+		if err != nil {
+			return nil // non-edge subject in absence — skip
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM eg_edge_projection WHERE from_subject = $1 AND to_subject = $2 AND edge_type = $3 AND source = $4`,
+			fromSubject, toSubject, edgeType, obs.Source,
+		); err != nil {
+			return fmt.Errorf("entitygraph/database: delete edge projection for absence: %w", err)
+		}
+		return nil
+	}
 	edgeType, fromSubject, toSubject, err := parseEdgeSubject(obs.Subject)
 	if err != nil {
 		return err

--- a/pkg/entitygraph/providers/database/entity_reads.go
+++ b/pkg/entitygraph/providers/database/entity_reads.go
@@ -384,6 +384,20 @@ func (p *DatabaseEntityGraphProvider) RebuildProjections(ctx context.Context) er
 		if subjectKind(lr.subject) != "entity" {
 			continue
 		}
+		if lr.kind == string(types.ObservationKindAbsence) {
+			// Absence: remove the source assertion and let the index reflect the
+			// remaining sources so that retraction events survive a full replay.
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM eg_entity_current WHERE subject = $1 AND source = $2`,
+				lr.subject, lr.source,
+			); err != nil {
+				return fmt.Errorf("entitygraph/database: replay absence seq %d: %w", lr.id, err)
+			}
+			if err := rebuildEntityIndex(ctx, tx, lr.subject); err != nil {
+				return fmt.Errorf("entitygraph/database: rebuild index seq %d: %w", lr.id, err)
+			}
+			continue
+		}
 		// Replay: fold the log row into eg_entity_current (same supersede logic as
 		// ReportObservations) then rebuild the index from the accumulated state.
 		if _, err := tx.ExecContext(ctx,
@@ -446,9 +460,58 @@ func (p *DatabaseEntityGraphProvider) GetDriftState(_ context.Context, _ interfa
 	return nil, interfaces.ErrNotImplemented
 }
 
-// GetHistory returns the versioned observation log for a subject over a range.
-func (p *DatabaseEntityGraphProvider) GetHistory(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
-	return nil, interfaces.ErrNotImplemented
+// GetHistory returns the versioned observation log for a subject over a time
+// range in ascending sequence order. Both state and absence observations are
+// included so that source-closure events are visible in the history stream.
+func (p *DatabaseEntityGraphProvider) GetHistory(ctx context.Context, eid interfaces.EIDRef, r interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
+	subject := eid.String()
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT l.id, l.source, l.observed_at, l.recorded_at, l.kind, l.confidence, p.payload_json
+		 FROM eg_observation_log l
+		 JOIN eg_payload_content p ON p.content_hash = l.payload_hash
+		 WHERE l.subject = $1 AND l.observed_at >= $2 AND l.observed_at <= $3
+		 ORDER BY l.id ASC`,
+		subject,
+		r.From.UTC().Format(time.RFC3339Nano),
+		r.To.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: get history: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var records []*interfaces.ObservationRecord
+	for rows.Next() {
+		var id int64
+		var source, observedAt, recordedAt, kind, confidence, payloadJSON string
+		if err := rows.Scan(&id, &source, &observedAt, &recordedAt, &kind, &confidence, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/database: scan history row: %w", err)
+		}
+		var payload map[string]interface{}
+		if payloadJSON != "" {
+			if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+				payload = map[string]interface{}{}
+			}
+		}
+		oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+		ra, _ := time.Parse(time.RFC3339Nano, recordedAt)
+		records = append(records, &interfaces.ObservationRecord{
+			Observation: types.Observation{
+				Source:     source,
+				ObservedAt: oa,
+				RecordedAt: ra,
+				Subject:    subject,
+				Kind:       types.ObservationKind(kind),
+				Confidence: types.Confidence(confidence),
+				Payload:    payload,
+			},
+			Version: id,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: iterate history: %w", err)
+	}
+	return records, nil
 }
 
 // Diff returns the attribute delta between two points in time for a subject.

--- a/pkg/entitygraph/providers/database/observations.go
+++ b/pkg/entitygraph/providers/database/observations.go
@@ -87,7 +87,7 @@ func tenantPathOf(obs types.Observation) string {
 // per-source current-state table, and dispatched to the registered projection
 // updater — all inside a single transaction so partial batches never persist.
 func (p *DatabaseEntityGraphProvider) ReportObservations(ctx context.Context, batch interfaces.ObservationBatch) error {
-	if len(batch.Observations) == 0 {
+	if len(batch.Observations) == 0 && len(batch.ClaimScopes) == 0 {
 		return nil
 	}
 
@@ -188,6 +188,12 @@ func (p *DatabaseEntityGraphProvider) ReportObservations(ctx context.Context, ba
 
 		if err := dispatchProjectionUpdate(ctx, tx, subjectKind(obs.Subject), obs, logSeq); err != nil {
 			return fmt.Errorf("entitygraph/database: projection update: %w", err)
+		}
+	}
+
+	if len(batch.ClaimScopes) > 0 {
+		if err := processClaimScopes(ctx, tx, batch.Source, batch.ClaimScopes, batch.Observations); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/entitygraph/providers/sqlite/claimscope.go
+++ b/pkg/entitygraph/providers/sqlite/claimscope.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// claimScopeKey builds the eg_claim_scope_prior PRIMARY KEY for a (source,
+// pattern) pair. Source is embedded so that two different sources using the same
+// pattern do not collide on the table's single-column PRIMARY KEY.
+func claimScopeKey(source string, pattern types.ClaimScopePattern) string {
+	switch {
+	case pattern.Edge != nil:
+		e := pattern.Edge
+		return source + "\x1fedge\x1f" + e.EdgeType + "\x1f" + e.AnchorEID.String() + "\x1f" + string(e.Direction)
+	case pattern.Entity != nil:
+		en := pattern.Entity
+		return source + "\x1fentity\x1f" + en.EntityType + "\x1f" + en.AuthorityPrefix
+	default:
+		return source + "\x1fempty"
+	}
+}
+
+// subjectMatchesEntityScope reports whether a subject string falls within an
+// entity scope pattern. Empty EntityType or AuthorityPrefix match all values.
+func subjectMatchesEntityScope(subject string, p *types.EntityScopePattern) bool {
+	eid, err := types.ParseEID(subject)
+	if err != nil {
+		return false
+	}
+	if p.EntityType != "" && eid.AuthorityType() != p.EntityType {
+		return false
+	}
+	if p.AuthorityPrefix != "" && !strings.HasPrefix(subject, p.AuthorityPrefix) {
+		return false
+	}
+	return true
+}
+
+// subjectMatchesEdgeScope reports whether an edge subject string falls within an
+// edge scope pattern. The anchor EID and traversal direction determine which end
+// of the edge is fixed to the anchor.
+func subjectMatchesEdgeScope(subject string, p *types.EdgeScopePattern) bool {
+	edgeType, fromSubject, toSubject, err := parseEdgeSubject(subject)
+	if err != nil {
+		return false
+	}
+	if p.EdgeType != "" && edgeType != p.EdgeType {
+		return false
+	}
+	anchor := p.AnchorEID.String()
+	switch p.Direction {
+	case types.TraversalOutbound:
+		return fromSubject == anchor
+	case types.TraversalInbound:
+		return toSubject == anchor
+	default: // TraversalBoth
+		return fromSubject == anchor || toSubject == anchor
+	}
+}
+
+// collectScopeSubjects returns the set of subjects from observations that match
+// the given source and pattern. Per-observation source falls back to batchSource
+// when empty, mirroring ReportObservations behaviour.
+func collectScopeSubjects(batchSource, scopeSource string, pattern types.ClaimScopePattern, observations []types.Observation) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, obs := range observations {
+		src := obs.Source
+		if src == "" {
+			src = batchSource
+		}
+		if src != scopeSource {
+			continue
+		}
+		switch {
+		case pattern.Entity != nil && subjectMatchesEntityScope(obs.Subject, pattern.Entity):
+			result[obs.Subject] = struct{}{}
+		case pattern.Edge != nil && subjectMatchesEdgeScope(obs.Subject, pattern.Edge):
+			result[obs.Subject] = struct{}{}
+		}
+	}
+	return result
+}
+
+// processClaimScopes applies claim-scope diff-and-retract for every scope
+// declared in the batch. It runs inside the same write transaction as the
+// observation ingest so that partial retractions can never persist.
+//
+// Overlapping scopes (same source + pattern key) within one batch are rejected
+// immediately per ADR-022 §4.
+func processClaimScopes(ctx context.Context, tx *sql.Tx, batchSource string, scopes []types.ClaimScope, observations []types.Observation) error {
+	// Detect overlapping scopes before any writes.
+	seen := make(map[string]bool, len(scopes))
+	for _, cs := range scopes {
+		src := cs.Source
+		if src == "" {
+			src = batchSource
+		}
+		key := claimScopeKey(src, cs.Pattern)
+		if seen[key] {
+			return fmt.Errorf("entitygraph/sqlite: overlapping claim scope for source %q pattern key %q", src, key)
+		}
+		seen[key] = true
+	}
+
+	for _, cs := range scopes {
+		src := cs.Source
+		if src == "" {
+			src = batchSource
+		}
+		scopeKey := claimScopeKey(src, cs.Pattern)
+		asOf := cs.AsOf
+		if asOf.IsZero() {
+			asOf = time.Now().UTC()
+		}
+
+		prior, err := loadPriorSubjects(ctx, tx, scopeKey)
+		if err != nil {
+			return err
+		}
+
+		current := collectScopeSubjects(batchSource, src, cs.Pattern, observations)
+
+		// Retract each subject present in the prior set but absent from the
+		// current enumeration.
+		for subject := range prior {
+			if _, ok := current[subject]; ok {
+				continue
+			}
+			if err := retractSubject(ctx, tx, subject, src, cs.Pattern, asOf); err != nil {
+				return fmt.Errorf("entitygraph/sqlite: retract subject %q in scope %q: %w", subject, scopeKey, err)
+			}
+		}
+
+		// AC5: update the prior-assertion table in a single indexed batch upsert.
+		if err := savePriorSubjects(ctx, tx, scopeKey, src, asOf, current); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: save prior subjects for scope %q: %w", scopeKey, err)
+		}
+	}
+	return nil
+}
+
+// loadPriorSubjects reads the JSON-encoded prior subject set from
+// eg_claim_scope_prior for the given scope key.
+func loadPriorSubjects(ctx context.Context, tx *sql.Tx, scopeKey string) (map[string]struct{}, error) {
+	var subjectsJSON string
+	err := tx.QueryRowContext(ctx,
+		`SELECT subjects FROM eg_claim_scope_prior WHERE scope_key = ?`, scopeKey,
+	).Scan(&subjectsJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return make(map[string]struct{}), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: load prior subjects for key %q: %w", scopeKey, err)
+	}
+	var list []string
+	if err := json.Unmarshal([]byte(subjectsJSON), &list); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: decode prior subjects: %w", err)
+	}
+	result := make(map[string]struct{}, len(list))
+	for _, s := range list {
+		result[s] = struct{}{}
+	}
+	return result, nil
+}
+
+// savePriorSubjects writes the current subject set to eg_claim_scope_prior
+// as a single indexed upsert (AC5: not an N+1-per-row loop). The subjects
+// are stored as a JSON array — one row per (source, pattern) scope.
+func savePriorSubjects(ctx context.Context, tx *sql.Tx, scopeKey, source string, asOf time.Time, subjects map[string]struct{}) error {
+	list := make([]string, 0, len(subjects))
+	for s := range subjects {
+		list = append(list, s)
+	}
+	data, err := json.Marshal(list)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: marshal current subjects: %w", err)
+	}
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO eg_claim_scope_prior (scope_key, source, as_of, subjects)
+		 VALUES(?, ?, ?, ?)
+		 ON CONFLICT(scope_key) DO UPDATE SET
+			source   = excluded.source,
+			as_of    = excluded.as_of,
+			subjects = excluded.subjects`,
+		scopeKey, source, rfc3339(asOf), string(data),
+	)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: save prior subjects: %w", err)
+	}
+	return nil
+}
+
+// retractSubject emits an absence observation into the log (making the
+// retraction permanently visible in the history stream per ADR-022 §4) and
+// removes the subject from its current-state projection.
+func retractSubject(ctx context.Context, tx *sql.Tx, subject, source string, pattern types.ClaimScopePattern, asOf time.Time) error {
+	if err := appendAbsenceLog(ctx, tx, subject, source, asOf); err != nil {
+		return err
+	}
+	if pattern.Entity != nil {
+		return retractEntityProjection(ctx, tx, subject, source)
+	}
+	return retractEdgeProjection(ctx, tx, subject, source)
+}
+
+// appendAbsenceLog writes a single absence observation to eg_observation_log so
+// that source-closure events are permanently visible in the history stream
+// (ADR-022 §4 / AC4).
+func appendAbsenceLog(ctx context.Context, tx *sql.Tx, subject, source string, asOf time.Time) error {
+	hash, err := payloadHash(map[string]interface{}{})
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO eg_payload_content(payload_hash, payload) VALUES(?, '{}')`, hash,
+	); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: insert absence payload: %w", err)
+	}
+	sc := resolveSourceClass(source)
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO eg_observation_log
+			(subject, source, source_class, observed_at, recorded_at, kind, confidence, claim_scope_key, payload_hash, tenant_path)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, '', ?, '')`,
+		subject, source, string(sc),
+		rfc3339(asOf), rfc3339(asOf),
+		string(types.ObservationKindAbsence), string(types.ConfidenceHigh),
+		hash,
+	)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: append absence log for %q: %w", subject, err)
+	}
+	return nil
+}
+
+// retractEntityProjection removes a source's assertion of an entity from the
+// current-state table and rebuilds the entity index for the subject.
+func retractEntityProjection(ctx context.Context, tx *sql.Tx, subject, source string) error {
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM eg_entity_current WHERE subject = ? AND source = ?`, subject, source,
+	); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: delete entity current for retraction: %w", err)
+	}
+	return rebuildEntityIndex(ctx, tx, subject)
+}
+
+// retractEdgeProjection removes an edge from eg_edge_projection.
+func retractEdgeProjection(ctx context.Context, tx *sql.Tx, subject, source string) error {
+	edgeType, fromSubject, toSubject, err := parseEdgeSubject(subject)
+	if err != nil {
+		return fmt.Errorf("entitygraph/sqlite: parse edge subject for retraction: %w", err)
+	}
+	key := edgeProjectionKey(fromSubject, edgeType, toSubject, source)
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM eg_edge_projection WHERE edge_key = ?`, key,
+	); err != nil {
+		return fmt.Errorf("entitygraph/sqlite: delete edge projection for retraction: %w", err)
+	}
+	return nil
+}

--- a/pkg/entitygraph/providers/sqlite/edges.go
+++ b/pkg/entitygraph/providers/sqlite/edges.go
@@ -44,8 +44,21 @@ func parseEdgeSubject(subject string) (edgeType, fromSubject, toSubject string, 
 // updateEdgeProjection is the "edge" subject-kind projection updater registered
 // via init(). It upserts the per-source edge projection row and materializes
 // placeholder nodes in eg_entity_index for any referenced EID that has no
-// prior observation (ADR-022 §2).
+// prior observation (ADR-022 §2). Absence observations retract the edge.
 func updateEdgeProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, logSeq int64) error {
+	if obs.Kind == types.ObservationKindAbsence {
+		edgeType, fromSubject, toSubject, err := parseEdgeSubject(obs.Subject)
+		if err != nil {
+			return nil // non-edge subject in absence — skip
+		}
+		key := edgeProjectionKey(fromSubject, edgeType, toSubject, obs.Source)
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM eg_edge_projection WHERE edge_key = ?`, key,
+		); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: delete edge projection for absence: %w", err)
+		}
+		return nil
+	}
 	edgeType, fromSubject, toSubject, err := parseEdgeSubject(obs.Subject)
 	if err != nil {
 		return err

--- a/pkg/entitygraph/providers/sqlite/entity_reads.go
+++ b/pkg/entitygraph/providers/sqlite/entity_reads.go
@@ -384,9 +384,54 @@ func (p *SQLiteEntityGraphProvider) GetDriftState(_ context.Context, _ interface
 	return nil, interfaces.ErrNotImplemented
 }
 
-// GetHistory is implemented by a later story.
-func (p *SQLiteEntityGraphProvider) GetHistory(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
-	return nil, interfaces.ErrNotImplemented
+// GetHistory returns the versioned observation log for a subject over a time
+// range in ascending sequence order. Both state and absence observations are
+// included so that source-closure events are visible in the history stream.
+func (p *SQLiteEntityGraphProvider) GetHistory(ctx context.Context, eid interfaces.EIDRef, r interfaces.TimeRange) ([]*interfaces.ObservationRecord, error) {
+	subject := eid.String()
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT l.id, l.source, l.observed_at, l.recorded_at, l.kind, l.confidence, p.payload
+		 FROM eg_observation_log l
+		 JOIN eg_payload_content p ON p.payload_hash = l.payload_hash
+		 WHERE l.subject = ? AND l.observed_at >= ? AND l.observed_at <= ?
+		 ORDER BY l.id ASC`,
+		subject, rfc3339(r.From), rfc3339(r.To),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: get history: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var records []*interfaces.ObservationRecord
+	for rows.Next() {
+		var id int64
+		var source, observedAt, recordedAt, kind, confidence, payloadJSON string
+		if err := rows.Scan(&id, &source, &observedAt, &recordedAt, &kind, &confidence, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan history row: %w", err)
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			payload = map[string]interface{}{}
+		}
+		oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+		ra, _ := time.Parse(time.RFC3339Nano, recordedAt)
+		records = append(records, &interfaces.ObservationRecord{
+			Observation: types.Observation{
+				Source:     source,
+				ObservedAt: oa,
+				RecordedAt: ra,
+				Subject:    subject,
+				Kind:       types.ObservationKind(kind),
+				Confidence: types.Confidence(confidence),
+				Payload:    payload,
+			},
+			Version: id,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate history: %w", err)
+	}
+	return records, nil
 }
 
 // Diff is implemented by a later story.

--- a/pkg/entitygraph/providers/sqlite/observations.go
+++ b/pkg/entitygraph/providers/sqlite/observations.go
@@ -54,8 +54,11 @@ func rfc3339(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }
 // observation is content-hash-deduped, appended to the observation log, and
 // projected into the current-state and index tables — all within a single
 // transaction so a partial batch never leaves torn projections.
+//
+// When ClaimScopes is non-empty the provider also diffs the current enumeration
+// against the prior-assertion set and retracts missing subjects (ADR-022 §4).
 func (p *SQLiteEntityGraphProvider) ReportObservations(ctx context.Context, batch interfaces.ObservationBatch) error {
-	if len(batch.Observations) == 0 {
+	if len(batch.Observations) == 0 && len(batch.ClaimScopes) == 0 {
 		return nil
 	}
 
@@ -133,6 +136,12 @@ func (p *SQLiteEntityGraphProvider) ReportObservations(ctx context.Context, batc
 		}
 	}
 
+	if len(batch.ClaimScopes) > 0 {
+		if err := processClaimScopes(ctx, tx, batch.Source, batch.ClaimScopes, batch.Observations); err != nil {
+			return err
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("entitygraph/sqlite: commit: %w", err)
 	}
@@ -142,7 +151,16 @@ func (p *SQLiteEntityGraphProvider) ReportObservations(ctx context.Context, batc
 // updateEntityProjection is the "entity" subject-kind projection updater. It
 // upserts the current-state row for (subject, source) with the new log
 // sequence and rebuilds the entity index from all current sources.
+// Absence observations retract the source's assertion instead of upserting.
 func updateEntityProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, logSeq int64) error {
+	if obs.Kind == types.ObservationKindAbsence {
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM eg_entity_current WHERE subject = ? AND source = ?`, obs.Subject, obs.Source,
+		); err != nil {
+			return fmt.Errorf("entitygraph/sqlite: delete entity current for absence: %w", err)
+		}
+		return rebuildEntityIndex(ctx, tx, obs.Subject)
+	}
 	hash, err := payloadHash(obs.Payload)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Implements ADR-022 §4 claim-scope diff-on-enumeration for SQLite and PostgreSQL providers: prior subjects absent from the new batch are retracted via `absence` observations written to `eg_observation_log`, making source-closure events permanently visible in history
- `GetHistory` implemented in both providers (replaces `ErrNotImplemented`), reading all observation kinds (state + absence) in ascending sequence order over a time range
- `RebuildProjections` (database) and `updateEntityProjection`/`updateEdgeProjection` (both providers) updated to handle absence observations correctly, so a full log replay produces identical state after retraction
- 4 new `RunEntityGraphContractTests` subtests (`ClaimScopeEntityReplace`, `ClaimScopeEdgeReplace`, `ClaimScopeOverlapRejected`, `SourceClosure`) cover all 4 story ACs against the shared harness

## Test plan

- [ ] `TestSQLiteEntityGraphProvider_ContractSuite/ClaimScopeEntityReplace` — entity scope retraction, other sources untouched
- [ ] `TestSQLiteEntityGraphProvider_ContractSuite/ClaimScopeEdgeReplace` — edge scope retraction via edge projection diff
- [ ] `TestSQLiteEntityGraphProvider_ContractSuite/ClaimScopeOverlapRejected` — overlapping scope key from same source → error
- [ ] `TestSQLiteEntityGraphProvider_ContractSuite/SourceClosure` — empty enumeration retracts all, absence visible in `GetHistory`
- [ ] `TestDatabaseEntityGraphProvider_ContractSuite` — same 4 subtests against PostgreSQL (runs in CI with live DB)
- [ ] `make test-agent-complete` passes (lint, cross-platform build, all unit + integration tests)
- [ ] `make check-architecture` — no central provider violations
- [ ] story-review workflow: passed (1 round, 0 fix rounds, 0 findings across code/tests/security)

Fixes #2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)