### PR TITLE
maintenance: steward-side reboot Gate primitive and StatusDeferred outcome (Issue #2977)

### DIFF
--- a/features/modules/module.go
+++ b/features/modules/module.go
@@ -4,6 +4,9 @@ package modules
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 )
 
 // Module defines the core interface that all modules must implement.
@@ -118,3 +121,43 @@ const (
 	ChangeTypeDeleted
 	ChangeTypePermissions
 )
+
+// RebootDeferredError is returned by a module's Set when a reboot-gated action falls
+// outside its reboot_window. The executor recognizes this error with errors.As and
+// classifies the result as StatusDeferred, populating DeferredUntil from NextWindow.
+//
+// Use NewRebootDeferredError to construct and errors.As to extract:
+//
+//	var re *modules.RebootDeferredError
+//	if errors.As(err, &re) {
+//	    deferredUntil = re.NextWindow
+//	}
+type RebootDeferredError struct {
+	// NextWindow is the next instant at which the reboot-gated action may proceed.
+	// Zero means no upcoming window is known (ungated or schedule not yet computed).
+	NextWindow time.Time
+}
+
+// Error implements the error interface.
+func (e *RebootDeferredError) Error() string {
+	if e.NextWindow.IsZero() {
+		return "reboot deferred: no upcoming window scheduled"
+	}
+	return fmt.Sprintf("reboot deferred: next window opens at %s", e.NextWindow.Format(time.RFC3339))
+}
+
+// ErrRebootDeferred is a package-level sentinel for reboot deferral detection via errors.Is.
+// Prefer errors.As when the next-window time is needed.
+var ErrRebootDeferred = errors.New("reboot deferred outside reboot_window")
+
+// NewRebootDeferredError constructs a RebootDeferredError with the given next window time.
+// Pass a zero time.Time when the next window is not yet known.
+func NewRebootDeferredError(nextWindow time.Time) *RebootDeferredError {
+	return &RebootDeferredError{NextWindow: nextWindow}
+}
+
+// Is implements errors.Is support so that errors.Is(err, ErrRebootDeferred) returns true
+// for any *RebootDeferredError, regardless of the wrapped NextWindow value.
+func (e *RebootDeferredError) Is(target error) bool {
+	return target == ErrRebootDeferred
+}

--- a/features/modules/reboot_deferred_test.go
+++ b/features/modules/reboot_deferred_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package modules_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+func TestRebootDeferredError_Is(t *testing.T) {
+	nextWindow := time.Date(2026, time.January, 12, 2, 0, 0, 0, time.UTC)
+	err := modules.NewRebootDeferredError(nextWindow)
+
+	assert.True(t, errors.Is(err, modules.ErrRebootDeferred),
+		"errors.Is must return true for a *RebootDeferredError against ErrRebootDeferred")
+
+	// Wrapping must still match.
+	wrapped := errors.Join(errors.New("outer"), err)
+	assert.True(t, errors.Is(wrapped, modules.ErrRebootDeferred),
+		"errors.Is must return true when the RebootDeferredError is wrapped")
+}
+
+func TestRebootDeferredError_As(t *testing.T) {
+	nextWindow := time.Date(2026, time.January, 12, 2, 0, 0, 0, time.UTC)
+	orig := modules.NewRebootDeferredError(nextWindow)
+
+	var extracted *modules.RebootDeferredError
+	assert.True(t, errors.As(orig, &extracted),
+		"errors.As must succeed for *RebootDeferredError")
+	assert.Equal(t, nextWindow, extracted.NextWindow)
+}
+
+func TestRebootDeferredError_ErrorString_WithNextWindow(t *testing.T) {
+	nextWindow := time.Date(2026, time.January, 12, 2, 0, 0, 0, time.UTC)
+	err := modules.NewRebootDeferredError(nextWindow)
+
+	msg := err.Error()
+	assert.True(t, strings.Contains(msg, "reboot deferred"),
+		"error message must contain 'reboot deferred'")
+	assert.True(t, strings.Contains(msg, "2026-01-12"),
+		"error message must contain the next-window date")
+}
+
+func TestRebootDeferredError_ErrorString_ZeroNextWindow(t *testing.T) {
+	err := modules.NewRebootDeferredError(time.Time{})
+
+	msg := err.Error()
+	assert.Contains(t, msg, "no upcoming window",
+		"zero NextWindow must produce 'no upcoming window' message")
+}
+
+func TestErrRebootDeferred_IsNotMatchedByOtherErrors(t *testing.T) {
+	plain := errors.New("some other error")
+	assert.False(t, errors.Is(plain, modules.ErrRebootDeferred),
+		"a plain error must not match ErrRebootDeferred")
+}

--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -59,6 +59,7 @@ type ExecutionReport struct {
 	FailedCount       int
 	SkippedCount      int
 	NonCompliantCount int
+	DeferredCount     int
 	ResourceResults   []ResourceResult
 	Errors            []string
 }
@@ -73,6 +74,9 @@ type ResourceResult struct {
 	ExecutionTime  time.Duration
 	Error          string
 	StateDiff      *stewardtesting.StateDiff
+	// DeferredUntil is the next instant at which a deferred reboot-gated action
+	// may be retried. Zero when Status is not StatusDeferred.
+	DeferredUntil time.Time
 }
 
 // ResourceStatus represents the execution status of a resource
@@ -90,6 +94,12 @@ const (
 	// exceeded the configured per-call timeout. Treated as a failure in all aggregation
 	// paths. The emitted outcome event carries action=did-not-finish(timeout) (ADR-012 §7).
 	StatusTimeout
+	// StatusDeferred indicates a reboot-gated action was withheld because the current
+	// time falls outside the resource's reboot_window. The deferred action will be retried
+	// on the next convergence pass; ResourceResult.DeferredUntil carries the next window
+	// open time when known. Distinct from StatusFailed (the action is not in error — it is
+	// intentionally deferred) and StatusSkipped (the module did run but could not proceed).
+	StatusDeferred
 )
 
 // NewConfigState creates a ConfigState from a raw configuration map.

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -224,6 +224,8 @@ func (e *Executor) ExecuteConfiguration(ctx context.Context, cfg config.StewardC
 				report.SkippedCount++
 			case StatusNonCompliant:
 				report.NonCompliantCount++
+			case StatusDeferred:
+				report.DeferredCount++
 			}
 		}
 	}
@@ -245,6 +247,7 @@ func (e *Executor) ExecuteConfiguration(ctx context.Context, cfg config.StewardC
 		"failed", report.FailedCount,
 		"skipped", report.SkippedCount,
 		"non_compliant", report.NonCompliantCount,
+		"deferred", report.DeferredCount,
 		"duration", report.EndTime.Sub(report.StartTime))
 
 	return report
@@ -460,6 +463,22 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 				"module", resource.Module,
 				"timeout_ms", setEffectiveBudget.Milliseconds(),
 				"elapsed_ms", result.ExecutionTime.Milliseconds())
+			return result
+		}
+		// Reboot-deferred: a module's Set returned ErrRebootDeferred because the
+		// current time falls outside the resource's reboot_window. This is not a
+		// failure — the action is intentionally deferred and will be retried on the
+		// next convergence pass once the window opens.
+		var rebootErr *modules.RebootDeferredError
+		if errors.As(err, &rebootErr) {
+			result.Status = StatusDeferred
+			result.DeferredUntil = rebootErr.NextWindow
+			result.Error = err.Error()
+			e.enqueueOutcome(correlationID, "deferred", result.ExecutionTime)
+			e.logger.Info("module.Set deferred: reboot outside window",
+				"resource", resource.Name,
+				"module", resource.Module,
+				"deferred_until", result.DeferredUntil)
 			return result
 		}
 		result.Error = fmt.Sprintf("failed to apply configuration: %v", err)
@@ -691,6 +710,7 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 		successCount, _ := moduleStatus.Details["success_count"].(int)
 		errorCount, _ := moduleStatus.Details["error_count"].(int)
 		nonCompliantCount, _ := moduleStatus.Details["non_compliant_count"].(int)
+		deferredCount, _ := moduleStatus.Details["deferred_count"].(int)
 		totalCount, _ := moduleStatus.Details["total_count"].(int)
 		totalCount++
 
@@ -714,17 +734,26 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 			if moduleStatus.Status == "OK" {
 				moduleStatus.Status = "NON_COMPLIANT"
 			}
+		case StatusDeferred:
+			// Reboot-gated action deferred outside window — not an error; retried next pass.
+			deferredCount++
+			if moduleStatus.Status == "OK" {
+				moduleStatus.Status = "DEFERRED"
+			}
 		}
 
 		moduleStatus.Details["success_count"] = successCount
 		moduleStatus.Details["error_count"] = errorCount
 		moduleStatus.Details["non_compliant_count"] = nonCompliantCount
+		moduleStatus.Details["deferred_count"] = deferredCount
 		moduleStatus.Details["total_count"] = totalCount
 
 		if errorCount > 0 {
 			moduleStatus.Message = fmt.Sprintf("Applied %d/%d resources (%d errors)", successCount, totalCount, errorCount)
 		} else if nonCompliantCount > 0 {
 			moduleStatus.Message = fmt.Sprintf("Monitored %d resources (%d non-compliant)", totalCount, nonCompliantCount)
+		} else if deferredCount > 0 {
+			moduleStatus.Message = fmt.Sprintf("Deferred %d/%d resources (outside reboot_window)", deferredCount, totalCount)
 		} else {
 			moduleStatus.Message = fmt.Sprintf("Applied %d resources", totalCount)
 		}
@@ -736,12 +765,17 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 		hasErrors = true
 	}
 
+	hasDeferred := execReport.DeferredCount > 0
+
 	if hasErrors {
 		report.Status = "ERROR"
 		report.Message = "Configuration applied with errors"
 	} else if hasNonCompliant {
 		report.Status = "NON_COMPLIANT"
 		report.Message = "Configuration monitored: drift detected but not corrected"
+	} else if hasDeferred {
+		report.Status = "DEFERRED"
+		report.Message = "Configuration partially deferred: reboot-gated actions outside window"
 	}
 
 	report.ExecutionTimeMs = time.Since(startTime).Milliseconds()

--- a/features/steward/execution/executor_test.go
+++ b/features/steward/execution/executor_test.go
@@ -1064,3 +1064,189 @@ func TestExecuteResource_ManagedElsewhere_CompliantNoSet(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&mod.setCalled),
 		"Set must never be called for a resource managed on another node")
 }
+
+// ─── Story #2977: reboot-deferred sentinel classification ──────────────────────
+
+// rebootDeferredSetModule is a real test module that reports drift on Get() and then
+// returns a *modules.RebootDeferredError from Set(), simulating a module that
+// withholds a reboot because the current time is outside the reboot_window.
+type rebootDeferredSetModule struct {
+	nextWindow time.Time
+}
+
+func (m *rebootDeferredSetModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	return &mapConfigState{data: map[string]interface{}{"state": "drifted"}}, nil
+}
+
+func (m *rebootDeferredSetModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return modules.NewRebootDeferredError(m.nextWindow)
+}
+
+var _ modules.Module = (*rebootDeferredSetModule)(nil)
+
+// TestExecuteResource_RebootDeferred_ProducesStatusDeferred verifies that when a
+// module's Set() returns a *modules.RebootDeferredError, the executor:
+//   - classifies the result as StatusDeferred (not StatusFailed or StatusSkipped)
+//   - populates DeferredUntil from the error's NextWindow field
+//   - does NOT call verifyChanges (ChangesApplied must remain false)
+func TestExecuteResource_RebootDeferred_ProducesStatusDeferred(t *testing.T) {
+	nextWindow := time.Date(2026, time.January, 12, 2, 0, 0, 0, time.UTC)
+
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	f.RegisterModule("reboot-deferred", &rebootDeferredSetModule{nextWindow: nextWindow})
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logging.ForModule("executor_test"),
+		Factory:       f,
+		ErrorHandling: errCfg,
+		DriftMode:     stewardconfig.DriftModeApply,
+	})
+	require.NoError(t, err)
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "reboot-gated-resource",
+		Module: "reboot-deferred",
+		Config: map[string]interface{}{"state": "desired"},
+	}
+
+	result := executor.ExecuteResource(context.Background(), resource)
+
+	assert.Equal(t, execution.StatusDeferred, result.Status,
+		"a module.Set returning RebootDeferredError must produce StatusDeferred")
+	assert.False(t, result.ChangesApplied,
+		"ChangesApplied must be false when Set returns RebootDeferredError (no change was applied)")
+	assert.Equal(t, nextWindow, result.DeferredUntil,
+		"DeferredUntil must be populated from the RebootDeferredError's NextWindow field")
+	assert.NotEmpty(t, result.Error,
+		"result.Error must carry the deferred error message for operator visibility")
+}
+
+// TestExecuteResource_RebootDeferred_DistinctFromFailed verifies that
+// StatusDeferred is distinct from StatusFailed — a plain non-deferred error from
+// Set must produce StatusFailed, not StatusDeferred.
+func TestExecuteResource_RebootDeferred_DistinctFromFailed(t *testing.T) {
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	f.RegisterModule("set-fail", &plainErrorSetModule{})
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logging.ForModule("executor_test"),
+		Factory:       f,
+		ErrorHandling: errCfg,
+		DriftMode:     stewardconfig.DriftModeApply,
+	})
+	require.NoError(t, err)
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "plain-fail-resource",
+		Module: "set-fail",
+		Config: map[string]interface{}{"state": "desired"},
+	}
+
+	result := executor.ExecuteResource(context.Background(), resource)
+
+	assert.NotEqual(t, execution.StatusDeferred, result.Status,
+		"a plain (non-deferred) Set error must NOT produce StatusDeferred")
+	assert.Equal(t, execution.StatusFailed, result.Status,
+		"a plain Set error must produce StatusFailed")
+	assert.True(t, result.DeferredUntil.IsZero(),
+		"DeferredUntil must be zero for a plain (non-deferred) failure")
+}
+
+// plainErrorSetModule reports drift on Get and returns a plain error from Set.
+type plainErrorSetModule struct{}
+
+func (m *plainErrorSetModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	return &mapConfigState{data: map[string]interface{}{"state": "drifted"}}, nil
+}
+
+func (m *plainErrorSetModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return fmt.Errorf("plain set failure — not a reboot deferral")
+}
+
+var _ modules.Module = (*plainErrorSetModule)(nil)
+
+// TestExecuteResource_RebootDeferred_ZeroNextWindow verifies that a
+// RebootDeferredError with a zero NextWindow (no upcoming window known) still
+// produces StatusDeferred with a zero DeferredUntil — no panic, no fallthrough
+// to StatusFailed.
+func TestExecuteResource_RebootDeferred_ZeroNextWindow(t *testing.T) {
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	f.RegisterModule("reboot-deferred-zero", &rebootDeferredSetModule{nextWindow: time.Time{}})
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logging.ForModule("executor_test"),
+		Factory:       f,
+		ErrorHandling: errCfg,
+		DriftMode:     stewardconfig.DriftModeApply,
+	})
+	require.NoError(t, err)
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "reboot-gated-zero",
+		Module: "reboot-deferred-zero",
+		Config: map[string]interface{}{"state": "desired"},
+	}
+
+	result := executor.ExecuteResource(context.Background(), resource)
+
+	assert.Equal(t, execution.StatusDeferred, result.Status,
+		"zero NextWindow RebootDeferredError must still produce StatusDeferred")
+	assert.True(t, result.DeferredUntil.IsZero(),
+		"DeferredUntil must be zero when RebootDeferredError carries no next window")
+}
+
+// TestExecuteConfiguration_DeferredCount verifies that StatusDeferred resources
+// are counted in ExecutionReport.DeferredCount and not in FailedCount.
+func TestExecuteConfiguration_DeferredCount(t *testing.T) {
+	nextWindow := time.Date(2026, time.January, 12, 2, 0, 0, 0, time.UTC)
+
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.New(discovery.ModuleRegistry{}, errCfg, logging.ForModule("executor_test"))
+	f.RegisterModule("reboot-deferred", &rebootDeferredSetModule{nextWindow: nextWindow})
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:        logging.ForModule("executor_test"),
+		Factory:       f,
+		ErrorHandling: errCfg,
+		DriftMode:     stewardconfig.DriftModeApply,
+	})
+	require.NoError(t, err)
+
+	cfg := stewardconfig.StewardConfig{
+		Resources: []stewardconfig.ResourceConfig{
+			{
+				Name:   "deferred-resource",
+				Module: "reboot-deferred",
+				Config: map[string]interface{}{"state": "desired"},
+			},
+		},
+	}
+
+	report := executor.ExecuteConfiguration(context.Background(), cfg)
+
+	assert.Equal(t, 1, report.TotalResources)
+	assert.Equal(t, 1, report.DeferredCount,
+		"deferred resource must increment DeferredCount")
+	assert.Equal(t, 0, report.FailedCount,
+		"deferred resource must NOT increment FailedCount")
+	assert.Equal(t, 0, report.SkippedCount)
+}

--- a/pkg/maintenance/interfaces/contract_test.go
+++ b/pkg/maintenance/interfaces/contract_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package interfaces_test contains protocol-agnostic contract tests for the Gate interface.
+//
+// # Usage by Gate Implementors
+//
+// Call RunGateContractTests from within a test in this package, providing a factory
+// that constructs the three fixture gates. See TestGate_StewardContractSuite below
+// for the reference implementation.
+package interfaces_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	maintinterfaces "github.com/cfgis/cfgms/pkg/maintenance/interfaces"
+	stewardgate "github.com/cfgis/cfgms/pkg/maintenance/providers/steward"
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
+)
+
+// GateContractFixture carries the three Gate instances the contract suite needs.
+type GateContractFixture struct {
+	// Ungated is a Gate with no reboot_window declared. CanReboot must always return true.
+	Ungated maintinterfaces.Gate
+
+	// InsideWindow is a Gate whose internal clock is set to a moment inside the
+	// declared reboot_window. CanReboot must return true.
+	InsideWindow maintinterfaces.Gate
+
+	// OutsideWindow is a Gate whose internal clock is set to a moment outside the
+	// declared reboot_window. CanReboot must return false and NextWindow must return
+	// a non-zero future time.
+	OutsideWindow maintinterfaces.Gate
+}
+
+// GateFixtureFactory creates a GateContractFixture for the contract suite.
+type GateFixtureFactory func(t *testing.T) GateContractFixture
+
+// RunGateContractTests runs the full Gate interface contract suite.
+func RunGateContractTests(t *testing.T, factory GateFixtureFactory) {
+	t.Helper()
+	const deviceID = "contract-device-0"
+
+	fix := factory(t)
+
+	t.Run("UngatedAlwaysCanReboot", func(t *testing.T) {
+		can, err := fix.Ungated.CanReboot(context.Background(), deviceID)
+		require.NoError(t, err)
+		assert.True(t, can,
+			"device with no declared reboot_window must always return CanReboot=true")
+	})
+
+	t.Run("UngatedNextWindowIsZero", func(t *testing.T) {
+		next, err := fix.Ungated.NextWindow(context.Background(), deviceID)
+		require.NoError(t, err)
+		assert.True(t, next.IsZero(),
+			"ungated device has no window to report; NextWindow must return zero time")
+	})
+
+	t.Run("WindowedInsideCanReboot", func(t *testing.T) {
+		can, err := fix.InsideWindow.CanReboot(context.Background(), deviceID)
+		require.NoError(t, err)
+		assert.True(t, can,
+			"current time inside declared window must return CanReboot=true")
+	})
+
+	t.Run("WindowedOutsideCannotReboot", func(t *testing.T) {
+		can, err := fix.OutsideWindow.CanReboot(context.Background(), deviceID)
+		require.NoError(t, err)
+		assert.False(t, can,
+			"current time outside declared window must return CanReboot=false")
+	})
+
+	t.Run("WindowedOutsideNextWindowIsNonZero", func(t *testing.T) {
+		next, err := fix.OutsideWindow.NextWindow(context.Background(), deviceID)
+		require.NoError(t, err)
+		assert.False(t, next.IsZero(),
+			"gate outside window must report a non-zero next-window time")
+	})
+
+	t.Run("ContextCancellationNoPanic", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		// Must not panic — implementations may ignore the cancelled ctx for cheap in-memory checks.
+		assert.NotPanics(t, func() {
+			_, _ = fix.Ungated.CanReboot(ctx, deviceID)
+		})
+	})
+}
+
+// =============================================================================
+// Top-level test: run full suite against the steward Gate implementation
+// =============================================================================
+
+// weeklyMondayWindowCfg returns a Config with a single weekly window: Monday 02:00–04:00 UTC.
+func weeklyMondayWindowCfg() *maintenanceschedule.Config {
+	return &maintenanceschedule.Config{
+		Timezone: "UTC",
+		Schedules: []maintenanceschedule.Schedule{
+			{
+				Freq:  maintenanceschedule.FreqWeekly,
+				Days:  []time.Weekday{time.Monday},
+				Start: maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0},
+				End:   maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0},
+			},
+		},
+	}
+}
+
+// monday3amUTC is inside the weeklyMondayWindow (Mon 03:00 UTC).
+var monday3amUTC = time.Date(2026, time.January, 5, 3, 0, 0, 0, time.UTC)
+
+// tuesday3amUTC is outside the weeklyMondayWindow (Tue 03:00 UTC).
+var tuesday3amUTC = time.Date(2026, time.January, 6, 3, 0, 0, 0, time.UTC)
+
+// TestGate_StewardContractSuite runs all Gate contract tests against the steward
+// Gate implementation.
+func TestGate_StewardContractSuite(t *testing.T) {
+	RunGateContractTests(t, func(t *testing.T) GateContractFixture {
+		t.Helper()
+
+		ungated, err := stewardgate.New(stewardgate.Config{
+			Window:   nil,
+			Timezone: "UTC",
+			DeviceID: "contract-device-0",
+			Now:      func() time.Time { return tuesday3amUTC },
+		})
+		require.NoError(t, err)
+
+		inside, err := stewardgate.New(stewardgate.Config{
+			Window:   weeklyMondayWindowCfg(),
+			Timezone: "UTC",
+			DeviceID: "contract-device-0",
+			Now:      func() time.Time { return monday3amUTC },
+		})
+		require.NoError(t, err)
+
+		outside, err := stewardgate.New(stewardgate.Config{
+			Window:   weeklyMondayWindowCfg(),
+			Timezone: "UTC",
+			DeviceID: "contract-device-0",
+			Now:      func() time.Time { return tuesday3amUTC },
+		})
+		require.NoError(t, err)
+
+		return GateContractFixture{
+			Ungated:       ungated,
+			InsideWindow:  inside,
+			OutsideWindow: outside,
+		}
+	})
+}

--- a/pkg/maintenance/interfaces/gate.go
+++ b/pkg/maintenance/interfaces/gate.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package interfaces defines the pluggable maintenance gate abstraction for CFGMS.
+//
+// The gate is the central reboot-gating primitive: any module that can trigger a
+// host reboot consults the gate before doing so (ADR-026 decision 6). The interface
+// is deviceID-scoped so a single implementation can serve a fleet without keeping
+// per-device state inside the gate itself.
+package interfaces
+
+import (
+	"context"
+	"time"
+)
+
+// Gate is the pluggable interface any reboot-capable module consults before
+// triggering a host reboot.
+//
+// ADR-026 decision 6 is explicit: there is no emergency-override method on
+// this interface. No ForceReboot or similar escape hatch exists on the
+// declarative path.
+type Gate interface {
+	// CanReboot reports whether deviceID may reboot at the current instant.
+	// Returns true when no reboot_window is declared (ungated — correct, not
+	// fail-open), and false when the current time falls outside the window.
+	CanReboot(ctx context.Context, deviceID string) (bool, error)
+
+	// NextWindow returns the next instant at which deviceID may reboot.
+	// Returns a zero time.Time when no window is declared (ungated devices
+	// may reboot at any time; there is no "next" window to report).
+	NextWindow(ctx context.Context, deviceID string) (time.Time, error)
+}

--- a/pkg/maintenance/providers/steward/gate.go
+++ b/pkg/maintenance/providers/steward/gate.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package steward provides the steward-side reboot Gate backed by the resolved
+// reboot_window from the steward's synced configuration (ADR-026 story 3).
+package steward
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	maintinterfaces "github.com/cfgis/cfgms/pkg/maintenance/interfaces"
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
+)
+
+// Gate is the steward-side reboot gate. It is constructed from the resolved
+// reboot_window config that the steward received in its synced StewardConfig
+// and is consulted by any module that can trigger a host reboot (ADR-026 §6).
+//
+// A nil or empty Schedules list means no window is declared: CanReboot returns
+// true unconditionally and NextWindow returns a zero time. This is the correct
+// behavior for a device that never declared a window — it is not the fail-open
+// bug; it is the intended ungated behavior.
+type Gate struct {
+	cfg      *maintenanceschedule.Config
+	loc      *time.Location
+	deviceID string
+	now      func() time.Time
+}
+
+// Compile-time check: *Gate implements maintinterfaces.Gate.
+var _ maintinterfaces.Gate = (*Gate)(nil)
+
+// Config carries the constructor parameters for a steward Gate.
+type Config struct {
+	// Window is the resolved reboot_window config from StewardConfig.Steward.RebootWindow.
+	// A nil pointer or empty Schedules means no window is declared (ungated).
+	Window *maintenanceschedule.Config
+
+	// Timezone is the resolved IANA timezone name for the window, as returned by
+	// pkg/config.ResolveRebootWindowTimezone. An empty string or "device" both mean
+	// "use the host's local zone" — the gate substitutes time.Local in both cases.
+	Timezone string
+
+	// DeviceID is the steward's own registered identity (cfg.Steward.ID). Used as
+	// the lookup key for CanReboot/NextWindow — the steward gate is device-scoped.
+	DeviceID string
+
+	// Now, when non-nil, overrides the host clock. Used in tests to pin the current
+	// time without modifying global state. Leave nil in production.
+	Now func() time.Time
+}
+
+// New constructs a steward-side Gate from the provided Config.
+// Returns an error only when Timezone is a non-empty, non-"device" string that
+// cannot be resolved to an IANA location.
+func New(cfg Config) (*Gate, error) {
+	loc, err := resolveLocation(cfg.Timezone)
+	if err != nil {
+		return nil, fmt.Errorf("maintenance gate: %w", err)
+	}
+
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	return &Gate{
+		cfg:      cfg.Window,
+		loc:      loc,
+		deviceID: cfg.DeviceID,
+		now:      now,
+	}, nil
+}
+
+// CanReboot reports whether the gate's device may reboot at the current instant.
+//
+// When no reboot_window is declared (nil config or empty Schedules), returns true:
+// the device is ungated and may always reboot. This is correct behavior, not the
+// fail-open bug — a device that never declared a window has nothing to gate against.
+//
+// The deviceID parameter is accepted for interface compliance and future multi-device
+// gate implementations; this single-device gate only serves its own device.
+func (g *Gate) CanReboot(_ context.Context, _ string) (bool, error) {
+	if g.cfg == nil || len(g.cfg.Schedules) == 0 {
+		return true, nil
+	}
+
+	now := g.now().In(g.loc)
+	for _, s := range g.cfg.Schedules {
+		if maintenanceschedule.InWindow(now, s) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// NextWindow returns the next instant at which the gate's device may reboot.
+//
+// Returns a zero time.Time when no window is declared (ungated devices may reboot
+// at any time; there is no "next" window to report).
+//
+// When multiple schedules are declared, returns the earliest upcoming window start
+// across all of them.
+func (g *Gate) NextWindow(_ context.Context, _ string) (time.Time, error) {
+	if g.cfg == nil || len(g.cfg.Schedules) == 0 {
+		return time.Time{}, nil
+	}
+
+	now := g.now().In(g.loc)
+	var earliest time.Time
+	for _, s := range g.cfg.Schedules {
+		next := maintenanceschedule.NextOccurrence(now, s)
+		if next.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || next.Before(earliest) {
+			earliest = next
+		}
+	}
+	return earliest, nil
+}
+
+// resolveLocation converts a resolved timezone string into a *time.Location.
+// An empty string or "device" both map to time.Local (the host's own zone).
+// Any other non-empty string is loaded via time.LoadLocation.
+func resolveLocation(tz string) (*time.Location, error) {
+	if tz == "" || tz == "device" {
+		return time.Local, nil
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load timezone %q: %w", tz, err)
+	}
+	return loc, nil
+}

--- a/pkg/maintenance/providers/steward/gate_test.go
+++ b/pkg/maintenance/providers/steward/gate_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package steward_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stewardgate "github.com/cfgis/cfgms/pkg/maintenance/providers/steward"
+	maintenanceschedule "github.com/cfgis/cfgms/pkg/maintenance/schedule"
+)
+
+// weeklyMondayWindow returns a schedule.Config with a single weekly window:
+// Monday 02:00–04:00 UTC.
+func weeklyMondayWindow() *maintenanceschedule.Config {
+	return &maintenanceschedule.Config{
+		Timezone: "UTC",
+		Schedules: []maintenanceschedule.Schedule{
+			{
+				Freq:  maintenanceschedule.FreqWeekly,
+				Days:  []time.Weekday{time.Monday},
+				Start: maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0},
+				End:   maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0},
+			},
+		},
+	}
+}
+
+// monday3am is a time known to be inside the weeklyMondayWindow (Mon 03:00 UTC).
+var monday3am = time.Date(2026, time.January, 5, 3, 0, 0, 0, time.UTC)
+
+// tuesday3am is a time known to be outside the weeklyMondayWindow (Tue 03:00 UTC).
+var tuesday3am = time.Date(2026, time.January, 6, 3, 0, 0, 0, time.UTC)
+
+func TestNew_InvalidTimezone(t *testing.T) {
+	_, err := stewardgate.New(stewardgate.Config{
+		Window:   weeklyMondayWindow(),
+		Timezone: "Not/A/Real/Zone",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return tuesday3am },
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timezone")
+}
+
+func TestNew_DeviceTimezoneUsesLocal(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   weeklyMondayWindow(),
+		Timezone: "device",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return time.Now() },
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, g)
+}
+
+func TestNew_EmptyTimezoneUsesLocal(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   weeklyMondayWindow(),
+		Timezone: "",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return time.Now() },
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, g)
+}
+
+func TestCanReboot_NilConfig_ReturnsTrue(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   nil,
+		Timezone: "UTC",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return tuesday3am },
+	})
+	require.NoError(t, err)
+
+	can, err := g.CanReboot(context.Background(), "test-device")
+	require.NoError(t, err)
+	assert.True(t, can, "nil window config must return CanReboot=true (ungated)")
+}
+
+func TestCanReboot_EmptySchedules_ReturnsTrue(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   &maintenanceschedule.Config{Timezone: "UTC", Schedules: nil},
+		Timezone: "UTC",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return tuesday3am },
+	})
+	require.NoError(t, err)
+
+	can, err := g.CanReboot(context.Background(), "test-device")
+	require.NoError(t, err)
+	assert.True(t, can, "empty Schedules list must return CanReboot=true (ungated)")
+}
+
+func TestCanReboot_InsideWindow_ReturnsTrue(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   weeklyMondayWindow(),
+		Timezone: "UTC",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return monday3am },
+	})
+	require.NoError(t, err)
+
+	can, err := g.CanReboot(context.Background(), "test-device")
+	require.NoError(t, err)
+	assert.True(t, can, "time inside window must return CanReboot=true")
+}
+
+func TestCanReboot_OutsideWindow_ReturnsFalse(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   weeklyMondayWindow(),
+		Timezone: "UTC",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return tuesday3am },
+	})
+	require.NoError(t, err)
+
+	can, err := g.CanReboot(context.Background(), "test-device")
+	require.NoError(t, err)
+	assert.False(t, can, "time outside window must return CanReboot=false")
+}
+
+func TestNextWindow_NilConfig_ReturnsZero(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   nil,
+		Timezone: "UTC",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return tuesday3am },
+	})
+	require.NoError(t, err)
+
+	next, err := g.NextWindow(context.Background(), "test-device")
+	require.NoError(t, err)
+	assert.True(t, next.IsZero(), "nil window config must return zero NextWindow (ungated)")
+}
+
+func TestNextWindow_OutsideWindow_ReturnsNextMonday(t *testing.T) {
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   weeklyMondayWindow(),
+		Timezone: "UTC",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return tuesday3am },
+	})
+	require.NoError(t, err)
+
+	next, err := g.NextWindow(context.Background(), "test-device")
+	require.NoError(t, err)
+	assert.False(t, next.IsZero(), "outside window must return non-zero next window")
+	// tuesday3am is 2026-01-06: next window should be the following Monday 2026-01-12 02:00 UTC.
+	expected := time.Date(2026, time.January, 12, 2, 0, 0, 0, time.UTC)
+	assert.Equal(t, expected, next, "NextWindow must return the start of the next weekly window")
+}
+
+func TestNextWindow_MultipleSchedules_ReturnsEarliest(t *testing.T) {
+	cfg := &maintenanceschedule.Config{
+		Timezone: "UTC",
+		Schedules: []maintenanceschedule.Schedule{
+			{
+				// Monday 02:00-04:00
+				Freq:  maintenanceschedule.FreqWeekly,
+				Days:  []time.Weekday{time.Monday},
+				Start: maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0},
+				End:   maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0},
+			},
+			{
+				// Wednesday 02:00-04:00
+				Freq:  maintenanceschedule.FreqWeekly,
+				Days:  []time.Weekday{time.Wednesday},
+				Start: maintenanceschedule.TimeOfDay{Hour: 2, Minute: 0},
+				End:   maintenanceschedule.TimeOfDay{Hour: 4, Minute: 0},
+			},
+		},
+	}
+
+	// tuesday3am is 2026-01-06: next window across both schedules is Wed 2026-01-07 02:00 UTC
+	// (before Monday 2026-01-12 02:00 UTC).
+	g, err := stewardgate.New(stewardgate.Config{
+		Window:   cfg,
+		Timezone: "UTC",
+		DeviceID: "test-device",
+		Now:      func() time.Time { return tuesday3am },
+	})
+	require.NoError(t, err)
+
+	next, err := g.NextWindow(context.Background(), "test-device")
+	require.NoError(t, err)
+	expected := time.Date(2026, time.January, 7, 2, 0, 0, 0, time.UTC) // Wednesday
+	assert.Equal(t, expected, next, "NextWindow must return the earliest across multiple schedules")
+}


### PR DESCRIPTION
## Summary

- Adds a pluggable `Gate` interface (`pkg/maintenance/interfaces`) that any reboot-capable module consults before triggering a host reboot (ADR-026 §6)
- Implements the steward-side `Gate` provider (`pkg/maintenance/providers/steward`) backed by the resolved `reboot_window` from `StewardConfig` and the schedule evaluator from #2975
- Adds `RebootDeferredError` typed sentinel to `features/modules/module.go` so any module can signal deferral from `Set()` without per-module error types
- Adds `StatusDeferred` / `DeferredUntil` to the execution engine's `ResourceResult` so reboot-gated work is visibly deferred rather than silently skipped or misreported as failure
- Wires the `module.Set` call site to recognize `*modules.RebootDeferredError` via `errors.As` and produce `StatusDeferred` with `DeferredUntil` populated

## Why

ADR-026 decision 5: every module that can trigger a host reboot must consult the gate before doing so. This story builds the primitive and execution-engine plumbing; Story 4 (patch module) becomes the first consumer.

`StatusDeferred` is distinct from `StatusFailed` (the action is not in error; it is intentionally withheld until the window opens) and from `StatusSkipped` (the module did run and attempted `Set`; the deferral is an affirmative outcome, not a load failure).

## Specialist Review Results

- **QA Code Review**: PASS — no mocks, no t.Skip without justification, all assertions non-empty. Three warnings (all non-blocking): missing direct test for `errors.Is` path on `RebootDeferredError` (addressed post-review), missing test for `Error()` string branches (addressed post-review), and a note requesting policy confirmation that OS-platform `t.Skip` is in the acceptable-skip category (pre-existing pattern, not introduced by this story).
- **Security Review**: PASS — no hardcoded secrets, no SQL/injection, no TLS/x509 misuse, no central-provider construction violations, security-scan clean, gate is not fail-open and has no emergency-override escape hatch per ADR-026 decision 6.
- **QA Tests**: `make test` — 215/215 passed. All changed packages pass `go test` with no skips on the new tests.

## Test plan

- [ ] `go test ./pkg/maintenance/...` — Gate interface contract suite + steward provider unit tests
- [ ] `go test ./features/modules/` — `RebootDeferredError` errors.Is/As/Error() tests
- [ ] `go test ./features/steward/execution/...` — StatusDeferred classification, DeferredCount aggregation, distinct-from-failed
- [ ] `make security-scan` — gosec/Trivy/Nancy/staticcheck all pass
- [ ] `make check-architecture` — no central-provider violations

Fixes #2977

🤖 Generated with [Claude Code](https://claude.com/claude-code)