### PR TITLE
entitygraph: temporal reads (Diff/GetTimeline) + same-as collapse-group (sqlite + database) (Issue #2876)

### DIFF
--- a/pkg/entitygraph/interfaces/contract_test.go
+++ b/pkg/entitygraph/interfaces/contract_test.go
@@ -69,6 +69,13 @@ func RunEntityGraphContractTests(t *testing.T, factory EntityGraphProviderFactor
 	t.Run("DriftLifecycleTransition", func(t *testing.T) { testEGDriftLifecycle(t, factory) })             // AC 4
 	t.Run("DriftProjectionRebuildRecovery", func(t *testing.T) { testEGDriftRebuildRecovery(t, factory) }) // AC 4 + AC 7
 	t.Run("DesiredStateIsolation", func(t *testing.T) { testEGDesiredStateIsolation(t, factory) })         // AC 5 (isolation)
+	// Story-6: temporal reads + same-as collapse-group (Issue #2876)
+	t.Run("HistoryDiffCorrectness", func(t *testing.T) { testEGHistoryDiffCorrectness(t, factory) })         // AC 1
+	t.Run("TimelineMultiSubject", func(t *testing.T) { testEGTimelineMultiSubject(t, factory) })             // AC 2
+	t.Run("CollapseGroupTenantCut", func(t *testing.T) { testEGCollapseGroupTenantCut(t, factory) })         // AC 3 REQUIRED
+	t.Run("MovedEntityHistoricalScan", func(t *testing.T) { testEGMovedEntityHistoricalScan(t, factory) })   // AC 4 REQUIRED
+	t.Run("CollapseGroupConflictsRetained", func(t *testing.T) { testEGCollapseGroupConflicts(t, factory) }) // AC 5
+	t.Run("CollapseGroupMultiMember", func(t *testing.T) { testEGCollapseGroupMultiMember(t, factory) })     // AC 6
 }
 
 // --- Contract test helpers ---
@@ -604,7 +611,7 @@ func testEGOptsNoOp(t *testing.T, factory EntityGraphProviderFactory) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, view)
-	assert.Nil(t, view.CollapseGroup, "CollapseGroup opt is a pass-through no-op in this round")
+	assert.Nil(t, view.CollapseGroup, "entity with no same-as edges has a single-member group: CollapseGroup is nil")
 }
 
 // egReportEdge ingests a single-observation edge batch, failing on error.
@@ -1313,6 +1320,372 @@ func testEGDriftLifecycle(t *testing.T, factory EntityGraphProviderFactory) {
 		Actor:      "ops-bot",
 	})
 	require.Error(t, err, "unknown lifecycle transition must return an error")
+}
+
+// --- Story-6: temporal reads + same-as collapse-group (Issue #2876) ---
+
+// testEGHistoryDiffCorrectness verifies that GetHistory returns all observations
+// in sequence order and that Diff computes the correct attribute delta between two
+// as-of states (AC1).
+func testEGHistoryDiffCorrectness(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	eid := egEID(t, "host:hd-auth/host1")
+	subject := eid.String()
+
+	t0 := time.Now().UTC().Truncate(time.Second)
+	t1 := t0.Add(time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+	t4 := t0.Add(4 * time.Second)
+
+	// Three observations with different payloads; different hashes prevent dedup.
+	for i, rec := range []struct {
+		at       time.Time
+		hostname string
+	}{{t1, "server-v1"}, {t2, "server-v2"}, {t3, "server-v3"}} {
+		require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+			Source: "observer:scan",
+			Observations: []types.Observation{{
+				Source:     "observer:scan",
+				ObservedAt: rec.at,
+				RecordedAt: rec.at,
+				Subject:    subject,
+				Kind:       types.ObservationKindState,
+				Confidence: types.ConfidenceHigh,
+				Payload: map[string]interface{}{
+					"entity_kind":   "host",
+					"hostname":      rec.hostname,
+					"owning_tenant": "root/hd-tenant",
+				},
+			}},
+		}), "report obs %d", i)
+	}
+
+	// GetHistory over [t0, t4] must return all 3 records in ascending order.
+	history, err := p.GetHistory(ctx, eid, interfaces.TimeRange{From: t0, To: t4})
+	require.NoError(t, err)
+	require.Len(t, history, 3, "GetHistory must return all 3 observations")
+	assert.Equal(t, "server-v1", history[0].Observation.Payload["hostname"])
+	assert.Equal(t, "server-v2", history[1].Observation.Payload["hostname"])
+	assert.Equal(t, "server-v3", history[2].Observation.Payload["hostname"])
+
+	// Diff between t1 and t3 must report the hostname change.
+	diff, err := p.Diff(ctx, eid, interfaces.TimeRange{From: t1, To: t3})
+	require.NoError(t, err)
+	require.NotNil(t, diff)
+
+	var hostnameChange *interfaces.AttributeChange
+	for i := range diff.Changes {
+		if diff.Changes[i].Attribute == "hostname" {
+			hostnameChange = &diff.Changes[i]
+		}
+	}
+	require.NotNil(t, hostnameChange, "Diff must report the hostname change")
+	assert.Equal(t, "server-v1", hostnameChange.Before, "Before value must be server-v1")
+	assert.Equal(t, "server-v3", hostnameChange.After, "After value must be server-v3")
+}
+
+// testEGTimelineMultiSubject verifies that GetTimeline returns a merged,
+// time-ordered state-change stream across multiple subjects (AC2).
+func testEGTimelineMultiSubject(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	eid1 := egEID(t, "host:tl-auth/host1")
+	eid2 := egEID(t, "host:tl-auth/host2")
+
+	t0 := time.Now().UTC().Truncate(time.Second)
+	t1 := t0.Add(time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+	t4 := t0.Add(4 * time.Second)
+	t5 := t0.Add(5 * time.Second)
+
+	for _, item := range []struct {
+		eid      interfaces.EIDRef
+		at       time.Time
+		hostname string
+	}{
+		{eid1, t1, "host1-v1"},
+		{eid2, t2, "host2-v1"},
+		{eid1, t3, "host1-v2"},
+		{eid2, t4, "host2-v2"},
+	} {
+		require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+			Source: "observer:scan",
+			Observations: []types.Observation{{
+				Source:     "observer:scan",
+				ObservedAt: item.at,
+				RecordedAt: item.at,
+				Subject:    item.eid.String(),
+				Kind:       types.ObservationKindState,
+				Confidence: types.ConfidenceHigh,
+				Payload: map[string]interface{}{
+					"entity_kind":   "host",
+					"hostname":      item.hostname,
+					"owning_tenant": "root/tl-tenant",
+				},
+			}},
+		}))
+	}
+
+	events, err := p.GetTimeline(ctx, []interfaces.EIDRef{eid1, eid2}, interfaces.TimeRange{From: t0, To: t5})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(events), 4, "timeline must include at least 4 state-change events")
+
+	// Events must be in non-decreasing time order.
+	for i := 1; i < len(events); i++ {
+		assert.False(t, events[i].OccurredAt.Before(events[i-1].OccurredAt),
+			"timeline events must be time-ordered (index %d < %d)", i-1, i)
+	}
+	// All entity state events carry kind "state-change".
+	for _, e := range events {
+		if e.Kind != "state-change" && e.Kind != "same-as-change" {
+			t.Errorf("unexpected timeline event kind %q", e.Kind)
+		}
+	}
+}
+
+// testEGCollapseGroupTenantCut verifies that the tenant cut is applied BEFORE
+// the collapse-group merge — a member in an out-of-subtree tenant is excluded
+// entirely (AC3, REQUIRED TEST).
+func testEGCollapseGroupTenantCut(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	memberA := egEID(t, "host:cgtc-auth/member-a")
+	memberB := egEID(t, "host:cgtc-auth/member-b")
+	memberC := egEID(t, "host:cgtc-auth/member-c") // lives in a different tenant
+
+	egReport(ctx, t, p, "operator-assertion:admin", memberA.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/tenant-a",
+		"hostname": "member-a-host", "attr_only_a": "val-a",
+	})
+	egReport(ctx, t, p, "operator-assertion:admin", memberB.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/tenant-a",
+		"hostname": "member-b-host", "attr_only_b": "val-b",
+	})
+	egReport(ctx, t, p, "operator-assertion:admin", memberC.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/tenant-b",
+		"hostname": "member-c-host", "attr_only_c": "val-c",
+	})
+
+	// A—B—C: same-as group connecting all three.
+	egReportEdge(ctx, t, p, "operator-assertion:admin", memberA.String(), memberB.String(), "same-as")
+	egReportEdge(ctx, t, p, "operator-assertion:admin", memberB.String(), memberC.String(), "same-as")
+
+	// Query from tenant-a: A and B are visible, C is not.
+	view, err := p.GetEntity(ctx, memberA, interfaces.GetEntityOpts{
+		CollapseGroup: true,
+		TenantFilter:  "root/tenant-a",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	require.NotNil(t, view.CollapseGroup, "A and B are both in tenant-a: collapsed view must be non-nil")
+
+	// memberC must be absent from the group (tenant cut).
+	for _, m := range view.CollapseGroup.Members {
+		assert.NotEqual(t, memberC.String(), m.String(),
+			"out-of-subtree memberC must be excluded by the tenant cut")
+	}
+
+	// memberC's unique attribute must NOT appear in the merged view.
+	_, hasAttrC := view.CollapseGroup.Merged["attr_only_c"]
+	assert.False(t, hasAttrC, "attr_only_c from out-of-tenant memberC must not appear in merged view")
+
+	// memberA and memberB's attributes must both appear.
+	assert.Equal(t, "val-a", view.CollapseGroup.Merged["attr_only_a"],
+		"memberA's attribute must be in merged view")
+	assert.Equal(t, "val-b", view.CollapseGroup.Merged["attr_only_b"],
+		"memberB's attribute must be in merged view")
+}
+
+// testEGMovedEntityHistoricalScan verifies that GetHistory, Diff, and GetTimeline
+// return rows from ALL epochs of a moved entity — authorization is resolved once
+// via the current owning tenant, never per-row via the frozen ingest-time
+// tenant_path column (AC4, REQUIRED TEST).
+func testEGMovedEntityHistoricalScan(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	eid := egEID(t, "host:mehs-auth/host1")
+	subject := eid.String()
+
+	t0 := time.Now().UTC().Truncate(time.Second)
+	t1 := t0.Add(time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+
+	// Record entity under tenant-A.
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "enforcing-module:mover",
+		Observations: []types.Observation{{
+			Source:     "enforcing-module:mover",
+			Subject:    subject,
+			ObservedAt: t1,
+			RecordedAt: t1,
+			Kind:       types.ObservationKindState,
+			Confidence: types.ConfidenceHigh,
+			Payload: map[string]interface{}{
+				"entity_kind":   "host",
+				"owning_tenant": "root/tenant-a",
+				"hostname":      "moved-host",
+			},
+		}},
+	}))
+
+	// Move entity to tenant-B (different payload → different hash → new log row).
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "enforcing-module:mover",
+		Observations: []types.Observation{{
+			Source:     "enforcing-module:mover",
+			Subject:    subject,
+			ObservedAt: t2,
+			RecordedAt: t2,
+			Kind:       types.ObservationKindState,
+			Confidence: types.ConfidenceHigh,
+			Payload: map[string]interface{}{
+				"entity_kind":   "host",
+				"owning_tenant": "root/tenant-b",
+				"hostname":      "moved-host",
+			},
+		}},
+	}))
+
+	// GetHistory must return BOTH rows — pre-move (tenant_path=a) and post-move (tenant_path=b).
+	// An implementation that filters per-row by tenant_path would omit one of them.
+	history, err := p.GetHistory(ctx, eid, interfaces.TimeRange{From: t0, To: t3})
+	require.NoError(t, err)
+	require.Len(t, history, 2, "GetHistory must return both pre- and post-move rows")
+
+	assert.Equal(t, "root/tenant-a", history[0].Observation.Payload["owning_tenant"],
+		"first row must carry tenant-a's path as ingest-time provenance")
+	assert.Equal(t, "root/tenant-b", history[1].Observation.Payload["owning_tenant"],
+		"second row must carry tenant-b's path as ingest-time provenance")
+
+	// Diff over [t1, t2] must show the owning_tenant change.
+	diff, err := p.Diff(ctx, eid, interfaces.TimeRange{From: t1, To: t2})
+	require.NoError(t, err)
+	require.NotNil(t, diff)
+
+	var tenantChange *interfaces.AttributeChange
+	for i := range diff.Changes {
+		if diff.Changes[i].Attribute == "owning_tenant" {
+			tenantChange = &diff.Changes[i]
+		}
+	}
+	require.NotNil(t, tenantChange, "Diff must show owning_tenant change across the move")
+	assert.Equal(t, "root/tenant-a", tenantChange.Before)
+	assert.Equal(t, "root/tenant-b", tenantChange.After)
+
+	// GetTimeline must include events from both epochs.
+	events, err := p.GetTimeline(ctx, []interfaces.EIDRef{eid}, interfaces.TimeRange{From: t0, To: t3})
+	require.NoError(t, err)
+	require.Len(t, events, 2, "GetTimeline must include one event per observation epoch")
+
+	// Entity is now accessible only under tenant-b (current-ownership check).
+	_, errA := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{TenantFilter: "root/tenant-a"})
+	assert.Error(t, errA, "entity must not be visible to former owning tenant after move")
+
+	_, errB := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{TenantFilter: "root/tenant-b"})
+	assert.NoError(t, errB, "entity must be visible to current owning tenant")
+}
+
+// testEGCollapseGroupConflicts verifies that losing attribute values are retained
+// in CollapseGroupView.Conflicts and are not silently discarded (AC5).
+func testEGCollapseGroupConflicts(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	memberA := egEID(t, "host:cgcon-auth/member-a")
+	memberB := egEID(t, "host:cgcon-auth/member-b")
+
+	// Higher-precedence source (enforcing-module) asserts hostname="correct-name".
+	egReport(ctx, t, p, "enforcing-module:winner", memberA.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/con-tenant",
+		"hostname": "correct-name",
+	})
+	// Lower-precedence source (correlator-inference) asserts hostname="wrong-name".
+	egReport(ctx, t, p, "correlator-inference:loser", memberB.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/con-tenant",
+		"hostname": "wrong-name",
+	})
+
+	egReportEdge(ctx, t, p, "operator-assertion:admin", memberA.String(), memberB.String(), "same-as")
+
+	view, err := p.GetEntity(ctx, memberA, interfaces.GetEntityOpts{
+		CollapseGroup: true,
+		TenantFilter:  "root/con-tenant",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	require.NotNil(t, view.CollapseGroup, "CollapseGroup must be non-nil for a 2-member group")
+
+	// Winning value is in Merged.
+	assert.Equal(t, "correct-name", view.CollapseGroup.Merged["hostname"],
+		"enforcing-module must win the hostname attribute")
+
+	// Losing value must be retained in Conflicts, not discarded.
+	hostnameConflicts := view.CollapseGroup.Conflicts["hostname"]
+	require.NotEmpty(t, hostnameConflicts, "losing hostname value must be in Conflicts")
+	conflictValues := make([]interface{}, len(hostnameConflicts))
+	for i, c := range hostnameConflicts {
+		conflictValues[i] = c.Value
+	}
+	assert.Contains(t, conflictValues, "wrong-name",
+		"the losing value must be accessible per-member in Conflicts")
+}
+
+// testEGCollapseGroupMultiMember verifies that CollapseGroup opts now resolves
+// real multi-member same-as groups — GetEntity returns a non-nil CollapseGroupView
+// with merged attributes from all visible same-as group members (AC6).
+func testEGCollapseGroupMultiMember(t *testing.T, factory EntityGraphProviderFactory) {
+	t.Helper()
+	p := factory(t)
+	ctx := context.Background()
+
+	memberA := egEID(t, "host:cgmm-auth/member-a")
+	memberB := egEID(t, "host:cgmm-auth/member-b")
+
+	egReport(ctx, t, p, "observer:scan", memberA.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/mm-tenant",
+		"hostname": "member-a", "attr_a": "val-a",
+	})
+	egReport(ctx, t, p, "observer:scan", memberB.String(), map[string]interface{}{
+		"entity_kind": "host", "owning_tenant": "root/mm-tenant",
+		"hostname": "member-b", "attr_b": "val-b",
+	})
+
+	egReportEdge(ctx, t, p, "operator-assertion:admin", memberA.String(), memberB.String(), "same-as")
+
+	// Without CollapseGroup flag: no group view.
+	viewNoCollapse, err := p.GetEntity(ctx, memberA, interfaces.GetEntityOpts{TenantFilter: "root/mm-tenant"})
+	require.NoError(t, err)
+	require.NotNil(t, viewNoCollapse)
+	assert.Nil(t, viewNoCollapse.CollapseGroup, "CollapseGroup must be nil when flag is false")
+
+	// With CollapseGroup=true: non-nil group view with merged attributes.
+	view, err := p.GetEntity(ctx, memberA, interfaces.GetEntityOpts{
+		CollapseGroup: true,
+		TenantFilter:  "root/mm-tenant",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	require.NotNil(t, view.CollapseGroup, "CollapseGroup must be non-nil for a 2-member same-as group")
+	assert.Len(t, view.CollapseGroup.Members, 2, "group must have 2 members")
+
+	// Both members' non-conflicting attributes must appear in the merged view.
+	assert.Equal(t, "val-a", view.CollapseGroup.Merged["attr_a"],
+		"memberA's unique attribute must be in merged view")
+	assert.Equal(t, "val-b", view.CollapseGroup.Merged["attr_b"],
+		"memberB's unique attribute must be in merged view")
 }
 
 // --- Compile-time assertion ---

--- a/pkg/entitygraph/providers/database/collapse.go
+++ b/pkg/entitygraph/providers/database/collapse.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// resolveGroupMembersCurrentState walks the same-as graph from eid using the
+// current edge projection (fast path for non-temporal reads). Returns all group
+// member EIDs including the subject itself. The group is traversed as an
+// undirected graph: the same-as edge is symmetric.
+func (p *DatabaseEntityGraphProvider) resolveGroupMembersCurrentState(ctx context.Context, eid interfaces.EIDRef) ([]interfaces.EIDRef, error) {
+	visited := map[string]struct{}{eid.String(): {}}
+	queue := []string{eid.String()}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		rows, err := p.db.QueryContext(ctx,
+			`SELECT DISTINCT from_subject, to_subject
+			 FROM eg_edge_projection
+			 WHERE edge_type = 'same-as'
+			   AND (from_subject = $1 OR to_subject = $2)`,
+			current, current,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/database: resolve group edges for %s: %w", current, err)
+		}
+
+		for rows.Next() {
+			var fromSubj, toSubj string
+			if err := rows.Scan(&fromSubj, &toSubj); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("entitygraph/database: scan group edge: %w", err)
+			}
+			for _, peer := range []string{fromSubj, toSubj} {
+				if _, seen := visited[peer]; !seen {
+					visited[peer] = struct{}{}
+					queue = append(queue, peer)
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("entitygraph/database: iterate group edges: %w", err)
+		}
+		_ = rows.Close()
+	}
+
+	return sortedGroupMembers(visited), nil
+}
+
+// resolveGroupMembersAsOf walks the same-as graph from eid using the observation
+// log, considering only edges that were active (not absent) at or before asOf.
+// Uses DISTINCT ON to pick the latest kind per edge subject at or before asOf.
+func (p *DatabaseEntityGraphProvider) resolveGroupMembersAsOf(ctx context.Context, eid interfaces.EIDRef, asOf time.Time) ([]interfaces.EIDRef, error) {
+	asOfStr := asOf.UTC().Format(time.RFC3339Nano)
+	visited := map[string]struct{}{eid.String(): {}}
+	queue := []string{eid.String()}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		// DISTINCT ON picks the most-recent log row per edge subject at or before asOf.
+		rows, err := p.db.QueryContext(ctx, `
+			SELECT DISTINCT ON (l.subject) l.subject, l.kind
+			FROM eg_observation_log l
+			WHERE (l.subject LIKE $1 OR l.subject LIKE $2)
+			  AND l.observed_at <= $3
+			ORDER BY l.subject, l.observed_at DESC, l.id DESC`,
+			"same-as|"+current+"|%",
+			"same-as|%|"+current,
+			asOfStr,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/database: resolve group as-of for %s: %w", current, err)
+		}
+
+		for rows.Next() {
+			var edgeSubject, kind string
+			if err := rows.Scan(&edgeSubject, &kind); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("entitygraph/database: scan group as-of edge: %w", err)
+			}
+			// Absence means the edge was retracted at asOf.
+			if kind == string(types.ObservationKindAbsence) {
+				continue
+			}
+			_, fromSubj, toSubj, err := parseEdgeSubject(edgeSubject)
+			if err != nil {
+				continue
+			}
+			for _, peer := range []string{fromSubj, toSubj} {
+				if _, seen := visited[peer]; !seen {
+					visited[peer] = struct{}{}
+					queue = append(queue, peer)
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("entitygraph/database: iterate group as-of edges: %w", err)
+		}
+		_ = rows.Close()
+	}
+
+	return sortedGroupMembers(visited), nil
+}
+
+// sortedGroupMembers converts a visited-set map to a sorted EID slice.
+func sortedGroupMembers(visited map[string]struct{}) []interfaces.EIDRef {
+	var members []interfaces.EIDRef
+	for subj := range visited {
+		eid, err := types.ParseEID(subj)
+		if err != nil {
+			continue
+		}
+		members = append(members, eid)
+	}
+	sort.Slice(members, func(i, j int) bool {
+		return members[i].String() < members[j].String()
+	})
+	return members
+}
+
+// applyTenantCut filters group members to those whose current owning_tenant is
+// visible to tenantFilter (ADR-022 §3: tenant cut before merge). Uses the current
+// eg_entity_index ownership (not ingest-time tenant_path) as the access-control axis.
+func (p *DatabaseEntityGraphProvider) applyTenantCut(ctx context.Context, members []interfaces.EIDRef, tenantFilter string) ([]interfaces.EIDRef, error) {
+	if tenantFilter == "" {
+		return members, nil
+	}
+
+	var visible []interfaces.EIDRef
+	for _, m := range members {
+		var owningTenant string
+		err := p.db.QueryRowContext(ctx,
+			`SELECT owning_tenant FROM eg_entity_index WHERE subject = $1`,
+			m.String(),
+		).Scan(&owningTenant)
+		if err != nil {
+			// Not in index (placeholder with no real owning_tenant) → excluded.
+			continue
+		}
+		if tenantVisible(owningTenant, tenantFilter) {
+			visible = append(visible, m)
+		}
+	}
+	return visible, nil
+}
+
+// loadMemberSources loads all current sourceEntry values for a group member from
+// eg_entity_current. Used during step 3 (attribute merge) of the collapse-group
+// read contract.
+func (p *DatabaseEntityGraphProvider) loadMemberSources(ctx context.Context, subject string) ([]sourceEntry, error) {
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT c.source, c.source_class, c.observed_at, c.payload_hash, pc.payload_json
+		 FROM eg_entity_current c
+		 JOIN eg_payload_content pc ON pc.content_hash = c.payload_hash
+		 WHERE c.subject = $1`,
+		subject,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: load member sources for %s: %w", subject, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []sourceEntry
+	for rows.Next() {
+		var source, sourceClass, observedAt, hash, payloadJSON string
+		if err := rows.Scan(&source, &sourceClass, &observedAt, &hash, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/database: scan member source: %w", err)
+		}
+		var payload map[string]interface{}
+		if payloadJSON != "" {
+			if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+				return nil, fmt.Errorf("entitygraph/database: decode member payload: %w", err)
+			}
+		}
+		t, _ := time.Parse(time.RFC3339Nano, observedAt)
+		entries = append(entries, sourceEntry{
+			source:      source,
+			sourceClass: sourceClass,
+			observedAt:  t,
+			payloadHash: hash,
+			payload:     payload,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/database: iterate member sources: %w", err)
+	}
+	return entries, nil
+}
+
+// buildConflicts collects per-attribute values from sources that lost the
+// precedence merge. An attribute has a conflict when multiple sources assert
+// different values for it.
+func buildConflicts(entries []sourceEntry, merged map[string]interface{}) map[string][]types.AttributeConflict {
+	conflicts := make(map[string][]types.AttributeConflict)
+
+	for _, e := range entries {
+		for k, v := range e.payload {
+			mergedV, ok := merged[k]
+			if !ok {
+				continue
+			}
+			vJSON, _ := json.Marshal(v)
+			mergedJSON, _ := json.Marshal(mergedV)
+			if string(vJSON) != string(mergedJSON) {
+				conflicts[k] = append(conflicts[k], types.AttributeConflict{
+					Source: e.source,
+					Value:  v,
+				})
+			}
+		}
+	}
+
+	if len(conflicts) == 0 {
+		return nil
+	}
+
+	for k, cs := range conflicts {
+		sort.Slice(cs, func(i, j int) bool { return cs[i].Source < cs[j].Source })
+		conflicts[k] = cs
+	}
+	return conflicts
+}
+
+// resolveCollapseGroup implements the three-step collapse-group read contract
+// (ADR-022 §3, ADR-023 §4):
+//  1. Resolve same-as group membership as-of query time from edge history.
+//  2. Apply tenant cut (current-ownership axis) before any merge.
+//  3. Per-attribute precedence merge across visible members.
+//
+// Returns nil when the entity has no same-as group or all other group members
+// are cut by the tenant filter (single-visible-member group is a no-op).
+func (p *DatabaseEntityGraphProvider) resolveCollapseGroup(ctx context.Context, eid interfaces.EIDRef, asOf *time.Time, tenantFilter string) (*types.CollapseGroupView, error) {
+	// Step 1: resolve group membership.
+	var members []interfaces.EIDRef
+	var err error
+	if asOf != nil {
+		members, err = p.resolveGroupMembersAsOf(ctx, eid, *asOf)
+	} else {
+		members, err = p.resolveGroupMembersCurrentState(ctx, eid)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// No same-as edges: single-member group, no collapse needed.
+	if len(members) <= 1 {
+		return nil, nil
+	}
+
+	// Step 2: tenant cut before merge.
+	visible, err := p.applyTenantCut(ctx, members, tenantFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	// After the cut only the requesting entity is visible: no group to collapse.
+	if len(visible) <= 1 {
+		return nil, nil
+	}
+
+	// Step 3: per-attribute precedence merge across all visible members' sources.
+	var allEntries []sourceEntry
+	for _, m := range visible {
+		entries, err := p.loadMemberSources(ctx, m.String())
+		if err != nil {
+			return nil, err
+		}
+		allEntries = append(allEntries, entries...)
+	}
+
+	merged := mergeAttributes(allEntries)
+	conflicts := buildConflicts(allEntries, merged)
+
+	return &types.CollapseGroupView{
+		Members:   visible,
+		Merged:    merged,
+		Conflicts: conflicts,
+	}, nil
+}

--- a/pkg/entitygraph/providers/database/collapse.go
+++ b/pkg/entitygraph/providers/database/collapse.go
@@ -8,11 +8,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
 	"github.com/cfgis/cfgms/pkg/entitygraph/types"
 )
+
+// escapeLIKE escapes SQL LIKE metacharacters (\, %, _) in s so s is treated as
+// a literal substring when used in a LIKE pattern with ESCAPE '\'.
+func escapeLIKE(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
 
 // resolveGroupMembersCurrentState walks the same-as graph from eid using the
 // current edge projection (fast path for non-temporal reads). Returns all group
@@ -76,11 +86,11 @@ func (p *DatabaseEntityGraphProvider) resolveGroupMembersAsOf(ctx context.Contex
 		rows, err := p.db.QueryContext(ctx, `
 			SELECT DISTINCT ON (l.subject) l.subject, l.kind
 			FROM eg_observation_log l
-			WHERE (l.subject LIKE $1 OR l.subject LIKE $2)
+			WHERE (l.subject LIKE $1 ESCAPE '\' OR l.subject LIKE $2 ESCAPE '\')
 			  AND l.observed_at <= $3
 			ORDER BY l.subject, l.observed_at DESC, l.id DESC`,
-			"same-as|"+current+"|%",
-			"same-as|%|"+current,
+			"same-as|"+escapeLIKE(current)+"|%",
+			"same-as|%|"+escapeLIKE(current),
 			asOfStr,
 		)
 		if err != nil {

--- a/pkg/entitygraph/providers/database/contract_test.go
+++ b/pkg/entitygraph/providers/database/contract_test.go
@@ -127,3 +127,17 @@ func TestParseEdgeSubject_Database(t *testing.T) {
 	_, _, _, err = parseEdgeSubject("two|parts")
 	require.Error(t, err)
 }
+
+func TestEscapeLIKE_Database(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"host:abc", "host:abc"},
+		{"host:server%01", `host:server\%01`},
+		{"host:server_01", `host:server\_01`},
+		{`host:back\slash`, `host:back\\slash`},
+		{`100%_done`, `100\%\_done`},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, escapeLIKE(tc.in), "input: %q", tc.in)
+	}
+}

--- a/pkg/entitygraph/providers/database/entity_reads.go
+++ b/pkg/entitygraph/providers/database/entity_reads.go
@@ -110,6 +110,16 @@ func (p *DatabaseEntityGraphProvider) GetEntity(ctx context.Context, eid interfa
 			RecordedAt: rows[win].recordedAt,
 		},
 	}
+
+	// Wire collapse-group resolution when requested (ADR-022 §3).
+	if opts.CollapseGroup {
+		cg, err := p.resolveCollapseGroup(ctx, eid, opts.AsOf, opts.TenantFilter)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/database: resolve collapse group: %w", err)
+		}
+		view.CollapseGroup = cg
+	}
+
 	return view, nil
 }
 
@@ -561,19 +571,4 @@ func (p *DatabaseEntityGraphProvider) GetHistory(ctx context.Context, eid interf
 		return nil, fmt.Errorf("entitygraph/database: iterate history: %w", err)
 	}
 	return records, nil
-}
-
-// Diff returns the attribute delta between two points in time for a subject.
-func (p *DatabaseEntityGraphProvider) Diff(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) (*interfaces.StateDiff, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
-// GetTimeline returns a merged change-event stream for the given subjects.
-func (p *DatabaseEntityGraphProvider) GetTimeline(_ context.Context, _ []interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.TimelineEvent, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
-// Watch returns a durable, cursor-replayable change feed.
-func (p *DatabaseEntityGraphProvider) Watch(_ context.Context, _ interfaces.WatchFilter, _ string) (<-chan interfaces.WatchEvent, error) {
-	return nil, interfaces.ErrNotImplemented
 }

--- a/pkg/entitygraph/providers/database/temporal.go
+++ b/pkg/entitygraph/providers/database/temporal.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+)
+
+// computeAttributeChanges returns the set of attributes that differ between two
+// merged state snapshots. Either snapshot may be nil (entity did not exist at
+// that time). Attributes present in only one snapshot are included (Before or
+// After nil). The result is sorted by attribute name for deterministic output.
+func computeAttributeChanges(atT1, atT2 map[string]interface{}) []interfaces.AttributeChange {
+	keys := make(map[string]struct{})
+	for k := range atT1 {
+		keys[k] = struct{}{}
+	}
+	for k := range atT2 {
+		keys[k] = struct{}{}
+	}
+
+	var changes []interfaces.AttributeChange
+	for k := range keys {
+		v1, ok1 := atT1[k]
+		v2, ok2 := atT2[k]
+		if !ok1 && !ok2 {
+			continue
+		}
+		j1, _ := json.Marshal(v1)
+		j2, _ := json.Marshal(v2)
+		if ok1 == ok2 && string(j1) == string(j2) {
+			continue
+		}
+		changes = append(changes, interfaces.AttributeChange{
+			Attribute: k,
+			Before:    v1,
+			After:     v2,
+		})
+	}
+
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Attribute < changes[j].Attribute
+	})
+	return changes
+}
+
+// entityStateAsOf projects the merged entity state at or before asOf from the
+// observation log. Returns nil when no state observations existed at that time.
+func (p *DatabaseEntityGraphProvider) entityStateAsOf(ctx context.Context, subject string, asOf time.Time) (map[string]interface{}, error) {
+	rows, err := p.queryCurrentRows(ctx, subject, "", &asOf)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	entries := make([]sourceEntry, len(rows))
+	for i, r := range rows {
+		entries[i] = sourceEntry{
+			source:      r.source,
+			sourceClass: r.sourceClass,
+			observedAt:  r.observedAt,
+			payloadHash: r.payloadHash,
+			payload:     r.payload,
+		}
+	}
+	return mergeAttributes(entries), nil
+}
+
+// Diff computes the attribute delta between two as-of states of a subject. It
+// projects the merged entity state at r.From and r.To, then returns the set of
+// attributes whose values differ.
+func (p *DatabaseEntityGraphProvider) Diff(ctx context.Context, eid interfaces.EIDRef, r interfaces.TimeRange) (*interfaces.StateDiff, error) {
+	subject := eid.String()
+
+	atT1, err := p.entityStateAsOf(ctx, subject, r.From)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: diff state at T1: %w", err)
+	}
+	atT2, err := p.entityStateAsOf(ctx, subject, r.To)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/database: diff state at T2: %w", err)
+	}
+
+	return &interfaces.StateDiff{
+		Subject: eid,
+		T1:      r.From,
+		T2:      r.To,
+		Changes: computeAttributeChanges(atT1, atT2),
+	}, nil
+}
+
+// GetTimeline returns a merged, time-ordered change-event stream across the
+// supplied subjects over the time range. This story delivers state-change events
+// (entity state and absence observations) and same-as-change events (same-as edge
+// observations). Drift and apply-outcome events are deferred per ADR-022 §9.
+func (p *DatabaseEntityGraphProvider) GetTimeline(ctx context.Context, eids []interfaces.EIDRef, r interfaces.TimeRange) ([]*interfaces.TimelineEvent, error) {
+	if len(eids) == 0 {
+		return nil, nil
+	}
+
+	fromStr := r.From.UTC().Format(time.RFC3339Nano)
+	toStr := r.To.UTC().Format(time.RFC3339Nano)
+
+	var events []*interfaces.TimelineEvent
+
+	for _, eid := range eids {
+		subject := eid.String()
+
+		// State and absence observations for this subject.
+		srows, err := p.db.QueryContext(ctx, `
+			SELECT l.id, l.source, l.observed_at, l.kind, p.payload_json
+			FROM eg_observation_log l
+			JOIN eg_payload_content p ON p.content_hash = l.payload_hash
+			WHERE l.subject = $1
+			  AND l.kind IN ('state', 'absence')
+			  AND l.observed_at >= $2
+			  AND l.observed_at <= $3
+			ORDER BY l.id ASC`,
+			subject, fromStr, toStr,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/database: timeline scan for %s: %w", subject, err)
+		}
+
+		for srows.Next() {
+			var id int64
+			var source, observedAt, kind, payloadJSON string
+			if err := srows.Scan(&id, &source, &observedAt, &kind, &payloadJSON); err != nil {
+				_ = srows.Close()
+				return nil, fmt.Errorf("entitygraph/database: scan timeline row: %w", err)
+			}
+			var payload map[string]interface{}
+			if payloadJSON != "" {
+				if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+					payload = map[string]interface{}{}
+				}
+			}
+			oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+			events = append(events, &interfaces.TimelineEvent{
+				Subject:    eid,
+				OccurredAt: oa,
+				Kind:       "state-change",
+				Detail: map[string]interface{}{
+					"source":           source,
+					"observation_kind": kind,
+					"version":          id,
+					"payload":          payload,
+				},
+			})
+		}
+		if err := srows.Err(); err != nil {
+			_ = srows.Close()
+			return nil, fmt.Errorf("entitygraph/database: iterate timeline rows for %s: %w", subject, err)
+		}
+		_ = srows.Close()
+
+		// Same-as edge observations involving this subject (group-membership changes).
+		saRows, err := p.db.QueryContext(ctx, `
+			SELECT l.id, l.observed_at, l.kind, l.subject
+			FROM eg_observation_log l
+			WHERE (l.subject LIKE $1 OR l.subject LIKE $2)
+			  AND l.observed_at >= $3
+			  AND l.observed_at <= $4
+			ORDER BY l.id ASC`,
+			"same-as|"+subject+"|%",
+			"same-as|%|"+subject,
+			fromStr, toStr,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/database: timeline same-as scan for %s: %w", subject, err)
+		}
+
+		for saRows.Next() {
+			var id int64
+			var observedAt, kind, edgeSubject string
+			if err := saRows.Scan(&id, &observedAt, &kind, &edgeSubject); err != nil {
+				_ = saRows.Close()
+				return nil, fmt.Errorf("entitygraph/database: scan same-as timeline row: %w", err)
+			}
+			oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+			_, fromSubj, toSubj, _ := parseEdgeSubject(edgeSubject)
+			events = append(events, &interfaces.TimelineEvent{
+				Subject:    eid,
+				OccurredAt: oa,
+				Kind:       "same-as-change",
+				Detail: map[string]interface{}{
+					"edge_subject":     edgeSubject,
+					"from":             fromSubj,
+					"to":               toSubj,
+					"observation_kind": kind,
+					"version":          id,
+				},
+			})
+		}
+		if err := saRows.Err(); err != nil {
+			_ = saRows.Close()
+			return nil, fmt.Errorf("entitygraph/database: iterate same-as timeline rows for %s: %w", subject, err)
+		}
+		_ = saRows.Close()
+	}
+
+	// Merge all events into a single time-ordered stream.
+	sort.SliceStable(events, func(i, j int) bool {
+		if events[i].OccurredAt.Equal(events[j].OccurredAt) {
+			vi, _ := events[i].Detail["version"].(int64)
+			vj, _ := events[j].Detail["version"].(int64)
+			return vi < vj
+		}
+		return events[i].OccurredAt.Before(events[j].OccurredAt)
+	})
+
+	return events, nil
+}
+
+// Watch is implemented by a later story.
+func (p *DatabaseEntityGraphProvider) Watch(_ context.Context, _ interfaces.WatchFilter, _ string) (<-chan interfaces.WatchEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}

--- a/pkg/entitygraph/providers/database/temporal.go
+++ b/pkg/entitygraph/providers/database/temporal.go
@@ -166,12 +166,12 @@ func (p *DatabaseEntityGraphProvider) GetTimeline(ctx context.Context, eids []in
 		saRows, err := p.db.QueryContext(ctx, `
 			SELECT l.id, l.observed_at, l.kind, l.subject
 			FROM eg_observation_log l
-			WHERE (l.subject LIKE $1 OR l.subject LIKE $2)
+			WHERE (l.subject LIKE $1 ESCAPE '\' OR l.subject LIKE $2 ESCAPE '\')
 			  AND l.observed_at >= $3
 			  AND l.observed_at <= $4
 			ORDER BY l.id ASC`,
-			"same-as|"+subject+"|%",
-			"same-as|%|"+subject,
+			"same-as|"+escapeLIKE(subject)+"|%",
+			"same-as|%|"+escapeLIKE(subject),
 			fromStr, toStr,
 		)
 		if err != nil {

--- a/pkg/entitygraph/providers/sqlite/collapse.go
+++ b/pkg/entitygraph/providers/sqlite/collapse.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// resolveGroupMembersCurrentState walks the same-as graph from eid using the
+// current edge projection (fast path for non-temporal reads). Returns all group
+// member EIDs including the subject itself. The group is traversed as an
+// undirected graph: the same-as edge is symmetric.
+func (p *SQLiteEntityGraphProvider) resolveGroupMembersCurrentState(ctx context.Context, eid interfaces.EIDRef) ([]interfaces.EIDRef, error) {
+	visited := map[string]struct{}{eid.String(): {}}
+	queue := []string{eid.String()}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		rows, err := p.db.QueryContext(ctx,
+			`SELECT DISTINCT from_subject, to_subject
+			 FROM eg_edge_projection
+			 WHERE edge_type = 'same-as'
+			   AND (from_subject = ? OR to_subject = ?)`,
+			current, current,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: resolve group edges for %s: %w", current, err)
+		}
+
+		for rows.Next() {
+			var fromSubj, toSubj string
+			if err := rows.Scan(&fromSubj, &toSubj); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("entitygraph/sqlite: scan group edge: %w", err)
+			}
+			for _, peer := range []string{fromSubj, toSubj} {
+				if _, seen := visited[peer]; !seen {
+					visited[peer] = struct{}{}
+					queue = append(queue, peer)
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("entitygraph/sqlite: iterate group edges: %w", err)
+		}
+		_ = rows.Close()
+	}
+
+	return sortedGroupMembers(visited), nil
+}
+
+// resolveGroupMembersAsOf walks the same-as graph from eid using the observation
+// log, considering only edges that were active (not absent) at or before asOf.
+func (p *SQLiteEntityGraphProvider) resolveGroupMembersAsOf(ctx context.Context, eid interfaces.EIDRef, asOf time.Time) ([]interfaces.EIDRef, error) {
+	asOfStr := rfc3339(asOf)
+	visited := map[string]struct{}{eid.String(): {}}
+	queue := []string{eid.String()}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		// Find edge subjects involving current that were observed at or before asOf.
+		// For each edge, the most recent observation (by id) determines if it existed.
+		rows, err := p.db.QueryContext(ctx, `
+			SELECT l.subject, l.kind
+			FROM eg_observation_log l
+			WHERE (l.subject LIKE ? OR l.subject LIKE ?)
+			  AND l.observed_at <= ?
+			  AND l.id = (
+			      SELECT MAX(id) FROM eg_observation_log
+			      WHERE subject = l.subject AND observed_at <= ?
+			  )`,
+			"same-as|"+current+"|%",
+			"same-as|%|"+current,
+			asOfStr, asOfStr,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: resolve group as-of for %s: %w", current, err)
+		}
+
+		for rows.Next() {
+			var edgeSubject, kind string
+			if err := rows.Scan(&edgeSubject, &kind); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("entitygraph/sqlite: scan group as-of edge: %w", err)
+			}
+			// Absence means the edge was retracted at asOf.
+			if kind == string(types.ObservationKindAbsence) {
+				continue
+			}
+			_, fromSubj, toSubj, err := parseEdgeSubject(edgeSubject)
+			if err != nil {
+				continue
+			}
+			for _, peer := range []string{fromSubj, toSubj} {
+				if _, seen := visited[peer]; !seen {
+					visited[peer] = struct{}{}
+					queue = append(queue, peer)
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("entitygraph/sqlite: iterate group as-of edges: %w", err)
+		}
+		_ = rows.Close()
+	}
+
+	return sortedGroupMembers(visited), nil
+}
+
+// sortedGroupMembers converts a visited-set map to a sorted EID slice.
+func sortedGroupMembers(visited map[string]struct{}) []interfaces.EIDRef {
+	var members []interfaces.EIDRef
+	for subj := range visited {
+		eid, err := types.ParseEID(subj)
+		if err != nil {
+			continue
+		}
+		members = append(members, eid)
+	}
+	sort.Slice(members, func(i, j int) bool {
+		return members[i].String() < members[j].String()
+	})
+	return members
+}
+
+// applyTenantCut filters group members to those whose current owning_tenant is
+// visible to tenantFilter (ADR-022 §3: tenant cut before merge). Uses the current
+// eg_entity_index ownership (not ingest-time tenant_path) as the access-control axis.
+func (p *SQLiteEntityGraphProvider) applyTenantCut(ctx context.Context, members []interfaces.EIDRef, tenantFilter string) ([]interfaces.EIDRef, error) {
+	if tenantFilter == "" {
+		return members, nil
+	}
+
+	var visible []interfaces.EIDRef
+	for _, m := range members {
+		var owningTenant string
+		err := p.db.QueryRowContext(ctx,
+			`SELECT owning_tenant FROM eg_entity_index WHERE subject = ?`,
+			m.String(),
+		).Scan(&owningTenant)
+		if err != nil {
+			// Not in index (placeholder with no real owning_tenant) → excluded.
+			continue
+		}
+		if tenantVisible(owningTenant, tenantFilter) {
+			visible = append(visible, m)
+		}
+	}
+	return visible, nil
+}
+
+// loadMemberSources loads all current sourceEntry values for a group member from
+// eg_entity_current. Used during step 3 (attribute merge) of the collapse-group
+// read contract.
+func (p *SQLiteEntityGraphProvider) loadMemberSources(ctx context.Context, subject string) ([]sourceEntry, error) {
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT c.source, c.source_class, c.observed_at, c.payload_hash, pc.payload
+		 FROM eg_entity_current c
+		 JOIN eg_payload_content pc ON pc.payload_hash = c.payload_hash
+		 WHERE c.subject = ?`,
+		subject,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: load member sources for %s: %w", subject, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []sourceEntry
+	for rows.Next() {
+		var source, sourceClass, observedAt, hash, payloadJSON string
+		if err := rows.Scan(&source, &sourceClass, &observedAt, &hash, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan member source: %w", err)
+		}
+		var payload map[string]interface{}
+		if payloadJSON != "" {
+			if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+				return nil, fmt.Errorf("entitygraph/sqlite: decode member payload: %w", err)
+			}
+		}
+		t, _ := time.Parse(time.RFC3339Nano, observedAt)
+		entries = append(entries, sourceEntry{
+			source:      source,
+			sourceClass: sourceClass,
+			observedAt:  t,
+			payloadHash: hash,
+			payload:     payload,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate member sources: %w", err)
+	}
+	return entries, nil
+}
+
+// buildConflicts collects per-attribute values from sources that lost the
+// precedence merge. An attribute has a conflict when multiple sources assert
+// different values for it.
+func buildConflicts(entries []sourceEntry, merged map[string]interface{}) map[string][]types.AttributeConflict {
+	conflicts := make(map[string][]types.AttributeConflict)
+
+	for _, e := range entries {
+		for k, v := range e.payload {
+			mergedV, ok := merged[k]
+			if !ok {
+				continue
+			}
+			vJSON, _ := json.Marshal(v)
+			mergedJSON, _ := json.Marshal(mergedV)
+			if string(vJSON) != string(mergedJSON) {
+				conflicts[k] = append(conflicts[k], types.AttributeConflict{
+					Source: e.source,
+					Value:  v,
+				})
+			}
+		}
+	}
+
+	if len(conflicts) == 0 {
+		return nil
+	}
+
+	for k, cs := range conflicts {
+		sort.Slice(cs, func(i, j int) bool { return cs[i].Source < cs[j].Source })
+		conflicts[k] = cs
+	}
+	return conflicts
+}
+
+// resolveCollapseGroup implements the three-step collapse-group read contract
+// (ADR-022 §3, ADR-023 §4):
+//  1. Resolve same-as group membership as-of query time from edge history.
+//  2. Apply tenant cut (current-ownership axis) before any merge.
+//  3. Per-attribute precedence merge across visible members.
+//
+// Returns nil when the entity has no same-as group or all other group members
+// are cut by the tenant filter (single-visible-member group is a no-op).
+func (p *SQLiteEntityGraphProvider) resolveCollapseGroup(ctx context.Context, eid interfaces.EIDRef, asOf *time.Time, tenantFilter string) (*types.CollapseGroupView, error) {
+	// Step 1: resolve group membership.
+	var members []interfaces.EIDRef
+	var err error
+	if asOf != nil {
+		members, err = p.resolveGroupMembersAsOf(ctx, eid, *asOf)
+	} else {
+		members, err = p.resolveGroupMembersCurrentState(ctx, eid)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// No same-as edges: single-member group, no collapse needed.
+	if len(members) <= 1 {
+		return nil, nil
+	}
+
+	// Step 2: tenant cut before merge.
+	visible, err := p.applyTenantCut(ctx, members, tenantFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	// After the cut only the requesting entity is visible: no group to collapse.
+	if len(visible) <= 1 {
+		return nil, nil
+	}
+
+	// Step 3: per-attribute precedence merge across all visible members' sources.
+	var allEntries []sourceEntry
+	for _, m := range visible {
+		entries, err := p.loadMemberSources(ctx, m.String())
+		if err != nil {
+			return nil, err
+		}
+		allEntries = append(allEntries, entries...)
+	}
+
+	merged := mergeAttributes(allEntries)
+	conflicts := buildConflicts(allEntries, merged)
+
+	return &types.CollapseGroupView{
+		Members:   visible,
+		Merged:    merged,
+		Conflicts: conflicts,
+	}, nil
+}

--- a/pkg/entitygraph/providers/sqlite/collapse.go
+++ b/pkg/entitygraph/providers/sqlite/collapse.go
@@ -8,11 +8,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
 	"github.com/cfgis/cfgms/pkg/entitygraph/types"
 )
+
+// escapeLIKE escapes SQL LIKE metacharacters (\, %, _) in s so s is treated as
+// a literal substring when used in a LIKE pattern with ESCAPE '\'.
+func escapeLIKE(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
 
 // resolveGroupMembersCurrentState walks the same-as graph from eid using the
 // current edge projection (fast path for non-temporal reads). Returns all group
@@ -76,14 +86,14 @@ func (p *SQLiteEntityGraphProvider) resolveGroupMembersAsOf(ctx context.Context,
 		rows, err := p.db.QueryContext(ctx, `
 			SELECT l.subject, l.kind
 			FROM eg_observation_log l
-			WHERE (l.subject LIKE ? OR l.subject LIKE ?)
+			WHERE (l.subject LIKE ? ESCAPE '\' OR l.subject LIKE ? ESCAPE '\')
 			  AND l.observed_at <= ?
 			  AND l.id = (
 			      SELECT MAX(id) FROM eg_observation_log
 			      WHERE subject = l.subject AND observed_at <= ?
 			  )`,
-			"same-as|"+current+"|%",
-			"same-as|%|"+current,
+			"same-as|"+escapeLIKE(current)+"|%",
+			"same-as|%|"+escapeLIKE(current),
 			asOfStr, asOfStr,
 		)
 		if err != nil {

--- a/pkg/entitygraph/providers/sqlite/entity_reads.go
+++ b/pkg/entitygraph/providers/sqlite/entity_reads.go
@@ -35,9 +35,14 @@ func tenantVisible(owningTenant, tenantFilter string) bool {
 
 // GetEntity returns the current entity state, provenance, and freshness,
 // applying the caller's tenant cut and source-precedence attribute merge.
+// When opts.AsOf is set the state is projected from the observation log at that
+// time. When opts.CollapseGroup is set the same-as group is resolved, a tenant
+// cut is applied before the merge, and a CollapseGroupView is populated.
 func (p *SQLiteEntityGraphProvider) GetEntity(ctx context.Context, eid interfaces.EIDRef, opts interfaces.GetEntityOpts) (*types.EntityView, error) {
 	subject := eid.String()
 
+	// Always look up current-state index for kind and owning_tenant — the sole
+	// access-control axis (ADR-023 §111-119).
 	var entityKind, owningTenant string
 	err := p.db.QueryRowContext(ctx,
 		`SELECT entity_kind, owning_tenant FROM eg_entity_index WHERE subject = ?`,
@@ -50,64 +55,38 @@ func (p *SQLiteEntityGraphProvider) GetEntity(ctx context.Context, eid interface
 		return nil, fmt.Errorf("entitygraph/sqlite: lookup index: %w", err)
 	}
 
-	// Apply the tenant cut. A filtered-out entity is indistinguishable from a
-	// missing one to the caller.
+	// Apply the tenant cut. A filtered-out entity is indistinguishable from missing.
 	if !tenantVisible(owningTenant, opts.TenantFilter) {
 		return nil, fmt.Errorf("entitygraph/sqlite: entity %s: %w", subject, ErrNotFound)
 	}
 
-	rows, err := p.db.QueryContext(ctx,
-		`SELECT c.source, c.source_class, c.kind, c.confidence, c.observed_at, c.recorded_at, c.payload_hash, p.payload
-		 FROM eg_entity_current c
-		 JOIN eg_payload_content p ON p.payload_hash = c.payload_hash
-		 WHERE c.subject = ? AND c.kind != 'desired-state'`,
-		subject,
-	)
+	// Load per-source current state from the projection table (fast path) or
+	// reconstructed from the log (temporal as-of path).
+	var entityRows []currentEntityRow
+	if opts.AsOf != nil {
+		entityRows, err = p.loadEntityRowsAsOf(ctx, subject, *opts.AsOf)
+	} else {
+		entityRows, err = p.loadEntityRowsCurrent(ctx, subject)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("entitygraph/sqlite: load sources: %w", err)
+		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
-
-	var (
-		entries      []sourceEntry
-		observations []types.Observation
-	)
-	for rows.Next() {
-		var source, sourceClass, kind, confidence, observedAt, recordedAt, hash, payloadJSON string
-		if err := rows.Scan(&source, &sourceClass, &kind, &confidence, &observedAt, &recordedAt, &hash, &payloadJSON); err != nil {
-			return nil, fmt.Errorf("entitygraph/sqlite: scan source: %w", err)
-		}
-		var payload map[string]interface{}
-		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
-			return nil, fmt.Errorf("entitygraph/sqlite: decode payload: %w", err)
-		}
-		oa, _ := time.Parse(time.RFC3339Nano, observedAt)
-		ra, _ := time.Parse(time.RFC3339Nano, recordedAt)
-		entries = append(entries, sourceEntry{
-			source:      source,
-			sourceClass: sourceClass,
-			observedAt:  oa,
-			payloadHash: hash,
-			payload:     payload,
-		})
-		observations = append(observations, types.Observation{
-			Source:     source,
-			ObservedAt: oa,
-			RecordedAt: ra,
-			Subject:    subject,
-			Kind:       types.ObservationKind(kind),
-			Confidence: types.Confidence(confidence),
-			Payload:    payload,
-		})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("entitygraph/sqlite: iterate sources: %w", err)
-	}
-
-	// The index row exists, so there must be at least one current source; guard
-	// defensively rather than index into an empty slice.
-	if len(entries) == 0 {
+	if len(entityRows) == 0 {
 		return nil, fmt.Errorf("entitygraph/sqlite: entity %s: %w", subject, ErrNotFound)
+	}
+
+	entries := entityRowsToEntries(entityRows)
+	observations := make([]types.Observation, len(entityRows))
+	for i, r := range entityRows {
+		observations[i] = types.Observation{
+			Source:     r.source,
+			ObservedAt: r.observedAt,
+			RecordedAt: r.recordedAt,
+			Subject:    subject,
+			Kind:       types.ObservationKind(r.kind),
+			Confidence: types.Confidence(r.confidence),
+			Payload:    r.payload,
+		}
 	}
 
 	winIdx := winningSourceIdx(entries)
@@ -125,9 +104,17 @@ func (p *SQLiteEntityGraphProvider) GetEntity(ctx context.Context, eid interface
 			ObservedAt: observations[winIdx].ObservedAt,
 			RecordedAt: observations[winIdx].RecordedAt,
 		},
-		// CollapseGroup is wired by STORY-6; a pass-through no-op here.
-		CollapseGroup: nil,
 	}
+
+	// Wire collapse-group resolution when requested (ADR-022 §3).
+	if opts.CollapseGroup {
+		cg, err := p.resolveCollapseGroup(ctx, eid, opts.AsOf, opts.TenantFilter)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: resolve collapse group: %w", err)
+		}
+		view.CollapseGroup = cg
+	}
+
 	return view, nil
 }
 
@@ -427,19 +414,4 @@ func (p *SQLiteEntityGraphProvider) GetHistory(ctx context.Context, eid interfac
 		return nil, fmt.Errorf("entitygraph/sqlite: iterate history: %w", err)
 	}
 	return records, nil
-}
-
-// Diff is implemented by a later story.
-func (p *SQLiteEntityGraphProvider) Diff(_ context.Context, _ interfaces.EIDRef, _ interfaces.TimeRange) (*interfaces.StateDiff, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
-// GetTimeline is implemented by a later story.
-func (p *SQLiteEntityGraphProvider) GetTimeline(_ context.Context, _ []interfaces.EIDRef, _ interfaces.TimeRange) ([]*interfaces.TimelineEvent, error) {
-	return nil, interfaces.ErrNotImplemented
-}
-
-// Watch is implemented by a later story.
-func (p *SQLiteEntityGraphProvider) Watch(_ context.Context, _ interfaces.WatchFilter, _ string) (<-chan interfaces.WatchEvent, error) {
-	return nil, interfaces.ErrNotImplemented
 }

--- a/pkg/entitygraph/providers/sqlite/provider_test.go
+++ b/pkg/entitygraph/providers/sqlite/provider_test.go
@@ -337,3 +337,108 @@ func TestDedupErrorPathIsClean(t *testing.T) {
 	// ErrNotFound is a valid non-nil sentinel; confirm it is not accidentally nil.
 	require.NotNil(t, ErrNotFound, "ErrNotFound must be a non-nil sentinel error")
 }
+
+func TestEscapeLIKE(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"host:abc", "host:abc"},
+		{"host:server%01", `host:server\%01`},
+		{"host:server_01", `host:server\_01`},
+		{`host:back\slash`, `host:back\\slash`},
+		{`100%_done`, `100\%\_done`},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, escapeLIKE(tc.in), "input: %q", tc.in)
+	}
+}
+
+// TestLIKEWildcardInEID_CollapseAsOf verifies that an EID containing SQL LIKE
+// metacharacters (%, _) does not produce spurious group members during temporal BFS.
+// Without LIKE escaping, pattern 'same-as|host:server%01|%' (where % is a wildcard)
+// would match 'same-as|host:server01|host:wildcard-peer', wrongly including those
+// entities in the group for host:server%01.
+func TestLIKEWildcardInEID_CollapseAsOf(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// decoy: host:server01 — an EID that an unescaped LIKE pattern for host:server%01
+	// would spuriously match (% wildcard matches empty string, so server%01 matches server01).
+	decoy := "host:server01"
+	peer := "host:wildcard-peer"
+	subject := "host:server%01"
+
+	for _, e := range []string{decoy, peer, subject} {
+		require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+			Source: "observer:scan",
+			Observations: []types.Observation{
+				obs(e, "observer:scan", types.ObservationKindState, now, map[string]interface{}{
+					"entity_kind": "host", "owning_tenant": "root",
+				}),
+			},
+		}))
+	}
+
+	// Create a same-as edge between decoy and peer — NOT involving the test subject.
+	edgeSubject := "same-as|" + decoy + "|" + peer
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "operator:test",
+		Observations: []types.Observation{
+			obs(edgeSubject, "operator:test", types.ObservationKindState, now, map[string]interface{}{}),
+		},
+	}))
+
+	testEID := mustEID(t, subject)
+	members, err := p.resolveGroupMembersAsOf(ctx, testEID, now.Add(time.Second))
+	require.NoError(t, err)
+	// The subject has no same-as edges; only itself should be returned.
+	require.Len(t, members, 1, "subject with %% in EID must not match decoy's edges via unescaped LIKE")
+	require.Equal(t, subject, members[0].String())
+}
+
+// TestLIKEWildcardInEID_Timeline verifies that GetTimeline does not include
+// same-as-change events from edges unrelated to the queried subject when the
+// subject EID contains SQL LIKE metacharacters.
+func TestLIKEWildcardInEID_Timeline(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	decoy := "host:server01"
+	peer := "host:wildcard-peer2"
+	subject := "host:server%01"
+
+	for _, e := range []string{decoy, peer, subject} {
+		require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+			Source: "observer:scan",
+			Observations: []types.Observation{
+				obs(e, "observer:scan", types.ObservationKindState, now, map[string]interface{}{
+					"entity_kind": "host", "owning_tenant": "root",
+				}),
+			},
+		}))
+	}
+
+	// Same-as edge between decoy and peer — not involving subject.
+	edgeSubject := "same-as|" + decoy + "|" + peer
+	require.NoError(t, p.ReportObservations(ctx, interfaces.ObservationBatch{
+		Source: "operator:test",
+		Observations: []types.Observation{
+			obs(edgeSubject, "operator:test", types.ObservationKindState, now, map[string]interface{}{}),
+		},
+	}))
+
+	testEID := mustEID(t, subject)
+	events, err := p.GetTimeline(ctx, []interfaces.EIDRef{testEID}, interfaces.TimeRange{
+		From: now.Add(-time.Second),
+		To:   now.Add(time.Minute),
+	})
+	require.NoError(t, err)
+
+	// Only state-change events for subject itself should be present — no spurious
+	// same-as-change events from the decoy's edge.
+	for _, ev := range events {
+		require.NotEqual(t, "same-as-change", ev.Kind,
+			"no same-as-change events expected for a subject with no same-as edges")
+	}
+}

--- a/pkg/entitygraph/providers/sqlite/temporal.go
+++ b/pkg/entitygraph/providers/sqlite/temporal.go
@@ -266,12 +266,12 @@ func (p *SQLiteEntityGraphProvider) GetTimeline(ctx context.Context, eids []inte
 		saRows, err := p.db.QueryContext(ctx, `
 			SELECT l.id, l.observed_at, l.kind, l.subject
 			FROM eg_observation_log l
-			WHERE (l.subject LIKE ? OR l.subject LIKE ?)
+			WHERE (l.subject LIKE ? ESCAPE '\' OR l.subject LIKE ? ESCAPE '\')
 			  AND l.observed_at >= ?
 			  AND l.observed_at <= ?
 			ORDER BY l.id ASC`,
-			"same-as|"+subject+"|%",
-			"same-as|%|"+subject,
+			"same-as|"+escapeLIKE(subject)+"|%",
+			"same-as|%|"+escapeLIKE(subject),
 			rfc3339(r.From), rfc3339(r.To),
 		)
 		if err != nil {

--- a/pkg/entitygraph/providers/sqlite/temporal.go
+++ b/pkg/entitygraph/providers/sqlite/temporal.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+)
+
+// currentEntityRow holds one scanned row from the entity source queries,
+// carrying both the fields needed for precedence resolution and the fields
+// needed for building types.Observation values.
+type currentEntityRow struct {
+	source      string
+	sourceClass string
+	kind        string
+	confidence  string
+	observedAt  time.Time
+	recordedAt  time.Time
+	payloadHash string
+	payload     map[string]interface{}
+}
+
+// loadEntityRowsCurrent returns all per-source current-state rows for subject
+// from eg_entity_current (the fast path for non-temporal reads).
+func (p *SQLiteEntityGraphProvider) loadEntityRowsCurrent(ctx context.Context, subject string) ([]currentEntityRow, error) {
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT c.source, c.source_class, c.kind, c.confidence, c.observed_at, c.recorded_at, c.payload_hash, pc.payload
+		 FROM eg_entity_current c
+		 JOIN eg_payload_content pc ON pc.payload_hash = c.payload_hash
+		 WHERE c.subject = ? AND c.kind != 'desired-state'`,
+		subject,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: load current rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []currentEntityRow
+	for rows.Next() {
+		var r currentEntityRow
+		var observedAt, recordedAt, payloadJSON string
+		if err := rows.Scan(&r.source, &r.sourceClass, &r.kind, &r.confidence,
+			&observedAt, &recordedAt, &r.payloadHash, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan current row: %w", err)
+		}
+		r.observedAt, _ = time.Parse(time.RFC3339Nano, observedAt)
+		r.recordedAt, _ = time.Parse(time.RFC3339Nano, recordedAt)
+		if payloadJSON != "" {
+			if err := json.Unmarshal([]byte(payloadJSON), &r.payload); err != nil {
+				return nil, fmt.Errorf("entitygraph/sqlite: decode current payload: %w", err)
+			}
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate current rows: %w", err)
+	}
+	return out, nil
+}
+
+// loadEntityRowsAsOf reconstructs the per-source state at or before asOf by
+// scanning the observation log. For each source the highest-id state or presence
+// observation at or before asOf is returned; sources whose latest row is an
+// absence are excluded (the source had retracted its assertion at that time).
+func (p *SQLiteEntityGraphProvider) loadEntityRowsAsOf(ctx context.Context, subject string, asOf time.Time) ([]currentEntityRow, error) {
+	asOfStr := rfc3339(asOf)
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT l.source, l.source_class, l.kind, l.confidence, l.observed_at, l.recorded_at, l.payload_hash, pc.payload
+		FROM eg_observation_log l
+		JOIN eg_payload_content pc ON pc.payload_hash = l.payload_hash
+		WHERE l.subject = ?
+		  AND l.observed_at <= ?
+		  AND l.id = (
+		      SELECT MAX(id) FROM eg_observation_log
+		      WHERE subject = l.subject AND source = l.source AND observed_at <= ?
+		  )
+		  AND l.kind IN ('state', 'presence')`,
+		subject, asOfStr, asOfStr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: load as-of rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []currentEntityRow
+	for rows.Next() {
+		var r currentEntityRow
+		var observedAt, recordedAt, payloadJSON string
+		if err := rows.Scan(&r.source, &r.sourceClass, &r.kind, &r.confidence,
+			&observedAt, &recordedAt, &r.payloadHash, &payloadJSON); err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: scan as-of row: %w", err)
+		}
+		r.observedAt, _ = time.Parse(time.RFC3339Nano, observedAt)
+		r.recordedAt, _ = time.Parse(time.RFC3339Nano, recordedAt)
+		if payloadJSON != "" {
+			if err := json.Unmarshal([]byte(payloadJSON), &r.payload); err != nil {
+				return nil, fmt.Errorf("entitygraph/sqlite: decode as-of payload: %w", err)
+			}
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: iterate as-of rows: %w", err)
+	}
+	return out, nil
+}
+
+// entityRowsToEntries converts currentEntityRow slices to sourceEntry slices for
+// use with the precedence resolution helpers.
+func entityRowsToEntries(rows []currentEntityRow) []sourceEntry {
+	entries := make([]sourceEntry, len(rows))
+	for i, r := range rows {
+		entries[i] = sourceEntry{
+			source:      r.source,
+			sourceClass: r.sourceClass,
+			observedAt:  r.observedAt,
+			payloadHash: r.payloadHash,
+			payload:     r.payload,
+		}
+	}
+	return entries
+}
+
+// entityStateAsOf returns the merged attribute map for a subject as-of asOf, or
+// nil if no state observations existed at or before that time.
+func (p *SQLiteEntityGraphProvider) entityStateAsOf(ctx context.Context, subject string, asOf time.Time) (map[string]interface{}, error) {
+	rows, err := p.loadEntityRowsAsOf(ctx, subject, asOf)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return mergeAttributes(entityRowsToEntries(rows)), nil
+}
+
+// computeAttributeChanges returns the set of attributes that differ between two
+// merged state snapshots. Either snapshot may be nil (entity did not exist).
+// Attributes present in only one snapshot are included (Before or After nil).
+// The result is sorted by attribute name for deterministic output.
+func computeAttributeChanges(atT1, atT2 map[string]interface{}) []interfaces.AttributeChange {
+	keys := make(map[string]struct{})
+	for k := range atT1 {
+		keys[k] = struct{}{}
+	}
+	for k := range atT2 {
+		keys[k] = struct{}{}
+	}
+
+	var changes []interfaces.AttributeChange
+	for k := range keys {
+		v1, ok1 := atT1[k]
+		v2, ok2 := atT2[k]
+		if !ok1 && !ok2 {
+			continue
+		}
+		j1, _ := json.Marshal(v1)
+		j2, _ := json.Marshal(v2)
+		if ok1 == ok2 && string(j1) == string(j2) {
+			continue
+		}
+		changes = append(changes, interfaces.AttributeChange{
+			Attribute: k,
+			Before:    v1,
+			After:     v2,
+		})
+	}
+
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Attribute < changes[j].Attribute
+	})
+	return changes
+}
+
+// Diff computes the attribute delta between two as-of states of a subject. It
+// projects the merged entity state at r.From and r.To, then returns the set of
+// attributes whose values differ.
+func (p *SQLiteEntityGraphProvider) Diff(ctx context.Context, eid interfaces.EIDRef, r interfaces.TimeRange) (*interfaces.StateDiff, error) {
+	subject := eid.String()
+
+	atT1, err := p.entityStateAsOf(ctx, subject, r.From)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: diff state at T1: %w", err)
+	}
+	atT2, err := p.entityStateAsOf(ctx, subject, r.To)
+	if err != nil {
+		return nil, fmt.Errorf("entitygraph/sqlite: diff state at T2: %w", err)
+	}
+
+	return &interfaces.StateDiff{
+		Subject: eid,
+		T1:      r.From,
+		T2:      r.To,
+		Changes: computeAttributeChanges(atT1, atT2),
+	}, nil
+}
+
+// GetTimeline returns a merged, time-ordered change-event stream across the
+// supplied subjects over the time range. This story delivers state-change events
+// (entity state and absence observations) and same-as-change events (same-as edge
+// observations). Drift and apply-outcome events are deferred per ADR-022 §9.
+func (p *SQLiteEntityGraphProvider) GetTimeline(ctx context.Context, eids []interfaces.EIDRef, r interfaces.TimeRange) ([]*interfaces.TimelineEvent, error) {
+	if len(eids) == 0 {
+		return nil, nil
+	}
+
+	var events []*interfaces.TimelineEvent
+
+	for _, eid := range eids {
+		subject := eid.String()
+
+		// State and absence observations for this subject.
+		srows, err := p.db.QueryContext(ctx, `
+			SELECT l.id, l.source, l.observed_at, l.kind, pc.payload
+			FROM eg_observation_log l
+			JOIN eg_payload_content pc ON pc.payload_hash = l.payload_hash
+			WHERE l.subject = ?
+			  AND l.kind IN ('state', 'absence')
+			  AND l.observed_at >= ?
+			  AND l.observed_at <= ?
+			ORDER BY l.id ASC`,
+			subject, rfc3339(r.From), rfc3339(r.To),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: timeline scan for %s: %w", subject, err)
+		}
+
+		for srows.Next() {
+			var id int64
+			var source, observedAt, kind, payloadJSON string
+			if err := srows.Scan(&id, &source, &observedAt, &kind, &payloadJSON); err != nil {
+				_ = srows.Close()
+				return nil, fmt.Errorf("entitygraph/sqlite: scan timeline row: %w", err)
+			}
+			var payload map[string]interface{}
+			if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+				payload = map[string]interface{}{}
+			}
+			oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+			events = append(events, &interfaces.TimelineEvent{
+				Subject:    eid,
+				OccurredAt: oa,
+				Kind:       "state-change",
+				Detail: map[string]interface{}{
+					"source":           source,
+					"observation_kind": kind,
+					"version":          id,
+					"payload":          payload,
+				},
+			})
+		}
+		if err := srows.Err(); err != nil {
+			_ = srows.Close()
+			return nil, fmt.Errorf("entitygraph/sqlite: iterate timeline rows for %s: %w", subject, err)
+		}
+		_ = srows.Close()
+
+		// Same-as edge observations involving this subject (group-membership changes).
+		saRows, err := p.db.QueryContext(ctx, `
+			SELECT l.id, l.observed_at, l.kind, l.subject
+			FROM eg_observation_log l
+			WHERE (l.subject LIKE ? OR l.subject LIKE ?)
+			  AND l.observed_at >= ?
+			  AND l.observed_at <= ?
+			ORDER BY l.id ASC`,
+			"same-as|"+subject+"|%",
+			"same-as|%|"+subject,
+			rfc3339(r.From), rfc3339(r.To),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("entitygraph/sqlite: timeline same-as scan for %s: %w", subject, err)
+		}
+
+		for saRows.Next() {
+			var id int64
+			var observedAt, kind, edgeSubject string
+			if err := saRows.Scan(&id, &observedAt, &kind, &edgeSubject); err != nil {
+				_ = saRows.Close()
+				return nil, fmt.Errorf("entitygraph/sqlite: scan same-as timeline row: %w", err)
+			}
+			oa, _ := time.Parse(time.RFC3339Nano, observedAt)
+			_, fromSubj, toSubj, _ := parseEdgeSubject(edgeSubject)
+			events = append(events, &interfaces.TimelineEvent{
+				Subject:    eid,
+				OccurredAt: oa,
+				Kind:       "same-as-change",
+				Detail: map[string]interface{}{
+					"edge_subject":     edgeSubject,
+					"from":             fromSubj,
+					"to":               toSubj,
+					"observation_kind": kind,
+					"version":          id,
+				},
+			})
+		}
+		if err := saRows.Err(); err != nil {
+			_ = saRows.Close()
+			return nil, fmt.Errorf("entitygraph/sqlite: iterate same-as timeline rows for %s: %w", subject, err)
+		}
+		_ = saRows.Close()
+	}
+
+	// Merge all events into a single time-ordered stream.
+	sort.SliceStable(events, func(i, j int) bool {
+		if events[i].OccurredAt.Equal(events[j].OccurredAt) {
+			vi, _ := events[i].Detail["version"].(int64)
+			vj, _ := events[j].Detail["version"].(int64)
+			return vi < vj
+		}
+		return events[i].OccurredAt.Before(events[j].OccurredAt)
+	})
+
+	return events, nil
+}
+
+// Watch is implemented by a later story.
+func (p *SQLiteEntityGraphProvider) Watch(_ context.Context, _ interfaces.WatchFilter, _ string) (<-chan interfaces.WatchEvent, error) {
+	return nil, interfaces.ErrNotImplemented
+}


### PR DESCRIPTION
## Summary

- **Diff**: projects entity state at two timestamps and returns the attribute-level delta sorted by attribute name. Uses SQLite correlated-MAX as-of and PostgreSQL `DISTINCT ON` as-of patterns (consistent with existing `queryCurrentRows` approach).
- **GetTimeline**: range-scans the observation log and returns a merged, time-ordered `state-change` / `same-as-change` event stream across N subjects. Edge observations are discovered via `LIKE 'same-as|<subject>|%'` and `LIKE 'same-as|%|<subject>'` patterns (EIDs never contain `|`).
- **CollapseGroup** (ADR-022 §3 three-step contract): (1) resolve same-as group membership as-of query time via BFS over edge history, (2) apply tenant cut using *current* `eg_entity_index.owning_tenant` (never ingest-time `tenant_path`) before any merge, (3) per-attribute precedence merge across visible members' sources; losing values retained in `Conflicts`.
- **Moved-entity history**: `GetHistory` returns all historical rows for a moved entity using current-ownership as the access gate — no per-row `tenant_path` filtering (ADR-023 §111-119).
- Both SQLite (`modernc.org/sqlite`, `?` placeholders) and PostgreSQL (`lib/pq`, `$N` placeholders) providers implement all behaviours.

New files: `sqlite/temporal.go`, `sqlite/collapse.go`, `database/temporal.go`, `database/collapse.go`.
Modified: `interfaces/contract_test.go` (+6 Story-6 tests), `sqlite/entity_reads.go` (stubs removed, `GetEntity` wired), `database/entity_reads.go` (stubs removed, `GetEntity` wired).

## Test plan

- [ ] All 6 new contract tests pass on SQLite: `HistoryDiffCorrectness`, `TimelineMultiSubject`, `CollapseGroupTenantCut` (REQUIRED), `MovedEntityHistoricalScan` (REQUIRED), `CollapseGroupConflictsRetained`, `CollapseGroupMultiMember`
- [ ] All prior 25 contract tests still pass (no regressions)
- [ ] `go build ./pkg/entitygraph/...` clean
- [ ] `make check-architecture` clean — no central provider violations
- [ ] Pre-existing e2e and script test failures (`TestAuthTierE2E_Tier3Enforcement`, `trust_boundary_test.sh phase2`) confirmed pre-existing on develop base commit `6b66180d`; not introduced by this PR

Fixes #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)