### PR TITLE
pipeline: derive zero-work retry count from pipeline state, not issue comments (Issue #2928)

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -154,6 +154,64 @@ gh_api_with_retry() {
     return 1
 }
 
+# _zero_work_retry — handle a zero-work failure retry/escalation.
+# Reads the retry count from the ZeroWorkRetries project field rather than from
+# issue comments, so comment content (or count) cannot influence dispatch state.
+# A read failure is treated conservatively: Blocked, not re-dispatch.
+# Globals used: PROJECT_QUEUE, CFGMS_PROJECT_ITEM_ID, ISSUE_NUM, EXIT_CODE
+_zero_work_retry() {
+    local zw_marker="<!-- cfgms-zero-work-retry -->"
+
+    # Read retry count from the project field. On get-item failure zw_read_ok
+    # stays false — a read failure must never be treated as "count is zero".
+    local zw_item_json zw_read_ok=false
+    if zw_item_json=$(bash "$PROJECT_QUEUE" get-item "$CFGMS_PROJECT_ITEM_ID" 2>/dev/null); then
+        zw_read_ok=true
+    fi
+
+    if [[ "$zw_read_ok" != "true" ]]; then
+        bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" status "Blocked" \
+            2>/dev/null || echo "WARN: failed to set status Blocked"
+        [[ -n "${ISSUE_NUM:-}" ]] && gh issue comment "$ISSUE_NUM" --body \
+            "${zw_marker} Zero-work agent failure (exit ${EXIT_CODE}) — retry counter unavailable (project field read failed). Status set to Blocked for operator review." \
+            2>/dev/null || true
+        echo "Zero-work failure: retry counter unavailable — set to Blocked (conservative)"
+        return
+    fi
+
+    # Parse ZeroWorkRetries; a missing or empty value means first failure (treat as 0).
+    local zw_count
+    zw_count=$(printf '%s' "$zw_item_json" | python3 -c \
+        'import json,sys; d=json.load(sys.stdin); v=d.get("fields",{}).get("ZeroWorkRetries",""); print(v if v and v.strip() else "0")' \
+        2>/dev/null || echo "PARSE_ERROR")
+
+    if [[ "$zw_count" == "PARSE_ERROR" ]] || ! [[ "$zw_count" =~ ^[0-9]+$ ]]; then
+        bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" status "Blocked" \
+            2>/dev/null || echo "WARN: failed to set status Blocked"
+        echo "Zero-work failure: retry counter parse error — set to Blocked (conservative)"
+        return
+    fi
+
+    if [ "$zw_count" -lt 3 ]; then
+        local new_count=$((zw_count + 1))
+        bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" "ZeroWorkRetries" "$new_count" \
+            2>/dev/null || echo "WARN: failed to increment ZeroWorkRetries field"
+        bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" status "Ready" \
+            2>/dev/null || echo "WARN: failed to reset status Ready"
+        [[ -n "${ISSUE_NUM:-}" ]] && gh issue comment "$ISSUE_NUM" --body \
+            "${zw_marker} Zero-work agent failure (exit ${EXIT_CODE}) — no changes produced (likely usage limit / token reauth / early crash). Status reset to Ready for re-dispatch (retry ${new_count}/3)." \
+            2>/dev/null || true
+        echo "Zero-work failure: reset to Ready for re-dispatch (retry ${new_count}/3)"
+    else
+        bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" status "Blocked" \
+            2>/dev/null || echo "WARN: failed to set status Blocked"
+        [[ -n "${ISSUE_NUM:-}" ]] && gh issue comment "$ISSUE_NUM" --body \
+            "${zw_marker} Zero-work agent failure (exit ${EXIT_CODE}) — 3 re-dispatch retries exhausted with no progress. Status set to Blocked for operator review." \
+            2>/dev/null || true
+        echo "Zero-work failure: retry cap reached — set to Blocked for operator review"
+    fi
+}
+
 # --- Shared prompt sections ---
 # These are appended to ALL mode prompts for consistent quality standards.
 
@@ -916,36 +974,18 @@ else
             # strands it forever (the cron won't re-dispatch In Progress work).
             # Reset it to Ready so the next cron cycle re-dispatches it, capped
             # so a persistent failure escalates instead of looping. The retry
-            # count is the number of marker comments on the story issue.
+            # count is read from the ZeroWorkRetries project field — not from
+            # issue comments — so comment content cannot influence dispatch state.
             if [[ -z "${CFGMS_PROJECT_ITEM_ID:-}" ]]; then
                 echo "Zero-work failure: no project item id — cannot route for re-dispatch"
             elif [[ -z "$ISSUE_NUM" ]]; then
-                # No issue to track retries on — escalate rather than risk an
-                # unbounded re-dispatch loop.
+                # No issue linked — escalate rather than risk dispatch loops without
+                # operator-visible comment history.
                 bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" status "Blocked" \
                     2>/dev/null || echo "WARN: failed to set status Blocked"
-                echo "Zero-work failure (no issue for retry tracking) — set to Blocked"
+                echo "Zero-work failure (no issue linked) — set to Blocked"
             else
-                zw_marker="<!-- cfgms-zero-work-retry -->"
-                zw_count=$(gh issue view "$ISSUE_NUM" --json comments \
-                    --jq "[.comments[] | select(.body | contains(\"$zw_marker\"))] | length" \
-                    2>/dev/null || echo 0)
-                zw_count=${zw_count:-0}
-                if [ "$zw_count" -lt 3 ]; then
-                    bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" status "Ready" \
-                        2>/dev/null || echo "WARN: failed to reset status Ready"
-                    gh issue comment "$ISSUE_NUM" --body \
-                        "${zw_marker} Zero-work agent failure (exit ${EXIT_CODE}) — no changes produced (likely usage limit / token reauth / early crash). Status reset to Ready for re-dispatch (retry $((zw_count + 1))/3)." \
-                        2>/dev/null || true
-                    echo "Zero-work failure: reset to Ready for re-dispatch (retry $((zw_count + 1))/3)"
-                else
-                    bash "$PROJECT_QUEUE" update-field "$CFGMS_PROJECT_ITEM_ID" status "Blocked" \
-                        2>/dev/null || echo "WARN: failed to set status Blocked"
-                    gh issue comment "$ISSUE_NUM" --body \
-                        "${zw_marker} Zero-work agent failure (exit ${EXIT_CODE}) — 3 re-dispatch retries exhausted with no progress. Status set to Blocked for operator review." \
-                        2>/dev/null || true
-                    echo "Zero-work failure: retry cap reached — set to Blocked for operator review"
-                fi
+                _zero_work_retry
             fi
         fi
     fi

--- a/test/security/trust_boundary_test.sh
+++ b/test/security/trust_boundary_test.sh
@@ -760,6 +760,188 @@ test_skip_tracking_and_verdict_regression() {
 }
 
 # ===========================================================================
+# Helper: build a zero-work-retry driver script.
+#
+# Extracts _zero_work_retry() from entrypoint.sh (by name-anchored awk range),
+# prepends a minimal bash header, and appends the caller-supplied environment
+# assignments.  The driver is written to a caller-managed temp file so that the
+# caller can chmod+execute it with a PATH-injected stub directory.
+#
+# Arguments:
+#   $1  path to driver file (already created by caller)
+#   $2  path to mock project-queue.sh
+#   $3  project item id
+#   $4  issue number
+#   $5  exit code to simulate (default 1)
+# ===========================================================================
+_build_zw_driver() {
+    local driver="$1" mock_pq="$2" item_id="$3" issue_num="$4" exit_code="${5:-1}"
+
+    printf '#!/usr/bin/env bash\nset -euo pipefail\n' > "$driver"
+
+    # Extract the _zero_work_retry function body from entrypoint.sh.
+    # The awk range opens on the exact function header line and closes on the
+    # first bare "}" at column 0 — the function's closing brace.  This is
+    # reliable because bash uses fi/done/esac to close control structures, so
+    # the only ^}$ inside a well-formatted function is its own closing brace.
+    awk '/^_zero_work_retry\(\) \{$/,/^}$/' "$ENTRYPOINT" >> "$driver"
+
+    # Append environment setup with values from the caller's shell.
+    cat >> "$driver" <<DRIVER_ENV
+PROJECT_QUEUE="${mock_pq}"
+CFGMS_PROJECT_ITEM_ID="${item_id}"
+ISSUE_NUM="${issue_num}"
+EXIT_CODE="${exit_code}"
+_zero_work_retry
+DRIVER_ENV
+
+    chmod +x "$driver"
+}
+
+# ===========================================================================
+# TEST (AC5): zero-work retry reads field count, not comment count.
+#
+# Setup: get-item returns ZeroWorkRetries=0; gh returns 10 marker comments.
+# If the code still counted comments (count=10 ≥ 3), it would set Blocked.
+# Correct code reads the field (count=0 < 3) and sets Ready.
+# ===========================================================================
+test_zw_field_ignores_comments() {
+    echo ""
+    echo "--- AC5: zero-work retry reads project field, not issue comment count ---"
+
+    local stub_dir status_file driver
+    stub_dir=$(mktemp -d)
+    status_file="$stub_dir/status.txt"
+    driver=$(mktemp)
+    trap 'rm -rf "$stub_dir" "$driver" 2>/dev/null || true' RETURN
+
+    # Mock project-queue.sh: get-item returns ZeroWorkRetries=0; captures status.
+    cat > "$stub_dir/project-queue.sh" <<PQMOCK
+#!/usr/bin/env bash
+case "\${1:-}" in
+    get-item)
+        printf '{"item_id":"TEST1","title":"T","body":"B","status":"In Progress","fields":{"ZeroWorkRetries":"0"}}\n'
+        exit 0
+        ;;
+    update-field)
+        if [[ "\${3:-}" == "status" ]]; then
+            echo "\${4:-}" > "${status_file}"
+        fi
+        exit 0
+        ;;
+esac
+exit 0
+PQMOCK
+    chmod +x "$stub_dir/project-queue.sh"
+
+    # Mock gh: returns 10 marker comments.  If the code still counted these,
+    # it would treat zw_count=10 ≥ 3 and set Blocked instead of Ready.
+    cat > "$stub_dir/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+    "issue comment") exit 0 ;;
+    "issue view")
+        printf '{"comments":[{"body":"<!-- cfgms-zero-work-retry --> a1"},{"body":"<!-- cfgms-zero-work-retry --> a2"},{"body":"<!-- cfgms-zero-work-retry --> a3"},{"body":"<!-- cfgms-zero-work-retry --> a4"},{"body":"<!-- cfgms-zero-work-retry --> a5"},{"body":"<!-- cfgms-zero-work-retry --> a6"},{"body":"<!-- cfgms-zero-work-retry --> a7"},{"body":"<!-- cfgms-zero-work-retry --> a8"},{"body":"<!-- cfgms-zero-work-retry --> a9"},{"body":"<!-- cfgms-zero-work-retry --> a10"}]}\n'
+        exit 0 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+    chmod +x "$stub_dir/gh"
+
+    _build_zw_driver "$driver" "$stub_dir/project-queue.sh" "TEST1" "999" "1"
+
+    PATH="$stub_dir:$PATH" bash "$driver" 2>/dev/null || true
+
+    local status
+    status=$(cat "$status_file" 2>/dev/null || echo "NOT_SET")
+    assert_eq "$status" "Ready" \
+        "AC5: ZeroWorkRetries field=0 with 10 marker comments → status Ready (field count wins, not comment count)"
+}
+
+# ===========================================================================
+# TEST (AC6): a failed retry-count read must not produce Ready.
+#
+# Setup: get-item fails (API error); update-field captures status updates.
+# Correct code detects the read failure and sets Blocked (conservative).
+# ===========================================================================
+test_zw_read_failure_blocks() {
+    echo ""
+    echo "--- AC6: zero-work retry read failure → Blocked (not Ready) ---"
+
+    local stub_dir status_file driver
+    stub_dir=$(mktemp -d)
+    status_file="$stub_dir/status.txt"
+    driver=$(mktemp)
+    trap 'rm -rf "$stub_dir" "$driver" 2>/dev/null || true' RETURN
+
+    # Mock project-queue.sh: get-item FAILS; captures status updates.
+    cat > "$stub_dir/project-queue.sh" <<PQMOCK
+#!/usr/bin/env bash
+case "\${1:-}" in
+    get-item)
+        echo "ERROR: Cannot reach GitHub API" >&2
+        exit 1
+        ;;
+    update-field)
+        if [[ "\${3:-}" == "status" ]]; then
+            echo "\${4:-}" > "${status_file}"
+        fi
+        exit 0
+        ;;
+esac
+exit 0
+PQMOCK
+    chmod +x "$stub_dir/project-queue.sh"
+
+    # Minimal gh stub (comment calls are best-effort; ignored for the decision).
+    cat > "$stub_dir/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+exit 0
+GHSTUB
+    chmod +x "$stub_dir/gh"
+
+    _build_zw_driver "$driver" "$stub_dir/project-queue.sh" "TEST1" "999" "1"
+
+    PATH="$stub_dir:$PATH" bash "$driver" 2>/dev/null || true
+
+    local status
+    status=$(cat "$status_file" 2>/dev/null || echo "NOT_SET")
+
+    if [[ "$status" != "Ready" ]]; then
+        _pass "AC6: get-item failure → status NOT set to Ready (read failure is conservative)"
+    else
+        _fail "AC6: get-item failure must NOT set status to Ready — got Ready"
+    fi
+
+    if [[ "$status" == "Blocked" ]]; then
+        _pass "AC6: get-item failure → status set to Blocked"
+    else
+        _fail "AC6: get-item failure should set status to Blocked — got: ${status}"
+    fi
+}
+
+# ===========================================================================
+# STRUCTURAL TEST: _zero_work_retry contains no gh issue view call.
+#
+# Regression guard: the function must not call `gh issue view` (comment
+# fetching) — only `project-queue.sh get-item` for the retry count.
+# ===========================================================================
+test_structural_zero_work_retry_no_comment_fetch() {
+    echo ""
+    echo "--- Structural: _zero_work_retry contains no gh issue view call ---"
+
+    local body count
+    body=$(awk '/^_zero_work_retry\(\) \{$/,/^}$/' "$ENTRYPOINT")
+    if [[ -z "$body" ]]; then
+        _fail "_zero_work_retry structural: awk range matched nothing — function may have been renamed"
+        return
+    fi
+    count=$(printf '%s' "$body" | grep -c "gh issue view" 2>/dev/null || true)
+    assert_eq "$count" "0" \
+        "_zero_work_retry body: zero 'gh issue view' calls (dispatch state must not derive from comments)"
+}
+
+# ===========================================================================
 # Main
 # ===========================================================================
 echo "🔐 Trust Boundary Regression Test Suite"
@@ -779,6 +961,9 @@ test_project_queue_integration
 test_phase2_lifecycle
 test_phase2_step_i_fail_open_regression
 test_skip_tracking_and_verdict_regression
+test_zw_field_ignores_comments
+test_zw_read_failure_blocks
+test_structural_zero_work_retry_no_comment_fetch
 
 echo ""
 echo "📊 Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_SKIPPED skipped"

--- a/test/security/trust_boundary_test.sh
+++ b/test/security/trust_boundary_test.sh
@@ -772,7 +772,7 @@ test_skip_tracking_and_verdict_regression() {
 #   $2  path to mock project-queue.sh
 #   $3  project item id
 #   $4  issue number
-#   $5  exit code to simulate (default 1)
+#   $5  exit code for driver to return (default 1)
 # ===========================================================================
 _build_zw_driver() {
     local driver="$1" mock_pq="$2" item_id="$3" issue_num="$4" exit_code="${5:-1}"


### PR DESCRIPTION
## Summary

- Replaces comment-count-based zero-work retry logic in `entrypoint.sh` with a project-field-based counter (`ZeroWorkRetries` Projects V2 text field), eliminating issue comment content as a control input to dispatch state.
- Distinguishes "retry count unavailable" (API read failure → Blocked, conservative) from "retry count is zero" (missing/empty field → 0, first attempt). Removes the `|| echo 0` pattern that collapsed API errors into a full retry budget.
- Keeps posting the operator-visible `<!-- cfgms-zero-work-retry -->` marker comment but derives no decision from it.

## Security Context

The defect was medium severity (not critical): pipeline stories are born locked (`internal`), so only write-access accounts can comment. But CLAUDE.md's trust boundary only constrained comment *text* reaching agent prompts — nothing constrained comment *counts* reaching pipeline state. Lock drift is an expected condition (`lock-sweep` exists to handle it), so the comment-count surface was one lock-drift event away from being exploitable. The `|| echo 0` API-failure path also allowed unbounded re-dispatch of genuinely broken stories.

## Specialist Review Results

| Lens | Verdict |
|------|---------|
| Security (a64b531741) | **PASS** — trust-boundary hardening verified; one non-blocking defense-in-depth note on test helper using fixed literals only |
| QA/Test (a035ed121b) | **PASS** — no test quality issues |
| Test runner (a97759305c) | **PASS** — `make test-agent-complete` exit 0; 40/40 trust boundary tests |

`story-review` workflow: `passed: true`, 1 review round, 0 fix rounds, 0 remaining findings.

## Test plan

- [ ] `bash test/security/trust_boundary_test.sh` → 40/40 pass (includes new AC5, AC6, structural tests)
- [ ] `make test-agent-complete` → all gates pass
- [ ] Verify `ZeroWorkRetries` text field exists in the GitHub Projects board (infrastructure prerequisite)
- [ ] On next zero-work failure in production: confirm status transitions use field value, comment shows attempt N/3

## Infrastructure note

The `ZeroWorkRetries` project field must be a text field on the GitHub Projects board. `project-queue.sh update-field` discovers it dynamically by name; if it does not exist, `update-field ZeroWorkRetries N` will fail with a WARN (and status will still be set correctly for the first dispatch since missing field → count=0). Create the field before the next zero-work failure occurs to ensure reliable retry tracking.

Fixes #2928

🤖 Generated with [Claude Code](https://claude.com/claude-code)