### PR TITLE
entitygraph: ConfigStore desired-state observation internal writer (Issue #2879)

### DIFF
--- a/features/controller/api/handlers_push.go
+++ b/features/controller/api/handlers_push.go
@@ -17,10 +17,19 @@ import (
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	egtypes "github.com/cfgis/cfgms/pkg/entitygraph/types"
+	configstorewriter "github.com/cfgis/cfgms/pkg/entitygraph/writers/configstore"
 	"github.com/cfgis/cfgms/pkg/fleet/selector"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
+
+// egConfigstoreIngestor is the narrow interface the config-push handler needs
+// to record desired-state observations into the entity graph after a push is
+// accepted. *configstorewriter.Writer satisfies it.
+type egConfigstoreIngestor interface {
+	Ingest(ctx context.Context, rev configstorewriter.ConfigRevision, eids []egtypes.EID) error
+}
 
 // leaderStatus is the minimal interface the config-push handler needs from the
 // HA manager. *ha.Manager satisfies it automatically; test doubles use stubLeaderStatus.
@@ -136,6 +145,34 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 
 	pushID := fmt.Sprintf("push-%d", time.Now().UnixNano())
 	queuedAt := time.Now().UTC()
+
+	// Write desired-state observations for every targeted steward into the
+	// entity graph so that GetDesiredState reflects the new config revision
+	// before the fan-out completes (ADR-022 §6). Best-effort: a failure here
+	// does not block the push — the fan-out and audit are more critical.
+	if s.egConfigstoreWriter != nil {
+		eids := make([]egtypes.EID, 0, len(targeted))
+		for _, st := range targeted {
+			if eid, eidErr := egtypes.NewEID("cfgms", "controller", st.ID); eidErr == nil {
+				eids = append(eids, eid)
+			}
+		}
+		egRev := configstorewriter.ConfigRevision{
+			ConfigID: cfg.ConfigID,
+			Revision: cfg.Version,
+			TenantID: cfg.TenantID,
+			DesiredState: map[string]interface{}{
+				"policies": cfg.Policies,
+				"modules":  cfg.Modules,
+			},
+		}
+		if err := s.egConfigstoreWriter.Ingest(r.Context(), egRev, eids); err != nil {
+			s.logger.Warn("Failed to ingest desired-state observations into entity graph",
+				"push_id", pushID,
+				"error", err,
+			)
+		}
+	}
 
 	s.emitConfigPushAudit(r, cfg.TenantID, cfg.ConfigID, pushID)
 

--- a/features/controller/api/handlers_push_test.go
+++ b/features/controller/api/handlers_push_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +31,9 @@ import (
 	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	sqliteprovider "github.com/cfgis/cfgms/pkg/entitygraph/providers/sqlite"
+	egtypes "github.com/cfgis/cfgms/pkg/entitygraph/types"
+	configstorewriter "github.com/cfgis/cfgms/pkg/entitygraph/writers/configstore"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -419,6 +423,83 @@ func TestHandleConfigPush_FanoutToActiveStewards(t *testing.T) {
 	cp.wg.Wait()
 
 	assert.ElementsMatch(t, []string{stewardID}, cp.ReceivedIDs())
+}
+
+// newConfigStoreWriterProvider builds a real SQLite-backed entity-graph provider
+// and a real configstore.Writer over it, wires the writer into the server via
+// SetConfigStoreWriter, and returns the provider so the test can query it. No
+// mocks: the writer records desired-state observations into a live SQLite store.
+func newConfigStoreWriterProvider(t *testing.T, server *Server) *sqliteprovider.SQLiteEntityGraphProvider {
+	t.Helper()
+	p, err := sqliteprovider.NewSQLiteEntityGraphProvider(filepath.Join(t.TempDir(), "eg.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	w, err := configstorewriter.New(p)
+	require.NoError(t, err)
+	server.SetConfigStoreWriter(w)
+	return p
+}
+
+// TestHandleConfigPush_ConfigStoreWriterIngestsDesiredState verifies the happy
+// path of the egConfigstoreWriter block: with a real SQLite-backed writer wired
+// via SetConfigStoreWriter, a successful push records a desired-state observation
+// for each targeted steward's EID, retrievable via GetDesiredState with the
+// config revision carried by the push.
+func TestHandleConfigPush_ConfigStoreWriterIngestsDesiredState(t *testing.T) {
+	server := setupTestServer(t)
+	server.pushLeaderStatus = nil // leader
+
+	p := newConfigStoreWriterProvider(t, server)
+
+	payload := validPushPayload()
+	stewardID := registerActiveSteward(t, server.controllerService, "eg-ingest-dna-1", payload.TenantID)
+
+	req := withScopedPrincipal(newPushRequest(t, payload), payload.TenantID)
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Ingest is synchronous (runs before the 202 response), so the desired-state
+	// observation is already durable in the entity graph for the targeted steward.
+	eid, err := egtypes.NewEID("cfgms", "controller", stewardID)
+	require.NoError(t, err)
+
+	ds, err := p.GetDesiredState(context.Background(), eid)
+	require.NoError(t, err)
+	require.NotNil(t, ds, "desired-state observation must be recorded for the targeted steward")
+	assert.Equal(t, payload.Version, ds.ConfigRevision,
+		"desired-state ConfigRevision must match the pushed config version")
+}
+
+// TestHandleConfigPush_ConfigStoreWriterFailureDoesNotBlock verifies the
+// best-effort error path: when the wired writer's Ingest fails, the failure is
+// swallowed (logged as a warning) and the push still returns 202 Accepted. The
+// failure is produced by a real closed-store provider, not a mock.
+func TestHandleConfigPush_ConfigStoreWriterFailureDoesNotBlock(t *testing.T) {
+	server := setupTestServer(t)
+	server.pushLeaderStatus = nil // leader
+
+	p, err := sqliteprovider.NewSQLiteEntityGraphProvider(filepath.Join(t.TempDir(), "eg.db"))
+	require.NoError(t, err)
+	w, err := configstorewriter.New(p)
+	require.NoError(t, err)
+	// Close the underlying store so every Ingest attempt fails against a real,
+	// non-mock provider whose database connection is gone.
+	require.NoError(t, p.Close())
+	server.SetConfigStoreWriter(w)
+
+	payload := validPushPayload()
+	registerActiveSteward(t, server.controllerService, "eg-fail-dna-1", payload.TenantID)
+
+	req := withScopedPrincipal(newPushRequest(t, payload), payload.TenantID)
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+
+	// The Ingest failure must not block the push.
+	require.Equal(t, http.StatusAccepted, rec.Code)
 }
 
 // TestHandleConfigPush_PersistenceRecord verifies that a successful push request

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -146,6 +146,7 @@ type Server struct {
 	webAuthnPresenceSessions       sync.Map                              // Issue #2784: pending presence-assertion sessions; key=principalID, value=*webAuthnPendingSession
 	presenceTokens                 sync.Map                              // Issue #2784: short-lived single-use presence tokens; key=tokenHash, value=*presenceTokenRecord
 	telemetryHandler               http.Handler                          // Issue #2765: telemetry fan-out WebSocket handler
+	egConfigstoreWriter            egConfigstoreIngestor                 // Issue #2879: desired-state entity-graph internal writer (nil = disabled)
 }
 
 // SetDraining implements cluster.DrainHealthRegistrar. When draining is true,
@@ -1169,6 +1170,15 @@ func (s *Server) SetModuleBundleReviewer(r resolution.BundleReviewer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.moduleBundleReviewer = r
+}
+
+// SetConfigStoreWriter wires the ConfigStore → desired-state entity-graph writer
+// (Issue #2879). When set, handleConfigPush records desired-state observations
+// for every targeted steward immediately on push acceptance.
+func (s *Server) SetConfigStoreWriter(w egConfigstoreIngestor) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.egConfigstoreWriter = w
 }
 
 // getHTTPListenAddr determines the HTTP listen address with the

--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -68,6 +68,7 @@ func RunEntityGraphContractTests(t *testing.T, factory EntityGraphProviderFactor
 	t.Run("DriftStateRoundTrip", func(t *testing.T) { testEGDriftStateRoundTrip(t, factory) })             // AC 2+3
 	t.Run("DriftLifecycleTransition", func(t *testing.T) { testEGDriftLifecycle(t, factory) })             // AC 4
 	t.Run("DriftProjectionRebuildRecovery", func(t *testing.T) { testEGDriftRebuildRecovery(t, factory) }) // AC 4 + AC 7
+	t.Run("DesiredStateIsolation", func(t *testing.T) { testEGDesiredStateIsolation(t, factory) })         // AC 5 (isolation)
 }
 
 // --- Contract test helpers ---
@@ -429,6 +430,109 @@ func testEGDriftRebuildRecovery(t *testing.T, factory EntityGraphProviderFactory
 	require.Len(t, after.Fields, 1, "drift fields must survive rebuild")
 	assert.Equal(t, "state", after.Fields[0].Attribute)
 	assert.False(t, after.Fields[0].Matching)
+}
+
+// testEGDesiredStateIsolation verifies that desired-state observations are fully
+// isolated from the entity view and entity index and that the isolation survives
+// a projection rebuild. This locks down four provider code paths that would
+// otherwise be untested:
+//
+//  1. the GetEntity current-row query filter that excludes kind='desired-state'
+//     rows (queryCurrentRows / eg_entity_current read);
+//  2. the updateEntityProjection early return that folds a desired-state row into
+//     eg_entity_current for dedup but skips the entity-index rebuild;
+//  3. the rebuildEntityIndex query filter (kind != 'desired-state') — exercised
+//     because the desired-state row is ingested *before* the state observation,
+//     so it is already present in eg_entity_current when the later state
+//     observation triggers an index rebuild;
+//  4. the RebuildProjections desired-state replay branch — after corruption the
+//     log is replayed and the desired-state row must fold into current without
+//     polluting the rebuilt index.
+//
+// GetDesiredState (which reads the log directly) must continue to surface the
+// record throughout. ADR-022 §6 / ADR-023 §3.
+func testEGDesiredStateIsolation(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+	eid := egEID(t, "host:ds-iso-auth/ent1")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// 1. Ingest a desired-state observation FIRST, before any state observation.
+	//    This forces the ordering where a desired-state row is already resident in
+	//    eg_entity_current when the later state observation rebuilds the index —
+	//    the exact scenario the rebuildEntityIndex filter must survive.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "config:rev-ds-1",
+		Observations: []types.Observation{{
+			Source:     "config:rev-ds-1",
+			ObservedAt: now,
+			RecordedAt: now,
+			Subject:    eid.String(),
+			Kind:       types.ObservationKindDesiredState,
+			Confidence: types.ConfidenceHigh,
+			Payload: map[string]interface{}{
+				"config_revision": "rev-ds-1",
+				"poison_key":      "must-not-appear",
+				"hostname":        "desired-not-actual",
+				"policies":        map[string]interface{}{"enforce_firewall": true},
+			},
+		}},
+	}))
+
+	// 2. Report a real state observation for the same subject. Its projection
+	//    upsert is followed by an entity-index rebuild that reads every current
+	//    row for the subject — including the desired-state row from step 1.
+	egReport(ctx, t, p, "observer:test", eid.String(), map[string]interface{}{
+		"entity_kind":   "host",
+		"hostname":      "web01",
+		"owning_tenant": "root/ds-iso",
+	})
+
+	// assertIsolated checks the invariants that must hold both before and after a
+	// projection rebuild.
+	assertIsolated := func(t *testing.T, phase string) {
+		t.Helper()
+		view, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{TenantFilter: "root/ds-iso"})
+		require.NoError(t, err, "%s: GetEntity", phase)
+		require.NotNil(t, view)
+
+		// The desired-state source must not appear in the entity view sources.
+		for _, src := range view.Sources {
+			assert.NotEqual(t, types.ObservationKindDesiredState, src.Kind,
+				"%s: desired-state observation must not appear in entity Sources", phase)
+		}
+		// The desired-state-only payload key must not contaminate merged attributes
+		// or the entity index, and the state observation's hostname must win.
+		_, hasPoison := view.Entity.Attributes["poison_key"]
+		assert.False(t, hasPoison,
+			"%s: desired-state payload key must not appear in merged entity attributes", phase)
+		assert.Equal(t, "web01", view.Entity.Attributes["hostname"],
+			"%s: hostname must come from the state observation, not the desired-state row", phase)
+
+		// GetDesiredState must still surface the desired-state record from the log.
+		ds, err := p.GetDesiredState(ctx, eid)
+		require.NoError(t, err, "%s: GetDesiredState", phase)
+		require.NotNil(t, ds, "%s: GetDesiredState must return the desired-state record", phase)
+		assert.Equal(t, "rev-ds-1", ds.ConfigRevision, "%s: ConfigRevision", phase)
+		_, hasRev := ds.State["config_revision"]
+		assert.False(t, hasRev, "%s: config_revision must be stripped from State", phase)
+	}
+
+	assertIsolated(t, "pre-rebuild")
+
+	// 3. Corrupt the derived projections and rebuild from the log. The replay must
+	//    fold the desired-state row into current without rebuilding the index from
+	//    it, and the state row's index rebuild must again exclude the desired-state
+	//    row. Providers without a corruption hook still validate rebuild idempotency.
+	if c, ok := p.(corruptibleProvider); ok {
+		require.NoError(t, c.CorruptProjectionsForTesting(ctx))
+		_, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{TenantFilter: "root/ds-iso"})
+		require.Error(t, err, "entity must be unreachable after projection corruption")
+	}
+	require.NoError(t, p.RebuildProjections(ctx))
+
+	assertIsolated(t, "post-rebuild")
 }
 
 // testEGResolveIdentity verifies identity-claim resolution to EIDs (AC 8).

--- a/pkg/entitygraph/providers/database/entity_reads.go
+++ b/pkg/entitygraph/providers/database/entity_reads.go
@@ -126,7 +126,7 @@ func (p *DatabaseEntityGraphProvider) queryCurrentRows(ctx context.Context, subj
 		query = `SELECT c.source, c.source_class, c.kind, c.confidence, c.observed_at, c.recorded_at, c.payload_hash, p.payload_json
 			 FROM eg_entity_current c
 			 JOIN eg_payload_content p ON p.content_hash = c.payload_hash
-			 WHERE c.subject = $1`
+			 WHERE c.subject = $1 AND c.kind != 'desired-state'`
 		if tenantFilter != "" {
 			query += ` AND (c.tenant_path = $2 OR c.tenant_path LIKE $3)`
 			args = append(args, tenantFilter, tenantFilter+"/%")
@@ -136,7 +136,7 @@ func (p *DatabaseEntityGraphProvider) queryCurrentRows(ctx context.Context, subj
 		query = `SELECT DISTINCT ON (l.source) l.source, l.source_class, l.kind, l.confidence, l.observed_at, l.recorded_at, l.payload_hash, p.payload_json
 			 FROM eg_observation_log l
 			 JOIN eg_payload_content p ON p.content_hash = l.payload_hash
-			 WHERE l.subject = $1 AND l.observed_at <= $2`
+			 WHERE l.subject = $1 AND l.observed_at <= $2 AND l.kind != 'desired-state'`
 		args = append(args, asOf.UTC().Format(time.RFC3339Nano))
 		if tenantFilter != "" {
 			query += ` AND (l.tenant_path = $3 OR l.tenant_path LIKE $4)`
@@ -433,6 +433,30 @@ func (p *DatabaseEntityGraphProvider) RebuildProjections(ctx context.Context) er
 			}
 			if err := rebuildEntityIndex(ctx, tx, lr.subject); err != nil {
 				return fmt.Errorf("entitygraph/database: rebuild index seq %d: %w", lr.id, err)
+			}
+			continue
+		}
+		if lr.kind == string(types.ObservationKindDesiredState) {
+			// Desired-state: fold into eg_entity_current for dedup tracking but do
+			// not rebuild the entity index — desired-state payloads must not pollute
+			// the merged attribute set or identity columns.
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO eg_entity_current
+					(subject, source, source_class, kind, confidence, observed_at, recorded_at, payload_hash, tenant_path, log_seq)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+				 ON CONFLICT (subject, source) DO UPDATE SET
+					source_class = EXCLUDED.source_class,
+					kind         = EXCLUDED.kind,
+					confidence   = EXCLUDED.confidence,
+					observed_at  = EXCLUDED.observed_at,
+					recorded_at  = EXCLUDED.recorded_at,
+					payload_hash = EXCLUDED.payload_hash,
+					tenant_path  = EXCLUDED.tenant_path,
+					log_seq      = EXCLUDED.log_seq`,
+				lr.subject, lr.source, lr.sourceClass, lr.kind, lr.confidence,
+				lr.observedAt, lr.recordedAt, lr.payloadHash, lr.tenantPath, lr.id,
+			); err != nil {
+				return fmt.Errorf("entitygraph/database: replay desired-state seq %d: %w", lr.id, err)
 			}
 			continue
 		}

--- a/pkg/entitygraph/providers/database/observations.go
+++ b/pkg/entitygraph/providers/database/observations.go
@@ -210,12 +210,17 @@ func (p *DatabaseEntityGraphProvider) ReportObservations(ctx context.Context, ba
 // updateEntityProjection rebuilds the entity index row for the observation's
 // subject from the merged current state. Registered for the "entity" subject
 // kind. Drift-diff and lifecycle observations route to eg_drift_projection.
+// Desired-state observations project to eg_entity_current for dedup but must
+// not contribute to the entity index.
 func updateEntityProjection(ctx context.Context, tx *sql.Tx, obs types.Observation, _ int64) error {
 	if obs.Kind == types.ObservationKindDriftDiff {
 		return updateDriftProjectionFromObservation(ctx, tx, obs)
 	}
 	if obs.Kind == types.ObservationKindLifecycle {
 		return applyLifecycleTransitionFromObs(ctx, tx, obs)
+	}
+	if obs.Kind == types.ObservationKindDesiredState {
+		return nil
 	}
 	return rebuildEntityIndex(ctx, tx, obs.Subject)
 }
@@ -229,7 +234,7 @@ func rebuildEntityIndex(ctx context.Context, tx *sql.Tx, subject string) error {
 		`SELECT c.source, c.source_class, c.observed_at, c.payload_hash, p.payload_json
 		 FROM eg_entity_current c
 		 JOIN eg_payload_content p ON p.content_hash = c.payload_hash
-		 WHERE c.subject = $1`, subject)
+		 WHERE c.subject = $1 AND c.kind != 'desired-state'`, subject)
 	if err != nil {
 		return fmt.Errorf("entitygraph/database: read current state: %w", err)
 	}

--- a/pkg/entitygraph/providers/sqlite/entity_reads.go
+++ b/pkg/entitygraph/providers/sqlite/entity_reads.go
@@ -60,7 +60,7 @@ func (p *SQLiteEntityGraphProvider) GetEntity(ctx context.Context, eid interface
 		`SELECT c.source, c.source_class, c.kind, c.confidence, c.observed_at, c.recorded_at, c.payload_hash, p.payload
 		 FROM eg_entity_current c
 		 JOIN eg_payload_content p ON p.payload_hash = c.payload_hash
-		 WHERE c.subject = ?`,
+		 WHERE c.subject = ? AND c.kind != 'desired-state'`,
 		subject,
 	)
 	if err != nil {

--- a/pkg/entitygraph/providers/sqlite/observations.go
+++ b/pkg/entitygraph/providers/sqlite/observations.go
@@ -194,6 +194,13 @@ func updateEntityProjection(ctx context.Context, tx *sql.Tx, obs types.Observati
 		return fmt.Errorf("entitygraph/sqlite: upsert current: %w", err)
 	}
 
+	// Desired-state observations project to eg_entity_current for content-hash
+	// dedup (so re-ingesting an identical revision is a no-op) but must not
+	// contribute to the entity index — GetDesiredState reads the log directly.
+	if obs.Kind == types.ObservationKindDesiredState {
+		return nil
+	}
+
 	return rebuildEntityIndex(ctx, tx, obs.Subject)
 }
 
@@ -207,7 +214,7 @@ func rebuildEntityIndex(ctx context.Context, tx *sql.Tx, subject string) error {
 		`SELECT c.source, c.source_class, c.observed_at, c.payload_hash, p.payload
 		 FROM eg_entity_current c
 		 JOIN eg_payload_content p ON p.payload_hash = c.payload_hash
-		 WHERE c.subject = ?`,
+		 WHERE c.subject = ? AND c.kind != 'desired-state'`,
 		subject,
 	)
 	if err != nil {

--- a/pkg/entitygraph/types/observation.go
+++ b/pkg/entitygraph/types/observation.go
@@ -22,6 +22,15 @@ const (
 	// Tagged by actor rather than a source provenance class; appears distinctly
 	// in GetHistory alongside state and drift-diff observations.
 	ObservationKindLifecycle ObservationKind = "lifecycle"
+
+	// ObservationKindDesiredState is written by the ConfigStore internal writer
+	// (ADR-022 §6) when a config revision is pushed to a set of entities. Each
+	// entity receives one desired-state observation per push; GetDesiredState
+	// reads the most-recent such observation from the log. Desired-state
+	// observations project into eg_entity_current for content-hash dedup but are
+	// excluded from entity-state views and the entity index so they do not
+	// contaminate the merged attribute set.
+	ObservationKindDesiredState ObservationKind = "desired-state"
 )
 
 // Confidence is the producer-declared confidence level for an observation.

--- a/pkg/entitygraph/writers/configstore/writer.go
+++ b/pkg/entitygraph/writers/configstore/writer.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package configstore implements the ConfigStore → desired-state entity-graph
+// internal writer (ADR-022 §6). It is one of the three internal writers named
+// in ADR-022 §9.
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// ConfigRevision describes the desired state captured by a single config push.
+// It is defined here (not imported from features/) to preserve the import
+// direction rule: pkg/ must never import features/.
+type ConfigRevision struct {
+	// ConfigID is the configuration document identifier.
+	ConfigID string
+	// Revision is the version string that labels the desired-state observation.
+	// The source written to the entity graph will be "config:<Revision>".
+	Revision string
+	// TenantID is the tenant this configuration targets.
+	TenantID string
+	// DesiredState carries the attribute payload recorded per entity. The key
+	// "config_revision" is reserved; the writer injects it automatically.
+	DesiredState map[string]interface{}
+}
+
+// Writer is the ConfigStore → desired-state entity-graph internal writer.
+// It translates a config push event into ReportObservations calls, writing
+// ObservationKindDesiredState observations sourced as "config:<revision>" for
+// each addressed entity (ADR-022 §6).
+type Writer struct {
+	provider interfaces.EntityGraphProvider
+}
+
+// New returns a Writer backed by provider. provider must not be nil.
+func New(provider interfaces.EntityGraphProvider) (*Writer, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("configstore/writer: provider must not be nil")
+	}
+	return &Writer{provider: provider}, nil
+}
+
+// Ingest writes a desired-state observation for each EID in eids, sourced from
+// "config:<rev.Revision>".
+//
+// Sparse population (AC3): EIDs not yet registered in the entity graph are
+// written unconditionally. GetDesiredState queries the observation log directly,
+// so the desired-state record is accessible even before the entity appears in
+// the entity index.
+//
+// Idempotency (AC4): re-ingesting an identical revision for a known EID
+// produces no new log row — the underlying provider's content-hash dedup
+// mechanism silently skips bit-identical observations.
+//
+// If eids is empty the call is a no-op and returns nil.
+func (w *Writer) Ingest(ctx context.Context, rev ConfigRevision, eids []types.EID) error {
+	if len(eids) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	source := "config:" + rev.Revision
+
+	// Build the shared payload. All targeted entities receive the same
+	// desired-state record for this revision; config_revision is injected so
+	// GetDesiredState can surface it via ConfigRevision on DesiredStateView.
+	payload := make(map[string]interface{}, len(rev.DesiredState)+1)
+	for k, v := range rev.DesiredState {
+		payload[k] = v
+	}
+	payload["config_revision"] = rev.Revision
+
+	observations := make([]types.Observation, len(eids))
+	for i, eid := range eids {
+		observations[i] = types.Observation{
+			Source:     source,
+			ObservedAt: now,
+			RecordedAt: now,
+			Subject:    eid.String(),
+			Kind:       types.ObservationKindDesiredState,
+			Confidence: types.ConfidenceHigh,
+			Payload:    payload,
+		}
+	}
+
+	return w.provider.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source:       source,
+		Observations: observations,
+	})
+}

--- a/pkg/entitygraph/writers/configstore/writer_test.go
+++ b/pkg/entitygraph/writers/configstore/writer_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package configstore_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	sqliteprovider "github.com/cfgis/cfgms/pkg/entitygraph/providers/sqlite"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/cfgis/cfgms/pkg/entitygraph/writers/configstore"
+)
+
+func newTestProvider(t *testing.T) *sqliteprovider.SQLiteEntityGraphProvider {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "eg.db")
+	p, err := sqliteprovider.NewSQLiteEntityGraphProvider(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func mustEID(t *testing.T, s string) types.EID {
+	t.Helper()
+	eid, err := types.ParseEID(s)
+	require.NoError(t, err)
+	return eid
+}
+
+func baseRev() configstore.ConfigRevision {
+	return configstore.ConfigRevision{
+		ConfigID: "cfg-001",
+		Revision: "v1.2.3",
+		TenantID: "root/msp-a/client-1",
+		DesiredState: map[string]interface{}{
+			"policies": map[string]interface{}{"enforce_firewall": true},
+			"modules":  []interface{}{"firewall", "patch"},
+		},
+	}
+}
+
+// TestAC1_DesiredStateObservationPerEID verifies that Ingest writes a
+// desired-state observation to the entity graph for each targeted EID.
+func TestAC1_DesiredStateObservationPerEID(t *testing.T) {
+	p := newTestProvider(t)
+	w, err := configstore.New(p)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	eid1 := mustEID(t, "cfgms:controller/steward-aaa")
+	eid2 := mustEID(t, "cfgms:controller/steward-bbb")
+	rev := baseRev()
+
+	require.NoError(t, w.Ingest(ctx, rev, []types.EID{eid1, eid2}))
+
+	// Verify via GetHistory that both EIDs have exactly one desired-state record.
+	wide := interfaces.TimeRange{
+		From: time.Unix(0, 0).UTC(),
+		To:   time.Now().UTC().Add(time.Hour),
+	}
+	for _, eid := range []types.EID{eid1, eid2} {
+		records, err := p.GetHistory(ctx, eid, wide)
+		require.NoError(t, err)
+		var dsCount int
+		for _, rec := range records {
+			if rec.Observation.Kind == types.ObservationKindDesiredState {
+				dsCount++
+			}
+		}
+		require.Equal(t, 1, dsCount, "EID %s must have exactly one desired-state log row", eid)
+	}
+}
+
+// TestAC2_GetDesiredStateReturnsCorrectRevision verifies that GetDesiredState
+// returns the config-revision label and desired-state attributes after Ingest.
+func TestAC2_GetDesiredStateReturnsCorrectRevision(t *testing.T) {
+	p := newTestProvider(t)
+	w, err := configstore.New(p)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	eid := mustEID(t, "cfgms:controller/steward-ccc")
+	rev := baseRev()
+
+	require.NoError(t, w.Ingest(ctx, rev, []types.EID{eid}))
+
+	ds, err := p.GetDesiredState(ctx, eid)
+	require.NoError(t, err)
+	require.NotNil(t, ds, "GetDesiredState must return non-nil after Ingest")
+
+	require.Equal(t, rev.Revision, ds.ConfigRevision,
+		"ConfigRevision must match the ingested revision label")
+	require.False(t, ds.ObservedAt.IsZero(), "ObservedAt must be set")
+
+	// config_revision must be stripped from State (it is a reserved key).
+	_, hasRev := ds.State["config_revision"]
+	require.False(t, hasRev, "config_revision must not appear in State")
+
+	// The custom desired-state attributes must be present.
+	policies, ok := ds.State["policies"]
+	require.True(t, ok, "policies attribute must be in State")
+	require.NotNil(t, policies)
+}
+
+// TestAC3_EmptyEIDsIsNoop verifies that Ingest with an empty EID slice returns
+// nil and writes no observations (sparse population — no panic or error).
+func TestAC3_EmptyEIDsIsNoop(t *testing.T) {
+	p := newTestProvider(t)
+	w, err := configstore.New(p)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, w.Ingest(ctx, baseRev(), nil))
+	require.NoError(t, w.Ingest(ctx, baseRev(), []types.EID{}))
+}
+
+// TestAC4_IdenticalRevisionProducesNoDuplicate verifies that re-ingesting the
+// same (revision, EID) pair does not append a second log row (content-hash dedup).
+func TestAC4_IdenticalRevisionProducesNoDuplicate(t *testing.T) {
+	p := newTestProvider(t)
+	w, err := configstore.New(p)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	eid := mustEID(t, "cfgms:controller/steward-ddd")
+	rev := baseRev()
+
+	require.NoError(t, w.Ingest(ctx, rev, []types.EID{eid}))
+	require.NoError(t, w.Ingest(ctx, rev, []types.EID{eid})) // bit-identical → dedup
+
+	wide := interfaces.TimeRange{
+		From: time.Unix(0, 0).UTC(),
+		To:   time.Now().UTC().Add(time.Hour),
+	}
+	records, err := p.GetHistory(ctx, eid, wide)
+	require.NoError(t, err)
+
+	var dsCount int
+	for _, rec := range records {
+		if rec.Observation.Kind == types.ObservationKindDesiredState {
+			dsCount++
+		}
+	}
+	require.Equal(t, 1, dsCount,
+		"bit-identical re-ingest must not append a second desired-state log row")
+}
+
+// TestDesiredStateDoesNotPollutEntityView verifies that after ingesting a
+// desired-state observation for a steward that also has a state observation,
+// GetEntity does not include the desired-state source in its view or attributes.
+func TestDesiredStateDoesNotPollutEntityView(t *testing.T) {
+	p := newTestProvider(t)
+	w, err := configstore.New(p)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	eid := mustEID(t, "cfgms:controller/steward-eee")
+	now := time.Now().UTC()
+
+	// Register the entity with a state observation.
+	stateRev := configstore.ConfigRevision{
+		ConfigID: "c1",
+		Revision: "v1",
+		TenantID: "root/t",
+		DesiredState: map[string]interface{}{
+			"poison_key": "must-not-appear",
+		},
+	}
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "enforcing-module:test",
+		Observations: []types.Observation{{
+			Source:     "enforcing-module:test",
+			ObservedAt: now,
+			RecordedAt: now,
+			Subject:    eid.String(),
+			Kind:       types.ObservationKindState,
+			Confidence: types.ConfidenceHigh,
+			Payload: map[string]interface{}{
+				"entity_kind":   "cfgms",
+				"owning_tenant": "root/t",
+				"hostname":      "ctrl-node",
+			},
+		}},
+	}))
+
+	// Ingest a desired-state observation with a poison key.
+	require.NoError(t, w.Ingest(ctx, stateRev, []types.EID{eid}))
+
+	// GetEntity must not expose the desired-state source or its attributes.
+	view, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+
+	for _, src := range view.Sources {
+		require.NotEqual(t, types.ObservationKindDesiredState, src.Kind,
+			"desired-state observation must not appear in entity Sources")
+	}
+	_, hasPoisonKey := view.Entity.Attributes["poison_key"]
+	require.False(t, hasPoisonKey,
+		"desired-state payload key must not appear in merged entity attributes")
+}
+
+// TestNewWriterNilProvider verifies that New rejects a nil provider.
+func TestNewWriterNilProvider(t *testing.T) {
+	_, err := configstore.New(nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Adds `ObservationKindDesiredState = "desired-state"` to the observation taxonomy (ADR-022 §4)
- Implements `pkg/entitygraph/writers/configstore` — the ConfigStore → desired-state entity-graph internal writer (ADR-022 §6): `Writer.Ingest()` calls `ReportObservations` with `source: config:<revision>` for each targeted EID
- Desired-state observations project into `eg_entity_current` for content-hash dedup (AC4) but are excluded from entity-state views, merged attributes, and the entity index via `kind != 'desired-state'` filters in both the SQLite and database providers
- `RebuildProjections` in the database provider folds desired-state replay rows into `eg_entity_current` without rebuilding the entity index
- Hooks `features/controller/api/handlers_push.go` to call the writer for each targeted steward immediately on push acceptance (best-effort; failure is swallowed so the push is never blocked)

## Test plan

- [x] `TestAC1_DesiredStateObservationPerEID` — Ingest writes one desired-state log row per EID
- [x] `TestAC2_GetDesiredStateReturnsCorrectRevision` — GetDesiredState surfaces correct revision label and strips `config_revision` from State
- [x] `TestAC3_EmptyEIDsIsNoop` — nil/empty EID slice returns nil with no observations written
- [x] `TestAC4_IdenticalRevisionProducesNoDuplicate` — re-ingest with same revision produces no second log row
- [x] `TestDesiredStateDoesNotPollutEntityView` — desired-state payload keys must not appear in GetEntity merged attributes
- [x] `testEGDesiredStateIsolation` contract test covers all 4 provider code paths (entity query filter, projection early-return, index rebuild filter, RebuildProjections replay) for both SQLite and database providers
- [x] `TestHandleConfigPush_ConfigStoreWriterIngestsDesiredState` — handler hook records desired-state for targeted stewards with a real SQLite-backed writer
- [x] `TestHandleConfigPush_ConfigStoreWriterFailureDoesNotBlock` — writer failure against a closed store swallowed; push returns 202

Fixes #2879

🤖 Generated with [Claude Code](https://claude.com/claude-code)