### PR TITLE
web: align fleet row health with tile aggregate taxonomy (Issue #2920)

### DIFF
--- a/web/src/fleet/FleetOverview.test.tsx
+++ b/web/src/fleet/FleetOverview.test.tsx
@@ -452,22 +452,26 @@ describe('columns', () => {
 describe('health column', () => {
   it('maps Status + LastSeen staleness onto semantic pills', async () => {
     mockFleet([
-      makeSteward({ id: 's1', hostname: 'fresh', status: 'active', lastSeenMsAgo: 10_000 }),
-      makeSteward({ id: 's2', hostname: 'stale', status: 'active', lastSeenMsAgo: STALE_AFTER_MS + 60_000 }),
-      makeSteward({ id: 's3', hostname: 'degraded', status: 'degraded' }),
+      // active + fresh  → Healthy/ok
+      makeSteward({ id: 's1', hostname: 'fresh',   status: 'active', lastSeenMsAgo: 10_000 }),
+      // active + stale  → Degraded/warn (matches server handleFleetHealth bucket; Issue #2920)
+      makeSteward({ id: 's2', hostname: 'stale',   status: 'active', lastSeenMsAgo: STALE_AFTER_MS + 60_000 }),
+      // lost            → Unreachable/crit
+      makeSteward({ id: 's3', hostname: 'lost',    status: 'lost' }),
+      // registered (no heartbeat) → Registered/neutral
       makeSteward({ id: 's4', hostname: 'enrolled', status: 'registered', lastSeenMsAgo: null }),
     ])
     renderFleet()
     await screen.findByRole('table')
 
     expect(screen.getByText('Healthy')).toBeInTheDocument()
-    expect(screen.getByText('Unreachable')).toBeInTheDocument()
     expect(screen.getByText('Degraded')).toBeInTheDocument()
+    expect(screen.getByText('Unreachable')).toBeInTheDocument()
     expect(screen.getByText('Registered')).toBeInTheDocument()
 
     expect(screen.getByText('Healthy').className).toContain('ok')
-    expect(screen.getByText('Unreachable').className).toContain('crit')
     expect(screen.getByText('Degraded').className).toContain('warn')
+    expect(screen.getByText('Unreachable').className).toContain('crit')
     expect(screen.getByText('Registered').className).toContain('neutral')
   })
 })

--- a/web/src/fleet/health.test.ts
+++ b/web/src/fleet/health.test.ts
@@ -103,10 +103,12 @@ describe('deriveHealth ↔ handleFleetHealth taxonomy contract', () => {
     return null // not counted by server aggregate
   }
 
-  const serverToClient: Record<string, { label: string; tone: HealthTone }> = {
-    healthy:     { label: 'Healthy',     tone: 'ok' },
-    degraded:    { label: 'Degraded',    tone: 'warn' },
-    unreachable: { label: 'Unreachable', tone: 'crit' },
+  function bucketToHealth(bucket: 'healthy' | 'degraded' | 'unreachable'): { label: string; tone: HealthTone } {
+    switch (bucket) {
+      case 'healthy':     return { label: 'Healthy',     tone: 'ok' }
+      case 'degraded':    return { label: 'Degraded',    tone: 'warn' }
+      case 'unreachable': return { label: 'Unreachable', tone: 'crit' }
+    }
   }
 
   const fixtures: Array<{
@@ -131,7 +133,7 @@ describe('deriveHealth ↔ handleFleetHealth taxonomy contract', () => {
       const clientHealth = deriveHealth(status, lastSeen, NOW)
       if (bucket !== null) {
         // For states the server counts, client label must match the server bucket.
-        expect(clientHealth).toEqual(serverToClient[bucket])
+        expect(clientHealth).toEqual(bucketToHealth(bucket))
       } else {
         // For states the server does not count, client must not produce a bucket
         // label that would imply the server tracks it (healthy/degraded/unreachable).

--- a/web/src/fleet/health.test.ts
+++ b/web/src/fleet/health.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   STALE_AFTER_MS,
+  type HealthTone,
   deriveHealth,
   fetchFleetHealth,
   formatLastSeen,
@@ -21,21 +22,27 @@ describe('deriveHealth', () => {
     })
   })
 
-  it('maps an active steward with a stale heartbeat to Unreachable/crit', () => {
+  it('maps an active steward with a stale heartbeat to Degraded/warn', () => {
     expect(deriveHealth('active', iso(STALE_AFTER_MS + 60_000), NOW)).toEqual({
-      label: 'Unreachable',
-      tone: 'crit',
+      label: 'Degraded',
+      tone: 'warn',
     })
   })
 
-  it('treats exactly-at-threshold as still fresh, one ms past as stale', () => {
+  it('treats exactly-at-threshold as still fresh, one ms past as stale (Degraded)', () => {
     expect(deriveHealth('active', iso(STALE_AFTER_MS), NOW).tone).toBe('ok')
-    expect(deriveHealth('active', iso(STALE_AFTER_MS + 1), NOW).tone).toBe('crit')
+    expect(deriveHealth('active', iso(STALE_AFTER_MS + 1), NOW).tone).toBe('warn')
   })
 
-  it('maps an active steward that has never checked in to Unreachable', () => {
-    expect(deriveHealth('active', '0001-01-01T00:00:00Z', NOW).tone).toBe('crit')
-    expect(deriveHealth('active', undefined, NOW).tone).toBe('crit')
+  it('maps an active steward that has never checked in to Degraded', () => {
+    expect(deriveHealth('active', '0001-01-01T00:00:00Z', NOW)).toEqual({
+      label: 'Degraded',
+      tone: 'warn',
+    })
+    expect(deriveHealth('active', undefined, NOW)).toEqual({
+      label: 'Degraded',
+      tone: 'warn',
+    })
   })
 
   it('maps lifecycle states independently of staleness', () => {
@@ -69,6 +76,69 @@ describe('deriveHealth', () => {
       tone: 'neutral',
     })
   })
+})
+
+// ── Server/client taxonomy contract (Issue #2920) ─────────────────────────────
+//
+// Mirrors the bucketing logic from handleFleetHealth
+// (features/controller/api/handlers_fleet.go) so we can assert that
+// deriveHealth and the server aggregate classify the same (status, last_seen)
+// pair into the same bucket. Drift here reproduces the "Degraded: 5 /
+// Unreachable: 0" tile vs. 5 Unreachable rows bug.
+
+describe('deriveHealth ↔ handleFleetHealth taxonomy contract', () => {
+  // TypeScript mirror of handleFleetHealth's bucketing (handlers_fleet.go:142-152).
+  // Update this whenever DegradedHeartbeatAge changes on the server.
+  function serverBucket(
+    status: string,
+    lastSeen: string | undefined,
+    nowMs: number,
+  ): 'healthy' | 'degraded' | 'unreachable' | null {
+    if (status === 'active') {
+      const seen = parseLastSeen(lastSeen)
+      const ageMs = seen !== null ? nowMs - seen : Infinity
+      return ageMs <= STALE_AFTER_MS ? 'healthy' : 'degraded'
+    }
+    if (status === 'lost') return 'unreachable'
+    return null // not counted by server aggregate
+  }
+
+  const serverToClient: Record<string, { label: string; tone: HealthTone }> = {
+    healthy:     { label: 'Healthy',     tone: 'ok' },
+    degraded:    { label: 'Degraded',    tone: 'warn' },
+    unreachable: { label: 'Unreachable', tone: 'crit' },
+  }
+
+  const fixtures: Array<{
+    desc: string
+    status: string
+    lastSeen: string | undefined
+  }> = [
+    { desc: 'active + fresh heartbeat',        status: 'active', lastSeen: iso(30_000) },
+    { desc: 'active + stale heartbeat',         status: 'active', lastSeen: iso(STALE_AFTER_MS + 60_000) },
+    { desc: 'active + never checked in (zero)', status: 'active', lastSeen: '0001-01-01T00:00:00Z' },
+    { desc: 'active + undefined last_seen',      status: 'active', lastSeen: undefined },
+    { desc: 'lost',                              status: 'lost',   lastSeen: iso(60_000) },
+    { desc: 'registered (not counted)',          status: 'registered',  lastSeen: undefined },
+    { desc: 'dormant (not counted)',             status: 'dormant',     lastSeen: iso(0) },
+    { desc: 'archived (not counted)',            status: 'archived',    lastSeen: iso(0) },
+    { desc: 'revoked (not counted)',             status: 'revoked',     lastSeen: iso(0) },
+  ]
+
+  for (const { desc, status, lastSeen } of fixtures) {
+    it(`agrees with server for: ${desc}`, () => {
+      const bucket = serverBucket(status, lastSeen, NOW)
+      const clientHealth = deriveHealth(status, lastSeen, NOW)
+      if (bucket !== null) {
+        // For states the server counts, client label must match the server bucket.
+        expect(clientHealth).toEqual(serverToClient[bucket])
+      } else {
+        // For states the server does not count, client must not produce a bucket
+        // label that would imply the server tracks it (healthy/degraded/unreachable).
+        expect(['Healthy', 'Degraded', 'Unreachable']).not.toContain(clientHealth.label)
+      }
+    })
+  }
 })
 
 describe('parseLastSeen', () => {

--- a/web/src/fleet/health.ts
+++ b/web/src/fleet/health.ts
@@ -9,9 +9,11 @@ import { apiFetch } from '../api/client.ts'
  * The API payload carries a lifecycle `status` (business.StewardStatus:
  * registered/active/lost/dormant/archived/revoked — plus online/offline on
  * the filtered fleet-query path) and a `last_seen` heartbeat timestamp. The
- * Health column folds both into one signal: an "active" steward whose
- * heartbeat has gone stale is presented as Unreachable, because a healthy
- * label next to a 20-minute-old check-in would be a lie.
+ * Health column folds both into one signal using the same taxonomy as the
+ * server-side handleFleetHealth aggregate (handlers_fleet.go):
+ *   - active + fresh heartbeat  → Healthy (ok)
+ *   - active + stale heartbeat  → Degraded (warn)
+ *   - lost                      → Unreachable (crit)
  *
  * Colors carry meaning only (design-system pillar 2): each tone maps to a
  * semantic state token (--state-ok/-warn/-crit/-neutral), never a decorative
@@ -27,9 +29,10 @@ export interface Health {
 
 /*
  * Heartbeat age beyond which an otherwise-active steward is presented as
- * Unreachable. The payload pins no heartbeat contract, so this is a display
- * threshold, not protocol truth; 5 minutes matches the reference mockup's
- * semantics (a 6-minute-old check-in renders critical).
+ * Degraded. Must match DegradedHeartbeatAge in
+ * features/controller/api/handlers_fleet.go (currently 5 minutes); drift
+ * between these two constants re-introduces the tile/row disagreement fixed
+ * in Issue #2920.
  */
 export const STALE_AFTER_MS = 5 * 60_000
 
@@ -64,7 +67,7 @@ export function deriveHealth(
       const fresh = seen !== null && nowMs - seen <= STALE_AFTER_MS
       return fresh
         ? { label: 'Healthy', tone: 'ok' }
-        : { label: 'Unreachable', tone: 'crit' }
+        : { label: 'Degraded', tone: 'warn' }
     }
     case 'degraded':
       return { label: 'Degraded', tone: 'warn' }


### PR DESCRIPTION
## Summary

- `deriveHealth` in `web/src/fleet/health.ts` classified `active + stale-heartbeat` as **Unreachable/crit**, while the server-side `handleFleetHealth` counted the same stewards as **Degraded**. This caused tiles to show "Degraded: 5 / Unreachable: 0" while 5 rows displayed "Unreachable" badges.
- Fixed by changing the stale-active branch in `deriveHealth` to return `{ label: 'Degraded', tone: 'warn' }`, matching the server taxonomy.
- Updated `STALE_AFTER_MS` JSDoc to cross-reference `DegradedHeartbeatAge` in `handlers_fleet.go` so threshold drift is visible to maintainers.

## Changes

| File | Change |
|------|--------|
| `web/src/fleet/health.ts` | `active + stale` → `Degraded/warn` (was `Unreachable/crit`); updated comments |
| `web/src/fleet/health.test.ts` | Corrected 3 existing tests; added fixture-driven taxonomy contract block |
| `web/src/fleet/FleetOverview.test.tsx` | Swapped `status:'degraded'` fixture for `status:'lost'` to cover Unreachable via the correct path |

## Specialist Review Results

- **Code Review**: PASS
- **Test Quality**: PASS
- **Security**: PASS

All 481 web tests pass. Zero findings from adversarial review (1 round, 0 fix iterations).

Fixes #2920