### PR TITLE
test: establish Go native fuzzing (config, DNA-transport, EID, cert PEM) (Issue #2952)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,46 @@
+name: Nightly Fuzz
+
+on:
+  schedule:
+    # Run nightly at 02:00 UTC. Fuzzing is time-boxed and NOT a PR gate —
+    # time-boxed fuzz runs are flaky as required checks (either the budget finds
+    # nothing, proving little, or intermittently finds something and blocks
+    # unrelated PRs).
+    - cron: '0 2 * * *'
+  # Allow manual dispatch to re-run or test the workflow without waiting for midnight.
+  workflow_dispatch:
+
+env:
+  GO_VERSION: '1.26.5'
+  FUZZTIME: 60s
+
+jobs:
+  fuzz:
+    name: Fuzz targets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run fuzz targets
+        run: ./scripts/fuzz-all.sh "${{ env.FUZZTIME }}"
+
+      - name: Upload crash corpora
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-crash-corpora
+          # Each target writes crashes to testdata/fuzz/<FuzzName>/ under its package.
+          path: |
+            pkg/config/testdata/fuzz/
+            features/controller/transport/testdata/fuzz/
+            pkg/entitygraph/types/testdata/fuzz/
+            pkg/cert/testdata/fuzz/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -18,9 +18,13 @@ jobs:
   fuzz:
     name: Fuzz targets
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -82,6 +82,36 @@ Decision path for a CodeQL alert:
 | 0.0.6 | #747–#751 | log-injection | Dismiss | handlers_registration_refresh.go — json.Decode field-selection sources; all sites use `SanitizeLogValue`. Same heuristic-source class as #669–#722. |
 | 0.0.5 | safeJoin | path-injection | Model | `summaryModel` + `barrierModel` for `pkg/storage/providers/flatfile.safeJoin`. |
 
+### 6. Go Native Fuzzing
+
+- **Purpose**: Finds panics and unexpected crashes in parse/decode boundaries under adversarial input — the threat-model-relevant surfaces a compromised steward or malicious config push would hit
+- **Scope**: Four CFGMS-owned parse surfaces (does NOT fuzz `crypto/x509`, `google.golang.org/protobuf`, or any vendored library's own internals)
+- **Blocking**: **NOT a PR gate** — time-boxed fuzzing is flaky as a required check. Runs nightly via `.github/workflows/fuzz-nightly.yml`
+- **Discovery**: `scripts/fuzz-all.sh` auto-discovers all `Fuzz*` targets via `go test -list '^Fuzz'` for each listed package — any new `Fuzz*` target in a listed package is picked up automatically, no workflow edit needed
+
+**Fuzz targets:**
+
+| Target | File | Surface |
+|--------|------|---------|
+| `FuzzUnmarshalStewardConfig` | `pkg/config/manager_fuzz_test.go` | `yaml.Unmarshal` + `ValidateConfiguration` on steward config payloads (the config-parsing boundary a malformed `cfg push` would hit) |
+| `FuzzReassembleDNA` | `features/controller/transport/dna_handler_fuzz_test.go` | Both `json.Unmarshal` calls in `reassembleDNA` on concatenated steward-supplied `DNAChunk` payload bytes (the compromised-steward-to-controller wire boundary) |
+| `FuzzParseEID` | `pkg/entitygraph/types/eid_fuzz_test.go` | Hand-rolled `ParseEID` parser on steward/directory-supplied identifier strings |
+| `FuzzParseCertificateFromPEM` | `pkg/cert/utils_fuzz_test.go` | PEM decode + `x509.ParseCertificate` (mTLS-everywhere means cert parsing is the highest threat-model-relevant fuzz surface) |
+| `FuzzParseCertificateChainFromPEM` | `pkg/cert/utils_fuzz_test.go` | Multi-block `pem.Decode` loop |
+| `FuzzParsePrivateKeyFromPEM` | `pkg/cert/utils_fuzz_test.go` | PEM block type dispatch to `x509.ParsePKCS1PrivateKey` / `ParsePKCS8PrivateKey` / `ParseECPrivateKey` |
+
+**Corpus locations:** `<package>/testdata/fuzz/<FuzzName>/` — crash entries are committed as regression fixtures and uploaded as workflow artifacts by `fuzz-nightly.yml`.
+
+**Local run:**
+
+```bash
+# Run a single target for 30 seconds
+go test -run='^$' -fuzz='^FuzzParseEID$' -fuzztime=30s ./pkg/entitygraph/types/
+
+# Run all targets via the auto-discovery script (same as CI)
+./scripts/fuzz-all.sh 30s
+```
+
 ## Local Development Workflow
 
 ### Prerequisites

--- a/features/controller/transport/dna_handler_fuzz_test.go
+++ b/features/controller/transport/dna_handler_fuzz_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package transport
+
+import (
+	"encoding/json"
+	"testing"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	dptypes "github.com/cfgis/cfgms/pkg/dataplane/types"
+)
+
+// FuzzReassembleDNA fuzzes the two json.Unmarshal calls in reassembleDNA
+// (dna_handler.go:170, :174) at the compromised-steward-to-controller wire
+// boundary. The function takes a typed chunk slice rather than raw bytes, so
+// the fuzz input is wrapped in a single-chunk slice matching the real 1-chunk
+// reassembly path. Multi-chunk ordering invariants are covered by existing
+// conventional tests in dna_handler_test.go.
+func FuzzReassembleDNA(f *testing.F) {
+	// Seed with real DNATransfer JSON fixtures matching the steward send path.
+	seeds := []map[string]string{
+		{"hostname": "cfg-70-02", "os": "windows", "cpu_count": "8"},
+		{"hostname": "cfg-ab-02", "os": "linux", "arch": "amd64"},
+		{"os": "windows", "primary_mac": "00:15:5d:ea:a3:35", "memory_bytes": "17179869184"},
+		{},
+	}
+	for _, attrs := range seeds {
+		attrJSON, err := json.Marshal(attrs)
+		if err != nil {
+			f.Fatal(err)
+		}
+		payload, err := json.Marshal(&dptypes.DNATransfer{
+			StewardID:  "fuzz-steward",
+			TenantID:   "t1",
+			Attributes: attrJSON,
+		})
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(payload)
+	}
+
+	// Empty payload seed — exercises the len(payload)==0 short-circuit.
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		chunks := []*transportpb.DNAChunk{
+			{
+				Data:        data,
+				ChunkIndex:  0,
+				TotalChunks: 1,
+			},
+		}
+		// Any panic inside reassembleDNA is a bug. Errors are expected and safe.
+		_, _ = reassembleDNA(chunks, "fuzz-steward")
+	})
+}

--- a/pkg/cert/utils_fuzz_test.go
+++ b/pkg/cert/utils_fuzz_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"testing"
+)
+
+// newFuzzCA creates a fresh, initialized CA for fuzz seed generation.
+func newFuzzCA(f *testing.F) *CA {
+	f.Helper()
+	ca, err := NewCA(&CAConfig{
+		Organization: "CFGMS Fuzz Test",
+		Country:      "US",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	if err != nil {
+		f.Fatalf("NewCA: %v", err)
+	}
+	if err := ca.Initialize(nil); err != nil {
+		f.Fatalf("CA.Initialize: %v", err)
+	}
+	return ca
+}
+
+// FuzzParseCertificateFromPEM fuzzes ParseCertificateFromPEM (utils.go:15),
+// which decodes a single PEM block and passes its DER bytes to x509.ParseCertificate.
+func FuzzParseCertificateFromPEM(f *testing.F) {
+	ca := newFuzzCA(f)
+
+	// Seed: real CA certificate PEM.
+	caPEM, err := ca.GetCACertificate()
+	if err != nil {
+		f.Fatalf("GetCACertificate: %v", err)
+	}
+	f.Add(caPEM)
+
+	// Seed: real client certificate PEM.
+	clientCert, err := ca.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "fuzz-client",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	if err != nil {
+		f.Fatalf("GenerateClientCertificate: %v", err)
+	}
+	f.Add(clientCert.CertificatePEM)
+
+	// Seed: real server certificate PEM.
+	serverCert, err := ca.GenerateServerCertificate(&ServerCertConfig{
+		CommonName:   "localhost",
+		DNSNames:     []string{"localhost"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	if err != nil {
+		f.Fatalf("GenerateServerCertificate: %v", err)
+	}
+	f.Add(serverCert.CertificatePEM)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Errors are expected for malformed input; panics are bugs.
+		_, _ = ParseCertificateFromPEM(data)
+	})
+}
+
+// FuzzParseCertificateChainFromPEM fuzzes ParseCertificateChainFromPEM (utils.go:34),
+// which loops pem.Decode to parse multi-block PEM data — a good multi-block
+// malformed-input target.
+func FuzzParseCertificateChainFromPEM(f *testing.F) {
+	ca := newFuzzCA(f)
+
+	// Seed: single-cert chain (CA cert).
+	caPEM, err := ca.GetCACertificate()
+	if err != nil {
+		f.Fatalf("GetCACertificate: %v", err)
+	}
+	f.Add(caPEM)
+
+	// Seed: multi-cert chain (client cert + CA cert concatenated).
+	clientCert, err := ca.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "fuzz-client",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	if err != nil {
+		f.Fatalf("GenerateClientCertificate: %v", err)
+	}
+	chain := append(clientCert.CertificatePEM, caPEM...)
+	f.Add(chain)
+
+	// Seed: server cert + CA cert chain.
+	serverCert, err := ca.GenerateServerCertificate(&ServerCertConfig{
+		CommonName:   "localhost",
+		DNSNames:     []string{"localhost"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	if err != nil {
+		f.Fatalf("GenerateServerCertificate: %v", err)
+	}
+	serverChain := append(serverCert.CertificatePEM, caPEM...)
+	f.Add(serverChain)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ParseCertificateChainFromPEM(data)
+	})
+}
+
+// FuzzParsePrivateKeyFromPEM fuzzes ParsePrivateKeyFromPEM (utils.go:66),
+// which dispatches on PEM block type to x509.ParsePKCS1PrivateKey /
+// ParsePKCS8PrivateKey / ParseECPrivateKey.
+func FuzzParsePrivateKeyFromPEM(f *testing.F) {
+	ca := newFuzzCA(f)
+
+	// Seed: RSA private key (PKCS#1 — GenerateClientCertificate produces RSA).
+	clientCert, err := ca.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "fuzz-key-client",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	if err != nil {
+		f.Fatalf("GenerateClientCertificate: %v", err)
+	}
+	f.Add(clientCert.PrivateKeyPEM)
+
+	// Seed: server private key.
+	serverCert, err := ca.GenerateServerCertificate(&ServerCertConfig{
+		CommonName:   "localhost",
+		DNSNames:     []string{"localhost"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	if err != nil {
+		f.Fatalf("GenerateServerCertificate: %v", err)
+	}
+	f.Add(serverCert.PrivateKeyPEM)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ParsePrivateKeyFromPEM(data)
+	})
+}

--- a/pkg/config/manager_fuzz_test.go
+++ b/pkg/config/manager_fuzz_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+)
+
+// FuzzUnmarshalStewardConfig fuzzes the YAML-unmarshal-then-validate path that
+// GetConfiguration and GetConfigurationWithInheritance both call when they read
+// a stored config entry (manager.go:97, :121). It exercises the full end-to-end
+// parse boundary a malformed `cfg push` payload would hit.
+func FuzzUnmarshalStewardConfig(f *testing.F) {
+	// Seed with valid StewardConfig YAML fixtures matching what manager_test.go uses.
+	seeds := []string{
+		// Minimal valid config
+		`steward:
+  id: fuzz-steward
+  mode: standalone
+  logging:
+    level: info
+    format: text
+`,
+		// Config with resources
+		`steward:
+  id: fuzz-steward-2
+  mode: standalone
+  logging:
+    level: debug
+resources:
+  - name: test-resource
+    module: directory
+    config:
+      path: /opt/test
+`,
+		// Controller mode config
+		`steward:
+  id: fuzz-steward-3
+  mode: controller
+  logging:
+    level: warn
+    format: json
+`,
+		// Config with modules map
+		`steward:
+  id: fuzz-steward-4
+  mode: standalone
+  logging:
+    level: error
+modules:
+  file: file
+  service: service
+resources:
+  - name: r1
+    module: file
+    config:
+      path: /tmp/x
+`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var config stewardconfig.StewardConfig
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			// Unmarshal errors are expected for arbitrary input; not a bug.
+			return
+		}
+		// Run the real validation path — panics here are bugs.
+		_ = stewardconfig.ValidateConfiguration(config)
+	})
+}

--- a/pkg/entitygraph/types/eid_fuzz_test.go
+++ b/pkg/entitygraph/types/eid_fuzz_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package types_test
+
+import (
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// FuzzParseEID fuzzes the hand-rolled ParseEID parser (eid.go:61), which splits
+// on the first '/' and then on the first ':'. Covers all five registered
+// authority types. Any panic is a bug; errors are expected for adversarial input.
+func FuzzParseEID(f *testing.F) {
+	// Seed corpus: valid EIDs covering all five registered authority types.
+	seeds := []string{
+		// host
+		"host:web-01",
+		"host:web-01/fragment-abc",
+		"host:a1b2/file:/etc/hosts",
+		"host:a1b2c3/service:sshd",
+		// cluster
+		"cluster:hv-east-guid",
+		"cluster:k8s-prod/node:worker-3",
+		// directory
+		"directory:ldap-corp",
+		"directory:ldap-corp/user:jdoe",
+		// m365
+		"m365:tenant-contoso",
+		"m365:tenant-acme/device:laptop-01",
+		// cfgms
+		"cfgms:root",
+		"cfgms:root/policy:baseline",
+		// edge cases with long local IDs
+		"host:srv-01/file:/var/log/syslog",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		eid, err := types.ParseEID(s)
+		if err != nil {
+			return
+		}
+		// Round-trip invariant: a successfully parsed EID must produce a string
+		// that parses back to an equal EID.
+		reparsed, err := types.ParseEID(eid.String())
+		if err != nil {
+			t.Fatalf("round-trip parse failed for %q (string=%q): %v", s, eid.String(), err)
+		}
+		if eid.String() != reparsed.String() {
+			t.Fatalf("round-trip mismatch: original=%q reparsed=%q", eid.String(), reparsed.String())
+		}
+	})
+}

--- a/scripts/fuzz-all.sh
+++ b/scripts/fuzz-all.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# fuzz-all.sh — auto-discovers and runs all Go native fuzz targets in the listed
+# packages, then uploads any crash corpora as workflow artifacts.
+#
+# Usage:
+#   ./scripts/fuzz-all.sh [fuzztime]
+#
+# fuzztime defaults to 30s. Any new Fuzz* target added to a listed package is
+# picked up automatically — no edits to this script or the CI workflow are needed.
+
+set -euo pipefail
+
+FUZZTIME="${1:-30s}"
+
+PACKAGES=(
+  "pkg/config"
+  "features/controller/transport"
+  "pkg/entitygraph/types"
+  "pkg/cert"
+)
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+overall_exit=0
+
+for pkg in "${PACKAGES[@]}"; do
+  echo "=== Discovering fuzz targets in ./${pkg} ==="
+  targets=$(go test -list '^Fuzz' "./${pkg}" 2>/dev/null || true)
+  if [ -z "$targets" ]; then
+    echo "  No fuzz targets found in ./${pkg}, skipping."
+    continue
+  fi
+
+  while IFS= read -r target; do
+    [ -z "$target" ] && continue
+    echo "--- Running ${target} in ./${pkg} for ${FUZZTIME} ---"
+    if ! go test -run='^$' -fuzz="^${target}$" -fuzztime="${FUZZTIME}" "./${pkg}"; then
+      echo "FAIL: ${target} in ./${pkg}"
+      overall_exit=1
+    fi
+
+    # Collect any crash corpus entries produced during this run.
+    corpus_dir="${pkg}/testdata/fuzz/${target}"
+    if [ -d "${corpus_dir}" ] && [ "$(ls -A "${corpus_dir}")" ]; then
+      echo "  Crash corpus found in ${corpus_dir} — will be uploaded as artifact."
+    fi
+  done <<< "$targets"
+done
+
+exit $overall_exit


### PR DESCRIPTION
## Summary

- Adds six Go native fuzz targets across four parse boundaries that a compromised steward or malformed `cfg push` payload would hit in production, closing gap 5 from the #2930 security-testing audit
- Adds `scripts/fuzz-all.sh` for auto-discovery of `Fuzz*` targets and `.github/workflows/fuzz-nightly.yml` for nightly CI (not a PR gate)
- Adds "6. Go Native Fuzzing" subsection to `docs/development/security-workflow-guide.md`

## Fuzz targets

| Target | Package | Surface |
|--------|---------|---------|
| `FuzzUnmarshalStewardConfig` | `pkg/config` | `yaml.Unmarshal` + `ValidateConfiguration` on steward config payloads |
| `FuzzReassembleDNA` | `features/controller/transport` | Both `json.Unmarshal` calls in `reassembleDNA` at the compromised-steward wire boundary |
| `FuzzParseEID` | `pkg/entitygraph/types` | Hand-rolled `ParseEID` parser on steward/directory-supplied identifier strings |
| `FuzzParseCertificateFromPEM` | `pkg/cert` | `pem.Decode` + `x509.ParseCertificate` |
| `FuzzParseCertificateChainFromPEM` | `pkg/cert` | Multi-block `pem.Decode` loop |
| `FuzzParsePrivateKeyFromPEM` | `pkg/cert` | PEM block type dispatch to PKCS1/PKCS8/EC key parsers |

## Review results

Adversarial team review (code reviewer + QA test runner + security engineer) — **PASS, 1 round, 0 fix rounds, 0 remaining findings**.

## Test plan

- [ ] `go test -run='^$' -fuzz='^FuzzUnmarshalStewardConfig$' -fuzztime=30s ./pkg/config/`
- [ ] `go test -run='^$' -fuzz='^FuzzReassembleDNA$' -fuzztime=30s ./features/controller/transport/`
- [ ] `go test -run='^$' -fuzz='^FuzzParseEID$' -fuzztime=30s ./pkg/entitygraph/types/`
- [ ] `go test -run='^$' -fuzz='^FuzzParseCertificateFromPEM$' -fuzztime=30s ./pkg/cert/`
- [ ] `go test -run='^$' -fuzz='^FuzzParseCertificateChainFromPEM$' -fuzztime=30s ./pkg/cert/`
- [ ] `go test -run='^$' -fuzz='^FuzzParsePrivateKeyFromPEM$' -fuzztime=30s ./pkg/cert/`
- [ ] `./scripts/fuzz-all.sh 30s`
- [ ] All regular tests pass: `go test ./pkg/config/... ./features/controller/transport/... ./pkg/entitygraph/types/... ./pkg/cert/...`

Fixes #2952

🤖 Generated with [Claude Code](https://claude.com/claude-code)