### PR TITLE
web: fleet row action menu with tag edit (Issue #2938)

### DIFF
--- a/docs/design/mockups/README.md
+++ b/docs/design/mockups/README.md
@@ -21,6 +21,8 @@ principles, and token rationale these mockups express.
 | [`login.html`](login.html) | The authentication screen — terminal-window framing, single mTLS/session sign-in, with `signin` / `loading` / `invalid` / `expired` states and a **passkey/WebAuthn MFA seam** (`mfa` state) designed now, built later. Both themes. | **Reference** |
 | [`fleet-overview.html`](fleet-overview.html) | The read-only fleet overview inside the app shell — tenant-scope switcher, live-filter search, sort, saved views, selectable **device-DNA columns**, scale-aware pagination, and a row drill-in **asset-DNA drawer**. Both themes; Ready / Loading / Error / Empty states. | **Reference** |
 | [`fleet-overview-generic-v0.html`](fleet-overview-generic-v0.html) | The initial generic management dashboard, before brand alignment. Kept for provenance only. | Superseded |
+| [`asset-live-activity.html`](asset-live-activity.html) | The asset live-activity tab — real-time process table and service list driven by the telemetry WebSocket; includes the `.rowkebab` per-row action menu pattern (applied to fleet rows in Story #2938). Both themes. | **Reference** |
+| [`asset-shell.html`](asset-shell.html) | The asset interactive shell tab — terminal emulator panel with WebSocket-backed session, command history, and resize handling. Both themes. | **Reference** |
 
 > These are design references, not production code. The shipped UI is
 > React + TypeScript + Vite (Epic #2344), built against

--- a/web/src/fleet/FleetOverview.css
+++ b/web/src/fleet/FleetOverview.css
@@ -385,7 +385,8 @@ table.tbl {
   .tbl td.c-model,
   .tbl td.c-mac,
   .tbl td.c-ring,
-  .tbl td.c-spacer {
+  .tbl td.c-spacer,
+  .tbl td.c-act {
     display: none;
   }
 }
@@ -686,4 +687,177 @@ a.row-link {
 }
 .det .kv .skel {
   height: 12px;
+}
+
+/* Row action column — kebab button and popover (Story #2938).
+ * Mirrors the `.rowkebab` idiom from `asset-live-activity.html` lines 204-205.
+ * The `.pop .row` base styles come from AppShell.css; only resets/overrides here. */
+.tbl .c-act {
+  width: 36px;
+  padding: 0 4px;
+  text-align: center;
+}
+.ram-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.rowkebab {
+  opacity: 0;
+  border: 0;
+  appearance: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: var(--radius-sm);
+  line-height: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.tbl tbody tr:hover .rowkebab,
+.rowkebab:focus-visible {
+  opacity: 1;
+}
+.rowkebab:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+/* Override the .pop base top/left defaults for the row-anchored popover. */
+.ram-pop {
+  top: calc(100% + 2px);
+  min-width: 160px;
+}
+.ram-pop button.row {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  width: 100%;
+}
+
+/* Inline tag editor within the row action popover (Story #2938).
+ * Destructive affordances (remove button hover) use --state-crit per design tokens. */
+.row-tag-editor {
+  padding: 4px 0;
+}
+.rtag-hd {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+.rtag-back {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  padding: 2px 5px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+}
+.rtag-back:hover {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+.rtag-title {
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-faint);
+  font-weight: 600;
+}
+.rtag-err {
+  font-size: var(--text-sm);
+  color: var(--state-crit);
+  padding: 4px 10px;
+}
+.rtag-spin {
+  font-size: var(--text-sm);
+  color: var(--text-faint);
+  padding: 6px 10px;
+}
+.rtag-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 8px 8px;
+  min-height: 34px;
+}
+.rtag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 2px 6px 2px 10px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+.rtag-rm {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 14px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+.rtag-rm:hover {
+  color: var(--state-crit);
+}
+.rtag-rm:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.rtag-empty {
+  font-size: var(--text-sm);
+  color: var(--text-faint);
+  align-self: center;
+}
+.rtag-row {
+  display: flex;
+  gap: 4px;
+  padding: 4px 8px 6px;
+  border-top: 1px solid var(--border);
+}
+.rtag-in {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: var(--bg-sunk);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 5px 8px;
+}
+.rtag-in::placeholder {
+  color: var(--text-faint);
+}
+.rtag-btn {
+  appearance: none;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.rtag-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
 }

--- a/web/src/fleet/FleetTable.test.tsx
+++ b/web/src/fleet/FleetTable.test.tsx
@@ -134,3 +134,36 @@ describe('row anchor (Story #2917 AC)', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
 })
+
+describe('row action menu (Story #2938 AC)', () => {
+  it('each interactive row has a kebab action button', () => {
+    renderTable([makeSteward('stw-1', 'host1')], vi.fn())
+
+    expect(screen.getByRole('button', { name: 'Actions' })).toBeInTheDocument()
+  })
+
+  it('no action button when table is not interactive (no onRowSelect)', () => {
+    renderTable([makeSteward('stw-1', 'host1')])
+
+    expect(screen.queryByRole('button', { name: 'Actions' })).not.toBeInTheDocument()
+  })
+
+  it('clicking the kebab does NOT call onRowSelect — navigation unchanged', () => {
+    const onRowSelect = vi.fn()
+    renderTable([makeSteward('stw-1', 'host1')], onRowSelect)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+
+    expect(onRowSelect).not.toHaveBeenCalled()
+  })
+
+  it('a direct row click still calls onRowSelect after kebab is present', () => {
+    const onRowSelect = vi.fn()
+    renderTable([makeSteward('stw-1', 'host1')], onRowSelect)
+
+    fireEvent.click(screen.getByRole('link', { name: 'host1' }), { button: 0 })
+
+    expect(onRowSelect).toHaveBeenCalledTimes(1)
+    expect(onRowSelect.mock.calls[0]?.[0].id).toBe('stw-1')
+  })
+})

--- a/web/src/fleet/FleetTable.tsx
+++ b/web/src/fleet/FleetTable.tsx
@@ -14,6 +14,7 @@
  */
 import { deriveHealth, formatLastSeen } from './health.ts'
 import type { ColumnDef, Steward } from './columns.ts'
+import RowActionMenu from './RowActionMenu.tsx'
 
 export interface SortState {
   key: string
@@ -128,6 +129,7 @@ export default function FleetTable({
               </th>
             )
           })}
+          {onRowSelect !== undefined && <th className="c-act" aria-hidden="true" />}
           <th className="c-spacer" aria-hidden="true" />
         </tr>
       </thead>
@@ -159,6 +161,11 @@ export default function FleetTable({
                   onRowSelect={onRowSelect ? () => onRowSelect(steward) : undefined}
                 />
               ))}
+              {onRowSelect !== undefined && (
+                <td className="c-act">
+                  <RowActionMenu stewardId={steward.id} />
+                </td>
+              )}
               <td className="c-spacer" />
             </tr>
           )

--- a/web/src/fleet/RowActionMenu.test.tsx
+++ b/web/src/fleet/RowActionMenu.test.tsx
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * RowActionMenu suite (Story #2938): per-row action popover, stop-propagation
+ * guard, and fully functional tag editor (add / remove via the tag endpoints,
+ * state reflected immediately in the editor on each successful response).
+ *
+ * Security A10.2: parseTags validates the untrusted wire envelope; non-string
+ * values in the tags array are dropped before any render.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import RowActionMenu, { parseTags } from './RowActionMenu.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function mockTagsOk(tags: string[]) {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({ data: { tags }, timestamp: '' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  )
+}
+
+function mockTagsSeq(...responses: Array<{ status: number; tags?: string[] }>) {
+  for (const r of responses) {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        r.tags !== undefined
+          ? JSON.stringify({ data: { tags: r.tags }, timestamp: '' })
+          : JSON.stringify({ error: 'fail' }),
+        { status: r.status, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseTags unit tests
+// ---------------------------------------------------------------------------
+
+describe('parseTags (untrusted wire data)', () => {
+  it('returns empty array for non-object data', () => {
+    expect(parseTags(null)).toEqual([])
+    expect(parseTags('string')).toEqual([])
+    expect(parseTags(42)).toEqual([])
+  })
+
+  it('returns empty array when tags field is absent or not an array', () => {
+    expect(parseTags({})).toEqual([])
+    expect(parseTags({ tags: 'not-array' })).toEqual([])
+    expect(parseTags({ tags: null })).toEqual([])
+  })
+
+  it('drops non-string values from the tags array', () => {
+    expect(parseTags({ tags: ['prod', 42, null, 'dev', { obj: true }] })).toEqual([
+      'prod',
+      'dev',
+    ])
+  })
+
+  it('returns a valid string array unchanged', () => {
+    expect(parseTags({ tags: ['prod', 'dev', 'infra'] })).toEqual([
+      'prod',
+      'dev',
+      'infra',
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Kebab button behaviour
+// ---------------------------------------------------------------------------
+
+describe('kebab button', () => {
+  it('renders a button with aria-label "Actions"', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    expect(screen.getByRole('button', { name: 'Actions' })).toBeInTheDocument()
+  })
+
+  it('click opens the action menu', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('second click closes the menu', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    const btn = screen.getByRole('button', { name: 'Actions' })
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('Escape closes the menu', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('click outside closes the menu', () => {
+    render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <RowActionMenu stewardId="stw-1" />
+      </div>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('click stops propagation — does not reach parent onClick', () => {
+    const parentClick = vi.fn()
+    render(
+      <div onClick={parentClick}>
+        <RowActionMenu stewardId="stw-1" />
+      </div>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+
+  it('menu shows "Edit tags" item', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    expect(screen.getByRole('menuitem', { name: 'Edit tags' })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag editor
+// ---------------------------------------------------------------------------
+
+describe('tag editor', () => {
+  it('clicking "Edit tags" shows the tag editor with a text input', async () => {
+    mockTagsOk([])
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+    expect(screen.getByRole('textbox', { name: 'New tag' })).toBeInTheDocument()
+  })
+
+  it('fetches current tags from GET /stewards/:id/tags when the editor opens', async () => {
+    mockTagsOk(['prod'])
+    render(<RowActionMenu stewardId="stw-42" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    expect(await screen.findByText('prod')).toBeInTheDocument()
+
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toBe('/api/v1/stewards/stw-42/tags')
+    expect((fetchMock.mock.calls[0]?.[1]?.method ?? 'GET').toUpperCase()).toBe('GET')
+  })
+
+  it('encodes special characters in the steward ID', async () => {
+    mockTagsOk([])
+    render(<RowActionMenu stewardId="stw/sp ec" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toBe('/api/v1/stewards/stw%2Fsp%20ec/tags')
+  })
+
+  it('renders existing tags as removable chips', async () => {
+    mockTagsOk(['prod', 'dev'])
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    expect(await screen.findByText('prod')).toBeInTheDocument()
+    expect(screen.getByText('dev')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove tag prod' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove tag dev' })).toBeInTheDocument()
+  })
+
+  it('shows "No tags" when the list is empty', async () => {
+    mockTagsOk([])
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    expect(await screen.findByText('No tags')).toBeInTheDocument()
+  })
+
+  it('removing a tag calls DELETE and reflects the updated list', async () => {
+    mockTagsSeq({ status: 200, tags: ['prod'] }, { status: 200, tags: [] })
+
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove tag prod' }))
+
+    await waitFor(() => expect(screen.getByText('No tags')).toBeInTheDocument())
+
+    const delCall = fetchMock.mock.calls.find(
+      (c) => (c[1]?.method ?? '').toUpperCase() === 'DELETE',
+    )
+    expect(delCall).toBeDefined()
+    const body = JSON.parse(String(delCall?.[1]?.body)) as { tags: string[] }
+    expect(body.tags).toContain('prod')
+  })
+
+  it('shows an error alert when remove fails with non-200 status', async () => {
+    mockTagsSeq({ status: 200, tags: ['prod'] }, { status: 422 })
+
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove tag prod' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('422')
+    // Tag still shown — the list was not updated after the failed remove.
+    expect(screen.getByText('prod')).toBeInTheDocument()
+  })
+
+  it('shows an error alert when remove fails with a network error', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { tags: ['prod'] }, timestamp: '' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockRejectedValueOnce(new Error('network down'))
+
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove tag prod' }))
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+  })
+
+  it('adding a tag calls POST and reflects the updated list', async () => {
+    mockTagsSeq({ status: 200, tags: [] }, { status: 200, tags: ['dev'] })
+
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    await screen.findByText('No tags')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'New tag' }), {
+      target: { value: 'dev' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(screen.getByText('dev')).toBeInTheDocument())
+
+    const postCall = fetchMock.mock.calls.find(
+      (c) => (c[1]?.method ?? '').toUpperCase() === 'POST',
+    )
+    expect(postCall).toBeDefined()
+    const body = JSON.parse(String(postCall?.[1]?.body)) as { tags: string[] }
+    expect(body.tags).toContain('dev')
+  })
+
+  it('pressing Enter in the input adds a tag', async () => {
+    mockTagsSeq({ status: 200, tags: [] }, { status: 200, tags: ['qa'] })
+
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    await screen.findByText('No tags')
+
+    const input = screen.getByRole('textbox', { name: 'New tag' })
+    fireEvent.change(input, { target: { value: 'qa' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('qa')).toBeInTheDocument())
+  })
+
+  it('shows an error alert when the tag fetch fails (non-200 status)', async () => {
+    mockTagsSeq({ status: 503 })
+
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('503')
+  })
+
+  it('shows an error alert when add fails (non-200 status)', async () => {
+    mockTagsSeq({ status: 200, tags: [] }, { status: 400 })
+
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    await screen.findByText('No tags')
+    fireEvent.change(screen.getByRole('textbox', { name: 'New tag' }), {
+      target: { value: 'INVALID' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('400')
+  })
+
+  it('back button returns to the menu from the tag editor', async () => {
+    mockTagsOk([])
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags' }))
+
+    await screen.findByRole('textbox', { name: 'New tag' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to menu' }))
+
+    expect(screen.getByRole('menuitem', { name: 'Edit tags' })).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/fleet/RowActionMenu.tsx
+++ b/web/src/fleet/RowActionMenu.tsx
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Per-row action menu (Story #2938) — mockup `.rowkebab` / `.pop .row` pattern
+ * from `asset-live-activity.html` lines 204-205/500, applied to FleetTable.
+ *
+ * The component is structured as an ordered MenuItemSpec list so later entries
+ * can be appended without restructuring the JSX. Only tag edit is wired in
+ * this story — move-tenant and decommission are out of scope (Section 2).
+ *
+ * Popover lifecycle (Escape + outside-click) is a verbatim reuse of the
+ * pattern established by ColumnPicker.tsx and SavedViews.tsx.
+ *
+ * Security: tag values from the wire are validated by parseTags before render
+ * (same parse-validate-untrusted-wire discipline as useStewards / DnaDrawer).
+ * All tag strings reach the DOM through JSX text nodes only.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+
+export interface MenuItemSpec {
+  id: string
+  label: string
+  onActivate: () => void
+}
+
+/** Validate the tag list from untrusted wire data (security A10.2). */
+export function parseTags(data: unknown): string[] {
+  if (typeof data !== 'object' || data === null) return []
+  const record = data as Record<string, unknown>
+  if (!Array.isArray(record.tags)) return []
+  return record.tags.filter((t): t is string => typeof t === 'string')
+}
+
+function TagEditor({
+  stewardId,
+  onBack,
+}: {
+  stewardId: string
+  onBack: () => void
+}) {
+  const [tags, setTags] = useState<string[] | null>(null)
+  const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch(`/api/v1/stewards/${encodeURIComponent(stewardId)}/tags`)
+      .then(async (resp) => {
+        const body: unknown = await resp.json()
+        if (cancelled) return
+        if (!resp.ok) {
+          setError(`Failed to load tags (${resp.status})`)
+          return
+        }
+        setTags(parseTags((body as Record<string, unknown>)?.data))
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load tags')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [stewardId])
+
+  async function add(raw: string) {
+    const tag = raw.trim()
+    if (!tag) return
+    setBusy(true)
+    setError(null)
+    try {
+      const resp = await apiFetch(
+        `/api/v1/stewards/${encodeURIComponent(stewardId)}/tags`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tags: [tag] }),
+        },
+      )
+      const body: unknown = await resp.json()
+      if (!resp.ok) {
+        setError(`Failed to add tag (${resp.status})`)
+        return
+      }
+      setTags(parseTags((body as Record<string, unknown>)?.data))
+      setInput('')
+    } catch {
+      setError('Failed to add tag')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function remove(tag: string) {
+    setBusy(true)
+    setError(null)
+    try {
+      const resp = await apiFetch(
+        `/api/v1/stewards/${encodeURIComponent(stewardId)}/tags`,
+        {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tags: [tag] }),
+        },
+      )
+      const body: unknown = await resp.json()
+      if (!resp.ok) {
+        setError(`Failed to remove tag (${resp.status})`)
+        return
+      }
+      setTags(parseTags((body as Record<string, unknown>)?.data))
+    } catch {
+      setError('Failed to remove tag')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="row-tag-editor">
+      <div className="rtag-hd">
+        <button type="button" className="rtag-back" aria-label="Back to menu" onClick={onBack}>
+          ←
+        </button>
+        <span className="rtag-title">Edit tags</span>
+      </div>
+      {error !== null && (
+        <div className="rtag-err" role="alert">
+          {error}
+        </div>
+      )}
+      {tags === null && error === null && <div className="rtag-spin">Loading…</div>}
+      {tags !== null && (
+        <div className="rtag-chips">
+          {tags.length === 0 && <span className="rtag-empty">No tags</span>}
+          {tags.map((tag) => (
+            <span key={tag} className="rtag-chip">
+              {tag}
+              <button
+                type="button"
+                className="rtag-rm"
+                aria-label={`Remove tag ${tag}`}
+                disabled={busy}
+                onClick={() => void remove(tag)}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="rtag-row">
+        <input
+          type="text"
+          className="rtag-in"
+          placeholder="add-tag"
+          value={input}
+          aria-label="New tag"
+          disabled={busy}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              void add(input)
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="rtag-btn"
+          disabled={busy || !input.trim()}
+          onClick={() => void add(input)}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function RowActionMenu({ stewardId }: { stewardId: string }) {
+  const [open, setOpen] = useState(false)
+  const [mode, setMode] = useState<'menu' | 'tags'>('menu')
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  /* Escape and outside-click lifecycle — verbatim reuse of ColumnPicker.tsx pattern. */
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false)
+        setMode('menu')
+      }
+    }
+    function onDown(e: MouseEvent) {
+      if (!wrapRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+        setMode('menu')
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onDown)
+    }
+  }, [open])
+
+  /* Ordered spec list — append later entries here without restructuring the JSX. */
+  const MENU_ITEMS: MenuItemSpec[] = [
+    { id: 'tags', label: 'Edit tags', onActivate: () => setMode('tags') },
+  ]
+
+  return (
+    <div className="ram-wrap" ref={wrapRef}>
+      <button
+        type="button"
+        className="rowkebab"
+        aria-label="Actions"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((was) => {
+            if (was) setMode('menu')
+            return !was
+          })
+        }}
+        onKeyDown={(e) => {
+          /* Stop Enter/Space from bubbling to the tr's onKeyDown so it doesn't
+           * fire onRowSelect while the kebab button handles the keypress. */
+          if (e.key === 'Enter' || e.key === ' ') e.stopPropagation()
+        }}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle cx="12" cy="5" r="1.6" fill="currentColor" />
+          <circle cx="12" cy="12" r="1.6" fill="currentColor" />
+          <circle cx="12" cy="19" r="1.6" fill="currentColor" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          className="pop right ram-pop"
+          role={mode === 'menu' ? 'menu' : undefined}
+        >
+          {mode === 'menu' &&
+            MENU_ITEMS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className="row"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  item.onActivate()
+                }}
+              >
+                {item.label}
+              </button>
+            ))}
+          {mode === 'tags' && (
+            <TagEditor stewardId={stewardId} onBack={() => setMode('menu')} />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a per-row `.rowkebab` action menu to `FleetTable` using the mockup idiom from `asset-live-activity.html` (lines 204-205). The kebab button is revealed on row hover/focus and stops propagation so it **never triggers `onRowSelect`** or row-drill-in navigation — existing click behavior is unchanged.
- `RowActionMenu` is structured as an ordered `MenuItemSpec[]` list; Section 2 (move-tenant, decommission) can append entries without restructuring the JSX.
- Inline `TagEditor` calls `GET`/`POST`/`DELETE /stewards/{id}/tags` (existing endpoints, no backend changes). The chip list updates immediately on each successful response. Wire data validated by `parseTags` before render (security A10.2).
- `docs/design/mockups/README.md` catalog updated with the two entries missing since #2762/#2766.

Fixes #2938

## Specialist Review Results

| Lens | Round 1 | Round 2 |
|------|---------|---------|
| Code review | FAIL (missing remove-error tests) | **PASS** |
| Test quality | **PASS** | — |
| Security | **PASS** | — |

**Aggregate: PASSED** (1 fix round, 0 remaining findings)

Security reviewer notes: `stewardId` is `encodeURIComponent`-escaped in all API paths; untrusted wire tags validated by `parseTags`; all values reach the DOM as JSX text nodes only; CSRF handled centrally by `apiFetch`; no hardcoded secrets.

## Test plan

- [ ] Verify kebab button appears on row hover and is invisible at rest
- [ ] Verify clicking the kebab opens the action menu without navigating to the asset page
- [ ] Verify direct row click (name link) still opens the drawer
- [ ] Verify "Edit tags" shows the inline tag editor with current tags loaded
- [ ] Verify adding a tag persists and updates the chip list immediately
- [ ] Verify removing a tag persists and removes the chip immediately
- [ ] Verify error states show for network / non-200 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)