### PR TITLE
registration: tenant-scope reads/writes, redact token secrets, add ip-trust list, audit mutations (Issue #2932)

### DIFF
--- a/docs/architecture/decisions/018-web-session-semantics.md
+++ b/docs/architecture/decisions/018-web-session-semantics.md
@@ -186,3 +186,37 @@ This addendum closes it:
   epic (candidate follow-on); the login mockup's WebAuthn/passkey `mfa` state
   is a designed seam, built later. Reset is admin-driven via the same Tier-3
   endpoint — no self-service reset.
+
+---
+
+## Addendum (Issue #2932): Registration/Token/IP-Trust Cluster Tenant Scoping
+
+The registration, registration-token, and IP-trust API clusters are now
+caller-tenant-scoped. A web-session or API-key principal carrying a non-empty
+`TenantID` in context (`ctxkeys.TenantID`, set by `authenticationMiddleware`)
+can only read or mutate resources whose `TenantID` equals or is a path-prefix
+descendant of the caller's own tenant. Unscoped mTLS admin principals
+(`callerTenantID == ""`) retain global visibility and are unaffected.
+
+Specific changes:
+- `handleListPendingRegistrations`, `handleApproveAllRegistrations`,
+  `handleApproveByCIDR` pass `callerTenantID` to `ListPending` (was `""`).
+- `handleApproveRegistration`, `handleDenyRegistration` 404 when the entry's
+  `TenantID` is outside the caller's subtree.
+- `handleListRegistrationTokens`, `handleGetRegistrationToken` scope to
+  `callerTenantID`; list/get responses omit the raw `token` field (only
+  `token_prefix` — first 6 chars — is returned). The full secret is disclosed
+  only at create and rotate time.
+- `handleCreateRegistrationToken`, `handleRotateRegistrationToken`,
+  `handleRevokeRegistrationToken`, `handleDeleteRegistrationToken` enforce
+  caller subtree on the target tenant.
+- `GET /api/v1/registration/ip-trust` (new) lists trusted IP ranges for the
+  caller's tenant. Unscoped callers must supply `?tenant_id=`.
+- `handleAddIPTrust`, `handleRevokeIPTrust` reject requests whose `tenant_id`
+  is outside the caller's subtree.
+- All state-changing operations emit an audit event via `auditManager`.
+
+Roles already granted `registration:manage-ip-trust` should also be granted
+`registration:list-ip-trust` so operators who manage IP trust can also view
+the list (no static role-seed file exists; roles are provisioned via
+`POST /rbac/roles`).

--- a/features/controller/api/handlers_ip_trust.go
+++ b/features/controller/api/handlers_ip_trust.go
@@ -5,9 +5,12 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -19,8 +22,21 @@ type addIPTrustRequest struct {
 	PreSeeded bool   `json:"pre_seeded"`
 }
 
+// IPTrustEntryResponse is the per-entry shape for GET /api/v1/registration/ip-trust.
+// Mirrors the IPTrustEntry storage model for the response envelope.
+type IPTrustEntryResponse struct {
+	CIDR         string     `json:"cidr"`
+	TenantID     string     `json:"tenant_id"`
+	PreSeeded    bool       `json:"pre_seeded"`
+	TrustedSince time.Time  `json:"trusted_since"`
+	LastActivity time.Time  `json:"last_activity,omitempty"`
+	Revoked      bool       `json:"revoked"`
+	RevokedAt    *time.Time `json:"revoked_at,omitempty"`
+}
+
 // handleAddIPTrust handles POST /api/v1/registration/ip-trust.
 // Adds a trusted CIDR range for a tenant; pre_seeded marks the range as operator-seeded.
+// Scoped callers may only add ranges for tenants within their own subtree.
 func (s *Server) handleAddIPTrust(w http.ResponseWriter, r *http.Request) {
 	if s.ipTrustStore == nil {
 		http.Error(w, "ip-trust store unavailable", http.StatusServiceUnavailable)
@@ -37,6 +53,16 @@ func (s *Server) handleAddIPTrust(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Tenant subtree enforcement: scoped callers may not add ranges for other tenants.
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := req.TenantID == callerTenant || strings.HasPrefix(req.TenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "forbidden: target tenant is outside caller's tenant subtree", http.StatusForbidden)
+			return
+		}
+	}
+
 	if err := s.ipTrustStore.AddTrustedRange(r.Context(), req.TenantID, req.CIDR, req.PreSeeded); err != nil {
 		s.logger.Error("Failed to add IP trust range",
 			"tenant_id", logging.SanitizeLogValue(req.TenantID),
@@ -50,12 +76,14 @@ func (s *Server) handleAddIPTrust(w http.ResponseWriter, r *http.Request) {
 		"tenant_id", logging.SanitizeLogValue(req.TenantID),
 		"cidr", logging.SanitizeLogValue(req.CIDR),
 		"pre_seeded", req.PreSeeded)
+	s.emitIPTrustAudit(r, "ip_trust.added", req.TenantID, req.CIDR)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 // handleRevokeIPTrust handles DELETE /api/v1/registration/ip-trust/{tenant_id}/{cidr:.+}.
 // Revokes a trusted CIDR range for a tenant. The {cidr:.+} pattern allows the CIDR slash
 // to appear in the URL path (gorilla/mux decodes %2F before extraction).
+// Scoped callers may only revoke ranges for tenants within their own subtree.
 func (s *Server) handleRevokeIPTrust(w http.ResponseWriter, r *http.Request) {
 	if s.ipTrustStore == nil {
 		http.Error(w, "ip-trust store unavailable", http.StatusServiceUnavailable)
@@ -69,6 +97,16 @@ func (s *Server) handleRevokeIPTrust(w http.ResponseWriter, r *http.Request) {
 	if tenantID == "" || cidr == "" {
 		http.Error(w, "tenant_id and cidr are required", http.StatusBadRequest)
 		return
+	}
+
+	// Tenant subtree enforcement: scoped callers may not revoke ranges for other tenants.
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := tenantID == callerTenant || strings.HasPrefix(tenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "forbidden: target tenant is outside caller's tenant subtree", http.StatusForbidden)
+			return
+		}
 	}
 
 	if err := s.ipTrustStore.RevokeTrustedRange(r.Context(), tenantID, cidr); err != nil {
@@ -87,5 +125,79 @@ func (s *Server) handleRevokeIPTrust(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("IP trust range revoked",
 		"tenant_id", logging.SanitizeLogValue(tenantID),
 		"cidr", logging.SanitizeLogValue(cidr))
+	s.emitIPTrustAudit(r, "ip_trust.revoked", tenantID, cidr)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleListIPTrust handles GET /api/v1/registration/ip-trust.
+// Scoped callers (API-key principals) always see only their own tenant's ranges.
+// Unscoped (mTLS admin) callers must supply ?tenant_id= to narrow the result.
+func (s *Server) handleListIPTrust(w http.ResponseWriter, r *http.Request) {
+	if s.ipTrustStore == nil {
+		http.Error(w, "ip-trust store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Scoped callers: always use their own tenant.
+	// Unscoped (admin): require tenant_id query param to avoid open-ended scans.
+	callerTenant := s.callerTenantID(r)
+	tenantID := callerTenant
+	if tenantID == "" {
+		tenantID = r.URL.Query().Get("tenant_id")
+		if tenantID == "" {
+			http.Error(w, "tenant_id query parameter is required for unscoped callers", http.StatusBadRequest)
+			return
+		}
+	}
+
+	entries, err := s.ipTrustStore.ListTrustedRanges(r.Context(), tenantID)
+	if err != nil {
+		s.logger.Error("Failed to list IP trust ranges",
+			"tenant_id", logging.SanitizeLogValue(tenantID), "error", err)
+		http.Error(w, "Failed to list IP trust ranges", http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]IPTrustEntryResponse, 0, len(entries))
+	for _, e := range entries {
+		resp = append(resp, IPTrustEntryResponse{
+			CIDR:         e.CIDR,
+			TenantID:     e.TenantID,
+			PreSeeded:    e.PreSeeded,
+			TrustedSince: e.TrustedSince,
+			LastActivity: e.LastActivity,
+			Revoked:      e.Revoked,
+			RevokedAt:    e.RevokedAt,
+		})
+	}
+	s.writeSuccessResponse(w, resp)
+}
+
+// emitIPTrustAudit records an audit event for an IP trust mutation (add or revoke).
+// It is a no-op when auditManager is nil.
+func (s *Server) emitIPTrustAudit(r *http.Request, action, tenantID, cidr string) {
+	if s.auditManager == nil {
+		return
+	}
+	auditTenantID := tenantID
+	if auditTenantID == "" {
+		auditTenantID = audit.SystemTenantID
+	}
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	principalID := ""
+	if principal != nil {
+		principalID = principal.ID
+	}
+	b := audit.NewEventBuilder().
+		Tenant(auditTenantID).
+		Type(business.AuditEventSystemAccess).
+		Action(action).
+		User(principalID, business.AuditUserTypeHuman).
+		Resource("ip_trust", cidr, "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityHigh).
+		Detail("cidr", cidr)
+	if err := s.auditManager.RecordEvent(r.Context(), b); err != nil {
+		s.logger.Warn("Failed to emit ip-trust audit event", "error", err, "action", action)
+	}
 }

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -104,12 +104,15 @@ type denyRegistrationRequest struct {
 
 // handleListPendingRegistrations handles GET /api/v1/registration/pending.
 // Returns all quarantined stewards awaiting operator approval.
+// Scoped callers (API-key principals) see only their own tenant's entries; unscoped
+// (mTLS admin, callerTenant == "") retain global visibility.
 func (s *Server) handleListPendingRegistrations(w http.ResponseWriter, r *http.Request) {
 	if s.pendingStore == nil {
 		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	entries, err := s.pendingStore.ListPending(r.Context(), "")
+	callerTenant := s.callerTenantID(r)
+	entries, err := s.pendingStore.ListPending(r.Context(), callerTenant)
 	if err != nil {
 		s.logger.Error("Failed to list pending registrations", "error", err)
 		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
@@ -134,13 +137,15 @@ func (s *Server) handleListPendingRegistrations(w http.ResponseWriter, r *http.R
 
 // handleApproveRegistration handles POST /api/v1/registration/{id}/approve.
 // Marks the pending entry as approved; no cert is generated here (generate-on-claim).
+// Returns 404 when the entry's tenant is outside the caller's subtree (no existence disclosure).
 func (s *Server) handleApproveRegistration(w http.ResponseWriter, r *http.Request) {
 	pendingID := mux.Vars(r)["id"]
 	if s.pendingStore == nil {
 		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	if _, err := s.pendingStore.GetPendingByID(r.Context(), pendingID); err != nil {
+	entry, err := s.pendingStore.GetPendingByID(r.Context(), pendingID)
+	if err != nil {
 		if err == business.ErrPendingRegistrationNotFound {
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
@@ -148,6 +153,14 @@ func (s *Server) handleApproveRegistration(w http.ResponseWriter, r *http.Reques
 		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
+	}
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := entry.TenantID == callerTenant || strings.HasPrefix(entry.TenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "pending registration not found", http.StatusNotFound)
+			return
+		}
 	}
 	if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusApproved); err != nil {
 		s.logger.Error("Failed to approve pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
@@ -155,18 +168,22 @@ func (s *Server) handleApproveRegistration(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	s.logger.Info("Steward registration approved (awaiting claim)", "pending_id", logging.SanitizeLogValue(pendingID))
+	s.emitRegistrationManagementAudit(r, "registration.approved",
+		map[string]interface{}{"pending_id": pendingID, "tenant_id": entry.TenantID})
 	w.WriteHeader(http.StatusOK)
 }
 
 // handleDenyRegistration handles POST /api/v1/registration/{id}/deny.
 // Marks the pending entry as denied; no certs are issued.
+// Returns 404 when the entry's tenant is outside the caller's subtree (no existence disclosure).
 func (s *Server) handleDenyRegistration(w http.ResponseWriter, r *http.Request) {
 	pendingID := mux.Vars(r)["id"]
 	if s.pendingStore == nil {
 		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	if _, err := s.pendingStore.GetPendingByID(r.Context(), pendingID); err != nil {
+	entry, err := s.pendingStore.GetPendingByID(r.Context(), pendingID)
+	if err != nil {
 		if err == business.ErrPendingRegistrationNotFound {
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
@@ -174,6 +191,14 @@ func (s *Server) handleDenyRegistration(w http.ResponseWriter, r *http.Request) 
 		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
+	}
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := entry.TenantID == callerTenant || strings.HasPrefix(entry.TenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "pending registration not found", http.StatusNotFound)
+			return
+		}
 	}
 	var req denyRegistrationRequest
 	_ = json.NewDecoder(r.Body).Decode(&req)
@@ -185,6 +210,8 @@ func (s *Server) handleDenyRegistration(w http.ResponseWriter, r *http.Request) 
 	s.logger.Info("Steward registration denied",
 		"pending_id", logging.SanitizeLogValue(pendingID),
 		"reason", logging.SanitizeLogValue(req.Reason))
+	s.emitRegistrationManagementAudit(r, "registration.denied",
+		map[string]interface{}{"pending_id": pendingID, "tenant_id": entry.TenantID, "reason": req.Reason})
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -379,12 +406,14 @@ type approveByCIDRRequest struct {
 // handleApproveAllRegistrations handles POST /api/v1/registration/approve-all.
 // Approves every entry currently in "pending" status and returns the count.
 // Idempotent: entries already approved/claimed/denied are skipped without error.
+// Scoped callers approve only within their own tenant subtree.
 func (s *Server) handleApproveAllRegistrations(w http.ResponseWriter, r *http.Request) {
 	if s.pendingStore == nil {
 		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	entries, err := s.pendingStore.ListPending(r.Context(), "")
+	callerTenant := s.callerTenantID(r)
+	entries, err := s.pendingStore.ListPending(r.Context(), callerTenant)
 	if err != nil {
 		s.logger.Error("Failed to list pending registrations for approve-all", "error", err)
 		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
@@ -405,6 +434,8 @@ func (s *Server) handleApproveAllRegistrations(w http.ResponseWriter, r *http.Re
 	}
 
 	s.logger.Info("Bulk approve-all completed", "approved", approved)
+	s.emitRegistrationManagementAudit(r, "registration.approve_all",
+		map[string]interface{}{"approved_count": approved})
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(approveAllResponse{Approved: approved}); err != nil {
 		s.logger.Error("Failed to encode approve-all response", "error", err)
@@ -414,6 +445,7 @@ func (s *Server) handleApproveAllRegistrations(w http.ResponseWriter, r *http.Re
 // handleApproveByCIDR handles POST /api/v1/registration/approve-by-cidr.
 // Filters pending entries by source IP containment in the given CIDR (evaluated in Go,
 // not delegated to storage) and approves matching entries. Returns the count approved.
+// Scoped callers approve only within their own tenant subtree.
 func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
 	if s.pendingStore == nil {
 		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
@@ -432,7 +464,8 @@ func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entries, err := s.pendingStore.ListPending(r.Context(), "")
+	callerTenant := s.callerTenantID(r)
+	entries, err := s.pendingStore.ListPending(r.Context(), callerTenant)
 	if err != nil {
 		s.logger.Error("Failed to list pending registrations for approve-by-cidr", "error", err)
 		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
@@ -458,6 +491,8 @@ func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Info("CIDR bulk approve completed",
 		"cidr", logging.SanitizeLogValue(req.CIDR), "approved", approved)
+	s.emitRegistrationManagementAudit(r, "registration.approve_by_cidr",
+		map[string]interface{}{"cidr": req.CIDR, "approved_count": approved})
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(approveAllResponse{Approved: approved}); err != nil {
 		s.logger.Error("Failed to encode approve-by-cidr response", "error", err)
@@ -877,6 +912,38 @@ func extractSourceIP(r *http.Request, trustedProxies []net.IPNet) string {
 	}
 
 	return peerHost
+}
+
+// emitRegistrationManagementAudit records an audit event for a registration management action
+// (approve, deny, approve-all, approve-by-cidr). It is a no-op when auditManager is nil.
+func (s *Server) emitRegistrationManagementAudit(r *http.Request, action string, extras map[string]interface{}) {
+	if s.auditManager == nil {
+		return
+	}
+	callerTenant := s.callerTenantID(r)
+	tenantID := callerTenant
+	if tenantID == "" {
+		tenantID = audit.SystemTenantID
+	}
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	principalID := ""
+	if principal != nil {
+		principalID = principal.ID
+	}
+	b := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(business.AuditEventSystemAccess).
+		Action(action).
+		User(principalID, business.AuditUserTypeHuman).
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityHigh)
+	for k, v := range extras {
+		b = b.Detail(k, v)
+	}
+	if err := s.auditManager.RecordEvent(r.Context(), b); err != nil {
+		s.logger.Warn("Failed to emit registration management audit event",
+			"error", err, "action", action)
+	}
 }
 
 // emitRegistrationAudit records a registration audit event. It is a no-op when auditManager is nil.

--- a/features/controller/api/handlers_registration_tenant_scope_test.go
+++ b/features/controller/api/handlers_registration_tenant_scope_test.go
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/registration"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// newTenantScopeTestServer creates a server with pendingStore, tokenStore, and ipTrustStore
+// wired, for cross-tenant isolation contract tests.
+func newTenantScopeTestServer(t *testing.T) (*Server, business.PendingRegistrationStore, registration.Store, business.IPTrustStore) {
+	t.Helper()
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	sm := pkgtesting.SetupTestStorage(t)
+	pendingStore := sm.GetPendingRegistrationStore()
+	require.NotNil(t, pendingStore)
+	server.SetPendingStore(pendingStore)
+
+	ipStore := newInMemIPTrustStore()
+	server.SetIPTrustStore(ipStore)
+
+	return server, pendingStore, tokenStore, ipStore
+}
+
+// TestF1_PendingRegistrationTenantScope verifies that a tenant-A caller cannot observe or
+// mutate tenant-B's pending registrations (Issue #2932 F1 contract test).
+func TestF1_PendingRegistrationTenantScope(t *testing.T) {
+	server, pendingStore, _, _ := newTenantScopeTestServer(t)
+	ctx := context.Background()
+
+	// Seed a pending entry for tenant-b.
+	entryB := &business.PendingRegistrationEntry{
+		PendingID:    "pending-b-1",
+		StewardID:    "steward-b-1",
+		TenantID:     "tenant-b",
+		TokenStr:     "tok-b",
+		SourceIP:     "10.0.0.1",
+		RegisteredAt: time.Now().UTC(),
+		ExpiresAt:    time.Now().UTC().Add(24 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
+	}
+	require.NoError(t, pendingStore.AddPending(ctx, entryB))
+
+	// Seed a pending entry for tenant-a.
+	entryA := &business.PendingRegistrationEntry{
+		PendingID:    "pending-a-1",
+		StewardID:    "steward-a-1",
+		TenantID:     "tenant-a",
+		TokenStr:     "tok-a",
+		SourceIP:     "10.0.1.1",
+		RegisteredAt: time.Now().UTC(),
+		ExpiresAt:    time.Now().UTC().Add(24 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
+	}
+	require.NoError(t, pendingStore.AddPending(ctx, entryA))
+
+	t.Run("list does not include tenant-b entries", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v1/registration/pending", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		server.handleListPendingRegistrations(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var entries []PendingRegistration
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+
+		for _, e := range entries {
+			assert.NotEqual(t, "tenant-b", e.TenantID,
+				"tenant-a caller must never see tenant-b pending registration")
+		}
+		// Exactly one entry should be visible: tenant-a's own.
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "tenant-a", entries[0].TenantID)
+	})
+
+	t.Run("tenant-a cannot approve tenant-b pending ID", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/registration/pending-b-1/approve", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"id": "pending-b-1"})
+		rec := httptest.NewRecorder()
+		server.handleApproveRegistration(rec, req)
+
+		// Must be 404 (no existence disclosure).
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("tenant-a cannot deny tenant-b pending ID", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/registration/pending-b-1/deny", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"id": "pending-b-1"})
+		rec := httptest.NewRecorder()
+		server.handleDenyRegistration(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("tenant-a can approve its own pending ID", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/registration/pending-a-1/approve", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"id": "pending-a-1"})
+		rec := httptest.NewRecorder()
+		server.handleApproveRegistration(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("unscoped admin sees all entries", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/pending", nil)
+		req = withAdminPrincipal(req)
+		rec := httptest.NewRecorder()
+		server.handleListPendingRegistrations(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var entries []PendingRegistration
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+		assert.GreaterOrEqual(t, len(entries), 2, "unscoped admin must see all tenants")
+	})
+}
+
+// TestF2_RegistrationTokenTenantScope verifies that a tenant-A caller cannot list or get
+// tenant-B's tokens, and that list/get responses never contain the full raw secret
+// (Issue #2932 F2 contract test).
+func TestF2_RegistrationTokenTenantScope(t *testing.T) {
+	server, _, tokenStore, _ := newTenantScopeTestServer(t)
+	ctx := context.Background()
+
+	// Create a token for tenant-b.
+	tokB, err := registration.CreateToken(&registration.TokenCreateRequest{
+		TenantID:      "tenant-b",
+		ControllerURL: "grpc://controller.example.com:7443",
+		Group:         "group-b",
+	})
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.SaveToken(ctx, tokB))
+
+	// Create a token for tenant-a.
+	tokA, err := registration.CreateToken(&registration.TokenCreateRequest{
+		TenantID:      "tenant-a",
+		ControllerURL: "grpc://controller.example.com:7443",
+		Group:         "group-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.SaveToken(ctx, tokA))
+
+	t.Run("tenant-a list does not include tenant-b tokens", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/tokens", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		rec := httptest.NewRecorder()
+		server.handleListRegistrationTokens(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp TokenListResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+		for _, tok := range resp.Tokens {
+			assert.NotEqual(t, "tenant-b", tok.TenantID,
+				"tenant-a caller must never see tenant-b tokens")
+		}
+	})
+
+	t.Run("listed token body contains no raw secret", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/tokens", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		rec := httptest.NewRecorder()
+		server.handleListRegistrationTokens(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		body := rec.Body.String()
+
+		var resp TokenListResponse
+		require.NoError(t, json.Unmarshal([]byte(body), &resp))
+
+		for _, tok := range resp.Tokens {
+			// The full token secret must not appear in the JSON response body.
+			assert.False(t, strings.Contains(body, tokA.Token),
+				"list response must not contain the raw token secret")
+			// Token field in the response must be empty.
+			assert.Empty(t, tok.Token, "Token field must not be set in list response")
+			// TokenPrefix must be present and be the first 6 chars.
+			assert.NotEmpty(t, tok.TokenPrefix)
+			if len(tokA.Token) >= 6 {
+				assert.Equal(t, tokA.Token[:6], tok.TokenPrefix)
+			}
+		}
+	})
+
+	t.Run("tenant-a cannot get tenant-b token by its secret", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/tokens/"+tokB.Token, nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"token": tokB.Token})
+		rec := httptest.NewRecorder()
+		server.handleGetRegistrationToken(rec, req)
+
+		// 404 to avoid existence disclosure.
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("get response contains no raw secret", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/tokens/"+tokA.Token, nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"token": tokA.Token})
+		rec := httptest.NewRecorder()
+		server.handleGetRegistrationToken(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp TokenResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+		assert.Empty(t, resp.Token, "Token field must not be set in get response")
+		assert.NotEmpty(t, resp.TokenPrefix)
+		assert.False(t, strings.Contains(rec.Body.String(), tokA.Token),
+			"get response must not contain the raw token secret")
+	})
+
+	t.Run("unscoped admin sees all tokens in list", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/tokens", nil)
+		req = withAdminPrincipal(req)
+		rec := httptest.NewRecorder()
+		server.handleListRegistrationTokens(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp TokenListResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.GreaterOrEqual(t, resp.Total, 2, "unscoped admin must see all tenant tokens")
+	})
+
+	t.Run("tenant-a cannot create a token for tenant-b", func(t *testing.T) {
+		body, _ := json.Marshal(registration.TokenCreateRequest{
+			TenantID:      "tenant-b",
+			ControllerURL: "grpc://controller.example.com:7443",
+		})
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withScopedPrincipal(req, "tenant-a")
+		rec := httptest.NewRecorder()
+		server.handleCreateRegistrationToken(rec, req)
+
+		// Outside-subtree target is forbidden (403), and no token is minted for tenant-b.
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		listed, err := tokenStore.ListTokens(ctx, "tenant-b")
+		require.NoError(t, err)
+		assert.Len(t, listed, 1, "tenant-b must still have only its original token")
+	})
+
+	t.Run("tenant-a can create a token within its own subtree", func(t *testing.T) {
+		body, _ := json.Marshal(registration.TokenCreateRequest{
+			TenantID:      "tenant-a/child",
+			ControllerURL: "grpc://controller.example.com:7443",
+		})
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withScopedPrincipal(req, "tenant-a")
+		rec := httptest.NewRecorder()
+		server.handleCreateRegistrationToken(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+	})
+
+	t.Run("tenant-a cannot delete tenant-b token", func(t *testing.T) {
+		req := httptest.NewRequest("DELETE", "/api/v1/registration/tokens/"+tokB.Token, nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"token": tokB.Token})
+		rec := httptest.NewRecorder()
+		server.handleDeleteRegistrationToken(rec, req)
+
+		// 404 to avoid existence disclosure, and tenant-b's token survives.
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		_, err := tokenStore.GetToken(ctx, tokB.Token)
+		assert.NoError(t, err, "tenant-b token must not be deleted by a tenant-a caller")
+	})
+
+	t.Run("tenant-a cannot revoke tenant-b token", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/"+tokB.Token+"/revoke", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"token": tokB.Token})
+		rec := httptest.NewRecorder()
+		server.handleRevokeRegistrationToken(rec, req)
+
+		// 404 to avoid existence disclosure, and tenant-b's token stays active.
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		got, err := tokenStore.GetToken(ctx, tokB.Token)
+		require.NoError(t, err)
+		assert.False(t, got.Revoked, "tenant-b token must not be revoked by a tenant-a caller")
+	})
+
+	t.Run("tenant-a cannot rotate tokens for tenant-b", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/tenant-b/rotate", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"tenant_id": "tenant-b"})
+		rec := httptest.NewRecorder()
+		server.handleRotateRegistrationToken(rec, req)
+
+		// Outside-subtree target is forbidden (403), and tenant-b's token is untouched.
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		got, err := tokenStore.GetToken(ctx, tokB.Token)
+		require.NoError(t, err)
+		assert.False(t, got.Revoked, "tenant-b token must not be rotated by a tenant-a caller")
+	})
+
+	t.Run("tenant-a can rotate tokens within its own subtree", func(t *testing.T) {
+		// Seed an active groupless token for tenant-a so rotation has something to rotate.
+		seed, err := registration.CreateToken(&registration.TokenCreateRequest{
+			TenantID:      "tenant-a",
+			ControllerURL: "grpc://controller.example.com:7443",
+		})
+		require.NoError(t, err)
+		require.NoError(t, tokenStore.SaveToken(ctx, seed))
+
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/tenant-a/rotate", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"tenant_id": "tenant-a"})
+		rec := httptest.NewRecorder()
+		server.handleRotateRegistrationToken(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+	})
+}
+
+// TestF3_IPTrustTenantScope verifies that a tenant-A caller cannot list, add, or revoke
+// tenant-B's IP trust ranges (Issue #2932 F3 contract test).
+func TestF3_IPTrustTenantScope(t *testing.T) {
+	server, _, _, ipStore := newTenantScopeTestServer(t)
+	ctx := context.Background()
+
+	// Seed a trusted range for tenant-b.
+	require.NoError(t, ipStore.AddTrustedRange(ctx, "tenant-b", "192.168.1.0/24", true))
+	// Seed a trusted range for tenant-a.
+	require.NoError(t, ipStore.AddTrustedRange(ctx, "tenant-a", "10.0.0.0/8", false))
+
+	t.Run("list returns only tenant-a ranges for tenant-a caller", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/ip-trust", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		rec := httptest.NewRecorder()
+		server.handleListIPTrust(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var envelope struct {
+			Data []IPTrustEntryResponse `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+
+		for _, e := range envelope.Data {
+			assert.NotEqual(t, "tenant-b", e.TenantID,
+				"tenant-a caller must never see tenant-b ip-trust ranges")
+		}
+	})
+
+	t.Run("tenant-a cannot add a range for tenant-b", func(t *testing.T) {
+		body, _ := json.Marshal(addIPTrustRequest{TenantID: "tenant-b", CIDR: "172.16.0.0/12"})
+		req := httptest.NewRequest("POST", "/api/v1/registration/ip-trust", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withScopedPrincipal(req, "tenant-a")
+		rec := httptest.NewRecorder()
+		server.handleAddIPTrust(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("tenant-a cannot revoke tenant-b's range", func(t *testing.T) {
+		req := httptest.NewRequest("DELETE", "/api/v1/registration/ip-trust/tenant-b/192.168.1.0/24", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"tenant_id": "tenant-b", "cidr": "192.168.1.0/24"})
+		rec := httptest.NewRecorder()
+		server.handleRevokeIPTrust(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("tenant-a can revoke its own range", func(t *testing.T) {
+		req := httptest.NewRequest("DELETE", "/api/v1/registration/ip-trust/tenant-a/10.0.0.0/8", nil)
+		req = withScopedPrincipal(req, "tenant-a")
+		req = mux.SetURLVars(req, map[string]string{"tenant_id": "tenant-a", "cidr": "10.0.0.0/8"})
+		rec := httptest.NewRecorder()
+		server.handleRevokeIPTrust(rec, req)
+
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+	})
+
+	t.Run("unscoped admin can list any tenant by query param", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/ip-trust?tenant_id=tenant-b", nil)
+		req = withAdminPrincipal(req)
+		rec := httptest.NewRecorder()
+		server.handleListIPTrust(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var envelope struct {
+			Data []IPTrustEntryResponse `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+		assert.NotEmpty(t, envelope.Data, "unscoped admin with tenant_id=tenant-b must see tenant-b ranges")
+	})
+
+	t.Run("unscoped admin without tenant_id returns 400", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/registration/ip-trust", nil)
+		req = withAdminPrincipal(req)
+		rec := httptest.NewRecorder()
+		server.handleListIPTrust(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -492,10 +492,12 @@ func TestHandleListPendingRegistrations(t *testing.T) {
 
 	t.Run("returns pending entries from durable store", func(t *testing.T) {
 		now := time.Now().UTC()
+		// Use the same TenantID as the API key created in newRegistrationApprovalServer
+		// ("default") so the scoped list returns this entry (Issue #2932 tenant scoping).
 		entry := &business.PendingRegistrationEntry{
 			PendingID:    "pending-list-test-1",
 			StewardID:    "steward-list-test-1",
-			TenantID:     "tenant-a",
+			TenantID:     "default",
 			TokenStr:     "tok-list-1",
 			SourceIP:     "192.168.1.1",
 			RegisteredAt: now,
@@ -514,7 +516,7 @@ func TestHandleListPendingRegistrations(t *testing.T) {
 		require.Len(t, pending, 1)
 		assert.Equal(t, "pending-list-test-1", pending[0].PendingID)
 		assert.Equal(t, "steward-list-test-1", pending[0].StewardID)
-		assert.Equal(t, "tenant-a", pending[0].TenantID)
+		assert.Equal(t, "default", pending[0].TenantID)
 		assert.Equal(t, "192.168.1.1", pending[0].SourceIP)
 	})
 }
@@ -709,7 +711,8 @@ func TestHandleDenyRegistration(t *testing.T) {
 	}
 
 	t.Run("happy path - marks entry as denied in durable store", func(t *testing.T) {
-		addEntry(t, "pending-deny-1", "steward-deny-1", "tenant-b", "10.0.0.2")
+		// "default" matches the API key's TenantID (Issue #2932: deny enforces caller subtree).
+		addEntry(t, "pending-deny-1", "steward-deny-1", "default", "10.0.0.2")
 
 		resp := makeDeny(t, "pending-deny-1", "")
 		defer func() { _ = resp.Body.Close() }()
@@ -722,7 +725,7 @@ func TestHandleDenyRegistration(t *testing.T) {
 	})
 
 	t.Run("deny with reason - marks entry as denied", func(t *testing.T) {
-		addEntry(t, "pending-deny-2", "steward-deny-2", "tenant-b", "10.0.0.3")
+		addEntry(t, "pending-deny-2", "steward-deny-2", "default", "10.0.0.3")
 
 		resp := makeDeny(t, "pending-deny-2", `{"reason":"Unauthorized deployment"}`)
 		defer func() { _ = resp.Body.Close() }()

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -9,13 +9,18 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
-// TokenResponse represents a registration token in API responses
+// TokenResponse represents a registration token in API responses.
+// Token (full secret) is only populated by create and rotate responses.
+// All other endpoints (list, get, revoke) set TokenPrefix only.
 type TokenResponse struct {
-	Token         string  `json:"token"`
+	Token         string  `json:"token,omitempty"`        // full secret — create/rotate only
+	TokenPrefix   string  `json:"token_prefix,omitempty"` // first 6 chars — always set
 	TenantID      string  `json:"tenant_id"`
 	ControllerURL string  `json:"controller_url"`
 	Group         string  `json:"group,omitempty"`
@@ -73,6 +78,17 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Tenant subtree enforcement: scoped callers may only create tokens for tenants
+	// within their own subtree. Unscoped (mTLS admin) callers have no restriction.
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := req.TenantID == callerTenant || strings.HasPrefix(req.TenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "forbidden: target tenant is outside caller's tenant subtree", http.StatusForbidden)
+			return
+		}
+	}
+
 	// Check if registration token store is available
 	if s.registrationTokenStore == nil {
 		s.logger.Error("Registration token store not available")
@@ -98,8 +114,10 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 	s.logger.Info("Created registration token",
 		"token_prefix", token.Token[:min(len(token.Token), 6)],
 		"tenant_id", logging.SanitizeLogValue(token.TenantID))
+	s.emitTokenManagementAudit(r, "registration_token.created",
+		token.Token[:min(len(token.Token), 6)], token.TenantID)
 
-	// Return token response
+	// Return full token response — create is the one-time mint window where the secret is disclosed.
 	resp := tokenToResponse(token)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -122,8 +140,13 @@ func (s *Server) handleListRegistrationTokens(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Get tenant_id from query parameter (optional filter)
-	tenantID := r.URL.Query().Get("tenant_id")
+	// Tenant scoping: scoped callers always see only their own tenant (query param is ignored).
+	// Unscoped (mTLS admin) callers may supply ?tenant_id= to narrow the result.
+	callerTenant := s.callerTenantID(r)
+	tenantID := callerTenant
+	if tenantID == "" {
+		tenantID = r.URL.Query().Get("tenant_id")
+	}
 
 	// List tokens
 	tokens, err := s.registrationTokenStore.ListTokens(r.Context(), tenantID)
@@ -133,13 +156,13 @@ func (s *Server) handleListRegistrationTokens(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Convert to response format
+	// Convert to redacted response format — list callers never receive the full secret.
 	resp := TokenListResponse{
 		Tokens: make([]TokenResponse, 0, len(tokens)),
 		Total:  len(tokens),
 	}
 	for _, token := range tokens {
-		resp.Tokens = append(resp.Tokens, tokenToResponse(token))
+		resp.Tokens = append(resp.Tokens, tokenToResponseRedacted(token))
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -182,8 +205,19 @@ func (s *Server) handleGetRegistrationToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Return token response
-	resp := tokenToResponse(token)
+	// Tenant subtree enforcement: scoped callers may not read tokens from other tenants.
+	// 404 (not 403) avoids existence disclosure across tenant boundaries.
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := token.TenantID == callerTenant || strings.HasPrefix(token.TenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "Token not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	// Return redacted response — get callers never receive the full secret.
+	resp := tokenToResponseRedacted(token)
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.logger.Error("Failed to encode token response", "error", err)
@@ -212,6 +246,28 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Look up the token first for tenant scope enforcement and audit.
+	token, err := s.registrationTokenStore.GetToken(r.Context(), tokenStr)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			http.Error(w, "Token not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to get registration token for delete", "error", err)
+		http.Error(w, "Failed to delete token", http.StatusInternalServerError)
+		return
+	}
+
+	// Tenant subtree enforcement: scoped callers may not delete tokens from other tenants.
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := token.TenantID == callerTenant || strings.HasPrefix(token.TenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "Token not found", http.StatusNotFound)
+			return
+		}
+	}
+
 	// Delete token from store
 	if err := s.registrationTokenStore.DeleteToken(r.Context(), tokenStr); err != nil {
 		if strings.Contains(err.Error(), "not found") {
@@ -223,7 +279,9 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	s.logger.Info("Deleted registration token", "token_prefix", tokenStr[:min(len(tokenStr), 6)])
+	tokenPrefix := tokenStr[:min(len(tokenStr), 6)]
+	s.logger.Info("Deleted registration token", "token_prefix", tokenPrefix)
+	s.emitTokenManagementAudit(r, "registration_token.deleted", tokenPrefix, token.TenantID)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -262,6 +320,16 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Tenant subtree enforcement: scoped callers may not revoke tokens from other tenants.
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := token.TenantID == callerTenant || strings.HasPrefix(token.TenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "Token not found", http.StatusNotFound)
+			return
+		}
+	}
+
 	// Revoke the token
 	token.Revoke()
 
@@ -272,10 +340,12 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	s.logger.Info("Revoked registration token", "token_prefix", tokenStr[:min(len(tokenStr), 6)])
+	tokenPrefix := tokenStr[:min(len(tokenStr), 6)]
+	s.logger.Info("Revoked registration token", "token_prefix", tokenPrefix)
+	s.emitTokenManagementAudit(r, "registration_token.revoked", tokenPrefix, token.TenantID)
 
-	// Return updated token
-	resp := tokenToResponse(token)
+	// Return redacted response — revoke callers do not receive the raw secret.
+	resp := tokenToResponseRedacted(token)
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.logger.Error("Failed to encode token response", "error", err)
@@ -299,6 +369,17 @@ func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Tenant subtree enforcement: scoped callers may only rotate tokens for tenants
+	// within their own subtree.
+	callerTenant := s.callerTenantID(r)
+	if callerTenant != "" {
+		inSubtree := tenantID == callerTenant || strings.HasPrefix(tenantID, callerTenant+"/")
+		if !inSubtree {
+			http.Error(w, "forbidden: target tenant is outside caller's tenant subtree", http.StatusForbidden)
+			return
+		}
+	}
+
 	// Parse optional request body for group filter
 	var req rotateTokenRequest
 	if r.ContentLength > 0 {
@@ -319,10 +400,13 @@ func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	tokenPrefix := newToken.Token[:min(len(newToken.Token), 6)]
 	s.logger.Info("Rotated registration token",
-		"token_prefix", newToken.Token[:min(len(newToken.Token), 6)],
+		"token_prefix", tokenPrefix,
 		"tenant_id", logging.SanitizeLogValue(tenantID))
+	s.emitTokenManagementAudit(r, "registration_token.rotated", tokenPrefix, tenantID)
 
+	// Return full token response — rotate is a mint window where the new secret is disclosed once.
 	resp := tokenToResponse(newToken)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -331,10 +415,12 @@ func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 }
 
-// tokenToResponse converts a registration.Token to TokenResponse
+// tokenToResponse converts a registration.Token to TokenResponse including the full secret.
+// Use ONLY for create and rotate responses where the secret must be returned once.
 func tokenToResponse(token *registration.Token) TokenResponse {
 	resp := TokenResponse{
 		Token:         token.Token,
+		TokenPrefix:   token.Token[:min(len(token.Token), 6)],
 		TenantID:      token.TenantID,
 		ControllerURL: token.ControllerURL,
 		Group:         token.Group,
@@ -353,4 +439,42 @@ func tokenToResponse(token *registration.Token) TokenResponse {
 	}
 
 	return resp
+}
+
+// tokenToResponseRedacted converts a registration.Token to TokenResponse WITHOUT the full secret.
+// Use for list, get, and revoke responses — callers must never see the raw token outside of
+// the create/rotate mint window.
+func tokenToResponseRedacted(token *registration.Token) TokenResponse {
+	resp := tokenToResponse(token)
+	resp.Token = "" // never expose the secret in list/get/revoke responses
+	return resp
+}
+
+// emitTokenManagementAudit records an audit event for a token management action
+// (create, rotate, revoke, delete). It is a no-op when auditManager is nil.
+func (s *Server) emitTokenManagementAudit(r *http.Request, action, tokenPrefix, tenantID string) {
+	if s.auditManager == nil {
+		return
+	}
+	auditTenantID := tenantID
+	if auditTenantID == "" {
+		auditTenantID = audit.SystemTenantID
+	}
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	principalID := ""
+	if principal != nil {
+		principalID = principal.ID
+	}
+	b := audit.NewEventBuilder().
+		Tenant(auditTenantID).
+		Type(business.AuditEventSystemAccess).
+		Action(action).
+		User(principalID, business.AuditUserTypeHuman).
+		Resource("registration_token", tokenPrefix, "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityHigh)
+	if err := s.auditManager.RecordEvent(r.Context(), b); err != nil {
+		s.logger.Warn("Failed to emit token management audit event",
+			"error", err, "action", action)
+	}
 }

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -279,9 +279,7 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Slice first, then sanitize, so the sanitizer output flows directly into the sink.
-	// CodeQL's ReplaceSanitizer barrier attaches to the SanitizeLogValue result node and
-	// does not survive an intervening string-slice, so sanitizing last clears the taint.
+	// SanitizeLogValue wraps strings.ReplaceAll so CodeQL's ReplaceSanitizer clears the taint.
 	tokenPrefix := logging.SanitizeLogValue(tokenStr[:min(len(tokenStr), 6)])
 	s.logger.Info("Deleted registration token", "token_prefix", tokenPrefix)
 	s.emitTokenManagementAudit(r, "registration_token.deleted", tokenPrefix, token.TenantID)
@@ -343,9 +341,7 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Slice first, then sanitize, so the sanitizer output flows directly into the sink.
-	// CodeQL's ReplaceSanitizer barrier attaches to the SanitizeLogValue result node and
-	// does not survive an intervening string-slice, so sanitizing last clears the taint.
+	// SanitizeLogValue wraps strings.ReplaceAll so CodeQL's ReplaceSanitizer clears the taint.
 	tokenPrefix := logging.SanitizeLogValue(tokenStr[:min(len(tokenStr), 6)])
 	s.logger.Info("Revoked registration token", "token_prefix", tokenPrefix)
 	s.emitTokenManagementAudit(r, "registration_token.revoked", tokenPrefix, token.TenantID)

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -280,7 +280,7 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 
 	tokenPrefix := tokenStr[:min(len(tokenStr), 6)]
-	s.logger.Info("Deleted registration token", "token_prefix", tokenPrefix)
+	s.logger.Info("Deleted registration token", "token_prefix", logging.SanitizeLogValue(tokenPrefix))
 	s.emitTokenManagementAudit(r, "registration_token.deleted", tokenPrefix, token.TenantID)
 
 	w.WriteHeader(http.StatusNoContent)
@@ -341,7 +341,7 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 
 	tokenPrefix := tokenStr[:min(len(tokenStr), 6)]
-	s.logger.Info("Revoked registration token", "token_prefix", tokenPrefix)
+	s.logger.Info("Revoked registration token", "token_prefix", logging.SanitizeLogValue(tokenPrefix))
 	s.emitTokenManagementAudit(r, "registration_token.revoked", tokenPrefix, token.TenantID)
 
 	// Return redacted response — revoke callers do not receive the raw secret.

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -279,8 +279,11 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	tokenPrefix := tokenStr[:min(len(tokenStr), 6)]
-	s.logger.Info("Deleted registration token", "token_prefix", logging.SanitizeLogValue(tokenPrefix))
+	// Slice first, then sanitize, so the sanitizer output flows directly into the sink.
+	// CodeQL's ReplaceSanitizer barrier attaches to the SanitizeLogValue result node and
+	// does not survive an intervening string-slice, so sanitizing last clears the taint.
+	tokenPrefix := logging.SanitizeLogValue(tokenStr[:min(len(tokenStr), 6)])
+	s.logger.Info("Deleted registration token", "token_prefix", tokenPrefix)
 	s.emitTokenManagementAudit(r, "registration_token.deleted", tokenPrefix, token.TenantID)
 
 	w.WriteHeader(http.StatusNoContent)
@@ -340,8 +343,11 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	tokenPrefix := tokenStr[:min(len(tokenStr), 6)]
-	s.logger.Info("Revoked registration token", "token_prefix", logging.SanitizeLogValue(tokenPrefix))
+	// Slice first, then sanitize, so the sanitizer output flows directly into the sink.
+	// CodeQL's ReplaceSanitizer barrier attaches to the SanitizeLogValue result node and
+	// does not survive an intervening string-slice, so sanitizing last clears the taint.
+	tokenPrefix := logging.SanitizeLogValue(tokenStr[:min(len(tokenStr), 6)])
+	s.logger.Info("Revoked registration token", "token_prefix", tokenPrefix)
 	s.emitTokenManagementAudit(r, "registration_token.revoked", tokenPrefix, token.TenantID)
 
 	// Return redacted response — revoke callers do not receive the raw secret.

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -278,7 +278,9 @@ func TestListRegistrationTokens(t *testing.T) {
 	err = tokenStore.SaveToken(ctx, otherToken)
 	require.NoError(t, err)
 
-	t.Run("list all tokens", func(t *testing.T) {
+	t.Run("list all tokens — scoped caller sees only own tenant", func(t *testing.T) {
+		// apiKey is scoped to "test-tenant" (via NewTestKey). After Issue #2932, scoped callers
+		// always see only their own tenant's tokens regardless of any query param.
 		req := httptest.NewRequest("GET", "/api/v1/registration/tokens", nil)
 		req.Header.Set("X-API-Key", apiKey)
 		rec := httptest.NewRecorder()
@@ -291,11 +293,18 @@ func TestListRegistrationTokens(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &resp)
 		require.NoError(t, err)
 
-		assert.Equal(t, 4, resp.Total)
-		assert.Len(t, resp.Tokens, 4)
+		// Scoped caller sees only the 3 "test-tenant" tokens, not the "other-tenant" one.
+		assert.Equal(t, 3, resp.Total)
+		assert.Len(t, resp.Tokens, 3)
+		for _, tok := range resp.Tokens {
+			assert.Equal(t, "test-tenant", tok.TenantID)
+			assert.Empty(t, tok.Token, "list response must not include the raw secret")
+			assert.NotEmpty(t, tok.TokenPrefix, "list response must include token_prefix")
+		}
 	})
 
 	t.Run("filter by tenant_id", func(t *testing.T) {
+		// Scoped caller: query param is ignored; they still see their own tenant tokens.
 		req := httptest.NewRequest("GET", "/api/v1/registration/tokens?tenant_id=test-tenant", nil)
 		req.Header.Set("X-API-Key", apiKey)
 		rec := httptest.NewRecorder()
@@ -316,7 +325,9 @@ func TestListRegistrationTokens(t *testing.T) {
 		}
 	})
 
-	t.Run("filter returns empty for non-existent tenant", func(t *testing.T) {
+	t.Run("scoped caller ignores tenant_id query param — sees own tenant only", func(t *testing.T) {
+		// Before Issue #2932: scoped caller with ?tenant_id=nonexistent returned 0 entries.
+		// After: scoped caller ignores the query param and returns their own tenant's tokens.
 		req := httptest.NewRequest("GET", "/api/v1/registration/tokens?tenant_id=nonexistent", nil)
 		req.Header.Set("X-API-Key", apiKey)
 		rec := httptest.NewRecorder()
@@ -329,8 +340,11 @@ func TestListRegistrationTokens(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &resp)
 		require.NoError(t, err)
 
-		assert.Equal(t, 0, resp.Total)
-		assert.Len(t, resp.Tokens, 0)
+		// The query param is ignored; the scoped key's own tenant (test-tenant) is used.
+		assert.Equal(t, 3, resp.Total)
+		for _, tok := range resp.Tokens {
+			assert.Equal(t, "test-tenant", tok.TenantID)
+		}
 	})
 
 	t.Run("unauthorized without API key", func(t *testing.T) {
@@ -373,7 +387,9 @@ func TestGetRegistrationToken(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &resp)
 		require.NoError(t, err)
 
-		assert.Equal(t, token.Token, resp.Token)
+		// After Issue #2932: GET redacts the token secret; only token_prefix is returned.
+		assert.Empty(t, resp.Token, "GET response must not include the raw token secret")
+		assert.Equal(t, token.Token[:6], resp.TokenPrefix, "GET response must include the first 6 chars as token_prefix")
 		assert.Equal(t, "test-tenant", resp.TenantID)
 		assert.Equal(t, "grpc://controller.example.com:7443", resp.ControllerURL)
 		assert.Equal(t, "test-group", resp.Group)
@@ -605,14 +621,16 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 
 		assert.GreaterOrEqual(t, resp.Total, 1)
 
+		// After Issue #2932: list responses redact the token secret; match by TokenPrefix.
+		wantPrefix := createdToken[:6]
 		found := false
 		for _, token := range resp.Tokens {
-			if token.Token == createdToken {
+			if token.TokenPrefix == wantPrefix {
 				found = true
 				break
 			}
 		}
-		assert.True(t, found, "Created token should be in the list")
+		assert.True(t, found, "Created token should be in the list (matched by token_prefix)")
 	})
 
 	// 3. Get specific token (Tier-1)
@@ -628,7 +646,9 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &resp)
 		require.NoError(t, err)
 
-		assert.Equal(t, createdToken, resp.Token)
+		// After Issue #2932: GET redacts the token secret; verify via token_prefix.
+		assert.Empty(t, resp.Token, "GET response must not include the raw token secret")
+		assert.Equal(t, createdToken[:6], resp.TokenPrefix, "GET response must include the first 6 chars as token_prefix")
 		assert.Equal(t, "crud-test-tenant", resp.TenantID)
 		assert.Equal(t, "crud-test-group", resp.Group)
 		assert.False(t, resp.Revoked)
@@ -690,12 +710,10 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 
 func TestTokenResponseFormat(t *testing.T) {
 	server, tokenStore := setupTestServerWithTokenStore(t)
-
-	// Create API key with read permission
-	apiKey := NewTestKey(t, server, []string{"registration:read-token"})
 	ctx := context.Background()
 
-	// Create a token with all fields populated
+	// Create a token with all fields populated.
+	// Use the token's literal value as the raw secret (len >= 6 required for prefix check).
 	now := time.Now()
 	expiresAt := now.Add(24 * time.Hour)
 	revokedAt := now.Add(2 * time.Hour)
@@ -714,8 +732,9 @@ func TestTokenResponseFormat(t *testing.T) {
 	err := tokenStore.SaveToken(ctx, token)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", "/api/v1/registration/tokens/"+token.Token, nil)
-	req.Header.Set("X-API-Key", apiKey)
+	// Use an unscoped mTLS admin request: "format-test-tenant" is outside "test-tenant"
+	// so a scoped API key would receive 404 after Issue #2932's tenant-scope enforcement.
+	req := makeAdminRequest(t, "GET", "/api/v1/registration/tokens/"+token.Token, nil)
 	rec := httptest.NewRecorder()
 
 	server.router.ServeHTTP(rec, req)
@@ -726,8 +745,9 @@ func TestTokenResponseFormat(t *testing.T) {
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
 	require.NoError(t, err)
 
-	// Verify all fields are present and correctly formatted
-	assert.Equal(t, "testformat123", resp.Token)
+	// After Issue #2932: GET redacts the token secret; token_prefix (first 6 chars) is returned.
+	assert.Empty(t, resp.Token, "GET response must not include the raw token secret")
+	assert.Equal(t, token.Token[:6], resp.TokenPrefix, "token_prefix should be the first 6 chars of the secret")
 	assert.Equal(t, "format-test-tenant", resp.TenantID)
 	assert.Equal(t, "grpc://controller.example.com:7443", resp.ControllerURL)
 	assert.Equal(t, "format-group", resp.Group)

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -759,4 +760,146 @@ func TestTokenResponseFormat(t *testing.T) {
 	// Verify timestamps are ISO 8601 format
 	_, err = time.Parse(time.RFC3339, resp.CreatedAt)
 	assert.NoError(t, err, "CreatedAt should be RFC3339 format")
+}
+
+// findAuditEntryByAction returns the first entry whose Action matches, or fails the test.
+func findAuditEntryByAction(t *testing.T, entries []*business.AuditEntry, action string) *business.AuditEntry {
+	t.Helper()
+	for _, e := range entries {
+		if e.Action == action {
+			return e
+		}
+	}
+	t.Fatalf("no audit entry with action %q found among %d entries", action, len(entries))
+	return nil
+}
+
+// The four token-management mutation handlers (create, delete, revoke, rotate) each
+// emit a durable audit event via emitTokenManagementAudit. These tests flush the audit
+// manager and assert the event actually reaches the store with the correct action,
+// tenant, and resource fields — mirroring the register-path assertions in
+// handlers_registration_test.go.
+
+func TestCreateRegistrationToken_EmitsAuditEvent(t *testing.T) {
+	server, _ := setupTestServerWithTokenStore(t)
+	ctx := context.Background()
+
+	reqBody := registration.TokenCreateRequest{
+		TenantID:      "audit-tenant",
+		ControllerURL: "grpc://controller.example.com:7443",
+	}
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp TokenResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Token)
+
+	require.NoError(t, server.auditManager.Flush(ctx))
+	entries, err := server.auditManager.QueryEntries(ctx, &business.AuditFilter{TenantID: "audit-tenant"})
+	require.NoError(t, err)
+
+	entry := findAuditEntryByAction(t, entries, "registration_token.created")
+	assert.Equal(t, "audit-tenant", entry.TenantID)
+	assert.Equal(t, "registration_token", entry.ResourceType)
+	assert.Equal(t, resp.Token[:6], entry.ResourceID, "audit resource must record the token prefix")
+	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
+	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
+}
+
+func TestDeleteRegistrationToken_EmitsAuditEvent(t *testing.T) {
+	server, tokenStore := setupTestServerWithTokenStore(t)
+	ctx := context.Background()
+
+	token, err := registration.CreateToken(&registration.TokenCreateRequest{
+		TenantID:      "audit-tenant",
+		ControllerURL: "grpc://controller.example.com:7443",
+	})
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.SaveToken(ctx, token))
+
+	req := makeAdminRequest(t, "DELETE", "/api/v1/registration/tokens/"+token.Token, nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.NoError(t, server.auditManager.Flush(ctx))
+	entries, err := server.auditManager.QueryEntries(ctx, &business.AuditFilter{TenantID: "audit-tenant"})
+	require.NoError(t, err)
+
+	entry := findAuditEntryByAction(t, entries, "registration_token.deleted")
+	assert.Equal(t, "audit-tenant", entry.TenantID)
+	assert.Equal(t, "registration_token", entry.ResourceType)
+	assert.Equal(t, token.Token[:6], entry.ResourceID, "audit resource must record the token prefix")
+	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
+	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
+}
+
+func TestRevokeRegistrationToken_EmitsAuditEvent(t *testing.T) {
+	server, tokenStore := setupTestServerWithTokenStore(t)
+	ctx := context.Background()
+
+	token, err := registration.CreateToken(&registration.TokenCreateRequest{
+		TenantID:      "audit-tenant",
+		ControllerURL: "grpc://controller.example.com:7443",
+	})
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.SaveToken(ctx, token))
+
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/"+token.Token+"/revoke", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, server.auditManager.Flush(ctx))
+	entries, err := server.auditManager.QueryEntries(ctx, &business.AuditFilter{TenantID: "audit-tenant"})
+	require.NoError(t, err)
+
+	entry := findAuditEntryByAction(t, entries, "registration_token.revoked")
+	assert.Equal(t, "audit-tenant", entry.TenantID)
+	assert.Equal(t, "registration_token", entry.ResourceType)
+	assert.Equal(t, token.Token[:6], entry.ResourceID, "audit resource must record the token prefix")
+	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
+	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
+}
+
+func TestRotateRegistrationToken_EmitsAuditEvent(t *testing.T) {
+	server, tokenStore := setupTestServerWithTokenStore(t)
+	ctx := context.Background()
+
+	seed, err := registration.CreateToken(&registration.TokenCreateRequest{
+		TenantID:      "audit-tenant",
+		ControllerURL: "grpc://controller.example.com:7443",
+		Group:         "rotate-group",
+	})
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.SaveToken(ctx, seed))
+
+	body := []byte(`{"group":"rotate-group"}`)
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/audit-tenant/rotate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp TokenResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Token)
+
+	require.NoError(t, server.auditManager.Flush(ctx))
+	entries, err := server.auditManager.QueryEntries(ctx, &business.AuditFilter{TenantID: "audit-tenant"})
+	require.NoError(t, err)
+
+	entry := findAuditEntryByAction(t, entries, "registration_token.rotated")
+	assert.Equal(t, "audit-tenant", entry.TenantID)
+	assert.Equal(t, "registration_token", entry.ResourceType)
+	assert.Equal(t, resp.Token[:6], entry.ResourceID, "audit resource must record the new token prefix")
+	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
+	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
 }

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -56,7 +56,8 @@ var knownPermissions = map[string]bool{
 	"registration:list-pending": true,
 	"registration:approve":      true,
 	"registration:deny":         true,
-	// IP-trust management (Issue #1698)
+	// IP-trust management (Issue #1698, #2932)
+	"registration:list-ip-trust":   true,
 	"registration:manage-ip-trust": true,
 	// Monitoring
 	"monitoring:read-health":            true,

--- a/features/controller/api/route_registry_test.go
+++ b/features/controller/api/route_registry_test.go
@@ -131,6 +131,7 @@ var goldenRouteTable = []string{
 	"GET /api/v1/rbac/roles",
 	"GET /api/v1/rbac/roles/{id}",
 	"GET /api/v1/ready",
+	"GET /api/v1/registration/ip-trust",
 	"GET /api/v1/registration/pending",
 	"GET /api/v1/registration/status/{pending_id}",
 	"GET /api/v1/registration/tokens",

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -509,6 +509,7 @@ func (s *Server) setupRouter() {
 	// Bulk registration approval and IP-trust management (Issue #1698)
 	api.Handle("/registration/approve-all", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveAllRegistrations))).Methods("POST")
 	api.Handle("/registration/approve-by-cidr", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveByCIDR))).Methods("POST")
+	api.Handle("/registration/ip-trust", s.requirePermission("registration", "list-ip-trust")(http.HandlerFunc(s.handleListIPTrust))).Methods("GET")
 	api.Handle("/registration/ip-trust", s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleAddIPTrust))).Methods("POST")
 	// {cidr:.+} allows the CIDR slash to appear literally in the URL path after decoding.
 	api.Handle("/registration/ip-trust/{tenant_id}/{cidr:.+}", s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleRevokeIPTrust))).Methods("DELETE")


### PR DESCRIPTION
## Summary

- **F1 — Pending registrations**: `list`, `approve`, `deny`, `approve-all`, `approve-by-cidr` all enforce `callerTenantID`; cross-tenant access returns 404 (no existence disclosure); all mutations emit audit events
- **F2 — Registration tokens**: `list` and `get` redact the raw `token` field and expose only `token_prefix` (first 6 chars); `create` and `rotate` still return the full secret; all four mutations audit; cross-tenant reads return 404, cross-tenant writes return 403
- **F3 — IP-trust list**: new `GET /api/v1/registration/ip-trust` endpoint; scoped callers see their own tenant's ranges; unscoped admins must supply `?tenant_id=`; `add` and `revoke` enforce caller subtree (403); all mutations audit
- New `registration:list-ip-trust` permission added alongside `registration:manage-ip-trust`
- ADR-018 addendum documents the scoping rules for this cluster

## Test plan

- [ ] New contract tests in `handlers_registration_tenant_scope_test.go` cover all three feature areas (F1/F2/F3) for cross-tenant isolation
- [ ] Existing token and pending-registration tests updated to match new scoped/redacted behavior
- [ ] Route table parity test updated to include the new `GET /api/v1/registration/ip-trust` route
- [ ] `make test-agent-complete` passed (~95% of CI coverage, Docker-dependent tests deferred to CI)
- [ ] `make check-architecture` passes — no central provider violations
- [ ] `golangci-lint` clean — no formatting or vet issues
- [ ] story-review workflow: 2 rounds, 1 fix round, 0 remaining findings

Fixes #2932

🤖 Generated with [Claude Code](https://claude.com/claude-code)