### PR TITLE
test: web-only path-filter validation for CodeQL javascript-typescript (Issue #2949)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,30 @@ updates:
 
     target-branch: "develop"
 
+  # npm dependency updates for the web SPA (web/)
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+
+    open-pull-requests-limit: 10
+
+    reviewers:
+      - "cfg-is/maintainers"
+
+    labels:
+      - "dependencies"
+      - "npm"
+      - "automated"
+
+    commit-message:
+      prefix: "deps-web"
+
+    target-branch: "develop"
+
   # Docker base image updates
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -84,12 +84,12 @@ Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to 
 
 #### `codeql-analysis.yml` — CodeQL Security Analysis
 
-**Triggers**: Pull Requests (Go/CodeQL paths), Merge Group, push to main/develop, Weekly schedule
+**Triggers**: Pull Requests (Go/CodeQL/web paths), Merge Group, push to main/develop, Weekly schedule
 
 **What it does**:
-- Semantic code analysis using the `cfg-is/cfgms-go-extensions` data-extension pack (published via `codeql-pack-publish.yml`)
+- Semantic code analysis for Go (with `cfg-is/cfgms-go-extensions` data-extension pack) and `javascript-typescript` (web SPA)
 - Uploads findings to GitHub Security tab
-- Emits the `CodeQL` required context for Go PRs
+- Emits the `CodeQL` required context for Go and web PRs
 
 **Runtime**: ~5–10 min
 
@@ -97,7 +97,7 @@ Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to 
 
 #### `codeql-stub.yml` — CodeQL Stub
 
-**Triggers**: Pull Requests that touch no Go code or CodeQL config (exact complement of `codeql-analysis.yml`'s path filter)
+**Triggers**: Pull Requests that touch no Go code, CodeQL config, or web sources (exact complement of `codeql-analysis.yml`'s path filter)
 
 **What it does**: Emits `CodeQL` as success for docs-only / scripts-only / yaml-only PRs so the required check is satisfied without running the full analysis. Does NOT trigger on `merge_group` (the real analysis is authoritative there).
 
@@ -221,8 +221,8 @@ Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to 
 | `cross-platform-build.yml` | ❌ | ✅ | ✅ | ❌ | ✅ |
 | `fleet-e2e.yml` | ❌ | ❌ | ✅ | ❌ | ❌ |
 | `security-scan.yml` | ✅ | ✅ | ✅ | Daily 3 AM UTC | ❌ |
-| `codeql-analysis.yml` | ✅ | ✅ (Go paths) | ✅ | Weekly | ❌ |
-| `codeql-stub.yml` | ❌ | ✅ (non-Go) | ❌ | ❌ | ❌ |
+| `codeql-analysis.yml` | ✅ | ✅ (Go/CodeQL/web paths) | ✅ | Weekly | ❌ |
+| `codeql-stub.yml` | ❌ | ✅ (non-Go/non-web) | ❌ | ❌ | ❌ |
 | `codeql-pack-publish.yml` | ✅ (extensions path) | ❌ | ❌ | ❌ | ✅ |
 | `docker-security.yml` | ✅ | ✅ | ❌ | ❌ | ✅ |
 | `zizmor.yml` | ❌ | ✅ | ✅ | ❌ | ✅ |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,7 @@ on:
       - 'go.sum'
       - '.github/codeql/**'
       - '.github/workflows/codeql-analysis.yml'
+      - 'web/**'
   pull_request:
     branches: [ main, develop ]
     paths:
@@ -40,6 +41,7 @@ on:
       - 'go.sum'
       - '.github/codeql/**'
       - '.github/workflows/codeql-analysis.yml'
+      - 'web/**'
   # Merge queue. merge_group events ignore `paths` filters, so CodeQL runs on
   # EVERY merge group regardless of what changed. This is REQUIRED, not
   # optional: with `CodeQL` a required check, the merge-group evaluation must
@@ -75,8 +77,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
-        # CodeQL supports: 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby'
+        language: [ 'go', 'javascript-typescript' ]
+        # CodeQL supports: 'cpp', 'csharp', 'go', 'java', 'javascript-typescript', 'python', 'ruby'
 
     steps:
     - name: Checkout repository
@@ -85,6 +87,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
+      if: matrix.language == 'go'
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ env.GO_VERSION }}
@@ -96,6 +99,7 @@ jobs:
     # or a non-Go change in the same series get a fast restore + analyze.
     # Cache scope: the CodeQL action stores its DB under runner.temp by default.
     - name: Cache CodeQL database
+      if: matrix.language == 'go'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/codeql_databases
@@ -104,6 +108,7 @@ jobs:
           ${{ runner.os }}-codeql-db-${{ matrix.language }}-
 
     - name: Download dependencies
+      if: matrix.language == 'go'
       run: go mod download
 
     # Initialize CodeQL tools for scanning.
@@ -129,7 +134,9 @@ jobs:
 
     # Build the Go code for CodeQL to analyze
     # CodeQL needs to trace the build to understand code flow
+    # javascript-typescript is interpreted — no build step needed
     - name: Build project
+      if: matrix.language == 'go'
       run: |
         echo "🔨 Building CFGMS for CodeQL analysis..."
         # Build all binaries to ensure complete code coverage

--- a/.github/workflows/codeql-stub.yml
+++ b/.github/workflows/codeql-stub.yml
@@ -26,6 +26,7 @@ on:
       - 'go.sum'
       - '.github/codeql/**'
       - '.github/workflows/codeql-analysis.yml'
+      - 'web/**'
 
 permissions: {}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,3 +52,4 @@ function App() {
 }
 
 export default App
+


### PR DESCRIPTION
**DO NOT MERGE — draft test PR for AC4 validation of PR #2949**

This draft PR has exactly one change beyond the `feature/story-2949-agent` baseline: a trailing newline appended to `web/src/App.tsx`. Its purpose is to generate empirical evidence that the new `web/**` path filter in `codeql-analysis.yml` triggers the real `CodeQL Analysis (javascript-typescript)` leg and bypasses the stub.

Expected:
- `CodeQL Analysis (go)` ✅ runs (merge commit includes `codeql-analysis.yml` in changed files)
- `CodeQL Analysis (javascript-typescript)` ✅ runs (same trigger)
- `CodeQL Stub` ❌ does NOT run (`codeql-analysis.yml` is in its `paths-ignore`)

Closes after URL is recorded in PR #2956.