### PR TITLE
audit: calibrate event severity server-side (Issue #2964)

### DIFF
--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -840,7 +840,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// emitRegistrationAudit calls logging.RedactedID internally; raw token is not stored
 	s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, stewardID,
 		business.AuditEventAuthentication, "steward_registered",
-		business.AuditResultSuccess, business.AuditSeverityHigh, nil)
+		business.AuditResultSuccess, business.AuditSeverityLow, nil)
 
 	// Return response
 	w.Header().Set("Content-Type", "application/json")

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -100,7 +100,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 	if s.stewardStore == nil {
 		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 			business.AuditEventSystemEvent, "refresh_challenge_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "steward_store_unavailable"})
 		http.Error(w, "steward store unavailable", http.StatusServiceUnavailable)
 		return
@@ -119,7 +119,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
 		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 			business.AuditEventSystemEvent, "refresh_challenge_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "store_error"})
 		http.Error(w, "failed to look up device", http.StatusInternalServerError)
 		return
@@ -151,7 +151,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 		s.logger.Error("Failed to generate refresh nonce", "error", err)
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSystemEvent, "refresh_challenge_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "nonce_generation_failed"})
 		http.Error(w, "failed to generate challenge", http.StatusInternalServerError)
 		return
@@ -169,7 +169,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 		s.logger.Error("Failed to store nonce in cache", "error", err)
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSystemEvent, "refresh_challenge_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "cache_store_failed"})
 		http.Error(w, "failed to issue challenge", http.StatusInternalServerError)
 		return
@@ -221,7 +221,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
 		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 			business.AuditEventSystemEvent, "refresh_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "store_error"})
 		http.Error(w, "failed to look up device", http.StatusInternalServerError)
 		return
@@ -262,7 +262,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSystemEvent, "refresh_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "nonce_type_error"})
 		http.Error(w, "internal error reading challenge", http.StatusInternalServerError)
 		return
@@ -348,7 +348,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("Failed to get refresh policy", "tenant_id", logging.SanitizeLogValue(record.TenantID), "error", err)
 			s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 				business.AuditEventSystemEvent, "refresh_error",
-				business.AuditResultError, business.AuditSeverityHigh,
+				business.AuditResultError, business.AuditSeverityMedium,
 				map[string]interface{}{"reason": "policy_store_error"})
 			http.Error(w, "failed to get refresh policy", http.StatusInternalServerError)
 			return
@@ -391,14 +391,14 @@ func (s *Server) handleRefreshByPolicy(
 			s.logger.Error("Failed to issue refresh certificate", "steward_id", record.ID, "error", err)
 			s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 				business.AuditEventSystemEvent, "refresh_error",
-				business.AuditResultError, business.AuditSeverityHigh,
+				business.AuditResultError, business.AuditSeverityMedium,
 				map[string]interface{}{"reason": "cert_issuance_failed"})
 			http.Error(w, "failed to issue certificate", http.StatusInternalServerError)
 			return
 		}
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventAuthentication, "refresh_cert_issued",
-			business.AuditResultSuccess, business.AuditSeverityHigh,
+			business.AuditResultSuccess, business.AuditSeverityLow,
 			map[string]interface{}{"decision": "approved", "reason": "auto_accept"})
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -420,7 +420,7 @@ func (s *Server) handleRefreshQueueEntry(
 	if s.pendingRefreshStore == nil {
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSystemEvent, "refresh_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "pending_store_unavailable"})
 		http.Error(w, "pending refresh store unavailable", http.StatusServiceUnavailable)
 		return
@@ -442,7 +442,7 @@ func (s *Server) handleRefreshQueueEntry(
 		s.logger.Error("Failed to add pending refresh", "steward_id", record.ID, "error", err)
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSystemEvent, "refresh_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"reason": "pending_store_write_failed"})
 		http.Error(w, "failed to queue refresh request", http.StatusInternalServerError)
 		return
@@ -679,7 +679,7 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 		if err == business.ErrStewardNotFound {
 			s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
 				business.AuditEventSystemEvent, "refresh_admin_approve_error",
-				business.AuditResultError, business.AuditSeverityHigh,
+				business.AuditResultError, business.AuditSeverityMedium,
 				map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "reason": "steward_not_found"})
 			http.Error(w, "steward not found", http.StatusNotFound)
 			return
@@ -687,7 +687,7 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("Failed to get steward for refresh approval", "device_id", logging.SanitizeLogValue(entry.DeviceID), "error", err)
 		s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
 			business.AuditEventSystemEvent, "refresh_admin_approve_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "reason": "store_error"})
 		http.Error(w, "failed to get steward", http.StatusInternalServerError)
 		return
@@ -712,7 +712,7 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("Failed to build refresh cert for approval", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
 			business.AuditEventSystemEvent, "refresh_admin_approve_error",
-			business.AuditResultError, business.AuditSeverityHigh,
+			business.AuditResultError, business.AuditSeverityMedium,
 			map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "reason": "cert_issuance_failed"})
 		http.Error(w, "failed to issue certificate", http.StatusInternalServerError)
 		return

--- a/features/controller/api/handlers_web_session.go
+++ b/features/controller/api/handlers_web_session.go
@@ -324,6 +324,11 @@ func (s *Server) emitWebLoginAudit(ctx context.Context, username, tenantID, acti
 	if tenantID == "" {
 		tenantID = audit.SystemTenantID
 	}
+	// Severity is outcome-aware: success (including logout) is Low; failure/denial is High.
+	severity := business.AuditSeverityHigh
+	if result == business.AuditResultSuccess {
+		severity = business.AuditSeverityLow
+	}
 	b := audit.NewEventBuilder().
 		Tenant(tenantID).
 		Type(business.AuditEventAuthentication).
@@ -331,7 +336,7 @@ func (s *Server) emitWebLoginAudit(ctx context.Context, username, tenantID, acti
 		User(logging.SanitizeLogValue(username), business.AuditUserTypeHuman).
 		Resource("web-session", logging.SanitizeLogValue(username), "").
 		Result(result).
-		Severity(business.AuditSeverityHigh)
+		Severity(severity)
 	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
 		s.logger.Warn("Failed to emit web login audit event",
 			"action", action,

--- a/features/rbac/advanced_engine.go
+++ b/features/rbac/advanced_engine.go
@@ -298,7 +298,10 @@ func (a *AdvancedAuthEngine) CreateTemporaryPermission(ctx context.Context, req 
 		if err := a.auditManager.RecordEvent(ctx, audit.AuthorizationEvent(
 			req.TenantID, req.SubjectID, "permission", req.PermissionID,
 			"grant_permission", business.AuditResultSuccess,
-		).Detail("granted_by", req.GrantedBy).
+		).
+			// permission grant is a sensitive admin action
+			Severity(business.AuditSeverityHigh).
+			Detail("granted_by", req.GrantedBy).
 			Detail("type", "temporary").
 			Detail("expires_at", fmt.Sprintf("%d", req.ExpiresAt))); err != nil {
 			slog.Warn("failed to record permission grant audit event", "error", err)

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -185,7 +185,7 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 		entry := auditEntries[0]
 		assert.Equal(t, "delete_role", entry.Action)
 		assert.Equal(t, business.AuditResultSuccess, entry.Result)
-		assert.Equal(t, business.AuditSeverityCritical, entry.Severity, "Role deletion should be critical severity")
+		assert.Equal(t, business.AuditSeverityHigh, entry.Severity, "Role deletion is a sensitive admin action (High); Critical is reserved for compromise indicators (Issue #2964)")
 
 		// Verify deleted role information is captured
 		assert.Contains(t, entry.Details, "deleted_permissions")

--- a/features/rbac/jit/access_manager.go
+++ b/features/rbac/jit/access_manager.go
@@ -296,7 +296,10 @@ func (jam *JITAccessManager) recordJITAccessApproval(ctx context.Context, reques
 	if err := jam.auditManager.RecordEvent(ctx, audit.AuthorizationEvent(
 		request.TenantID, request.RequesterID, "jit_access", request.ID, "approve",
 		business.AuditResultSuccess,
-	).Detail("approver_id", approverID).Detail("grant_id", grant.ID)); err != nil {
+	).
+		// JIT approval is a sensitive admin action
+		Severity(business.AuditSeverityHigh).
+		Detail("approver_id", approverID).Detail("grant_id", grant.ID)); err != nil {
 		slog.Warn("failed to record jit access approval audit event", "error", err)
 	}
 }
@@ -322,7 +325,10 @@ func (jam *JITAccessManager) recordJITAccessExtension(ctx context.Context, grant
 	if err := jam.auditManager.RecordEvent(ctx, audit.AuthorizationEvent(
 		grant.TenantID, requesterID, "jit_access", grant.ID, "extend",
 		business.AuditResultSuccess,
-	).Detail("duration", duration.String()).Detail("reason", reason)); err != nil {
+	).
+		// JIT extension is a sensitive admin action
+		Severity(business.AuditSeverityHigh).
+		Detail("duration", duration.String()).Detail("reason", reason)); err != nil {
 		slog.Warn("failed to record jit access extension audit event", "error", err)
 	}
 }
@@ -335,7 +341,10 @@ func (jam *JITAccessManager) recordJITAccessRevocation(ctx context.Context, gran
 	if err := jam.auditManager.RecordEvent(ctx, audit.AuthorizationEvent(
 		grant.TenantID, revokerID, "jit_access", grant.ID, "revoke",
 		business.AuditResultSuccess,
-	).Detail("reason", reason)); err != nil {
+	).
+		// JIT revocation is a sensitive admin action
+		Severity(business.AuditSeverityHigh).
+		Detail("reason", reason)); err != nil {
 		slog.Warn("failed to record jit access revocation audit event", "error", err)
 	}
 }
@@ -1049,7 +1058,10 @@ func (jam *JITAccessManager) recordStageApproval(ctx context.Context, request *J
 	if err := jam.auditManager.RecordEvent(ctx, audit.AuthorizationEvent(
 		request.TenantID, request.RequesterID, "jit_access", request.ID, "stage_approved",
 		business.AuditResultSuccess,
-	).Detail("stage_id", stageID).Detail("approver_id", approverID)); err != nil {
+	).
+		// workflow stage approval is a sensitive admin action
+		Severity(business.AuditSeverityHigh).
+		Detail("stage_id", stageID).Detail("approver_id", approverID)); err != nil {
 		slog.Warn("failed to record jit stage approval audit event", "error", err)
 	}
 }

--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -401,7 +401,7 @@ func (m *Manager) CreateRole(ctx context.Context, role *common.Role) error {
 					Result(business.AuditResultError).
 					Error("RBAC_PARENT_ROLE_NOT_FOUND", fmt.Sprintf("parent role %s not found: %v", role.ParentRoleId, err)).
 					Detail("parent_role_id", role.ParentRoleId).
-					Severity(business.AuditSeverityCritical)
+					Severity(business.AuditSeverityHigh)
 				if auditErr := m.auditManager.RecordEvent(ctx, event); auditErr != nil {
 					slog.Warn("rbac: failed to record audit event", "error", auditErr)
 				}
@@ -644,7 +644,7 @@ func (m *Manager) DeleteRole(ctx context.Context, id string) error {
 				Resource("role", id, roleName).
 				Result(business.AuditResultError).
 				Error("RBAC_DELETE_ROLE_FAILED", err.Error()).
-				Severity(business.AuditSeverityCritical)
+				Severity(business.AuditSeverityHigh)
 			if auditErr := m.auditManager.RecordEvent(ctx, event); auditErr != nil {
 				slog.Warn("rbac: failed to record audit event", "error", auditErr)
 			}
@@ -668,7 +668,7 @@ func (m *Manager) DeleteRole(ctx context.Context, id string) error {
 					Resource("role", id, roleName).
 					Result(business.AuditResultError).
 					Error("RBAC_DELETE_ROLE_PERSISTENCE_FAILED", persistErr.Error()).
-					Severity(business.AuditSeverityCritical)
+					Severity(business.AuditSeverityHigh)
 				if auditErr := m.auditManager.RecordEvent(ctx, event); auditErr != nil {
 					slog.Warn("rbac: failed to record audit event", "error", auditErr)
 				}
@@ -690,7 +690,7 @@ func (m *Manager) DeleteRole(ctx context.Context, id string) error {
 		event := audit.UserManagementEvent(tenantID, "system", id, "delete_role").
 			Resource("role", id, roleName).
 			Result(business.AuditResultSuccess).
-			Severity(business.AuditSeverityCritical) // Role deletion is critical
+			Severity(business.AuditSeverityHigh)
 
 		if deletedRole != nil {
 			event = event.Detail("deleted_permissions", len(deletedRole.PermissionIds)).

--- a/features/rbac/sensitive_operations.go
+++ b/features/rbac/sensitive_operations.go
@@ -147,7 +147,7 @@ func (m *Manager) AuditSensitiveOperation(ctx context.Context, opCtx *SensitiveO
 		Detail("operation_type", string(opCtx.OperationType)).
 		// M-AUTH-2: Mark as sensitive operation
 		Detail("security_classification", "sensitive_admin_operation").
-		Severity(business.AuditSeverityCritical)
+		Severity(business.AuditSeverityHigh)
 
 	// M-AUTH-2: Include any additional metadata
 	for key, value := range opCtx.Metadata {

--- a/features/rbac/sensitive_operations_test.go
+++ b/features/rbac/sensitive_operations_test.go
@@ -173,6 +173,56 @@ func TestAuditSensitiveOperation(t *testing.T) {
 	})
 }
 
+// TestAuditSensitiveOperationValidationErrorSeverity verifies that validation
+// errors (missing/short/long justification) for sensitive operations emit High
+// severity, not Critical. Validation failures are admin API bad-request errors,
+// not compromise indicators (Issue #2964, AC 4).
+func TestAuditSensitiveOperationValidationErrorSeverity(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	ctx := context.Background()
+	require.NoError(t, manager.Initialize(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = manager.Close(stopCtx)
+	})
+
+	opCtx := &SensitiveOperationContext{
+		OperationType: SensitiveOpDeleteRole,
+		SubjectID:     "user-severity-test",
+		TenantID:      "severity-test-tenant",
+		ResourceID:    "role-severity-test",
+		Justification: "", // empty → validation error path
+	}
+	validationErr := ErrJustificationRequired
+
+	manager.AuditSensitiveOperation(ctx, opCtx, business.AuditResultError, validationErr)
+
+	flushCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, manager.auditManager.Flush(flushCtx))
+
+	entries, err := manager.auditManager.QueryEntries(ctx, &business.AuditFilter{
+		TenantID: "severity-test-tenant",
+		Limit:    10,
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "expected exactly one audit entry for the validation error")
+
+	assert.Equal(t, business.AuditSeverityHigh, entries[0].Severity,
+		"RBAC validation errors are admin API bad-request failures, not compromise indicators — must be High, not Critical (Issue #2964)")
+	assert.Equal(t, business.AuditResultError, entries[0].Result)
+}
+
 // TestManagerSensitiveGates verifies that each newly-gated Manager operation returns
 // ErrJustificationRequired when called without a justification in context and succeeds
 // when WithSensitiveOperationJustification is used.

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -786,7 +786,21 @@ func (b *AuditEventBuilder) build(entry *business.AuditEntry) {
 
 // Predefined audit event builders for common operations
 
-// AuthenticationEvent creates an authentication event builder
+// authOutcomeSeverity maps an AuditResult to the calibrated severity for auth/authz events.
+// Success is Low (routine operation); anything else is High (failure, denial, or error).
+// Call sites that want Critical (e.g. compromised-device or session-hijack indicators) must
+// override with .Severity(business.AuditSeverityCritical) after the constructor.
+func authOutcomeSeverity(result business.AuditResult) business.AuditSeverity {
+	if result == business.AuditResultSuccess {
+		return business.AuditSeverityLow
+	}
+	return business.AuditSeverityHigh
+}
+
+// AuthenticationEvent creates an authentication event builder.
+// Severity is outcome-aware: success → Low, failure/denied/error → High.
+// Call sites for compromise-indicator-grade failures (revoked device, session hijack, invalid PoP)
+// must add .Severity(business.AuditSeverityCritical) to override.
 func AuthenticationEvent(tenantID, userID, action string, result business.AuditResult) *AuditEventBuilder {
 	return NewEventBuilder().
 		Tenant(tenantID).
@@ -795,10 +809,14 @@ func AuthenticationEvent(tenantID, userID, action string, result business.AuditR
 		User(userID, business.AuditUserTypeHuman).
 		Resource("session", userID, "").
 		Result(result).
-		Severity(business.AuditSeverityHigh)
+		Severity(authOutcomeSeverity(result))
 }
 
-// AuthorizationEvent creates an authorization event builder
+// AuthorizationEvent creates an authorization event builder.
+// Severity is outcome-aware: success → Low, failure/denied/error → High.
+// Call sites for sensitive authorization management actions (permission grants, JIT approvals)
+// must add .Severity(business.AuditSeverityHigh) to override, since those represent
+// security-relevant operations regardless of outcome.
 func AuthorizationEvent(tenantID, userID, resourceType, resourceID, action string, result business.AuditResult) *AuditEventBuilder {
 	return NewEventBuilder().
 		Tenant(tenantID).
@@ -807,7 +825,7 @@ func AuthorizationEvent(tenantID, userID, resourceType, resourceID, action strin
 		User(userID, business.AuditUserTypeHuman).
 		Resource(resourceType, resourceID, "").
 		Result(result).
-		Severity(business.AuditSeverityHigh)
+		Severity(authOutcomeSeverity(result))
 }
 
 // ConfigurationEvent creates a configuration change event builder

--- a/pkg/audit/manager_test.go
+++ b/pkg/audit/manager_test.go
@@ -423,7 +423,8 @@ func TestPredefinedEventBuilders(t *testing.T) {
 		assert.Equal(t, "session", entry.ResourceType)
 		assert.Equal(t, "user1", entry.ResourceID)
 		assert.Equal(t, business.AuditResultSuccess, entry.Result)
-		assert.Equal(t, business.AuditSeverityHigh, entry.Severity)
+		// Success is Low — routine authentication; failures/denials are High (Issue #2964).
+		assert.Equal(t, business.AuditSeverityLow, entry.Severity)
 	})
 
 	t.Run("AuthorizationEvent", func(t *testing.T) {
@@ -438,6 +439,7 @@ func TestPredefinedEventBuilders(t *testing.T) {
 		assert.Equal(t, "config", entry.ResourceType)
 		assert.Equal(t, "config1", entry.ResourceID)
 		assert.Equal(t, business.AuditResultDenied, entry.Result)
+		// Denied is High — ordinary access denial (Issue #2964).
 		assert.Equal(t, business.AuditSeverityHigh, entry.Severity)
 	})
 
@@ -1473,4 +1475,142 @@ func TestWithSecretsStore_StoreFailureFallsBack(t *testing.T) {
 
 	breaks := m.VerifyChain(entries)
 	assert.Empty(t, breaks, "chain must be intact even with an in-process fallback HMAC key")
+}
+
+// TestConvenienceBuilderSeverity verifies that the predefined convenience constructors
+// emit calibrated severity at the source (Issue #2964).
+// The table covers all four tiers and all four AuditResult variants so that a future
+// unconditional hardcode would be caught by at least one row.
+func TestConvenienceBuilderSeverity(t *testing.T) {
+	cases := []struct {
+		name    string
+		builder *audit.AuditEventBuilder
+		want    business.AuditSeverity
+	}{
+		// AuthenticationEvent — success must be Low (routine login/registration path)
+		{
+			name:    "AuthenticationEvent/success → Low",
+			builder: audit.AuthenticationEvent("t", "u", "web.login.success", business.AuditResultSuccess),
+			want:    business.AuditSeverityLow,
+		},
+		// AuthenticationEvent — failure/denied must be High (ordinary auth failure)
+		{
+			name:    "AuthenticationEvent/failure → High",
+			builder: audit.AuthenticationEvent("t", "u", "web.login.failure", business.AuditResultFailure),
+			want:    business.AuditSeverityHigh,
+		},
+		{
+			name:    "AuthenticationEvent/denied → High",
+			builder: audit.AuthenticationEvent("t", "u", "web.login.lockout", business.AuditResultDenied),
+			want:    business.AuditSeverityHigh,
+		},
+		{
+			name:    "AuthenticationEvent/error → High",
+			builder: audit.AuthenticationEvent("t", "u", "web.login.error", business.AuditResultError),
+			want:    business.AuditSeverityHigh,
+		},
+		// AuthenticationEvent — Critical override: call sites for compromise indicators
+		// (revoked device, invalid PoP, session hijack) must be able to override.
+		{
+			name: "AuthenticationEvent/success + Critical override",
+			builder: audit.AuthenticationEvent("t", "u", "steward_registered", business.AuditResultSuccess).
+				Severity(business.AuditSeverityCritical),
+			want: business.AuditSeverityCritical,
+		},
+		// AuthorizationEvent — success must be Low (routine check_permission granted)
+		{
+			name:    "AuthorizationEvent/success → Low",
+			builder: audit.AuthorizationEvent("t", "u", "permission", "read", "check_permission", business.AuditResultSuccess),
+			want:    business.AuditSeverityLow,
+		},
+		// AuthorizationEvent — denied must be High (ordinary access denial)
+		{
+			name:    "AuthorizationEvent/denied → High",
+			builder: audit.AuthorizationEvent("t", "u", "permission", "write", "check_permission", business.AuditResultDenied),
+			want:    business.AuditSeverityHigh,
+		},
+		{
+			name:    "AuthorizationEvent/failure → High",
+			builder: audit.AuthorizationEvent("t", "u", "permission", "admin", "check_permission", business.AuditResultFailure),
+			want:    business.AuditSeverityHigh,
+		},
+		{
+			name:    "AuthorizationEvent/error → High",
+			builder: audit.AuthorizationEvent("t", "u", "permission", "admin", "check_permission", business.AuditResultError),
+			want:    business.AuditSeverityHigh,
+		},
+		// AuthorizationEvent — sensitive management actions must override to High
+		{
+			name: "AuthorizationEvent/grant_permission success + High override",
+			builder: audit.AuthorizationEvent("t", "u", "permission", "write", "grant_permission", business.AuditResultSuccess).
+				Severity(business.AuditSeverityHigh),
+			want: business.AuditSeverityHigh,
+		},
+		// UserManagementEvent — always High (sensitive admin actions)
+		{
+			name:    "UserManagementEvent/success stays High",
+			builder: audit.UserManagementEvent("t", "admin", "user1", "create_user"),
+			want:    business.AuditSeverityHigh,
+		},
+		// ConfigurationEvent — Medium baseline
+		{
+			name:    "ConfigurationEvent stays Medium",
+			builder: audit.ConfigurationEvent("t", "admin", "config", "cfg1", "settings", "update"),
+			want:    business.AuditSeverityMedium,
+		},
+		// SystemEvent — Low (routine system lifecycle)
+		{
+			name:    "SystemEvent stays Low",
+			builder: audit.SystemEvent("t", "controller_start", "started"),
+			want:    business.AuditSeverityLow,
+		},
+		// Regression guard: routine success must NOT be High or Critical
+		{
+			name:    "AuthenticationEvent/success not High",
+			builder: audit.AuthenticationEvent("t", "u", "web.login.success", business.AuditResultSuccess),
+			want:    business.AuditSeverityLow, // definitively not High
+		},
+		{
+			name:    "AuthorizationEvent/success not High",
+			builder: audit.AuthorizationEvent("t", "u", "permission", "read", "check_permission", business.AuditResultSuccess),
+			want:    business.AuditSeverityLow, // definitively not High
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var entry business.AuditEntry
+			audit.BuildEntry(tc.builder, &entry)
+			assert.Equal(t, tc.want, entry.Severity,
+				"expected severity %q but got %q for %s", tc.want, entry.Severity, tc.name)
+		})
+	}
+}
+
+// TestConvenienceBuilderSeverityNotHighOnSuccess verifies the key regression guard:
+// routine authentication and authorization successes must never emit High or Critical severity.
+// This is the canonical regression test for Issue #2964.
+func TestConvenienceBuilderSeverityNotHighOnSuccess(t *testing.T) {
+	successes := []struct {
+		name    string
+		builder *audit.AuditEventBuilder
+	}{
+		{"web.login.success", audit.AuthenticationEvent("t", "u", "web.login.success", business.AuditResultSuccess)},
+		{"web.logout", audit.AuthenticationEvent("t", "u", "web.logout", business.AuditResultSuccess)},
+		{"steward_registered", audit.AuthenticationEvent("t", "s", "steward_registered", business.AuditResultSuccess)},
+		{"check_permission granted", audit.AuthorizationEvent("t", "u", "permission", "read", "check_permission", business.AuditResultSuccess)},
+		{"jit_access_request", audit.AuthorizationEvent("t", "u", "jit_access", "req1", "request", business.AuditResultSuccess)},
+		{"jit_access_expired", audit.AuthorizationEvent("t", "u", "jit_access", "grant1", "expired", business.AuditResultSuccess)},
+	}
+
+	for _, tc := range successes {
+		t.Run(tc.name, func(t *testing.T) {
+			var entry business.AuditEntry
+			audit.BuildEntry(tc.builder, &entry)
+			if entry.Severity == business.AuditSeverityHigh || entry.Severity == business.AuditSeverityCritical {
+				t.Errorf("routine success %q emits severity %q — must be Low or Medium (Issue #2964 regression)",
+					tc.name, entry.Severity)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Convenience constructors (`AuthenticationEvent`, `AuthorizationEvent`) are now outcome-aware: success → Low, failure/denied/error → High
- `AuditResultError` paths in registration refresh downgraded High → Medium (system infrastructure errors are not security events)
- Sensitive admin actions (JIT approve/extend/revoke, permission grant, role deletion) carry explicit `.Severity(High)` overrides so the constructor change does not lower their signal
- Critical preserved at call sites for true compromise indicators: revoked device, invalid PoP signature, cross-tenant isolation violations, session hijack detection
- 21 new unit-test cases covering all four severity tiers; existing tests updated to match calibrated expectations

## Story-review results

| Reviewer | Verdict | Notes |
|----------|---------|-------|
| Security | PASS | gosec/Trivy/Nancy/staticcheck clean; no secrets; no central-provider violations; one non-blocking note on SIEM threshold retuning |
| Code review | PASS | Two pre-existing warnings (web login audit test checks log output only; JIT expiry tests use `time.Sleep`) — neither introduced by this change |
| QA test runner | PASS | All unit/integration/cross-platform compilation checks green after gofmt fix |

## Test plan

- [ ] `make test-agent-complete` passes (verified locally and via workflow)
- [ ] `TestConvenienceBuilderSeverity` — 15 table cases, all four tiers
- [ ] `TestConvenienceBuilderSeverityNotHighOnSuccess` — 6 regression guards for routine successes
- [ ] `TestRBACManager_AuditIntegration/DeleteRole` — asserts High (not Critical)
- [ ] `TestPredefinedEventBuilders/AuthenticationEvent` — asserts Low for success

Fixes #2964

🤖 Generated with [Claude Code](https://claude.com/claude-code)