### PR TITLE
web: workflow execution variable inputs + per-step result rendering (Issue #2985)

### DIFF
--- a/features/controller/api/server_tls_ha_test.go
+++ b/features/controller/api/server_tls_ha_test.go
@@ -4,8 +4,9 @@ package api
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -229,9 +230,16 @@ func TestSetupManagedTLS_ClusterMode_AdminCertAndHAPeerCertBothVerify(t *testing
 // --- helpers for the cluster-mode HA+admin cert test ---
 
 // makeCommercialTestCA creates an in-memory CA (cert, key, PEM) for test use.
-func makeCommercialTestCA(t *testing.T) (*x509.Certificate, *rsa.PrivateKey, []byte) {
+//
+// Uses an ECDSA P-256 key rather than RSA: key generation is the dominant cost of
+// these TLS handshake tests, and under the FIPS-140 module RSA prime search
+// (Miller-Rabin over Montgomery multiplication) is ~1000× slower than ECDSA curve
+// point generation. P-256 is FIPS-140 approved, so the trust properties under test
+// are unchanged while removing the slow key-generation frame that pushed the
+// package over the 5m test-fast budget (cf. Issue #2591 for the argon2id analog).
+func makeCommercialTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
 	t.Helper()
-	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	template := &x509.Certificate{
@@ -267,9 +275,10 @@ func makeCommercialTestClientCert(t *testing.T, certMgr *cert.Manager) tls.Certi
 }
 
 // makeCommercialTestClientCertFromCA creates a client cert signed by an arbitrary CA.
-func makeCommercialTestClientCertFromCA(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey) tls.Certificate {
+// ECDSA P-256 for the same key-generation-cost reason as makeCommercialTestCA.
+func makeCommercialTestClientCertFromCA(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) tls.Certificate {
 	t.Helper()
-	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	template := &x509.Certificate{
@@ -277,16 +286,19 @@ func makeCommercialTestClientCertFromCA(t *testing.T, caCert *x509.Certificate, 
 		Subject:      pkix.Name{CommonName: "ha-peer"},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(24 * time.Hour),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &leafKey.PublicKey, caKey)
 	require.NoError(t, err)
 
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	keyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(leafKey),
+		Type:  "EC PRIVATE KEY",
+		Bytes: keyDER,
 	})
 
 	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>CFGMS</title>
-    <script type="module" crossorigin src="/assets/index-kX8guFEc.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DTwDfFfH.css">
+    <script type="module" crossorigin src="/assets/index-Dx_A5HW-.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-B6kDu8Ni.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/workflow/WorkflowExecutionView.test.tsx
+++ b/web/src/workflow/WorkflowExecutionView.test.tsx
@@ -2,13 +2,18 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * WorkflowExecutionView test suite (Story #2731).
+ * WorkflowExecutionView test suite (Story #2731, extended Story #2985).
  *
- * Required AC: covers the execute → status → cancel flow end-to-end:
+ * Required AC (Story #2731): covers the execute → status → cancel flow end-to-end:
  *   1. Execute button shows confirm dialog.
  *   2. Confirming execute POSTs to /execute and shows live status.
  *   3. Cancel button shows confirm dialog.
  *   4. Confirming cancel POSTs to /cancel.
+ *
+ * Required AC (Story #2985): variable inputs and per-step result rendering:
+ *   5. Confirm dialog includes variable key/value editor.
+ *   6. Execute POST body includes { variables: {...} }.
+ *   7. Active execution status renders step_results per-step table.
  */
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -276,6 +281,56 @@ describe('WorkflowExecutionView — execute → status → cancel flow (required
     )
   })
 
+  it('shows cancel error when cancel POST fails', async () => {
+    // Execute/status succeed so an active running execution is shown; the cancel
+    // POST returns a non-2xx with a server error body, exercising the error branch
+    // of handleConfirmCancel (setCancelError → data-testid="cancel-error").
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1'))
+      }
+      if (url.endsWith('/cancel')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'execution already completed' }), {
+            status: 409,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(
+          makeExecutionStatusResponse(makeExecution({ id: 'exec-1', status: 'running' })),
+        )
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cancel-active-btn')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('cancel-active-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('cancel-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cancel-error')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('cancel-error')).toHaveTextContent(
+      'execution already completed',
+    )
+  })
+
   it('dismisses cancel confirm dialog when Keep running is clicked', async () => {
     fetchMock.mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : (input as Request).url
@@ -375,6 +430,292 @@ describe('WorkflowExecutionView — security (A9.1)', () => {
     expect(screen.getAllByText(xss).length).toBeGreaterThan(0)
     expect(
       (window as unknown as Record<string, unknown>).__xssExec,
+    ).toBeUndefined()
+  })
+})
+
+describe('WorkflowExecutionView — variables and step results (required AC #2985)', () => {
+  it('shows variable editor in the confirm dialog', async () => {
+    fetchMock.mockResolvedValue(makeExecutionsResponse([]))
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('add-var-row-btn')).toBeInTheDocument()
+  })
+
+  it('adds and removes variable rows in the confirm dialog', async () => {
+    fetchMock.mockResolvedValue(makeExecutionsResponse([]))
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('add-var-row-btn'))
+    expect(screen.getByTestId('var-key-0')).toBeInTheDocument()
+    expect(screen.getByTestId('var-value-0')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('remove-var-row-0'))
+    expect(screen.queryByTestId('var-key-0')).toBeNull()
+  })
+
+  it('posts { variables: {...} } when operator enters variables in confirm dialog', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1'))
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(
+          makeExecutionStatusResponse(makeExecution({ id: 'exec-1', status: 'running' })),
+        )
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('add-var-row-btn'))
+    fireEvent.change(screen.getByTestId('var-key-0'), { target: { value: 'env' } })
+    fireEvent.change(screen.getByTestId('var-value-0'), { target: { value: 'prod' } })
+
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-status')).toBeInTheDocument(),
+    )
+
+    const executeCall = fetchMock.mock.calls.find(([url]) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      return u.endsWith('/execute')
+    })
+    expect(executeCall).toBeDefined()
+    const body = JSON.parse(executeCall![1]?.body as string) as Record<string, unknown>
+    expect(body).toEqual({ variables: { env: 'prod' } })
+  })
+
+  it('posts { variables: {} } when no variable rows are entered', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1'))
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(
+          makeExecutionStatusResponse(makeExecution({ id: 'exec-1', status: 'running' })),
+        )
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-status')).toBeInTheDocument(),
+    )
+
+    const executeCall = fetchMock.mock.calls.find(([url]) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      return u.endsWith('/execute')
+    })
+    expect(executeCall).toBeDefined()
+    const body = JSON.parse(executeCall![1]?.body as string) as Record<string, unknown>
+    expect(body).toEqual({ variables: {} })
+  })
+
+  it('skips variable rows with empty keys when building POST body', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1'))
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(
+          makeExecutionStatusResponse(makeExecution({ id: 'exec-1', status: 'running' })),
+        )
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('add-var-row-btn'))
+    fireEvent.click(screen.getByTestId('add-var-row-btn'))
+    // Fill only the second row; first has empty key
+    fireEvent.change(screen.getByTestId('var-key-1'), { target: { value: 'target' } })
+    fireEvent.change(screen.getByTestId('var-value-1'), { target: { value: 'us-east' } })
+
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-status')).toBeInTheDocument(),
+    )
+
+    const executeCall = fetchMock.mock.calls.find(([url]) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      return u.endsWith('/execute')
+    })
+    expect(executeCall).toBeDefined()
+    const body = JSON.parse(executeCall![1]?.body as string) as Record<string, unknown>
+    expect(body).toEqual({ variables: { target: 'us-east' } })
+  })
+
+  it('renders step_results as a per-step table for completed execution', async () => {
+    const execWithResults = makeExecution({
+      id: 'exec-1',
+      status: 'completed',
+      step_results: {
+        'step-a': { output: 'hello' },
+        'step-b': 42,
+      },
+    })
+
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1', 'completed'))
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(makeExecutionStatusResponse(execWithResults))
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('step-results')).toBeInTheDocument(),
+    )
+
+    expect(screen.getAllByTestId('step-result-row')).toHaveLength(2)
+    expect(screen.getByText('step-a')).toBeInTheDocument()
+    expect(screen.getByText('step-b')).toBeInTheDocument()
+  })
+
+  it('renders step_results alongside error for failed execution', async () => {
+    const execWithResults = makeExecution({
+      id: 'exec-1',
+      status: 'failed',
+      error: 'step-b timed out',
+      step_results: {
+        'step-a': { output: 'ok' },
+      },
+    })
+
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1', 'failed'))
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(makeExecutionStatusResponse(execWithResults))
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-status')).toBeInTheDocument(),
+    )
+
+    expect(screen.getByText('step-b timed out')).toBeInTheDocument()
+    expect(screen.getByTestId('step-results')).toBeInTheDocument()
+    expect(screen.getByText('step-a')).toBeInTheDocument()
+  })
+
+  it('does not render step-results section when execution has no step_results', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1', 'completed'))
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(
+          makeExecutionStatusResponse(makeExecution({ id: 'exec-1', status: 'completed' })),
+        )
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-status')).toBeInTheDocument(),
+    )
+
+    expect(screen.queryByTestId('step-results')).toBeNull()
+  })
+
+  it('renders step result values as text nodes, not HTML (security A9.1)', async () => {
+    const xss = '<img src=x onerror="window.__xssStep=1">'
+    const execWithResults = makeExecution({
+      id: 'exec-1',
+      status: 'completed',
+      step_results: { [xss]: xss },
+    })
+
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (url.endsWith('/execute')) {
+        return Promise.resolve(makeExecuteResponse('exec-1', 'completed'))
+      }
+      if (url.includes('/executions/exec-1')) {
+        return Promise.resolve(makeExecutionStatusResponse(execWithResults))
+      }
+      return Promise.resolve(makeExecutionsResponse([]))
+    })
+
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByTestId('exec-empty')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('execute-btn'))
+    fireEvent.click(screen.getByTestId('exec-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('step-results')).toBeInTheDocument(),
+    )
+
+    expect(
+      (window as unknown as Record<string, unknown>).__xssStep,
     ).toBeUndefined()
   })
 })

--- a/web/src/workflow/WorkflowExecutionView.tsx
+++ b/web/src/workflow/WorkflowExecutionView.tsx
@@ -107,19 +107,24 @@ export default function WorkflowExecutionView({
   const [executing, setExecuting] = useState(false)
   const [executeError, setExecuteError] = useState<string | null>(null)
   const [cancelError, setCancelError] = useState<string | null>(null)
+  const [execVarRows, setExecVarRows] = useState<Array<{ key: string; value: string }>>([])
 
   async function handleConfirmExecute() {
     setConfirmExecute(false)
     setExecuting(true)
     setExecuteError(null)
     setActiveExecId(null)
+    const variables: Record<string, string> = {}
+    for (const { key, value } of execVarRows) {
+      if (key.trim()) variables[key.trim()] = value
+    }
     try {
       const response = await apiFetch(
         `/api/v1/workflows/${encodeURIComponent(workflowName)}/execute`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
+          body: JSON.stringify({ variables }),
         },
       )
       if (!response.ok) {
@@ -225,6 +230,35 @@ export default function WorkflowExecutionView({
           {activeExec.error && (
             <span className="wf-form-error">{activeExec.error}</span>
           )}
+          {activeExec.step_results &&
+            Object.keys(activeExec.step_results).length > 0 && (
+              <div className="wf-step-results" data-testid="step-results">
+                <table className="tbl">
+                  <thead>
+                    <tr>
+                      <th>Step</th>
+                      <th>Result</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(activeExec.step_results).map(
+                      ([step, result]) => (
+                        <tr key={step} data-testid="step-result-row">
+                          <td>
+                            <span className="nm">{step}</span>
+                          </td>
+                          <td>
+                            <span className="mono2">
+                              {JSON.stringify(result)}
+                            </span>
+                          </td>
+                        </tr>
+                      ),
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            )}
           {activeIsNonTerminal && (
             <button
               type="button"
@@ -306,6 +340,62 @@ export default function WorkflowExecutionView({
               This workflow will execute against real infrastructure. Ensure the
               workflow steps are correct before proceeding.
             </p>
+            <div className="wf-var-editor" data-testid="var-editor">
+              <span className="wf-form-label">Variables</span>
+              {execVarRows.map((row, idx) => (
+                <div key={idx} className="wf-var-row">
+                  <input
+                    type="text"
+                    aria-label={`Variable key ${idx}`}
+                    placeholder="key"
+                    value={row.key}
+                    onChange={(e) =>
+                      setExecVarRows((prev) =>
+                        prev.map((r, i) =>
+                          i === idx ? { ...r, key: e.target.value } : r,
+                        ),
+                      )
+                    }
+                    data-testid={`var-key-${idx}`}
+                  />
+                  <input
+                    type="text"
+                    aria-label={`Variable value ${idx}`}
+                    placeholder="value"
+                    value={row.value}
+                    onChange={(e) =>
+                      setExecVarRows((prev) =>
+                        prev.map((r, i) =>
+                          i === idx ? { ...r, value: e.target.value } : r,
+                        ),
+                      )
+                    }
+                    data-testid={`var-value-${idx}`}
+                  />
+                  <button
+                    type="button"
+                    className="wf-btn-sm-danger"
+                    aria-label={`Remove variable ${idx}`}
+                    onClick={() =>
+                      setExecVarRows((prev) => prev.filter((_, i) => i !== idx))
+                    }
+                    data-testid={`remove-var-row-${idx}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="wf-btn-sm"
+                onClick={() =>
+                  setExecVarRows((prev) => [...prev, { key: '', value: '' }])
+                }
+                data-testid="add-var-row-btn"
+              >
+                + Add variable
+              </button>
+            </div>
             <div className="wf-modal-actions">
               <button
                 type="button"


### PR DESCRIPTION
## Summary

- Add key/value row editor to the execute confirm dialog so operators can pass named variables into a workflow run; POST body now sends `{ variables: {...} }` instead of always `{}`
- Render `step_results` as a per-step table in the active execution status area alongside the existing error string (the field was already fetched but never displayed)
- Switch TLS HA test helpers from RSA-2048 to ECDSA P-256 to fix a pre-existing `test-fast` timeout under the FIPS-140 module

Fixes #2985

## Specialist Review Results

| Lens | Round 1 | Round 2 |
|------|---------|---------|
| Code Review | ❌ (TypeScript type annotation) | ✅ PASS |
| Test Quality | ❌ (same TS error) | ✅ PASS |
| Security | ✅ PASS | — |

**Final verdict: PASS** — 0 remaining findings.

## Test plan

- [x] All 26 `WorkflowExecutionView.test.tsx` tests pass (9 new tests for Story #2985 AC)
- [x] All 647 frontend tests pass (`npm test`)
- [x] `npm run lint`, `npm run typecheck`, `npm run build` all pass
- [x] Go TLS HA tests pass with ECDSA P-256 keys
- [x] `make test-fast` passes with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)