### PR TITLE
web: structured diff view in rollback preview (Issue #2981)

### DIFF
--- a/web/src/config/Config.css
+++ b/web/src/config/Config.css
@@ -617,3 +617,44 @@ table.tbl {
   font-weight: 600;
   color: var(--text-primary);
 }
+.cfg-rb-changes {
+  margin: 0;
+}
+.cfg-rb-change {
+  border-top: 1px solid var(--border);
+  padding: 10px 0 8px;
+}
+.cfg-rb-change:first-child {
+  border-top: 0;
+}
+.cfg-rb-change-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.cfg-rb-change-path {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cfg-diff-block {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+  background: var(--bg-surface);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  white-space: pre;
+}
+.cfg-diff-line.add {
+  color: var(--state-ok);
+}
+.cfg-diff-line.del {
+  color: var(--state-crit);
+}

--- a/web/src/config/RollbackPanel.test.tsx
+++ b/web/src/config/RollbackPanel.test.tsx
@@ -71,11 +71,23 @@ function makeOperation(id = 'rb-1') {
   }
 }
 
-function makePreviewResponse() {
+function makePreviewResponse(changes: object[] = []) {
   return new Response(
-    JSON.stringify({ preview: { changes: [], affected_modules: [] } }),
+    JSON.stringify({ preview: { changes, affected_modules: [] } }),
     { status: 200, headers: { 'Content-Type': 'application/json' } },
   )
+}
+
+function makeChange(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    path: 'configs/sw-1/base.yaml',
+    current_version: 'abc123',
+    rollback_version: 'def456',
+    diff: '--- a/configs/sw-1/base.yaml\n+++ b/configs/sw-1/base.yaml\n-old line\n+new line\n context',
+    risk: 'medium',
+    module: 'patch',
+    ...overrides,
+  }
 }
 
 function makeExecuteResponse(id = 'rb-new-1') {
@@ -282,6 +294,110 @@ describe('RollbackPanel — preview', () => {
     fireEvent.click(screen.getByTestId('rb-preview-btn'))
 
     await waitFor(() => expect(screen.getByTestId('rb-preview-error')).toBeInTheDocument())
+  })
+})
+
+describe('RollbackPanel — structured diff preview (Story #2981)', () => {
+  it('renders one row per ConfigurationChange with path, module, and risk pill', async () => {
+    fetchMock.mockResolvedValueOnce(makePointsResponse([makePoint()]))
+    fetchMock.mockResolvedValueOnce(makeHistoryResponse([]))
+    fetchMock.mockResolvedValueOnce(
+      makePreviewResponse([
+        makeChange({ path: 'configs/sw-1/base.yaml', module: 'patch', risk: 'medium' }),
+        makeChange({ path: 'configs/sw-1/firewall.yaml', module: 'firewall', risk: 'high' }),
+      ]),
+    )
+
+    renderRollbackPanel()
+    await waitFor(() => expect(screen.getAllByTestId('rb-preview-btn')).toHaveLength(1))
+    fireEvent.click(screen.getByTestId('rb-preview-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('rb-preview-result')).toBeInTheDocument())
+
+    const rows = screen.getAllByTestId('rb-change-row')
+    expect(rows).toHaveLength(2)
+
+    expect(rows[0]).toHaveTextContent('configs/sw-1/base.yaml')
+    expect(rows[0]).toHaveTextContent('patch')
+    expect(rows[0]).toHaveTextContent('medium')
+
+    expect(rows[1]).toHaveTextContent('configs/sw-1/firewall.yaml')
+    expect(rows[1]).toHaveTextContent('firewall')
+    expect(rows[1]).toHaveTextContent('high')
+  })
+
+  it('renders diff lines with added/removed class markers', async () => {
+    const diff = '--- a/file\n+++ b/file\n-removed line\n+added line\n context line'
+    fetchMock.mockResolvedValueOnce(makePointsResponse([makePoint()]))
+    fetchMock.mockResolvedValueOnce(makeHistoryResponse([]))
+    fetchMock.mockResolvedValueOnce(makePreviewResponse([makeChange({ diff })]))
+
+    renderRollbackPanel()
+    await waitFor(() => expect(screen.getAllByTestId('rb-preview-btn')).toHaveLength(1))
+    fireEvent.click(screen.getByTestId('rb-preview-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('rb-change-row')).toBeInTheDocument())
+
+    const addedLines = document.querySelectorAll('.cfg-diff-line.add')
+    const removedLines = document.querySelectorAll('.cfg-diff-line.del')
+    expect(addedLines.length).toBeGreaterThanOrEqual(1)
+    expect(removedLines.length).toBeGreaterThanOrEqual(1)
+
+    const allLines = document.querySelectorAll('.cfg-diff-line')
+    const texts = Array.from(allLines).map((el) => el.textContent ?? '')
+    expect(texts).toContain('-removed line')
+    expect(texts).toContain('+added line')
+  })
+
+  it('shows empty-changes notice when preview has no changes', async () => {
+    fetchMock.mockResolvedValueOnce(makePointsResponse([makePoint()]))
+    fetchMock.mockResolvedValueOnce(makeHistoryResponse([]))
+    fetchMock.mockResolvedValueOnce(makePreviewResponse([]))
+
+    renderRollbackPanel()
+    await waitFor(() => expect(screen.getAllByTestId('rb-preview-btn')).toHaveLength(1))
+    fireEvent.click(screen.getByTestId('rb-preview-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('rb-preview-result')).toBeInTheDocument())
+    expect(screen.queryAllByTestId('rb-change-row')).toHaveLength(0)
+    expect(screen.getByTestId('rb-preview-no-changes')).toBeInTheDocument()
+  })
+
+  it('does not render raw JSON blob (no truncated slice behaviour)', async () => {
+    fetchMock.mockResolvedValueOnce(makePointsResponse([makePoint()]))
+    fetchMock.mockResolvedValueOnce(makeHistoryResponse([]))
+    fetchMock.mockResolvedValueOnce(makePreviewResponse([makeChange()]))
+
+    renderRollbackPanel()
+    await waitFor(() => expect(screen.getAllByTestId('rb-preview-btn')).toHaveLength(1))
+    fireEvent.click(screen.getByTestId('rb-preview-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('rb-preview-result')).toBeInTheDocument())
+
+    // Raw JSON stringify output would start with '{"changes"' — must not appear
+    const container = screen.getByTestId('rb-preview-result')
+    expect(container.textContent).not.toMatch(/^\{"changes"/)
+    expect(container.textContent).not.toContain('"current_version"')
+  })
+
+  it('renders diff content as text nodes, not HTML markup', async () => {
+    const xssAttempt = '<img src=x onerror=alert(1)>'
+    fetchMock.mockResolvedValueOnce(makePointsResponse([makePoint()]))
+    fetchMock.mockResolvedValueOnce(makeHistoryResponse([]))
+    fetchMock.mockResolvedValueOnce(
+      makePreviewResponse([makeChange({ diff: `+${xssAttempt}` })]),
+    )
+
+    renderRollbackPanel()
+    await waitFor(() => expect(screen.getAllByTestId('rb-preview-btn')).toHaveLength(1))
+    fireEvent.click(screen.getByTestId('rb-preview-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('rb-change-row')).toBeInTheDocument())
+
+    // The img tag must not be rendered as an HTML element — it must appear as text only
+    expect(document.querySelector('img')).toBeNull()
+    const rowText = screen.getByTestId('rb-change-row').textContent ?? ''
+    expect(rowText).toContain('<img src=x onerror=alert(1)>')
   })
 })
 

--- a/web/src/config/RollbackPanel.tsx
+++ b/web/src/config/RollbackPanel.tsx
@@ -18,8 +18,11 @@ import { apiFetch } from '../api/client.ts'
 import {
   useRollbackPoints,
   useRollbackHistory,
+  parseRollbackPreview,
   type RollbackPoint,
   type RollbackOperation,
+  type RollbackPreview,
+  type ConfigurationChange,
 } from './useConfigs.ts'
 
 interface RollbackPanelProps {
@@ -53,6 +56,35 @@ function statusTone(status: string): string {
     default:
       return 'neutral'
   }
+}
+
+function DiffLine({ line }: { line: string }) {
+  let cls = 'cfg-diff-line'
+  if (line.startsWith('+')) cls += ' add'
+  else if (line.startsWith('-')) cls += ' del'
+  return <div className={cls}>{line}</div>
+}
+
+function ChangeRow({ change }: { change: ConfigurationChange }) {
+  return (
+    <div className="cfg-rb-change" data-testid="rb-change-row">
+      <div className="cfg-rb-change-header">
+        <span className="mono2 cfg-rb-change-path">{change.path}</span>
+        {change.module && <span className="mut">{change.module}</span>}
+        <span className={`pill ${riskTone(change.risk)}`}>
+          <span className="dot" />
+          {change.risk || 'unknown'}
+        </span>
+      </div>
+      {change.diff && (
+        <pre className="cfg-diff-block">
+          {change.diff.split('\n').map((line, i) => (
+            <DiffLine key={i} line={line} />
+          ))}
+        </pre>
+      )}
+    </div>
+  )
 }
 
 function LoadingRows() {
@@ -182,7 +214,7 @@ export default function RollbackPanel({ stewardId }: RollbackPanelProps) {
   const [view, setView] = useState<PanelView>('points')
   const [selectedSha, setSelectedSha] = useState<string | null>(null)
 
-  const [preview, setPreview] = useState<Record<string, unknown> | null>(null)
+  const [preview, setPreview] = useState<RollbackPreview | null>(null)
   const [previewing, setPreviewing] = useState(false)
   const [previewError, setPreviewError] = useState<string | null>(null)
 
@@ -217,7 +249,7 @@ export default function RollbackPanel({ stewardId }: RollbackPanelProps) {
       })
       if (!response.ok) throw new Error(`Preview failed — ${response.status}`)
       const result = (await response.json()) as Record<string, unknown>
-      setPreview(result?.preview as Record<string, unknown> | null ?? {})
+      setPreview(parseRollbackPreview(result?.preview))
     } catch (cause: unknown) {
       setPreviewError(
         cause instanceof Error && cause.message ? cause.message : 'Preview failed',
@@ -314,9 +346,17 @@ export default function RollbackPanel({ stewardId }: RollbackPanelProps) {
             {preview !== null && (
               <div className="cfg-rb-preview" data-testid="rb-preview-result">
                 <h4>Preview</h4>
-                <p className="mono2">
-                  {JSON.stringify(preview, null, 2).slice(0, 400)}
-                </p>
+                {preview.changes.length === 0 ? (
+                  <p className="mut" data-testid="rb-preview-no-changes">
+                    No configuration changes detected.
+                  </p>
+                ) : (
+                  <div className="cfg-rb-changes">
+                    {preview.changes.map((change, i) => (
+                      <ChangeRow key={`${change.path}-${i}`} change={change} />
+                    ))}
+                  </div>
+                )}
               </div>
             )}
 

--- a/web/src/config/useConfigs.ts
+++ b/web/src/config/useConfigs.ts
@@ -106,6 +106,22 @@ export interface RollbackOperation {
   reason: string
 }
 
+export interface ConfigurationChange {
+  path: string
+  current_version: string
+  rollback_version: string
+  diff: string
+  risk: string
+  module: string
+}
+
+export interface RollbackPreview {
+  changes: ConfigurationChange[]
+  affected_modules: string[]
+  requires_approval: boolean
+  risk_assessment: Record<string, unknown>
+}
+
 // ── Parse helpers ─────────────────────────────────────────────────────────────
 
 function parseConfigSummary(value: unknown): ConfigSummary | null {
@@ -163,6 +179,41 @@ export function parsePushStatus(data: unknown): PushStatus {
     initiated_by: str(r.initiated_by),
     created_at: str(r.created_at),
     updated_at: str(r.updated_at),
+  }
+}
+
+function parseConfigurationChange(value: unknown): ConfigurationChange | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  return {
+    path: str(r.path),
+    current_version: str(r.current_version),
+    rollback_version: str(r.rollback_version),
+    diff: str(r.diff),
+    risk: str(r.risk),
+    module: str(r.module),
+  }
+}
+
+export function parseRollbackPreview(data: unknown): RollbackPreview {
+  const r = typeof data === 'object' && data !== null ? (data as Record<string, unknown>) : {}
+  const changes: ConfigurationChange[] = []
+  if (Array.isArray(r.changes)) {
+    for (const item of r.changes) {
+      const c = parseConfigurationChange(item)
+      if (c !== null) changes.push(c)
+    }
+  }
+  return {
+    changes,
+    affected_modules: Array.isArray(r.affected_modules)
+      ? r.affected_modules.filter((m): m is string => typeof m === 'string')
+      : [],
+    requires_approval: bool(r.requires_approval),
+    risk_assessment:
+      typeof r.risk_assessment === 'object' && r.risk_assessment !== null
+        ? (r.risk_assessment as Record<string, unknown>)
+        : {},
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the truncated `JSON.stringify(...).slice(0, 400)` raw-JSON blob in `RollbackPanel.tsx` with a typed, per-file structured diff view
- Adds `ConfigurationChange` and `RollbackPreview` interfaces to `useConfigs.ts` mirroring `features/config/rollback/types.go:184-224`
- Renders one row per `ConfigurationChange` showing path, risk pill (reusing `riskTone`), module, and per-line unified diff coloured via CSS (green for `+`, red for `-`)
- Diff content rendered as text nodes only — no `dangerouslySetInnerHTML` (Security A9.1)

## Changes

- `web/src/config/useConfigs.ts` — `ConfigurationChange`/`RollbackPreview` interfaces + `parseRollbackPreview` helper
- `web/src/config/RollbackPanel.tsx` — `ChangeRow`/`DiffLine` components, typed preview state, structured render
- `web/src/config/Config.css` — `cfg-rb-change`, `cfg-diff-block`, `cfg-diff-line.add/.del` tokens
- `web/src/config/RollbackPanel.test.tsx` — 5 new tests: multi-change rows, line CSS classes, empty-changes notice, no-JSON-blob, XSS safety

## Specialist Review Results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

All three lenses cleared in round 1, zero fix rounds required, zero remaining findings.

## Test Plan

- [ ] `git grep -n "slice(0, 400)" -- web/` returns no hits ✅
- [ ] All 653 frontend tests pass (`npm run test`) ✅
- [ ] TypeScript typecheck passes (`npm run typecheck`) ✅
- [ ] ESLint passes (`npm run lint`) ✅
- [ ] `make test-agent-complete` passes

Fixes #2981