### PR TITLE
docs: passkey-only login mockup — usernameless-first hybrid (Issue #2993)

### DIFF
--- a/docs/design/mockups/README.md
+++ b/docs/design/mockups/README.md
@@ -18,7 +18,7 @@ principles, and token rationale these mockups express.
 | File | What it is | Status |
 |------|------------|--------|
 | [`troubleshooting-cockpit.html`](troubleshooting-cockpit.html) | The chosen direction — agentic troubleshooting cockpit: case bar, dense ticket quick-reference, tabbed Investigation/Chat rail, and an evidence→cause→action canvas (drift-diff, blast-radius graph, change timeline, remediation). Brand-aligned, both themes. | **Reference** |
-| [`login.html`](login.html) | The authentication screen — terminal-window framing, single mTLS/session sign-in, with `signin` / `loading` / `invalid` / `expired` states and a **passkey/WebAuthn MFA seam** (`mfa` state) designed now, built later. Both themes. | **Reference** |
+| [`login.html`](login.html) | The authentication screen — **passkey-only** (ADR-021 Amendment 1): usernameless-first "Sign in with a passkey", optional username to scope to a specific account, "Remember Username" prefill, no password. `signin` / `waiting` / `invalid` (no passkey) / `expired` states, both themes. | **Reference** |
 | [`fleet-overview.html`](fleet-overview.html) | The read-only fleet overview inside the app shell — tenant-scope switcher, live-filter search, sort, saved views, selectable **device-DNA columns**, scale-aware pagination, and a row drill-in **asset-DNA drawer**. Both themes; Ready / Loading / Error / Empty states. | **Reference** |
 | [`fleet-overview-generic-v0.html`](fleet-overview-generic-v0.html) | The initial generic management dashboard, before brand alignment. Kept for provenance only. | Superseded |
 

--- a/docs/design/mockups/login.html
+++ b/docs/design/mockups/login.html
@@ -1,6 +1,6 @@
 <style>
   :root {
-    --bg:#f0ebe4; --chrome:#f7f4ef; --chrome-2:#ffffff; --border:#d4cfc4;
+    --bg:#f7f4ef; --chrome:#f0ebe4; --chrome-2:#ffffff; --border:#d4cfc4;
     --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff;
     --shadow:0 18px 50px -22px rgba(60,45,30,.4); --radius:14px;
   }
@@ -8,7 +8,7 @@
     --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
     --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a;
     --shadow:0 22px 60px -26px rgba(0,0,0,.8); } }
-  :root[data-theme="light"]{ --bg:#f0ebe4; --chrome:#f7f4ef; --chrome-2:#ffffff; --border:#d4cfc4;
+  :root[data-theme="light"]{ --bg:#f7f4ef; --chrome:#f0ebe4; --chrome-2:#ffffff; --border:#d4cfc4;
     --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff; --shadow:0 18px 50px -22px rgba(60,45,30,.4); }
   :root[data-theme="dark"]{ --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
     --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a; --shadow:0 22px 60px -26px rgba(0,0,0,.8); }
@@ -33,11 +33,11 @@
   .frame-wrap{position:relative; margin:0 auto; border-radius:var(--radius); overflow:hidden; box-shadow:var(--shadow);
     border:1px solid var(--border); background:var(--chrome); transition:width .22s ease, height .22s ease;}
   .frame{display:block; border:0; transform-origin:0 0; background:transparent;}
-  .hint{text-align:center; color:var(--text-dim); font-size:12.5px; line-height:1.6; padding:0 20px 30px; max-width:560px; margin:0 auto;}
+  .hint{text-align:center; color:var(--text-dim); font-size:12.5px; line-height:1.6; padding:0 20px 30px; max-width:600px; margin:0 auto;}
 </style>
 
 <div class="topbar">
-  <div class="brand"><b>CFGMS</b><span>login screen</span></div>
+  <div class="brand"><b>CFGMS</b><span>login screen · passkey-only</span></div>
   <div class="seg" role="group" aria-label="Preview viewport">
     <span class="thumb" aria-hidden="true"></span>
     <button data-dev="desktop" aria-pressed="true">Desktop</button>
@@ -58,8 +58,11 @@
 </div>
 
 <p class="hint">
-  Login screen · session-token credential auth (Epic #2344). Use the <b>state</b> switcher in the mockup to see
-  <b>Sign in / Invalid credentials / Session expired</b>. Auto/Light/Dark + Desktop/Mobile toggles above.
+  Passkey-only login (ADR-021 Amendment 1 · Epic #2931/#2993) — rebuilt on the <b>live</b>
+  <code>Login.tsx</code> (no titlebar dots, copyright footer). <b>Usernameless-first hybrid:</b>
+  <b>Sign in with a passkey</b> is primary (leave username blank to pick the account on your key); the
+  optional username scopes to one account (e.g. a separate admin identity); <b>Remember Username</b>
+  prefills it only. Use the <b>state</b> switcher for <b>Sign in / Waiting / No passkey / Expired</b>. No password.
 </p>
 
 <script>
@@ -73,134 +76,138 @@
 
   const MOCK_CSS = `
     :root{
-      --bg:#f0ebe4; --panel:#ffffff; --elev:#f7f4ef; --sunk:#f0ebe4; --border:#d4cfc4;
-      --text:#6b5a4a; --dim:#7a6a5a; --faint:#8f7d66;
+      --bg-primary:#f7f4ef; --bg-surface:#ffffff; --bg-elevated:#f0ebe4; --bg-sunk:#f0ebe4; --border:#d4cfc4;
+      --text-primary:#6b5a4a; --text-secondary:#7a6a5a; --text-faint:#8f7d66;
       --accent:#4a6b7c; --accent-ink:#ffffff;
-      --ok:#507055; --warn:#a05a35; --warn-bg:#f7e8db; --crit:#b56a5a; --crit-bg:#f2e5e3;
-      --tl-red:#e6564c; --tl-yellow:#d9a441; --tl-green:#5a9367;
+      --warn:#a05a35; --warn-bg:#f7e8db; --crit:#b56a5a; --crit-bg:#f2e5e3;
     }
     :root[data-theme="dark"]{
-      --bg:#181817; --panel:#1e1e1e; --elev:#252526; --sunk:#161616; --border:#3c3c3c;
-      --text:#c4b4a4; --dim:#a89888; --faint:#8a7a68;
+      --bg-primary:#1e1e1e; --bg-surface:#252526; --bg-elevated:#2d2d2d; --bg-sunk:#1a1a1a; --border:#3c3c3c;
+      --text-primary:#c4b4a4; --text-secondary:#a89888; --text-faint:#8a7a68;
       --accent:#7b9fb0; --accent-ink:#16202a;
-      --ok:#6d9472; --warn:#d4864f; --warn-bg:#332518; --crit:#c97a6a; --crit-bg:#2d1f1c;
-      --tl-red:#ff5f56; --tl-yellow:#ffbd2e; --tl-green:#6d9472;
+      --warn:#d4864f; --warn-bg:#332518; --crit:#c97a6a; --crit-bg:#2d1f1c;
     }
     *{box-sizing:border-box;}
     html,body{margin:0; height:100%;}
-    body{background:var(--bg); color:var(--text); font-size:14px; line-height:1.45;
+    body{background:var(--bg-primary); color:var(--text-primary); font-size:13.5px; line-height:1.45;
       font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased;
       display:flex; flex-direction:column; align-items:center; justify-content:center; padding:24px 18px; gap:16px;}
     .mono{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace;}
 
     /* demo-only preview-state switch (not part of the real screen) */
-    .demo{display:flex; align-items:center; gap:8px; font-size:11px; color:var(--faint);}
+    .demo{display:flex; align-items:center; gap:8px; font-size:11px; color:var(--text-faint);}
     .demo .lbl{letter-spacing:.06em; text-transform:uppercase; font-weight:600;}
-    .demo .sw{display:inline-flex; background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:2px;}
+    .demo .sw{display:inline-flex; background:var(--bg-surface); border:1px solid var(--border); border-radius:8px; padding:2px;}
     .demo .sw button{appearance:none; border:0; background:transparent; font:inherit; font-size:11px; font-weight:600;
-      color:var(--dim); padding:4px 9px; border-radius:6px; cursor:pointer;}
+      color:var(--text-secondary); padding:4px 9px; border-radius:6px; cursor:pointer;}
     .demo .sw button.on{background:var(--accent); color:var(--accent-ink);}
 
-    /* terminal-window login card */
-    .win{width:100%; max-width:400px; background:var(--panel); border:1px solid var(--border); border-radius:12px;
-      overflow:hidden; box-shadow:0 24px 60px -30px rgba(0,0,0,.45);}
-    .titlebar{display:flex; align-items:center; gap:8px; padding:10px 13px; background:var(--elev); border-bottom:1px solid var(--border);}
-    .lights{display:flex; gap:6px;}
-    .lights i{width:11px; height:11px; border-radius:50%; display:block;}
-    .lights .r{background:var(--tl-red);} .lights .y{background:var(--tl-yellow);} .lights .g{background:var(--tl-green);}
-    .titlebar .tt{font-size:11.5px; color:var(--faint); margin:0 auto; letter-spacing:.02em;}
+    /* terminal-window login card (live Login.css — no titlebar dots) */
+    .login-win{width:100%; max-width:400px; background:var(--bg-surface); border:1px solid var(--border); border-radius:13px;
+      overflow:hidden; box-shadow:0 18px 50px -22px rgba(60,45,30,.4);}
+    .login-titlebar{display:flex; align-items:center; gap:8px; padding:10px 13px; background:var(--bg-elevated); border-bottom:1px solid var(--border);}
+    .login-title{font-size:11.5px; color:var(--text-faint); margin:0 auto; letter-spacing:.02em;}
 
-    .body{padding:26px 26px 22px; display:flex; flex-direction:column; gap:16px;}
-    .wordmark{display:flex; flex-direction:column; gap:3px; align-items:center; text-align:center; margin-bottom:2px;}
-    .wordmark b{font-size:22px; font-weight:700; letter-spacing:.16em; text-transform:uppercase;}
-    .wordmark span{font-size:11px; color:var(--faint); letter-spacing:.06em; text-transform:uppercase;}
-    .lead{text-align:center; font-size:13px; color:var(--dim); margin:-4px 0 4px;}
+    .login-body{padding:26px 26px 22px; display:flex; flex-direction:column; gap:16px;}
+    .login-wordmark{display:flex; flex-direction:column; gap:3px; align-items:center; text-align:center; margin-bottom:2px;}
+    .login-wordmark b{font-family:'Ubuntu Mono','JetBrains Mono',monospace; font-size:22px; font-weight:700; letter-spacing:.16em; text-transform:uppercase;}
+    .login-wordmark span{font-size:11.5px; color:var(--text-faint); letter-spacing:.06em; text-transform:uppercase;}
+    .login-lead{text-align:center; font-size:13.5px; color:var(--text-secondary); margin:-4px 0 4px;}
 
-    .expired{display:none; align-items:flex-start; gap:9px; padding:10px 12px; border-radius:9px;
+    .login-expired{display:none; align-items:flex-start; gap:9px; padding:10px 12px; border-radius:9px;
       background:var(--warn-bg); border:1px solid var(--warn); font-size:12.5px; color:var(--warn);}
-    body[data-state="expired"] .expired{display:flex;}
+    body[data-state="expired"] .login-expired{display:flex;}
 
-    .field{display:flex; flex-direction:column; gap:6px;}
-    .field label{font-size:11px; letter-spacing:.06em; text-transform:uppercase; color:var(--faint); font-weight:600;}
-    .field .inp{display:flex; align-items:center; gap:9px; padding:11px 13px; background:var(--sunk);
+    .login-field{display:flex; flex-direction:column; gap:6px;}
+    .login-field .inp{display:flex; align-items:center; padding:11px 13px; background:var(--bg-sunk);
       border:1px solid var(--border); border-radius:9px;}
-    .field .inp .val{font-size:14px; color:var(--text); font-family:'JetBrains Mono',Menlo,monospace;}
-    .field .inp .val.ph{color:var(--faint);}
-    body[data-state="invalid"] .field .inp{border-color:var(--crit); background:var(--crit-bg);}
+    .login-field .inp .val{font-size:14px; color:var(--text-primary); font-family:'JetBrains Mono',Menlo,monospace;}
+    .login-field .inp .val.ph{color:var(--text-faint);}
+    body[data-state="invalid"] .login-field .inp{border-color:var(--crit); background:var(--crit-bg);}
 
-    .err{display:none; align-items:center; gap:8px; font-size:12.5px; color:var(--crit); margin-top:-4px;}
-    .err .dot{width:6px; height:6px; border-radius:50%; background:currentColor;}
-    body[data-state="invalid"] .err{display:flex;}
+    .login-remember{display:flex; align-items:center; gap:9px; font-size:12.5px; color:var(--text-secondary); cursor:pointer; margin-top:-6px;}
+    .login-remember .cbx{width:17px; height:17px; border-radius:5px; border:1px solid var(--border); background:var(--bg-sunk);
+      display:grid; place-items:center; color:var(--accent-ink); flex:none;}
+    .login-remember .cbx svg{opacity:0;}
+    .login-remember.on .cbx{background:var(--accent); border-color:var(--accent);}
+    .login-remember.on .cbx svg{opacity:1;}
 
-    .signin{appearance:none; border:0; width:100%; padding:12px; border-radius:9px; background:var(--accent);
+    .login-err{display:none; align-items:center; gap:8px; font-size:12.5px; color:var(--crit); margin-top:-6px;}
+    .login-err .dot{width:6px; height:6px; border-radius:50%; background:currentColor;}
+    body[data-state="invalid"] .login-err{display:flex;}
+
+    .login-signin{appearance:none; border:0; width:100%; padding:13px; border-radius:9px; background:var(--accent);
       color:var(--accent-ink); font:inherit; font-size:14px; font-weight:600; cursor:pointer; display:flex;
       align-items:center; justify-content:center; gap:9px; margin-top:2px;}
-    .signin .spin{width:14px; height:14px; border:2px solid currentColor; border-right-color:transparent; border-radius:50%; display:none;}
-    body[data-state="loading"] .signin .spin{display:block; animation:sp .7s linear infinite;}
-    body[data-state="loading"] .signin .txt{opacity:.85;}
+    .login-signin .spin{width:14px; height:14px; border:2px solid currentColor; border-right-color:transparent; border-radius:50%; display:none;}
+    body[data-state="loading"] .login-signin .spin{display:block; animation:sp .7s linear infinite;}
+    body[data-state="loading"] .login-signin .txt{opacity:.85;}
     @keyframes sp{to{transform:rotate(360deg);}}
-    @media (prefers-reduced-motion:reduce){.signin .spin{animation:none;}}
+    @media (prefers-reduced-motion:reduce){.login-signin .spin{animation:none;}}
 
-    .mfa{display:none; flex-direction:column; gap:12px; align-items:center; text-align:center; padding:4px 0;}
-    body[data-state="mfa"] .mfa{display:flex;}
-    body[data-state="mfa"] .lead, body[data-state="mfa"] .field, body[data-state="mfa"] .err, body[data-state="mfa"] .signin{display:none;}
-    .mfa .mic{width:52px; height:52px; border-radius:14px; background:var(--sunk); color:var(--accent); display:grid; place-items:center;}
+    .login-helper{text-align:center; font-size:11.5px; color:var(--text-faint); margin:-8px 0 0; line-height:1.5;}
+
+    /* passkey-in-progress ("waiting") — the primary ceremony, not a 2nd factor */
+    .mfa{display:none; flex-direction:column; gap:12px; align-items:center; text-align:center; padding:6px 0;}
+    body[data-state="waiting"] .mfa{display:flex;}
+    body[data-state="waiting"] .login-lead, body[data-state="waiting"] .login-field, body[data-state="waiting"] .login-remember,
+    body[data-state="waiting"] .login-err, body[data-state="waiting"] .login-signin, body[data-state="waiting"] .login-helper{display:none;}
+    .mfa .mic{width:52px; height:52px; border-radius:14px; background:var(--bg-sunk); color:var(--accent); display:grid; place-items:center;}
     .mfa h3{margin:0; font-size:16px; font-weight:700;}
-    .mfa p{margin:0; font-size:12.5px; color:var(--dim); max-width:290px;}
-    .mbtn{appearance:none; border:0; width:100%; padding:12px; border-radius:9px; background:var(--accent); color:var(--accent-ink);
-      font:inherit; font-size:14px; font-weight:600; cursor:pointer; display:flex; align-items:center; justify-content:center; gap:9px;}
-    .mfa .alt{font-size:12px; color:var(--accent); font-weight:600; cursor:pointer;}
+    .mfa p{margin:0; font-size:12.5px; color:var(--text-secondary); max-width:300px;}
+    .mfa .cancel{font-size:12px; color:var(--accent); font-weight:600; cursor:pointer;}
 
-    .foot{display:flex; justify-content:space-between; align-items:center; padding-top:4px; font-size:11px; color:var(--faint);}
-    .foot a{color:var(--accent); text-decoration:none; font-weight:600;}
-    .foot .ep{font-family:'JetBrains Mono',Menlo,monospace;}
+    .login-foot{display:flex; justify-content:space-between; align-items:center; padding-top:4px; font-size:11.5px; color:var(--text-faint);}
+    .login-foot a{color:var(--accent); text-decoration:none; font-weight:600;}
   `;
+
+  const KEY = '<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>';
+  const KEY_BIG = '<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>';
 
   const MOCK_HTML = `
     <div class="demo">
       <span class="lbl">Preview state</span>
       <div class="sw" role="group" aria-label="Preview state">
         <button data-state="signin" class="on">Sign in</button>
-        <button data-state="invalid">Invalid</button>
-        <button data-state="mfa">MFA</button>
+        <button data-state="waiting">Waiting</button>
+        <button data-state="invalid">No passkey</button>
         <button data-state="expired">Expired</button>
       </div>
     </div>
 
-    <div class="win">
-      <div class="titlebar">
-        <span class="lights"><i class="r"></i><i class="y"></i><i class="g"></i></span>
-        <span class="tt mono">cfgms · secure session</span>
+    <div class="login-win">
+      <div class="login-titlebar">
+        <span class="login-title mono">cfgms · secure session</span>
       </div>
-      <div class="body">
-        <div class="wordmark"><b>CFGMS</b><span>config management</span></div>
-        <p class="lead">Sign in to the controller</p>
+      <div class="login-body">
+        <div class="login-wordmark"><b>CFGMS</b><span>config management</span></div>
+        <p class="login-lead">Sign in to the controller</p>
 
-        <div class="expired"><span class="mono">⚠</span><span>Your session expired. Sign in again to continue.</span></div>
+        <div class="login-expired"><span class="mono">⚠</span><span>Your session expired. Sign in again with your passkey to continue.</span></div>
 
-        <div class="field">
-          <label>Username</label>
-          <div class="inp"><span class="val">admin@msp-a</span></div>
+        <div class="login-field">
+          <div class="inp"><span class="val ph">Username (Optional)</span></div>
         </div>
-        <div class="field">
-          <label>Password</label>
-          <div class="inp"><span class="val">••••••••••••</span></div>
-        </div>
-        <div class="err"><span class="dot"></span>Invalid username or password.</div>
+        <label class="login-remember on">
+          <span class="cbx"><svg width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M5 12.5l4.2 4.2L19 7" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+          Remember Username
+        </label>
+        <div class="login-err"><span class="dot"></span>No passkey matched. Check the username, or use the key that holds this account.</div>
 
-        <button class="signin"><span class="spin"></span><span class="txt">Sign in</span></button>
+        <button class="login-signin">${KEY}<span class="txt">Sign in with a passkey</span><span class="spin"></span></button>
+
+        <p class="login-helper">Your passkey never leaves your device. No password to phish.</p>
 
         <div class="mfa">
-          <div class="mic"><svg width="26" height="26" viewBox="0 0 24 24" fill="none"><path d="M12 2a7 7 0 00-7 7v2M12 2a7 7 0 017 7v2M8 11h8v9a1 1 0 01-1 1H9a1 1 0 01-1-1v-9z" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="15.5" r="1.4" fill="currentColor"/></svg></div>
-          <h3>Verify it's you</h3>
-          <p>Signing in as <b class="mono">admin@msp-a</b>. Use your passkey or security key to finish.</p>
-          <button class="mbtn"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M7.5 13.5a3.5 3.5 0 113.5-3.5M11 10h9l-2 2 2 2-3 3" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>Verify with passkey</button>
-          <span class="alt">Use a recovery code</span>
+          <div class="mic">${KEY_BIG}</div>
+          <h3>Waiting for your passkey</h3>
+          <p>Confirm on your security key or device to finish signing in.</p>
+          <span class="cancel">Cancel</span>
         </div>
 
-        <div class="foot">
+        <div class="login-foot">
           <a>Trouble signing in?</a>
-          <span class="ep">controller · v0.42</span>
+          <span class="mono">© 2026 cfg.is</span>
         </div>
       </div>
     </div>
@@ -212,10 +219,14 @@
       document.body.dataset.state=b.dataset.state;
       sb.forEach(function(x){x.classList.toggle('on',x===b);});});});
     document.body.dataset.state='signin';
-    var btn=document.querySelector('.signin');
+    var rem=document.querySelector('.login-remember');
+    if(rem){rem.addEventListener('click',function(){rem.classList.toggle('on');});}
+    var btn=document.querySelector('.login-signin');
     if(btn){btn.addEventListener('click',function(){
-      var prev=document.body.dataset.state; document.body.dataset.state='loading';
-      setTimeout(function(){document.body.dataset.state=prev==='loading'?'signin':prev;},1300);});}
+      document.body.dataset.state='loading';
+      setTimeout(function(){document.body.dataset.state='waiting';},1100);});}
+    var cancel=document.querySelector('.mfa .cancel');
+    if(cancel){cancel.addEventListener('click',function(){document.body.dataset.state='signin';});}
   `;
 
   function currentTheme(){ if(themeMode!=="auto") return themeMode; const d=document.documentElement.getAttribute("data-theme"); return d || (matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"); }


### PR DESCRIPTION
Docs-only. Rebuilds `docs/design/mockups/login.html` for the passkey-only model (ADR-021 Amendment 1), on top of the live `web/src/pages/Login.tsx` layout.

- **Usernameless-first hybrid:** "Sign in with a passkey" is primary; an **optional** username field (placeholder "Username (Optional)") scopes to a specific account so an admin with a separate admin identity on one key authenticates deterministically.
- **"Remember Username"** = prefill only, never a longer session.
- **No password.** Lucide "key" icon (matches the shipped `StepUpModal`).
- States: signin / waiting-for-passkey / invalid (no passkey) / expired; both themes.

Founder-approved 2026-07-24. Clears the design gate on **#2993** (passkey-only login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAr3HLU7SoNtaMmzvJX6Hv