### PR TITLE
web: step-up modal elevation path + global apiFetch interceptor (Issue #2967)

### DIFF
--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -142,21 +142,43 @@ func openDB(path string) (*sql.DB, error) {
 	// real-world controller batch commits and gives Windows CI's I/O
 	// variance enough headroom without hiding genuine deadlocks (those
 	// would still surface after 15s).
-	const pragmas = "_pragma=busy_timeout(15000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)"
+	// File-backed databases use WAL for genuine multi-connection concurrency.
+	const filePragmas = "_pragma=busy_timeout(15000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)"
+	// In-memory databases are pinned to a single connection (see below), so
+	// neither WAL nor shared-cache buys anything: one connection can never
+	// contend with itself. Shared-cache in-memory is actively harmful — it
+	// routes every statement through the pure-Go driver's process-global
+	// shared-cache lock manager, whose lock-ordering can wedge a CREATE
+	// TABLE/INDEX in VDBE exec indefinitely when many parallel tests are
+	// initialising their own memory schemas at once. busy_timeout does not
+	// cover that wait, so the transaction never completes and the test binary
+	// hangs to its timeout (Issue #2967: schema.go initialiseSchema hang seen
+	// in features/controller/api). A private, single-connection memory DB with
+	// the default rollback journal removes the shared-cache lock manager from
+	// the picture entirely while preserving per-pool isolation and data sharing
+	// across all stores that hold the same *sql.DB.
+	const memPragmas = "_pragma=busy_timeout(15000)&_pragma=foreign_keys(on)"
+
+	inMemory := path == ":memory:" || strings.Contains(path, "mode=memory")
 
 	var dsn string
 	switch {
-	case path == ":memory:":
-		// Shared cache so multiple connections in tests see the same data.
-		dsn = "file::memory:?cache=shared&" + pragmas
+	case inMemory:
+		// Collapse every in-memory request (":memory:" or a named
+		// "file:...?mode=memory[&cache=shared]" DSN) to a private, unnamed
+		// memory DB. The single pinned connection means each pool owns exactly
+		// one private database that lives for the pool's lifetime; the caller's
+		// name only ever served to distinguish shared caches, which no longer
+		// exist here, so dropping it is safe and isolation becomes automatic.
+		dsn = "file::memory:?" + memPragmas
 	case strings.HasPrefix(path, "file:"):
 		sep := "?"
 		if strings.Contains(path, "?") {
 			sep = "&"
 		}
-		dsn = path + sep + pragmas
+		dsn = path + sep + filePragmas
 	default:
-		dsn = "file:" + path + "?" + pragmas
+		dsn = "file:" + path + "?" + filePragmas
 	}
 
 	db, err := sql.Open("sqlite", dsn)
@@ -164,16 +186,17 @@ func openDB(path string) (*sql.DB, error) {
 		return nil, fmt.Errorf("sqlite: failed to open %s: %w", path, err)
 	}
 
-	// A named shared-cache in-memory database (":memory:" or "mode=memory")
-	// exists only while at least one connection to it remains open: SQLite frees
-	// the database the instant the connection pool drops to zero live handles.
-	// Under a parallel test suite the default multi-connection pool churns and
-	// closes idle connections under memory pressure, tearing the database down
-	// mid-run — after which the next query hits a freed handle and the driver
-	// nil-dereferences. Pin such databases to a single, never-expiring
-	// connection so the backing store lives for the pool's entire lifetime.
-	// File-backed databases keep the default pool (WAL gives real concurrency).
-	if path == ":memory:" || strings.Contains(dsn, "mode=memory") {
+	// A private in-memory database exists only while at least one connection to
+	// it remains open: SQLite frees the database the instant the connection pool
+	// drops to zero live handles. Under a parallel test suite the default
+	// multi-connection pool churns and closes idle connections under memory
+	// pressure, tearing the database down mid-run — after which the next query
+	// hits a freed handle and the driver nil-dereferences. Pin such databases to
+	// a single, never-expiring connection so the backing store lives for the
+	// pool's entire lifetime, and so all stores sharing the *sql.DB see one
+	// consistent database. File-backed databases keep the default pool (WAL
+	// gives real concurrency).
+	if inMemory {
 		db.SetMaxOpenConns(1)
 		db.SetMaxIdleConns(1)
 		db.SetConnMaxLifetime(0)

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>CFGMS</title>
-    <script type="module" crossorigin src="/assets/index-DZVkbSCl.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-ByDDWjO4.css">
+    <script type="module" crossorigin src="/assets/index-pOoyNo6q.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D2CWu187.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -260,6 +260,85 @@ describe('apiFetch', () => {
     expect(result.status).toBe(401)
     expect(expired).not.toHaveBeenCalled()
   })
+
+  // ── Concurrent step-up dedup (Story #2967) ────────────────────────────────
+
+  it('concurrent CFGMS-StepUp 401s deduplicate: only one ceremony runs', async () => {
+    const stepUp = vi.fn(async () => jsonResponse(200, { ok: true }))
+    onStepUpRequired(stepUp)
+
+    const makeStepUp401 = () =>
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: { 'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"' },
+      })
+
+    // First two fetches (initial requests) return 401; the dedup retry returns 200.
+    fetchMock
+      .mockResolvedValueOnce(makeStepUp401())
+      .mockResolvedValueOnce(makeStepUp401())
+      .mockResolvedValue(jsonResponse(200, {}))
+
+    const [r1, r2] = await Promise.all([
+      apiFetch('/api/v1/stewards'),
+      apiFetch('/api/v1/fleet'),
+    ])
+
+    // The step-up listener must be called exactly once (not twice).
+    expect(stepUp).toHaveBeenCalledTimes(1)
+    // r1 gets the listener's response; r2 gets the dedup-retry response.
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
+  })
+
+  it('deduplicated concurrent request re-attaches CSRF on its retry', async () => {
+    document.cookie = 'cfgms_csrf=dedup-csrf-tok; path=/'
+
+    // Use a deferred promise so we can resolve the ceremony after both requests start.
+    let resolveCeremony!: (r: Response | null) => void
+    const ceremonyPromise = new Promise<Response | null>((r) => { resolveCeremony = r })
+    onStepUpRequired(() => ceremonyPromise)
+
+    const makeStepUp401 = () =>
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: { 'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"' },
+      })
+
+    // Initial fetches return 401; the dedup retry for the second caller returns 200.
+    fetchMock
+      .mockResolvedValueOnce(makeStepUp401())
+      .mockResolvedValueOnce(makeStepUp401())
+      .mockResolvedValue(jsonResponse(200, {}))
+
+    // Start both concurrent requests.
+    const p1 = apiFetch('/api/v1/stewards', { method: 'POST' })
+    const p2 = apiFetch('/api/v1/fleet', { method: 'DELETE' })
+
+    // Yield so both initial fetches complete and r2 is waiting for the ceremony.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Resolve the ceremony (r1 receives this response).
+    resolveCeremony(jsonResponse(200, { ok: true }))
+
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
+
+    // The dedup retry (for DELETE /api/v1/fleet) must carry CSRF.
+    const dedupeRetry = fetchMock.mock.calls.find(
+      ([url]) => String(url).includes('/api/v1/fleet') &&
+        new Headers(fetchMock.mock.calls.find(([u]) => String(u).includes('/api/v1/fleet'))?.[1]?.headers)
+          .get('X-CSRF-Token') !== null,
+    )
+    // More direct: the last fleet fetch call should carry CSRF.
+    const fleetCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('/api/v1/fleet'))
+    expect(fleetCalls.length).toBeGreaterThanOrEqual(1)
+    const lastFleetHeaders = new Headers(fleetCalls.at(-1)?.[1]?.headers)
+    expect(lastFleetHeaders.get('X-CSRF-Token')).toBe('dedup-csrf-tok')
+    void dedupeRetry
+  })
 })
 
 describe('loginRequest', () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -92,7 +92,18 @@ let stepUpRequiredListener: StepUpRequiredListener | null = null
  */
 export function onStepUpRequired(listener: StepUpRequiredListener | null): void {
   stepUpRequiredListener = listener
+  if (listener === null) {
+    // Clear any dangling in-progress slot when the provider unmounts.
+    stepUpCeremonyDone = null
+  }
 }
+
+// Concurrent step-up deduplication (Story #2967, ADR-021 Decision 6).
+// If two requests from the same tab simultaneously receive a CFGMS-StepUp 401,
+// only the first starts the ceremony. Subsequent callers wait for it to finish,
+// then retry with a fresh CSRF header. Resolves once the ceremony completes
+// (regardless of success/failure) so waiters can attempt one more retry.
+let stepUpCeremonyDone: Promise<void> | null = null
 
 /**
  * Fetch wrapper for all cookie-authenticated API calls.
@@ -123,15 +134,39 @@ export async function apiFetch(
       // Step-up challenge: NEVER fire session-expired regardless of listener state.
       // A CFGMS-StepUp 401 means the operator's session is intact but needs a
       // higher assurance proof — the operator is NOT signed out (ADR-021 Decision 6).
+
+      // Concurrent dedup: a ceremony is already running from another simultaneous
+      // request in this tab. Wait for it to finish, then retry this request once
+      // with a fresh CSRF header. Cap: if the retry is STILL a 401, return it
+      // directly — never start a second ceremony for the same original request.
+      if (stepUpCeremonyDone !== null) {
+        await stepUpCeremonyDone
+        const dedupeHeaders = new Headers(headers)
+        if (UNSAFE_METHODS.has(method)) {
+          const freshCsrf = readCookie(csrfCookieSession)
+          if (freshCsrf !== null) dedupeHeaders.set(csrfHeader, freshCsrf)
+        }
+        return fetch(path, { ...init, headers: dedupeHeaders, credentials: 'same-origin' })
+      }
+
       if (stepUpRequiredListener !== null) {
-        const retryResponse = await stepUpRequiredListener({
-          path,
-          init,
-          presenceRequired: wwwAuth.includes('presence="required"'),
-        })
-        // Listener resolves with the retry response (success) or null (cancel/failure).
-        // On null: return the original 401 — caller sees the failure; session stays intact.
-        return retryResponse ?? response
+        // Claim the in-progress slot before awaiting so concurrent 401s see it.
+        let ceremonyDone!: () => void
+        stepUpCeremonyDone = new Promise<void>((r) => { ceremonyDone = r })
+        try {
+          const retryResponse = await stepUpRequiredListener({
+            path,
+            init,
+            presenceRequired: wwwAuth.includes('presence="required"'),
+          })
+          // Cap: return whatever the listener resolved (including a failed 401) —
+          // never re-enter the step-up handler for this apiFetch call.
+          return retryResponse ?? response
+        } finally {
+          // Signal waiters before clearing the slot so they see the resolved promise.
+          stepUpCeremonyDone = null
+          ceremonyDone()
+        }
       }
       // No listener registered: return the 401 without firing session-expired.
       return response

--- a/web/src/auth/StepUpModal.test.tsx
+++ b/web/src/auth/StepUpModal.test.tsx
@@ -377,6 +377,221 @@ describe('StepUpModal — retry', () => {
   })
 })
 
+// ── Elevation path (presenceRequired: false) ──────────────────────────────────
+
+const elevationRequest: StepUpRequest = {
+  path: '/api/v1/web/accounts/admin/delete',
+  init: { method: 'DELETE' },
+  presenceRequired: false,
+}
+
+describe('StepUpModal — elevation path (presenceRequired: false)', () => {
+  it('calls elevate/begin (not presence/begin) when presenceRequired is false', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+    render(
+      <StepUpModal
+        request={elevationRequest}
+        principalUsername="admin@msp-a"
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    const beginCalls = fetchMock.mock.calls.map(([u]) => String(u))
+    expect(beginCalls.some((u) => u.includes('elevate/begin'))).toBe(true)
+    expect(beginCalls.some((u) => u.includes('presence/begin'))).toBe(false)
+  })
+
+  it('calls elevate/finish (not presence/finish) and completes ceremony', async () => {
+    const mockCred = makePublicKeyCredential()
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn().mockResolvedValue(mockCred) },
+    })
+
+    const retryResponse = jsonResponse(200, { ok: true })
+    fetchMock.mockImplementation((url) => {
+      const u = String(url)
+      if (u.includes('elevate/begin')) return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      if (u.includes('elevate/finish')) {
+        return Promise.resolve(
+          jsonResponse(200, { assurance: 'strong', elevated_at: '2026-01-01T00:00:00Z' }),
+        )
+      }
+      return Promise.resolve(retryResponse)
+    })
+
+    const onSuccess = vi.fn()
+    render(
+      <StepUpModal
+        request={elevationRequest}
+        principalUsername="admin@msp-a"
+        onSuccess={onSuccess}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
+
+    const finishCalls = fetchMock.mock.calls.map(([u]) => String(u))
+    expect(finishCalls.some((u) => u.includes('elevate/finish'))).toBe(true)
+    expect(finishCalls.some((u) => u.includes('presence/finish'))).toBe(false)
+  })
+
+  it('does NOT attach X-Presence-Token on the retry for elevation path', async () => {
+    const mockCred = makePublicKeyCredential()
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn().mockResolvedValue(mockCred) },
+    })
+
+    fetchMock.mockImplementation((url) => {
+      const u = String(url)
+      if (u.includes('elevate/begin')) return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      if (u.includes('elevate/finish')) {
+        return Promise.resolve(
+          jsonResponse(200, { assurance: 'strong', elevated_at: '2026-01-01T00:00:00Z' }),
+        )
+      }
+      return Promise.resolve(jsonResponse(200, {}))
+    })
+
+    const onSuccess = vi.fn()
+    render(
+      <StepUpModal
+        request={elevationRequest}
+        principalUsername={null}
+        onSuccess={onSuccess}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
+
+    const retryCalls = fetchMock.mock.calls.filter(
+      ([u]) =>
+        !String(u).includes('elevate/begin') && !String(u).includes('elevate/finish'),
+    )
+    expect(retryCalls.length).toBe(1)
+    const retryHeaders = new Headers(retryCalls[0]?.[1]?.headers)
+    expect(retryHeaders.get('X-Presence-Token')).toBeNull()
+  })
+
+  it('re-attaches X-CSRF-Token on the elevation retry for unsafe methods', async () => {
+    // Set a CSRF cookie readable by the modal's readSessionCsrf().
+    document.cookie = 'cfgms_csrf=csrf-tok-elevate; path=/'
+
+    const mockCred = makePublicKeyCredential()
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn().mockResolvedValue(mockCred) },
+    })
+
+    fetchMock.mockImplementation((url) => {
+      const u = String(url)
+      if (u.includes('elevate/begin')) return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      if (u.includes('elevate/finish')) {
+        return Promise.resolve(
+          jsonResponse(200, { assurance: 'strong', elevated_at: '2026-01-01T00:00:00Z' }),
+        )
+      }
+      return Promise.resolve(jsonResponse(200, {}))
+    })
+
+    const onSuccess = vi.fn()
+    render(
+      <StepUpModal
+        request={elevationRequest}
+        principalUsername={null}
+        onSuccess={onSuccess}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
+
+    const retryCalls = fetchMock.mock.calls.filter(
+      ([u]) =>
+        !String(u).includes('elevate/begin') && !String(u).includes('elevate/finish'),
+    )
+    expect(retryCalls.length).toBe(1)
+    const retryHeaders = new Headers(retryCalls[0]?.[1]?.headers)
+    expect(retryHeaders.get('X-CSRF-Token')).toBe('csrf-tok-elevate')
+  })
+
+  it('shows error when elevate/begin fails', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'WEBAUTHN_NOT_CONFIGURED' }))
+    render(
+      <StepUpModal
+        request={elevationRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    await waitFor(() => expect(screen.getByTestId('step-up-error')).toBeInTheDocument())
+    expect(screen.getByTestId('step-up-retry-btn')).toBeInTheDocument()
+  })
+
+  it('shows error when elevate/finish fails', async () => {
+    const mockCred = makePublicKeyCredential()
+    vi.stubGlobal('navigator', {
+      credentials: { get: vi.fn().mockResolvedValue(mockCred) },
+    })
+
+    fetchMock.mockImplementation((url) => {
+      const u = String(url)
+      if (u.includes('elevate/begin')) return Promise.resolve(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+      if (u.includes('elevate/finish')) return Promise.resolve(jsonResponse(400, { error: 'WEBAUTHN_VERIFY_ERROR' }))
+      return Promise.resolve(jsonResponse(200, {}))
+    })
+
+    render(
+      <StepUpModal
+        request={elevationRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    act(() => screen.getByTestId('step-up-verify-btn').click())
+
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-error')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('step-up-retry-btn')).toBeInTheDocument()
+  })
+
+  it('calls elevate/begin again on retry after elevate/begin failure', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(503, { error: 'WEBAUTHN_NOT_CONFIGURED' }))
+      .mockResolvedValueOnce(jsonResponse(200, MOCK_BEGIN_OPTIONS))
+
+    render(
+      <StepUpModal
+        request={elevationRequest}
+        principalUsername={null}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => screen.getByTestId('step-up-retry-btn'))
+    act(() => screen.getByTestId('step-up-retry-btn').click())
+
+    await waitFor(() => screen.getByTestId('step-up-verify-btn'))
+    const elevateCalls = fetchMock.mock.calls.filter(([u]) =>
+      String(u).includes('elevate/begin'),
+    )
+    expect(elevateCalls.length).toBe(2)
+  })
+})
+
 // ── Accessibility: no click-outside dismissal ─────────────────────────────────
 
 describe('StepUpModal — security constraints', () => {

--- a/web/src/auth/StepUpModal.tsx
+++ b/web/src/auth/StepUpModal.tsx
@@ -187,21 +187,27 @@ export default function StepUpModal({
     }
   }, [])
 
-  // Fetch a fresh presence challenge on mount and on each retry.
+  // Fetch a fresh challenge on mount and on each retry.
+  // Routes to the elevation endpoint (Basic→Strong) when presenceRequired is false,
+  // or the presence endpoint (per-action assertion) when presenceRequired is true.
   useEffect(() => {
     let aborted = false
 
-    async function beginPresence() {
+    async function beginCeremony() {
       setPhase('loading')
       setErrorMsg(null)
       optsRef.current = null
+
+      const beginUrl = request.presenceRequired
+        ? '/api/v1/webauthn/presence/begin'
+        : '/api/v1/webauthn/elevate/begin'
 
       try {
         const csrf = readSessionCsrf()
         const headers = new Headers()
         if (csrf !== null) headers.set('X-CSRF-Token', csrf)
 
-        const resp = await fetch('/api/v1/webauthn/presence/begin', {
+        const resp = await fetch(beginUrl, {
           method: 'POST',
           headers,
           credentials: 'same-origin',
@@ -228,11 +234,11 @@ export default function StepUpModal({
       }
     }
 
-    void beginPresence()
+    void beginCeremony()
     return () => {
       aborted = true
     }
-  }, [beginKey])
+  }, [beginKey, request.presenceRequired])
 
   const handleVerify = useCallback(async () => {
     const opts = optsRef.current
@@ -253,12 +259,17 @@ export default function StepUpModal({
       }
       const cred = rawCred as PublicKeyCredential
 
-      // Finish the ceremony: send the assertion to the server and get the token.
+      // Send the assertion to the server. Route to the correct finish endpoint:
+      //   - elevate/finish: upgrades the session to AssuranceStrong (Basic→Strong)
+      //   - presence/finish: mints a short-lived presence token for the action gate
       const csrf = readSessionCsrf()
+      const finishUrl = request.presenceRequired
+        ? '/api/v1/webauthn/presence/finish'
+        : '/api/v1/webauthn/elevate/finish'
       const finishHeaders = new Headers({ 'Content-Type': 'application/json' })
       if (csrf !== null) finishHeaders.set('X-CSRF-Token', csrf)
 
-      const finishResp = await fetch('/api/v1/webauthn/presence/finish', {
+      const finishResp = await fetch(finishUrl, {
         method: 'POST',
         headers: finishHeaders,
         credentials: 'same-origin',
@@ -271,14 +282,22 @@ export default function StepUpModal({
         return
       }
 
-      const finishData = (await finishResp.json()) as { presence_token: string }
-      const presenceToken = finishData.presence_token
-
-      // Retry the original request with the minted presence token.
-      // Raw fetch avoids re-triggering the step-up listener in apiFetch.
+      // Build retry headers, then replay the original request using raw fetch
+      // (not apiFetch) to avoid re-triggering the step-up listener.
       const method = (request.init.method ?? 'GET').toUpperCase()
       const retryHeaders = new Headers(request.init.headers)
-      retryHeaders.set('X-Presence-Token', presenceToken)
+
+      if (request.presenceRequired) {
+        // Presence path: attach the single-use token minted by presence/finish.
+        const presenceData = (await finishResp.json()) as { presence_token: string }
+        retryHeaders.set('X-Presence-Token', presenceData.presence_token)
+      } else {
+        // Elevation path: the session cookie is now Strong — no extra header needed.
+        // Consume the response body to avoid a connection leak.
+        await finishResp.json()
+      }
+
+      // Re-attach the session CSRF token on unsafe-method retries (ADR-018 §3).
       if (UNSAFE.has(method) && csrf !== null) {
         retryHeaders.set('X-CSRF-Token', csrf)
       }


### PR DESCRIPTION
## Summary

- **StepUpModal** now branches on `presenceRequired` to route between two ceremonies: `elevate/begin→finish` (Basic→Strong session upgrade) for pure elevation, and `presence/begin→finish` (existing path, unchanged) for RequireUserPresence actions
- **`apiFetch` interceptor** gains concurrent-tab dedup (`stepUpCeremonyDone` promise serialises simultaneous 401s — only one modal, rest retry after ceremony) and explicit retry cap (listener fires at most once per `apiFetch` call)
- **SQLite fix**: removed `cache=shared` + WAL from in-memory DSNs to eliminate shared-cache lock-manager deadlock observed in parallel integration tests

## What changed and why

### `web/src/auth/StepUpModal.tsx`
The modal now checks `request.presenceRequired` to choose the begin/finish URL pair. For the elevation path (`false`), the finish response (`{ assurance: "strong", elevated_at }`) is consumed and discarded — the elevated session cookie is the credential; no extra header is needed on the retry. CSRF is re-attached on unsafe-method retries in both paths (ADR-018 §3).

### `web/src/api/client.ts`
Added `stepUpCeremonyDone: Promise<void> | null` for concurrent dedup. First 401 to win the race claims the slot, runs the ceremony, then signals all waiters via `ceremonyDone()`. Waiters retry once with fresh CSRF; if still 401, they return it directly (cap). The slot is cleared atomically in a `finally` block before signalling.

### `pkg/storage/providers/sqlite/plugin.go`
Separate pragma strings for file (`WAL + busy_timeout`) vs in-memory (no WAL, no shared-cache, just `busy_timeout + foreign_keys`). Named shared-cache in-memory DSNs are collapsed to a private unnamed `file::memory:` DSN pinned to a single connection, removing the pure-Go shared-cache lock manager from the critical path and fixing a `CREATE TABLE` wedge under high test concurrency.

## Specialist review results

- **Code review**: PASS  
- **QA test runner**: PASS (647/647 TypeScript, 215/215 Go/script)  
- **Security**: PASS  
- Review rounds: 2 (1 fix round for test runner issue resolved in round 1)  
- Remaining findings: none

## Test plan

- [x] `web/src/auth/StepUpModal.test.tsx` — 7 new elevation-path tests: elevate/begin called, elevate/finish called, no X-Presence-Token on retry, CSRF re-attached, begin/finish failure states, begin-retry
- [x] `web/src/api/client.test.ts` — 2 new concurrent-dedup tests: only one ceremony runs, deduped retry carries CSRF
- [x] All existing 638 tests continue to pass (presence path, session expired, CSRF, login/logout)
- [x] `make test` (215/215 Go + script tests)

Fixes #2967

🤖 Generated with [Claude Code](https://claude.com/claude-code)