### PR TITLE
config: reboot_window tenant cascade, free override, and timezone resolution (Issue #2976)

### DIFF
--- a/features/config/stewardtypes/types.go
+++ b/features/config/stewardtypes/types.go
@@ -8,7 +8,11 @@
 // shapes without importing steward-internal packages.
 package stewardtypes
 
-import "time"
+import (
+	"time"
+
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
+)
 
 // StewardConfig represents the complete steward configuration.
 type StewardConfig struct {
@@ -60,6 +64,16 @@ type StewardSettings struct {
 	// attribute deltas while connected to the controller (Issue #1915).
 	// Accepts Go duration strings (e.g. "30m", "1h"). Default: 30m.
 	DNARefreshInterval string `yaml:"dna_refresh_interval,omitempty" json:"dna_refresh_interval,omitempty"`
+
+	// TenantDefaultTimezone is the IANA timezone name applied when a reboot_window
+	// does not declare an explicit timezone. A future story reuses this same field
+	// for the workflow-trigger scheduler's timezone default (ADR-026 decision 4).
+	TenantDefaultTimezone string `yaml:"tenant_default_timezone,omitempty" json:"tenant_default_timezone,omitempty"`
+
+	// RebootWindow declares the maintenance window during which reboots are permitted.
+	// Cascades MSP → Client → Group → Cluster → Role → Device with free override in
+	// either direction (tighter or looser). Nil means no window is declared at this level.
+	RebootWindow *maintenanceschedule.Config `yaml:"reboot_window,omitempty" json:"reboot_window,omitempty"`
 }
 
 // UpgradeConfig holds upgrade-related steward policy settings. (Issue #1943)

--- a/features/config/stewardtypes/types_test.go
+++ b/features/config/stewardtypes/types_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package stewardtypes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
+)
+
+// TestStewardSettings_RebootWindowYAMLRoundTrip verifies that a StewardConfig
+// containing a RebootWindow round-trips through yaml.Marshal / yaml.Unmarshal
+// without data loss.
+func TestStewardSettings_RebootWindowYAMLRoundTrip(t *testing.T) {
+	nth := 1
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeController,
+			RebootWindow: &maintenanceschedule.Config{
+				Timezone: "America/New_York",
+				Schedules: []maintenanceschedule.Schedule{
+					{
+						Freq:  maintenanceschedule.FreqWeekly,
+						Days:  []time.Weekday{time.Monday, time.Thursday},
+						Start: maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0},
+						End:   maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0},
+					},
+					{
+						Freq:    maintenanceschedule.FreqMonthly,
+						Weekday: time.Saturday,
+						Nth:     &nth,
+						Start:   maintenanceschedule.TimeOfDay{Hour: 22, Minute: 0},
+						End:     maintenanceschedule.TimeOfDay{EndOfDay: true},
+					},
+				},
+			},
+			TenantDefaultTimezone: "Europe/London",
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err, "yaml.Marshal must not fail on a StewardConfig with RebootWindow")
+
+	var got StewardConfig
+	require.NoError(t, yaml.Unmarshal(data, &got), "yaml.Unmarshal must not fail on the marshaled output")
+
+	require.NotNil(t, got.Steward.RebootWindow, "RebootWindow must survive the round-trip")
+	assert.Equal(t, "America/New_York", got.Steward.RebootWindow.Timezone)
+	require.Len(t, got.Steward.RebootWindow.Schedules, 2)
+
+	weekly := got.Steward.RebootWindow.Schedules[0]
+	assert.Equal(t, maintenanceschedule.FreqWeekly, weekly.Freq)
+	assert.Equal(t, []time.Weekday{time.Monday, time.Thursday}, weekly.Days)
+	assert.Equal(t, maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0}, weekly.Start)
+	assert.Equal(t, maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0}, weekly.End)
+
+	monthly := got.Steward.RebootWindow.Schedules[1]
+	assert.Equal(t, maintenanceschedule.FreqMonthly, monthly.Freq)
+	assert.Equal(t, time.Saturday, monthly.Weekday)
+	require.NotNil(t, monthly.Nth)
+	assert.Equal(t, 1, *monthly.Nth)
+	assert.True(t, monthly.End.EndOfDay)
+
+	assert.Equal(t, "Europe/London", got.Steward.TenantDefaultTimezone)
+}
+
+// TestStewardSettings_RebootWindowNilOmitted verifies that a nil RebootWindow
+// is omitted from the YAML output and does not appear as a key.
+func TestStewardSettings_RebootWindowNilOmitted(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{ID: "test-steward", Mode: ModeStandalone},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), "reboot_window",
+		"nil RebootWindow must not appear in marshaled YAML")
+}
+
+// TestValidateConfiguration_RejectsBadRebootWindow verifies that a StewardConfig
+// with an invalid RebootWindow (empty schedules list) fails ValidateConfiguration
+// with a descriptive error referencing reboot_window.
+func TestValidateConfiguration_RejectsBadRebootWindow(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeStandalone,
+			RebootWindow: &maintenanceschedule.Config{
+				Timezone:  "America/New_York",
+				Schedules: []maintenanceschedule.Schedule{}, // empty — invalid
+			},
+		},
+	}
+
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err, "empty RebootWindow.Schedules must fail validation")
+	assert.Contains(t, err.Error(), "reboot_window",
+		"error must reference reboot_window to help operators identify the offending field")
+}
+
+// TestValidateConfiguration_AcceptsNilRebootWindow verifies that a nil RebootWindow
+// does not trigger any validation error.
+func TestValidateConfiguration_AcceptsNilRebootWindow(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:           "test-steward",
+			Mode:         ModeStandalone,
+			RebootWindow: nil,
+		},
+	}
+
+	assert.NoError(t, ValidateConfiguration(cfg),
+		"nil RebootWindow must not cause a validation error")
+}
+
+// TestValidateConfiguration_RejectsInvalidTimezoneInRebootWindow verifies that an
+// unknown IANA timezone name in RebootWindow.Timezone causes a validation error.
+func TestValidateConfiguration_RejectsInvalidTimezoneInRebootWindow(t *testing.T) {
+	nth := 1
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeStandalone,
+			RebootWindow: &maintenanceschedule.Config{
+				Timezone: "Not/A/Real/Zone",
+				Schedules: []maintenanceschedule.Schedule{
+					{
+						Freq:    maintenanceschedule.FreqMonthly,
+						Weekday: time.Wednesday,
+						Nth:     &nth,
+						Start:   maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0},
+						End:     maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0},
+					},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reboot_window")
+}

--- a/features/config/stewardtypes/validation.go
+++ b/features/config/stewardtypes/validation.go
@@ -6,6 +6,8 @@ package stewardtypes
 import (
 	"fmt"
 	"time"
+
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
 )
 
 // scriptSigningPolicyLevel returns the numeric strictness level of a signing policy.
@@ -110,6 +112,12 @@ func ValidateConfiguration(config StewardConfig) error {
 
 	if err := ValidateModuleTrustConfig(config.Steward.ModuleTrust); err != nil {
 		return fmt.Errorf("module_trust configuration invalid: %w", err)
+	}
+
+	if config.Steward.RebootWindow != nil {
+		if err := maintenanceschedule.Validate(config.Steward.RebootWindow); err != nil {
+			return fmt.Errorf("reboot_window configuration invalid: %w", err)
+		}
 	}
 
 	resourceNames := make(map[string]bool)

--- a/pkg/config/inheritance.go
+++ b/pkg/config/inheritance.go
@@ -14,6 +14,7 @@ import (
 	controllerconfig "github.com/cfgis/cfgms/features/controller/config"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/logging"
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -546,6 +547,16 @@ func (ir *InheritanceResolver) applyConfigurationWithSource(effective *Effective
 		effective.Sources["steward.error_handling.configuration_error"] = source
 	}
 
+	if config.Steward.TenantDefaultTimezone != "" {
+		effective.Config.Steward.TenantDefaultTimezone = config.Steward.TenantDefaultTimezone
+		effective.Sources["steward.tenant_default_timezone"] = source
+	}
+
+	if config.Steward.RebootWindow != nil {
+		effective.Config.Steward.RebootWindow = config.Steward.RebootWindow
+		effective.Sources["steward.reboot_window"] = source
+	}
+
 	// Apply module mappings
 	if effective.Config.Modules == nil {
 		effective.Config.Modules = make(map[string]string)
@@ -666,6 +677,27 @@ type TraceElement struct {
 // getConfigValue extracts the value at a specific configuration path
 func (ir *InheritanceResolver) getConfigValue(config *stewardconfig.StewardConfig, path string) interface{} {
 	return nil
+}
+
+// ResolveRebootWindowTimezone resolves the effective timezone for a reboot window
+// using precedence: explicit (cfg.Timezone) → tenantDefault → device ("").
+//
+// "device" as cfg.Timezone or as the return value signals the steward-side consumer
+// (Story 3) to substitute its own host zone. This package has no access to the host's
+// local zone, so the caller is responsible for that final fallback.
+//
+// Return value:
+//   - an explicit IANA name or "device" when cfg carries one
+//   - tenantDefault when cfg has no explicit timezone and tenantDefault is non-empty
+//   - "" when neither source provides a timezone (steward falls back to host zone)
+func ResolveRebootWindowTimezone(cfg *maintenanceschedule.Config, tenantDefault string) string {
+	if cfg != nil && cfg.Timezone != "" {
+		return cfg.Timezone
+	}
+	if tenantDefault != "" {
+		return tenantDefault
+	}
+	return ""
 }
 
 // ResolveRingVersion resolves the effective desired_version for a steward based on its

--- a/pkg/config/inheritance_test.go
+++ b/pkg/config/inheritance_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/logging"
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
@@ -1027,4 +1029,216 @@ func TestResolveConfiguration_RoleProviderError_LogValueSanitized(t *testing.T) 
 	cleanVal, ok := cleanEntry["steward_id"].(string)
 	require.True(t, ok, "steward_id must be a string in clean-value log entry")
 	assert.Equal(t, cleanStewardID, cleanVal, "clean value must pass through unchanged")
+}
+
+// --- RebootWindow cascade tests (Issue #2976) ---
+
+// makeWeeklyWindow returns a *maintenanceschedule.Config describing a weekly window
+// on the given days for use in cascade tests.
+func makeWeeklyWindow(tz string, days ...time.Weekday) *maintenanceschedule.Config {
+	return &maintenanceschedule.Config{
+		Timezone: tz,
+		Schedules: []maintenanceschedule.Schedule{
+			{
+				Freq:  maintenanceschedule.FreqWeekly,
+				Days:  days,
+				Start: maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0},
+				End:   maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0},
+			},
+		},
+	}
+}
+
+func makeMonthlyWindow(tz string, weekday time.Weekday, nth int) *maintenanceschedule.Config {
+	n := nth
+	return &maintenanceschedule.Config{
+		Timezone: tz,
+		Schedules: []maintenanceschedule.Schedule{
+			{
+				Freq:    maintenanceschedule.FreqMonthly,
+				Weekday: weekday,
+				Nth:     &n,
+				Start:   maintenanceschedule.TimeOfDay{Hour: 22, Minute: 0},
+				End:     maintenanceschedule.TimeOfDay{EndOfDay: true},
+			},
+		},
+	}
+}
+
+// TestApplyConfigurationWithSource_RebootWindowCascade_LaterWins is the REQUIRED TEST
+// from acceptance criteria: a three-level cascade where MSP declares a monthly window,
+// Client overrides with a more-frequent weekly window, and Device overrides again with
+// a looser monthly window. The lowest declaring level wins in each case, proving that
+// override works in both directions (tighter-at-child AND looser-at-child).
+func TestApplyConfigurationWithSource_RebootWindowCascade_LaterWins(t *testing.T) {
+	ir := &InheritanceResolver{}
+	effective := &EffectiveConfiguration{Sources: make(map[string]*InheritanceSource)}
+
+	mspSrc := &InheritanceSource{Source: "msp", TenantID: "msp"}
+	clientSrc := &InheritanceSource{Source: "client", TenantID: "client"}
+	deviceSrc := &InheritanceSource{Source: "device", TenantID: "client"}
+
+	// MSP: monthly window on 1st Saturday (looser/less-frequent)
+	mspWindow := makeMonthlyWindow("America/New_York", time.Saturday, 1)
+	ir.applyConfigurationWithSource(effective, &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{RebootWindow: mspWindow},
+	}, mspSrc)
+
+	assert.Equal(t, mspWindow, effective.Config.Steward.RebootWindow,
+		"after MSP pass, MSP window must be the effective window")
+	assert.Equal(t, mspSrc, effective.Sources["steward.reboot_window"])
+	assert.Equal(t, maintenanceschedule.FreqMonthly, effective.Config.Steward.RebootWindow.Schedules[0].Freq,
+		"MSP window must be monthly")
+
+	// Client: weekly Mon+Thu (tighter / more-frequent than MSP monthly)
+	clientWindow := makeWeeklyWindow("America/Chicago", time.Monday, time.Thursday)
+	ir.applyConfigurationWithSource(effective, &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{RebootWindow: clientWindow},
+	}, clientSrc)
+
+	assert.Equal(t, clientWindow, effective.Config.Steward.RebootWindow,
+		"client window (more-frequent) must override MSP window — tighter-at-child must win")
+	assert.Equal(t, clientSrc, effective.Sources["steward.reboot_window"])
+	assert.Equal(t, maintenanceschedule.FreqWeekly, effective.Config.Steward.RebootWindow.Schedules[0].Freq,
+		"effective window must be weekly after client override")
+
+	// Device: monthly 1st Wednesday (looser than client weekly)
+	deviceWindow := makeMonthlyWindow("UTC", time.Wednesday, 1)
+	ir.applyConfigurationWithSource(effective, &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{RebootWindow: deviceWindow},
+	}, deviceSrc)
+
+	assert.Equal(t, deviceWindow, effective.Config.Steward.RebootWindow,
+		"device window (looser/less-frequent) must override client window — looser-at-child must win")
+	assert.Equal(t, deviceSrc, effective.Sources["steward.reboot_window"])
+	assert.Equal(t, maintenanceschedule.FreqMonthly, effective.Config.Steward.RebootWindow.Schedules[0].Freq,
+		"effective window must be monthly after device override")
+}
+
+// TestApplyConfigurationWithSource_RebootWindowNilDoesNotClobber verifies that a nil
+// RebootWindow at a child level does not clear an inherited window.
+func TestApplyConfigurationWithSource_RebootWindowNilDoesNotClobber(t *testing.T) {
+	ir := &InheritanceResolver{}
+	effective := &EffectiveConfiguration{Sources: make(map[string]*InheritanceSource)}
+
+	parentSrc := &InheritanceSource{Source: "parent", TenantID: "msp"}
+	parentWindow := makeWeeklyWindow("America/New_York", time.Monday)
+	ir.applyConfigurationWithSource(effective, &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{RebootWindow: parentWindow},
+	}, parentSrc)
+
+	// Child has no RebootWindow (nil) — must not clear the inherited value.
+	childSrc := &InheritanceSource{Source: "child", TenantID: "client"}
+	ir.applyConfigurationWithSource(effective, &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{ID: "child-id"},
+	}, childSrc)
+
+	assert.Equal(t, parentWindow, effective.Config.Steward.RebootWindow,
+		"nil RebootWindow at child must not clobber inherited parent window")
+	assert.Equal(t, parentSrc, effective.Sources["steward.reboot_window"],
+		"source must remain the parent that set the window")
+}
+
+// TestResolveConfiguration_RebootWindowCascadeViaStore verifies end-to-end that
+// a reboot_window set at MSP level cascades to a descendant steward via the full
+// store-backed resolution path.
+func TestResolveConfiguration_RebootWindowCascadeViaStore(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+	ctx := context.Background()
+	seedThreeLevelTenants(t, ctx, sm)
+
+	cs := sm.GetConfigStore()
+	require.NotNil(t, cs)
+
+	mspWindow := makeWeeklyWindow("America/Chicago", time.Tuesday, time.Friday)
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{TenantID: "root", Namespace: "msp-policies", Name: "global"},
+		Data: marshalStewardConfig(t, stewardconfig.StewardConfig{
+			Steward: stewardconfig.StewardSettings{RebootWindow: mspWindow},
+		}),
+	}))
+
+	ir := NewInheritanceResolverWithStorageManager(sm)
+	effective, err := ir.ResolveConfiguration(ctx, "client", "steward-1")
+	require.NoError(t, err)
+
+	require.NotNil(t, effective.Config.Steward.RebootWindow,
+		"reboot_window set at MSP must cascade to descendant steward")
+	assert.Equal(t, "America/Chicago", effective.Config.Steward.RebootWindow.Timezone)
+	require.NotNil(t, effective.Sources["steward.reboot_window"],
+		"inheritance source for reboot_window must be recorded")
+}
+
+// TestApplyConfigurationWithSource_TenantDefaultTimezoneCascade verifies that
+// TenantDefaultTimezone follows the same later-overrides-earlier merge rule.
+func TestApplyConfigurationWithSource_TenantDefaultTimezoneCascade(t *testing.T) {
+	ir := &InheritanceResolver{}
+	effective := &EffectiveConfiguration{Sources: make(map[string]*InheritanceSource)}
+
+	rootSrc := &InheritanceSource{Source: "root", TenantID: "root"}
+	ir.applyConfigurationWithSource(effective, &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{TenantDefaultTimezone: "America/New_York"},
+	}, rootSrc)
+	assert.Equal(t, "America/New_York", effective.Config.Steward.TenantDefaultTimezone)
+	assert.Equal(t, rootSrc, effective.Sources["steward.tenant_default_timezone"])
+
+	clientSrc := &InheritanceSource{Source: "client", TenantID: "client"}
+	ir.applyConfigurationWithSource(effective, &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{TenantDefaultTimezone: "Europe/London"},
+	}, clientSrc)
+	assert.Equal(t, "Europe/London", effective.Config.Steward.TenantDefaultTimezone,
+		"client-level TenantDefaultTimezone must override root-level")
+	assert.Equal(t, clientSrc, effective.Sources["steward.tenant_default_timezone"])
+}
+
+// --- ResolveRebootWindowTimezone tests (Issue #2976) ---
+
+// TestResolveRebootWindowTimezone_ExplicitWins is the REQUIRED TEST from acceptance
+// criteria: all three cases are verified (explicit set, explicit absent+tenantDefault
+// set, both absent).
+func TestResolveRebootWindowTimezone_AllCases(t *testing.T) {
+	t.Run("explicit timezone wins over tenant default and device", func(t *testing.T) {
+		cfg := &maintenanceschedule.Config{Timezone: "America/New_York"}
+		got := ResolveRebootWindowTimezone(cfg, "Europe/London")
+		assert.Equal(t, "America/New_York", got,
+			"explicit cfg.Timezone must take highest precedence")
+	})
+
+	t.Run("tenant default used when explicit is absent", func(t *testing.T) {
+		cfg := &maintenanceschedule.Config{Timezone: ""} // not set
+		got := ResolveRebootWindowTimezone(cfg, "Europe/London")
+		assert.Equal(t, "Europe/London", got,
+			"tenant default must be used when cfg.Timezone is empty")
+	})
+
+	t.Run("returns empty string when both are absent (device fallback)", func(t *testing.T) {
+		cfg := &maintenanceschedule.Config{Timezone: ""}
+		got := ResolveRebootWindowTimezone(cfg, "")
+		assert.Equal(t, "", got,
+			`"" signals the steward consumer to fall back to host zone`)
+	})
+}
+
+// TestResolveRebootWindowTimezone_NilConfig verifies that a nil cfg falls back to
+// tenantDefault (no panic).
+func TestResolveRebootWindowTimezone_NilConfig(t *testing.T) {
+	got := ResolveRebootWindowTimezone(nil, "Asia/Tokyo")
+	assert.Equal(t, "Asia/Tokyo", got,
+		"nil cfg must fall back to tenantDefault")
+}
+
+// TestResolveRebootWindowTimezone_NilConfigNilDefault verifies that nil cfg and
+// empty tenantDefault return "".
+func TestResolveRebootWindowTimezone_NilConfigNilDefault(t *testing.T) {
+	got := ResolveRebootWindowTimezone(nil, "")
+	assert.Equal(t, "", got, `nil cfg + empty tenantDefault must return ""`)
+}
+
+// TestResolveRebootWindowTimezone_DeviceExplicit verifies that the literal "device"
+// value in cfg.Timezone is returned as-is (not treated as absent).
+func TestResolveRebootWindowTimezone_DeviceExplicit(t *testing.T) {
+	cfg := &maintenanceschedule.Config{Timezone: "device"}
+	got := ResolveRebootWindowTimezone(cfg, "America/New_York")
+	assert.Equal(t, "device", got,
+		`explicit "device" timezone must be returned as-is, not overridden by tenantDefault`)
 }

--- a/pkg/maintenance/schedule/marshal.go
+++ b/pkg/maintenance/schedule/marshal.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MarshalYAML encodes Config back to the human-readable raw form that Parse accepts,
+// so that a StewardConfig containing a *Config round-trips through yaml.Marshal /
+// yaml.Unmarshal unchanged.
+func (c Config) MarshalYAML() (interface{}, error) {
+	raw := rawConfig{
+		Timezone:  c.Timezone,
+		Schedules: make([]rawSchedule, len(c.Schedules)),
+	}
+	for i, s := range c.Schedules {
+		raw.Schedules[i] = toRawSchedule(s)
+	}
+	return raw, nil
+}
+
+// UnmarshalYAML decodes a YAML node for a reboot_window block by re-encoding the
+// node to bytes and passing them through Parse, which validates the schedule.
+func (c *Config) UnmarshalYAML(value *yaml.Node) error {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("reboot_window: cannot re-encode yaml node: %w", err)
+	}
+	parsed, _, err := Parse(data)
+	if err != nil {
+		return err
+	}
+	*c = *parsed
+	return nil
+}
+
+func weekdayName(w time.Weekday) string {
+	switch w {
+	case time.Sunday:
+		return "sunday"
+	case time.Monday:
+		return "monday"
+	case time.Tuesday:
+		return "tuesday"
+	case time.Wednesday:
+		return "wednesday"
+	case time.Thursday:
+		return "thursday"
+	case time.Friday:
+		return "friday"
+	case time.Saturday:
+		return "saturday"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(w))
+	}
+}
+
+func formatTimeOfDay(t TimeOfDay) string {
+	if t.EndOfDay {
+		return "24:00"
+	}
+	return fmt.Sprintf("%02d:%02d", t.Hour, t.Minute)
+}
+
+func toRawSchedule(s Schedule) rawSchedule {
+	rs := rawSchedule{
+		Freq:  string(s.Freq),
+		Start: formatTimeOfDay(s.Start),
+		End:   formatTimeOfDay(s.End),
+	}
+
+	switch s.Freq {
+	case FreqWeekly:
+		rs.Days = make([]string, len(s.Days))
+		for i, d := range s.Days {
+			rs.Days[i] = weekdayName(d)
+		}
+	case FreqMonthly:
+		rs.Weekday = weekdayName(s.Weekday)
+		switch {
+		case s.Nth != nil:
+			nth := *s.Nth
+			rs.Nth = &nth
+		case s.After != nil:
+			rs.After = &rawAnchor{
+				Weekday: weekdayName(s.After.Weekday),
+				Nth:     s.After.Nth,
+			}
+		case s.Before != nil:
+			rs.Before = &rawAnchor{
+				Weekday: weekdayName(s.Before.Weekday),
+				Nth:     s.Before.Nth,
+			}
+		}
+	}
+
+	return rs
+}

--- a/pkg/maintenance/schedule/validate.go
+++ b/pkg/maintenance/schedule/validate.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import (
+	"fmt"
+	"time"
+)
+
+// Validate checks that cfg is a structurally valid, fully-parsed Config.
+// It mirrors the invariants enforced during Parse; use it when a Config has
+// been constructed programmatically or deserialized outside of Parse.
+func Validate(cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("reboot_window: config is nil")
+	}
+	if len(cfg.Schedules) == 0 {
+		return fmt.Errorf("reboot_window: schedules must contain at least one entry")
+	}
+	if cfg.Timezone != "" && cfg.Timezone != "device" {
+		if _, err := time.LoadLocation(cfg.Timezone); err != nil {
+			return fmt.Errorf("reboot_window: invalid timezone %q: %w", cfg.Timezone, err)
+		}
+	}
+	for i, s := range cfg.Schedules {
+		if err := validateParsedSchedule(i, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateParsedSchedule(idx int, s Schedule) error {
+	prefix := fmt.Sprintf("schedules[%d]", idx)
+	switch s.Freq {
+	case FreqMonthly, FreqWeekly:
+		// valid
+	default:
+		return fmt.Errorf("%s: invalid freq %q", prefix, s.Freq)
+	}
+
+	anchorCount := 0
+	if s.Nth != nil {
+		anchorCount++
+	}
+	if s.After != nil {
+		anchorCount++
+	}
+	if s.Before != nil {
+		anchorCount++
+	}
+
+	if s.Freq == FreqWeekly {
+		if len(s.Days) == 0 {
+			return fmt.Errorf("%s: freq weekly requires at least one day", prefix)
+		}
+		if anchorCount > 0 {
+			return fmt.Errorf("%s: nth/after/before are only valid with freq monthly", prefix)
+		}
+	}
+
+	if s.Freq == FreqMonthly {
+		if len(s.Days) > 0 {
+			return fmt.Errorf("%s: days is only valid with freq weekly", prefix)
+		}
+		if anchorCount != 1 {
+			return fmt.Errorf("%s: freq monthly requires exactly one of nth, after, or before", prefix)
+		}
+	}
+
+	return nil
+}

--- a/pkg/maintenance/schedule/validate_test.go
+++ b/pkg/maintenance/schedule/validate_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func ptr(i int) *int { return &i }
+
+// TestValidate_NilConfig verifies that Validate rejects a nil pointer.
+func TestValidate_NilConfig(t *testing.T) {
+	err := Validate(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+// TestValidate_EmptySchedules verifies that an empty schedule list is rejected.
+func TestValidate_EmptySchedules(t *testing.T) {
+	err := Validate(&Config{Schedules: []Schedule{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schedules")
+}
+
+// TestValidate_BadTimezone verifies that an unknown IANA timezone is rejected.
+func TestValidate_BadTimezone(t *testing.T) {
+	err := Validate(&Config{
+		Timezone: "Not/Real/Zone",
+		Schedules: []Schedule{
+			{Freq: FreqWeekly, Days: []time.Weekday{time.Monday},
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timezone")
+}
+
+// TestValidate_DeviceTimezone verifies that the literal "device" timezone passes.
+func TestValidate_DeviceTimezone(t *testing.T) {
+	err := Validate(&Config{
+		Timezone: "device",
+		Schedules: []Schedule{
+			{Freq: FreqWeekly, Days: []time.Weekday{time.Monday},
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	assert.NoError(t, err)
+}
+
+// TestValidate_InvalidFreq covers the invalid-Freq branch in validateParsedSchedule.
+func TestValidate_InvalidFreq(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: Freq("quarterly"), Days: []time.Weekday{time.Monday},
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "freq")
+}
+
+// TestValidate_WeeklyWithNth covers FreqWeekly+Nth rejection.
+func TestValidate_WeeklyWithNth(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqWeekly, Days: []time.Weekday{time.Monday},
+				Nth:   ptr(1),
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nth")
+}
+
+// TestValidate_WeeklyWithAfter covers FreqWeekly+After rejection.
+func TestValidate_WeeklyWithAfter(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqWeekly, Days: []time.Weekday{time.Monday},
+				After: &Anchor{Weekday: time.Wednesday, Nth: 1},
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "monthly")
+}
+
+// TestValidate_WeeklyWithBefore covers FreqWeekly+Before rejection.
+func TestValidate_WeeklyWithBefore(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqWeekly, Days: []time.Weekday{time.Monday},
+				Before: &Anchor{Weekday: time.Wednesday, Nth: 1},
+				Start:  TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "monthly")
+}
+
+// TestValidate_MonthlyWithDays covers FreqMonthly+Days rejection.
+func TestValidate_MonthlyWithDays(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqMonthly, Weekday: time.Wednesday,
+				Nth:   ptr(1),
+				Days:  []time.Weekday{time.Monday},
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "days")
+}
+
+// TestValidate_MonthlyMissingAnchor covers FreqMonthly with zero anchors (anchorCount==0).
+func TestValidate_MonthlyMissingAnchor(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqMonthly, Weekday: time.Wednesday,
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "monthly")
+}
+
+// TestValidate_MonthlyMultipleAnchors covers FreqMonthly with anchorCount>1.
+func TestValidate_MonthlyMultipleAnchors(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqMonthly, Weekday: time.Wednesday,
+				Nth:   ptr(1),
+				After: &Anchor{Weekday: time.Monday, Nth: 2},
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "monthly")
+}
+
+// TestValidate_ValidWeekly verifies a well-formed weekly config passes.
+func TestValidate_ValidWeekly(t *testing.T) {
+	err := Validate(&Config{
+		Timezone: "America/New_York",
+		Schedules: []Schedule{
+			{Freq: FreqWeekly, Days: []time.Weekday{time.Monday, time.Thursday},
+				Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+		},
+	})
+	assert.NoError(t, err)
+}
+
+// TestValidate_ValidMonthlyNth verifies a well-formed monthly (nth) config passes.
+func TestValidate_ValidMonthlyNth(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqMonthly, Weekday: time.Saturday, Nth: ptr(1),
+				Start: TimeOfDay{Hour: 22}, End: TimeOfDay{EndOfDay: true}},
+		},
+	})
+	assert.NoError(t, err)
+}
+
+// TestValidate_ValidMonthlyAfter verifies a well-formed monthly (after) config passes.
+func TestValidate_ValidMonthlyAfter(t *testing.T) {
+	err := Validate(&Config{
+		Schedules: []Schedule{
+			{Freq: FreqMonthly, Weekday: time.Tuesday,
+				After: &Anchor{Weekday: time.Monday, Nth: 2},
+				Start: TimeOfDay{Hour: 3}, End: TimeOfDay{Hour: 5}},
+		},
+	})
+	assert.NoError(t, err)
+}
+
+// TestUnmarshalYAML_ErrorPath verifies that an invalid reboot_window YAML block causes
+// UnmarshalYAML to return the Parse error rather than silently producing a zero Config.
+func TestUnmarshalYAML_ErrorPath(t *testing.T) {
+	// A Config node with an empty schedules list must fail Parse and surface via UnmarshalYAML.
+	invalidYAML := []byte(`timezone: "America/New_York"
+schedules: []
+`)
+	var cfg Config
+	err := yaml.Unmarshal(invalidYAML, &cfg)
+	require.Error(t, err, "UnmarshalYAML must propagate Parse errors for invalid YAML blocks")
+	assert.Contains(t, err.Error(), "schedules")
+}
+
+// TestMarshalUnmarshal_RoundTrip verifies that MarshalYAML → UnmarshalYAML preserves
+// the full Config value for both weekly and monthly (after/before/nth) shapes.
+func TestMarshalUnmarshal_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "weekly",
+			cfg: Config{
+				Timezone: "America/Chicago",
+				Schedules: []Schedule{
+					{Freq: FreqWeekly, Days: []time.Weekday{time.Monday, time.Thursday},
+						Start: TimeOfDay{Hour: 2}, End: TimeOfDay{Hour: 4}},
+				},
+			},
+		},
+		{
+			name: "monthly-nth",
+			cfg: Config{
+				Schedules: []Schedule{
+					{Freq: FreqMonthly, Weekday: time.Saturday, Nth: ptr(-1),
+						Start: TimeOfDay{Hour: 22}, End: TimeOfDay{EndOfDay: true}},
+				},
+			},
+		},
+		{
+			name: "monthly-after",
+			cfg: Config{
+				Schedules: []Schedule{
+					{Freq: FreqMonthly, Weekday: time.Tuesday,
+						After: &Anchor{Weekday: time.Monday, Nth: 1},
+						Start: TimeOfDay{Hour: 3}, End: TimeOfDay{Hour: 5}},
+				},
+			},
+		},
+		{
+			name: "monthly-before",
+			cfg: Config{
+				Schedules: []Schedule{
+					{Freq: FreqMonthly, Weekday: time.Thursday,
+						Before: &Anchor{Weekday: time.Friday, Nth: 2},
+						Start:  TimeOfDay{Hour: 1}, End: TimeOfDay{Hour: 3}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tc.cfg)
+			require.NoError(t, err, "Marshal must not fail")
+
+			var got Config
+			require.NoError(t, yaml.Unmarshal(data, &got), "Unmarshal must not fail")
+			assert.Equal(t, tc.cfg, got, "round-trip must preserve all fields")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `RebootWindow *maintenanceschedule.Config` and `TenantDefaultTimezone string` to `StewardSettings` with full YAML/JSON round-trip support via custom `MarshalYAML`/`UnmarshalYAML` on `schedule.Config`
- Extends `applyConfigurationWithSource` in `pkg/config/inheritance.go` with later-overrides-earlier merge blocks for both fields, following the existing `DriftMode`/`DesiredVersion` pattern — no lattice/narrowing logic (ADR-026 decision 3)
- Adds `ResolveRebootWindowTimezone(cfg, tenantDefault)` resolver near `ResolveRingVersion`: explicit → tenantDefault → "" (device, caller resolves from host zone)
- Adds `schedule.Validate(*Config)` to the schedule package and delegates to it from `stewardtypes.ValidateConfiguration`

Fixes #2976

## Review results

**Code Review:** PASS (after fix — added `validate_test.go` to cover all `validateParsedSchedule` error branches and `UnmarshalYAML` error path flagged in review)
**QA Test Runner:** PASS
**Security:** PASS

## Test plan

- [ ] `TestStewardSettings_RebootWindowYAMLRoundTrip` — weekly + monthly shapes survive `yaml.Marshal` / `yaml.Unmarshal` unchanged
- [ ] `TestApplyConfigurationWithSource_RebootWindowCascade_LaterWins` — three-level cascade (MSP monthly → Client weekly (tighter) → Device monthly (looser)) proves free override in both directions
- [ ] `TestResolveRebootWindowTimezone_AllCases` — all three precedence cases (explicit, tenantDefault-only, both-absent)
- [ ] `TestValidate_*` — all `validateParsedSchedule` error branches and `Validate()` guards covered
- [ ] `TestMarshalUnmarshal_RoundTrip` — weekly/monthly-nth/monthly-after/monthly-before round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)