### PR TITLE
web: step-up assertion handler + Manager.Elevate (Issue #2965)

### DIFF
--- a/features/controller/api/assurance.go
+++ b/features/controller/api/assurance.go
@@ -71,6 +71,12 @@ var permissionAssurance = map[string]Requirement{
 	// before they can perform a fresh presence ceremony.
 	"webauthn:assert-presence": {Min: session.AssuranceStrong}, // POST /webauthn/presence/begin|finish
 
+	// WebAuthn step-up elevation endpoint (ADR-021 Amendment 2, Issue #2965).
+	// Callable at AssuranceBasic: this IS the step-up path (the caller cannot already be
+	// at AssuranceStrong via a different path to reach here). AssuranceMachine principals
+	// (API keys) cannot call this endpoint — they hold no web session to elevate.
+	"webauthn:elevate": {Min: session.AssuranceBasic}, // POST /webauthn/elevate/begin|finish
+
 	// Catastrophic permissions (no live REST routes yet — issue #2728/#2732 adds the routes).
 	// RequireUserPresence: true is ENFORCED as of Issue #2784: requirePermission now validates
 	// the X-Presence-Token header (minted by POST /api/v1/webauthn/presence/finish) and rejects

--- a/features/controller/api/handlers_webauthn.go
+++ b/features/controller/api/handlers_webauthn.go
@@ -77,6 +77,10 @@ func buildWebauthnUser(acct *webAccount) *webauthnUser {
 			ID:        c.ID,
 			PublicKey: c.PublicKey,
 			Transport: transports,
+			Flags: webauthn.CredentialFlags{
+				BackupEligible: c.BackupEligible,
+				BackupState:    c.BackupState,
+			},
 			Authenticator: webauthn.Authenticator{
 				SignCount: c.SignCount,
 			},
@@ -254,12 +258,14 @@ func (s *Server) handleWebAuthnRegisterFinish(w http.ResponseWriter, r *http.Req
 		transports = append(transports, string(t))
 	}
 	stored := WebAuthnCredential{
-		ID:           credential.ID,
-		PublicKey:    credential.PublicKey,
-		SignCount:    credential.Authenticator.SignCount,
-		Transport:    transports,
-		Label:        label,
-		RegisteredAt: time.Now().UTC(),
+		ID:             credential.ID,
+		PublicKey:      credential.PublicKey,
+		SignCount:      credential.Authenticator.SignCount,
+		Transport:      transports,
+		Label:          label,
+		RegisteredAt:   time.Now().UTC(),
+		BackupEligible: credential.Flags.BackupEligible,
+		BackupState:    credential.Flags.BackupState,
 	}
 
 	// Re-persist the account with the appended credential. The account loaded above

--- a/features/controller/api/handlers_webauthn_elevate.go
+++ b/features/controller/api/handlers_webauthn_elevate.go
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Issue #2965: WebAuthn step-up elevation — Basic → Strong (ADR-021 Amendment 2).
+//
+// Routes (webauthn:elevate permission, AssuranceBasic minimum):
+//
+//	POST /api/v1/webauthn/elevate/begin
+//	     Generates a WebAuthn assertion challenge scoped to the caller's account
+//	     credentials. The challenge is stored server-side keyed by session ID —
+//	     never trusted from the client.
+//
+//	POST /api/v1/webauthn/elevate/finish
+//	     Verifies the authenticator assertion, rotates the session token, and
+//	     upgrades the session to AssuranceStrong. Returns the new assurance level
+//	     and sets the rotated session cookie.
+//
+// Security properties enforced here:
+//   - Session bound: the pending session is keyed by session ID (not by account or username)
+//     so a second concurrent browser tab cannot consume another tab's elevation ceremony.
+//   - Server-side credential resolution: the account is loaded from context principal ID —
+//     never from a client-supplied username or credential hint.
+//   - Single-use challenge: the elevation session is deleted (LoadAndDelete) at the start
+//     of every finish call, preventing replay.
+//   - Sign-count advancement: if either the stored or response sign count is nonzero, the
+//     response count must strictly exceed the stored count (per W3C WebAuthn §7.2 step 21).
+//   - Per-session and per-IP throttle with backoff (no hard lockout).
+//   - Successful elevation audited: account, credential ID, source IP.
+//   - Session-revoke path is never gated on the throttle (ADR-021 Amendment 2).
+package api
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/webauthn"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// webAuthnElevateSession holds state for an in-progress step-up elevation ceremony.
+// Stored in s.webAuthnElevateSessions keyed by session ID. Single-use: deleted via
+// LoadAndDelete at the start of handleStepUpFinish regardless of outcome.
+type webAuthnElevateSession struct {
+	data      webauthn.SessionData
+	expires   time.Time
+	accountID string // principal.ID at begin time; finish re-derives this from context
+}
+
+// elevateThrottleRecord tracks per-key failed elevation attempts with exponential backoff.
+// Keys in s.webAuthnElevateThrottle are "session:<sessionID>" or "ip:<sourceIP>".
+// No hard lockout: callers may always retry after nextAllowed. The session-revoke path
+// is not gated on this throttle (ADR-021 Amendment 2).
+type elevateThrottleRecord struct {
+	mu          sync.Mutex
+	fails       int
+	nextAllowed time.Time
+}
+
+// handleStepUpBegin handles POST /api/v1/webauthn/elevate/begin.
+//
+// Issues a WebAuthn assertion challenge scoped to the calling principal's registered
+// credentials. The pending session is stored server-side keyed by the web session ID
+// (from context) — never by a client-supplied identifier.
+//
+// The endpoint requires a cookie-authenticated web session (webSessionIDContextKey
+// present in context). API-key and mTLS-cert callers have no web session to elevate
+// and receive 400/SESSION_REQUIRED.
+func (s *Server) handleStepUpBegin(w http.ResponseWriter, r *http.Request) {
+	wa := s.getWebAuthn()
+	if wa == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"WebAuthn not configured", "WEBAUTHN_NOT_CONFIGURED")
+		return
+	}
+
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	if principal == nil {
+		s.writeErrorResponse(w, http.StatusUnauthorized,
+			"Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	sessID, _ := r.Context().Value(webSessionIDContextKey).(string)
+	if sessID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Step-up elevation requires a cookie-authenticated web session", "SESSION_REQUIRED")
+		return
+	}
+
+	acct, err := s.getWebAccount(r.Context(), principal.ID)
+	if err != nil {
+		s.logger.Error("Step-up begin: failed to load web account",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to load web account", "STORE_ERROR")
+		return
+	}
+	if acct == nil {
+		s.writeErrorResponse(w, http.StatusNotFound,
+			"Web account not found", "WEB_ACCOUNT_NOT_FOUND")
+		return
+	}
+	if len(acct.Credentials) == 0 {
+		s.writeErrorResponse(w, http.StatusConflict,
+			"No WebAuthn credentials registered — enroll a passkey first", "NO_CREDENTIALS")
+		return
+	}
+
+	user := buildWebauthnUser(acct)
+
+	assertion, sessionData, err := wa.BeginLogin(user,
+		webauthn.WithUserVerification(protocol.VerificationRequired))
+	if err != nil {
+		s.logger.Error("Step-up begin: BeginLogin failed",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to begin step-up ceremony", "WEBAUTHN_BEGIN_ERROR")
+		return
+	}
+
+	s.webAuthnElevateSessions.Store(sessID, &webAuthnElevateSession{
+		data:      *sessionData,
+		expires:   time.Now().Add(webAuthnSessionTTL),
+		accountID: principal.ID,
+	})
+
+	s.logger.Info("WebAuthn step-up elevation ceremony started",
+		"principal_id", logging.SanitizeLogValue(principal.ID),
+		"session_id", logging.SanitizeLogValue(sessID))
+
+	s.writeResponse(w, http.StatusOK, assertion)
+}
+
+// handleStepUpFinish handles POST /api/v1/webauthn/elevate/finish.
+//
+// Verifies the authenticator assertion response against the server-stored challenge,
+// checks sign-count advancement, calls webSessionManager.Elevate to rotate the session
+// token and set AssuranceStrong, then sets the rotated cookie.
+//
+// A per-session and per-IP throttle with exponential backoff guards against brute-force
+// attempts. No hard lockout is applied; the session-revoke path is not gated (ADR-021
+// Amendment 2). Successful elevations are audited.
+func (s *Server) handleStepUpFinish(w http.ResponseWriter, r *http.Request) {
+	wa := s.getWebAuthn()
+	if wa == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"WebAuthn not configured", "WEBAUTHN_NOT_CONFIGURED")
+		return
+	}
+
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	if principal == nil {
+		s.writeErrorResponse(w, http.StatusUnauthorized,
+			"Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	sessID, _ := r.Context().Value(webSessionIDContextKey).(string)
+	if sessID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Step-up elevation requires a cookie-authenticated web session", "SESSION_REQUIRED")
+		return
+	}
+
+	acct, err := s.getWebAccount(r.Context(), principal.ID)
+	if err != nil {
+		s.logger.Error("Step-up finish: failed to load web account",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to load web account", "STORE_ERROR")
+		return
+	}
+	if acct == nil {
+		s.writeErrorResponse(w, http.StatusNotFound,
+			"Web account not found", "WEB_ACCOUNT_NOT_FOUND")
+		return
+	}
+
+	// Load and unconditionally delete the pending session (single-use enforcement).
+	rawSession, ok := s.webAuthnElevateSessions.LoadAndDelete(sessID)
+	if !ok {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"No active elevation session — call begin first", "NO_ACTIVE_ELEVATION_SESSION")
+		return
+	}
+	pending, ok := rawSession.(*webAuthnElevateSession)
+	if !ok {
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Invalid session state", "SESSION_STATE_ERROR")
+		return
+	}
+	if time.Now().After(pending.expires) {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Elevation session expired — restart with begin", "SESSION_EXPIRED")
+		return
+	}
+
+	// Extract source IP for throttle key and session binding.
+	sourceIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+
+	// Check per-session and per-IP throttle before the expensive FinishLogin call.
+	if blocked, wait := s.checkElevateThrottle("session:" + sessID); blocked {
+		s.logger.Warn("Step-up finish: per-session throttle active",
+			"session_id", logging.SanitizeLogValue(sessID),
+			"retry_after_seconds", int(wait.Seconds()))
+		s.writeErrorResponse(w, http.StatusTooManyRequests,
+			"Too many failed attempts — try again later", "THROTTLED")
+		return
+	}
+	if sourceIP != "" {
+		if blocked, wait := s.checkElevateThrottle("ip:" + sourceIP); blocked {
+			s.logger.Warn("Step-up finish: per-IP throttle active",
+				"source_ip", logging.SanitizeLogValue(sourceIP),
+				"retry_after_seconds", int(wait.Seconds()))
+			s.writeErrorResponse(w, http.StatusTooManyRequests,
+				"Too many failed attempts — try again later", "THROTTLED")
+			return
+		}
+	}
+
+	user := buildWebauthnUser(acct)
+
+	// Full server-side assertion verification: challenge (against the server-stored session
+	// value, never the client-echoed field), origin, RP-ID, and ECDSA/RS256 signature.
+	credential, err := wa.FinishLogin(user, pending.data, r)
+	if err != nil {
+		s.logger.Warn("Step-up finish: FinishLogin failed",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"session_id", logging.SanitizeLogValue(sessID),
+			"source_ip", logging.SanitizeLogValue(sourceIP),
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.recordElevateFailure("session:" + sessID)
+		if sourceIP != "" {
+			s.recordElevateFailure("ip:" + sourceIP)
+		}
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"WebAuthn verification failed", "WEBAUTHN_VERIFY_ERROR")
+		return
+	}
+
+	// Sign-count advancement check (W3C WebAuthn §7.2 step 21).
+	// If either the stored or response count is nonzero, the response must strictly exceed
+	// the stored count. Authenticators that do not implement sign counters return 0 for both;
+	// the spec permits this (0→0 is allowed, not a suspected clone signal).
+	newSignCount := credential.Authenticator.SignCount
+	var storedSignCount uint32
+	for _, c := range acct.Credentials {
+		if string(c.ID) == string(credential.ID) {
+			storedSignCount = c.SignCount
+			break
+		}
+	}
+	if (storedSignCount > 0 || newSignCount > 0) && newSignCount <= storedSignCount {
+		s.logger.Warn("Step-up finish: sign count not advancing — potential authenticator clone",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"session_id", logging.SanitizeLogValue(sessID),
+			"stored_count", storedSignCount,
+			"response_count", newSignCount)
+		s.recordElevateFailure("session:" + sessID)
+		if sourceIP != "" {
+			s.recordElevateFailure("ip:" + sourceIP)
+		}
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"WebAuthn verification failed", "WEBAUTHN_VERIFY_ERROR")
+		return
+	}
+
+	// Persist the advanced sign count. The credential is matched by ID.
+	updatedAcct := *acct
+	updatedAcct.Credentials = make([]WebAuthnCredential, len(acct.Credentials))
+	copy(updatedAcct.Credentials, acct.Credentials)
+	for i, c := range updatedAcct.Credentials {
+		if string(c.ID) == string(credential.ID) {
+			updatedAcct.Credentials[i].SignCount = newSignCount
+			break
+		}
+	}
+	if persistErr := s.persistWebAccount(r.Context(), &updatedAcct, principal.ID); persistErr != nil {
+		s.logger.Error("Step-up finish: failed to persist updated sign count",
+			"principal_id", logging.SanitizeLogValue(principal.ID),
+			"error", logging.SanitizeLogValue(persistErr.Error()))
+		// Non-fatal for session elevation: sign-count persistence failing does not
+		// compromise the cryptographic verification already performed. Log the error and proceed.
+	} else {
+		s.cacheWebAccount(&updatedAcct)
+	}
+
+	// Elevate the session: rotate the token and set AssuranceStrong.
+	_, newToken, elevateErr := s.webSessionManager.Elevate(r.Context(), sessID, credential.ID, sourceIP)
+	if elevateErr != nil {
+		s.logger.Error("Step-up finish: session elevation failed",
+			"session_id", logging.SanitizeLogValue(sessID),
+			"error", logging.SanitizeLogValue(elevateErr.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to elevate session", "SESSION_ELEVATION_ERROR")
+		return
+	}
+
+	// Set the rotated session cookie. The CSRF token binding survives because it is
+	// keyed by session ID, which does not change during elevation (Issue #2965).
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieWebSession,
+		Value:    newToken,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
+	})
+
+	now := time.Now().UTC()
+	s.logger.Info("WebAuthn step-up elevation successful",
+		"principal_id", logging.SanitizeLogValue(principal.ID),
+		"session_id", logging.SanitizeLogValue(sessID),
+		"credential_id", logging.SanitizeLogValue(string(credential.ID)),
+		"source_ip", logging.SanitizeLogValue(sourceIP),
+		"elevated_at", now.Format(time.RFC3339))
+
+	s.writeResponse(w, http.StatusOK, StepUpElevateFinishResponse{
+		Assurance:  "strong",
+		ElevatedAt: now,
+	})
+}
+
+// checkElevateThrottle returns (true, retryAfter) when the key is currently throttled,
+// or (false, 0) when the call may proceed. Thread-safe.
+func (s *Server) checkElevateThrottle(key string) (blocked bool, retryAfter time.Duration) {
+	raw, ok := s.webAuthnElevateThrottle.Load(key)
+	if !ok {
+		return false, 0
+	}
+	rec, ok := raw.(*elevateThrottleRecord)
+	if !ok {
+		return false, 0
+	}
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if !rec.nextAllowed.IsZero() && time.Now().Before(rec.nextAllowed) {
+		return true, time.Until(rec.nextAllowed)
+	}
+	return false, 0
+}
+
+// recordElevateFailure increments the failure counter for key and sets the next-allowed
+// timestamp based on the backoff schedule. No hard lockout is ever applied.
+func (s *Server) recordElevateFailure(key string) {
+	raw, _ := s.webAuthnElevateThrottle.LoadOrStore(key, &elevateThrottleRecord{})
+	rec := raw.(*elevateThrottleRecord)
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	rec.fails++
+	delay := elevateBackoff(rec.fails)
+	if delay > 0 {
+		rec.nextAllowed = time.Now().Add(delay)
+	}
+}
+
+// elevateBackoff returns the cooldown duration after a given number of consecutive failures.
+// No value in this schedule should be so large as to effectively lock out the account —
+// the maximum is 10 minutes, which an attacker can wait out but which impedes brute-force
+// at typical PIN lengths. The caller may always revoke the session regardless of throttle state.
+func elevateBackoff(fails int) time.Duration {
+	switch {
+	case fails <= 2:
+		return 0
+	case fails <= 4:
+		return 10 * time.Second
+	case fails <= 7:
+		return 30 * time.Second
+	case fails <= 11:
+		return 2 * time.Minute
+	default:
+		return 10 * time.Minute
+	}
+}

--- a/features/controller/api/handlers_webauthn_elevate_test.go
+++ b/features/controller/api/handlers_webauthn_elevate_test.go
@@ -1,0 +1,479 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Issue #2965: Tests for WebAuthn step-up elevation handlers.
+//
+// Coverage:
+//   - handleStepUpBegin: not-configured, no-principal, no-session-id,
+//     account-not-found, no-credentials, success (session stored server-side)
+//   - handleStepUpFinish: not-configured, no-principal, no-session-id,
+//     account-not-found, no-active-session, session-expired, throttle,
+//     sign-count-clone detection, success with W3C NoneES256 assertion spec vector
+//     (real WebAuthn library verification — no mocks)
+//   - elevateBackoff: schedule correctness
+//
+// The success test uses the W3C Level 3 NoneES256 authentication spec vector from
+// github.com/go-webauthn/webauthn@v0.17.0/protocol/specification_vectors_e2e_test.go.
+// This matches the NoneES256 registration vector (same credential ID and public key),
+// enabling end-to-end cryptographic verification without a real authenticator device.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// W3C Level 3 NoneES256 authentication spec vector.
+// Source: go-webauthn@v0.17.0/protocol/specification_vectors_e2e_test.go
+// TestSpecVectors_Authentication_E2E → NoneES256 vector.
+//
+// The same credential (identical credentialID + publicKey) appears in both the
+// registration and authentication vectors, enabling a full register-then-assert
+// test flow using only the spec vectors.
+const (
+	svAuthCredentialIDHex   = "f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4"
+	svAuthPublicKeyHex      = "a5010203262001215820afefa16f97ca9b2d23eb86ccb64098d20db90856062eb249c33a9b672f26df61225820930a56b87a2fca66334b03458abf879717c12cc68ed73290af2e2664796b9220"
+	svAuthChallengeHex      = "39c0e7521417ba54d43e8dc95174f423dee9bf3cd804ff6d65c857c9abf4d408"
+	svAuthAuthDataHex       = "bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b51900000000"
+	svAuthClientDataJSONHex = "7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a224f63446e55685158756c5455506f334a5558543049393770767a7a59425039745a63685879617630314167222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73657d"
+	svAuthSignatureHex      = "3046022100f50a4e2e4409249c4a853ba361282f09841df4dd4547a13a87780218deffcd380221008480ac0f0b93538174f575bf11a1dd5d78c6e486013f937295ea13653e331e87"
+	svAuthRPID              = "example.org"
+	svAuthOrigin            = "https://example.org"
+)
+
+// injectElevateSession stores a pending elevation session directly into the server,
+// bypassing handleStepUpBegin. Keyed by sessionID.
+func injectElevateSession(s *Server, sessionID string, sd webauthn.SessionData, ttl time.Duration, accountID string) {
+	s.webAuthnElevateSessions.Store(sessionID, &webAuthnElevateSession{
+		data:      sd,
+		expires:   time.Now().Add(ttl),
+		accountID: accountID,
+	})
+}
+
+// doStepUpBegin calls handleStepUpBegin directly.
+func doStepUpBegin(t *testing.T, server *Server, principal *Principal, sessID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webauthn/elevate/begin", nil)
+	if principal != nil {
+		req = withPrincipal(req, principal)
+	}
+	if sessID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), webSessionIDContextKey, sessID))
+	}
+	rec := httptest.NewRecorder()
+	server.handleStepUpBegin(rec, req)
+	return rec
+}
+
+// doStepUpFinish calls handleStepUpFinish directly.
+func doStepUpFinish(t *testing.T, server *Server, principal *Principal, sessID string, body *bytes.Reader) *httptest.ResponseRecorder {
+	t.Helper()
+	if body == nil {
+		body = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webauthn/elevate/finish", body)
+	if principal != nil {
+		req = withPrincipal(req, principal)
+	}
+	if sessID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), webSessionIDContextKey, sessID))
+	}
+	rec := httptest.NewRecorder()
+	server.handleStepUpFinish(rec, req)
+	return rec
+}
+
+// injectCredentialWithPublicKey adds a WebAuthn credential with a real public key to an
+// account, enabling FinishLogin to perform real cryptographic verification.
+func injectCredentialWithPublicKey(t *testing.T, server *Server, username string, credID, pubKey []byte, signCount uint32) {
+	t.Helper()
+	acct, err := server.getWebAccount(context.Background(), username)
+	require.NoError(t, err)
+	require.NotNil(t, acct, "account %q must exist before injecting credential", username)
+	// The W3C NoneES256 spec vector authData has BE=1, BS=1 (both authData bytes 0x59 and 0x19).
+	// We must store matching flags so FinishLogin's consistency check passes.
+	acct.Credentials = append(acct.Credentials, WebAuthnCredential{
+		ID:             credID,
+		PublicKey:      pubKey,
+		SignCount:      signCount,
+		Label:          "spec-vector-credential",
+		RegisteredAt:   time.Now(),
+		BackupEligible: true,
+		BackupState:    true,
+	})
+	require.NoError(t, server.persistWebAccount(context.Background(), acct, "test-injector"))
+	server.cacheWebAccount(acct)
+}
+
+// buildAssertionBody constructs a JSON PublicKeyCredential assertion response from raw bytes.
+func buildAssertionBody(t *testing.T, credID, authData, clientDataJSON, signature []byte) *bytes.Reader {
+	t.Helper()
+	type assertionResponse struct {
+		AuthenticatorData string `json:"authenticatorData"`
+		ClientDataJSON    string `json:"clientDataJSON"`
+		Signature         string `json:"signature"`
+	}
+	type assertionCredential struct {
+		ID       string            `json:"id"`
+		RawID    string            `json:"rawId"`
+		Type     string            `json:"type"`
+		Response assertionResponse `json:"response"`
+	}
+	credIDBase64 := base64.RawURLEncoding.EncodeToString(credID)
+	body := assertionCredential{
+		ID:    credIDBase64,
+		RawID: credIDBase64,
+		Type:  "public-key",
+		Response: assertionResponse{
+			AuthenticatorData: base64.RawURLEncoding.EncodeToString(authData),
+			ClientDataJSON:    base64.RawURLEncoding.EncodeToString(clientDataJSON),
+			Signature:         base64.RawURLEncoding.EncodeToString(signature),
+		},
+	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return bytes.NewReader(b)
+}
+
+// --- TestStepUpBegin ---
+
+func TestStepUpBegin_NotConfigured_503(t *testing.T) {
+	server := setupTestServer(t)
+	// No WebAuthn configured.
+	rec := doStepUpBegin(t, server, testAdminPrincipal(), "some-session-id")
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "WEBAUTHN_NOT_CONFIGURED", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpBegin_NoPrincipal_401(t *testing.T) {
+	server, _ := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	rec := doStepUpBegin(t, server, nil, "some-session-id")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, "AUTHENTICATION_REQUIRED", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpBegin_NoSessionID_400(t *testing.T) {
+	server, _ := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	// No webSessionIDContextKey → should return SESSION_REQUIRED.
+	rec := doStepUpBegin(t, server, testAdminPrincipal(), "" /* no session ID */)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "SESSION_REQUIRED", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpBegin_AccountNotFound_404(t *testing.T) {
+	server, _ := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	// testAdminPrincipal has ID="test-mtls-admin"; no web account with that name.
+	rec := doStepUpBegin(t, server, testAdminPrincipal(), "some-session-id")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, "WEB_ACCOUNT_NOT_FOUND", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpBegin_NoCredentials_409(t *testing.T) {
+	server, username := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	// A freshly-created account has zero credentials.
+	principal := &Principal{ID: username, Name: username}
+	rec := doStepUpBegin(t, server, principal, "some-session-id")
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Equal(t, "NO_CREDENTIALS", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpBegin_Success_200(t *testing.T) {
+	server, username := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+
+	credID := []byte("elevate-begin-cred-id")
+	injectCredential(t, server, username, credID)
+
+	const sessID = "test-web-session-id"
+	principal := &Principal{ID: username, Name: username}
+	rec := doStepUpBegin(t, server, principal, sessID)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	// Session must be stored server-side keyed by session ID (not principal ID or username).
+	raw, ok := server.webAuthnElevateSessions.Load(sessID)
+	require.True(t, ok, "elevation session must be stored after begin")
+	pending, ok := raw.(*webAuthnElevateSession)
+	require.True(t, ok)
+	assert.False(t, time.Now().After(pending.expires), "freshly created session must not be expired")
+	assert.NotEmpty(t, pending.data.Challenge, "server-side session must hold the challenge")
+
+	// Response must include a challenge with user-verification required.
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	opts, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "response.data must be an object")
+	pk, ok := opts["publicKey"].(map[string]interface{})
+	require.True(t, ok, "response.data.publicKey must be present")
+	assert.NotEmpty(t, pk["challenge"])
+	assert.Equal(t, "required", pk["userVerification"],
+		"step-up ceremony must require user verification")
+}
+
+// --- TestStepUpFinish ---
+
+func TestStepUpFinish_NotConfigured_503(t *testing.T) {
+	server := setupTestServer(t)
+	rec := doStepUpFinish(t, server, testAdminPrincipal(), "sess", nil)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "WEBAUTHN_NOT_CONFIGURED", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpFinish_NoPrincipal_401(t *testing.T) {
+	server, _ := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	rec := doStepUpFinish(t, server, nil, "sess", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, "AUTHENTICATION_REQUIRED", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpFinish_NoSessionID_400(t *testing.T) {
+	server, _ := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	rec := doStepUpFinish(t, server, testAdminPrincipal(), "" /* no session */, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "SESSION_REQUIRED", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpFinish_AccountNotFound_404(t *testing.T) {
+	server, _ := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	injectElevateSession(server, "sess", webauthn.SessionData{}, time.Minute, "test-mtls-admin")
+	rec := doStepUpFinish(t, server, testAdminPrincipal(), "sess", nil)
+	// Session is consumed by LoadAndDelete regardless; the account lookup fires first
+	// since session check is after account check — wait, need to confirm order.
+	// Account check is BEFORE session load in handleStepUpFinish.
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, "WEB_ACCOUNT_NOT_FOUND", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpFinish_NoActiveSession_400(t *testing.T) {
+	server, username := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	principal := &Principal{ID: username}
+	// No session injected — begin was never called.
+	rec := doStepUpFinish(t, server, principal, "sess", nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "NO_ACTIVE_ELEVATION_SESSION", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpFinish_SessionExpired_400(t *testing.T) {
+	server, username := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+	principal := &Principal{ID: username}
+	// Inject an already-expired session.
+	injectElevateSession(server, "sess", webauthn.SessionData{}, -time.Second, username)
+	rec := doStepUpFinish(t, server, principal, "sess", nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "SESSION_EXPIRED", errCode(t, rec.Body.Bytes()))
+}
+
+func TestStepUpFinish_Throttled_429(t *testing.T) {
+	server, username := setupWebAuthnServer(t, tvRPID, []string{tvOrigin})
+
+	credID := []byte("throttle-test-cred")
+	injectCredential(t, server, username, credID)
+	principal := &Principal{ID: username}
+
+	// Record enough failures to trigger the per-session throttle.
+	const sessID = "throttle-sess"
+	for i := 0; i < 4; i++ {
+		server.recordElevateFailure("session:" + sessID)
+	}
+
+	// Inject a fresh (non-expired) session.
+	injectElevateSession(server, sessID, webauthn.SessionData{}, time.Minute, username)
+
+	rec := doStepUpFinish(t, server, principal, sessID, nil)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	assert.Equal(t, "THROTTLED", errCode(t, rec.Body.Bytes()))
+}
+
+// TestStepUpFinish_SignCountClone verifies that a response with a non-advancing sign count
+// is rejected when either the stored or response count is nonzero.
+func TestStepUpFinish_SignCountClone_400(t *testing.T) {
+	server, username := setupWebAuthnServer(t, svAuthRPID, []string{svAuthOrigin})
+
+	// Decode the NoneES256 authentication spec vector bytes.
+	credIDBytes, err := hex.DecodeString(svAuthCredentialIDHex)
+	require.NoError(t, err)
+	pubKeyBytes, err := hex.DecodeString(svAuthPublicKeyHex)
+	require.NoError(t, err)
+	challengeBytes, err := hex.DecodeString(svAuthChallengeHex)
+	require.NoError(t, err)
+	authDataBytes, err := hex.DecodeString(svAuthAuthDataHex)
+	require.NoError(t, err)
+	clientDataJSONBytes, err := hex.DecodeString(svAuthClientDataJSONHex)
+	require.NoError(t, err)
+	sigBytes, err := hex.DecodeString(svAuthSignatureHex)
+	require.NoError(t, err)
+
+	// Inject a credential with SignCount=100 — the assertion response has SignCount=0,
+	// so this triggers the "stored > response and stored > 0" clone detection.
+	injectCredentialWithPublicKey(t, server, username, credIDBytes, pubKeyBytes, 100)
+
+	// Load the account to obtain its stable UUID for the session UserID field.
+	// FinishLogin checks bytes.Equal(user.WebAuthnID(), session.UserID); the user's
+	// WebAuthnID is []byte(acct.ID) (a UUID, not the username).
+	acct, err := server.getWebAccount(context.Background(), username)
+	require.NoError(t, err)
+	require.NotNil(t, acct)
+
+	challenge := base64.RawURLEncoding.EncodeToString(challengeBytes)
+	sd := webauthn.SessionData{
+		Challenge:            challenge,
+		RelyingPartyID:       svAuthRPID,
+		UserID:               []byte(acct.ID),
+		UserVerification:     protocol.VerificationPreferred, // spec vector has UP only; use Preferred to not block on UV
+		AllowedCredentialIDs: [][]byte{credIDBytes},
+		Expires:              time.Now().Add(10 * time.Minute),
+	}
+
+	const sessID = "clone-detect-sess"
+	injectElevateSession(server, sessID, sd, time.Minute, username)
+
+	body := buildAssertionBody(t, credIDBytes, authDataBytes, clientDataJSONBytes, sigBytes)
+	principal := &Principal{ID: username}
+	rec := doStepUpFinish(t, server, principal, sessID, body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+	assert.Equal(t, "WEBAUTHN_VERIFY_ERROR", errCode(t, rec.Body.Bytes()))
+}
+
+// TestStepUpFinish_Success verifies the full step-up elevation path using the W3C
+// NoneES256 authentication spec vector. This is a real assertion verification:
+// the go-webauthn/webauthn library parses the response, verifies the ECDSA signature
+// over SHA-256(authData + hash(clientDataJSON)), and checks challenge/origin/RP-ID.
+// No mock objects are used — the test exercises the same code path as production.
+//
+// The spec vector's authData does not have the UV (User Verified) flag set, so the
+// injected session uses VerificationPreferred to avoid the UV check. In production,
+// handleStepUpBegin always sets VerificationRequired; this test verifies the
+// cryptographic verification path, which is the same regardless of the UV policy.
+func TestStepUpFinish_Success(t *testing.T) {
+	server, username := setupWebAuthnServer(t, svAuthRPID, []string{svAuthOrigin})
+
+	// Initialize a real webSessionManager so webSessionManager.Elevate can succeed.
+	webCfg := session.Config{
+		IdleTimeout:     60 * time.Minute,
+		AbsoluteTimeout: 12 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	store := session.NewMemStore(webCfg, time.Now)
+	t.Cleanup(store.Close)
+	server.SetWebSessionManager(session.NewManager(webCfg, store, time.Now))
+
+	credIDBytes, err := hex.DecodeString(svAuthCredentialIDHex)
+	require.NoError(t, err)
+	pubKeyBytes, err := hex.DecodeString(svAuthPublicKeyHex)
+	require.NoError(t, err)
+	challengeBytes, err := hex.DecodeString(svAuthChallengeHex)
+	require.NoError(t, err)
+	authDataBytes, err := hex.DecodeString(svAuthAuthDataHex)
+	require.NoError(t, err)
+	clientDataJSONBytes, err := hex.DecodeString(svAuthClientDataJSONHex)
+	require.NoError(t, err)
+	sigBytes, err := hex.DecodeString(svAuthSignatureHex)
+	require.NoError(t, err)
+
+	// SignCount=0 in the spec vector; stored=0 → 0→0 is allowed per W3C §7.2 step 21.
+	injectCredentialWithPublicKey(t, server, username, credIDBytes, pubKeyBytes, 0)
+
+	// Load the account to obtain its stable UUID for the session UserID field.
+	// FinishLogin checks bytes.Equal(user.WebAuthnID(), session.UserID); the user's
+	// WebAuthnID is []byte(acct.ID) (a UUID, not the username).
+	acct, err := server.getWebAccount(context.Background(), username)
+	require.NoError(t, err)
+	require.NotNil(t, acct)
+
+	// The challenge stored in the session must match the base64url in clientDataJSON.
+	// clientDataJSON decodes to: {"type":"webauthn.get","challenge":"OcDnUhQXulTUPo3JUXt0I99pvzzYBP9tZchXyav01Ag","origin":"https://example.org","crossOrigin":false}
+	challenge := base64.RawURLEncoding.EncodeToString(challengeBytes)
+	sd := webauthn.SessionData{
+		Challenge:            challenge,
+		RelyingPartyID:       svAuthRPID,
+		UserID:               []byte(acct.ID),
+		UserVerification:     protocol.VerificationPreferred,
+		AllowedCredentialIDs: [][]byte{credIDBytes},
+		Expires:              time.Now().Add(10 * time.Minute),
+	}
+
+	// Issue a real web session so webSessionManager.Elevate can succeed.
+	_, token, issueErr := server.webSessionManager.Issue(context.Background(), username, "web-login", "default")
+	require.NoError(t, issueErr)
+	webSess, valErr := server.webSessionManager.Validate(context.Background(), token)
+	require.NoError(t, valErr)
+	realSessID := webSess.ID
+
+	injectElevateSession(server, realSessID, sd, time.Minute, username)
+
+	body := buildAssertionBody(t, credIDBytes, authDataBytes, clientDataJSONBytes, sigBytes)
+	principal := &Principal{ID: username}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webauthn/elevate/finish", body)
+	req = withPrincipal(req, principal)
+	ctx := context.WithValue(req.Context(), webSessionIDContextKey, realSessID)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	server.handleStepUpFinish(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	// Response must carry assurance=strong.
+	var envelope struct {
+		Data StepUpElevateFinishResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	assert.Equal(t, "strong", envelope.Data.Assurance)
+	assert.False(t, envelope.Data.ElevatedAt.IsZero(), "elevated_at must be set")
+
+	// A rotated session cookie must be set.
+	var newCookie string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == cookieWebSession {
+			newCookie = c.Value
+			break
+		}
+	}
+	assert.NotEmpty(t, newCookie, "response must set a rotated cfgms_session cookie")
+	assert.NotEqual(t, token, newCookie, "cookie must be rotated (different from pre-elevation token)")
+
+	// The new token must validate as AssuranceStrong.
+	elevated, validateErr := server.webSessionManager.Validate(context.Background(), newCookie)
+	require.NoError(t, validateErr)
+	assert.Equal(t, session.AssuranceStrong, elevated.Assurance, "session must carry AssuranceStrong after elevation")
+}
+
+// --- TestElevateBackoff ---
+
+func TestElevateBackoff(t *testing.T) {
+	cases := []struct {
+		fails int
+		want  time.Duration
+	}{
+		{0, 0},
+		{1, 0},
+		{2, 0},
+		{3, 10 * time.Second},
+		{4, 10 * time.Second},
+		{5, 30 * time.Second},
+		{7, 30 * time.Second},
+		{8, 2 * time.Minute},
+		{11, 2 * time.Minute},
+		{12, 10 * time.Minute},
+		{50, 10 * time.Minute},
+	}
+	for _, tc := range cases {
+		got := elevateBackoff(tc.fails)
+		if got != tc.want {
+			t.Errorf("elevateBackoff(%d) = %v, want %v", tc.fails, got, tc.want)
+		}
+	}
+}

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -91,6 +91,12 @@ type Principal struct {
 	CertSerial      string
 	CertFingerprint string
 	CertNotAfter    time.Time
+	// AuthenticatorCount is the number of WebAuthn credentials registered for this principal's
+	// web account. Set at Principal-build time for cookie-authenticated sessions only (Issue #2965).
+	// Zero for mTLS/API-key principals. -1 indicates the account could not be loaded.
+	// Confinement middleware and routing layers use this to distinguish "no passkeys" (0)
+	// from "unknown" (-1) or "has passkeys" (>0) without a per-request store query.
+	AuthenticatorCount int
 }
 
 // loggingMiddleware logs HTTP requests
@@ -410,14 +416,19 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 				}
 				// Build Principal mirroring the Bearer session path (the sessionPrincipal block above).
 				// Assurance and LastProvenAt are read from session state so that IP-change downgrades
-				// and future WebAuthn upgrades are reflected on every request (ADR-021 Decision 3/5).
+				// and WebAuthn upgrades (Issue #2965) are reflected on every request (ADR-021 Decision 3/5).
+				authCount := -1
+				if acct, err := s.getWebAccount(r.Context(), webSess.PrincipalID); err == nil && acct != nil {
+					authCount = len(acct.Credentials)
+				}
 				webPrincipal := &Principal{
-					ID:           webSess.PrincipalID,
-					Name:         "web-session:" + logging.SanitizeLogValue(webSess.PrincipalID),
-					Assurance:    webSess.Assurance,
-					LastProvenAt: webSess.LastProvenAt,
-					GlobalScope:  true,
-					TenantID:     webSess.TenantID,
+					ID:                 webSess.PrincipalID,
+					Name:               "web-session:" + logging.SanitizeLogValue(webSess.PrincipalID),
+					Assurance:          webSess.Assurance,
+					LastProvenAt:       webSess.LastProvenAt,
+					GlobalScope:        true,
+					TenantID:           webSess.TenantID,
+					AuthenticatorCount: authCount,
 				}
 				ctx := context.WithValue(r.Context(), principalContextKey, webPrincipal)
 				ctx = context.WithValue(ctx, ctxkeys.UserIDKey, logging.SanitizeLogValue(webSess.PrincipalID))

--- a/features/controller/api/route_registry_test.go
+++ b/features/controller/api/route_registry_test.go
@@ -222,6 +222,8 @@ var goldenRouteTable = []string{
 	"POST /api/v1/web/accounts/{username}/webauthn/revoke/{credential_id}",
 	"POST /api/v1/web/login",
 	"POST /api/v1/web/logout",
+	"POST /api/v1/webauthn/elevate/begin",
+	"POST /api/v1/webauthn/elevate/finish",
 	"POST /api/v1/webauthn/presence/begin",
 	"POST /api/v1/webauthn/presence/finish",
 	"POST /raft/message",

--- a/features/controller/api/routes_webauthn.go
+++ b/features/controller/api/routes_webauthn.go
@@ -23,4 +23,11 @@ func registerWebAuthnRoutes(s *Server, api *mux.Router) {
 		s.requirePermission("webauthn", "assert-presence")(http.HandlerFunc(s.handlePresenceBegin))).Methods("POST")
 	webAuthnRouter.Handle("/presence/finish",
 		s.requirePermission("webauthn", "assert-presence")(http.HandlerFunc(s.handlePresenceFinish))).Methods("POST")
+
+	// Step-up elevation endpoints (ADR-021 Amendment 2, Issue #2965).
+	// Callable at AssuranceBasic; on success the session is upgraded to AssuranceStrong.
+	webAuthnRouter.Handle("/elevate/begin",
+		s.requirePermission("webauthn", "elevate")(http.HandlerFunc(s.handleStepUpBegin))).Methods("POST")
+	webAuthnRouter.Handle("/elevate/finish",
+		s.requirePermission("webauthn", "elevate")(http.HandlerFunc(s.handleStepUpFinish))).Methods("POST")
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -145,6 +145,8 @@ type Server struct {
 	webAuthnSessions               sync.Map                              // Issue #2782: pending registration sessions; key=username, value=*webAuthnPendingSession
 	webAuthnPresenceSessions       sync.Map                              // Issue #2784: pending presence-assertion sessions; key=principalID, value=*webAuthnPendingSession
 	presenceTokens                 sync.Map                              // Issue #2784: short-lived single-use presence tokens; key=tokenHash, value=*presenceTokenRecord
+	webAuthnElevateSessions        sync.Map                              // Issue #2965: pending step-up elevation sessions; key=sessionID, value=*webAuthnElevateSession
+	webAuthnElevateThrottle        sync.Map                              // Issue #2965: per-session/per-IP failed elevation throttle; key="session:<id>"|"ip:<ip>", value=*elevateThrottleRecord
 	telemetryHandler               http.Handler                          // Issue #2765: telemetry fan-out WebSocket handler
 	egConfigstoreWriter            egConfigstoreIngestor                 // Issue #2879: desired-state entity-graph internal writer (nil = disabled)
 }

--- a/features/controller/api/tier_enforcement_test.go
+++ b/features/controller/api/tier_enforcement_test.go
@@ -38,8 +38,10 @@ type strongAssuranceRouteEntry struct {
 }
 
 // strongAssuranceRouteTable is the authoritative list of routes that enforce
-// AssuranceStrong via requirePermission (ADR-021, Issue #2780). The F2 parity
+// Min > AssuranceMachine via requirePermission (ADR-021, Issue #2780). The F2 parity
 // test verifies this matches the permissionAssurance registry (minus known-future entries).
+// Most entries require AssuranceStrong; AssuranceBasic-minimum entries are included so the
+// machine-403 and strong-passes invariants apply to them too (Issue #2965).
 //
 // Three routes share the "registration:approve" permission, and two share
 // "registration:manage-ip-trust" — all must appear here so the parity check
@@ -85,6 +87,11 @@ var strongAssuranceRouteTable = []strongAssuranceRouteEntry{
 	// WebAuthn presence ceremony (Issue #2784) — gates RequireUserPresence-gated actions.
 	{"POST", "/api/v1/webauthn/presence/begin", "webauthn:assert-presence"},
 	{"POST", "/api/v1/webauthn/presence/finish", "webauthn:assert-presence"},
+	// WebAuthn step-up elevation (Issue #2965, ADR-021 Amendment 2) — Basic→Strong.
+	// Min=AssuranceBasic: Machine gets 403, Strong passes, but Basic PASSES (not step-up).
+	// Part (d) skips step-up assertion for these; see assertBasicPassesFromRequirePermission.
+	{"POST", "/api/v1/webauthn/elevate/begin", "webauthn:elevate"},
+	{"POST", "/api/v1/webauthn/elevate/finish", "webauthn:elevate"},
 }
 
 // knownFuturePermissions lists permissionAssurance entries with Min > Machine
@@ -179,12 +186,20 @@ func TestF2_AssuranceGate_ParityWithPermissionRegistry(t *testing.T) {
 		})
 	}
 
-	// Part (d): Basic-assurance caller must get 401 + CFGMS-StepUp on every
-	// strong-assurance route. Uses requirePermission directly since mTLS/web-session
-	// credentials are not available in unit tests; the gate is in requirePermission,
-	// not in the authentication middleware (ADR-021 Decision 6).
+	// Part (d): Basic-assurance callers on Strong-minimum routes must get 401+CFGMS-StepUp;
+	// on Basic-minimum routes they must pass. Uses requirePermission directly.
 	for _, entry := range strongAssuranceRouteTable {
 		entry := entry
+		perm, permFound := permissionAssurance[entry.permission]
+		if permFound && perm.Min == session.AssuranceBasic {
+			// Basic-minimum route: a Basic caller must reach the handler (no step-up).
+			t.Run("d_basic_passes/"+entry.method+" "+entry.path, func(t *testing.T) {
+				parts := strings.SplitN(entry.permission, ":", 2)
+				require.Len(t, parts, 2, "permission %q must be resource:action", entry.permission)
+				assertBasicPassesFromRequirePermission(t, server, parts[0], parts[1])
+			})
+			continue
+		}
 		t.Run("d_basic_gets_stepup/"+entry.method+" "+entry.path, func(t *testing.T) {
 			parts := strings.SplitN(entry.permission, ":", 2)
 			require.Len(t, parts, 2, "permission %q must be resource:action", entry.permission)
@@ -429,6 +444,27 @@ func TestNonStrongRoute_RemainsReachableByAPIKey(t *testing.T) {
 		"valid API-key must be authenticated on non-strong-assurance route")
 	assert.Empty(t, rec.Header().Get("WWW-Authenticate"),
 		"non-strong-assurance route must not issue step-up challenge to API-key principal")
+}
+
+// assertBasicPassesFromRequirePermission verifies that requirePermission allows a Basic-assurance
+// caller through for a Basic-minimum permission (no step-up challenge). Used by Part (d) for
+// permissions with Min=AssuranceBasic (Issue #2965 elevate routes).
+func assertBasicPassesFromRequirePermission(t *testing.T, server *Server, resource, action string) {
+	t.Helper()
+	basicPrincipal := &Principal{
+		ID: "web-admin", Name: "web-session:web-admin",
+		Assurance: session.AssuranceBasic,
+	}
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := server.requirePermission(resource, action)(probe)
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req = req.WithContext(context.WithValue(req.Context(), principalContextKey, basicPrincipal))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"Basic-assurance caller must pass Basic-minimum permission %s:%s without step-up", resource, action)
+	assert.Empty(t, rec.Header().Get("WWW-Authenticate"),
+		"Basic-assurance pass-through must not set WWW-Authenticate on %s:%s", resource, action)
 }
 
 // assertStepUpFromRequirePermission is a shared helper for testing that the assurance gate

--- a/features/controller/api/webauthn_types.go
+++ b/features/controller/api/webauthn_types.go
@@ -17,12 +17,14 @@ import "time"
 // secrets-store seam is chosen for implementation simplicity (one record, one
 // persistence path) rather than because the keys require encryption.
 type WebAuthnCredential struct {
-	ID           []byte    `json:"id"`
-	PublicKey    []byte    `json:"public_key"`
-	SignCount    uint32    `json:"sign_count"`
-	Transport    []string  `json:"transport,omitempty"`
-	Label        string    `json:"label,omitempty"`
-	RegisteredAt time.Time `json:"registered_at"`
+	ID             []byte    `json:"id"`
+	PublicKey      []byte    `json:"public_key"`
+	SignCount      uint32    `json:"sign_count"`
+	Transport      []string  `json:"transport,omitempty"`
+	Label          string    `json:"label,omitempty"`
+	RegisteredAt   time.Time `json:"registered_at"`
+	BackupEligible bool      `json:"backup_eligible,omitempty"` // W3C WebAuthn BE flag (stored at registration)
+	BackupState    bool      `json:"backup_state,omitempty"`    // W3C WebAuthn BS flag (stored at registration)
 }
 
 // webAuthnSessionTTL is the maximum age of a pending WebAuthn registration session.
@@ -77,4 +79,11 @@ type presenceTokenRecord struct {
 type WebAuthnPresenceFinishResponse struct {
 	PresenceToken string `json:"presence_token"`
 	ExpiresIn     int    `json:"expires_in_seconds"` // informational; server enforces TTL
+}
+
+// StepUpElevateFinishResponse is returned by POST /api/v1/webauthn/elevate/finish
+// on successful step-up elevation. The assurance field echoes the new session assurance.
+type StepUpElevateFinishResponse struct {
+	Assurance  string    `json:"assurance"`
+	ElevatedAt time.Time `json:"elevated_at"`
 }

--- a/pkg/session/contract.go
+++ b/pkg/session/contract.go
@@ -133,12 +133,19 @@ func SourceIPFromContext(ctx context.Context) string {
 // List returns copies of all currently-live sessions across all tenants. A session is live
 // if it is not revoked, not absolute-expired, and not idle-expired — the same three checks
 // Validate applies. Tenant scoping is the caller's responsibility.
+//
+// Elevate atomically upgrades an existing session to AssuranceStrong (ADR-021 Amendment 2,
+// Issue #2965). It sets Assurance=Strong, BoundIP=sourceIP, CredentialID=credentialID,
+// LastProvenAt=now, and rotates the session token — preserving the session ID and CSRF
+// binding while invalidating a pre-elevation stolen cookie. The prior token stays valid for
+// GraceWindow to let concurrent requests complete cleanly.
 type Manager interface {
 	Issue(ctx context.Context, principalID, connectionName, tenantID string) (*Session, string, error)
 	Validate(ctx context.Context, token string) (*Session, error)
 	Renew(ctx context.Context, token string) (*Session, string, error)
 	Revoke(ctx context.Context, id string) error
 	List(ctx context.Context) ([]*Session, error)
+	Elevate(ctx context.Context, sessionID string, credentialID []byte, sourceIP string) (*Session, string, error)
 }
 
 // Store is the backing store for the session Manager (ADR-014 §2).

--- a/pkg/session/contract_test.go
+++ b/pkg/session/contract_test.go
@@ -40,6 +40,9 @@ func (s *stubManager) Renew(_ context.Context, _ string) (*session.Session, stri
 }
 func (s *stubManager) Revoke(_ context.Context, _ string) error           { return nil }
 func (s *stubManager) List(_ context.Context) ([]*session.Session, error) { return nil, nil }
+func (s *stubManager) Elevate(_ context.Context, _ string, _ []byte, _ string) (*session.Session, string, error) {
+	return nil, "", nil
+}
 
 // stubStore satisfies Store for compile-time interface verification.
 type stubStore struct{}

--- a/pkg/session/elevate_test.go
+++ b/pkg/session/elevate_test.go
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package session_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/session"
+)
+
+// TestElevate_UpgradesAssuranceAndRotatesToken verifies the core elevation contract:
+// after a successful Elevate call the session carries AssuranceStrong, the new token
+// is validated correctly, and the old token is still accepted during the grace window.
+func TestElevate_UpgradesAssuranceAndRotatesToken(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:           10 * time.Minute,
+		AbsoluteTimeout:       1 * time.Hour,
+		GraceWindow:           30 * time.Second,
+		SilentReproofInterval: 5 * time.Minute,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, oldToken, err := mgr.Issue(ctx, "alice", "web", "tenant-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if sess.Assurance != session.AssuranceBasic {
+		t.Fatalf("initial assurance = %v, want AssuranceBasic", sess.Assurance)
+	}
+
+	credID := []byte("cred-abc-123")
+	srcIP := "192.0.2.10"
+
+	elevated, newToken, err := mgr.Elevate(ctx, sess.ID, credID, srcIP)
+	if err != nil {
+		t.Fatalf("Elevate: %v", err)
+	}
+	if newToken == "" {
+		t.Fatal("Elevate must return a new token")
+	}
+	if newToken == oldToken {
+		t.Fatal("Elevate must rotate the token")
+	}
+	if elevated.Assurance != session.AssuranceStrong {
+		t.Errorf("elevated.Assurance = %v, want AssuranceStrong", elevated.Assurance)
+	}
+	if elevated.BoundIP != srcIP {
+		t.Errorf("elevated.BoundIP = %q, want %q", elevated.BoundIP, srcIP)
+	}
+	if !bytes.Equal(elevated.CredentialID, credID) {
+		t.Errorf("elevated.CredentialID = %v, want %v", elevated.CredentialID, credID)
+	}
+	if elevated.LastProvenAt.IsZero() {
+		t.Error("elevated.LastProvenAt must be set after elevation")
+	}
+	// Session ID must not change.
+	if elevated.ID != sess.ID {
+		t.Errorf("session ID changed: got %q, want %q", elevated.ID, sess.ID)
+	}
+
+	// New token validates as AssuranceStrong.
+	got, err := mgr.Validate(ctx, newToken)
+	if err != nil {
+		t.Fatalf("Validate(newToken): %v", err)
+	}
+	if got.Assurance != session.AssuranceStrong {
+		t.Errorf("Validate assurance = %v, want AssuranceStrong", got.Assurance)
+	}
+}
+
+// TestElevate_OldTokenValidDuringGrace verifies that the pre-elevation token is still
+// accepted during the grace window (so concurrent in-flight requests complete cleanly).
+func TestElevate_OldTokenValidDuringGrace(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     10 * time.Minute,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     200 * time.Millisecond,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, oldToken, err := mgr.Issue(ctx, "bob", "web", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	_, _, err = mgr.Elevate(ctx, sess.ID, []byte("cred"), "10.0.0.1")
+	if err != nil {
+		t.Fatalf("Elevate: %v", err)
+	}
+
+	// Immediately after elevation, old token should still be accepted.
+	if _, err := mgr.Validate(ctx, oldToken); err != nil {
+		t.Errorf("old token inside grace: Validate returned %v, want nil", err)
+	}
+
+	// After grace window elapses, old token must be rejected.
+	clock.advance(300 * time.Millisecond)
+	_, err = mgr.Validate(ctx, oldToken)
+	if !errors.Is(err, session.ErrSessionExpired) {
+		t.Errorf("old token after grace: got %v, want ErrSessionExpired", err)
+	}
+}
+
+// TestElevate_NotFound verifies that Elevate returns ErrSessionNotFound for unknown IDs.
+func TestElevate_NotFound(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	_, _, err := mgr.Elevate(ctx, "no-such-session", []byte("cred"), "10.0.0.1")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("got %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestElevate_RevokedSession verifies that Elevate refuses revoked sessions.
+func TestElevate_RevokedSession(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, _, err := mgr.Issue(ctx, "carol", "web", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if err := mgr.Revoke(ctx, sess.ID); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	_, _, err = mgr.Elevate(ctx, sess.ID, []byte("cred"), "10.0.0.1")
+	if !errors.Is(err, session.ErrSessionRevoked) {
+		t.Errorf("got %v, want ErrSessionRevoked", err)
+	}
+}
+
+// TestElevate_IdleExpiredSession verifies that Elevate refuses idle-expired sessions.
+func TestElevate_IdleExpiredSession(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     100 * time.Millisecond,
+		AbsoluteTimeout: 1 * time.Hour,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, _, err := mgr.Issue(ctx, "dave", "web", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	clock.advance(200 * time.Millisecond)
+
+	_, _, err = mgr.Elevate(ctx, sess.ID, []byte("cred"), "10.0.0.1")
+	if !errors.Is(err, session.ErrSessionExpired) {
+		t.Errorf("got %v, want ErrSessionExpired", err)
+	}
+}
+
+// TestElevate_AbsoluteExpiredSession verifies that Elevate refuses absolute-expired sessions.
+func TestElevate_AbsoluteExpiredSession(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:     1 * time.Hour,
+		AbsoluteTimeout: 100 * time.Millisecond,
+		GraceWindow:     30 * time.Second,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, _, err := mgr.Issue(ctx, "eve", "web", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	clock.advance(200 * time.Millisecond)
+
+	_, _, err = mgr.Elevate(ctx, sess.ID, []byte("cred"), "10.0.0.1")
+	if !errors.Is(err, session.ErrSessionExpired) {
+		t.Errorf("got %v, want ErrSessionExpired", err)
+	}
+}
+
+// TestElevate_IPChangeDowngradesAfterElevation verifies that a subsequent Validate
+// call after an IP change downgrades an elevated session back to AssuranceBasic
+// (ADR-021 Decision 5 / Issue #2788).
+func TestElevate_IPChangeDowngradesAfterElevation(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:           10 * time.Minute,
+		AbsoluteTimeout:       1 * time.Hour,
+		GraceWindow:           30 * time.Second,
+		SilentReproofInterval: 5 * time.Minute,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+
+	srcIP := "192.0.2.1"
+	ctx := session.WithSourceIP(context.Background(), srcIP)
+
+	sess, _, err := mgr.Issue(ctx, "frank", "web", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	_, newToken, err := mgr.Elevate(ctx, sess.ID, []byte("cred"), srcIP)
+	if err != nil {
+		t.Fatalf("Elevate: %v", err)
+	}
+
+	// Validate from same IP → still Strong.
+	got, err := mgr.Validate(ctx, newToken)
+	if err != nil {
+		t.Fatalf("Validate same IP: %v", err)
+	}
+	if got.Assurance != session.AssuranceStrong {
+		t.Errorf("same IP: assurance = %v, want AssuranceStrong", got.Assurance)
+	}
+
+	// Validate from different IP → downgraded to Basic.
+	newIPCtx := session.WithSourceIP(context.Background(), "10.0.0.99")
+	got, err = mgr.Validate(newIPCtx, newToken)
+	if err != nil {
+		t.Fatalf("Validate different IP: %v", err)
+	}
+	if got.Assurance != session.AssuranceBasic {
+		t.Errorf("IP change: assurance = %v, want AssuranceBasic", got.Assurance)
+	}
+}
+
+// TestElevate_SilentReproofIntervalDowngrades verifies that a session elevated with a
+// SilentReproofInterval is downgraded back to AssuranceBasic once the interval elapses
+// without a fresh assertion.
+func TestElevate_SilentReproofIntervalDowngrades(t *testing.T) {
+	cfg := session.Config{
+		IdleTimeout:           30 * time.Minute,
+		AbsoluteTimeout:       2 * time.Hour,
+		GraceWindow:           30 * time.Second,
+		SilentReproofInterval: 5 * time.Minute,
+	}
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, _, err := mgr.Issue(ctx, "grace", "web", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	_, newToken, err := mgr.Elevate(ctx, sess.ID, []byte("cred"), "10.0.0.1")
+	if err != nil {
+		t.Fatalf("Elevate: %v", err)
+	}
+
+	// Within the silent reproof interval — session stays Strong.
+	clock.advance(4 * time.Minute)
+	got, err := mgr.Validate(ctx, newToken)
+	if err != nil {
+		t.Fatalf("Validate within interval: %v", err)
+	}
+	if got.Assurance != session.AssuranceStrong {
+		t.Errorf("within interval: assurance = %v, want AssuranceStrong", got.Assurance)
+	}
+
+	// Past the silent reproof interval — downgraded to Basic.
+	clock.advance(2 * time.Minute) // total 6m > 5m SilentReproofInterval
+	got, err = mgr.Validate(ctx, newToken)
+	if err != nil {
+		t.Fatalf("Validate after interval: %v", err)
+	}
+	if got.Assurance != session.AssuranceBasic {
+		t.Errorf("after interval: assurance = %v, want AssuranceBasic", got.Assurance)
+	}
+}
+
+// TestElevate_ReturnsTokenWithCorrectLength verifies that the new token follows the
+// same format rules as Issue/Renew (43 chars, base64url no-padding, 256-bit entropy).
+func TestElevate_ReturnsTokenWithCorrectLength(t *testing.T) {
+	cfg := session.DefaultConfig()
+	clock := &fakeClock{t: time.Now()}
+	mgr, _ := newTestManager(t, cfg, clock)
+	ctx := context.Background()
+
+	sess, _, err := mgr.Issue(ctx, "henry", "web", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	_, newToken, err := mgr.Elevate(ctx, sess.ID, []byte("cred"), "10.0.0.1")
+	if err != nil {
+		t.Fatalf("Elevate: %v", err)
+	}
+	if len(newToken) != 43 {
+		t.Errorf("newToken length = %d, want 43 (base64url no-padding for 32 bytes)", len(newToken))
+	}
+}

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -356,6 +356,63 @@ func (m *manager) List(ctx context.Context) ([]*Session, error) {
 	return out, nil
 }
 
+// Elevate atomically upgrades a live session to AssuranceStrong (ADR-021 Amendment 2,
+// Issue #2965). It sets Assurance=Strong, BoundIP=sourceIP, CredentialID=credentialID,
+// LastProvenAt=now, and rotates the session token. The prior token stays valid for
+// GraceWindow so concurrent in-flight requests complete cleanly, but a pre-elevation
+// stolen cookie is severed as soon as the grace window elapses.
+//
+// The session identity (ID) and any CSRF binding keyed on that ID are preserved through
+// the rotation. Elevate is looked up by session ID, not by token, because the caller
+// (the step-up assertion handler) knows the session ID from context.
+func (m *manager) Elevate(ctx context.Context, sessionID string, credentialID []byte, sourceIP string) (*Session, string, error) {
+	m.mu.RLock()
+	ms := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if ms == nil {
+		return nil, "", ErrSessionNotFound
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if ms.revoked {
+		return nil, "", ErrSessionRevoked
+	}
+	now := m.clockFn()
+	if now.After(ms.session.AbsoluteExpiresAt) {
+		return nil, "", ErrSessionExpired
+	}
+	if now.After(ms.session.LastActivity.Add(m.cfg.IdleTimeout)) {
+		return nil, "", ErrSessionExpired
+	}
+	newToken, err := GenerateToken()
+	if err != nil {
+		return nil, "", err
+	}
+	newHash := HashToken(newToken)
+	ms.session.Assurance = AssuranceStrong
+	ms.session.BoundIP = sourceIP
+	ms.session.CredentialID = credentialID
+	ms.session.LastProvenAt = now
+	ms.session.LastActivity = now
+	if ms.prevHash != "" {
+		m.mu.Lock()
+		delete(m.byHash, ms.prevHash)
+		m.mu.Unlock()
+	}
+	ms.prevHash = ms.currentHash
+	ms.prevExpiry = now.Add(m.cfg.GraceWindow)
+	ms.currentHash = newHash
+	m.mu.Lock()
+	m.byHash[newHash] = ms
+	m.mu.Unlock()
+	_ = m.store.Set(ctx, newHash, ms.session)
+	if gs, ok := m.store.(graceStamper); ok {
+		_ = gs.StampGraceExpiry(ctx, ms.prevHash, ms.prevExpiry)
+	}
+	out := *ms.session
+	return &out, newToken, nil
+}
+
 // Revoke immediately invalidates the session identified by id. Subsequent Validate
 // or Renew calls for any token belonging to this session return ErrSessionRevoked.
 // Revoke deletes all token-hash records from the durable store so revocation is


### PR DESCRIPTION
## Summary

- Adds `Manager.Elevate` to the session contract: atomically sets `Assurance=Strong`, `BoundIP`, `CredentialID`, `LastProvenAt`, rotates the session token (preserving session identity + CSRF binding)
- Adds `POST /api/v1/webauthn/elevate/begin|finish` (Min: `AssuranceBasic`) for browser sessions to upgrade from Basic to Strong via WebAuthn assertion
- Fixes pre-existing `BackupEligible`/`BackupState` flag round-trip bug in the registration handler that would have broken `FinishLogin` for any platform authenticator with BE=1
- Adds `AuthenticatorCount` to `Principal` for zero-cost enrollment checks by downstream stories (#2966, #2968)

## Security properties enforced

- Server-side credential resolution: account loaded from context principal, never from client-supplied username
- Single-use challenge: elevation session deleted via `LoadAndDelete` on every `finish` call
- Per-session + per-IP throttle with backoff (no hard lockout; session-revoke unaffected)
- W3C §7.2 step-21 sign-count advancement: 0→0 allowed; non-zero must strictly advance
- Sign count persisted on every successful assertion
- Session token rotated; pre-elevation stolen cookie severed
- Successful elevation audited with account, credential ID, source IP

## Test plan

- [ ] `make test-agent-complete` — 2× confirmed passes (exit 0)
- [ ] 16 new handler unit tests (`handlers_webauthn_elevate_test.go`) — all pass
- [ ] 9 new session unit tests (`pkg/session/elevate_test.go`) — all pass
- [ ] W3C NoneES256 authentication spec vector end-to-end test with real ECDSA signature verification
- [ ] Route parity and assurance-gate parity tests updated and passing
- [ ] `make check-architecture` — no central provider violations
- [ ] `make lint-log-injection` — exit 0
- [ ] `golangci-lint run` — 0 issues

## Specialist review results

- **Security (gosec/staticcheck/Trivy/Nancy/architecture):** PASS — all automated scans clean; all dynamic log values sanitized; no hardcoded secrets
- **QA code review:** PASS — no blocking issues; real WebAuthn assertion, no mocks, error paths covered; named-constant fix applied (line 451)
- **QA test runner:** PASS — `make test-agent-complete` exit 0

Fixes #2965

🤖 Generated with [Claude Code](https://claude.com/claude-code)