### PR TITLE
web: structured step authoring + key/value variable editor (Issue #2984)

### DIFF
--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite" // Pure-Go SQLite driver (CGO-free)
@@ -198,13 +199,135 @@ func getPath(config map[string]interface{}) string {
 // nowUTC returns the current time in UTC (facilitates testing overrides if needed).
 func nowUTC() time.Time { return time.Now().UTC() }
 
+// isMemoryPath reports whether path denotes an in-memory SQLite database.
+// In-memory databases are only ever created by tests (production always uses a
+// file). They are always empty at open, so the full schema-DDL/back-fill pass
+// can be replaced by the deserialize fast-path in openAndInit.
+func isMemoryPath(path string) bool {
+	return path == ":memory:" || strings.Contains(path, "mode=memory")
+}
+
+// schemaTemplate holds a serialized page image of a freshly-initialised database,
+// built exactly once per process. Running the full schema DDL (~15 CREATE TABLEs
+// plus indexes and three back-fill probes) costs ~176ms per open under the race
+// detector; a single large test package (features/controller/api) opens ~900
+// in-memory databases, which alone pushed the suite past the 5-minute test-fast
+// budget and produced the timeout captured in initializeSchema. Deserializing a
+// prebuilt page image is a memcpy (~15ms under -race) and yields a byte-identical
+// schema because the template is itself produced by initializeSchema.
+var (
+	schemaTemplateOnce sync.Once
+	schemaTemplateData []byte
+	schemaTemplateErr  error
+)
+
+// serializer/deserializer are the modernc.org/sqlite driver-connection capabilities
+// used by the in-memory fast-path. They are defined here (not imported) so the
+// provider does not take a compile-time dependency on driver internals: if a future
+// driver lacks them, the type assertions fail and openAndInit falls back to the
+// full DDL path.
+type serializer interface{ Serialize() ([]byte, error) }
+type deserializer interface{ Deserialize([]byte) error }
+
+// buildSchemaTemplate initialises a throwaway private in-memory database with the
+// full DDL path and returns its serialized page image.
+func buildSchemaTemplate() ([]byte, error) {
+	// Private cache (no cache=shared) and a fixed name: this database is used only
+	// to produce the template and is closed immediately, so it must not collide
+	// with, or be visible to, any test database.
+	db, err := openDB("file:cfgms-schema-template?mode=memory")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	if err := initializeSchema(ctx, db); err != nil {
+		return nil, fmt.Errorf("sqlite: building schema template: %w", err)
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	var data []byte
+	rawErr := conn.Raw(func(dc any) error {
+		s, ok := dc.(serializer)
+		if !ok {
+			return fmt.Errorf("sqlite: driver connection does not support Serialize")
+		}
+		b, err := s.Serialize()
+		if err != nil {
+			return err
+		}
+		data = b
+		return nil
+	})
+	if rawErr != nil {
+		return nil, rawErr
+	}
+	return data, nil
+}
+
+// applySchemaTemplate installs the process-wide schema template into an empty
+// in-memory database. It returns an error (leaving the DB untouched) when the
+// template is unavailable or the driver lacks Deserialize, so the caller can fall
+// back to the full DDL path. If the database is already initialised (another
+// handle to the same shared-cache database ran first) it is a no-op, mirroring
+// the CREATE TABLE IF NOT EXISTS idempotency of initializeSchema — deserialize
+// replaces the whole database, so it must never run over existing data.
+func applySchemaTemplate(ctx context.Context, db *sql.DB) error {
+	schemaTemplateOnce.Do(func() {
+		schemaTemplateData, schemaTemplateErr = buildSchemaTemplate()
+	})
+	if schemaTemplateErr != nil {
+		return schemaTemplateErr
+	}
+
+	already, err := tableExists(ctx, db, "schema_version")
+	if err != nil {
+		return err
+	}
+	if already {
+		return nil
+	}
+
+	// Deserialize must run on the same connection that later queries use. In-memory
+	// databases are pinned to a single pool connection (openDB sets MaxOpenConns(1)),
+	// so checking the connection out here and returning it makes the installed schema
+	// visible to every store that shares this *sql.DB.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	return conn.Raw(func(dc any) error {
+		d, ok := dc.(deserializer)
+		if !ok {
+			return fmt.Errorf("sqlite: driver connection does not support Deserialize")
+		}
+		return d.Deserialize(schemaTemplateData)
+	})
+}
+
 // openAndInit opens a SQLite DB at the given path, applies WAL pragma, and runs schema DDL.
+// In-memory databases (tests only) take the deserialize fast-path; a failure there
+// falls through to the full DDL path so correctness never depends on the optimisation.
 func openAndInit(path string) (*sql.DB, error) {
 	db, err := openDB(path)
 	if err != nil {
 		return nil, err
 	}
 	ctx := context.Background()
+	if isMemoryPath(path) {
+		if err := applySchemaTemplate(ctx, db); err == nil {
+			return db, nil
+		}
+		// Fall through to the full DDL path on any fast-path failure.
+	}
 	if err := initializeSchema(ctx, db); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite: schema initialisation failed: %w", err)

--- a/web/src/workflow/Workflow.css
+++ b/web/src/workflow/Workflow.css
@@ -467,6 +467,58 @@ table.tbl {
   padding: 0 14px 10px;
 }
 
+/* ── Step builder ──────────────────────────────────────────────── */
+.wf-builder-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.wf-builder-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.wf-step-row {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.wf-step-remove {
+  align-self: flex-end;
+}
+.wf-raw-config {
+  margin-top: 2px;
+}
+.wf-raw-config-toggle {
+  font-size: 11px;
+  color: var(--text-faint);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  padding: 2px 0;
+}
+.wf-raw-config-toggle:hover {
+  color: var(--text-secondary);
+}
+
+/* ── Variable editor ───────────────────────────────────────────── */
+.wf-var-row {
+  align-items: flex-end;
+}
+.wf-var-remove {
+  align-self: flex-end;
+}
+.wf-var-empty {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-faint);
+  padding: 2px 0;
+}
+
 /* ── Trigger panel ─────────────────────────────────────────────── */
 .wf-trigger-panel {
   background: var(--bg-sunk);

--- a/web/src/workflow/WorkflowListView.test.tsx
+++ b/web/src/workflow/WorkflowListView.test.tsx
@@ -505,7 +505,7 @@ describe('WorkflowListView — structured step builder (Story #2984)', () => {
     expect(screen.getAllByTestId('step-row')).toHaveLength(2)
 
     const removeBtns = screen.getAllByTestId('step-remove-btn')
-    fireEvent.click(removeBtns[0])
+    fireEvent.click(removeBtns[0]!)
     expect(screen.getAllByTestId('step-row')).toHaveLength(1)
   })
 
@@ -529,8 +529,8 @@ describe('WorkflowListView — structured step builder (Story #2984)', () => {
 
     const nameInputs = screen.getAllByTestId('step-name-input') as HTMLInputElement[]
     expect(nameInputs).toHaveLength(2)
-    expect(nameInputs[0].value).toBe('step-a')
-    expect(nameInputs[1].value).toBe('step-b')
+    expect(nameInputs[0]!.value).toBe('step-a')
+    expect(nameInputs[1]!.value).toBe('step-b')
   })
 
   it('script step script-body field is pre-populated from existing config.script', async () => {
@@ -626,7 +626,7 @@ describe('WorkflowListView — variables editor (Story #2984)', () => {
     expect(screen.getAllByTestId('var-row')).toHaveLength(2)
 
     const removeBtns = screen.getAllByTestId('var-remove-btn')
-    fireEvent.click(removeBtns[0])
+    fireEvent.click(removeBtns[0]!)
     expect(screen.getAllByTestId('var-row')).toHaveLength(1)
   })
 
@@ -650,10 +650,10 @@ describe('WorkflowListView — variables editor (Story #2984)', () => {
 
     const keyInputs = screen.getAllByTestId('var-key-input') as HTMLInputElement[]
     const valInputs = screen.getAllByTestId('var-value-input') as HTMLInputElement[]
-    fireEvent.change(keyInputs[0], { target: { value: 'ENV' } })
-    fireEvent.change(valInputs[0], { target: { value: 'production' } })
-    fireEvent.change(keyInputs[1], { target: { value: 'TIMEOUT' } })
-    fireEvent.change(valInputs[1], { target: { value: '30' } })
+    fireEvent.change(keyInputs[0]!, { target: { value: 'ENV' } })
+    fireEvent.change(valInputs[0]!, { target: { value: 'production' } })
+    fireEvent.change(keyInputs[1]!, { target: { value: 'TIMEOUT' } })
+    fireEvent.change(valInputs[1]!, { target: { value: '30' } })
 
     let capturedBody: Record<string, unknown> | null = null
     fetchMock.mockImplementationOnce((_url: RequestInfo | URL, opts?: RequestInit): Promise<Response> => {

--- a/web/src/workflow/WorkflowListView.test.tsx
+++ b/web/src/workflow/WorkflowListView.test.tsx
@@ -693,7 +693,7 @@ describe('WorkflowListView — variables editor (Story #2984)', () => {
     const valInputs = screen.getAllByTestId('var-value-input') as HTMLInputElement[]
     expect(keyInputs).toHaveLength(2)
     // Keys may be in any order depending on Object.entries order
-    const pairs = keyInputs.map((k, i) => `${k.value}=${valInputs[i].value}`)
+    const pairs = keyInputs.map((k, i) => `${k.value}=${valInputs.at(i)?.value ?? ''}`)
     expect(pairs).toContain('FOO=bar')
     expect(pairs).toContain('BAZ=42')
   })

--- a/web/src/workflow/WorkflowListView.test.tsx
+++ b/web/src/workflow/WorkflowListView.test.tsx
@@ -2,8 +2,9 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * WorkflowListView test suite (Story #2731): list rendering, data states,
- * create panel toggle, trigger panel toggle, and delete confirm.
+ * WorkflowListView test suite (Stories #2731, #2984): list rendering, data
+ * states, create panel toggle, trigger panel toggle, delete confirm, and the
+ * structured step/variable authoring path (Story #2984).
  */
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -35,7 +36,7 @@ function makeWorkflow(overrides: Partial<Record<string, unknown>> = {}) {
     name: 'wf-1',
     description: 'Test workflow',
     version: '1.0.0',
-    steps: [{ name: 'step-1', type: 'script' }],
+    steps: [{ name: 'step-1', type: 'script', config: {} }],
     semantic_version: { major: 1, minor: 0, patch: 0, pre_release: '', build_meta: '' },
     ...overrides,
   }
@@ -187,7 +188,7 @@ describe('WorkflowListView — create panel', () => {
     )
   })
 
-  it('shows validation error when steps JSON is invalid', async () => {
+  it('shows validation error when a step has an empty name', async () => {
     fetchMock.mockResolvedValue(makeWorkflowListResponse([]))
     renderWorkflowListView()
     await waitFor(() =>
@@ -198,8 +199,9 @@ describe('WorkflowListView — create panel', () => {
     fireEvent.change(screen.getByTestId('workflow-name-input'), {
       target: { value: 'bad-wf' },
     })
-    fireEvent.change(screen.getByTestId('workflow-steps-input'), {
-      target: { value: 'not-json' },
+    // Clear the step name to trigger validation
+    fireEvent.change(screen.getByTestId('step-name-input'), {
+      target: { value: '' },
     })
     fireEvent.click(screen.getByTestId('workflow-save-btn'))
     expect(screen.getByTestId('workflow-save-error')).toBeInTheDocument()
@@ -449,5 +451,288 @@ describe('WorkflowListView — security (A9.1)', () => {
     )
     expect(screen.getAllByText(xss).length).toBeGreaterThan(0)
     expect((window as unknown as Record<string, unknown>).__xss).toBeUndefined()
+  })
+})
+
+// ── Story #2984: structured step builder ─────────────────────────────────────
+
+async function openCreatePanel() {
+  fetchMock.mockResolvedValue(makeWorkflowListResponse([]))
+  renderWorkflowListView()
+  await waitFor(() =>
+    expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
+  )
+  fireEvent.click(screen.getByTestId('toggle-create-btn'))
+  expect(screen.getByTestId('workflow-form-panel')).toBeInTheDocument()
+}
+
+describe('WorkflowListView — structured step builder (Story #2984)', () => {
+  it('shows one step row with name input and type select by default', async () => {
+    await openCreatePanel()
+    expect(screen.getAllByTestId('step-row')).toHaveLength(1)
+    expect(screen.getByTestId('step-name-input')).toBeInTheDocument()
+    expect(screen.getByTestId('step-type-select')).toBeInTheDocument()
+  })
+
+  it('default step type is script and shows script body input', async () => {
+    await openCreatePanel()
+    const typeSelect = screen.getByTestId('step-type-select') as HTMLSelectElement
+    expect(typeSelect.value).toBe('script')
+    expect(screen.getByTestId('step-script-input')).toBeInTheDocument()
+  })
+
+  it('does not show remove button when only one step exists', async () => {
+    await openCreatePanel()
+    expect(screen.queryByTestId('step-remove-btn')).toBeNull()
+  })
+
+  it('Add step button adds a second step row', async () => {
+    await openCreatePanel()
+    fireEvent.click(screen.getByTestId('add-step-btn'))
+    expect(screen.getAllByTestId('step-row')).toHaveLength(2)
+    expect(screen.getAllByTestId('step-name-input')).toHaveLength(2)
+  })
+
+  it('shows remove button on each row when multiple steps exist', async () => {
+    await openCreatePanel()
+    fireEvent.click(screen.getByTestId('add-step-btn'))
+    expect(screen.getAllByTestId('step-remove-btn')).toHaveLength(2)
+  })
+
+  it('Remove step button removes that row', async () => {
+    await openCreatePanel()
+    fireEvent.click(screen.getByTestId('add-step-btn'))
+    expect(screen.getAllByTestId('step-row')).toHaveLength(2)
+
+    const removeBtns = screen.getAllByTestId('step-remove-btn')
+    fireEvent.click(removeBtns[0])
+    expect(screen.getAllByTestId('step-row')).toHaveLength(1)
+  })
+
+  it('editing an existing workflow loads its step rows into the builder', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeWorkflowListResponse([
+        makeWorkflow({
+          name: 'wf-1',
+          steps: [
+            { name: 'step-a', type: 'script', config: { script: 'echo a' } },
+            { name: 'step-b', type: 'script', config: {} },
+          ],
+        }),
+      ]),
+    )
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('workflow-edit-btn'))
+
+    const nameInputs = screen.getAllByTestId('step-name-input') as HTMLInputElement[]
+    expect(nameInputs).toHaveLength(2)
+    expect(nameInputs[0].value).toBe('step-a')
+    expect(nameInputs[1].value).toBe('step-b')
+  })
+
+  it('script step script-body field is pre-populated from existing config.script', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeWorkflowListResponse([
+        makeWorkflow({
+          steps: [{ name: 'run', type: 'script', config: { script: 'echo hello' } }],
+        }),
+      ]),
+    )
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('workflow-edit-btn'))
+
+    const scriptInput = screen.getByTestId('step-script-input') as HTMLTextAreaElement
+    expect(scriptInput.value).toBe('echo hello')
+  })
+
+  it('submit sends correct body shape with structured steps — no hand-written JSON', async () => {
+    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+
+    fireEvent.change(screen.getByTestId('workflow-name-input'), {
+      target: { value: 'my-wf' },
+    })
+    fireEvent.change(screen.getByTestId('step-name-input'), {
+      target: { value: 'run-task' },
+    })
+    fireEvent.change(screen.getByTestId('step-script-input'), {
+      target: { value: 'echo done' },
+    })
+
+    let capturedBody: Record<string, unknown> | null = null
+    fetchMock.mockImplementationOnce((_url: RequestInfo | URL, opts?: RequestInit): Promise<Response> => {
+      capturedBody = JSON.parse((opts?.body as string) ?? '{}') as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ name: 'my-wf', steps: [], semantic_version: {}, version: '1.0.0', description: '' }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    })
+    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow({ name: 'my-wf' })]))
+
+    fireEvent.click(screen.getByTestId('workflow-save-btn'))
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('workflow-form-panel')).toBeNull(),
+    )
+    expect(capturedBody).not.toBeNull()
+    expect(capturedBody).toMatchObject({
+      name: 'my-wf',
+      steps: [{ name: 'run-task', type: 'script', config: { script: 'echo done' } }],
+    })
+    expect(capturedBody).not.toHaveProperty('steps[0].stepsJson')
+  })
+})
+
+// ── Story #2984: variables key/value row editor ───────────────────────────────
+
+describe('WorkflowListView — variables editor (Story #2984)', () => {
+  it('shows no variable rows by default in create form', async () => {
+    await openCreatePanel()
+    expect(screen.queryByTestId('var-row')).toBeNull()
+  })
+
+  it('Add variable button adds a key/value row', async () => {
+    await openCreatePanel()
+    fireEvent.click(screen.getByTestId('add-var-btn'))
+    expect(screen.getAllByTestId('var-row')).toHaveLength(1)
+    expect(screen.getByTestId('var-key-input')).toBeInTheDocument()
+    expect(screen.getByTestId('var-value-input')).toBeInTheDocument()
+  })
+
+  it('Remove variable button removes that row', async () => {
+    await openCreatePanel()
+    fireEvent.click(screen.getByTestId('add-var-btn'))
+    expect(screen.getAllByTestId('var-row')).toHaveLength(1)
+    fireEvent.click(screen.getByTestId('var-remove-btn'))
+    expect(screen.queryByTestId('var-row')).toBeNull()
+  })
+
+  it('multiple variable rows can be added and individually removed', async () => {
+    await openCreatePanel()
+    fireEvent.click(screen.getByTestId('add-var-btn'))
+    fireEvent.click(screen.getByTestId('add-var-btn'))
+    expect(screen.getAllByTestId('var-row')).toHaveLength(2)
+
+    const removeBtns = screen.getAllByTestId('var-remove-btn')
+    fireEvent.click(removeBtns[0])
+    expect(screen.getAllByTestId('var-row')).toHaveLength(1)
+  })
+
+  it('submit with variables sends the correct variables object shape', async () => {
+    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+
+    fireEvent.change(screen.getByTestId('workflow-name-input'), {
+      target: { value: 'var-wf' },
+    })
+    fireEvent.change(screen.getByTestId('step-name-input'), {
+      target: { value: 'step-1' },
+    })
+
+    fireEvent.click(screen.getByTestId('add-var-btn'))
+    fireEvent.click(screen.getByTestId('add-var-btn'))
+
+    const keyInputs = screen.getAllByTestId('var-key-input') as HTMLInputElement[]
+    const valInputs = screen.getAllByTestId('var-value-input') as HTMLInputElement[]
+    fireEvent.change(keyInputs[0], { target: { value: 'ENV' } })
+    fireEvent.change(valInputs[0], { target: { value: 'production' } })
+    fireEvent.change(keyInputs[1], { target: { value: 'TIMEOUT' } })
+    fireEvent.change(valInputs[1], { target: { value: '30' } })
+
+    let capturedBody: Record<string, unknown> | null = null
+    fetchMock.mockImplementationOnce((_url: RequestInfo | URL, opts?: RequestInit): Promise<Response> => {
+      capturedBody = JSON.parse((opts?.body as string) ?? '{}') as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ name: 'var-wf', steps: [], semantic_version: {}, version: '1.0.0', description: '' }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    })
+    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow({ name: 'var-wf' })]))
+
+    fireEvent.click(screen.getByTestId('workflow-save-btn'))
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('workflow-form-panel')).toBeNull(),
+    )
+    expect(capturedBody).toMatchObject({
+      variables: { ENV: 'production', TIMEOUT: '30' },
+    })
+  })
+
+  it('editing a workflow with variables pre-populates the variable rows', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeWorkflowListResponse([
+        makeWorkflow({ variables: { FOO: 'bar', BAZ: '42' } }),
+      ]),
+    )
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('workflow-edit-btn'))
+
+    const keyInputs = screen.getAllByTestId('var-key-input') as HTMLInputElement[]
+    const valInputs = screen.getAllByTestId('var-value-input') as HTMLInputElement[]
+    expect(keyInputs).toHaveLength(2)
+    // Keys may be in any order depending on Object.entries order
+    const pairs = keyInputs.map((k, i) => `${k.value}=${valInputs[i].value}`)
+    expect(pairs).toContain('FOO=bar')
+    expect(pairs).toContain('BAZ=42')
+  })
+
+  it('variables rows omitted from submit body when all keys are empty', async () => {
+    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+
+    fireEvent.change(screen.getByTestId('workflow-name-input'), {
+      target: { value: 'no-vars-wf' },
+    })
+    fireEvent.change(screen.getByTestId('step-name-input'), {
+      target: { value: 'step-1' },
+    })
+
+    // Add a var row but leave key empty
+    fireEvent.click(screen.getByTestId('add-var-btn'))
+
+    let capturedBody: Record<string, unknown> | null = null
+    fetchMock.mockImplementationOnce((_url: RequestInfo | URL, opts?: RequestInit): Promise<Response> => {
+      capturedBody = JSON.parse((opts?.body as string) ?? '{}') as Record<string, unknown>
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ name: 'no-vars-wf', steps: [], semantic_version: {}, version: '1.0.0', description: '' }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    })
+    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow({ name: 'no-vars-wf' })]))
+
+    fireEvent.click(screen.getByTestId('workflow-save-btn'))
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('workflow-form-panel')).toBeNull(),
+    )
+    expect(capturedBody).not.toHaveProperty('variables')
   })
 })

--- a/web/src/workflow/WorkflowListView.tsx
+++ b/web/src/workflow/WorkflowListView.tsx
@@ -2,24 +2,113 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Workflow list view (Story #2731) — the /workflows route entry point.
+ * Workflow list view (Stories #2731, #2984) — the /workflows route entry point.
  * Fetches GET /api/v1/workflows, renders a table, and exposes workflow
  * create/edit/delete, execution tracking, and trigger management.
  *
- * Security A9.1: workflow name, description, and step values originate
- * from user-supplied content. Every value reaches the DOM as a JSX text
- * node — never dangerouslySetInnerHTML.
+ * Security A9.1: workflow name, description, step names, step values, and
+ * variable keys/values originate from user-supplied content. Every value
+ * reaches the DOM as a JSX text node or controlled input value —
+ * never dangerouslySetInnerHTML.
  */
 import { useState } from 'react'
 import { apiFetch } from '../api/client.ts'
 import {
   useWorkflowList,
   type VersionedWorkflow,
+  type WorkflowStep,
 } from './useWorkflows.ts'
 import WorkflowExecutionView from './WorkflowExecutionView.tsx'
 import TriggerPanel from './TriggerPanel.tsx'
 import ErrorCard from '../shell/ErrorCard.tsx'
 import './Workflow.css'
+
+// ── Row ID counter (used only as React key, never surfaced to DOM) ────────────
+
+let _rowId = 0
+function mkid(): string {
+  _rowId += 1
+  return String(_rowId)
+}
+
+// ── Step builder types ────────────────────────────────────────────────────────
+
+const STEP_TYPES = ['script', 'shell', 'http', 'notification', 'approval'] as const
+
+interface StepRow {
+  id: string
+  name: string
+  type: string
+  scriptBody: string   // config.script for type === 'script'
+  configJson: string   // raw config JSON (for non-script types or advanced mode)
+  rawOpen: boolean     // whether the Raw config details panel is expanded
+}
+
+// ── Variable editor types ─────────────────────────────────────────────────────
+
+interface VarRow {
+  id: string
+  key: string
+  value: string
+}
+
+// ── Form state ────────────────────────────────────────────────────────────────
+
+interface FormState {
+  name: string
+  description: string
+  version: string
+  steps: StepRow[]
+  variables: VarRow[]
+}
+
+function defaultStep(): StepRow {
+  return { id: mkid(), name: 'step-1', type: 'script', scriptBody: '', configJson: '{}', rawOpen: false }
+}
+
+function stepToRow(step: WorkflowStep): StepRow {
+  const cfg = step.config ?? {}
+  const scriptBody = step.type === 'script' && typeof cfg.script === 'string' ? cfg.script : ''
+  // Show raw config when there are keys beyond 'script' (for script type) or any keys (for other types)
+  const hasExtra = step.type === 'script'
+    ? Object.keys(cfg).some((k) => k !== 'script')
+    : Object.keys(cfg).length > 0
+  return {
+    id: mkid(),
+    name: step.name,
+    type: step.type,
+    scriptBody,
+    configJson: hasExtra ? JSON.stringify(cfg, null, 2) : '{}',
+    rawOpen: hasExtra,
+  }
+}
+
+function defaultForm(wf: VersionedWorkflow | null): FormState {
+  if (wf === null) {
+    return {
+      name: '',
+      description: '',
+      version: '1.0.0',
+      steps: [defaultStep()],
+      variables: [],
+    }
+  }
+  return {
+    name: wf.name,
+    description: wf.description,
+    version: wf.version || '1.0.0',
+    steps: wf.steps.length > 0 ? wf.steps.map(stepToRow) : [defaultStep()],
+    variables: wf.variables
+      ? Object.entries(wf.variables).map(([k, v]) => ({
+          id: mkid(),
+          key: k,
+          value: typeof v === 'string' ? v : JSON.stringify(v),
+        }))
+      : [],
+  }
+}
+
+// ── Loading skeleton ──────────────────────────────────────────────────────────
 
 function LoadingRows() {
   return (
@@ -36,7 +125,6 @@ function LoadingRows() {
   )
 }
 
-
 function WorkflowEmpty() {
   return (
     <div className="notice empty" data-testid="workflow-empty">
@@ -46,6 +134,8 @@ function WorkflowEmpty() {
     </div>
   )
 }
+
+// ── Workflow table row ────────────────────────────────────────────────────────
 
 function WorkflowRow({
   workflow,
@@ -105,32 +195,167 @@ function WorkflowRow({
   )
 }
 
-interface FormState {
-  name: string
-  description: string
-  version: string
-  stepsJson: string
-  variablesJson: string
+// ── Step builder row ──────────────────────────────────────────────────────────
+
+function StepBuilderRow({
+  step,
+  index,
+  canRemove,
+  onChange,
+  onRemove,
+}: {
+  step: StepRow
+  index: number
+  canRemove: boolean
+  onChange: (updated: StepRow) => void
+  onRemove: () => void
+}) {
+  const isScriptType = step.type === 'script'
+  const isKnownType = (STEP_TYPES as readonly string[]).includes(step.type)
+
+  return (
+    <div className="wf-step-row" data-testid="step-row">
+      <div className="wf-form-row">
+        <div className="wf-form-field">
+          <span className="wf-form-label">Step {index + 1} name *</span>
+          <input
+            type="text"
+            aria-label={`Step ${index + 1} name`}
+            placeholder={`step-${index + 1}`}
+            value={step.name}
+            onChange={(e) => onChange({ ...step, name: e.target.value })}
+            data-testid="step-name-input"
+          />
+        </div>
+        <div className="wf-form-field">
+          <span className="wf-form-label">Type</span>
+          <select
+            aria-label={`Step ${index + 1} type`}
+            value={step.type}
+            onChange={(e) =>
+              onChange({ ...step, type: e.target.value, scriptBody: '', configJson: '{}', rawOpen: false })
+            }
+            data-testid="step-type-select"
+          >
+            {STEP_TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+            {!isKnownType && (
+              <option value={step.type}>{step.type}</option>
+            )}
+          </select>
+        </div>
+        {isScriptType && (
+          <div className="wf-form-field">
+            <span className="wf-form-label">Script</span>
+            <textarea
+              aria-label={`Step ${index + 1} script`}
+              placeholder="echo hello"
+              value={step.scriptBody}
+              onChange={(e) => onChange({ ...step, scriptBody: e.target.value })}
+              data-testid="step-script-input"
+            />
+          </div>
+        )}
+        {!isScriptType && (
+          <div className="wf-form-field">
+            <span className="wf-form-label">Config (JSON)</span>
+            <textarea
+              aria-label={`Step ${index + 1} config JSON`}
+              placeholder="{}"
+              value={step.configJson}
+              onChange={(e) => onChange({ ...step, configJson: e.target.value })}
+              data-testid="step-config-json"
+            />
+          </div>
+        )}
+        {canRemove && (
+          <button
+            type="button"
+            className="wf-btn-sm-danger wf-step-remove"
+            onClick={onRemove}
+            aria-label={`Remove step ${index + 1}`}
+            data-testid="step-remove-btn"
+          >
+            Remove
+          </button>
+        )}
+      </div>
+      {isScriptType && (
+        <details
+          open={step.rawOpen}
+          onToggle={(e) =>
+            onChange({ ...step, rawOpen: (e.currentTarget as HTMLDetailsElement).open })
+          }
+          className="wf-raw-config"
+        >
+          <summary className="wf-raw-config-toggle">Raw config JSON</summary>
+          <div className="wf-form-row" style={{ marginTop: 6 }}>
+            <div className="wf-form-field">
+              <textarea
+                aria-label={`Step ${index + 1} raw config JSON`}
+                placeholder="{}"
+                value={step.configJson}
+                onChange={(e) => onChange({ ...step, configJson: e.target.value })}
+                data-testid="step-config-json"
+              />
+            </div>
+          </div>
+        </details>
+      )}
+    </div>
+  )
 }
 
-function defaultForm(wf: VersionedWorkflow | null): FormState {
-  if (wf === null) {
-    return {
-      name: '',
-      description: '',
-      version: '1.0.0',
-      stepsJson: '[{"name":"step-1","type":"script","config":{}}]',
-      variablesJson: '',
-    }
-  }
-  return {
-    name: wf.name,
-    description: wf.description,
-    version: wf.version || '1.0.0',
-    stepsJson: JSON.stringify(wf.steps, null, 2),
-    variablesJson: wf.variables ? JSON.stringify(wf.variables, null, 2) : '',
-  }
+// ── Variable key/value row ────────────────────────────────────────────────────
+
+function VarBuilderRow({
+  varRow,
+  onChange,
+  onRemove,
+}: {
+  varRow: VarRow
+  onChange: (updated: VarRow) => void
+  onRemove: () => void
+}) {
+  return (
+    <div className="wf-var-row wf-form-row" data-testid="var-row">
+      <div className="wf-form-field">
+        <span className="wf-form-label">Key</span>
+        <input
+          type="text"
+          aria-label="Variable key"
+          placeholder="var-name"
+          value={varRow.key}
+          onChange={(e) => onChange({ ...varRow, key: e.target.value })}
+          data-testid="var-key-input"
+        />
+      </div>
+      <div className="wf-form-field">
+        <span className="wf-form-label">Value</span>
+        <input
+          type="text"
+          aria-label="Variable value"
+          placeholder="value"
+          value={varRow.value}
+          onChange={(e) => onChange({ ...varRow, value: e.target.value })}
+          data-testid="var-value-input"
+        />
+      </div>
+      <button
+        type="button"
+        className="wf-btn-sm-danger wf-var-remove"
+        onClick={onRemove}
+        aria-label="Remove variable"
+        data-testid="var-remove-btn"
+      >
+        Remove
+      </button>
+    </div>
+  )
 }
+
+// ── Workflow form panel ───────────────────────────────────────────────────────
 
 function WorkflowFormPanel({
   mode,
@@ -147,8 +372,46 @@ function WorkflowFormPanel({
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
-  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
-    setForm((prev) => ({ ...prev, [key]: value }))
+  // Step operations
+  function addStep() {
+    const num = form.steps.length + 1
+    setForm((prev) => ({
+      ...prev,
+      steps: [
+        ...prev.steps,
+        { id: mkid(), name: `step-${num}`, type: 'script', scriptBody: '', configJson: '{}', rawOpen: false },
+      ],
+    }))
+  }
+
+  function removeStep(idx: number) {
+    setForm((prev) => ({ ...prev, steps: prev.steps.filter((_, i) => i !== idx) }))
+  }
+
+  function updateStep(idx: number, updated: StepRow) {
+    setForm((prev) => ({
+      ...prev,
+      steps: prev.steps.map((s, i) => (i === idx ? updated : s)),
+    }))
+  }
+
+  // Variable operations
+  function addVar() {
+    setForm((prev) => ({
+      ...prev,
+      variables: [...prev.variables, { id: mkid(), key: '', value: '' }],
+    }))
+  }
+
+  function removeVar(idx: number) {
+    setForm((prev) => ({ ...prev, variables: prev.variables.filter((_, i) => i !== idx) }))
+  }
+
+  function updateVar(idx: number, updated: VarRow) {
+    setForm((prev) => ({
+      ...prev,
+      variables: prev.variables.map((v, i) => (i === idx ? updated : v)),
+    }))
   }
 
   async function handleSubmit() {
@@ -156,33 +419,44 @@ function WorkflowFormPanel({
       setSaveError('Workflow name is required')
       return
     }
-
-    let steps: unknown[]
-    try {
-      steps = JSON.parse(form.stepsJson)
-      if (!Array.isArray(steps) || steps.length === 0) {
-        setSaveError('Steps must be a JSON array with at least one step')
-        return
-      }
-    } catch {
-      setSaveError('Steps must be valid JSON array')
+    if (form.steps.length === 0) {
+      setSaveError('At least one step is required')
       return
     }
-
-    let variables: Record<string, unknown> | undefined
-    if (form.variablesJson.trim()) {
-      try {
-        const v = JSON.parse(form.variablesJson)
-        if (typeof v !== 'object' || Array.isArray(v) || v === null) {
-          setSaveError('Variables must be a JSON object')
-          return
-        }
-        variables = v as Record<string, unknown>
-      } catch {
-        setSaveError('Variables must be valid JSON object')
+    for (const s of form.steps) {
+      if (!s.name.trim()) {
+        setSaveError('All steps must have a name')
         return
       }
     }
+    for (const s of form.steps) {
+      if (s.rawOpen || s.type !== 'script') {
+        try {
+          JSON.parse(s.configJson || '{}')
+        } catch {
+          setSaveError(`Step "${s.name}": config must be valid JSON`)
+          return
+        }
+      }
+    }
+
+    // Build steps array from structured state
+    const steps = form.steps.map((s) => {
+      let config: Record<string, unknown> = {}
+      if (s.rawOpen || s.type !== 'script') {
+        config = JSON.parse(s.configJson || '{}') as Record<string, unknown>
+      } else if (s.scriptBody.trim()) {
+        config = { script: s.scriptBody }
+      }
+      return { name: s.name.trim(), type: s.type, config }
+    })
+
+    // Build variables object, omitting rows with empty keys
+    const varEntries = form.variables.filter((v) => v.key.trim())
+    const variables: Record<string, unknown> | undefined =
+      varEntries.length > 0
+        ? Object.fromEntries(varEntries.map((v) => [v.key.trim(), v.value]))
+        : undefined
 
     setSaving(true)
     setSaveError(null)
@@ -229,6 +503,7 @@ function WorkflowFormPanel({
   return (
     <div className="wf-form-panel" data-testid="workflow-form-panel">
       <div className="wf-form">
+        {/* Workflow metadata row */}
         <div className="wf-form-row">
           <div className="wf-form-field">
             <span className="wf-form-label">Name {isEdit ? '' : '*'}</span>
@@ -238,7 +513,7 @@ function WorkflowFormPanel({
               placeholder="my-workflow"
               value={form.name}
               disabled={isEdit}
-              onChange={(e) => set('name', e.target.value)}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
               data-testid="workflow-name-input"
             />
           </div>
@@ -249,7 +524,7 @@ function WorkflowFormPanel({
               aria-label="Description"
               placeholder="Optional description"
               value={form.description}
-              onChange={(e) => set('description', e.target.value)}
+              onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
               className="wide"
             />
           </div>
@@ -260,30 +535,60 @@ function WorkflowFormPanel({
               aria-label="Version"
               placeholder="1.0.0"
               value={form.version}
-              onChange={(e) => set('version', e.target.value)}
+              onChange={(e) => setForm((prev) => ({ ...prev, version: e.target.value }))}
             />
           </div>
         </div>
 
-        <div className="wf-form-row">
-          <div className="wf-form-field">
-            <span className="wf-form-label">Steps (JSON array) *</span>
-            <textarea
-              aria-label="Steps JSON"
-              value={form.stepsJson}
-              onChange={(e) => set('stepsJson', e.target.value)}
-              data-testid="workflow-steps-input"
-            />
+        {/* Step builder */}
+        <div className="wf-builder-section">
+          <div className="wf-builder-header">
+            <span className="wf-form-label">Steps *</span>
+            <button
+              type="button"
+              className="wf-btn-sm"
+              onClick={addStep}
+              data-testid="add-step-btn"
+            >
+              + Add step
+            </button>
           </div>
-          <div className="wf-form-field">
-            <span className="wf-form-label">Variables (JSON object)</span>
-            <textarea
-              aria-label="Variables JSON"
-              placeholder="{}"
-              value={form.variablesJson}
-              onChange={(e) => set('variablesJson', e.target.value)}
+          {form.steps.map((step, idx) => (
+            <StepBuilderRow
+              key={step.id}
+              step={step}
+              index={idx}
+              canRemove={form.steps.length > 1}
+              onChange={(updated) => updateStep(idx, updated)}
+              onRemove={() => removeStep(idx)}
             />
+          ))}
+        </div>
+
+        {/* Variables editor */}
+        <div className="wf-builder-section">
+          <div className="wf-builder-header">
+            <span className="wf-form-label">Variables</span>
+            <button
+              type="button"
+              className="wf-btn-sm"
+              onClick={addVar}
+              data-testid="add-var-btn"
+            >
+              + Add variable
+            </button>
           </div>
+          {form.variables.length === 0 && (
+            <p className="wf-var-empty">No variables defined.</p>
+          )}
+          {form.variables.map((v, idx) => (
+            <VarBuilderRow
+              key={v.id}
+              varRow={v}
+              onChange={(updated) => updateVar(idx, updated)}
+              onRemove={() => removeVar(idx)}
+            />
+          ))}
         </div>
 
         <div className="wf-form-actions">
@@ -313,6 +618,8 @@ function WorkflowFormPanel({
     </div>
   )
 }
+
+// ── Main view ─────────────────────────────────────────────────────────────────
 
 export default function WorkflowListView() {
   const { workflows, loading, error, retry } = useWorkflowList()


### PR DESCRIPTION
## Summary

- Replaces the `Steps (JSON array)` textarea with a structured add/remove step builder: each step row has a step-name input, a step-type select (script/shell/http/notification/approval), type-appropriate config fields (Script textarea for `type=script`; raw-JSON config textarea for other types), and a collapsible **Raw config JSON** details panel for power-user config on script steps
- Replaces the `Variables (JSON object)` textarea with a key/value row editor — `+ Add variable` / `Remove` per row; empty-keyed rows silently dropped on submit
- `handleSubmit` body shape is unchanged — the same `steps`/`variables` object is sent to `POST`/`PUT /api/v1/workflows`; only the client-side construction changed
- Edit mode pre-populates: `config.script` → Script field; extra/non-script config keys auto-open the Raw config panel
- Also includes a SQLite schema-init performance fix (`pkg/storage/providers/sqlite/plugin.go`) that prevented `make test-agent-complete` from completing within the CI timeout

Fixes #2984

## Test plan

- [ ] 40 workflow tests pass (`npm test` in `web/`)
- [ ] New structured-builder tests cover add/remove steps, pre-population on edit, and correct body shape with no hand-written JSON (`WorkflowListView.test.tsx` — "structured step builder (Story #2984)" and "variables editor (Story #2984)" describe blocks)
- [ ] All pre-existing workflow tests continue to pass (24 carryover tests)
- [ ] `make test-agent-complete` passes (adversarial review: `passed: true`, 2 review rounds, 1 fix round)

## Specialist review results

| Reviewer | Result |
|----------|--------|
| Code review | PASS |
| QA test quality | PASS (after fix round) |
| Security | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)