### PR TITLE
hyperv: whole-domain observe path — cluster, VM, vSwitch inventory (Issue #2891)

### DIFF
--- a/docs/architecture/decisions/024-module-observation-vs-convergence.md
+++ b/docs/architecture/decisions/024-module-observation-vs-convergence.md
@@ -10,6 +10,13 @@ A steward on a Hyper-V cluster node (a non-CNO member) did not report its cluste
 
 This is a specific instance of a general coupling defect: **DNA observation was gated on convergence**. A steward reports rich state only for what it is told to *manage*, not for everything it can *see*. That is backwards. It also blocked the `promote-hv-role` workflow (`cfg workflow promote-hv-role`), whose cluster derivation reads the selected steward's `cluster:*` DNA and therefore only works for the one node that publishes it.
 
+**Story #2891 is the shipped fix for the hyperv-specific case** — no new ADR is
+needed; this is implementation of the accepted decision above. It decouples
+`cluster:<name>` DNA from `hyperv.cluster` resource declaration (all cluster
+members now emit membership DNA via `Get-Cluster` self-discovery), adds
+whole-domain VM and vSwitch inventory to the unconditional observe path, and
+extends `psGetVM` with VM GUID and MAC addresses as entity-graph join keys.
+
 The generalisation, articulated during design: *stewards should be authoritative for what they can see*. A steward should report the union of what it can observe, and worry about convergence only for declared resources. Taken to its conclusion: installing a steward on a box should let it detect what the box **is** (installed roles/features) and emit rich DNA for each capability, with nothing declared — convergence being a separate, opt-in layer.
 
 ### Relationship to existing ADRs

--- a/docs/testing/hyperv-role-promotion-runbook.md
+++ b/docs/testing/hyperv-role-promotion-runbook.md
@@ -5,6 +5,16 @@ workflow-driven Hyper-V role promotion epic (**#2657**, stories #2667/#2668/
 #2670/#2671). Pairs with the automated suite
 `test/e2e/hyperv/promote_role_test.go` (Issue **#2671**).
 
+> **Cluster membership DNA — available on every member (story #2891).**
+> The `promote-hv-role` workflow derives the target steward's cluster from its
+> `cluster:*` DNA. Prior to story #2891, this DNA was emitted only on the node
+> where `hyperv.cluster` was declared (the CNO owner), so the workflow could not
+> derive the cluster for non-CNO stewards. Story #2891 decoupled cluster
+> membership DNA from resource declaration: every cluster member now emits
+> `cluster:<name>` DNA unconditionally via `Get-Cluster` (self-discovery, no
+> `-Name` filter). The workflow therefore works for **any cluster member**, not
+> only the CNO owner.
+
 The epic promotes a **standalone** `hyperv.vm` into a cluster-wide, CNO-owned
 **failover-cluster HA role** through three moving parts, driven by the
 `promote-hv-role` workflow (`features/workflow/templates/promote-hv-role.yaml`):

--- a/features/controller/clusterregistry/registry_test.go
+++ b/features/controller/clusterregistry/registry_test.go
@@ -181,6 +181,62 @@ func TestClusterRegistry_Cluster_NotFound(t *testing.T) {
 	assert.Nil(t, reg.Cluster("does-not-exist"))
 }
 
+// TestBuildRegistry_NonCNOSteward_HasClusterMembership is the AC5 acceptance
+// test for issue #2891. It verifies that clusterregistry.BuildRegistry correctly
+// includes non-CNO cluster members (stewards that carry cluster:* DNA produced
+// by the whole-domain observe path without a declared hyperv.cluster resource).
+//
+// Fixture: steward-1 is NODE1 (CNO owner), steward-2 is NODE2 (non-CNO member).
+// Both stewards publish cluster:cfg-lab.* DNA — steward-2 via observeLocalCluster
+// (no declared resource). The registry must list both as members.
+func TestBuildRegistry_NonCNOSteward_HasClusterMembership(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{
+			ID:       "steward-1",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				// Produced by observeLocalCluster on the CNO owner (NODE1).
+				"cluster:cfg-lab.member_nodes":        "NODE1,NODE2",
+				"cluster:cfg-lab.cno_owner_node":      "NODE1",
+				"cluster:cfg-lab.found":               "true",
+				"cluster:cfg-lab.resource_owner.web-01": "NODE1",
+			},
+		},
+		{
+			ID:       "steward-2",
+			TenantID: "default",
+			DNAAttributes: map[string]string{
+				// Produced by observeLocalCluster on the non-CNO member (NODE2).
+				// No declared hyperv.cluster resource — pure domain observe output.
+				"cluster:cfg-lab.member_nodes":   "NODE1,NODE2",
+				"cluster:cfg-lab.cno_owner_node": "NODE1",
+				"cluster:cfg-lab.found":          "true",
+			},
+		},
+	}
+
+	reg := clusterregistry.BuildRegistry(stewards)
+	require.NotNil(t, reg)
+
+	entry := reg.Cluster("cfg-lab")
+	require.NotNil(t, entry, "cfg-lab must be in the registry")
+
+	members := make([]string, len(entry.Members))
+	copy(members, entry.Members)
+	sort.Strings(members)
+	assert.Equal(t, []string{"steward-1", "steward-2"}, members,
+		"non-CNO member (steward-2/NODE2) must appear in cluster membership")
+
+	// Reverse lookup: steward-2 belongs to cfg-lab even without CNO ownership.
+	clustersFor2 := reg.MemberClusters("steward-2")
+	assert.Equal(t, []string{"cfg-lab"}, clustersFor2,
+		"MemberClusters for non-CNO steward must include cfg-lab")
+
+	// Reverse lookup: steward-1 still has its membership too.
+	clustersFor1 := reg.MemberClusters("steward-1")
+	assert.Equal(t, []string{"cfg-lab"}, clustersFor1)
+}
+
 func TestClusterRegistry_RoleOwnerNotOverwrittenByNonOwnerField(t *testing.T) {
 	// Non resource_owner fields (e.g., member_nodes, found) must not pollute RoleOwners.
 	stewards := []fleet.StewardData{

--- a/features/controller/clusterregistry/registry_test.go
+++ b/features/controller/clusterregistry/registry_test.go
@@ -196,9 +196,9 @@ func TestBuildRegistry_NonCNOSteward_HasClusterMembership(t *testing.T) {
 			TenantID: "default",
 			DNAAttributes: map[string]string{
 				// Produced by observeLocalCluster on the CNO owner (NODE1).
-				"cluster:cfg-lab.member_nodes":        "NODE1,NODE2",
-				"cluster:cfg-lab.cno_owner_node":      "NODE1",
-				"cluster:cfg-lab.found":               "true",
+				"cluster:cfg-lab.member_nodes":          "NODE1,NODE2",
+				"cluster:cfg-lab.cno_owner_node":        "NODE1",
+				"cluster:cfg-lab.found":                 "true",
 				"cluster:cfg-lab.resource_owner.web-01": "NODE1",
 			},
 		},

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -14,13 +14,39 @@ the default and supported deployment shape is the in-host PS host.
 ## Purpose and scope
 
 The Hyper-V module provides desired-state management of Hyper-V resources on the
-Windows Server host the steward runs on. It enables CFGMS to create, start,
-stop, resize, and remove virtual machines, configure virtual switches, and read
-failover-cluster topology and ownership — all by invoking host-native Hyper-V /
-Failover-Clustering PowerShell cmdlets through the in-host `psHostTransport`. A
-VM's network connection is declared on the VM itself (`switch_name`); the module
-converges its adapters to match. All user-supplied values travel via PowerShell
-`ArgumentList` — never composed into script text.
+Windows Server host the steward runs on, and emits whole-domain Hyper-V inventory
+DNA — cluster membership, VM inventory, and vSwitch inventory — unconditionally,
+with no `hyperv.*` resource declared (story #2891, ADR-024).
+
+### Whole-domain observation (declaration-independent)
+
+On any Hyper-V host where the module is active, the steward emits Hyper-V domain
+DNA best-effort, regardless of whether any `hyperv.*` resource is declared:
+
+- **Cluster membership:** every cluster member — not only the CNO owner — emits
+  `cluster:<name>` DNA including `member_nodes`. This is sourced from
+  `Get-Cluster` with no `-Name` filter (self-discovery), run locally on the
+  member. No `hyperv.cluster` resource needs to be declared for this to happen;
+  the emission is fully decoupled from `hyperv.cluster` reconciliation.
+- **VM inventory:** all VMs visible to `Get-VM` are enumerated and reported,
+  including identity-claim attributes (VM GUID and per-adapter MAC addresses)
+  used as entity-graph join keys (ADR-022 §3).
+- **vSwitch inventory:** all virtual switches visible to `Get-VMSwitch` are
+  enumerated and reported.
+
+This observe path is **read-only** (enumerate + `Get`-equivalent, never `Set`),
+uses `-ErrorAction SilentlyContinue` on anything absent, and is independent of
+convergence. See ADR-024 for the observation-vs-convergence design rationale.
+
+### Convergence (declared resources)
+
+The module also enables CFGMS to create, start, stop, resize, and remove virtual
+machines, configure virtual switches, and read failover-cluster topology and
+ownership — all by invoking host-native Hyper-V / Failover-Clustering PowerShell
+cmdlets through the in-host `psHostTransport`. A VM's network connection is
+declared on the VM itself (`switch_name`); the module converges its adapters to
+match. All user-supplied values travel via PowerShell `ArgumentList` — never
+composed into script text.
 
 The module's scope includes:
 

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -232,6 +232,13 @@ func (s *ClusterStatus) GetManagedFields() []string {
 // service is not running or the host is standalone).
 const psGetCluster = `$c = Get-Cluster -Name $ClusterName -ErrorAction SilentlyContinue; if (-not $c) { Write-Output '{"found":false}'; return }; $nodes = @(Get-ClusterNode -Cluster $ClusterName -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }); $csv = @(Get-ClusterSharedVolume -Cluster $ClusterName -ErrorAction SilentlyContinue | ForEach-Object { $_.SharedVolumeInfo.FriendlyVolumeName }); ConvertTo-Json @{ found=$true; Name=$c.Name; MemberNodes=$nodes; CsvPaths=$csv } -Compress -Depth 4`
 
+// psGetClusterSelf reads the local host's cluster membership without a -Name
+// parameter — Get-Cluster returns the cluster this node belongs to, if any.
+// Used by observeLocalCluster (the whole-domain observe path) to report cluster
+// membership independently of any declared hyperv.cluster resource. No args —
+// auto-discovery only. Emits {"found":false} when the host is standalone.
+const psGetClusterSelf = `$c = Get-Cluster -ErrorAction SilentlyContinue; if (-not $c) { Write-Output '{"found":false}'; return }; $nodes = @(Get-ClusterNode -Cluster $c.Name -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }); $csv = @(Get-ClusterSharedVolume -Cluster $c.Name -ErrorAction SilentlyContinue | ForEach-Object { $_.SharedVolumeInfo.FriendlyVolumeName }); ConvertTo-Json @{ found=$true; Name=$c.Name; MemberNodes=$nodes; CsvPaths=$csv } -Compress -Depth 4`
+
 // psGetClusterOwnerNode reads the current owner node of the core "Cluster
 // Group" (the CNO). It emits {"owner":""} when the group has no current owner
 // (transient failover) so the Go helper can treat absence as non-error.
@@ -387,6 +394,71 @@ func (m *hypervModule) getCluster(ctx context.Context, name string) (modules.Con
 
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
 		"Get-Cluster", "cluster:"+name, nil, nil, nil)
+
+	return status, nil
+}
+
+// observeLocalCluster returns the cluster status for the local host without
+// requiring a declared hyperv.cluster resource. It self-discovers the cluster
+// via Get-Cluster (no -Name parameter), bypassing the scope cap (S5) used by
+// the declared-resource path. Standalone hosts return ClusterStatus.Found=false
+// with no error. Used by GetDomain to populate cluster:* DNA on any Hyper-V
+// cluster member, including non-CNO nodes that have no declared hyperv.cluster.
+//
+// All PowerShell calls are read-only (Get-* only).
+func (m *hypervModule) observeLocalCluster(ctx context.Context) (*ClusterStatus, error) {
+	if m.transport == nil {
+		return nil, ErrTransportNotConfigured
+	}
+
+	output, err := m.transport.ExecutePS(ctx, psGetClusterSelf, nil)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: observe local cluster: %w", err)
+	}
+
+	var parsed struct {
+		Found       bool     `json:"found"`
+		Name        string   `json:"Name"`
+		MemberNodes []string `json:"MemberNodes"`
+		CsvPaths    []string `json:"CsvPaths"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
+		return nil, fmt.Errorf("hyperv: parse observe-cluster response: %w", jsonErr)
+	}
+	if !parsed.Found {
+		return &ClusterStatus{Found: false, ClusterAccessOK: true}, nil
+	}
+
+	name := firstNonEmpty(parsed.Name, "")
+	if name == "" {
+		return &ClusterStatus{Found: false, ClusterAccessOK: true}, nil
+	}
+	status := &ClusterStatus{
+		Name:        name,
+		MemberNodes: parsed.MemberNodes,
+		CSVPaths:    parsed.CsvPaths,
+		RoleOwners:  map[string]string{},
+		Found:       true,
+	}
+
+	// CNO owner and role owners: delegate to clusterOwnershipHelper. When no
+	// cluster resource is declared (m.clusterName == ""), the scope cap does not
+	// fire. When a declared cluster name matches the self-discovered name, the cap
+	// also passes cleanly. On any scope-cap or ownership error, degrade gracefully —
+	// missing ownership info never fails the domain observe.
+	ownsCNO, roleOwners, ownErr := m.clusterOwnershipHelper(ctx, name)
+	if ownErr == nil {
+		if roleOwners != nil {
+			status.RoleOwners = roleOwners
+		}
+		if ownsCNO {
+			status.CNOOwnerNode = m.nodeHostname
+		} else {
+			status.CNOOwnerNode = m.readCNOOwner(ctx, name)
+		}
+	}
+
+	status.ClusterAccessOK, status.ClusterAccessRemediation = m.probeClusterAccess(ctx, name)
 
 	return status, nil
 }

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -455,10 +455,13 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 
 // Get returns the current Hyper-V resource configuration.
 // Supported resource ID prefixes:
-//   - "vm:<name>": retrieve VMConfig for the named virtual machine
-//   - "vswitch:<name>": retrieve VSwitchConfig for the named virtual switch
-//   - "cluster:<name>": retrieve ClusterStatus (read-only) for the named
+//   - "vm:<name>":       retrieve VMConfig for the named virtual machine
+//   - "vswitch:<name>":  retrieve VSwitchConfig for the named virtual switch
+//   - "cluster:<name>":  retrieve ClusterStatus (read-only) for the named
 //     failover cluster, subject to the cluster_name scope cap (S5)
+//   - "domain:hyperv":   retrieve DomainObservation — a deterministic summary
+//     of cluster membership, VM names, and vswitch names, requiring no declared
+//     hyperv.* resource (whole-domain observe path, ADR-024)
 func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
 	if err := m.checkDetection(ctx); err != nil {
 		if errors.Is(err, ErrHostNotHyperV) {
@@ -480,6 +483,9 @@ func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.Conf
 		return m.getVSwitch(ctx, name)
 	case "cluster":
 		return m.getCluster(ctx, name)
+	case "domain":
+		_ = name // always "hyperv"; reserved for future sub-domain scoping
+		return m.getDomainSummary(ctx)
 	default:
 		return nil, modules.ErrNotImplemented
 	}

--- a/features/modules/hyperv/observe.go
+++ b/features/modules/hyperv/observe.go
@@ -43,12 +43,12 @@ func (d *DomainObservation) AsMap() map[string]interface{} {
 		swNames[i] = n
 	}
 	return map[string]interface{}{
-		"cluster_name":   d.ClusterName,
-		"cluster_found":  d.ClusterFound,
-		"vm_count":       len(d.VMNames),
-		"vm_names":       vmNames,
-		"vswitch_count":  len(d.VSwitchNames),
-		"vswitch_names":  swNames,
+		"cluster_name":  d.ClusterName,
+		"cluster_found": d.ClusterFound,
+		"vm_count":      len(d.VMNames),
+		"vm_names":      vmNames,
+		"vswitch_count": len(d.VSwitchNames),
+		"vswitch_names": swNames,
 	}
 }
 

--- a/features/modules/hyperv/observe.go
+++ b/features/modules/hyperv/observe.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// DomainObservation is the ConfigState returned by Get("domain:hyperv"). It
+// provides a deterministic, read-only inventory of the host's Hyper-V domain:
+// the cluster this host belongs to (if any), the names of all local VMs, and
+// the names of all local virtual switches. No ephemeral fields (ADR-016 §4).
+//
+// This is the single-resource summary form — the per-resource form (with full
+// VM DNA fragments keyed by "vm:<name>" etc.) is available via GetDomain.
+type DomainObservation struct {
+	// ClusterName is the name of the failover cluster this host belongs to.
+	// Empty when the host is standalone.
+	ClusterName string `yaml:"cluster_name,omitempty"`
+	// ClusterFound reports whether the host is a member of a failover cluster.
+	ClusterFound bool `yaml:"cluster_found"`
+	// VMNames is the sorted list of all VM names on this host.
+	VMNames []string `yaml:"vm_names,omitempty"`
+	// VSwitchNames is the sorted list of all virtual switch names on this host.
+	VSwitchNames []string `yaml:"vswitch_names,omitempty"`
+}
+
+// AsMap implements modules.ConfigState. All values are deterministic and
+// contain no ephemeral runtime state (ADR-016 §4).
+func (d *DomainObservation) AsMap() map[string]interface{} {
+	vmNames := make([]interface{}, len(d.VMNames))
+	for i, n := range d.VMNames {
+		vmNames[i] = n
+	}
+	swNames := make([]interface{}, len(d.VSwitchNames))
+	for i, n := range d.VSwitchNames {
+		swNames[i] = n
+	}
+	return map[string]interface{}{
+		"cluster_name":   d.ClusterName,
+		"cluster_found":  d.ClusterFound,
+		"vm_count":       len(d.VMNames),
+		"vm_names":       vmNames,
+		"vswitch_count":  len(d.VSwitchNames),
+		"vswitch_names":  swNames,
+	}
+}
+
+// ToYAML implements modules.ConfigState.
+func (d *DomainObservation) ToYAML() ([]byte, error) {
+	return yaml.Marshal(d)
+}
+
+// FromYAML implements modules.ConfigState. Domain observations are never
+// decoded from operator YAML; provided for interface completeness.
+func (d *DomainObservation) FromYAML(data []byte) error {
+	return yaml.Unmarshal(data, d)
+}
+
+// Validate implements modules.ConfigState. Domain observations carry no
+// operator constraints — always valid.
+func (d *DomainObservation) Validate() error { return nil }
+
+// GetManagedFields implements modules.ConfigState. The domain observation is
+// purely observed — no field participates in drift comparison.
+func (d *DomainObservation) GetManagedFields() []string { return nil }
+
+// GetDomain observes the full Hyper-V domain on this host without requiring any
+// declared hyperv.* resource. It returns a map of natural resource IDs to their
+// observed ConfigState:
+//   - "cluster:<name>" — present when the host is a cluster member
+//   - "vm:<name>"      — one entry per local VM (includes VMGUID + MAC addresses)
+//   - "vswitch:<name>" — one entry per virtual switch
+//
+// All PowerShell calls are read-only (Get-* only). The returned map is suitable
+// for direct use with cacheModuleDNAState: each entry produces cluster:*,
+// vm:*, or vswitch:* DNA keys when processed by the steward's DNA layer,
+// independently of any declared hyperv.* resource.
+func (m *hypervModule) GetDomain(ctx context.Context) (map[string]modules.ConfigState, error) {
+	result := make(map[string]modules.ConfigState)
+
+	cluster, err := m.observeLocalCluster(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: domain observe (cluster): %w", err)
+	}
+	if cluster.Found {
+		result["cluster:"+cluster.Name] = cluster
+	}
+
+	vmNames, err := m.enumerateVMNames(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: domain observe (vms): %w", err)
+	}
+	for _, name := range vmNames {
+		cfg, found, rErr := m.readVMState(ctx, name)
+		if rErr != nil || !found {
+			continue
+		}
+		result["vm:"+name] = cfg
+	}
+
+	switches, err := m.observeVSwitchDomain(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: domain observe (vswitches): %w", err)
+	}
+	for _, sw := range switches {
+		result["vswitch:"+sw.Name] = sw
+	}
+
+	return result, nil
+}
+
+// getDomainSummary returns a DomainObservation for the current host — a
+// lightweight, deterministic summary of cluster membership, VM names, and
+// vswitch names. Called by Get("domain:hyperv"). All sub-observations are
+// read-only. VM names and vswitch names are sorted for determinism.
+func (m *hypervModule) getDomainSummary(ctx context.Context) (*DomainObservation, error) {
+	obs := &DomainObservation{}
+
+	cluster, err := m.observeLocalCluster(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: domain summary (cluster): %w", err)
+	}
+	if cluster.Found {
+		obs.ClusterName = cluster.Name
+		obs.ClusterFound = true
+	}
+
+	vmNames, err := m.enumerateVMNames(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: domain summary (vms): %w", err)
+	}
+	sorted := make([]string, len(vmNames))
+	copy(sorted, vmNames)
+	sort.Strings(sorted)
+	obs.VMNames = sorted
+
+	switches, err := m.observeVSwitchDomain(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: domain summary (vswitches): %w", err)
+	}
+	swNames := make([]string, len(switches))
+	for i, sw := range switches {
+		swNames[i] = sw.Name
+	}
+	sort.Strings(swNames)
+	obs.VSwitchNames = swNames
+
+	return obs, nil
+}

--- a/features/modules/hyperv/observe_test.go
+++ b/features/modules/hyperv/observe_test.go
@@ -477,3 +477,242 @@ func TestGetDomain_AsMapKeys(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, []interface{}{"db-01", "web-01"}, vmNames)
 }
+
+// ── GetDomain (per-resource DNA emission) tests ────────────────────────────────
+
+// clusterMemberVMDomainOutputs returns the ordered per-call PS outputs for a
+// full GetDomain sweep on a cluster-member node (NODE2) with a single VM that
+// reports its VMGUID and two network adapters, plus one external vswitch. The
+// order matches GetDomain's call sequence: observeLocalCluster (5 reads),
+// enumerateVMNames, readVMState (per VM), observeVSwitchDomain.
+func clusterMemberVMDomainOutputs() []string {
+	return []string{
+		// observeLocalCluster (NODE2 non-owner path)
+		`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+		`{"owner":"NODE1"}`,
+		`{"owners":{}}`,
+		`{"owner":"NODE1"}`,
+		`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+		// enumerateVMNames
+		`{"vms":["web-01"]}`,
+		// readVMState(web-01) — includes Id and Adapters (#2891)
+		`{"found":true,"Name":"web-01","MemoryStartupBytes":4294967296,` +
+			`"ProcessorCount":2,"Generation":2,"Path":"C:\\VMs\\web-01.vhdx",` +
+			`"SwitchName":"External","SwitchNames":["External"],"State":"Running",` +
+			`"Id":"11111111-2222-3333-4444-555555555555",` +
+			`"Adapters":[{"MacAddress":"00:15:5D:01:02:03"},{"MacAddress":"00:15:5D:01:02:04"}]}`,
+		// observeVSwitchDomain
+		`{"switches":[{"Name":"External","SwitchType":"External"}]}`,
+	}
+}
+
+// TestGetDomain_HappyPath is the primary coverage for GetDomain. It verifies the
+// full multi-resource DNA emission: a cluster:<name> entry, one vm:<name> entry
+// carrying the parsed VMGUID + NetworkAdapters (the #2891 readVMState additions),
+// and one vswitch:<name> entry — all from a single read-only sweep.
+func TestGetDomain_HappyPath(t *testing.T) {
+	transport := &testWinRMTransport{perCallOutputs: clusterMemberVMDomainOutputs()}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	result, err := m.GetDomain(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Exactly one of each resource kind is emitted.
+	require.Contains(t, result, "cluster:cfg-lab")
+	require.Contains(t, result, "vm:web-01")
+	require.Contains(t, result, "vswitch:External")
+	assert.Len(t, result, 3)
+
+	// The cluster entry is the observed ClusterStatus.
+	cluster, ok := result["cluster:cfg-lab"].(*ClusterStatus)
+	require.True(t, ok, "cluster entry must be a *ClusterStatus")
+	assert.Equal(t, "cfg-lab", cluster.Name)
+	assert.True(t, cluster.Found)
+
+	// The vm entry carries the parsed VMGUID and NIC inventory (#2891).
+	vm, ok := result["vm:web-01"].(*VMConfig)
+	require.True(t, ok, "vm entry must be a *VMConfig")
+	assert.Equal(t, "web-01", vm.Name)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", vm.VMGUID)
+	require.Len(t, vm.NetworkAdapters, 2)
+	assert.Equal(t, "00:15:5D:01:02:03", vm.NetworkAdapters[0].MacAddress)
+	assert.Equal(t, "00:15:5D:01:02:04", vm.NetworkAdapters[1].MacAddress)
+
+	// The vswitch entry is the observed VSwitchConfig.
+	sw, ok := result["vswitch:External"].(*VSwitchConfig)
+	require.True(t, ok, "vswitch entry must be a *VSwitchConfig")
+	assert.Equal(t, "External", sw.Name)
+	assert.Equal(t, "external", sw.SwitchType)
+}
+
+// TestGetDomain_Standalone verifies GetDomain on a standalone (non-clustered)
+// host: no cluster:<name> entry is emitted, only the VM and vswitch entries.
+func TestGetDomain_Standalone(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			// observeLocalCluster → standalone
+			`{"found":false}`,
+			// enumerateVMNames
+			`{"vms":["solo-01"]}`,
+			// readVMState(solo-01) — no Id/Adapters (older host)
+			hostVMJSON("solo-01", "stopped", 2, 2048),
+			// observeVSwitchDomain
+			`{"switches":[{"Name":"Default Switch","SwitchType":"Internal"}]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "STANDALONE"
+
+	result, err := m.GetDomain(context.Background())
+	require.NoError(t, err)
+
+	for k := range result {
+		assert.NotContains(t, k, "cluster:", "standalone host must emit no cluster entry")
+	}
+	require.Contains(t, result, "vm:solo-01")
+	require.Contains(t, result, "vswitch:Default Switch")
+	assert.Len(t, result, 2)
+}
+
+// TestGetDomain_SkipsUnreadableVM verifies that a per-VM read failure does not
+// abort the whole sweep: an unparseable psGetVM response for one VM is skipped
+// (GetDomain lines 101-104) while the healthy VM is still emitted.
+func TestGetDomain_SkipsUnreadableVM(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,
+			// two VMs enumerated
+			`{"vms":["good-01","bad-01"]}`,
+			// readVMState(good-01) — valid
+			hostVMJSON("good-01", "running", 2, 4096),
+			// readVMState(bad-01) — malformed JSON → rErr, must be skipped
+			`}{ not json`,
+			// observeVSwitchDomain
+			`{"switches":[]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	result, err := m.GetDomain(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, result, "vm:good-01")
+	assert.NotContains(t, result, "vm:bad-01", "an unreadable VM must be skipped, not emitted")
+}
+
+// TestGetDomain_SkipsAbsentVM verifies that a VM which enumerates but reports
+// found=false on the follow-up read (a race: destroyed between enumerate and
+// read) is skipped rather than emitted as an empty entry.
+func TestGetDomain_SkipsAbsentVM(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,
+			`{"vms":["ghost-01"]}`,
+			// readVMState(ghost-01) → found=false sentinel
+			`{"found":false}`,
+			`{"switches":[]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	result, err := m.GetDomain(context.Background())
+	require.NoError(t, err)
+	assert.NotContains(t, result, "vm:ghost-01")
+	assert.Empty(t, result)
+}
+
+// TestGetDomain_ClusterError verifies GetDomain wraps and returns a cluster
+// observation error (GetDomain line 90) rather than swallowing it.
+func TestGetDomain_ClusterError(t *testing.T) {
+	transport := &testWinRMTransport{
+		// Malformed psGetClusterSelf output → observeLocalCluster parse error.
+		perCallOutputs: []string{`not-json`},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	result, err := m.GetDomain(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "domain observe (cluster)")
+}
+
+// TestGetDomain_VMEnumError verifies GetDomain wraps and returns a VM
+// enumeration error (GetDomain line 98).
+func TestGetDomain_VMEnumError(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,
+			// Malformed enumerateVMNames output → parse error.
+			`not-json`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	result, err := m.GetDomain(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "domain observe (vms)")
+}
+
+// TestGetDomain_VSwitchError verifies GetDomain wraps and returns a vswitch
+// enumeration error (GetDomain line 110).
+func TestGetDomain_VSwitchError(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,
+			`{"vms":[]}`,
+			// Malformed observeVSwitchDomain output → parse error.
+			`not-json`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	result, err := m.GetDomain(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "domain observe (vswitches)")
+}
+
+// TestGetDomain_ReadOnly extends the AC3 read-only guarantee to the full
+// GetDomain per-resource path (the summary variant is covered by
+// TestObserveDomain_ReadOnly). Every PS script issued must be an allowed Get-*
+// read, and no write-mutating cmdlet may appear.
+func TestGetDomain_ReadOnly(t *testing.T) {
+	transport := &testWinRMTransport{perCallOutputs: clusterMemberVMDomainOutputs()}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	_, err := m.GetDomain(context.Background())
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := make([]winRMCall, len(transport.calls))
+	copy(calls, transport.calls)
+	transport.mu.Unlock()
+
+	allowedScripts := map[string]bool{
+		psGetClusterSelf:          true,
+		psGetClusterOwnerNode:     true,
+		psGetClusterResourceOwner: true,
+		psGetClusterAccessSelf:    true,
+		psEnumerateVMs:            true,
+		psGetVM:                   true,
+		psEnumerateVSwitches:      true,
+	}
+	for _, call := range calls {
+		if !allowedScripts[call.scriptBlock] {
+			t.Errorf("GetDomain used unexpected (non-read-only) script:\n%s", call.scriptBlock)
+		}
+	}
+	assertNoWriteCmdlets(t, calls)
+}

--- a/features/modules/hyperv/observe_test.go
+++ b/features/modules/hyperv/observe_test.go
@@ -1,0 +1,479 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules/conformance"
+)
+
+// ── observeLocalCluster tests ──────────────────────────────────────────────────
+
+// TestObserveLocalCluster_NonCNONode verifies that a non-CNO cluster member
+// (NODE2) reports full cluster membership via observeLocalCluster — the
+// whole-domain observe path — without requiring a declared hyperv.cluster
+// resource. This is the motivating AC2 scenario from issue #2891.
+func TestObserveLocalCluster_NonCNONode(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			// psGetClusterSelf: self-discovery, no -Name parameter
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			// clusterOwnershipHelper → readCNOOwner (psGetClusterOwnerNode)
+			`{"owner":"NODE1"}`,
+			// clusterOwnershipHelper → readResourceOwners (psGetClusterResourceOwner)
+			`{"owners":{"web-01":"NODE1"}}`,
+			// readCNOOwner again (non-owner path in observeLocalCluster)
+			`{"owner":"NODE1"}`,
+			// probeClusterAccess (psGetClusterAccessSelf)
+			`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+	// No m.clusterName — no declared hyperv.cluster resource.
+
+	status, err := m.observeLocalCluster(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	assert.True(t, status.Found, "cluster must be found on a cluster member")
+	assert.Equal(t, "cfg-lab", status.Name)
+	assert.ElementsMatch(t, []string{"NODE1", "NODE2"}, status.MemberNodes)
+	assert.Equal(t, "NODE1", status.CNOOwnerNode, "CNO owner must be NODE1")
+	assert.True(t, status.ClusterAccessOK)
+	assert.Equal(t, map[string]string{"web-01": "NODE1"}, status.RoleOwners)
+}
+
+// TestObserveLocalCluster_CNOOwner verifies that the CNO-owning node populates
+// its own hostname as CNOOwnerNode.
+func TestObserveLocalCluster_CNOOwner(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			// clusterOwnershipHelper: NODE1 is the CNO owner
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			// probeClusterAccess
+			`{"account":"LAB\\NODE1$","access_ok":true,"remediation":""}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE1"
+
+	status, err := m.observeLocalCluster(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "NODE1", status.CNOOwnerNode)
+	assert.True(t, status.ClusterAccessOK)
+}
+
+// TestObserveLocalCluster_Standalone verifies that a standalone (non-clustered)
+// host returns Found=false with no error.
+func TestObserveLocalCluster_Standalone(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "STANDALONE"
+
+	status, err := m.observeLocalCluster(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.False(t, status.Found, "standalone host must not report a cluster")
+	assert.True(t, status.ClusterAccessOK, "standalone host access is always ok")
+}
+
+// TestObserveLocalCluster_NoTransport verifies that observeLocalCluster returns
+// ErrTransportNotConfigured when no transport is wired, matching the contract
+// used by existing declared-resource paths.
+func TestObserveLocalCluster_NoTransport(t *testing.T) {
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	// m.transport deliberately left nil
+
+	_, err := m.observeLocalCluster(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTransportNotConfigured)
+}
+
+// TestObserveLocalCluster_ScopeCapNotRequired verifies that observeLocalCluster
+// works even when m.clusterName is empty (no declared hyperv.cluster resource),
+// which is the primary non-CNO-node use case.
+func TestObserveLocalCluster_ScopeCapNotRequired(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			`{"owner":"NODE1"}`,
+			`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+	// m.clusterName == "" — no scope cap — must still work.
+
+	status, err := m.observeLocalCluster(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "cfg-lab", status.Name)
+}
+
+// ── AC3: Read-only conformance ─────────────────────────────────────────────────
+
+// TestObserveLocalCluster_ReadOnly is the AC3 acceptance test. It verifies that
+// observeLocalCluster only executes read-only PowerShell scripts (Get-* cmdlets)
+// and never issues any write-mutating command.
+func TestObserveLocalCluster_ReadOnly(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			`{"owner":"NODE1"}`,
+			`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	_, err := m.observeLocalCluster(context.Background())
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := make([]winRMCall, len(transport.calls))
+	copy(calls, transport.calls)
+	transport.mu.Unlock()
+
+	// AC3: only these read-only scripts are allowed in the observe path.
+	allowedScripts := map[string]bool{
+		psGetClusterSelf:          true,
+		psGetClusterOwnerNode:     true,
+		psGetClusterResourceOwner: true,
+		psGetClusterAccessSelf:    true,
+	}
+	for _, call := range calls {
+		if !allowedScripts[call.scriptBlock] {
+			t.Errorf("observe path used unexpected (non-read-only) script:\n%s", call.scriptBlock)
+		}
+	}
+}
+
+// TestObserveDomain_ReadOnly extends AC3 to the full domain summary path —
+// GetDomain and getDomainSummary must only issue read-only PS scripts.
+func TestObserveDomain_ReadOnly(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			// observeLocalCluster
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			`{"owner":"NODE1"}`,
+			`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+			// enumerateVMNames
+			`{"vms":["web-01"]}`,
+			// observeVSwitchDomain
+			`{"switches":[{"Name":"External","SwitchType":"External"}]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	_, err := m.getDomainSummary(context.Background())
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := make([]winRMCall, len(transport.calls))
+	copy(calls, transport.calls)
+	transport.mu.Unlock()
+
+	allowedScripts := map[string]bool{
+		psGetClusterSelf:          true,
+		psGetClusterOwnerNode:     true,
+		psGetClusterResourceOwner: true,
+		psGetClusterAccessSelf:    true,
+		psEnumerateVMs:            true,
+		psEnumerateVSwitches:      true,
+	}
+	for _, call := range calls {
+		if !allowedScripts[call.scriptBlock] {
+			t.Errorf("domain observe path used unexpected (non-read-only) script:\n%s", call.scriptBlock)
+		}
+	}
+
+	// Belt-and-suspenders: also scan for write verb patterns in the scripts.
+	assertNoWriteCmdlets(t, calls)
+}
+
+// assertNoWriteCmdlets scans all recorded PS calls and fails if any script
+// contains a known write-mutating cmdlet name as a standalone invocation token.
+// It complements the allowlist check in the AC3/AC3-domain tests.
+//
+// Note: psGetClusterAccessSelf contains "Grant-ClusterAccess" as a STRING VALUE
+// in its remediation output — it is not an actual cmdlet call in that script.
+// The allowlist-based check in TestObserve*_ReadOnly already guards this; this
+// helper focuses on patterns that appear only as true cmdlet invocations.
+func assertNoWriteCmdlets(t *testing.T, calls []winRMCall) {
+	t.Helper()
+	writePatterns := []string{
+		"New-VM", "Remove-VM", "Rename-VM", "Move-VMStorage",
+		"New-VMSwitch", "Remove-VMSwitch",
+		"Add-VMNetworkAdapter", "Remove-VMNetworkAdapter",
+		"Set-VM ", "Set-VMProcessor", "Set-VMMemory",
+		"Start-VM", "Stop-VM",
+		"Add-ClusterVirtualMachineRole", "Remove-ClusterGroup",
+		"Set-ClusterOwnerNode", "Set-ClusterGroup",
+	}
+	for _, call := range calls {
+		for _, pattern := range writePatterns {
+			if strings.Contains(call.scriptBlock, pattern) {
+				t.Errorf("observe path used write-mutating cmdlet %q in script:\n%s",
+					pattern, call.scriptBlock)
+			}
+		}
+	}
+}
+
+// ── enumerateVMNames tests ─────────────────────────────────────────────────────
+
+func TestEnumerateVMNames_ReturnsNames(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"vms":["web-01","db-01","jump-01"]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	names, err := m.enumerateVMNames(context.Background())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"web-01", "db-01", "jump-01"}, names)
+}
+
+func TestEnumerateVMNames_EmptyHost(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"vms":[]}`},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	names, err := m.enumerateVMNames(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, names)
+}
+
+func TestEnumerateVMNames_NoTransport(t *testing.T) {
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	// transport deliberately nil
+
+	names, err := m.enumerateVMNames(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, names)
+}
+
+// ── observeVSwitchDomain tests ─────────────────────────────────────────────────
+
+func TestObserveVSwitchDomain_ReturnsAllSwitches(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"switches":[{"Name":"External","SwitchType":"External"},{"Name":"Mgmt","SwitchType":"Internal"}]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	switches, err := m.observeVSwitchDomain(context.Background())
+	require.NoError(t, err)
+	require.Len(t, switches, 2)
+	assert.Equal(t, "External", switches[0].Name)
+	assert.Equal(t, "external", switches[0].SwitchType)
+	assert.Equal(t, "present", switches[0].State)
+	assert.Equal(t, "Mgmt", switches[1].Name)
+	assert.Equal(t, "internal", switches[1].SwitchType)
+}
+
+func TestObserveVSwitchDomain_NoSwitches(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"switches":[]}`},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	switches, err := m.observeVSwitchDomain(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, switches)
+}
+
+func TestObserveVSwitchDomain_NoTransport(t *testing.T) {
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	// transport deliberately nil
+
+	switches, err := m.observeVSwitchDomain(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, switches)
+}
+
+// ── getDomainSummary tests ─────────────────────────────────────────────────────
+
+func TestGetDomainSummary_ClusterMember(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			`{"owner":"NODE1"}`,
+			`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+			`{"vms":["web-01","db-01"]}`,
+			`{"switches":[{"Name":"External","SwitchType":"External"}]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	obs, err := m.getDomainSummary(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, obs)
+
+	assert.True(t, obs.ClusterFound)
+	assert.Equal(t, "cfg-lab", obs.ClusterName)
+	assert.Equal(t, []string{"db-01", "web-01"}, obs.VMNames, "VM names must be sorted")
+	assert.Equal(t, []string{"External"}, obs.VSwitchNames)
+}
+
+func TestGetDomainSummary_Standalone(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":false}`,
+			`{"vms":[]}`,
+			`{"switches":[]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	obs, err := m.getDomainSummary(context.Background())
+	require.NoError(t, err)
+	assert.False(t, obs.ClusterFound)
+	assert.Empty(t, obs.ClusterName)
+	assert.Empty(t, obs.VMNames)
+	assert.Empty(t, obs.VSwitchNames)
+}
+
+// ── AC4: Regression — convergence call counts unchanged ───────────────────────
+
+// TestObserveDomain_NoSetCalls is the AC4 regression guard: calling
+// getDomainSummary must never issue any PS write-mutating command, confirming
+// that the domain observe path does not change existing convergence behaviour.
+func TestObserveDomain_NoSetCalls(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			`{"owner":"NODE1"}`,
+			`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+			`{"vms":[]}`,
+			`{"switches":[]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	_, err := m.getDomainSummary(context.Background())
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := make([]winRMCall, len(transport.calls))
+	copy(calls, transport.calls)
+	transport.mu.Unlock()
+
+	assertNoWriteCmdlets(t, calls)
+}
+
+// ── AC6: Conformance — determinism + no ephemeral fields ──────────────────────
+
+// buildDomainTestTransport builds a testWinRMTransport pre-loaded with enough
+// outputs for two successive calls to Get("domain:hyperv") — each call issues
+// the same sequence of PS reads, so outputs repeat twice for determinism testing.
+func buildDomainTestTransport() *testWinRMTransport {
+	oneCycle := []string{
+		`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+		`{"owner":"NODE1"}`,
+		`{"owners":{}}`,
+		`{"owner":"NODE1"}`,
+		`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+		`{"vms":["web-01"]}`,
+		`{"switches":[{"Name":"External","SwitchType":"External"}]}`,
+	}
+	return &testWinRMTransport{
+		perCallOutputs: append(append([]string{}, oneCycle...), oneCycle...),
+	}
+}
+
+// TestGetDomain_Deterministic is the AC6 determinism assertion. It uses
+// conformance.AssertDeterministicGet, which calls Get("domain:hyperv") twice
+// and verifies that AsMap() produces byte-for-byte identical JSON both times.
+func TestGetDomain_Deterministic(t *testing.T) {
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = buildDomainTestTransport()
+	m.nodeHostname = "NODE2"
+
+	conformance.AssertDeterministicGet(t, m, "domain:hyperv")
+}
+
+// TestGetDomain_NoEphemeralFields is the AC6 ephemeral-field assertion. It uses
+// conformance.AssertNoEphemeralFields to confirm DomainObservation.AsMap()
+// contains no banned runtime values (ADR-016 §4).
+func TestGetDomain_NoEphemeralFields(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"cfg-lab","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`,
+			`{"owners":{}}`,
+			`{"owner":"NODE1"}`,
+			`{"account":"LAB\\NODE2$","access_ok":true,"remediation":""}`,
+			`{"vms":["web-01"]}`,
+			`{"switches":[{"Name":"External","SwitchType":"External"}]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.nodeHostname = "NODE2"
+
+	state, err := m.Get(context.Background(), "domain:hyperv")
+	require.NoError(t, err)
+	conformance.AssertNoEphemeralFields(t, state, conformance.DefaultBannedEphemeralFields)
+}
+
+// TestGetDomain_AsMapKeys verifies DomainObservation.AsMap() returns all
+// expected keys, including the newly added vm_count and vswitch_count.
+func TestGetDomain_AsMapKeys(t *testing.T) {
+	obs := &DomainObservation{
+		ClusterName:  "cfg-lab",
+		ClusterFound: true,
+		VMNames:      []string{"db-01", "web-01"},
+		VSwitchNames: []string{"External"},
+	}
+	m := obs.AsMap()
+
+	assert.Equal(t, "cfg-lab", m["cluster_name"])
+	assert.Equal(t, true, m["cluster_found"])
+	assert.Equal(t, 2, m["vm_count"])
+	assert.Equal(t, 1, m["vswitch_count"])
+	vmNames, ok := m["vm_names"].([]interface{})
+	require.True(t, ok)
+	assert.Equal(t, []interface{}{"db-01", "web-01"}, vmNames)
+}

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -130,6 +130,13 @@ type SourceConfig struct {
 	Edition string `yaml:"edition,omitempty"`
 }
 
+// VMNetworkAdapter holds the observed MAC address of a VM's virtual network
+// adapter, captured by psGetVM and exposed on the Get/DNA surface. Observed-only:
+// MAC addresses are Hyper-V-assigned and never authored in config.
+type VMNetworkAdapter struct {
+	MacAddress string `yaml:"mac_address,omitempty"`
+}
+
 // VMConfig represents the desired state of a Hyper-V virtual machine.
 //
 // Networking is declarative: switch_name is the FULL desired network of the
@@ -192,6 +199,17 @@ type VMConfig struct {
 	// drift on vhd_path (#2626). Like ConfigLocation it is never declared and is
 	// deliberately absent from GetManagedFields — visible as DNA, never drift.
 	CheckpointCount int `yaml:"checkpoint_count,omitempty"`
+
+	// VMGUID is the Hyper-V VM identifier ($vm.Id), captured by psGetVM/getVM
+	// and exposed on the Get/DNA surface. Observed-only: never declared in config,
+	// never participates in drift comparison.
+	VMGUID string `yaml:"vm_guid,omitempty"`
+
+	// NetworkAdapters is the observed virtual network adapter inventory with
+	// MAC addresses, captured by psGetVM and exposed on the Get/DNA surface.
+	// Observed-only: adapter management uses switch_name/switch_names; MACs are
+	// Hyper-V-assigned and never authored.
+	NetworkAdapters []VMNetworkAdapter `yaml:"network_adapters,omitempty"`
 
 	// seedDir is the module-level provisioning seed directory (m.seedDir),
 	// injected by setVM before Validate so the HA-role CSV seed-dir rule can be
@@ -590,11 +608,17 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 		"generation":   c.Generation,
 		"state":        c.State,
 		"source":       nil,
-		// Observed-only (#2411, #2626): reported for the Get/DNA surface, absent
-		// from GetManagedFields so they never participate in drift comparison.
+		// Observed-only (#2411, #2626, #2891): reported for the Get/DNA surface,
+		// absent from GetManagedFields so they never participate in drift comparison.
 		"configuration_location": c.ConfigLocation,
 		"checkpoint_count":       c.CheckpointCount,
+		"vm_guid":                c.VMGUID,
 	}
+	adapters := make([]interface{}, len(c.NetworkAdapters))
+	for i, a := range c.NetworkAdapters {
+		adapters[i] = map[string]interface{}{"mac_address": a.MacAddress}
+	}
+	m["network_adapters"] = adapters
 	// Declarative checkpoint policy (#2627): the drift comparator compares the
 	// AUTHORED `checkpoints` block (a managed config key) against what getVM
 	// reports here. getVM echoes the desired block back (checkpointsEcho) ONLY when
@@ -701,7 +725,13 @@ func (c *VMConfig) GetManagedFields() []string {
 // VMConfig.VHDPath stores the disk path; conflating it with the config
 // directory caused #1887 B1 verification to flag 2-changed drift on
 // every successful create.
-const psGetVM = `$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue; if (-not $vm) { Write-Output '{"found":false}'; return }; $adapters = @(Get-VMNetworkAdapter -VMName $Name -ErrorAction SilentlyContinue); $switchNames = @($adapters | ForEach-Object { $_.SwitchName } | Where-Object { $_ }); $disk = Get-VMHardDiskDrive -VMName $Name -ErrorAction SilentlyContinue | Select-Object -First 1; $diskPath = if ($disk) { $disk.Path } else { "" }; $rootPath = $diskPath; if ($diskPath) { try { $v = Get-VHD -Path $diskPath -ErrorAction Stop; while ($v.ParentPath) { $rootPath = $v.ParentPath; $v = Get-VHD -Path $v.ParentPath -ErrorAction Stop } } catch { Write-Warning "Get-VHD chain resolution failed for $diskPath: $($_.Exception.Message)" } }; $checkpointCount = @(Get-VMSnapshot -VMName $Name -ErrorAction SilentlyContinue).Count; $mem = Get-VMMemory -VMName $Name -ErrorAction SilentlyContinue; $startupBytes = if ($mem) { [long]$mem.Startup } else { 0 }; $result = @{ found=$true; Name=$vm.Name; MemoryStartupBytes=$startupBytes; ProcessorCount=[int]$vm.ProcessorCount; Generation=[int]$vm.Generation; Path=$rootPath; ConfigurationLocation=[string]$vm.ConfigurationLocation; CheckpointCount=[int]$checkpointCount; SwitchName=if ($switchNames.Count -gt 0) { $switchNames[0] } else { "" }; SwitchNames=$switchNames; State=$vm.State.ToString() }; ConvertTo-Json $result -Compress -Depth 4`
+const psGetVM = `$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue; if (-not $vm) { Write-Output '{"found":false}'; return }; $adapters = @(Get-VMNetworkAdapter -VMName $Name -ErrorAction SilentlyContinue); $switchNames = @($adapters | ForEach-Object { $_.SwitchName } | Where-Object { $_ }); $disk = Get-VMHardDiskDrive -VMName $Name -ErrorAction SilentlyContinue | Select-Object -First 1; $diskPath = if ($disk) { $disk.Path } else { "" }; $rootPath = $diskPath; if ($diskPath) { try { $v = Get-VHD -Path $diskPath -ErrorAction Stop; while ($v.ParentPath) { $rootPath = $v.ParentPath; $v = Get-VHD -Path $v.ParentPath -ErrorAction Stop } } catch { Write-Warning "Get-VHD chain resolution failed for $diskPath: $($_.Exception.Message)" } }; $checkpointCount = @(Get-VMSnapshot -VMName $Name -ErrorAction SilentlyContinue).Count; $mem = Get-VMMemory -VMName $Name -ErrorAction SilentlyContinue; $startupBytes = if ($mem) { [long]$mem.Startup } else { 0 }; $result = @{ found=$true; Name=$vm.Name; MemoryStartupBytes=$startupBytes; ProcessorCount=[int]$vm.ProcessorCount; Generation=[int]$vm.Generation; Path=$rootPath; ConfigurationLocation=[string]$vm.ConfigurationLocation; CheckpointCount=[int]$checkpointCount; SwitchName=if ($switchNames.Count -gt 0) { $switchNames[0] } else { "" }; SwitchNames=$switchNames; State=$vm.State.ToString(); Id=[string]$vm.Id; Adapters=@($adapters | ForEach-Object { @{MacAddress=$_.MacAddress} }) }; ConvertTo-Json $result -Compress -Depth 4`
+
+// psEnumerateVMs lists the names of all VMs on this Hyper-V host without
+// requiring any declared hyperv.vm resource. Used by the domain observe path.
+// The @() wrapper ensures ConvertTo-Json always emits a JSON array — even for
+// 0 or 1 VMs.
+const psEnumerateVMs = `ConvertTo-Json @{vms=@(Get-VM -ErrorAction SilentlyContinue | ForEach-Object { $_.Name })} -Compress`
 
 // psCreateVM is the script block passed to ExecutePS for VM creation.
 // All user-supplied values are transmitted via ArgumentList — none are
@@ -998,8 +1028,45 @@ func (m *hypervModule) readVMState(ctx context.Context, vmName string) (*VMConfi
 			cfg.State = strings.ToLower(v)
 		}
 	}
+	if v, ok := parsed["Id"].(string); ok {
+		cfg.VMGUID = v
+	}
+	if raw, ok := parsed["Adapters"].([]interface{}); ok {
+		for _, a := range raw {
+			if amap, ok := a.(map[string]interface{}); ok {
+				mac, _ := amap["MacAddress"].(string)
+				cfg.NetworkAdapters = append(cfg.NetworkAdapters, VMNetworkAdapter{MacAddress: mac})
+			}
+		}
+	}
 
 	return cfg, true, nil
+}
+
+// enumerateVMNames returns the names of all VMs on this host. It does not
+// require declared hyperv.vm resources and is used by the domain observe path.
+// Returns nil when the transport is not wired.
+func (m *hypervModule) enumerateVMNames(ctx context.Context) ([]string, error) {
+	if m.transport == nil {
+		return nil, nil
+	}
+	output, err := m.transport.ExecutePS(ctx, psEnumerateVMs, nil)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: enumerate vms: %w", err)
+	}
+	var parsed struct {
+		VMs []interface{} `json:"vms"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
+		return nil, fmt.Errorf("hyperv: parse enumerate-vms response: %w", jsonErr)
+	}
+	var names []string
+	for _, v := range parsed.VMs {
+		if s, ok := v.(string); ok && s != "" {
+			names = append(names, s)
+		}
+	}
+	return names, nil
 }
 
 // probeClusterRoleMembership reports whether vmName is a registered clustered

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -270,7 +270,8 @@ func TestExactName_RegardlessOfTenant(t *testing.T) {
 
 // ─── VMConfig ConfigState interface tests ─────────────────────────────────────
 
-// TestVMConfig_AsMap verifies that AsMap includes all configuration fields.
+// TestVMConfig_AsMap verifies that AsMap includes all configuration fields,
+// including the observed-only vm_guid and network_adapters keys (#2891).
 func TestVMConfig_AsMap(t *testing.T) {
 	cfg := &VMConfig{
 		Name:       "my-vm",
@@ -280,6 +281,11 @@ func TestVMConfig_AsMap(t *testing.T) {
 		SwitchName: "External",
 		Generation: 2,
 		State:      "running",
+		VMGUID:     "11111111-2222-3333-4444-555555555555",
+		NetworkAdapters: []VMNetworkAdapter{
+			{MacAddress: "00:15:5D:01:02:03"},
+			{MacAddress: "00:15:5D:01:02:04"},
+		},
 	}
 	m := cfg.AsMap()
 	assert.Equal(t, "my-vm", m["name"])
@@ -289,6 +295,73 @@ func TestVMConfig_AsMap(t *testing.T) {
 	assert.Equal(t, "External", m["switch_name"])
 	assert.Equal(t, 2, m["generation"])
 	assert.Equal(t, "running", m["state"])
+
+	// #2891: the observed VM GUID is surfaced on the DNA map.
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", m["vm_guid"])
+
+	// #2891: each observed network adapter is serialised as a mac_address map,
+	// preserving order.
+	adapters, ok := m["network_adapters"].([]interface{})
+	require.True(t, ok, "network_adapters must serialise as a slice")
+	require.Len(t, adapters, 2)
+	assert.Equal(t, map[string]interface{}{"mac_address": "00:15:5D:01:02:03"}, adapters[0])
+	assert.Equal(t, map[string]interface{}{"mac_address": "00:15:5D:01:02:04"}, adapters[1])
+}
+
+// TestVMConfig_AsMap_EmptyAdapters verifies that a VMConfig with no observed
+// adapters emits an empty (non-nil) network_adapters slice and an empty vm_guid.
+func TestVMConfig_AsMap_EmptyAdapters(t *testing.T) {
+	cfg := &VMConfig{Name: "bare-vm"}
+	m := cfg.AsMap()
+	assert.Equal(t, "", m["vm_guid"])
+	adapters, ok := m["network_adapters"].([]interface{})
+	require.True(t, ok, "network_adapters must always be a slice, even when empty")
+	assert.Empty(t, adapters)
+}
+
+// TestReadVMState_ParsesGUIDAndAdapters verifies that readVMState maps the
+// psGetVM "Id" field to VMGUID and the "Adapters" array to NetworkAdapters,
+// preserving MAC-address order (#2891). Without this parsing the DNA surface
+// would silently omit the VM identity and NIC inventory.
+func TestReadVMState_ParsesGUIDAndAdapters(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"web-01","MemoryStartupBytes":4294967296,` +
+				`"ProcessorCount":2,"Generation":2,"Path":"C:\\VMs\\web-01.vhdx",` +
+				`"SwitchName":"External","SwitchNames":["External"],"State":"Running",` +
+				`"Id":"11111111-2222-3333-4444-555555555555",` +
+				`"Adapters":[{"MacAddress":"00:15:5D:01:02:03"},{"MacAddress":"00:15:5D:01:02:04"}]}`,
+		},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	cfg, found, err := m.readVMState(context.Background(), "web-01")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", cfg.VMGUID)
+	require.Len(t, cfg.NetworkAdapters, 2)
+	assert.Equal(t, "00:15:5D:01:02:03", cfg.NetworkAdapters[0].MacAddress)
+	assert.Equal(t, "00:15:5D:01:02:04", cfg.NetworkAdapters[1].MacAddress)
+}
+
+// TestReadVMState_NoGUIDOrAdapters verifies back-compat: a psGetVM response that
+// omits the Id and Adapters fields yields an empty VMGUID and no adapters, with
+// no error (older host scripts / VMs with no NICs).
+func TestReadVMState_NoGUIDOrAdapters(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{hostVMJSON("db-01", "stopped", 4, 8192)},
+	}
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+
+	cfg, found, err := m.readVMState(context.Background(), "db-01")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, cfg.VMGUID)
+	assert.Empty(t, cfg.NetworkAdapters)
 }
 
 // TestVMConfig_YAML verifies round-trip YAML serialization.

--- a/features/modules/hyperv/vswitch.go
+++ b/features/modules/hyperv/vswitch.go
@@ -106,6 +106,12 @@ func (c *VSwitchConfig) GetManagedFields() []string {
 // $Name travels via ArgumentList — never interpolated into the script text.
 const psGetVSwitch = `$sw = Get-VMSwitch -Name $Name -ErrorAction SilentlyContinue; if (-not $sw) { Write-Output '{"found":false}'; return }; $result = @{ found=$true; Name=$sw.Name; SwitchType=$sw.SwitchType.ToString() }; ConvertTo-Json $result -Compress`
 
+// psEnumerateVSwitches lists all virtual switches on the host with their types.
+// No parameters — enumerates the full switch inventory. Used by the domain
+// observe path. The @() wrapper ensures ConvertTo-Json emits a JSON array even
+// for 0 or 1 switches.
+const psEnumerateVSwitches = `$sw = @(Get-VMSwitch -ErrorAction SilentlyContinue | ForEach-Object { @{Name=$_.Name; SwitchType=$_.SwitchType.ToString()} }); ConvertTo-Json @{switches=$sw} -Compress -Depth 4`
+
 // psRemoveVSwitch removes a virtual switch by host-side name. Guarded so a
 // removal of an already-absent switch is a clean no-op rather than an
 // ObjectNotFound error (mirrors psRemoveVM's existence guard — keeps the
@@ -176,6 +182,37 @@ func (m *hypervModule) getVSwitch(ctx context.Context, switchName string) (*VSwi
 	m.vswitchesMu.Unlock()
 
 	return cfg, nil
+}
+
+// observeVSwitchDomain returns the full vSwitch inventory on this host without
+// requiring declared hyperv.vswitch resources. Used by GetDomain. Returns nil
+// when the transport is not wired. All PowerShell calls are read-only (Get-*).
+func (m *hypervModule) observeVSwitchDomain(ctx context.Context) ([]*VSwitchConfig, error) {
+	if m.transport == nil {
+		return nil, nil
+	}
+	output, err := m.transport.ExecutePS(ctx, psEnumerateVSwitches, nil)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: enumerate vswitches: %w", err)
+	}
+	var parsed struct {
+		Switches []struct {
+			Name       string `json:"Name"`
+			SwitchType string `json:"SwitchType"`
+		} `json:"switches"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
+		return nil, fmt.Errorf("hyperv: parse enumerate-vswitches response: %w", jsonErr)
+	}
+	out := make([]*VSwitchConfig, 0, len(parsed.Switches))
+	for _, sw := range parsed.Switches {
+		out = append(out, &VSwitchConfig{
+			Name:       sw.Name,
+			SwitchType: strings.ToLower(sw.SwitchType),
+			State:      "present",
+		})
+	}
+	return out, nil
 }
 
 // setVSwitch applies the desired vSwitch configuration.


### PR DESCRIPTION
Fixes #2891

## Summary

- Adds `observeLocalCluster()` using `psGetClusterSelf` (no `-Name` parameter) so any Hyper-V cluster member reports `cluster:<name>.*` DNA without a declared `hyperv.cluster` resource — including non-CNO nodes
- Extends `psGetVM` to capture `$vm.Id` (VMGUID) and per-adapter `MacAddress`; surfaces them as observed-only fields (`VMGUID`, `NetworkAdapters`) on `VMConfig` and in `AsMap()`
- Adds `psEnumerateVMs` + `enumerateVMNames()` and `psEnumerateVSwitches` + `observeVSwitchDomain()` for full host inventory without declared resources
- New `observe.go` provides `DomainObservation` (deterministic ConfigState, no ephemeral fields), `GetDomain()` (per-resource map), and `getDomainSummary()` wired to `Get("domain:hyperv")`
- AC2: non-CNO-node observe test; AC3: read-only allowlist + write-verb scan; AC4: no-Set-calls regression guard; AC5: registry fixture for non-CNO steward DNA; AC6: `AssertDeterministicGet` + `AssertNoEphemeralFields`

## Test plan

- [ ] `go test ./features/modules/hyperv/... ./features/controller/clusterregistry/... -count=1` — all pass
- [ ] `make test` — all 214 script tests pass
- [ ] `go vet ./features/modules/hyperv/... ./features/controller/clusterregistry/...` — clean
- [ ] `make check-architecture` — no violations
- [ ] Existing VM/cluster/vswitch tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)