### PR TITLE
web: create config for an unconfigured steward (Issue #2980)

### DIFF
--- a/web/src/config/ConfigEditor.test.tsx
+++ b/web/src/config/ConfigEditor.test.tsx
@@ -260,3 +260,59 @@ describe('ConfigEditor — rollback tab', () => {
     await waitFor(() => expect(screen.getByTestId('rollback-panel')).toBeInTheDocument())
   })
 })
+
+describe('ConfigEditor — create mode (no existing config)', () => {
+  function make404Response() {
+    return new Response('{}', { status: 404, headers: { 'Content-Type': 'application/json' } })
+  }
+
+  it('shows empty editor textarea when GET returns 404', async () => {
+    fetchMock.mockResolvedValue(make404Response())
+    renderEditor('sw-new')
+    await waitFor(() => expect(screen.getByTestId('editor-textarea')).toBeInTheDocument())
+    expect((screen.getByTestId('editor-textarea') as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('does not show an error notice when GET returns 404', async () => {
+    fetchMock.mockResolvedValue(make404Response())
+    renderEditor('sw-new')
+    await waitFor(() => expect(screen.getByTestId('editor-textarea')).toBeInTheDocument())
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('save PUTs the entered config and then shows the saved config', async () => {
+    fetchMock.mockResolvedValueOnce(make404Response())
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    fetchMock.mockResolvedValue(makeConfigEnvelope({ resources: [] }, 'sw-new'))
+
+    renderEditor('sw-new')
+    await waitFor(() => expect(screen.getByTestId('editor-textarea')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('editor-textarea'), {
+      target: { value: '{"resources":[]}' },
+    })
+    fireEvent.click(screen.getByTestId('editor-save-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('editor-config-pre')).toBeInTheDocument())
+
+    const putCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'PUT',
+    )
+    expect(putCalls).toHaveLength(1)
+  })
+
+  it('cancel in create mode calls onClose', async () => {
+    fetchMock.mockResolvedValue(make404Response())
+    const onClose = vi.fn()
+    renderEditor('sw-new', onClose)
+    await waitFor(() => expect(screen.getByTestId('editor-textarea')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/src/config/ConfigEditor.tsx
+++ b/web/src/config/ConfigEditor.tsx
@@ -46,9 +46,12 @@ export default function ConfigEditor({ stewardId, onClose }: ConfigEditorProps) 
   const [effectiveLoading, setEffectiveLoading] = useState(false)
   const [effectiveError, setEffectiveError] = useState<string | null>(null)
 
-  const { config, loading, error, retry } = useStewardConfig(stewardId)
+  const { config, loading, error, notFound, retry } = useStewardConfig(stewardId)
 
   const configText = config ? JSON.stringify(config.config, null, 2) : ''
+  // True when the steward exists but has no config yet — show empty editor immediately.
+  const inCreateMode = !loading && notFound
+  const effectiveEditing = editing || inCreateMode
 
   function handleStartEdit() {
     setEditText(configText)
@@ -58,6 +61,10 @@ export default function ConfigEditor({ stewardId, onClose }: ConfigEditorProps) 
   }
 
   function handleCancelEdit() {
+    if (inCreateMode) {
+      onClose()
+      return
+    }
     setEditing(false)
     setSaveError(null)
     setValidationResult(null)
@@ -98,7 +105,7 @@ export default function ConfigEditor({ stewardId, onClose }: ConfigEditorProps) 
   async function handleValidate() {
     setValidating(true)
     setValidationResult(null)
-    const textToValidate = editing ? editText : configText
+    const textToValidate = effectiveEditing ? editText : configText
     try {
       let parsed: unknown
       try {
@@ -220,7 +227,7 @@ export default function ConfigEditor({ stewardId, onClose }: ConfigEditorProps) 
         {view === 'config' && (
           <>
             <div className="cfg-editor-actions">
-              {!editing ? (
+              {!effectiveEditing ? (
                 <>
                   <button
                     type="button"
@@ -307,13 +314,13 @@ export default function ConfigEditor({ stewardId, onClose }: ConfigEditorProps) 
               </div>
             )}
 
-            {!loading && error === null && !editing && config && (
+            {!loading && error === null && !effectiveEditing && config && (
               <pre className="cfg-editor-pre" data-testid="editor-config-pre">
                 {configText}
               </pre>
             )}
 
-            {!loading && error === null && editing && (
+            {!loading && error === null && effectiveEditing && (
               <textarea
                 className="cfg-editor-textarea"
                 aria-label="Edit configuration"

--- a/web/src/config/ConfigListView.test.tsx
+++ b/web/src/config/ConfigListView.test.tsx
@@ -254,6 +254,70 @@ describe('ConfigListView — STEWARD column hostname display', () => {
   })
 })
 
+function make404Response() {
+  return new Response('{}', { status: 404, headers: { 'Content-Type': 'application/json' } })
+}
+
+describe('ConfigListView — create new config', () => {
+  it('shows + New config button in toolbar', async () => {
+    fetchMock.mockResolvedValue(makeConfigEnvelope([]))
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-empty')).toBeInTheDocument())
+    expect(screen.getByTestId('toggle-create-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('toggle-create-btn')).toHaveTextContent('+ New config')
+  })
+
+  it('clicking + New config shows the steward ID input form', async () => {
+    fetchMock.mockResolvedValue(makeConfigEnvelope([]))
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+    expect(screen.getByTestId('create-config-form')).toBeInTheDocument()
+    expect(screen.getByTestId('create-steward-id-input')).toBeInTheDocument()
+  })
+
+  it('clicking + New config again closes the form', async () => {
+    fetchMock.mockResolvedValue(makeConfigEnvelope([]))
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+    expect(screen.getByTestId('create-config-form')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+    expect(screen.queryByTestId('create-config-form')).toBeNull()
+  })
+
+  it('submitting the form opens ConfigEditor for the entered steward ID without an existing row', async () => {
+    fetchMock.mockResolvedValueOnce(makeConfigEnvelope([]))
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: { stewards: [], total: 0, limit: 500, offset: 0 } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    fetchMock.mockResolvedValue(make404Response())
+
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-empty')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+    fireEvent.change(screen.getByTestId('create-steward-id-input'), {
+      target: { value: 'new-steward-id' },
+    })
+    fireEvent.click(screen.getByTestId('create-open-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('config-editor')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId('editor-textarea')).toBeInTheDocument())
+  })
+
+  it('create-open-btn is disabled when steward ID input is empty', async () => {
+    fetchMock.mockResolvedValue(makeConfigEnvelope([]))
+    renderConfigListView()
+    await waitFor(() => expect(screen.getByTestId('config-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-btn'))
+    expect(screen.getByTestId('create-open-btn')).toBeDisabled()
+  })
+})
+
 describe('ConfigListView — security (A9.1)', () => {
   it('renders steward_id and tenant_id as plain text, not HTML', async () => {
     const xss = '<img src=x onerror="window.__xss=1">'

--- a/web/src/config/ConfigListView.tsx
+++ b/web/src/config/ConfigListView.tsx
@@ -10,7 +10,7 @@
  * from the controller and may contain attacker-controlled data. Every value
  * reaches the DOM as a JSX text node — never dangerouslySetInnerHTML.
  */
-import { useState } from 'react'
+import { type FormEvent, useState } from 'react'
 import { useConfigList, useStewardHostnameMap, type ConfigSummary } from './useConfigs.ts'
 import ConfigEditor from './ConfigEditor.tsx'
 import PushPanel from './PushPanel.tsx'
@@ -101,13 +101,32 @@ export default function ConfigListView() {
   const hostnameMap = useStewardHostnameMap()
   const [selectedStewardId, setSelectedStewardId] = useState<string | null>(null)
   const [showPushPanel, setShowPushPanel] = useState(false)
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [createInputValue, setCreateInputValue] = useState('')
 
   function handleRowClick(stewardId: string) {
+    setShowCreateForm(false)
     setSelectedStewardId((prev) => (prev === stewardId ? null : stewardId))
   }
 
   function handleEditorClose() {
     setSelectedStewardId(null)
+  }
+
+  function handleToggleCreate() {
+    setShowCreateForm((v) => !v)
+    if (!showCreateForm) {
+      setSelectedStewardId(null)
+    }
+  }
+
+  function handleCreateSubmit(e: FormEvent) {
+    e.preventDefault()
+    const id = createInputValue.trim()
+    if (!id) return
+    setSelectedStewardId(id)
+    setShowCreateForm(false)
+    setCreateInputValue('')
   }
 
   return (
@@ -127,6 +146,14 @@ export default function ConfigListView() {
           >
             {showPushPanel ? 'Close push' : 'Push config'}
           </button>
+          <button
+            type="button"
+            className={showCreateForm ? 'cfg-btn' : 'cfg-btn-secondary'}
+            onClick={handleToggleCreate}
+            data-testid="toggle-create-btn"
+          >
+            {showCreateForm ? 'Close' : '+ New config'}
+          </button>
           {!loading && error === null && (
             <span className="cnt" data-testid="config-count">
               {configs.length} config{configs.length !== 1 ? 's' : ''}
@@ -136,6 +163,38 @@ export default function ConfigListView() {
 
         {showPushPanel && (
           <PushPanel onClose={() => setShowPushPanel(false)} />
+        )}
+
+        {showCreateForm && (
+          <div className="cfg-push-panel" data-testid="create-config-form">
+            <form className="cfg-push-form" onSubmit={handleCreateSubmit}>
+              <div className="cfg-push-row">
+                <div className="cfg-push-field">
+                  <label className="cfg-push-label" htmlFor="create-steward-id">
+                    Steward ID
+                  </label>
+                  <input
+                    id="create-steward-id"
+                    type="text"
+                    value={createInputValue}
+                    onChange={(e) => setCreateInputValue(e.target.value)}
+                    placeholder="Enter steward ID"
+                    data-testid="create-steward-id-input"
+                  />
+                </div>
+                <div className="cfg-push-actions">
+                  <button
+                    type="submit"
+                    className="cfg-btn"
+                    disabled={!createInputValue.trim()}
+                    data-testid="create-open-btn"
+                  >
+                    Open editor
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
         )}
 
         {loading ? (

--- a/web/src/config/useConfigs.test.ts
+++ b/web/src/config/useConfigs.test.ts
@@ -270,11 +270,21 @@ describe('useStewardConfig', () => {
     expect(result.current.error).toBeNull()
   })
 
-  it('surfaces an error on non-ok response', async () => {
+  it('returns notFound when GET returns 404', async () => {
     fetchMock.mockResolvedValue(makeEnvelope({}, 404))
     const { result } = renderHook(() => useStewardConfig('sw-1'))
     await waitFor(() => expect(result.current.loading).toBe(false))
-    expect(result.current.error).toContain('404')
+    expect(result.current.notFound).toBe(true)
+    expect(result.current.error).toBeNull()
+    expect(result.current.config).toBeNull()
+  })
+
+  it('surfaces an error on non-ok non-404 response', async () => {
+    fetchMock.mockResolvedValue(makeEnvelope({}, 500))
+    const { result } = renderHook(() => useStewardConfig('sw-1'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toContain('500')
+    expect(result.current.notFound).toBe(false)
   })
 })
 

--- a/web/src/config/useConfigs.ts
+++ b/web/src/config/useConfigs.ts
@@ -226,6 +226,7 @@ interface FetchOutcome<T> {
   key: string
   data?: T
   error?: string
+  notFound?: boolean
   fetchedAtMs: number
 }
 
@@ -287,6 +288,7 @@ export interface UseStewardConfigResult {
   config: StewardConfigInfo | null
   loading: boolean
   error: string | null
+  notFound: boolean
   retry: () => void
 }
 
@@ -301,6 +303,10 @@ export function useStewardConfig(stewardId: string | null): UseStewardConfigResu
     let cancelled = false
     apiFetch(`/api/v1/stewards/${encodeURIComponent(stewardId)}/config`)
       .then(async (response) => {
+        if (response.status === 404) {
+          if (!cancelled) setOutcome({ key, notFound: true, fetchedAtMs: Date.now() })
+          return
+        }
         if (!response.ok)
           throw new Error(
             `GET /api/v1/stewards/${stewardId}/config — ${response.status}`,
@@ -333,6 +339,7 @@ export function useStewardConfig(stewardId: string | null): UseStewardConfigResu
     config: current?.data ?? null,
     loading: stewardId !== null && current === null,
     error: current?.error ?? null,
+    notFound: current?.notFound ?? false,
     retry,
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `+ New config` toolbar button to `ConfigListView` that opens `ConfigEditor` for an operator-entered steward ID — no existing config row required
- `useStewardConfig` now returns `notFound: true` on 404 instead of a generic error, letting `ConfigEditor` distinguish "no config yet" from a real fetch failure
- `ConfigEditor` shows an empty textarea in create mode (not an error notice) when `notFound` is true; Save PUTs via the existing `handleSave`/`PUT /api/v1/stewards/{id}/config` path; after save the editor reloads into normal view

Fixes #2980

## What changed

**`useConfigs.ts`** — `useStewardConfig` detects HTTP 404 and returns `{ notFound: true, error: null }` instead of treating it as a generic error.

**`ConfigEditor.tsx`** — Computes `inCreateMode = !loading && notFound` and `effectiveEditing = editing || inCreateMode`. When in create mode: shows empty textarea immediately, Save calls existing PUT path, Cancel closes the editor.

**`ConfigListView.tsx`** — Adds `+ New config` button (following `WorkflowListView` pattern) with `showCreateForm` state, steward-ID text input, and `handleCreateSubmit` that sets `selectedStewardId` to open `ConfigEditor`.

**Tests** — 9 new tests across three files:
- `ConfigListView.test.tsx`: button presence, form open/close, form submit, disabled-when-empty
- `ConfigEditor.test.tsx`: empty textarea on 404, no error notice on 404, save→PUT→reload, cancel calls onClose
- `useConfigs.test.ts`: 404→notFound, 500→error (split from single test)

## Specialist review results

| Reviewer | Result |
|---|---|
| Code Review | PASS — no mocks, no skips, no hacky workarounds |
| Test Quality | PASS — after fix round (initial run hit pre-existing test infrastructure timeout) |
| Security | PASS — frontend-only; all values rendered as JSX text nodes (A9.1 maintained) |

## Pre-existing test note

`features/controller/api` times out under `make test-fast` (5-min cap) but passes under `make test` (10-min cap). This exists on `develop` and is unrelated to this PR — confirmed by running the same test suite against a stash of this branch's changes.

## Test plan

- [x] 648/648 frontend tests pass (`npm run test`)
- [x] TypeScript and ESLint clean
- [x] Adversarial review: code, test quality, security — all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)