### PR TITLE
web: config hostname display + shared error-card failure classification (Issue #2945)

### DIFF
--- a/web/src/config/ConfigListView.test.tsx
+++ b/web/src/config/ConfigListView.test.tsx
@@ -197,6 +197,63 @@ describe('ConfigListView — push panel toggle', () => {
   })
 })
 
+function makeStewardsPageEnvelope(stewards: object[], status = 200) {
+  return new Response(
+    JSON.stringify({
+      data: { stewards, total: stewards.length, limit: 500, offset: 0 },
+      timestamp: new Date().toISOString(),
+    }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+describe('ConfigListView — STEWARD column hostname display', () => {
+  it('shows hostname from the stewards list when available', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeConfigEnvelope([makeStewardConfig({ steward_id: 'sw-1' })]),
+    )
+    fetchMock.mockResolvedValueOnce(
+      makeStewardsPageEnvelope([{ id: 'sw-1', dna: { hostname: 'CFG-AB-01' } }]),
+    )
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-table')).toBeInTheDocument())
+    expect(screen.getByText('CFG-AB-01')).toBeInTheDocument()
+    expect(screen.queryByText('sw-1')).toBeNull()
+  })
+
+  it('falls back to steward ID when hostname is absent from DNA', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeConfigEnvelope([makeStewardConfig({ steward_id: 'sw-2' })]),
+    )
+    fetchMock.mockResolvedValueOnce(
+      makeStewardsPageEnvelope([{ id: 'sw-2', dna: null }]),
+    )
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-table')).toBeInTheDocument())
+    expect(screen.getByText('sw-2')).toBeInTheDocument()
+  })
+
+  it('falls back to steward ID when steward is not in the hostname map', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeConfigEnvelope([makeStewardConfig({ steward_id: 'sw-3' })]),
+    )
+    fetchMock.mockResolvedValueOnce(makeStewardsPageEnvelope([]))
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-table')).toBeInTheDocument())
+    expect(screen.getByText('sw-3')).toBeInTheDocument()
+  })
+
+  it('shows ID when stewards fetch fails (graceful degradation)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeConfigEnvelope([makeStewardConfig({ steward_id: 'sw-4' })]),
+    )
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-table')).toBeInTheDocument())
+    expect(screen.getByText('sw-4')).toBeInTheDocument()
+  })
+})
+
 describe('ConfigListView — security (A9.1)', () => {
   it('renders steward_id and tenant_id as plain text, not HTML', async () => {
     const xss = '<img src=x onerror="window.__xss=1">'

--- a/web/src/config/ConfigListView.tsx
+++ b/web/src/config/ConfigListView.tsx
@@ -11,7 +11,7 @@
  * reaches the DOM as a JSX text node — never dangerouslySetInnerHTML.
  */
 import { useState } from 'react'
-import { useConfigList, type ConfigSummary } from './useConfigs.ts'
+import { useConfigList, useStewardHostnameMap, type ConfigSummary } from './useConfigs.ts'
 import ConfigEditor from './ConfigEditor.tsx'
 import PushPanel from './PushPanel.tsx'
 import './Config.css'
@@ -61,10 +61,12 @@ function ConfigEmpty() {
 
 function ConfigRow({
   config,
+  displayName,
   selected,
   onClick,
 }: {
   config: ConfigSummary
+  displayName: string
   selected: boolean
   onClick: () => void
 }) {
@@ -75,7 +77,7 @@ function ConfigRow({
       data-testid="config-row"
     >
       <td>
-        <span className="nm">{config.steward_id}</span>
+        <span className="nm">{displayName}</span>
       </td>
       <td>
         <span className="mono2">{String(config.version)}</span>
@@ -96,6 +98,7 @@ function ConfigRow({
 
 export default function ConfigListView() {
   const { configs, loading, error, retry } = useConfigList()
+  const hostnameMap = useStewardHostnameMap()
   const [selectedStewardId, setSelectedStewardId] = useState<string | null>(null)
   const [showPushPanel, setShowPushPanel] = useState(false)
 
@@ -158,6 +161,7 @@ export default function ConfigListView() {
                 <ConfigRow
                   key={c.steward_id}
                   config={c}
+                  displayName={hostnameMap.get(c.steward_id) ?? c.steward_id}
                   selected={selectedStewardId === c.steward_id}
                   onClick={() => handleRowClick(c.steward_id)}
                 />

--- a/web/src/config/useConfigs.test.ts
+++ b/web/src/config/useConfigs.test.ts
@@ -12,6 +12,7 @@ import {
   useConfigList,
   useStewardConfig,
   usePushStatus,
+  useStewardHostnameMap,
 } from './useConfigs.ts'
 
 const fetchMock = vi.fn<typeof fetch>()
@@ -311,5 +312,62 @@ describe('usePushStatus', () => {
     const { result } = renderHook(() => usePushStatus('push-bad'))
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.error).toContain('404')
+  })
+})
+
+// ── useStewardHostnameMap ─────────────────────────────────────────────────────
+
+function makeStewardsPageResponse(stewards: object[], status = 200) {
+  return new Response(
+    JSON.stringify({
+      data: { stewards, total: stewards.length, limit: 500, offset: 0 },
+      timestamp: new Date().toISOString(),
+    }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+describe('useStewardHostnameMap', () => {
+  it('returns an empty map before the stewards response arrives', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useStewardHostnameMap())
+    expect(result.current.size).toBe(0)
+  })
+
+  it('maps steward id → hostname when dna.hostname is present', async () => {
+    fetchMock.mockResolvedValue(
+      makeStewardsPageResponse([
+        { id: 'sw-1', dna: { hostname: 'CFG-AB-01' } },
+        { id: 'sw-2', dna: { hostname: 'CFG-AB-02' } },
+      ]),
+    )
+    const { result } = renderHook(() => useStewardHostnameMap())
+    await waitFor(() => expect(result.current.size).toBe(2))
+    expect(result.current.get('sw-1')).toBe('CFG-AB-01')
+    expect(result.current.get('sw-2')).toBe('CFG-AB-02')
+  })
+
+  it('falls back to steward id when dna.hostname is absent', async () => {
+    fetchMock.mockResolvedValue(
+      makeStewardsPageResponse([{ id: 'sw-3', dna: null }]),
+    )
+    const { result } = renderHook(() => useStewardHostnameMap())
+    await waitFor(() => expect(result.current.size).toBe(1))
+    expect(result.current.get('sw-3')).toBe('sw-3')
+  })
+
+  it('returns empty map and does not throw when stewards fetch fails', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    const { result } = renderHook(() => useStewardHostnameMap())
+    // Allow microtasks to settle; map must stay empty without throwing.
+    await act(async () => {})
+    expect(result.current.size).toBe(0)
+  })
+
+  it('returns empty map when stewards response is non-ok', async () => {
+    fetchMock.mockResolvedValue(makeStewardsPageResponse([], 503))
+    const { result } = renderHook(() => useStewardHostnameMap())
+    await act(async () => {})
+    expect(result.current.size).toBe(0)
   })
 })

--- a/web/src/config/useConfigs.ts
+++ b/web/src/config/useConfigs.ts
@@ -22,6 +22,8 @@
  */
 import { useCallback, useEffect, useState } from 'react'
 import { apiFetch } from '../api/client.ts'
+import { stewardDisplayName } from '../fleet/columns.ts'
+import { parseStewardPage } from '../fleet/useStewards.ts'
 
 // ── Primitive coercers ────────────────────────────────────────────────────────
 
@@ -514,4 +516,38 @@ export function useRollbackHistory(stewardId: string | null): UseRollbackHistory
     error: current?.error ?? null,
     retry,
   }
+}
+
+// ── useStewardHostnameMap ─────────────────────────────────────────────────────
+
+/*
+ * Fetches the steward list and returns a Map<stewardId, displayName> for
+ * hostname resolution in the config view. Uses the same hostname fallback
+ * logic as fleet/columns.ts's `name` column (dna.hostname || id). Errors
+ * are silently swallowed — the config view falls back to raw IDs when the
+ * stewards fetch fails or is slow.
+ */
+export function useStewardHostnameMap(): Map<string, string> {
+  const [map, setMap] = useState<Map<string, string>>(new Map())
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/stewards?limit=500&offset=0')
+      .then(async (response) => {
+        if (!response.ok) return
+        const body: unknown = await response.json()
+        const page = parseStewardPage((body as Record<string, unknown> | null)?.data)
+        const m = new Map<string, string>()
+        for (const s of page.stewards) {
+          m.set(s.id, stewardDisplayName(s))
+        }
+        if (!cancelled) setMap(m)
+      })
+      .catch(() => { /* hostname fetch failed; caller falls back to raw steward IDs */ })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return map
 }

--- a/web/src/fleet/ModulesPanel.test.tsx
+++ b/web/src/fleet/ModulesPanel.test.tsx
@@ -256,4 +256,21 @@ describe('error states', () => {
     expect(alert).toBeTruthy()
     expect(screen.queryByTestId('modules-list')).toBeNull()
   })
+
+  it('shows server-error copy (not connectivity) for a 5xx response', async () => {
+    mockError(503)
+    renderPanel()
+
+    await screen.findByRole('alert')
+    expect(screen.queryByText(/check your connection/i)).toBeNull()
+    expect(screen.getByText(/server.*error|returned an error/i)).toBeInTheDocument()
+  })
+
+  it('shows connectivity copy for a network-level failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    renderPanel()
+
+    await screen.findByRole('alert')
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
 })

--- a/web/src/fleet/ModulesPanel.tsx
+++ b/web/src/fleet/ModulesPanel.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { apiFetch } from '../api/client.ts'
+import ErrorCard from '../shell/ErrorCard.tsx'
 
 export interface StewardModule {
   name: string
@@ -100,19 +101,11 @@ export default function ModulesPanel() {
             </p>
           </div>
         ) : current.error !== undefined ? (
-          <div className="notice err" role="alert" data-testid="modules-error">
-            <div className="ic">!</div>
-            <h3>Couldn&apos;t load modules</h3>
-            <p>Module data for this steward isn&apos;t available right now.</p>
-            <span className="mono2 detail">{current.error}</span>
-            <button
-              type="button"
-              className="btn"
-              onClick={() => setAttempt((n) => n + 1)}
-            >
-              Retry
-            </button>
-          </div>
+          <ErrorCard
+            heading="Couldn&apos;t load modules"
+            detail={current.error}
+            onRetry={() => setAttempt((n) => n + 1)}
+          />
         ) : current.modules !== undefined && current.modules.length === 0 ? (
           <div className="notice" data-testid="modules-empty">
             <p>No modules loaded on this steward.</p>

--- a/web/src/fleet/columns.ts
+++ b/web/src/fleet/columns.ts
@@ -186,6 +186,11 @@ export const COLUMNS: readonly ColumnDef[] = [
   },
 ] as const
 
+/** Resolve the display name for a steward: hostname from DNA, falling back to the steward ID. */
+export function stewardDisplayName(steward: Pick<Steward, 'id' | 'dna'>): string {
+  return steward.dna?.hostname || steward.id
+}
+
 export const DEFAULT_VISIBLE: readonly ColumnKey[] = COLUMNS.filter(
   (c) => c.defaultVisible,
 ).map((c) => c.key)

--- a/web/src/modules/ModuleReviewQueue.test.tsx
+++ b/web/src/modules/ModuleReviewQueue.test.tsx
@@ -126,6 +126,21 @@ describe('ModuleReviewQueue — heading and list rendering', () => {
     await waitFor(() => expect(screen.getByTestId('modules-empty')).toBeInTheDocument())
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
+
+  it('shows server-error copy (not connectivity) for a 5xx response', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([], 503))
+    renderQueue()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.queryByText(/check your connection/i)).toBeNull()
+    expect(screen.getByText(/server.*error|returned an error/i)).toBeInTheDocument()
+  })
+
+  it('shows connectivity copy for a network-level failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    renderQueue()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
 })
 
 describe('ModuleReviewQueue — approve-confirm-fire', () => {

--- a/web/src/modules/ModuleReviewQueue.tsx
+++ b/web/src/modules/ModuleReviewQueue.tsx
@@ -20,6 +20,7 @@
 import { useState } from 'react'
 import { useModuleQueue } from './useModuleQueue.ts'
 import type { ModuleApprovalEntry } from './useModuleQueue.ts'
+import ErrorCard from '../shell/ErrorCard.tsx'
 
 interface PendingAction {
   bundle: ModuleApprovalEntry
@@ -41,19 +42,6 @@ function LoadingRows() {
   )
 }
 
-function ErrorNotice({ detail, onRetry }: { detail: string; onRetry: () => void }) {
-  return (
-    <div className="notice err" role="alert">
-      <div className="ic">!</div>
-      <h3>Couldn&apos;t load module queue</h3>
-      <p>The module approval list request failed. Check your connection and try again.</p>
-      <span className="mono2 detail">{detail}</span>
-      <button type="button" className="btn" onClick={onRetry}>
-        Retry
-      </button>
-    </div>
-  )
-}
 
 function ModuleEmpty() {
   return (
@@ -157,7 +145,7 @@ export default function ModuleReviewQueue() {
         {loading ? (
           <LoadingRows />
         ) : error !== null ? (
-          <ErrorNotice detail={error} onRetry={retry} />
+          <ErrorCard heading="Couldn&apos;t load module queue" detail={error} onRetry={retry} />
         ) : bundles.length === 0 ? (
           <ModuleEmpty />
         ) : (

--- a/web/src/shell/ErrorCard.test.tsx
+++ b/web/src/shell/ErrorCard.test.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * ErrorCard unit tests (Story #2945): error-class classification and
+ * copy selection.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import ErrorCard from './ErrorCard.tsx'
+
+afterEach(() => cleanup())
+
+describe('ErrorCard — structure', () => {
+  it('has role="alert"', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="network error" onRetry={() => {}} />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('renders the heading', () => {
+    render(<ErrorCard heading="Couldn't load widgets" detail="network error" onRetry={() => {}} />)
+    expect(screen.getByRole('heading', { name: /couldn't load widgets/i })).toBeInTheDocument()
+  })
+
+  it('renders the detail string', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="GET /api/v1/foo — 503" onRetry={() => {}} />)
+    expect(screen.getByText(/GET \/api\/v1\/foo — 503/)).toBeInTheDocument()
+  })
+
+  it('calls onRetry when the Retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<ErrorCard heading="Couldn't load data" detail="network error" onRetry={onRetry} />)
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+})
+
+describe('ErrorCard — error classification', () => {
+  it('shows connectivity copy for a plain network failure (no HTTP status)', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="GET /api/v1/foo — request failed" onRetry={() => {}} />)
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+
+  it('shows connectivity copy when error carries no HTTP status code', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="unexpected response shape" onRetry={() => {}} />)
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+
+  it('shows server-error copy for a 500 response — not connectivity', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="GET /api/v1/foo — 500" onRetry={() => {}} />)
+    expect(screen.queryByText(/check your connection/i)).toBeNull()
+    expect(screen.getByText(/server.*error|returned an error/i)).toBeInTheDocument()
+  })
+
+  it('shows server-error copy for a 503 response', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="GET /api/v1/foo — 503" onRetry={() => {}} />)
+    expect(screen.queryByText(/check your connection/i)).toBeNull()
+    expect(screen.getByText(/server.*error|returned an error/i)).toBeInTheDocument()
+  })
+
+  it('shows server-error copy for a 502 response', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="GET /api/v1/foo — 502" onRetry={() => {}} />)
+    expect(screen.queryByText(/check your connection/i)).toBeNull()
+  })
+
+  it('shows connectivity copy for a 4xx response (client error treated as connectivity in this schema)', () => {
+    render(<ErrorCard heading="Couldn't load data" detail="GET /api/v1/foo — 404" onRetry={() => {}} />)
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+})

--- a/web/src/shell/ErrorCard.tsx
+++ b/web/src/shell/ErrorCard.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Shared error card (Story #2945). Classifies the failure class from the
+ * error detail string the client already holds:
+ *   — 5xx in detail → server-side error (don't blame connectivity)
+ *   anything else   → connectivity / generic fallback
+ *
+ * Uses the existing `notice err` CSS class so it renders consistently with
+ * the app shell's error notice pattern.
+ */
+
+function isServerError(detail: string): boolean {
+  return /—\s*5\d\d/.test(detail)
+}
+
+export default function ErrorCard({
+  heading,
+  detail,
+  onRetry,
+}: {
+  heading: string
+  detail: string
+  onRetry: () => void
+}) {
+  const copy = isServerError(detail)
+    ? 'The server returned an error. Try again in a moment.'
+    : 'Check your connection and try again.'
+  return (
+    <div className="notice err" role="alert">
+      <div className="ic">!</div>
+      <h3>{heading}</h3>
+      <p>{copy}</p>
+      <span className="mono2 detail">{detail}</span>
+      <button type="button" className="btn" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  )
+}

--- a/web/src/workflow/WorkflowListView.test.tsx
+++ b/web/src/workflow/WorkflowListView.test.tsx
@@ -420,6 +420,23 @@ describe('WorkflowListView — trigger panel', () => {
   })
 })
 
+describe('WorkflowListView — error-card classification', () => {
+  it('shows server-error copy (not connectivity) for a 5xx response', async () => {
+    fetchMock.mockResolvedValue(makeWorkflowListResponse([], 500))
+    renderWorkflowListView()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.queryByText(/check your connection/i)).toBeNull()
+    expect(screen.getByText(/server.*error|returned an error/i)).toBeInTheDocument()
+  })
+
+  it('shows connectivity copy for a network-level failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    renderWorkflowListView()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+})
+
 describe('WorkflowListView — security (A9.1)', () => {
   it('renders workflow name and description as plain text, not HTML', async () => {
     const xss = '<img src=x onerror="window.__xss=1">'

--- a/web/src/workflow/WorkflowListView.tsx
+++ b/web/src/workflow/WorkflowListView.tsx
@@ -18,6 +18,7 @@ import {
 } from './useWorkflows.ts'
 import WorkflowExecutionView from './WorkflowExecutionView.tsx'
 import TriggerPanel from './TriggerPanel.tsx'
+import ErrorCard from '../shell/ErrorCard.tsx'
 import './Workflow.css'
 
 function LoadingRows() {
@@ -35,19 +36,6 @@ function LoadingRows() {
   )
 }
 
-function ErrorNotice({ detail, onRetry }: { detail: string; onRetry: () => void }) {
-  return (
-    <div className="notice err" role="alert">
-      <div className="ic">!</div>
-      <h3>Couldn&apos;t load workflows</h3>
-      <p>The workflow list request failed. Check your connection and try again.</p>
-      <span className="mono2 detail">{detail}</span>
-      <button type="button" className="btn" onClick={onRetry}>
-        Retry
-      </button>
-    </div>
-  )
-}
 
 function WorkflowEmpty() {
   return (
@@ -464,7 +452,7 @@ export default function WorkflowListView() {
         {loading ? (
           <LoadingRows />
         ) : error !== null ? (
-          <ErrorNotice detail={error} onRetry={retry} />
+          <ErrorCard heading="Couldn&apos;t load workflows" detail={error} onRetry={retry} />
         ) : workflows.length === 0 ? (
           <WorkflowEmpty />
         ) : (


### PR DESCRIPTION
## Summary

- **Config STEWARD column**: shows `dna.hostname` (falling back to steward ID) instead of raw IDs, by cross-referencing the stewards API. Reuses the hostname mapping logic from `fleet/columns.ts` via a new `stewardDisplayName` export.
- **Shared `ErrorCard` component**: classifies 5xx responses as server-side errors (renders "The server returned an error. Try again in a moment.") vs network failures (renders "Check your connection and try again."). Adopted in `WorkflowListView`, `ModulesPanel`, and `ModuleReviewQueue`.

## Changes

| File | What changed |
|------|-------------|
| `web/src/shell/ErrorCard.tsx` | New shared error card; classifies failure from the detail string |
| `web/src/shell/ErrorCard.test.tsx` | 10 unit tests (classification, structure, retry) |
| `web/src/fleet/columns.ts` | Exports `stewardDisplayName(steward)` for reuse |
| `web/src/config/useConfigs.ts` | New `useStewardHostnameMap()` hook; fetches stewards, builds id→name map |
| `web/src/config/useConfigs.test.ts` | 5 new tests for `useStewardHostnameMap` |
| `web/src/config/ConfigListView.tsx` | STEWARD column uses resolved displayName; imports hook |
| `web/src/config/ConfigListView.test.tsx` | 4 hostname display tests (happy path + 3 fallback scenarios) |
| `web/src/workflow/WorkflowListView.tsx` | Adopts `ErrorCard`, removes hand-rolled `ErrorNotice` |
| `web/src/workflow/WorkflowListView.test.tsx` | 2 error-class tests |
| `web/src/fleet/ModulesPanel.tsx` | Adopts `ErrorCard`, removes inline error notice |
| `web/src/fleet/ModulesPanel.test.tsx` | 2 error-class tests |
| `web/src/modules/ModuleReviewQueue.tsx` | Adopts `ErrorCard`, removes hand-rolled `ErrorNotice` |
| `web/src/modules/ModuleReviewQueue.test.tsx` | 2 error-class tests |

## Specialist Review Results

- **Code review**: PASS
- **Test quality**: PASS (round 2, after developer fix for a test runner transient)
- **Security**: PASS
- Adversarial gate: **passed** — 0 remaining findings

## Test Plan

- [x] 638 tests pass (613 pre-story + 25 new)
- [x] `npm run lint` — clean (no ESLint findings)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Story-review workflow: `passed: true`, `remainingFindings: []`

Fixes #2945

🤖 Generated with [Claude Code](https://claude.com/claude-code)