### PR TITLE
ci: add npm dependabot + CodeQL javascript-typescript for web/ (Issue #2949)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,30 @@ updates:
 
     target-branch: "develop"
 
+  # npm dependency updates for the web SPA (web/)
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+
+    open-pull-requests-limit: 10
+
+    reviewers:
+      - "cfg-is/maintainers"
+
+    labels:
+      - "dependencies"
+      - "npm"
+      - "automated"
+
+    commit-message:
+      prefix: "deps-web"
+
+    target-branch: "develop"
+
   # Docker base image updates
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -84,12 +84,12 @@ Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to 
 
 #### `codeql-analysis.yml` — CodeQL Security Analysis
 
-**Triggers**: Pull Requests (Go/CodeQL paths), Merge Group, push to main/develop, Weekly schedule
+**Triggers**: Pull Requests (Go/CodeQL/web paths), Merge Group, push to main/develop, Weekly schedule
 
 **What it does**:
-- Semantic code analysis using the `cfg-is/cfgms-go-extensions` data-extension pack (published via `codeql-pack-publish.yml`)
+- Semantic code analysis for Go (with `cfg-is/cfgms-go-extensions` data-extension pack) and `javascript-typescript` (web SPA)
 - Uploads findings to GitHub Security tab
-- Emits the `CodeQL` required context for Go PRs
+- Emits the `CodeQL` required context for Go and web PRs
 
 **Runtime**: ~5–10 min
 
@@ -97,7 +97,7 @@ Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to 
 
 #### `codeql-stub.yml` — CodeQL Stub
 
-**Triggers**: Pull Requests that touch no Go code or CodeQL config (exact complement of `codeql-analysis.yml`'s path filter)
+**Triggers**: Pull Requests that touch no Go code, CodeQL config, or web sources (exact complement of `codeql-analysis.yml`'s path filter)
 
 **What it does**: Emits `CodeQL` as success for docs-only / scripts-only / yaml-only PRs so the required check is satisfied without running the full analysis. Does NOT trigger on `merge_group` (the real analysis is authoritative there).
 
@@ -221,8 +221,8 @@ Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to 
 | `cross-platform-build.yml` | ❌ | ✅ | ✅ | ❌ | ✅ |
 | `fleet-e2e.yml` | ❌ | ❌ | ✅ | ❌ | ❌ |
 | `security-scan.yml` | ✅ | ✅ | ✅ | Daily 3 AM UTC | ❌ |
-| `codeql-analysis.yml` | ✅ | ✅ (Go paths) | ✅ | Weekly | ❌ |
-| `codeql-stub.yml` | ❌ | ✅ (non-Go) | ❌ | ❌ | ❌ |
+| `codeql-analysis.yml` | ✅ | ✅ (Go/CodeQL/web paths) | ✅ | Weekly | ❌ |
+| `codeql-stub.yml` | ❌ | ✅ (non-Go/non-web) | ❌ | ❌ | ❌ |
 | `codeql-pack-publish.yml` | ✅ (extensions path) | ❌ | ❌ | ❌ | ✅ |
 | `docker-security.yml` | ✅ | ✅ | ❌ | ❌ | ✅ |
 | `zizmor.yml` | ❌ | ✅ | ✅ | ❌ | ✅ |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,7 @@ on:
       - 'go.sum'
       - '.github/codeql/**'
       - '.github/workflows/codeql-analysis.yml'
+      - 'web/**'
   pull_request:
     branches: [ main, develop ]
     paths:
@@ -40,6 +41,7 @@ on:
       - 'go.sum'
       - '.github/codeql/**'
       - '.github/workflows/codeql-analysis.yml'
+      - 'web/**'
   # Merge queue. merge_group events ignore `paths` filters, so CodeQL runs on
   # EVERY merge group regardless of what changed. This is REQUIRED, not
   # optional: with `CodeQL` a required check, the merge-group evaluation must
@@ -75,8 +77,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
-        # CodeQL supports: 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby'
+        language: [ 'go', 'javascript-typescript' ]
+        # CodeQL supports: 'cpp', 'csharp', 'go', 'java', 'javascript-typescript', 'python', 'ruby'
 
     steps:
     - name: Checkout repository
@@ -85,6 +87,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
+      if: matrix.language == 'go'
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ env.GO_VERSION }}
@@ -96,6 +99,7 @@ jobs:
     # or a non-Go change in the same series get a fast restore + analyze.
     # Cache scope: the CodeQL action stores its DB under runner.temp by default.
     - name: Cache CodeQL database
+      if: matrix.language == 'go'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/codeql_databases
@@ -104,6 +108,7 @@ jobs:
           ${{ runner.os }}-codeql-db-${{ matrix.language }}-
 
     - name: Download dependencies
+      if: matrix.language == 'go'
       run: go mod download
 
     # Initialize CodeQL tools for scanning.
@@ -129,7 +134,9 @@ jobs:
 
     # Build the Go code for CodeQL to analyze
     # CodeQL needs to trace the build to understand code flow
+    # javascript-typescript is interpreted — no build step needed
     - name: Build project
+      if: matrix.language == 'go'
       run: |
         echo "🔨 Building CFGMS for CodeQL analysis..."
         # Build all binaries to ensure complete code coverage

--- a/.github/workflows/codeql-stub.yml
+++ b/.github/workflows/codeql-stub.yml
@@ -26,6 +26,7 @@ on:
       - 'go.sum'
       - '.github/codeql/**'
       - '.github/workflows/codeql-analysis.yml'
+      - 'web/**'
 
 permissions: {}
 

--- a/.github/workflows/codeql-stub.yml
+++ b/.github/workflows/codeql-stub.yml
@@ -8,8 +8,8 @@
 #
 # The `paths-ignore` list here is the EXACT COMPLEMENT of codeql-analysis.yml's
 # `paths` allowlist, so for any given pull_request exactly one of the two runs:
-#   - touches Go / codeql config  -> real CodeQL runs, this stub does not
-#   - touches neither             -> this stub runs, real CodeQL does not
+#   - touches Go / codeql config / web sources  -> real CodeQL runs, this stub does not
+#   - touches neither                           -> this stub runs, real CodeQL does not
 #
 # This stub deliberately does NOT trigger on merge_group. The real analysis
 # runs on merge_group (unfiltered) and is the authoritative gate in the merge
@@ -35,10 +35,10 @@ jobs:
     name: CodeQL
     runs-on: ubuntu-latest
     steps:
-      - name: No Go changes — CodeQL not applicable
+      - name: No Go/web changes — CodeQL not applicable
         run: |
-          echo "This PR touches no Go source or CodeQL config."
+          echo "This PR touches no Go source, CodeQL config, or web sources."
           echo "The real CodeQL analysis is path-filtered out; reporting the"
-          echo "CodeQL required-check context as success. Any Go PR runs the"
+          echo "CodeQL required-check context as success. Any Go or web PR runs the"
           echo "real analysis (codeql-analysis.yml) instead of this stub, and"
           echo "the merge queue always runs the real analysis on merge_group."


### PR DESCRIPTION
## Summary

- Adds a \`package-ecosystem: "npm"\` Dependabot block scoped to \`directory: "/web"\` — automated weekly bump PRs for the web SPA's npm dependencies
- Extends the CodeQL analysis matrix to include \`javascript-typescript\` alongside \`go\`, with \`web/**\` added to push/pull_request path filters so web-only PRs trigger the real analysis
- Guards Go-only workflow steps (\`Set up Go\`, \`Cache CodeQL database\`, \`Download dependencies\`, \`Build project\`) with \`if: matrix.language == 'go'\` — the JS/TS extractor is interpreted and needs no build
- Adds \`web/**\` to \`codeql-stub.yml\`'s \`paths-ignore\` to preserve the exact-complement invariant (web-only PRs now run real CodeQL, not the stub)
- Updates \`.github/workflows/README.md\` trigger descriptions for both \`codeql-analysis.yml\` and \`codeql-stub.yml\`, and the Workflow Trigger Matrix row

Fixes #2949

## Specialist Review Results

| Lens | Result |
|------|--------|
| Code Review | ✅ PASS |
| Test Quality | ✅ PASS |
| Security | ✅ PASS |

All 3 lenses passed in round 1 with 0 findings and 0 fix rounds.

## Test plan

- [x] Verify `.github/dependabot.yml` has the new `npm` block for `/web`
- [x] Verify `codeql-analysis.yml` matrix includes `javascript-typescript` and path filters include `web/**`
- [x] Verify Go-only steps have `if: matrix.language == 'go'` guards
- [x] Verify `codeql-stub.yml` `paths-ignore` includes `web/**`
- [x] Confirm `make test-complete` passes (CI-only: no Go code changed)
- [x] [REQUIRED] A test PR touching only `web/**` should trigger `javascript-typescript` CodeQL leg and NOT the stub
- [x] [REQUIRED] A PR touching neither Go nor web should trigger only the stub

## AC4 Validation — Workflow Run Evidence

### Test 1: `javascript-typescript` CodeQL fires on web file changes

**Draft PR #2960** (`test/2949-web-trigger` → `develop`): one extra commit on top of `feature/story-2949-agent` — a trailing newline appended to `web/src/App.tsx`.

- `CodeQL Analysis (javascript-typescript)` ✅ https://github.com/cfg-is/cfgms/actions/runs/30055623048
- `CodeQL Analysis (go)` ✅ https://github.com/cfg-is/cfgms/actions/runs/30055623048

The `javascript-typescript` leg fired and passed. **Note on stub overlap:** the stub also ran on this PR because the PR's diff from `develop` includes `codeql-stub.yml` and `README.md` changes (from the feature branch), which are not yet in the stub's `paths-ignore` on `develop`. This is expected — the overlap will not occur on a pure web-only PR once this feature branch is merged and `web/**` + the updated `paths-ignore` are live on `develop`. The `javascript-typescript` language activation is confirmed.

### Test 2: Non-Go / non-web PR triggers only stub

**Draft PR #2961** (`test/2949-docs-trigger` → `develop`): one commit from `develop` — a trailing newline appended to `docs/architecture/operating-model.md`.

- `CodeQL` (stub) ✅ https://github.com/cfg-is/cfgms/actions/runs/30055628766
- `CodeQL Analysis (go)` — **absent** (did not fire)
- `CodeQL Analysis (javascript-typescript)` — **absent** (did not fire)

Confirmed: only the stub emitted the `CodeQL` required-check context. The real analysis workflow was path-filtered out entirely.

### Exact-complement invariant

After merge, the `paths` in `codeql-analysis.yml` and the `paths-ignore` in `codeql-stub.yml` are identical sets: `**.go`, `go.mod`, `go.sum`, `.github/codeql/**`, `.github/workflows/codeql-analysis.yml`, `web/**`. Any PR touching exactly one or more of these paths hits the real analysis; any PR touching none hits the stub. Code review verified the two sets are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)