### PR TITLE
dna: two-level Merkle hash — FragmentHash + AggregateRoot (Issue #2903)

### DIFF
--- a/features/steward/dna/hash.go
+++ b/features/steward/dna/hash.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package dna
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+)
+
+// FragmentHash returns the SHA-256 of canonicalBytes as a lowercase hex string.
+//
+// Full 32-byte digest — no truncation, no alternate digest size (ADR-017 §6,
+// SE threat #3).
+func FragmentHash(canonicalBytes []byte) string {
+	sum := sha256.Sum256(canonicalBytes)
+	return fmt.Sprintf("%x", sum[:])
+}
+
+// AggregateRoot computes the Merkle-style aggregate root over the manifest.
+//
+// The manifest is sorted by fragment_id (byte-wise, not locale-aware) before
+// hashing so the result is independent of input order (ADR-017 §6, SE threat #3).
+//
+// Injection-proof encoding: each (fragment_id, fragment_hash) pair is written
+// as two length-prefixed fields (uint32 BE length + bytes) so that differently-
+// split strings cannot produce the same byte stream.  Naive concatenation
+// ("ab"+"c" vs "a"+"bc") is explicitly closed by the length prefix.
+func AggregateRoot(manifest []*commonpb.ManifestEntry) (string, error) {
+	sorted := make([]*commonpb.ManifestEntry, len(manifest))
+	copy(sorted, manifest)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].GetFragmentId() < sorted[j].GetFragmentId()
+	})
+
+	h := sha256.New()
+	var lenBuf [4]byte
+	for _, entry := range sorted {
+		idBytes := []byte(entry.GetFragmentId())
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(idBytes)))
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write(idBytes)
+
+		hashBytes := []byte(entry.GetFragmentHash())
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(hashBytes)))
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write(hashBytes)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/features/steward/dna/hash_test.go
+++ b/features/steward/dna/hash_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
 )
 
 func TestComputeHash_NilAttributes(t *testing.T) {
@@ -79,4 +82,119 @@ func TestComputeHash_ProducesHexString(t *testing.T) {
 		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
 			"hash must be a lowercase hex string, got char: %c", c)
 	}
+}
+
+// --- FragmentHash tests ---
+
+func TestFragmentHash_KnownVector(t *testing.T) {
+	// SHA-256 of empty input is the well-known constant.
+	got := FragmentHash([]byte{})
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", got)
+}
+
+func TestFragmentHash_FullDigest(t *testing.T) {
+	// Full SHA-256 hex is 64 lowercase hex characters — no truncation.
+	hash := FragmentHash([]byte("some canonical bytes"))
+	assert.Len(t, hash, 64, "FragmentHash must return full 32-byte SHA-256 hex (64 chars)")
+	for _, c := range hash {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+			"FragmentHash must be lowercase hex, got char: %c", c)
+	}
+}
+
+func TestFragmentHash_Deterministic(t *testing.T) {
+	b := []byte("canonical fragment state")
+	assert.Equal(t, FragmentHash(b), FragmentHash(b), "same bytes must produce same hash")
+}
+
+func TestFragmentHash_DifferentInputs(t *testing.T) {
+	assert.NotEqual(t, FragmentHash([]byte("a")), FragmentHash([]byte("b")))
+}
+
+// --- AggregateRoot tests ---
+
+func TestAggregateRoot_Empty(t *testing.T) {
+	root, err := AggregateRoot(nil)
+	require.NoError(t, err)
+	// SHA-256 of zero bytes written to the hasher.
+	assert.Len(t, root, 64)
+}
+
+func TestAggregateRoot_Deterministic(t *testing.T) {
+	entries := []*commonpb.ManifestEntry{
+		{FragmentId: "file:/etc/hosts", FragmentHash: "aabbcc"},
+		{FragmentId: "service:sshd", FragmentHash: "112233"},
+	}
+	r1, err := AggregateRoot(entries)
+	require.NoError(t, err)
+	r2, err := AggregateRoot(entries)
+	require.NoError(t, err)
+	assert.Equal(t, r1, r2)
+}
+
+func TestAggregateRoot_OrderIndependent(t *testing.T) {
+	// Reordering input must not change the root — AggregateRoot sorts internally.
+	a := []*commonpb.ManifestEntry{
+		{FragmentId: "aaa", FragmentHash: "111"},
+		{FragmentId: "bbb", FragmentHash: "222"},
+		{FragmentId: "ccc", FragmentHash: "333"},
+	}
+	b := []*commonpb.ManifestEntry{
+		{FragmentId: "ccc", FragmentHash: "333"},
+		{FragmentId: "aaa", FragmentHash: "111"},
+		{FragmentId: "bbb", FragmentHash: "222"},
+	}
+	ra, err := AggregateRoot(a)
+	require.NoError(t, err)
+	rb, err := AggregateRoot(b)
+	require.NoError(t, err)
+	assert.Equal(t, ra, rb, "AggregateRoot must be order-independent")
+}
+
+func TestAggregateRoot_DifferentHashesSameIDs(t *testing.T) {
+	a := []*commonpb.ManifestEntry{{FragmentId: "x", FragmentHash: "000"}}
+	b := []*commonpb.ManifestEntry{{FragmentId: "x", FragmentHash: "fff"}}
+	ra, err := AggregateRoot(a)
+	require.NoError(t, err)
+	rb, err := AggregateRoot(b)
+	require.NoError(t, err)
+	assert.NotEqual(t, ra, rb, "different fragment hashes must produce different aggregate roots")
+}
+
+// TestAggregateRoot_InjectionProof is the REQUIRED SECURITY TEST (AC).
+//
+// Proves that the manifest-entry encoding is injection-proof at this second
+// concatenation site (SE threat #3).  Two manifests with differently-split
+// strings that would collide under naive id+hash concatenation must produce
+// different roots because each field is length-prefixed.
+//
+// Example collision under naive concatenation:
+//
+//	entry A: id="ab", hash="c"   → "ab" + "c"  = "abc"
+//	entry B: id="a",  hash="bc"  → "a"  + "bc" = "abc"
+//
+// Length-prefix encoding distinguishes them:
+//
+//	A: [0,0,0,2]"ab" [0,0,0,1]"c"
+//	B: [0,0,0,1]"a"  [0,0,0,2]"bc"
+func TestAggregateRoot_InjectionProof(t *testing.T) {
+	manifestA := []*commonpb.ManifestEntry{
+		{FragmentId: "ab", FragmentHash: "c"},
+	}
+	manifestB := []*commonpb.ManifestEntry{
+		{FragmentId: "a", FragmentHash: "bc"},
+	}
+	ra, err := AggregateRoot(manifestA)
+	require.NoError(t, err)
+	rb, err := AggregateRoot(manifestB)
+	require.NoError(t, err)
+	assert.NotEqual(t, ra, rb,
+		"AggregateRoot must be injection-proof: id='ab',hash='c' must differ from id='a',hash='bc'")
+}
+
+func TestAggregateRoot_FullDigest(t *testing.T) {
+	entries := []*commonpb.ManifestEntry{{FragmentId: "f", FragmentHash: "h"}}
+	root, err := AggregateRoot(entries)
+	require.NoError(t, err)
+	assert.Len(t, root, 64, "AggregateRoot must return full 32-byte SHA-256 hex (64 chars — no truncation)")
 }


### PR DESCRIPTION
## Summary

- Adds `FragmentHash(canonicalBytes []byte) string` — full 32-byte SHA-256 hex digest over the canonical bytes from S2's `CanonicalizeFragment`, no truncation (ADR-017 §6, SE threat #3).
- Adds `AggregateRoot(manifest []*commonpb.ManifestEntry) (string, error)` — sorts the manifest by `fragment_id` (byte-wise) then hashes all entries with length-prefixed encoding, closing the injection collision class at this second concatenation site.

Fixes #2903

## Security

**Injection-proof manifest encoding (SE threat #3):** Each `(fragment_id, fragment_hash)` pair is written as two `[uint32 BE length][bytes]` fields. This prevents the split-string collision where naive concatenation of `id="ab", hash="c"` equals `id="a", hash="bc"`. The required security test `TestAggregateRoot_InjectionProof` verifies this directly.

## Specialist Review Results

| Reviewer | Round 1 | Round 2 |
|----------|---------|---------|
| Code Review | findings (fixed) | PASS |
| Test Quality | PASS | — |
| Security | PASS | — |

**Aggregate verdict: PASS** (1 fix round, 0 remaining findings)

## Test Plan

- [x] `TestFragmentHash_KnownVector` — SHA-256 known vector (empty input → well-known constant)
- [x] `TestFragmentHash_FullDigest` — 64-char hex, lowercase, no truncation
- [x] `TestFragmentHash_Deterministic` — same bytes → same hash
- [x] `TestFragmentHash_DifferentInputs` — distinct inputs → distinct hashes
- [x] `TestAggregateRoot_Empty` — nil manifest → valid 64-char root
- [x] `TestAggregateRoot_Deterministic` — same entries → same root
- [x] `TestAggregateRoot_OrderIndependent` — reordered input → identical root
- [x] `TestAggregateRoot_DifferentHashesSameIDs` — same id, different hash → different root
- [x] `TestAggregateRoot_InjectionProof` **(REQUIRED SECURITY TEST)** — length-prefix encoding closes split-string collision
- [x] `TestAggregateRoot_FullDigest` — 64-char hex, no truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)