### PR TITLE
web: steward asset page — Logs and Modules tabs (Issue #2940)

### DIFF
--- a/web/src/fleet/LogsPanel.test.tsx
+++ b/web/src/fleet/LogsPanel.test.tsx
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * LogsPanel suite (Story #2940): fetch and render of steward log records,
+ * loading/error/empty states, untrusted wire data validation, chronological
+ * ordering, and URL encoding of the steward ID.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import LogsPanel, { parseLogsResponse } from './LogsPanel.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function renderPanel(stewardId = 'stw-001') {
+  return render(
+    <MemoryRouter initialEntries={[`/stewards/${encodeURIComponent(stewardId)}`]}>
+      <Routes>
+        <Route path="/stewards/:id" element={<LogsPanel />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function makeEvent(overrides: Partial<{
+  timestamp: string
+  level: string
+  message: string
+  component: string
+}> = {}) {
+  return {
+    timestamp: overrides.timestamp ?? '2026-07-23T10:00:00Z',
+    level: overrides.level ?? 'INFO',
+    message: overrides.message ?? 'Test log message',
+    component: overrides.component ?? 'test-component',
+  }
+}
+
+function mockLogs(events: unknown[] = []) {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        data: { events },
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// parseLogsResponse (untrusted wire data)
+// ---------------------------------------------------------------------------
+
+describe('parseLogsResponse (untrusted wire data)', () => {
+  it('rejects non-object payloads', () => {
+    expect(() => parseLogsResponse(null)).toThrow()
+    expect(() => parseLogsResponse('str')).toThrow()
+    expect(() => parseLogsResponse(42)).toThrow()
+  })
+
+  it('rejects payloads without an events array', () => {
+    expect(() => parseLogsResponse({})).toThrow()
+    expect(() => parseLogsResponse({ events: 'not-array' })).toThrow()
+  })
+
+  it('returns an empty array for an empty events list', () => {
+    expect(parseLogsResponse({ events: [] })).toEqual([])
+  })
+
+  it('skips entries with no detection field', () => {
+    const result = parseLogsResponse({
+      events: [
+        { correlation_id: 'x' }, // no detection
+        { detection: makeEvent(), correlation_id: 'y' },
+      ],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.correlationId).toBe('y')
+  })
+
+  it('skips detection entries that are not objects', () => {
+    const result = parseLogsResponse({
+      events: [
+        { detection: 'not-an-object' },
+        { detection: makeEvent(), correlation_id: 'valid' },
+      ],
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('coerces missing event fields to empty strings', () => {
+    const result = parseLogsResponse({ events: [{ detection: {} }] })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.detection.timestamp).toBe('')
+    expect(result[0]?.detection.level).toBe('')
+    expect(result[0]?.detection.message).toBe('')
+    expect(result[0]?.detection.component).toBe('')
+  })
+
+  it('parses a full correlated record with detection and outcome', () => {
+    const detection = makeEvent({ timestamp: '2026-07-23T10:00:00Z', message: 'detected' })
+    const outcome = makeEvent({ timestamp: '2026-07-23T10:00:01Z', message: 'resolved' })
+    const result = parseLogsResponse({
+      events: [{ correlation_id: 'corr-1', detection, outcome, pending_outcome: false }],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.correlationId).toBe('corr-1')
+    expect(result[0]?.detection.message).toBe('detected')
+    expect(result[0]?.outcome?.message).toBe('resolved')
+    expect(result[0]?.pendingOutcome).toBe(false)
+  })
+
+  it('sets pendingOutcome=true when the field is true', () => {
+    const result = parseLogsResponse({
+      events: [{ detection: makeEvent(), pending_outcome: true }],
+    })
+    expect(result[0]?.pendingOutcome).toBe(true)
+  })
+
+  it('outcome is null when absent or not an object', () => {
+    const result = parseLogsResponse({
+      events: [
+        { detection: makeEvent() },
+        { detection: makeEvent(), outcome: 'bad' },
+      ],
+    })
+    expect(result[0]?.outcome).toBeNull()
+    expect(result[1]?.outcome).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetch and rendering
+// ---------------------------------------------------------------------------
+
+describe('LogsPanel fetch and rendering', () => {
+  it('fetches the correct endpoint for the route :id', async () => {
+    mockLogs([{ detection: makeEvent({ message: 'boot complete' }), correlation_id: '' }])
+    renderPanel('stw-42')
+
+    expect(await screen.findByText('boot complete')).toBeTruthy()
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toBe('/api/v1/stewards/stw-42/logs')
+  })
+
+  it('encodes special characters in the steward ID', async () => {
+    mockLogs([{ detection: makeEvent(), correlation_id: '' }])
+    renderPanel('stw/special id')
+
+    await screen.findByText('Test log message')
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toBe('/api/v1/stewards/stw%2Fspecial%20id/logs')
+  })
+
+  it('renders log entries with level and message', async () => {
+    mockLogs([
+      { detection: makeEvent({ level: 'ERROR', message: 'disk full' }), correlation_id: '' },
+      { detection: makeEvent({ level: 'INFO', message: 'task started' }), correlation_id: '' },
+    ])
+    renderPanel()
+
+    expect(await screen.findByText('disk full')).toBeTruthy()
+    expect(screen.getByText('ERROR')).toBeTruthy()
+    expect(screen.getByText('task started')).toBeTruthy()
+    expect(screen.getByText('INFO')).toBeTruthy()
+  })
+
+  it('renders events in chronological order (as returned by the API)', async () => {
+    mockLogs([
+      { detection: makeEvent({ timestamp: '2026-07-23T09:00:00Z', message: 'first event' }), correlation_id: 'a' },
+      { detection: makeEvent({ timestamp: '2026-07-23T10:00:00Z', message: 'second event' }), correlation_id: 'b' },
+    ])
+    renderPanel()
+
+    const messages = await screen.findAllByText(/first event|second event/)
+    expect(messages[0]?.textContent).toBe('first event')
+    expect(messages[1]?.textContent).toBe('second event')
+  })
+
+  it('renders the outcome event when a correlated pair is present', async () => {
+    mockLogs([
+      {
+        correlation_id: 'corr-x',
+        detection: makeEvent({ message: 'module drift detected' }),
+        outcome: makeEvent({ message: 'module applied' }),
+      },
+    ])
+    renderPanel()
+
+    expect(await screen.findByText('module drift detected')).toBeTruthy()
+    expect(screen.getByText('module applied')).toBeTruthy()
+  })
+
+  it('renders a pending-outcome indicator when pending_outcome is true', async () => {
+    mockLogs([
+      {
+        detection: makeEvent({ message: 'pending change' }),
+        pending_outcome: true,
+      },
+    ])
+    renderPanel()
+
+    await screen.findByText('pending change')
+    expect(screen.getByTestId('log-pending')).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Loading state
+// ---------------------------------------------------------------------------
+
+describe('loading state', () => {
+  it('shows a loading indicator before the response arrives', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderPanel()
+    expect(screen.getByTestId('logs-loading')).toBeTruthy()
+  })
+
+  it('loading state is distinct from error state', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderPanel()
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByTestId('logs-empty')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+describe('empty state', () => {
+  it('renders a distinct empty state when the events array is empty', async () => {
+    mockLogs([])
+    renderPanel()
+
+    expect(await screen.findByTestId('logs-empty')).toBeTruthy()
+    expect(screen.queryByTestId('logs-list')).toBeNull()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+describe('error states', () => {
+  it('renders an error alert on a non-ok HTTP response', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'internal error' }), { status: 500 }),
+    )
+    renderPanel()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('500')
+    expect(screen.queryByTestId('logs-loading')).toBeNull()
+    expect(screen.queryByTestId('logs-empty')).toBeNull()
+  })
+
+  it('renders an error alert on network failure with a retry button', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+    mockLogs([{ detection: makeEvent({ message: 'recovered' }), correlation_id: '' }])
+    renderPanel()
+
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(await screen.findByText('recovered')).toBeTruthy()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders an error alert on malformed response body (wire validation)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { not_events: [] } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    renderPanel()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toBeTruthy()
+    expect(screen.queryByTestId('logs-list')).toBeNull()
+  })
+
+  it('error state is distinct from empty state', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 503 }),
+    )
+    renderPanel()
+
+    await screen.findByRole('alert')
+    expect(screen.queryByTestId('logs-empty')).toBeNull()
+  })
+})

--- a/web/src/fleet/LogsPanel.tsx
+++ b/web/src/fleet/LogsPanel.tsx
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Logs tab panel (Story #2940) — chronological log records for one steward.
+ * Fetches GET /api/v1/stewards/{id}/logs using useParams for the steward ID,
+ * following the DnaDrawer self-contained panel pattern (no props required).
+ *
+ * Each log record may be a standalone detection or a correlated
+ * detection+outcome pair (ADR-012 §2). Untrusted wire data is validated
+ * by parseLogsResponse before rendering; values reach the DOM as JSX text
+ * nodes only — no dangerouslySetInnerHTML.
+ */
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { apiFetch } from '../api/client.ts'
+
+export interface LogEvent {
+  timestamp: string
+  level: string
+  message: string
+  component: string
+}
+
+export interface LogRecord {
+  correlationId: string
+  detection: LogEvent
+  outcome: LogEvent | null
+  pendingOutcome: boolean
+}
+
+function parseLogEvent(raw: unknown): LogEvent | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const r = raw as Record<string, unknown>
+  const str = (v: unknown) => (typeof v === 'string' ? v : '')
+  return {
+    timestamp: str(r.timestamp),
+    level: str(r.level),
+    message: str(r.message),
+    component: str(r.component),
+  }
+}
+
+/** Validate the logs response payload (untrusted wire data). Throws on invalid shape. */
+export function parseLogsResponse(data: unknown): LogRecord[] {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('unexpected response shape')
+  }
+  const r = data as Record<string, unknown>
+  if (!Array.isArray(r.events)) {
+    throw new Error('unexpected response shape')
+  }
+  const records: LogRecord[] = []
+  for (const item of r.events) {
+    if (typeof item !== 'object' || item === null) continue
+    const entry = item as Record<string, unknown>
+    const detection = parseLogEvent(entry.detection)
+    if (!detection) continue
+    const outcome = entry.outcome != null ? parseLogEvent(entry.outcome) : null
+    records.push({
+      correlationId: typeof entry.correlation_id === 'string' ? entry.correlation_id : '',
+      detection,
+      outcome,
+      pendingOutcome: entry.pending_outcome === true,
+    })
+  }
+  return records
+}
+
+interface FetchOutcome {
+  key: string
+  records?: LogRecord[]
+  error?: string
+}
+
+function LogEventRow({ event, label }: { event: LogEvent; label?: string }) {
+  return (
+    <div className="log-event">
+      {label !== undefined && <span className="log-event-label">{label}</span>}
+      <span className="log-ts mono2">{event.timestamp}</span>
+      <span className="log-lv">{event.level}</span>
+      {event.component !== '' && <span className="log-comp mono2">{event.component}</span>}
+      <span className="log-msg">{event.message}</span>
+    </div>
+  )
+}
+
+export default function LogsPanel() {
+  const { id: stewardId = '' } = useParams<{ id: string }>()
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+  const key = `${stewardId}:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    const path = `/api/v1/stewards/${encodeURIComponent(stewardId)}/logs`
+    apiFetch(path)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`GET ${path} — ${response.status}`)
+        }
+        const body: unknown = await response.json()
+        const records = parseLogsResponse((body as Record<string, unknown> | null)?.data)
+        if (!cancelled) setOutcome({ key, records })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : `GET ${path} — request failed`,
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, stewardId])
+
+  const current = outcome?.key === key ? outcome : null
+
+  return (
+    <div className="det">
+      <div className="db">
+        {current === null ? (
+          <div data-testid="logs-loading" aria-label="Loading steward logs">
+            {Array.from({ length: 5 }, (_, i) => (
+              <div className="log-skel" key={i}>
+                <span className="skel" style={{ width: '15%' }} />
+                <span className="skel" style={{ width: '5%' }} />
+                <span className="skel" style={{ width: '60%' }} />
+              </div>
+            ))}
+          </div>
+        ) : current.error !== undefined ? (
+          <div className="notice err" role="alert">
+            <div className="ic">!</div>
+            <h3>Couldn&apos;t load steward logs</h3>
+            <p>Log data for this steward isn&apos;t available right now.</p>
+            <span className="mono2 detail">{current.error}</span>
+            <button
+              type="button"
+              className="btn"
+              onClick={() => setAttempt((n) => n + 1)}
+            >
+              Retry
+            </button>
+          </div>
+        ) : current.records !== undefined && current.records.length === 0 ? (
+          <div className="notice" data-testid="logs-empty">
+            <p>No log entries for this steward in the selected time range.</p>
+          </div>
+        ) : (
+          current.records !== undefined && (
+            <div className="log-list" data-testid="logs-list">
+              {current.records.map((record, i) => (
+                <div key={record.correlationId || i} className="log-record">
+                  <LogEventRow event={record.detection} />
+                  {record.pendingOutcome && (
+                    <div className="log-pending" data-testid="log-pending">
+                      Convergence pending
+                    </div>
+                  )}
+                  {record.outcome !== null && (
+                    <LogEventRow event={record.outcome} label="→" />
+                  )}
+                </div>
+              ))}
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/fleet/ModulesPanel.test.tsx
+++ b/web/src/fleet/ModulesPanel.test.tsx
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * ModulesPanel suite (Story #2940): fetch and render of steward modules,
+ * distinct 501 MODULES_UNAVAILABLE state (separate from generic errors),
+ * loading/error/empty states, and untrusted wire data validation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import ModulesPanel, { parseModulesResponse } from './ModulesPanel.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function renderPanel(stewardId = 'stw-001') {
+  return render(
+    <MemoryRouter initialEntries={[`/stewards/${encodeURIComponent(stewardId)}`]}>
+      <Routes>
+        <Route path="/stewards/:id" element={<ModulesPanel />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockModules(names: string[]) {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        data: { modules: names.map((name) => ({ name })) },
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  )
+}
+
+function mockUnavailable() {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        error: {
+          code: 'MODULES_UNAVAILABLE',
+          message: 'steward does not report loaded modules in DNA; ensure steward version supports module DNA attributes',
+        },
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 501 },
+    ),
+  )
+}
+
+function mockError(status: number) {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({ error: { code: 'INTERNAL_ERROR', message: 'server error' } }),
+      { status },
+    ),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// parseModulesResponse (untrusted wire data)
+// ---------------------------------------------------------------------------
+
+describe('parseModulesResponse (untrusted wire data)', () => {
+  it('rejects non-object payloads', () => {
+    expect(() => parseModulesResponse(null)).toThrow()
+    expect(() => parseModulesResponse('str')).toThrow()
+    expect(() => parseModulesResponse(42)).toThrow()
+  })
+
+  it('rejects payloads without a modules array', () => {
+    expect(() => parseModulesResponse({})).toThrow()
+    expect(() => parseModulesResponse({ modules: 'not-array' })).toThrow()
+  })
+
+  it('returns an empty array for an empty modules list', () => {
+    expect(parseModulesResponse({ modules: [] })).toEqual([])
+  })
+
+  it('filters out entries where name is not a non-empty string', () => {
+    const result = parseModulesResponse({
+      modules: [
+        { name: 'file' },
+        { name: '' },        // empty string — filtered
+        { name: 42 },        // not a string — filtered
+        { name: null },      // null — filtered
+        { name: 'service' },
+      ],
+    })
+    expect(result).toHaveLength(2)
+    expect(result.map((m) => m.name)).toEqual(['file', 'service'])
+  })
+
+  it('filters out non-object array entries', () => {
+    const result = parseModulesResponse({
+      modules: ['bad', null, 42, { name: 'patch' }],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('patch')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 501 MODULES_UNAVAILABLE — distinct not-available state
+// ---------------------------------------------------------------------------
+
+describe('501 MODULES_UNAVAILABLE state', () => {
+  it('renders the not-available state on a 501 response', async () => {
+    mockUnavailable()
+    renderPanel()
+
+    const unavail = await screen.findByTestId('modules-unavailable')
+    expect(unavail).toBeTruthy()
+    expect(unavail.textContent?.toLowerCase()).toMatch(/older version|doesn.*t report|not available/i)
+  })
+
+  it('501 not-available state is distinct from the generic error alert', async () => {
+    mockUnavailable()
+    renderPanel()
+
+    await screen.findByTestId('modules-unavailable')
+    // The generic error alert (role="alert") must NOT be rendered.
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('501 not-available state is distinct from the generic error on a 500', async () => {
+    mockError(500)
+    renderPanel()
+
+    // Generic error uses role="alert" and data-testid="modules-error".
+    const alert = await screen.findByRole('alert')
+    expect(alert).toBeTruthy()
+    // The not-available node must NOT be rendered.
+    expect(screen.queryByTestId('modules-unavailable')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fetch and rendering
+// ---------------------------------------------------------------------------
+
+describe('ModulesPanel fetch and rendering', () => {
+  it('fetches the correct endpoint for the route :id', async () => {
+    mockModules(['file', 'service'])
+    renderPanel('stw-55')
+
+    await screen.findByText('file')
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toBe('/api/v1/stewards/stw-55/modules')
+  })
+
+  it('encodes special characters in the steward ID', async () => {
+    mockModules(['patch'])
+    renderPanel('stw/special id')
+
+    await screen.findByText('patch')
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toBe('/api/v1/stewards/stw%2Fspecial%20id/modules')
+  })
+
+  it('renders loaded module names', async () => {
+    mockModules(['file', 'service', 'patch', 'cert_trust'])
+    renderPanel()
+
+    expect(await screen.findByText('file')).toBeTruthy()
+    expect(screen.getByText('service')).toBeTruthy()
+    expect(screen.getByText('patch')).toBeTruthy()
+    expect(screen.getByText('cert_trust')).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Loading state
+// ---------------------------------------------------------------------------
+
+describe('loading state', () => {
+  it('shows a loading indicator before the response arrives', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderPanel()
+    expect(screen.getByTestId('modules-loading')).toBeTruthy()
+  })
+
+  it('loading state is distinct from error and not-available states', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderPanel()
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByTestId('modules-unavailable')).toBeNull()
+    expect(screen.queryByTestId('modules-empty')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+describe('empty state', () => {
+  it('renders a distinct empty state when modules array is empty', async () => {
+    mockModules([])
+    renderPanel()
+
+    expect(await screen.findByTestId('modules-empty')).toBeTruthy()
+    expect(screen.queryByTestId('modules-list')).toBeNull()
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByTestId('modules-unavailable')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+describe('error states', () => {
+  it('renders a generic error alert on a non-ok non-501 response', async () => {
+    mockError(503)
+    renderPanel()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('503')
+    expect(screen.queryByTestId('modules-loading')).toBeNull()
+    expect(screen.queryByTestId('modules-unavailable')).toBeNull()
+  })
+
+  it('renders an error alert on network failure with a retry button', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+    mockModules(['file'])
+    renderPanel()
+
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(await screen.findByText('file')).toBeTruthy()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders an error alert on malformed response body (wire validation)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { not_modules: [] } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    renderPanel()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toBeTruthy()
+    expect(screen.queryByTestId('modules-list')).toBeNull()
+  })
+})

--- a/web/src/fleet/ModulesPanel.tsx
+++ b/web/src/fleet/ModulesPanel.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Modules tab panel (Story #2940) — loaded modules for one steward.
+ * Fetches GET /api/v1/stewards/{id}/modules using useParams for the steward
+ * ID, following the DnaDrawer self-contained panel pattern (no props required).
+ *
+ * A 501 MODULES_UNAVAILABLE response is a distinct UI state: the steward's
+ * DNA doesn't include module data, which indicates an older steward version
+ * rather than an infrastructure failure — so it renders an informational
+ * notice rather than an error alert. Untrusted wire data is validated by
+ * parseModulesResponse before rendering.
+ */
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { apiFetch } from '../api/client.ts'
+
+export interface StewardModule {
+  name: string
+}
+
+/** Validate the modules response payload (untrusted wire data). Throws on invalid shape. */
+export function parseModulesResponse(data: unknown): StewardModule[] {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('unexpected response shape')
+  }
+  const r = data as Record<string, unknown>
+  if (!Array.isArray(r.modules)) {
+    throw new Error('unexpected response shape')
+  }
+  return r.modules
+    .filter((m): m is Record<string, unknown> => typeof m === 'object' && m !== null)
+    .filter((m) => typeof m.name === 'string' && (m.name as string).length > 0)
+    .map((m) => ({ name: m.name as string }))
+}
+
+interface FetchOutcome {
+  key: string
+  modules?: StewardModule[]
+  error?: string
+  unavailable?: true
+}
+
+export default function ModulesPanel() {
+  const { id: stewardId = '' } = useParams<{ id: string }>()
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+  const key = `${stewardId}:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    const path = `/api/v1/stewards/${encodeURIComponent(stewardId)}/modules`
+    apiFetch(path)
+      .then(async (response) => {
+        if (response.status === 501) {
+          if (!cancelled) setOutcome({ key, unavailable: true })
+          return
+        }
+        if (!response.ok) {
+          throw new Error(`GET ${path} — ${response.status}`)
+        }
+        const body: unknown = await response.json()
+        const modules = parseModulesResponse((body as Record<string, unknown> | null)?.data)
+        if (!cancelled) setOutcome({ key, modules })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : `GET ${path} — request failed`,
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, stewardId])
+
+  const current = outcome?.key === key ? outcome : null
+
+  return (
+    <div className="det">
+      <div className="db">
+        {current === null ? (
+          <div data-testid="modules-loading" aria-label="Loading steward modules">
+            {Array.from({ length: 4 }, (_, i) => (
+              <div className="kv" key={i}>
+                <span className="skel" style={{ width: '40%' }} />
+              </div>
+            ))}
+          </div>
+        ) : current.unavailable === true ? (
+          <div className="notice" data-testid="modules-unavailable">
+            <p>
+              Module information isn&apos;t available for this steward. The steward may be
+              running an older version that doesn&apos;t report loaded modules.
+            </p>
+          </div>
+        ) : current.error !== undefined ? (
+          <div className="notice err" role="alert" data-testid="modules-error">
+            <div className="ic">!</div>
+            <h3>Couldn&apos;t load modules</h3>
+            <p>Module data for this steward isn&apos;t available right now.</p>
+            <span className="mono2 detail">{current.error}</span>
+            <button
+              type="button"
+              className="btn"
+              onClick={() => setAttempt((n) => n + 1)}
+            >
+              Retry
+            </button>
+          </div>
+        ) : current.modules !== undefined && current.modules.length === 0 ? (
+          <div className="notice" data-testid="modules-empty">
+            <p>No modules loaded on this steward.</p>
+          </div>
+        ) : (
+          current.modules !== undefined && (
+            <div className="module-list" data-testid="modules-list">
+              <div className="grp">
+                <div className="lbl">Loaded modules</div>
+              </div>
+              {current.modules.map((mod) => (
+                <div key={mod.name} className="kv">
+                  <span className="v mono2">{mod.name}</span>
+                </div>
+              ))}
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/fleet/StewardAssetPage.test.tsx
+++ b/web/src/fleet/StewardAssetPage.test.tsx
@@ -80,7 +80,7 @@ function renderAssetPage(stewardId = 'stw-001') {
 }
 
 describe('tab strip', () => {
-  it('renders all four tabs: DNA, Config, Shell, Live Activity', () => {
+  it('renders all tabs: DNA, Config, Shell, Logs, Modules, Live Activity', () => {
     fetchMock.mockReturnValue(new Promise(() => {}))
     renderAssetPage()
 
@@ -89,6 +89,8 @@ describe('tab strip', () => {
     expect(screen.getByRole('tab', { name: /^DNA/i })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /^Config/i })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /^Shell/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /^Logs/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /^Modules/i })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /^Live Activity/i })).toBeInTheDocument()
   })
 
@@ -137,6 +139,42 @@ describe('tab strip', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /^Shell/i }))
     expect(screen.getByRole('tabpanel').textContent).toContain('Shell')
+  })
+
+  it('clicking Logs tab mounts LogsPanel (shows loading state, not a SoonPanel)', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderAssetPage()
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Logs/i }))
+
+    expect(screen.getByTestId('logs-loading')).toBeInTheDocument()
+    expect(screen.queryByText(/Logs is not yet available/i)).not.toBeInTheDocument()
+  })
+
+  it('Logs tab has no soon badge', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderAssetPage()
+
+    const logsTab = screen.getByRole('tab', { name: /^Logs/i })
+    expect(within(logsTab).queryByText(/soon/i)).not.toBeInTheDocument()
+  })
+
+  it('clicking Modules tab mounts ModulesPanel (shows loading state, not a SoonPanel)', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderAssetPage()
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Modules/i }))
+
+    expect(screen.getByTestId('modules-loading')).toBeInTheDocument()
+    expect(screen.queryByText(/Modules is not yet available/i)).not.toBeInTheDocument()
+  })
+
+  it('Modules tab has no soon badge', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderAssetPage()
+
+    const modulesTab = screen.getByRole('tab', { name: /^Modules/i })
+    expect(within(modulesTab).queryByText(/soon/i)).not.toBeInTheDocument()
   })
 
   it('clicking Live Activity mounts LiveActivityTab (not a SoonPanel)', () => {

--- a/web/src/fleet/StewardAssetPage.tsx
+++ b/web/src/fleet/StewardAssetPage.tsx
@@ -22,8 +22,10 @@ import { type ComponentType, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import DnaDrawer from './DnaDrawer.tsx'
 import LiveActivityTab from './LiveActivityTab.tsx'
+import LogsPanel from './LogsPanel.tsx'
+import ModulesPanel from './ModulesPanel.tsx'
 
-type TabKey = 'dna' | 'config' | 'shell' | 'live'
+type TabKey = 'dna' | 'config' | 'shell' | 'logs' | 'modules' | 'live'
 
 interface TabSpec {
   key: TabKey
@@ -41,6 +43,8 @@ export const TABS: readonly TabSpec[] = [
   { key: 'dna', label: 'DNA', soon: false, Panel: DnaDrawer },
   { key: 'config', label: 'Config', soon: true },
   { key: 'shell', label: 'Shell', soon: true },
+  { key: 'logs', label: 'Logs', soon: false, Panel: LogsPanel },
+  { key: 'modules', label: 'Modules', soon: false, Panel: ModulesPanel },
   { key: 'live', label: 'Live Activity', soon: false, Panel: LiveActivityPanel },
 ]
 


### PR DESCRIPTION
## Summary

- **LogsPanel** (`web/src/fleet/LogsPanel.tsx`): self-contained fetch of `GET /api/v1/stewards/{id}/logs`; `parseLogsResponse` validates wire shape; renders correlated detection+outcome pairs chronologically; distinct loading/error/empty states
- **ModulesPanel** (`web/src/fleet/ModulesPanel.tsx`): self-contained fetch of `GET /api/v1/stewards/{id}/modules`; 501 `MODULES_UNAVAILABLE` renders a distinct informational notice (not the generic error alert); `parseModulesResponse` validates wire shape; distinct loading/unavailable/error/empty states
- **StewardAssetPage.tsx**: only two `TABS` entries added (`logs` and `modules`) plus the corresponding imports and `TabKey` union extension — no wrapper functions, no other structural changes

Both panels follow the `DnaDrawer` self-contained pattern: `useParams` called internally, zero props, satisfying `TabSpec.Panel`'s `ComponentType` constraint.

Fixes #2940

## Specialist Review Results

| Lens | Result |
|------|--------|
| Tests (`make test-agent-complete`) | ✅ PASS |
| Code Review | ✅ PASS — follows DnaDrawer pattern exactly, 501 handled distinctly, minimal TABS integration |
| Security | ✅ PASS — XSS-safe (text nodes only), path injection protected (encodeURIComponent), wire validation, no secrets |
| QA Code Review | ✅ PASS — full coverage: loading/error/empty states, wire validation, retry flow, no mocks |

## Test plan

- [ ] Verify Logs tab appears on steward asset page without "soon" badge
- [ ] Verify Modules tab appears on steward asset page without "soon" badge
- [ ] Verify Logs tab shows loading state then log entries (or empty state)
- [ ] Verify Modules tab shows loading state then modules list (or "older version" notice for old stewards)
- [ ] Verify 501 from `/modules` endpoint shows informational notice, not error alert
- [ ] Verify keyboard navigation (ArrowLeft from DNA still wraps to Live Activity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)