### PR TITLE
test: add Go fuzz targets for DNA storage decompression + steward CIM/WMI attribute parsing (Issue #2953)

### DIFF
--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -85,7 +85,7 @@ Decision path for a CodeQL alert:
 ### 6. Go Native Fuzzing
 
 - **Purpose**: Finds panics and unexpected crashes in parse/decode boundaries under adversarial input — the threat-model-relevant surfaces a compromised steward or malicious config push would hit
-- **Scope**: Four CFGMS-owned parse surfaces (does NOT fuzz `crypto/x509`, `google.golang.org/protobuf`, or any vendored library's own internals)
+- **Scope**: CFGMS-owned parse surfaces (does NOT fuzz `crypto/x509`, `google.golang.org/protobuf`, or any vendored library's own internals)
 - **Blocking**: **NOT a PR gate** — time-boxed fuzzing is flaky as a required check. Runs nightly via `.github/workflows/fuzz-nightly.yml`
 - **Discovery**: `scripts/fuzz-all.sh` auto-discovers all `Fuzz*` targets via `go test -list '^Fuzz'` for each listed package — any new `Fuzz*` target in a listed package is picked up automatically, no workflow edit needed
 
@@ -99,6 +99,14 @@ Decision path for a CodeQL alert:
 | `FuzzParseCertificateFromPEM` | `pkg/cert/utils_fuzz_test.go` | PEM decode + `x509.ParseCertificate` (mTLS-everywhere means cert parsing is the highest threat-model-relevant fuzz surface) |
 | `FuzzParseCertificateChainFromPEM` | `pkg/cert/utils_fuzz_test.go` | Multi-block `pem.Decode` loop |
 | `FuzzParsePrivateKeyFromPEM` | `pkg/cert/utils_fuzz_test.go` | PEM block type dispatch to `x509.ParsePKCS1PrivateKey` / `ParsePKCS8PrivateKey` / `ParseECPrivateKey` |
+| `FuzzGzipDecompress` | `features/controller/fleet/storage/compression_fuzz_test.go` | Storage read-back decompression boundary: gzip-decompress then `proto.Unmarshal` into `commonpb.DNA`. Decompression-bomb surface — an attacker writing to the config store's compressed blob could trigger unbounded memory growth. |
+| `FuzzOptimizedDNADecompress` | `features/controller/fleet/storage/compression_fuzz_test.go` | Distinct second decode boundary for the `dna-optimized` compressor: gzip-decompress then `json.Unmarshal` into `serializedOptimizedPayload`, then manual field-by-field reconstruction with index bounds checks. |
+| `FuzzSplitCSVLine` | `features/steward/dna/hardware_parse_fuzz_test.go` | RFC-4180 CSV parser (hardware_parse.go:27) on raw CIM/WMI command output — real untrusted-input boundary when the invoked binary is compromised or its output is truncated/malformed. |
+| `FuzzCimDataRows` | `features/steward/dna/hardware_parse_fuzz_test.go` | Multi-row CSV splitter (hardware_parse.go:55) — exercises header-skip and blank-line-skip logic. |
+| `FuzzParseCIMComputerSystem` | `features/steward/dna/hardware_parse_fuzz_test.go` | Full Win32_ComputerSystem CIM parse pipeline including `strconv.ParseInt` on the TotalPhysicalMemory field. |
+| `FuzzParseCIMMemoryModules` | `features/steward/dna/hardware_parse_fuzz_test.go` | Multi-row memory module parser — sums capacities across arbitrarily many rows; higher combinatorial complexity than single-row parsers. |
+
+> **Why no `FuzzZstdDecompress` or `FuzzLZ4Decompress`:** `ZstdCompressor.Decompress` and `LZ4Compressor.Decompress` are one-line delegates to `GzipCompressor.Decompress` (compression.go:225, :308 — design decision documented at line 219: "zstd/LZ4 compression requires build tags... GZIP is the universal fallback"). A separate fuzz target for either would exercise the exact same code path as `FuzzGzipDecompress` and add zero real coverage.
 
 **Corpus locations:** `<package>/testdata/fuzz/<FuzzName>/` — crash entries are committed as regression fixtures and uploaded as workflow artifacts by `fuzz-nightly.yml`.
 

--- a/features/controller/fleet/storage/compression_fuzz_test.go
+++ b/features/controller/fleet/storage/compression_fuzz_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package storage
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+)
+
+// FuzzGzipDecompress fuzzes (*GzipCompressor).Decompress at the storage
+// read-back boundary (compression.go:111). The decompression-bomb surface:
+// an attacker who can write to the config store's compressed blob could trigger
+// unbounded memory growth on decompress without this check. Seed corpus is
+// real compressed DNA so the fuzzer starts from a structurally valid input.
+func FuzzGzipDecompress(f *testing.F) {
+	c, err := NewGzipCompressor(6)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	seeds := []*commonpb.DNA{
+		{
+			Id:              "device-seed-1",
+			ConfigHash:      "abc123",
+			AttributeCount:  3,
+			SyncFingerprint: "fp-seed-1",
+			LastUpdated:     &timestamppb.Timestamp{Seconds: 1700000000, Nanos: 123456789},
+			LastSyncTime:    &timestamppb.Timestamp{Seconds: 1700000100, Nanos: 987654321},
+			Attributes: map[string]string{
+				"os.name":    "Ubuntu",
+				"os.version": "22.04",
+				"os.arch":    "amd64",
+			},
+		},
+		{
+			Id:         "device-seed-2",
+			ConfigHash: "def456",
+			Attributes: map[string]string{},
+		},
+		{
+			Id:              "device-seed-3",
+			ConfigHash:      "ghi789",
+			AttributeCount:  1,
+			SyncFingerprint: "fp-seed-3",
+			Attributes: map[string]string{
+				"hardware.cpu": "AMD EPYC 7543",
+			},
+		},
+	}
+
+	for _, dna := range seeds {
+		compressed, _, err := c.Compress(dna)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(compressed)
+	}
+
+	// Seed with trivially invalid inputs so the fuzzer explores the error path.
+	f.Add([]byte{})
+	f.Add([]byte("not gzip"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Any panic is a bug. Errors from malformed input are expected and safe.
+		_, _ = c.Decompress(data)
+	})
+}
+
+// FuzzOptimizedDNADecompress fuzzes (*OptimizedDNACompressor).Decompress
+// (compression.go:468) — a distinct decode boundary from FuzzGzipDecompress:
+// gzip-decompress then json.Unmarshal into serializedOptimizedPayload, then
+// manual field-by-field reconstruction. Reachable via NewCompressor("dna-optimized",
+// level) called from storage.go with config.CompressionType. Zstd/LZ4 are
+// intentionally not separately fuzzed: their Decompress methods are one-line
+// delegates to GzipCompressor.Decompress (compression.go:225, :308) and would
+// exercise the exact same code path as FuzzGzipDecompress above.
+func FuzzOptimizedDNADecompress(f *testing.F) {
+	c, err := NewOptimizedDNACompressor("gzip", 6)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	seeds := []*commonpb.DNA{
+		buildRealisticDNA(),
+		{
+			Id:         "empty-device",
+			ConfigHash: "hash-empty",
+			Attributes: map[string]string{},
+		},
+		{
+			Id:              "no-timestamps",
+			ConfigHash:      "cfg",
+			SyncFingerprint: "fp",
+			AttributeCount:  2,
+			Attributes: map[string]string{
+				"key1": "val1",
+				"key2": "val2",
+			},
+		},
+	}
+
+	for _, dna := range seeds {
+		compressed, _, err := c.Compress(dna)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(compressed)
+	}
+
+	f.Add([]byte{})
+	f.Add([]byte("not gzip"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Any panic is a bug. Errors from malformed input are expected and safe.
+		_, _ = c.Decompress(data)
+	})
+}

--- a/features/steward/dna/hardware_parse_fuzz_test.go
+++ b/features/steward/dna/hardware_parse_fuzz_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"testing"
+)
+
+// No build tag — hardware_parse.go is also build-tag-free (confirmed: it
+// compiles clean under GOOS=linux) so these targets run in the normal Linux CI
+// job alongside hardware_parse_test.go.
+
+// FuzzSplitCSVLine fuzzes the RFC-4180 CSV parser (hardware_parse.go:27).
+// Real untrusted-input boundary: if the WMI/CIM tool's output is malformed,
+// truncated, or the invoked binary is compromised, the parser must not panic.
+func FuzzSplitCSVLine(f *testing.F) {
+	// Seeds are real ConvertTo-Csv -NoTypeInformation lines from a Windows Server
+	// 2025 host (same fixtures as hardware_parse_test.go).
+	seeds := []string{
+		`"HP","HP ProDesk 600 G5 SFF","34123063296"`,
+		`"HP","1/11/2026 7:00:00 PM","R07 Ver. 02.25.00"`,
+		`"HP","8597","PJEAP0DMVDH6K9","KBC Version 08.09.22"`,
+		`"3B4602D8-1C05-7372-352B-45BF6B1453FD"`,
+		`"17179869184","8","0","2667"`,
+		`"SCSI","Fixed hard disk media","Microsoft Storage Space Device","322101964800"`,
+		`"with, comma","plain"`,
+		`"he said ""hi""","x"`,
+		`a,b,c`,
+		``,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		// Any panic is a bug. The return value is discarded — only crash-freedom matters.
+		_ = splitCSVLine(line)
+	})
+}
+
+// FuzzCimDataRows fuzzes the multi-row CSV splitter (hardware_parse.go:55).
+// Exercises header-skip + blank-line-skip logic on arbitrary byte sequences.
+func FuzzCimDataRows(f *testing.F) {
+	seeds := []string{
+		"\"Manufacturer\",\"Model\",\"TotalPhysicalMemory\"\r\n\"HP\",\"HP ProDesk 600 G5 SFF\",\"34123063296\"\r\n",
+		"\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n\"17179869184\",\"8\",\"0\",\"2667\"\r\n\"8589934592\",\"8\",\"0\",\"3200\"\r\n",
+		"\"InterfaceType\",\"MediaType\",\"Model\",\"Size\"\r\n\"SCSI\",\"Fixed hard disk media\",\"Microsoft Storage Space Device\",\"322101964800\"\r\n",
+		"\"Manufacturer\",\"ReleaseDate\",\"SMBIOSBIOSVersion\"\r\n",
+		"",
+		"\n\n\n",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, csv string) {
+		_ = cimDataRows(csv)
+	})
+}
+
+// FuzzParseCIMComputerSystem fuzzes the full parse pipeline for
+// Win32_ComputerSystem CIM output (hardware_parse.go:74), including the
+// strconv.ParseInt path on the TotalPhysicalMemory field.
+func FuzzParseCIMComputerSystem(f *testing.F) {
+	seeds := []string{
+		"\"Manufacturer\",\"Model\",\"TotalPhysicalMemory\"\r\n\"HP\",\"HP ProDesk 600 G5 SFF\",\"34123063296\"\r\n",
+		"\"Manufacturer\",\"Model\",\"TotalPhysicalMemory\"\r\n\"Dell\",\"OptiPlex 7080\",\"not-a-number\"\r\n",
+		"\"Manufacturer\",\"Model\",\"TotalPhysicalMemory\"\r\n",
+		"",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, csv string) {
+		attrs := map[string]string{}
+		parseCIMComputerSystem(csv, attrs)
+	})
+}
+
+// FuzzParseCIMMemoryModules fuzzes the multi-row memory parser
+// (hardware_parse.go:157), which sums capacities and counts modules across
+// arbitrarily many rows — higher combinatorial complexity than single-row parsers.
+func FuzzParseCIMMemoryModules(f *testing.F) {
+	seeds := []string{
+		"\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n\"17179869184\",\"8\",\"0\",\"2667\"\r\n\"8589934592\",\"8\",\"0\",\"3200\"\r\n",
+		"\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n\"n/a\",\"8\",\"0\",\"2667\"\r\n",
+		"\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n",
+		"",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, csv string) {
+		attrs := map[string]string{}
+		parseCIMMemoryModules(csv, attrs)
+	})
+}

--- a/scripts/fuzz-all.sh
+++ b/scripts/fuzz-all.sh
@@ -17,6 +17,8 @@ PACKAGES=(
   "features/controller/transport"
   "pkg/entitygraph/types"
   "pkg/cert"
+  "features/controller/fleet/storage"
+  "features/steward/dna"
 )
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## Summary

- Adds `FuzzGzipDecompress` and `FuzzOptimizedDNADecompress` in `features/controller/fleet/storage/compression_fuzz_test.go` — covering the storage read-back decompression boundary (decompression-bomb surface) and the distinct `dna-optimized` JSON decode path
- Adds `FuzzSplitCSVLine`, `FuzzCimDataRows`, `FuzzParseCIMComputerSystem`, and `FuzzParseCIMMemoryModules` in `features/steward/dna/hardware_parse_fuzz_test.go` — covering the CIM/WMI CSV parse boundary on the no-build-tag hardware_parse.go (runs in Linux CI)
- Appends `features/controller/fleet/storage` and `features/steward/dna` to `scripts/fuzz-all.sh` package list; extends docs with all new targets and documents the intentional Zstd/LZ4 exclusion (both are one-line delegates to GzipCompressor.Decompress)

Fixes #2953

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| Code Review | PASS |
| Test Quality | PASS |
| Security | PASS |

1 review round, 0 fix rounds, 0 remaining findings.

## Test plan

- [ ] `go test ./features/controller/fleet/storage/... -run ^Test` passes
- [ ] `go test ./features/steward/dna/... -run ^Test` passes
- [ ] All 6 fuzz targets run ≥30s each with no crash: `./scripts/fuzz-all.sh 30s`
- [ ] Zstd/LZ4 intentional exclusion documented in security-workflow-guide.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)