### PR TITLE
test: docs-only path-filter validation for CodeQL stub (Issue #2949)

### DIFF
--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -468,3 +468,4 @@ and fans out `CommandPushStewardBinary`. Requires `installer:dispatch:steward` p
 ## Monitoring Export Credentials
 
 OTLP exporter credentials (API keys / bearer tokens) are stored in `pkg/secrets`, not in config files. Configure the secret key name via `config["secret_key"]` and use `NewOTLPExporterWithSecrets` to wire the store at construction time.
+


### PR DESCRIPTION
**DO NOT MERGE — draft test PR for AC4 validation of PR #2949**

This draft PR has exactly one change from `develop`: a trailing newline appended to `docs/architecture/operating-model.md`. Its purpose is to generate empirical evidence that a PR touching only non-Go/non-web files triggers the `CodeQL Stub` and bypasses the real CodeQL analysis.

Expected:
- `CodeQL` (stub) ✅ runs (markdown file not in stub's `paths-ignore`)
- `CodeQL Analysis (go)` ❌ does NOT run (no Go, codeql config, or web files changed)
- `CodeQL Analysis (javascript-typescript)` ❌ does NOT run (same reason)

Closes after URL is recorded in PR #2956.