### PR TITLE
api: decommission 404s for list-visible orphan records (Issue #2929)

### DIFF
--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -908,29 +908,59 @@ func (s *Server) handleDecommissionSteward(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
 	record, err := s.stewardStore.GetSteward(r.Context(), stewardID)
 	if err != nil {
-		if errors.Is(err, business.ErrStewardNotFound) {
+		if !errors.Is(err, business.ErrStewardNotFound) {
+			s.logger.Error("decommission failed: store lookup error",
+				"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to look up steward", "INTERNAL_ERROR")
+			return
+		}
+		// Fallback: steward registered via gRPC path exists only in the in-memory
+		// registry but not in the durable store (Issue #2929 root cause).
+		memInfo, memExists := s.controllerService.GetStewardInfo(stewardID)
+		if !memExists {
+			// Not in either store — genuinely unknown steward.
 			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
 			return
 		}
-		s.logger.Error("decommission failed: store lookup error",
-			"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
-		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to look up steward", "INTERNAL_ERROR")
-		return
-	}
-
-	// Cross-tenant scope check using the durable record's TenantID as the authoritative source.
-	// Admin mTLS (empty callerTenant) has global scope; API-key callers are rejected at the
-	// TierMTLSOnly gate before reaching here, so callerTenant is always from an mTLS principal.
-	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenant != "" {
-		sameTenant := record.TenantID == callerTenant
-		ancestorTenant := strings.HasPrefix(record.TenantID, callerTenant+"/")
-		if !sameTenant && !ancestorTenant {
-			// 404 instead of 403 to avoid existence disclosure across tenant boundaries.
-			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+		// Cross-tenant scope check using the in-memory record's TenantID (fallback path).
+		// 404 instead of 403 to avoid existence disclosure across tenant boundaries.
+		if callerTenant != "" {
+			sameTenant := memInfo.TenantID == callerTenant
+			ancestorTenant := strings.HasPrefix(memInfo.TenantID, callerTenant+"/")
+			if !sameTenant && !ancestorTenant {
+				s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+				return
+			}
+		}
+		// Backfill a durable record before tombstoning — must succeed before any in-memory
+		// updates (mirrors the "durable write must succeed first" invariant). Populate at
+		// minimum ID and TenantID; the store stamps RegisteredAt/LastSeen/Status itself.
+		backfill := &business.StewardRecord{
+			ID:       stewardID,
+			TenantID: memInfo.TenantID,
+		}
+		if backfillErr := s.stewardStore.RegisterSteward(r.Context(), backfill); backfillErr != nil && !errors.Is(backfillErr, business.ErrStewardAlreadyExists) {
+			s.logger.Error("decommission failed: backfill registration error",
+				"steward_id", logging.SanitizeLogValue(stewardID), "error", logging.SanitizeLogValue(backfillErr.Error()))
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decommission steward", "INTERNAL_ERROR")
 			return
+		}
+	} else {
+		// Cross-tenant scope check using the durable record's TenantID as the authoritative source.
+		// Admin mTLS (empty callerTenant) has global scope; API-key callers are rejected at the
+		// TierMTLSOnly gate before reaching here, so callerTenant is always from an mTLS principal.
+		if callerTenant != "" {
+			sameTenant := record.TenantID == callerTenant
+			ancestorTenant := strings.HasPrefix(record.TenantID, callerTenant+"/")
+			if !sameTenant && !ancestorTenant {
+				// 404 instead of 403 to avoid existence disclosure across tenant boundaries.
+				s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+				return
+			}
 		}
 	}
 

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -330,6 +330,123 @@ func TestHandleDecommissionSteward_DurableStoreWriteFails(t *testing.T) {
 		"record must remain Active when the durable tombstone write fails")
 }
 
+// TestHandleDecommissionSteward_ListVisibleNotInDurableStore verifies that a steward
+// registered only via the in-memory path (gRPC AcceptRegistration) can be decommissioned
+// even though it has no durable record at the time of the DELETE call (Issue #2929).
+func TestHandleDecommissionSteward_ListVisibleNotInDurableStore(t *testing.T) {
+	server, _ := setupDecommissionServer(t)
+
+	// Register steward only in-memory (never into the durable store).
+	require.NoError(t, server.controllerService.RegisterSteward("s-memonly", "test-tenant", "addr", "registered"))
+
+	// Steward must appear in the default (no-filter) list before decommission.
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	listReq = withTenant(listReq, "")
+	listRec := httptest.NewRecorder()
+	server.handleListStewards(listRec, listReq)
+	require.Equal(t, http.StatusOK, listRec.Code)
+	var listResp struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(listRec.Body).Decode(&listResp))
+	foundBefore := false
+	for _, s := range listResp.Data {
+		if s.ID == "s-memonly" {
+			foundBefore = true
+		}
+	}
+	require.True(t, foundBefore, "in-memory-only steward must appear in default list before decommission")
+
+	// Decommission must succeed even though steward is absent from durable store.
+	rec := deleteDecommissionSteward(server, "s-memonly")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "s-memonly", resp.Data["id"])
+	assert.Equal(t, "deregistered", resp.Data["status"])
+
+	// Steward must no longer appear in the default list after decommission.
+	listReq2 := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	listReq2 = withTenant(listReq2, "")
+	listRec2 := httptest.NewRecorder()
+	server.handleListStewards(listRec2, listReq2)
+	require.Equal(t, http.StatusOK, listRec2.Code)
+	var listResp2 struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(listRec2.Body).Decode(&listResp2))
+	for _, s := range listResp2.Data {
+		assert.NotEqual(t, "s-memonly", s.ID, "deregistered steward must not appear in default list")
+	}
+}
+
+// TestHandleDecommissionSteward_ListVisibleNotInDurableStore_CrossTenant verifies that a
+// scoped admin receives 404 STEWARD_NOT_FOUND when the in-memory-only record belongs to a
+// different tenant subtree — exercising the fallback path cross-tenant check (Issue #2929).
+func TestHandleDecommissionSteward_ListVisibleNotInDurableStore_CrossTenant(t *testing.T) {
+	server, _ := setupDecommissionServer(t)
+
+	// Register steward only in-memory in tenant-b (simulates gRPC registration path).
+	require.NoError(t, server.controllerService.RegisterSteward("s-memonly-xtenant", "tenant-b", "addr", "registered"))
+
+	// Caller is scoped to tenant-a; steward belongs to tenant-b.
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/stewards/s-memonly-xtenant", nil)
+	req = withPrincipal(req, &Principal{ID: "tenant-a-admin", Assurance: session.AssuranceBasic, TenantID: "tenant-a"})
+	req = withVars(req, map[string]string{"id": "s-memonly-xtenant"})
+	rec := httptest.NewRecorder()
+	server.handleDecommissionSteward(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant decommission via fallback path must return 404, not 403")
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "STEWARD_NOT_FOUND", errResp.Error.Code)
+}
+
+// TestHandleDecommissionSteward_BackfillWriteFails verifies that when the durable-store
+// backfill write (RegisterSteward) fails for an in-memory-only steward — after GetSteward
+// returns ErrStewardNotFound and the fallback scope check passes — the handler returns 500
+// INTERNAL_ERROR. This covers the RegisterSteward backfill error branch at
+// handlers_stewards.go:946-950 (Issue #2929), the mirror of the DeregisterSteward
+// write-failure path exercised by TestHandleDecommissionSteward_DurableStoreWriteFails.
+func TestHandleDecommissionSteward_BackfillWriteFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not enforce POSIX directory permissions on Windows")
+	}
+	server := setupTestServer(t)
+	st, root := newTestStewardDurableStore(t)
+	server.SetStewardStore(st)
+
+	// Register steward only in-memory (never into the durable store) so GetSteward returns
+	// ErrStewardNotFound and the handler takes the backfill fallback path.
+	require.NoError(t, server.controllerService.RegisterSteward("s-backfill-writefail", "test-tenant", "addr", "registered"))
+
+	// Induce a genuine durable-store write failure on the backfill: make the flat-file
+	// store's backing directory read-only. GetSteward for a missing record is a pure read
+	// (returns ErrStewardNotFound) and still succeeds, so the handler reaches the backfill
+	// RegisterSteward, whose atomic write (temp-file creation in the directory) then fails
+	// with a permission error — the handler must surface a 500. Restore the mode on cleanup
+	// so t.TempDir() removal can delete the tree.
+	stewardDir := filepath.Join(root, "stewards")
+	require.NoError(t, os.Chmod(stewardDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(stewardDir, 0o750) })
+
+	rec := deleteDecommissionSteward(server, "s-backfill-writefail")
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "INTERNAL_ERROR", errResp.Error.Code)
+
+	// The backfill must not have been persisted: restore write access and confirm the
+	// record is still absent from durable storage (the failed write left it unwritten).
+	require.NoError(t, os.Chmod(stewardDir, 0o750))
+	_, err := st.GetSteward(context.Background(), "s-backfill-writefail")
+	assert.ErrorIs(t, err, business.ErrStewardNotFound,
+		"record must remain absent when the durable backfill write fails")
+}
+
 // ---- buildFleetFilter unit tests (no server required) ----
 
 func TestBuildFleetFilter_Empty(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `handleDecommissionSteward` read exclusively from `stewardStore` (durable), but stewards registered via the gRPC `AcceptRegistration` path exist only in the in-memory `controllerService` registry — so 10/14 stale lab records returned 404 on decommission while still appearing in the fleet list.
- **Fix:** When `stewardStore.GetSteward` returns `ErrStewardNotFound`, the handler now falls back to `controllerService.GetStewardInfo`. If found in memory, it backfills a durable record (`RegisterSteward`) then tombstones it (`DeregisterSteward`), maintaining the "durable write must succeed first" invariant.
- **Scope enforced on fallback path:** The same cross-tenant 404 check (not 403) applies using the in-memory record's `TenantID`; a steward absent from both stores still returns 404 `STEWARD_NOT_FOUND` unchanged.

## Specialist review results

| Reviewer | Round 1 | Round 2 |
|----------|---------|---------|
| Code review | findings (fixed) | PASS |
| Test quality | findings (fixed) | PASS |
| Security | PASS | — |

**Aggregate verdict: PASS** (`passed: true`, 2 review rounds, 1 fix round, 0 remaining findings)

## Test plan

- [x] `TestHandleDecommissionSteward_ListVisibleNotInDurableStore` — in-memory-only steward decommissions with HTTP 200 and disappears from default list
- [x] `TestHandleDecommissionSteward_ListVisibleNotInDurableStore_CrossTenant` — scoped admin gets 404 for cross-tenant in-memory-only record (fallback path scope check)
- [x] `TestHandleDecommissionSteward_BackfillWriteFails` — backfill `RegisterSteward` write failure returns 500 INTERNAL_ERROR
- [x] All 10 pre-existing `TestHandleDecommissionSteward_*` tests continue to pass unmodified
- [x] `make check-architecture` — no central provider violations
- [x] `make lint-log-injection` — no log injection findings

Fixes #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)