### PR TITLE
design: darken dark-mode surfaces and fix badge contrast to WCAG AA

### DIFF
--- a/docs/design/web-ui-design-tokens.css
+++ b/docs/design/web-ui-design-tokens.css
@@ -34,10 +34,10 @@
 
   /* --- Semantic state (desaturated earth tones) --- */
   --state-ok:        #507055;  --state-ok-bg:    #e8f0e9; /* converged / success */
-  --state-warn:      #a05a35;  --state-warn-bg:  #f7e8db; /* drift / warning */
-  --state-crit:      #b56a5a;  --state-crit-bg:  #f2e5e3; /* error (terracotta) */
+  --state-warn:      #8f4f2e;  --state-warn-bg:  #f7e8db; /* drift / warning */
+  --state-crit:      #965044;  --state-crit-bg:  #f2e5e3; /* error (terracotta) */
   --state-mauve:     #7a5f6e;                              /* alt error (guide) */
-  --state-neutral:   #7a6a5a;  --state-neutral-bg:#e8e0d8; /* queued / inert */
+  --state-neutral:   #6b5c4d;  --state-neutral-bg:#e8e0d8; /* queued / inert */
 
   /* --- Card tints (background only; meaning-encoding, not decoration) --- */
   --tint-red:    #f2e5e3;  /* a problem / failing surface */
@@ -78,21 +78,21 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg-primary:  #1e1e1e;
-    --bg-surface:  #252526;
-    --bg-elevated: #2d2d2d;
-    --bg-sunk:     #1a1a1a;
-    --border:      #3c3c3c;
+    --bg-primary:  #1a1a1a;
+    --bg-surface:  #242426;
+    --bg-elevated: #31313a;
+    --bg-sunk:     #101010;
+    --border:      #52525c;
 
-    --text-primary:   #c4b4a4;
+    --text-primary:   #c8b8a6;
     --text-secondary: #a89888;
-    --text-faint:     #8a7a68;
+    --text-faint:     #9a8974;
     --accent:         #7b9fb0;
     --accent-ink:     #16202a;
 
-    --state-ok:      #6d9472;  --state-ok-bg:     #1a2e1d;
+    --state-ok:      #7fa985;  --state-ok-bg:     #1a2e1d;
     --state-warn:    #d4864f;  --state-warn-bg:   #332518;
-    --state-crit:    #c97a6a;  --state-crit-bg:   #2d1f1c;
+    --state-crit:    #d0846f;  --state-crit-bg:   #2d1f1c;
     --state-mauve:   #a58198;
     --state-neutral: #a89888;  --state-neutral-bg:#2a2520;
 
@@ -112,17 +112,17 @@
 :root[data-theme="light"] {
   --bg-primary: #f7f4ef; --bg-surface: #ffffff; --bg-elevated: #f0ebe4; --bg-sunk: #f0ebe4; --border: #d4cfc4;
   --text-primary: #6b5a4a; --text-secondary: #7a6a5a; --text-faint: #8f7d66; --accent: #4a6b7c; --accent-ink: #ffffff;
-  --state-ok: #507055; --state-ok-bg: #e8f0e9; --state-warn: #a05a35; --state-warn-bg: #f7e8db;
-  --state-crit: #b56a5a; --state-crit-bg: #f2e5e3; --state-mauve: #7a5f6e; --state-neutral: #7a6a5a; --state-neutral-bg: #e8e0d8;
+  --state-ok: #507055; --state-ok-bg: #e8f0e9; --state-warn: #8f4f2e; --state-warn-bg: #f7e8db;
+  --state-crit: #965044; --state-crit-bg: #f2e5e3; --state-mauve: #7a5f6e; --state-neutral: #6b5c4d; --state-neutral-bg: #e8e0d8;
   --tint-red: #f2e5e3; --tint-green: #e8f0e9; --tint-orange: #f7e8db; --tint-blue: #e6eef2; --tint-brown: #e8e0d8; --tint-cream: #faf8f5;
   --shadow: 0 18px 50px -22px rgba(60, 45, 30, 0.40);
 }
 
 :root[data-theme="dark"] {
-  --bg-primary: #1e1e1e; --bg-surface: #252526; --bg-elevated: #2d2d2d; --bg-sunk: #1a1a1a; --border: #3c3c3c;
-  --text-primary: #c4b4a4; --text-secondary: #a89888; --text-faint: #8a7a68; --accent: #7b9fb0; --accent-ink: #16202a;
-  --state-ok: #6d9472; --state-ok-bg: #1a2e1d; --state-warn: #d4864f; --state-warn-bg: #332518;
-  --state-crit: #c97a6a; --state-crit-bg: #2d1f1c; --state-mauve: #a58198; --state-neutral: #a89888; --state-neutral-bg: #2a2520;
+  --bg-primary: #1a1a1a; --bg-surface: #242426; --bg-elevated: #31313a; --bg-sunk: #101010; --border: #52525c;
+  --text-primary: #c8b8a6; --text-secondary: #a89888; --text-faint: #9a8974; --accent: #7b9fb0; --accent-ink: #16202a;
+  --state-ok: #7fa985; --state-ok-bg: #1a2e1d; --state-warn: #d4864f; --state-warn-bg: #332518;
+  --state-crit: #d0846f; --state-crit-bg: #2d1f1c; --state-mauve: #a58198; --state-neutral: #a89888; --state-neutral-bg: #2a2520;
   --tint-red: #2d1f1c; --tint-green: #1a2e1d; --tint-orange: #332518; --tint-blue: #1e2528; --tint-brown: #2a2520; --tint-cream: #252321;
   --shadow: 0 22px 60px -26px rgba(0, 0, 0, 0.80);
 }


### PR DESCRIPTION
## What
Two dark-theme readability issues in `docs/design/web-ui-design-tokens.css`, found during a live UI review and fixed with measured WCAG ratios. Light-theme structure (ground, surfaces, taupe text, accent, type) is unchanged; badge tint backgrounds are unchanged.

## 1. Dark mode read as "foggy"
Not a text-contrast problem (dark `text-primary` was 7.6–8.3:1). The dark surfaces were compressed into a ~15-level luminance band, so layers didn't separate:

| pair | before |
|---|---|
| `bg-surface` / `bg-primary` | 1.09:1 |
| `bg-elevated` / `bg-surface` | 1.11:1 |
| `border` / `bg-surface` | 1.39:1 |

Fixed by **darkening the ground and strengthening the border** (border-defined layering) rather than lightening surfaces — so it stays a dark theme:
`bg-primary 1e1e1e→1a1a1a`, `bg-surface 252526→242426`, `bg-elevated 2d2d2d→31313a`, `bg-sunk 1a1a1a→101010`, `border 3c3c3c→52525c` (border/surface **1.39→2.08:1**), `text-primary c4b4a4→c8b8a6`, `text-faint 8a7a68→9a8974`.

## 2. Color-on-color badges failed WCAG AA
Health/severity/result badges are state text on a same-hue tint (`state-*` on `state-*-bg`). Several missed AA (4.5:1) — light worse than dark:

| tone | before | after |
|---|---|---|
| light crit (Unreachable) | **3.30** | 4.85 |
| light warn (Degraded) | 4.37 | 5.27 |
| light neutral (quarantined) | 3.98 | 4.93 |
| dark ok (Healthy) | 4.22 | 5.45 |
| dark crit (Unreachable) | 4.89 | 5.45 |

Text color only; tint backgrounds untouched. All four tones now clear AA in both themes.

## Verification
- WCAG ratios computed for every text/surface/badge pair, both themes.
- Rendered before/after and confirmed live on the lab controller (dark + light fleet views and badges).

## Note
`docs/design/web-ui-design-tokens.css` is founder-owned; these values were chosen and approved in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kJXzKf5NM454dGY2WtP4g
