### PR TITLE
maintenance: reboot_window schema, parser, and evaluator (Issue #2975)

### DIFF
--- a/docs/architecture/decisions/026-reboot-windows.md
+++ b/docs/architecture/decisions/026-reboot-windows.md
@@ -1,16 +1,18 @@
-# ADR-026: Reboot windows — device-scoped reboot gating with tenant inheritance and structured schedules
+# ADR-026: Reboot Windows — device-scoped reboot gating with tenant inheritance and structured schedules
 
-**Status:** Accepted
+**Status:** Accepted (2026-07-22)
 
-**Date:** 2026-07-22
+**Deciders:** Founder + Architecture session (2026-07-22)
 
-**Deciders:** Founder, Architecture
-
-**Related:** [016](016-steward-module-foundation.md) (module foundation — every module that can reboot a host consults this gate). [006](006-module-packaging-and-distribution.md) (module packaging — the gate is a steward-side capability, not a per-module reimplementation). [022](022-entity-graph-model-and-access-contract.md) / [023](023-entity-graph-storage-shape.md) (entity graph — a guest VM is a first-class device/asset, which this ADR depends on for VM-scoped windows). Epic #2898 (implements this ADR). The `patch` stdlib module (`features/modules/stdlib/patch`) whose fail-open window gate this ADR replaces.
+**Related:** [ADR-016](016-steward-module-foundation.md) (module foundation — every module that can reboot a host consults this gate). [ADR-006](006-module-packaging-and-distribution.md) (module packaging — the gate is a steward-side capability, not a per-module reimplementation). [ADR-022](022-entity-graph-model-and-access-contract.md) / [ADR-023](023-entity-graph-storage-shape.md) (entity graph — a guest VM is a first-class device/asset, which this ADR depends on for VM-scoped windows). Epic #2898 (implements this ADR). The `patch` stdlib module (`features/modules/stdlib/patch`) whose fail-open window gate this ADR replaces.
 
 ---
 
 ## Context
+
+CFGMS has no mechanism to gate reboots to declared time windows. The `patch` module accepted a `maintenance.window` field that silently did nothing until #2892 closed the noop by rejecting the field at validation. Every module that causes a reboot — `patch`, `hyperv.vm` power-cycles, driver installs — fires at any hour. MSPs cannot promise a client that servers only reboot inside an agreed window.
+
+The design was settled in a founder + architecture session on 2026-07-22. This ADR records those decisions as the authoritative reference. Epic #2898 is the implementation plan; Stories #2975–#2979 and future stories in that epic all cite this document.
 
 ### The gate exists in name only, and it fails open
 
@@ -67,82 +69,64 @@ or controller compromise. A reboot is one of the highest-disruption declarative 
 fleet. The window is exactly such a bound — but only if it fails **closed** and cannot be
 bypassed by a compromised admin through a convenient "emergency override" path.
 
-## Decision
+---
 
-### 1. Name it `reboot_window`; it gates OS reboots only
+## Decisions
 
-The setting is `reboot_window`, not "maintenance window." It gates **OS reboots** — nothing
-else. Drift apply and config push are not gated by it.
+### Decision 1 — Name and scope: `reboot_window`, OS reboots only
 
-The **mechanism is general**: every module that can trigger a host reboot consults the gate
-before doing so. The **v1 policy is narrow**: only reboots are gated. Widening later (e.g. a
-"config-change window") is a *second window type alongside* `reboot_window`, never a
-redefinition of it. This keeps each window's semantics stable and auditable.
+The policy is named `reboot_window`. It gates **OS reboots only** — not drift apply, not
+config-push fanout. The module-consult mechanism is general (every module checks the window
+before rebooting); the v1 policy is reboots. Any future widening (maintenance windows for
+non-reboot disruption) is a *separate window type alongside* `reboot_window`, never a
+redefinition of a deployed field. This keeps each window's semantics stable and auditable.
 
-### 2. Device-scoped — and a guest VM is a device
+### Decision 2 — Device-scoped; a guest VM is a device
 
-Windows attach to **devices**. A host and each of its guest VMs have **their own**
-`reboot_window`.
+One window per device, governing all activity on it. The Hyper-V host has its own window; each
+guest VM has its own. `hyperv.vm` operations that power-cycle a guest consult **the guest's**
+window. A stewardless VM's window is evaluated by the Hyper-V host's steward on the guest's
+behalf. This is why the guest must be a first-class device/asset in the entity graph
+(ADR-022/023). A forced guest power-cycle (e.g., `Set-VM -MemoryStartupBytes`, which requires
+the guest off) counts as a reboot and is gated.
 
-- A `hyperv.vm` power-cycle operation consults the **guest's** window, not the host's.
-- A **stewardless** guest (no agent inside it) still has a window; the **Hyper-V host's
-  steward evaluates it on the guest's behalf** before performing the power-cycle. This is why
-  the guest must be a first-class device/asset in the entity graph (ADR-022/023).
-- A **forced** power-cycle counts as a reboot. Example: `Set-VM -MemoryStartupBytes` requires
-  the guest to be off; taking it down to satisfy that request is a reboot and is gated.
+### Decision 3 — Inheritance: cascade with free override, controlled by permission + audit
 
-### 3. Cascade with free override in both directions, gated by permission + audit
-
-A window set at a tenant cascades to descendants, and a descendant (or the device) may
-**override it in either direction** — looser *or* tighter. Override is controlled by
-**permission and audit**, not by "narrower-only" lattice semantics.
+Windows cascade down the tenant tree (root MSP default → children inherit). A child may
+override **in either direction** — looser *or* tighter patch cadence. The control is a distinct
+edit permission plus an audit event keyed to the cfg resource id — not a narrow-only lattice.
 
 The founder's decisive counter-example: a client that needs *tighter* patching — say Monday
 **and** Thursday weekly — expresses it through **more frequent** windows. A "narrower-only"
-rule rejects that as "wider." "Narrower" is ill-defined here because window **duration** and
-patch **cadence** move in opposite directions: more windows can mean more reboots but each
-smaller. The lattice can't encode the operator's intent; a permissioned, audited override can.
+rule rejects that as "wider." "Narrower" is ill-defined because window **duration** and patch
+**cadence** move in opposite directions: more windows can mean more reboots but each smaller.
+The lattice can't encode the operator's intent; a permissioned, audited override can.
 
-### 4. Resolution is `explicit → tenant default → device`; "local" is retired
+### Decision 4 — Timezone: `device` vs tenant default
 
-"local" is replaced by two explicit concepts:
+The word "local" is retired. Resolution order: explicit timezone on the window → tenant default
+(inherited) → `device` (endpoint's own zone). This same model repairs the workflow-trigger
+scheduler (tenant default → UTC, not controller-host local; tenant default is *data*, so HA
+nodes agree by construction). The `timezone` field in the schema is the window-level explicit
+value only; empty means "not set at this level."
 
-- **device** — the endpoint's own zone/policy.
-- **tenant default** — an MSP-account-level policy, inherited root-to-leaf.
+### Decision 5 — Notation: structured YAML, not cron
 
-A value resolves in order: an **explicit** window on the object, else the **tenant default**,
-else the **device**. The same fix applies to the workflow trigger scheduler: its timezone
-default is the **tenant default → UTC**, never the controller host's local clock (tenant
-default is *data*, so HA nodes agree by construction).
+Cron cannot express "nth weekday of month" (vendor patch cadences) and names an instant, not
+an interval. The schema uses `start`/`end` (makes DST handling a non-question) and
+`after: {weekday, nth}` / `before: {weekday, nth}` anchors so the top-level `weekday:` always
+names the day the window opens. No new Go module dependency. Semantics are anchored to RFC 5545
+(RRULE) for the plain cases; the anchored `after:`/`before:` case is a deliberate,
+more-legible divergence. A **midnight-wrap** predicate is required (a window may open before
+and close after midnight).
 
-### 5. Structured YAML, not cron
-
-The schedule is structured YAML:
-
-- **`start` / `end`**, not a duration. A duration makes DST an edge case; wall-clock
-  `start`/`end` make DST a non-question.
-- **`after: {weekday, nth}`** and **`before:`** anchors express "nth weekday of month."
-  `weekday:` always names the day the window **opens**.
-- A **midnight-wrap** predicate is required (a window may open before and close after
-  midnight).
-
-Illustrative shape (not a frozen schema — the implementing epic finalizes field names):
-
-```yaml
-reboot_window:
-  timezone: tenant-default        # explicit IANA zone overrides; else tenant default; else UTC
-  windows:
-    - after:  { weekday: tue, nth: 2 }   # opens 2nd Tuesday of the month
-      start:  "01:00"
-      end:    "05:00"                     # may wrap past midnight
-```
-
-### 6. No emergency override — by design
+### Decision 6 — No emergency override, by design
 
 There is **no "reboot now, ignore the window" escape hatch** on the declarative path.
-Declarative policies **obey** the window. Anything that legitimately needs to reboot outside a
-window uses an **imperative path** — a script, a workflow, the `cfg` CLI, or a remote shell —
-each of which already carries its own operator judgment, authentication, and audit trail.
+Declarative policies (modules, convergence) **obey** the window. Imperative paths (scripts,
+workflows, `cfg` CLI, remote shell) carry their own operator judgment and are ungated —
+eliminating any admin-compromise bypass surface. The resolved window is exposed as a readable
+value in script/workflow context.
 
 This is a **security decision**, not an ergonomics oversight: an "emergency override" on the
 declarative path is precisely the bypass a compromised or phished admin would reach for. Not
@@ -151,39 +135,146 @@ blast radius.
 
 ### Sequencing
 
-Not urgent — there is no production fleet yet, so the fail-open gate is not currently
-exposing anyone. It sequences **behind** the Entity Graph program (ADR-022/023, epics
+Not urgent — there is no production fleet yet, so the fail-open gate is not currently exposing
+anyone. It sequences **behind** the Entity Graph program (ADR-022/023, epics
 #2851/#2852/#2853/#2854), which supplies "VMs as first-class assets" that Decision 2 depends
 on. The gate must, however, be **replaced with a fail-closed implementation** as part of that
 work — the current fail-open behavior must not survive into production.
 
+---
+
+## Schema (authoritative)
+
+```yaml
+reboot_window:
+  timezone: device             # omit to inherit tenant default; or an IANA zone e.g. "America/Chicago"
+  schedules:
+    - freq: monthly
+      weekday: thursday        # the day the window OPENS
+      after: { weekday: tuesday, nth: 2 }   # anchor; nth: -1 = last; before: also valid
+      start: "02:00"
+      end: "04:00"
+    - freq: monthly
+      weekday: thursday
+      nth: 2                   # plain case: the 2nd Thursday
+      start: "02:00"
+      end: "06:00"
+    - freq: weekly
+      days: [saturday, sunday]
+      start: "01:00"
+      end: "06:00"
+```
+
+Field notes:
+- `timezone`: empty = not set (inherit); `"device"` = use device's own zone; any IANA tz string = use that zone.
+- `freq`: `"monthly"` or `"weekly"`.
+- `weekday` (monthly): the day the window **opens** — always present for `freq: monthly`.
+- `days` (weekly): list of weekday names — valid only with `freq: weekly`.
+- `nth` (monthly): the Nth occurrence of `weekday` in the month. `-1` = last occurrence.
+- `after` / `before` (monthly): anchor the window to the first occurrence of `weekday` after/before the Nth occurrence of the anchor weekday.
+- `start` / `end`: 24h clock strings (`"HH:MM"`). `end: "24:00"` means end-of-day.
+
+---
+
+## Evaluation semantics (authoritative)
+
+```
+if end > start:   inWindow = start <= now.time <= end
+else:             inWindow = now.time >= start || now.time <= end   # window wraps midnight
+```
+
+- The day selector applies to the **start** day.
+- `end: "24:00"` = end-of-day (the window never wraps midnight in this case).
+- For a midnight-wrapping window (`start > end`): if `now.time >= start`, check that today is the scheduled start day; if `now.time <= end`, check that yesterday was the scheduled start day.
+- DST: `start`/`end` are wall-clock times, not durations, so DST falls out correctly. A window whose entire span falls inside a spring-forward skipped hour never opens that day — emit a **validation-time warning** (not an error). This cannot affect a normal multi-hour window.
+
+---
+
+## Validation rules (authoritative)
+
+1. `nth` and `after`/`before` are mutually exclusive. With `freq: monthly` + `weekday:`, exactly one of `nth`, `after`, or `before` must be present.
+2. `after`, `before`, and `nth` are valid **only** with `freq: monthly`. `days:` is valid **only** with `freq: weekly`.
+3. **Same-weekday rule:** if the top-level `weekday:` equals the `after:` anchor weekday, the resolution is `anchor + 7 days` (after = strictly later). For `before:`, same weekday resolves to `anchor - 7 days`.
+4. Offsets crossing a month boundary (e.g., the Thursday `after` the last Tuesday of January falls in February) are legal and well-defined — the anchor is an occurrence, not a calendar constraint.
+5. Timezone must be empty, `"device"`, or a valid IANA timezone string; any other value is a validation error.
+6. `start` and `end` must be valid `"HH:MM"` strings (or `"24:00"` for `end` only).
+
+---
+
+## Out of Scope
+
+- **Gating anything other than reboots** — a future second window type, not this epic.
+- **Cluster-aware reboot concurrency** (min-nodes-up, max-concurrent) — tracked in roadmap as "Cluster-Aware Patching."
+- **`Remove-VMSwitch -Force`** and other non-reboot guest disruption — named known gap.
+- **workflow-trigger scheduler DST/timezone fix** — surfaced during design, tracked separately.
+
+---
+
 ## Consequences
 
-- **Positive:** a declared window becomes a real, fail-closed control. Multi-tenant inheritance
-  and per-device override match how MSPs actually run patch cadences. VM windows work even for
-  stewardless guests. No declarative bypass for a compromised admin.
-- **Cost:** requires a new central provider (a `reboot_window` / maintenance provider), a
-  structured-schedule parser with ordinal-weekday + midnight-wrap semantics, a resolver
-  implementing `explicit → tenant default → device` with cascade/override, and rewiring the
-  patch module's gate from fail-open to fail-closed. The Hyper-V module must evaluate a guest's
-  window on the host steward.
-- **Migration:** the patch module's `WindowManager` fail-open branches
-  (`module.go:399, 416`) are replaced; a `nil` manager or a check error must **deny** the
-  reboot (fail closed), not allow it. `TimeWindow`'s day-list model is superseded by the
-  structured schema.
+### Positive
 
-## Alternatives considered
+- A declared window becomes a real, fail-closed control.
+- Every module has a single, testable check before rebooting.
+- Multi-tenant inheritance and per-device override match how MSPs actually run patch cadences.
+- VM windows work even for stewardless guests.
+- No declarative bypass for a compromised admin.
+- The `nth weekday` expression maps directly to vendor patch cadences (e.g., "second Tuesday" Patch Tuesday windows).
+- No new Go module dependency; pure standard library.
+- DST-safe by construction (`start`/`end` are wall-clock, not duration-based).
 
-- **Cron expressions.** Rejected: standard 5-field cron cannot express "nth weekday of month,"
-  the dominant real-world cadence.
-- **Narrower-only override (lattice semantics).** Rejected: "narrower" is ill-defined when
-  duration and cadence move oppositely; it rejects legitimate tighter-cadence intent. Replaced
-  by permissioned, audited free override.
-- **One "maintenance window" gating reboots, drift apply, and config push together.** Rejected:
-  conflates controls with different risk profiles. A general mechanism with a narrow v1 policy,
-  extended by *additional* window types, keeps each gate's semantics stable.
-- **An emergency "reboot now" override on the declarative path.** Rejected: it is the exact
-  bypass an admin-compromise threat would use. Imperative paths already provide the escape with
-  their own judgment and audit.
-- **Duration instead of `start`/`end`.** Rejected: makes DST an edge case; wall-clock
-  `start`/`end` make it a non-question.
+### Negative
+
+- Requires a new central provider (`pkg/maintenance`), a structured-schedule parser with
+  ordinal-weekday + midnight-wrap semantics, a resolver implementing
+  `explicit → tenant default → device` with cascade/override, and rewiring the patch module's
+  gate from fail-open to fail-closed. The Hyper-V module must evaluate a guest's window on the
+  host steward.
+- Monthly anchor computation is more complex than cron.
+- Tenants that need per-device timezone resolution must wait for Story 2 (cascade + resolution).
+
+### Migration
+
+The patch module's `WindowManager` fail-open branches (`module.go:399, 416`) are replaced; a
+`nil` manager or a check error must **deny** the reboot (fail closed), not allow it.
+`TimeWindow`'s day-list model is superseded by the structured schema.
+
+### Neutral
+
+- Cron is explicitly rejected for this use case; the schema is purpose-built and not general-purpose.
+
+---
+
+## Alternatives Considered
+
+### Cron expression syntax
+
+Rejected. Cron cannot express "nth weekday of month," the primary use case (Patch Tuesday —
+second Tuesday of the month). Cron also names an instant, not an interval, complicating
+`start`/`end` semantics. No Go cron library in the dependency tree; adding one for this would
+be disproportionate.
+
+### Duration-based windows (start + duration)
+
+Rejected. Duration makes DST ambiguous (does "2 hours" include or exclude the skipped hour?).
+`start`/`end` wall-clock makes this a non-question.
+
+### `before:` / `after:` as relative day offsets
+
+Rejected. Named weekday + nth is more readable and maps directly to how MSPs express their
+patch windows ("first Thursday after Patch Tuesday").
+
+### Narrower-only override (lattice semantics)
+
+Rejected: "narrower" is ill-defined when duration and cadence move oppositely; it rejects
+legitimate tighter-cadence intent. Replaced by permissioned, audited free override.
+
+### One "maintenance window" gating reboots, drift apply, and config push together
+
+Rejected: conflates controls with different risk profiles. A general mechanism with a narrow v1
+policy, extended by *additional* window types, keeps each gate's semantics stable.
+
+### An emergency "reboot now" override on the declarative path
+
+Rejected: it is the exact bypass an admin-compromise threat would use. Imperative paths already
+provide the escape with their own judgment and audit.

--- a/pkg/maintenance/schedule/evaluate.go
+++ b/pkg/maintenance/schedule/evaluate.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import "time"
+
+// InWindow reports whether now falls inside the schedule's reboot window.
+//
+// Evaluation semantics (ADR-026 §"Evaluation semantics (authoritative)"):
+//
+//	if end > start:   inWindow = start <= now.time <= end
+//	else:             inWindow = now.time >= start || now.time <= end  (midnight-wrap)
+//
+// The day selector applies to the start day. For midnight-wrapping windows:
+// the "now.time >= start" branch checks today; the "now.time <= end" branch
+// checks whether yesterday was a scheduled start day.
+//
+// now must already be in the schedule's resolved timezone (timezone resolution
+// is handled by the pkg/maintenance cascade layer, not this package).
+func InWindow(now time.Time, s Schedule) bool {
+	nowMin := now.Hour()*60 + now.Minute()
+	startMin := s.Start.minutesSinceMidnight()
+	endMin := s.End.minutesSinceMidnight()
+
+	if endMin > startMin {
+		// Non-wrapping window (includes end: "24:00" since 1440 > any start).
+		if nowMin < startMin || nowMin > endMin {
+			return false
+		}
+		return isScheduledDay(now, s)
+	}
+
+	// Midnight-wrapping window (start > end).
+	if nowMin >= startMin {
+		return isScheduledDay(now, s)
+	}
+	if nowMin <= endMin {
+		return isScheduledDay(now.AddDate(0, 0, -1), s)
+	}
+	return false
+}
+
+// NextOccurrence returns the next window start time at or after the given time.
+//
+// now must already be in the schedule's resolved timezone.
+func NextOccurrence(after time.Time, s Schedule) time.Time {
+	// Try today's start time first (handles "at or after" semantics).
+	todayStart := time.Date(after.Year(), after.Month(), after.Day(),
+		s.Start.Hour, s.Start.Minute, 0, 0, after.Location())
+	if !todayStart.Before(after) && isScheduledDay(todayStart, s) {
+		return todayStart
+	}
+
+	// Search forward day by day (bounded to avoid infinite loops on invalid input).
+	day := after.AddDate(0, 0, 1)
+	for range 400 {
+		candidate := time.Date(day.Year(), day.Month(), day.Day(),
+			s.Start.Hour, s.Start.Minute, 0, 0, after.Location())
+		if isScheduledDay(candidate, s) {
+			return candidate
+		}
+		day = day.AddDate(0, 0, 1)
+	}
+
+	return time.Time{} // unreachable for well-formed schedules
+}
+
+// isScheduledDay reports whether the calendar date of t is a scheduled start
+// day according to s.
+func isScheduledDay(t time.Time, s Schedule) bool {
+	switch s.Freq {
+	case FreqWeekly:
+		for _, d := range s.Days {
+			if t.Weekday() == d {
+				return true
+			}
+		}
+		return false
+	case FreqMonthly:
+		return isMonthlyScheduledDay(t, s)
+	default:
+		return false
+	}
+}
+
+// isMonthlyScheduledDay reports whether t falls on the monthly schedule's
+// computed date. It checks both t's own month and the adjacent month to handle
+// cross-month boundary cases:
+//   - after: an anchor at the end of month M can push the result into M+1
+//     (e.g., Saturday after the last Thursday of January may fall in February).
+//   - before: an anchor at the start of month M can pull the result into M-1
+//     (e.g., Saturday before the first Monday of March may fall in February).
+func isMonthlyScheduledDay(t time.Time, s Schedule) bool {
+	if t.Weekday() != s.Weekday {
+		return false
+	}
+
+	y, m := t.Year(), t.Month()
+
+	// Primary check: resolve from t's own month.
+	if sameDay(resolveMonthlyDate(y, m, s), t) {
+		return true
+	}
+
+	// Cross-month: for after anchors, check whether the previous month's
+	// anchor resolution overflows into the current month.
+	if s.After != nil {
+		py, pm := shiftMonth(y, m, -1)
+		return sameDay(resolveMonthlyDate(py, pm, s), t)
+	}
+
+	// Cross-month: for before anchors, check whether the next month's
+	// anchor resolution underflows into the current month.
+	if s.Before != nil {
+		ny, nm := shiftMonth(y, m, +1)
+		return sameDay(resolveMonthlyDate(ny, nm, s), t)
+	}
+
+	return false
+}
+
+// resolveMonthlyDate returns the concrete scheduled date for a monthly schedule
+// in the given year/month, without regard to month boundaries.
+func resolveMonthlyDate(y int, m time.Month, s Schedule) time.Time {
+	switch {
+	case s.Nth != nil:
+		nth := *s.Nth
+		if nth == -1 {
+			return lastWeekdayOfMonth(y, m, s.Weekday)
+		}
+		return nthWeekdayOfMonth(y, m, s.Weekday, nth)
+	case s.After != nil:
+		return weekdayAfterAnchor(y, m, s.Weekday, s.After.Weekday, s.After.Nth)
+	case s.Before != nil:
+		return weekdayBeforeAnchor(y, m, s.Weekday, s.Before.Weekday, s.Before.Nth)
+	default:
+		return time.Time{}
+	}
+}
+
+// shiftMonth returns the year and month delta months away from (y, m).
+func shiftMonth(y int, m time.Month, delta int) (int, time.Month) {
+	t := time.Date(y, m, 1, 0, 0, 0, 0, time.UTC).AddDate(0, delta, 0)
+	return t.Year(), t.Month()
+}
+
+// sameDay reports whether a and b fall on the same calendar date.
+func sameDay(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// nthWeekdayOfMonth returns the nth occurrence of wd in year/month.
+// nth must be >= 1; use lastWeekdayOfMonth for nth == -1.
+func nthWeekdayOfMonth(year int, month time.Month, wd time.Weekday, nth int) time.Time {
+	first := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	daysToFirst := (int(wd) - int(first.Weekday()) + 7) % 7
+	return first.AddDate(0, 0, daysToFirst+(nth-1)*7)
+}
+
+// lastWeekdayOfMonth returns the last occurrence of wd in year/month.
+// The implementation is anchored to the first day of the next month (handles
+// 28/29/30/31-day months uniformly without a day-count table).
+func lastWeekdayOfMonth(year int, month time.Month, wd time.Weekday) time.Time {
+	// Last day of month = first day of next month minus one day.
+	lastDay := time.Date(year, month+1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -1)
+	daysBack := (int(lastDay.Weekday()) - int(wd) + 7) % 7
+	return lastDay.AddDate(0, 0, -daysBack)
+}
+
+// anchorDate returns the anchor occurrence for after/before rules.
+func anchorDate(year int, month time.Month, anchorWD time.Weekday, anchorNth int) time.Time {
+	if anchorNth == -1 {
+		return lastWeekdayOfMonth(year, month, anchorWD)
+	}
+	return nthWeekdayOfMonth(year, month, anchorWD, anchorNth)
+}
+
+// weekdayAfterAnchor returns the first occurrence of wd strictly after the
+// anchor date. When wd == anchorWD, the same-weekday rule applies: +7 days
+// (ADR-026 validation rule 3).
+func weekdayAfterAnchor(year int, month time.Month, wd time.Weekday, anchorWD time.Weekday, anchorNth int) time.Time {
+	anchor := anchorDate(year, month, anchorWD, anchorNth)
+	if wd == anchorWD {
+		return anchor.AddDate(0, 0, 7)
+	}
+	daysAfter := (int(wd) - int(anchor.Weekday()) + 7) % 7
+	if daysAfter == 0 {
+		daysAfter = 7
+	}
+	return anchor.AddDate(0, 0, daysAfter)
+}
+
+// weekdayBeforeAnchor returns the last occurrence of wd strictly before the
+// anchor date. When wd == anchorWD, the same-weekday rule applies: -7 days.
+func weekdayBeforeAnchor(year int, month time.Month, wd time.Weekday, anchorWD time.Weekday, anchorNth int) time.Time {
+	anchor := anchorDate(year, month, anchorWD, anchorNth)
+	if wd == anchorWD {
+		return anchor.AddDate(0, 0, -7)
+	}
+	daysBack := (int(anchor.Weekday()) - int(wd) + 7) % 7
+	if daysBack == 0 {
+		daysBack = 7
+	}
+	return anchor.AddDate(0, 0, -daysBack)
+}

--- a/pkg/maintenance/schedule/evaluate_test.go
+++ b/pkg/maintenance/schedule/evaluate_test.go
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loc is a helper for loading time zones in tests.
+func loc(t *testing.T, name string) *time.Location {
+	t.Helper()
+	l, err := time.LoadLocation(name)
+	require.NoError(t, err)
+	return l
+}
+
+// newTOD builds a TimeOfDay for a HH:MM string.
+func newTOD(h, m int) TimeOfDay { return TimeOfDay{Hour: h, Minute: m} }
+
+// weeklySchedule is a helper for weekly-only InWindow tests.
+func weeklySchedule(days []time.Weekday, start, end TimeOfDay) Schedule {
+	return Schedule{
+		Freq:  FreqWeekly,
+		Days:  days,
+		Start: start,
+		End:   end,
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InWindow
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInWindow_NonWrapping_Inside(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	now := time.Date(2025, 3, 3, 3, 0, 0, 0, time.UTC) // Monday, 03:00
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_NonWrapping_BeforeStart(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	now := time.Date(2025, 3, 3, 1, 59, 0, 0, time.UTC) // Monday, 01:59
+	assert.False(t, InWindow(now, s))
+}
+
+func TestInWindow_NonWrapping_AfterEnd(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	now := time.Date(2025, 3, 3, 4, 1, 0, 0, time.UTC) // Monday, 04:01
+	assert.False(t, InWindow(now, s))
+}
+
+func TestInWindow_NonWrapping_BoundaryStart(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	now := time.Date(2025, 3, 3, 2, 0, 0, 0, time.UTC) // Monday, exactly 02:00
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_NonWrapping_BoundaryEnd(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	now := time.Date(2025, 3, 3, 4, 0, 0, 0, time.UTC) // Monday, exactly 04:00
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_NonWrapping_WrongDay(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	now := time.Date(2025, 3, 4, 3, 0, 0, 0, time.UTC) // Tuesday, 03:00 — not Monday
+	assert.False(t, InWindow(now, s))
+}
+
+// Midnight-wrapping window: start > end (e.g., 23:00–02:00).
+func TestInWindow_MidnightWrap_OpenSide(t *testing.T) {
+	// Saturday 23:30 — scheduled day is Saturday, within [23:00, ∞)
+	s := weeklySchedule([]time.Weekday{time.Saturday}, newTOD(23, 0), newTOD(2, 0))
+	now := time.Date(2025, 3, 8, 23, 30, 0, 0, time.UTC) // Saturday 23:30
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_MidnightWrap_CloseSide(t *testing.T) {
+	// Sunday 01:00 — yesterday (Saturday) was the scheduled day, within [0, 02:00]
+	s := weeklySchedule([]time.Weekday{time.Saturday}, newTOD(23, 0), newTOD(2, 0))
+	now := time.Date(2025, 3, 9, 1, 0, 0, 0, time.UTC) // Sunday 01:00
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_MidnightWrap_Gap(t *testing.T) {
+	// Sunday 03:00 — after end, before next start
+	s := weeklySchedule([]time.Weekday{time.Saturday}, newTOD(23, 0), newTOD(2, 0))
+	now := time.Date(2025, 3, 9, 3, 0, 0, 0, time.UTC) // Sunday 03:00
+	assert.False(t, InWindow(now, s))
+}
+
+func TestInWindow_MidnightWrap_BoundaryStart(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Saturday}, newTOD(23, 0), newTOD(2, 0))
+	now := time.Date(2025, 3, 8, 23, 0, 0, 0, time.UTC) // Saturday exactly 23:00
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_MidnightWrap_BoundaryEnd(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Saturday}, newTOD(23, 0), newTOD(2, 0))
+	now := time.Date(2025, 3, 9, 2, 0, 0, 0, time.UTC) // Sunday exactly 02:00
+	assert.True(t, InWindow(now, s))
+}
+
+// end: "24:00" — end-of-day sentinel (non-wrapping).
+func TestInWindow_EndOfDay_Inside(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Wednesday}, newTOD(2, 0), TimeOfDay{EndOfDay: true})
+	now := time.Date(2025, 3, 5, 22, 0, 0, 0, time.UTC) // Wednesday 22:00
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_EndOfDay_BeforeStart(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Wednesday}, newTOD(2, 0), TimeOfDay{EndOfDay: true})
+	now := time.Date(2025, 3, 5, 1, 59, 0, 0, time.UTC) // Wednesday 01:59
+	assert.False(t, InWindow(now, s))
+}
+
+func TestInWindow_EndOfDay_WrongDay(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Wednesday}, newTOD(2, 0), TimeOfDay{EndOfDay: true})
+	now := time.Date(2025, 3, 6, 22, 0, 0, 0, time.UTC) // Thursday 22:00
+	assert.False(t, InWindow(now, s))
+}
+
+// Monthly nth schedule — InWindow on the correct nth weekday.
+func TestInWindow_Monthly_Nth_CorrectDay(t *testing.T) {
+	nth := 2
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Thursday,
+		Nth:     &nth,
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// 2nd Thursday of March 2025 is March 13.
+	now := time.Date(2025, 3, 13, 3, 0, 0, 0, time.UTC)
+	assert.True(t, InWindow(now, s))
+}
+
+func TestInWindow_Monthly_Nth_WrongWeek(t *testing.T) {
+	nth := 2
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Thursday,
+		Nth:     &nth,
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// 1st Thursday of March 2025 is March 6 — not the 2nd.
+	now := time.Date(2025, 3, 6, 3, 0, 0, 0, time.UTC)
+	assert.False(t, InWindow(now, s))
+}
+
+// Monthly after-anchor — InWindow on the correct after-anchor day.
+func TestInWindow_Monthly_After_CorrectDay(t *testing.T) {
+	// 2nd Thursday after the 2nd Tuesday of March 2025.
+	// 2nd Tuesday of March 2025 = March 11.
+	// First Thursday after March 11 = March 13.
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Thursday,
+		After:   &Anchor{Weekday: time.Tuesday, Nth: 2},
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	now := time.Date(2025, 3, 13, 3, 0, 0, 0, time.UTC)
+	assert.True(t, InWindow(now, s))
+}
+
+// Same-weekday rule: weekday: tuesday + after: {weekday: tuesday, nth: 2} → +7 days.
+func TestInWindow_Monthly_After_SameWeekday_PlusSeven(t *testing.T) {
+	// 2nd Tuesday of March 2025 = March 11.
+	// Same weekday rule: result = March 11 + 7 = March 18.
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Tuesday,
+		After:   &Anchor{Weekday: time.Tuesday, Nth: 2},
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// March 18 is a Tuesday (+7 from March 11)
+	assert.True(t, InWindow(time.Date(2025, 3, 18, 3, 0, 0, 0, time.UTC), s))
+	// March 11 itself must NOT match (it is the anchor, not +7)
+	assert.False(t, InWindow(time.Date(2025, 3, 11, 3, 0, 0, 0, time.UTC), s))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NextOccurrence
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestNextOccurrence_Weekly_Today(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	// Monday 01:00 — today's start (02:00) is after now, so return today's start.
+	after := time.Date(2025, 3, 3, 1, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 3, 3, 2, 0, 0, 0, time.UTC), next)
+}
+
+func TestNextOccurrence_Weekly_NextWeek(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	// Monday 03:00 — already past today's start, so next Monday.
+	after := time.Date(2025, 3, 3, 3, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 3, 10, 2, 0, 0, 0, time.UTC), next)
+}
+
+func TestNextOccurrence_Weekly_MultipleDays(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Saturday, time.Sunday}, newTOD(1, 0), newTOD(6, 0))
+	// Thursday — next occurrence is Saturday.
+	after := time.Date(2025, 3, 6, 12, 0, 0, 0, time.UTC) // Thursday
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 3, 8, 1, 0, 0, 0, time.UTC), next) // Saturday
+}
+
+// NextOccurrence with nth: -1 (last weekday of month) — 28-day month (Feb non-leap).
+func TestNextOccurrence_Monthly_LastWeekday_Feb28(t *testing.T) {
+	nth := -1
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Friday,
+		Nth:     &nth,
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// February 2025 has 28 days. Last Friday of Feb 2025:
+	// Feb 1 is Saturday; days: 1=Sat,2=Sun,...,7=Fri → Feb 7 is Fri.
+	// Fridays: Feb 7, 14, 21, 28. Last = Feb 28.
+	after := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 2, 28, 2, 0, 0, 0, time.UTC), next)
+}
+
+// NextOccurrence with nth: -1 — 30-day month (April).
+func TestNextOccurrence_Monthly_LastWeekday_30Day(t *testing.T) {
+	nth := -1
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Wednesday,
+		Nth:     &nth,
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// April 2025 has 30 days. Wednesdays: Apr 2, 9, 16, 23, 30. Last = Apr 30.
+	after := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 4, 30, 2, 0, 0, 0, time.UTC), next)
+}
+
+// NextOccurrence with nth: -1 — 31-day month (January).
+func TestNextOccurrence_Monthly_LastWeekday_31Day(t *testing.T) {
+	nth := -1
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Thursday,
+		Nth:     &nth,
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// January 2025 has 31 days. Thursdays: Jan 2, 9, 16, 23, 30. Last = Jan 30.
+	after := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 1, 30, 2, 0, 0, 0, time.UTC), next)
+}
+
+// NextOccurrence nth: -1 — does not use a day-count table (handles 28/29/30/31 uniformly).
+func TestNextOccurrence_Monthly_LastWeekday_Feb29_LeapYear(t *testing.T) {
+	nth := -1
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Saturday,
+		Nth:     &nth,
+		Start:   newTOD(3, 0),
+		End:     newTOD(5, 0),
+	}
+	// February 2020 (leap, 29 days). Saturdays: Feb 1, 8, 15, 22, 29. Last = Feb 29.
+	after := time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2020, 2, 29, 3, 0, 0, 0, time.UTC), next)
+}
+
+// NextOccurrence after-anchor: cross-month boundary is legal.
+func TestNextOccurrence_Monthly_After_CrossMonthBoundary(t *testing.T) {
+	// Last Tuesday of January 2025 is Jan 28. Thursday after = Jan 30.
+	// But in a month where last Tuesday is on the 30th (e.g., Jan has 31 days,
+	// last Tuesday = Jan 28, Thursday = Jan 30 — still in Jan).
+	// Test case: last Tuesday of October 2025. Oct has 31 days.
+	// Tuesdays in Oct 2025: 7, 14, 21, 28. Last = Oct 28.
+	// Thursday after Oct 28 = Oct 30 (in Oct, still).
+	// Now pick a month where the overflow goes into next month:
+	// Last Tuesday of November 2025. Nov has 30 days.
+	// Tuesdays in Nov 2025: 4, 11, 18, 25. Last = Nov 25.
+	// Thursday after Nov 25 = Nov 27.
+	// Pick a month where it overflows: last Tuesday of March 2025.
+	// Tuesdays in March 2025: 4, 11, 18, 25. Last = March 25.
+	// Thursday after March 25 = March 27 (same month).
+	// To get overflow: last Tuesday of January 2025 = Jan 28.
+	// Thursday after Jan 28 = Jan 30 (still in Jan).
+	// Try: last Sunday of January 2025 = Jan 26. Tuesday after Jan 26 = Jan 28.
+	// No overflow there either. Let's try Saturday after last Thursday of January:
+	// Thursdays Jan 2025: Jan 2, 9, 16, 23, 30. Last = Jan 30.
+	// Saturday after Jan 30 = Feb 1 (crosses to February).
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Saturday,
+		After:   &Anchor{Weekday: time.Thursday, Nth: -1},
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// Searching from Jan 1, 2025: last Thursday of Jan = Jan 30, Saturday after = Feb 1.
+	after := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 2, 1, 2, 0, 0, 0, time.UTC), next)
+}
+
+// NextOccurrence monthly with before anchor.
+func TestNextOccurrence_Monthly_Before(t *testing.T) {
+	// Thursday before the 2nd Tuesday of March 2025.
+	// 2nd Tuesday of March 2025 = March 11. Thursday before = March 6.
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Thursday,
+		Before:  &Anchor{Weekday: time.Tuesday, Nth: 2},
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	after := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 3, 6, 2, 0, 0, 0, time.UTC), next)
+}
+
+// Same-weekday rule for before: weekday == before anchor weekday resolves to -7 days.
+func TestInWindow_Monthly_Before_SameWeekday_MinusSeven(t *testing.T) {
+	// 2nd Tuesday of March 2025 = March 11. Same weekday rule: result = March 11 - 7 = March 4.
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Tuesday,
+		Before:  &Anchor{Weekday: time.Tuesday, Nth: 2},
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// March 4 is a Tuesday (-7 from March 11).
+	assert.True(t, InWindow(time.Date(2025, 3, 4, 3, 0, 0, 0, time.UTC), s))
+	// March 11 itself must NOT match (it is the anchor, not -7).
+	assert.False(t, InWindow(time.Date(2025, 3, 11, 3, 0, 0, 0, time.UTC), s))
+}
+
+// NextOccurrence monthly — after is exactly the window start time, should include it.
+func TestNextOccurrence_AtOrAfterSemantics(t *testing.T) {
+	nth := 1
+	s := Schedule{
+		Freq:    FreqMonthly,
+		Weekday: time.Thursday,
+		Nth:     &nth,
+		Start:   newTOD(2, 0),
+		End:     newTOD(4, 0),
+	}
+	// 1st Thursday of March 2025 = March 6. Exact start time.
+	exactly := time.Date(2025, 3, 6, 2, 0, 0, 0, time.UTC)
+	next := NextOccurrence(exactly, s)
+	assert.Equal(t, exactly, next)
+}
+
+// NextOccurrence respects the time zone in the provided time.Time.
+func TestNextOccurrence_RespectsTimezone(t *testing.T) {
+	s := weeklySchedule([]time.Weekday{time.Monday}, newTOD(2, 0), newTOD(4, 0))
+	chicago := loc(t, "America/Chicago")
+	// Monday 01:00 Chicago — today's start (02:00 Chicago) is still ahead.
+	after := time.Date(2025, 3, 3, 1, 0, 0, 0, chicago)
+	next := NextOccurrence(after, s)
+	assert.Equal(t, time.Date(2025, 3, 3, 2, 0, 0, 0, chicago), next)
+}

--- a/pkg/maintenance/schedule/parse.go
+++ b/pkg/maintenance/schedule/parse.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// rawConfig is the YAML-unmarshal target for a Config block.
+type rawConfig struct {
+	Timezone  string        `yaml:"timezone"`
+	Schedules []rawSchedule `yaml:"schedules"`
+}
+
+// rawSchedule is the YAML-unmarshal target for a single schedule entry.
+type rawSchedule struct {
+	Freq    string     `yaml:"freq"`
+	Weekday string     `yaml:"weekday"`
+	Days    []string   `yaml:"days"`
+	Nth     *int       `yaml:"nth"`
+	After   *rawAnchor `yaml:"after"`
+	Before  *rawAnchor `yaml:"before"`
+	Start   string     `yaml:"start"`
+	End     string     `yaml:"end"`
+}
+
+type rawAnchor struct {
+	Weekday string `yaml:"weekday"`
+	Nth     int    `yaml:"nth"`
+}
+
+// Parse unmarshals and validates a reboot_window config body (the YAML under
+// the reboot_window: key, not including that key itself).
+//
+// It returns the validated Config, a list of non-blocking warnings (e.g., DST
+// issues), and a non-nil error if any validation rule fails.
+func Parse(data []byte) (*Config, []string, error) {
+	var raw rawConfig
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal reboot_window: %w", err)
+	}
+
+	if len(raw.Schedules) == 0 {
+		return nil, nil, fmt.Errorf("reboot_window: schedules must contain at least one entry")
+	}
+
+	// Validate timezone before iterating schedules; we need the location for DST checks.
+	var loc *time.Location
+	if raw.Timezone != "" && raw.Timezone != "device" {
+		var err error
+		loc, err = time.LoadLocation(raw.Timezone)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reboot_window: invalid timezone %q: %w", raw.Timezone, err)
+		}
+	}
+
+	schedules := make([]Schedule, 0, len(raw.Schedules))
+	var warnings []string
+
+	for i, rs := range raw.Schedules {
+		s, ws, err := validateSchedule(i, rs, loc)
+		if err != nil {
+			return nil, nil, err
+		}
+		schedules = append(schedules, s)
+		warnings = append(warnings, ws...)
+	}
+
+	return &Config{
+		Timezone:  raw.Timezone,
+		Schedules: schedules,
+	}, warnings, nil
+}
+
+func validateSchedule(idx int, rs rawSchedule, loc *time.Location) (Schedule, []string, error) {
+	prefix := fmt.Sprintf("schedules[%d]", idx)
+
+	// Validate freq.
+	var freq Freq
+	switch strings.ToLower(rs.Freq) {
+	case "monthly":
+		freq = FreqMonthly
+	case "weekly":
+		freq = FreqWeekly
+	case "":
+		return Schedule{}, nil, fmt.Errorf("%s: freq is required", prefix)
+	default:
+		return Schedule{}, nil, fmt.Errorf("%s: invalid freq %q (must be 'monthly' or 'weekly')", prefix, rs.Freq)
+	}
+
+	// Validate mutual exclusivity: nth, after, before.
+	anchorCount := 0
+	if rs.Nth != nil {
+		anchorCount++
+	}
+	if rs.After != nil {
+		anchorCount++
+	}
+	if rs.Before != nil {
+		anchorCount++
+	}
+	if anchorCount > 1 {
+		return Schedule{}, nil, fmt.Errorf("%s: nth, after, and before are mutually exclusive; specify exactly one", prefix)
+	}
+
+	// Validate freq-scoping rules.
+	if freq == FreqWeekly {
+		if rs.Nth != nil {
+			return Schedule{}, nil, fmt.Errorf("%s: nth is only valid with freq: monthly", prefix)
+		}
+		if rs.After != nil {
+			return Schedule{}, nil, fmt.Errorf("%s: after is only valid with freq: monthly", prefix)
+		}
+		if rs.Before != nil {
+			return Schedule{}, nil, fmt.Errorf("%s: before is only valid with freq: monthly", prefix)
+		}
+		if len(rs.Days) == 0 {
+			return Schedule{}, nil, fmt.Errorf("%s: freq: weekly requires at least one entry in days", prefix)
+		}
+	}
+	if freq == FreqMonthly {
+		if len(rs.Days) > 0 {
+			return Schedule{}, nil, fmt.Errorf("%s: days: is only valid with freq: weekly", prefix)
+		}
+		if anchorCount == 0 {
+			return Schedule{}, nil, fmt.Errorf("%s: freq: monthly requires exactly one of nth, after, or before", prefix)
+		}
+	}
+
+	// Parse start time.
+	start, err := parseTimeOfDay(rs.Start, false)
+	if err != nil {
+		return Schedule{}, nil, fmt.Errorf("%s: invalid start %q: %w", prefix, rs.Start, err)
+	}
+
+	// Parse end time (24:00 is allowed).
+	end, err := parseTimeOfDay(rs.End, true)
+	if err != nil {
+		return Schedule{}, nil, fmt.Errorf("%s: invalid end %q: %w", prefix, rs.End, err)
+	}
+
+	// Build the Schedule.
+	s := Schedule{
+		Freq:  freq,
+		Start: start,
+		End:   end,
+	}
+
+	switch freq {
+	case FreqWeekly:
+		days := make([]time.Weekday, 0, len(rs.Days))
+		for _, d := range rs.Days {
+			wd, err := parseWeekday(d)
+			if err != nil {
+				return Schedule{}, nil, fmt.Errorf("%s: invalid day %q: %w", prefix, d, err)
+			}
+			days = append(days, wd)
+		}
+		s.Days = days
+
+	case FreqMonthly:
+		wd, err := parseWeekday(rs.Weekday)
+		if err != nil {
+			return Schedule{}, nil, fmt.Errorf("%s: invalid weekday %q: %w", prefix, rs.Weekday, err)
+		}
+		s.Weekday = wd
+
+		switch {
+		case rs.Nth != nil:
+			nth := *rs.Nth
+			s.Nth = &nth
+		case rs.After != nil:
+			anchorWD, err := parseWeekday(rs.After.Weekday)
+			if err != nil {
+				return Schedule{}, nil, fmt.Errorf("%s: invalid after.weekday %q: %w", prefix, rs.After.Weekday, err)
+			}
+			s.After = &Anchor{Weekday: anchorWD, Nth: rs.After.Nth}
+		case rs.Before != nil:
+			anchorWD, err := parseWeekday(rs.Before.Weekday)
+			if err != nil {
+				return Schedule{}, nil, fmt.Errorf("%s: invalid before.weekday %q: %w", prefix, rs.Before.Weekday, err)
+			}
+			s.Before = &Anchor{Weekday: anchorWD, Nth: rs.Before.Nth}
+		}
+	}
+
+	// DST warning check (requires a concrete timezone location).
+	var ws []string
+	if loc != nil && !end.EndOfDay {
+		if w := dstWarning(s, loc); w != "" {
+			ws = append(ws, w)
+		}
+	}
+
+	return s, ws, nil
+}
+
+// parseTimeOfDay parses "HH:MM" or, when allowEndOfDay is true, "24:00".
+func parseTimeOfDay(s string, allowEndOfDay bool) (TimeOfDay, error) {
+	if s == "" {
+		return TimeOfDay{}, fmt.Errorf("time string is empty")
+	}
+	if allowEndOfDay && s == "24:00" {
+		return TimeOfDay{EndOfDay: true}, nil
+	}
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return TimeOfDay{}, fmt.Errorf("expected HH:MM format")
+	}
+	h, err := strconv.Atoi(parts[0])
+	if err != nil || h < 0 || h > 23 {
+		return TimeOfDay{}, fmt.Errorf("hour must be 00–23")
+	}
+	m, err := strconv.Atoi(parts[1])
+	if err != nil || m < 0 || m > 59 {
+		return TimeOfDay{}, fmt.Errorf("minute must be 00–59")
+	}
+	return TimeOfDay{Hour: h, Minute: m}, nil
+}
+
+// parseWeekday parses a case-insensitive weekday name to time.Weekday.
+func parseWeekday(s string) (time.Weekday, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "sunday":
+		return time.Sunday, nil
+	case "monday":
+		return time.Monday, nil
+	case "tuesday":
+		return time.Tuesday, nil
+	case "wednesday":
+		return time.Wednesday, nil
+	case "thursday":
+		return time.Thursday, nil
+	case "friday":
+		return time.Friday, nil
+	case "saturday":
+		return time.Saturday, nil
+	default:
+		return 0, fmt.Errorf("unknown weekday %q", s)
+	}
+}
+
+// dstWarning checks whether the schedule's entire time window falls inside a
+// spring-forward DST-skipped hour in the given location. It scans a 10-year
+// window of dates so it catches both near-future and current-year transitions.
+//
+// Returns a non-empty warning string if a gap is found, or "" if no issue.
+func dstWarning(s Schedule, loc *time.Location) string {
+	startH, startM := s.Start.Hour, s.Start.Minute
+	endH, endM := s.End.Hour, s.End.Minute
+
+	// Scan 10 years starting from 2025.
+	for year := 2025; year <= 2035; year++ {
+		for month := time.January; month <= time.December; month++ {
+			// Find last day of this month.
+			lastDay := time.Date(year, month+1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -1).Day()
+			for day := 1; day <= lastDay; day++ {
+				ts := time.Date(year, month, day, startH, startM, 0, 0, loc)
+				te := time.Date(year, month, day, endH, endM, 0, 0, loc)
+
+				startSkipped := ts.Hour() != startH || ts.Minute() != startM
+				endSkipped := te.Hour() != endH || te.Minute() != endM
+
+				if startSkipped && endSkipped {
+					return fmt.Sprintf(
+						"schedule window %02d:%02d–%02d:%02d falls entirely within a spring-forward DST gap on %04d-%02d-%02d (in %s); window will not open that day",
+						startH, startM, endH, endM, year, month, day, loc,
+					)
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/maintenance/schedule/parse_test.go
+++ b/pkg/maintenance/schedule/parse_test.go
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scheduleYAML wraps a raw body under the Config fields (no reboot_window: wrapper).
+func scheduleYAML(body string) []byte {
+	return []byte(body)
+}
+
+func TestParse_ThreeShapes(t *testing.T) {
+	yaml := scheduleYAML(`
+timezone: America/Chicago
+schedules:
+  - freq: monthly
+    weekday: thursday
+    after:
+      weekday: tuesday
+      nth: 2
+    start: "02:00"
+    end: "04:00"
+  - freq: monthly
+    weekday: thursday
+    nth: 2
+    start: "02:00"
+    end: "06:00"
+  - freq: weekly
+    days: [saturday, sunday]
+    start: "01:00"
+    end: "06:00"
+`)
+	cfg, warnings, err := Parse(yaml)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.Len(t, cfg.Schedules, 3)
+
+	// Shape 1: monthly after-anchored
+	s0 := cfg.Schedules[0]
+	assert.Equal(t, FreqMonthly, s0.Freq)
+	assert.Equal(t, time.Thursday, s0.Weekday)
+	require.NotNil(t, s0.After)
+	assert.Equal(t, time.Tuesday, s0.After.Weekday)
+	assert.Equal(t, 2, s0.After.Nth)
+	assert.Nil(t, s0.Nth)
+	assert.Nil(t, s0.Before)
+	assert.Equal(t, TimeOfDay{Hour: 2, Minute: 0}, s0.Start)
+	assert.Equal(t, TimeOfDay{Hour: 4, Minute: 0}, s0.End)
+
+	// Shape 2: monthly plain nth
+	s1 := cfg.Schedules[1]
+	assert.Equal(t, FreqMonthly, s1.Freq)
+	assert.Equal(t, time.Thursday, s1.Weekday)
+	require.NotNil(t, s1.Nth)
+	assert.Equal(t, 2, *s1.Nth)
+	assert.Nil(t, s1.After)
+	assert.Nil(t, s1.Before)
+	assert.Equal(t, TimeOfDay{Hour: 2, Minute: 0}, s1.Start)
+	assert.Equal(t, TimeOfDay{Hour: 6, Minute: 0}, s1.End)
+
+	// Shape 3: weekly days
+	s2 := cfg.Schedules[2]
+	assert.Equal(t, FreqWeekly, s2.Freq)
+	assert.ElementsMatch(t, []time.Weekday{time.Saturday, time.Sunday}, s2.Days)
+	assert.Equal(t, TimeOfDay{Hour: 1, Minute: 0}, s2.Start)
+	assert.Equal(t, TimeOfDay{Hour: 6, Minute: 0}, s2.End)
+}
+
+func TestParse_WeekdayCaseInsensitive(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    days: [Saturday, SUNDAY, monday]
+    start: "01:00"
+    end: "06:00"
+`)
+	cfg, _, err := Parse(yaml)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []time.Weekday{time.Saturday, time.Sunday, time.Monday}, cfg.Schedules[0].Days)
+}
+
+func TestParse_End24h(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    days: [tuesday]
+    start: "02:00"
+    end: "24:00"
+`)
+	cfg, _, err := Parse(yaml)
+	require.NoError(t, err)
+	require.Len(t, cfg.Schedules, 1)
+	assert.True(t, cfg.Schedules[0].End.EndOfDay)
+	assert.Equal(t, 0, cfg.Schedules[0].End.Hour)
+	assert.Equal(t, 0, cfg.Schedules[0].End.Minute)
+}
+
+func TestParse_NthNegativeOne(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: monthly
+    weekday: friday
+    nth: -1
+    start: "03:00"
+    end: "05:00"
+`)
+	cfg, _, err := Parse(yaml)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Schedules[0].Nth)
+	assert.Equal(t, -1, *cfg.Schedules[0].Nth)
+}
+
+// Validation rule: nth and after/before are mutually exclusive.
+func TestParse_Validation_NthAndAfterMutuallyExclusive(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: monthly
+    weekday: thursday
+    nth: 2
+    after:
+      weekday: tuesday
+      nth: 2
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestParse_Validation_NthAndBeforeMutuallyExclusive(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: monthly
+    weekday: thursday
+    nth: 1
+    before:
+      weekday: tuesday
+      nth: 2
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestParse_Validation_AfterAndBeforeMutuallyExclusive(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: monthly
+    weekday: thursday
+    after:
+      weekday: tuesday
+      nth: 2
+    before:
+      weekday: wednesday
+      nth: 1
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// Validation rule: with freq: monthly + weekday, exactly one of nth/after/before must be present.
+func TestParse_Validation_MonthlyMissingAnchor(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: monthly
+    weekday: thursday
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+// Validation rule: after/before/nth valid only with freq: monthly.
+func TestParse_Validation_NthOnlyWithMonthly(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    days: [saturday]
+    nth: 2
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only valid with freq: monthly")
+}
+
+func TestParse_Validation_AfterOnlyWithMonthly(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    days: [saturday]
+    after:
+      weekday: tuesday
+      nth: 2
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only valid with freq: monthly")
+}
+
+func TestParse_Validation_BeforeOnlyWithMonthly(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    days: [saturday]
+    before:
+      weekday: tuesday
+      nth: 2
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only valid with freq: monthly")
+}
+
+// Validation rule: days valid only with freq: weekly.
+func TestParse_Validation_DaysOnlyWithWeekly(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: monthly
+    weekday: thursday
+    nth: 2
+    days: [saturday]
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only valid with freq: weekly")
+}
+
+// Validation rule: weekly must have at least one day.
+func TestParse_Validation_WeeklyNoDays(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+}
+
+// Validation rule: timezone must be empty, "device", or valid IANA zone.
+func TestParse_Validation_InvalidTimezone(t *testing.T) {
+	yaml := scheduleYAML(`
+timezone: Not/A/Real/Zone
+schedules:
+  - freq: weekly
+    days: [saturday]
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timezone")
+}
+
+func TestParse_Validation_TimezoneDevice(t *testing.T) {
+	yaml := scheduleYAML(`
+timezone: device
+schedules:
+  - freq: weekly
+    days: [saturday]
+    start: "01:00"
+    end: "06:00"
+`)
+	_, _, err := Parse(yaml)
+	require.NoError(t, err)
+}
+
+func TestParse_Validation_TimezoneEmpty(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    days: [saturday]
+    start: "01:00"
+    end: "06:00"
+`)
+	_, _, err := Parse(yaml)
+	require.NoError(t, err)
+}
+
+// Validation rule: missing freq is an error.
+func TestParse_Validation_MissingFreq(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - weekday: thursday
+    nth: 2
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+}
+
+// Validation rule: invalid freq string.
+func TestParse_Validation_InvalidFreq(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: biweekly
+    days: [saturday]
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "freq")
+}
+
+// DST warning: a schedule whose entire span falls inside a spring-forward
+// skipped hour must produce a warning (not an error), verified with a concrete
+// DST-transition date in America/New_York (second Sunday of March).
+func TestParse_DSTWarning_WindowInsideSpringForwardGap(t *testing.T) {
+	// America/New_York springs forward on the second Sunday of March:
+	// 2025-03-09 02:00 → 03:00. A window 02:15–02:45 is entirely skipped.
+	yaml := scheduleYAML(`
+timezone: America/New_York
+schedules:
+  - freq: weekly
+    days: [sunday]
+    start: "02:15"
+    end: "02:45"
+`)
+	cfg, warnings, err := Parse(yaml)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.NotEmpty(t, warnings, "expected DST warning for window entirely inside spring-forward gap")
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "DST") || strings.Contains(w, "spring-forward") || strings.Contains(w, "skipped") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "DST warning should mention spring-forward gap; got: %v", warnings)
+}
+
+// DST warning: a multi-hour window that only partially overlaps a DST gap must NOT warn.
+func TestParse_DSTWarning_MultiHourWindowNoWarn(t *testing.T) {
+	yaml := scheduleYAML(`
+timezone: America/New_York
+schedules:
+  - freq: weekly
+    days: [sunday]
+    start: "01:00"
+    end: "04:00"
+`)
+	_, warnings, err := Parse(yaml)
+	require.NoError(t, err)
+	// A multi-hour window spanning the gap should not produce a warning.
+	for _, w := range warnings {
+		assert.False(t, strings.Contains(w, "spring-forward"), "unexpected DST warning for multi-hour window: %s", w)
+	}
+}
+
+// Cross-month boundary offsets are legal: no validation error when after-anchor
+// resolution falls in the next month.
+func TestParse_CrossMonthOffsetIsLegal(t *testing.T) {
+	// Last Tuesday of January 2025 is Jan 28; Thursday after = Jan 30.
+	// But last Tuesday of some months will have Thursday spilling into next month
+	// (e.g., last Tuesday is Jan 30 → Thursday after = Feb 1).
+	// Parse should not error; the evaluator handles the overflow.
+	yaml := scheduleYAML(`
+schedules:
+  - freq: monthly
+    weekday: thursday
+    after:
+      weekday: tuesday
+      nth: -1
+    start: "02:00"
+    end: "04:00"
+`)
+	_, _, err := Parse(yaml)
+	require.NoError(t, err)
+}
+
+// Empty schedules list is an error (no point in a window with no schedules).
+func TestParse_EmptySchedulesList(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules: []
+`)
+	_, _, err := Parse(yaml)
+	require.Error(t, err)
+}
+
+// Minimum valid weekly schedule.
+func TestParse_MinimalWeekly(t *testing.T) {
+	yaml := scheduleYAML(`
+schedules:
+  - freq: weekly
+    days: [monday]
+    start: "00:00"
+    end: "01:00"
+`)
+	cfg, _, err := Parse(yaml)
+	require.NoError(t, err)
+	assert.Len(t, cfg.Schedules, 1)
+}

--- a/pkg/maintenance/schedule/types.go
+++ b/pkg/maintenance/schedule/types.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package schedule implements the reboot_window schema, parser, and evaluator (ADR-026).
+package schedule
+
+import "time"
+
+// Freq is the recurrence frequency for a schedule entry.
+type Freq string
+
+const (
+	FreqMonthly Freq = "monthly"
+	FreqWeekly  Freq = "weekly"
+)
+
+// TimeOfDay represents a wall-clock time within a day.
+type TimeOfDay struct {
+	Hour   int
+	Minute int
+	// EndOfDay is true when the original YAML value was "24:00".
+	EndOfDay bool
+}
+
+// minutesSinceMidnight returns the time as minutes since midnight (0–1440).
+// "24:00" is treated as 1440 (end-of-day sentinel, never wrapped).
+func (t TimeOfDay) minutesSinceMidnight() int {
+	if t.EndOfDay {
+		return 24 * 60
+	}
+	return t.Hour*60 + t.Minute
+}
+
+// Anchor is the reference point for a monthly after:/before: anchor rule.
+type Anchor struct {
+	Weekday time.Weekday
+	// Nth is the occurrence index within the month. -1 means "last".
+	Nth int
+}
+
+// Schedule is a single validated entry from the schedules: list.
+// All string fields from YAML have been resolved to typed values.
+type Schedule struct {
+	Freq Freq
+
+	// Weekday is the day the window opens (monthly only).
+	Weekday time.Weekday
+
+	// Days is the set of days the window opens (weekly only).
+	Days []time.Weekday
+
+	// Nth is set for the plain monthly case (1st, 2nd, … or last=-1).
+	// Nil when After or Before is set.
+	Nth *int
+
+	// After anchors the window to the first occurrence of Weekday strictly
+	// after the anchor day (monthly only). Nil when Nth or Before is set.
+	After *Anchor
+
+	// Before anchors the window to the last occurrence of Weekday strictly
+	// before the anchor day (monthly only). Nil when Nth or After is set.
+	Before *Anchor
+
+	Start TimeOfDay
+	End   TimeOfDay
+}
+
+// Config is the top-level reboot_window configuration for one device level.
+// Timezone is the window-level explicit value only: empty means "not set at
+// this level" (inherit from tenant or device); "device" means use the
+// endpoint's own zone. Timezone resolution is handled by Story 2 (pkg/maintenance
+// cascade layer) and does not belong here.
+type Config struct {
+	Timezone  string
+	Schedules []Schedule
+}

--- a/pkg/maintenance/schedule/types_test.go
+++ b/pkg/maintenance/schedule/types_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFreq_Constants(t *testing.T) {
+	assert.Equal(t, Freq("monthly"), FreqMonthly)
+	assert.Equal(t, Freq("weekly"), FreqWeekly)
+}
+
+func TestTimeOfDay_MinutesSinceMidnight(t *testing.T) {
+	cases := []struct {
+		tod  TimeOfDay
+		want int
+	}{
+		{TimeOfDay{Hour: 0, Minute: 0}, 0},
+		{TimeOfDay{Hour: 2, Minute: 0}, 120},
+		{TimeOfDay{Hour: 23, Minute: 59}, 1439},
+		{TimeOfDay{EndOfDay: true}, 1440},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.tod.minutesSinceMidnight(), "tod=%+v", tc.tod)
+	}
+}
+
+func TestTimeOfDay_EndOfDay_Sentinel(t *testing.T) {
+	tod := TimeOfDay{EndOfDay: true}
+	// EndOfDay=true should dominate Hour/Minute regardless of their values.
+	tod.Hour, tod.Minute = 0, 0
+	assert.Equal(t, 1440, tod.minutesSinceMidnight())
+}
+
+func TestConfig_TimezoneField(t *testing.T) {
+	c := Config{Timezone: "device", Schedules: []Schedule{}}
+	assert.Equal(t, "device", c.Timezone)
+}
+
+func TestConfig_EmptyTimezone(t *testing.T) {
+	c := Config{Schedules: []Schedule{}}
+	assert.Equal(t, "", c.Timezone, "empty timezone means not set at this level")
+}
+
+func TestSchedule_NthPointerNilByDefault(t *testing.T) {
+	s := Schedule{Freq: FreqMonthly, Weekday: time.Thursday}
+	assert.Nil(t, s.Nth)
+	assert.Nil(t, s.After)
+	assert.Nil(t, s.Before)
+}
+
+func TestAnchor_Fields(t *testing.T) {
+	a := Anchor{Weekday: time.Tuesday, Nth: 2}
+	assert.Equal(t, time.Tuesday, a.Weekday)
+	assert.Equal(t, 2, a.Nth)
+
+	last := Anchor{Weekday: time.Friday, Nth: -1}
+	assert.Equal(t, -1, last.Nth)
+}


### PR DESCRIPTION
## Summary

- Introduces `pkg/maintenance/schedule` — pure-Go `reboot_window` schema types, YAML parser, and evaluator (`InWindow` + `NextOccurrence`). No storage, no wiring — the foundation every other story in Epic #2898 builds on.
- Creates `docs/architecture/decisions/026-reboot-windows.md` (ADR-026, Status: Accepted, 2026-07-22), formalising the six settled design decisions and the authoritative schema/validation/evaluation rules. Unblocks Stories #2976–#2979 which all cite this ADR.

Fixes #2975

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Code Review | **PASS** | No blocking findings. Non-blocking note: added `TestInWindow_Monthly_Before_SameWeekday_MinusSeven` before commit to cover the symmetric before-anchor same-weekday case flagged by reviewer. |
| QA Test Runner | **PASS** | 100+ packages passing, 215 script tests, lint clean, architecture compliance OK, secret scan clean. |
| Security Engineer | **PASS** | No security issues. Pure algorithm, no HTTP surface, no external inputs, no logging of user data. |

## Key implementation decisions

- **Cross-month boundary:** `isMonthlyScheduledDay` checks the adjacent month for `after`/`before` anchors so that e.g. "Saturday after the last Thursday of January" correctly resolves to February 1 when that's where the anchor overflow lands.
- **DST warning:** scans 2025–2035 for spring-forward gaps; emits a warning (not error) when both `start` and `end` fall entirely inside a skipped hour. Tested with `America/New_York` on 2025-03-09.
- **nth: -1 (last weekday):** anchored to `first-day-of-next-month - N` so it handles 28/29/30/31-day months uniformly without a day-count table.
- **No new dependencies:** pure standard library (`time`, `fmt`, `strings`, `strconv`) + `gopkg.in/yaml.v3` (already in go.mod).

## Test plan

- [x] 61 unit tests covering all three schedule shapes from the ADR schema example
- [x] All validation rules by name (mutual exclusivity, freq-scoping, same-weekday +7/-7)
- [x] `InWindow` non-wrapping, midnight-wrapping, `end: "24:00"`
- [x] `NextOccurrence` with `nth: -1` across 28-day (Feb non-leap), 29-day (leap Feb), 30-day (April), 31-day (January) months
- [x] Cross-month boundary overflow/underflow
- [x] DST spring-forward warning with concrete `America/New_York` fixture
- [x] `make test-agent-complete` passed (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)