### PR TITLE
docs: fleet bulk selection + bulk-action bar mockup (Issue #2939)

### DIFF
--- a/docs/design/mockups/README.md
+++ b/docs/design/mockups/README.md
@@ -30,6 +30,7 @@ principles, and token rationale these mockups express.
 | [`refresh-queue.html`](refresh-queue.html) | The **Refresh requests** page (Epic #2931 · #2941) — its own nav entry / `/refresh` route (not a console tab). Pending steward device-credential rotations with a **provenance-match** column (partial match = amber, scrutinize); **Reject** live, **Approve** deferred ("SOON"). Tenant-scoped, both themes. | **Reference** |
 | [`asset-live-activity.html`](asset-live-activity.html) | The asset live-activity tab — real-time process table and service list driven by the telemetry WebSocket; includes the `.rowkebab` per-row action menu pattern (applied to fleet rows in Story #2938). Both themes. | **Reference** |
 | [`asset-shell.html`](asset-shell.html) | The asset interactive shell tab — terminal emulator panel with WebSocket-backed session, command history, and resize handling. Both themes. | **Reference** |
+| [`fleet-bulk.html`](fleet-bulk.html) | Fleet **bulk selection + actions** (Epic #2931 · #2939) — a checkbox column + select-all-on-page and a bulk-action bar layered on the fleet table: **Edit tags** live (one authorized call per steward), **Decommission** deferred ("SOON"). Selection clears on page/filter/sort. Both themes. | **Reference** |
 
 > These are design references, not production code. The shipped UI is
 > React + TypeScript + Vite (Epic #2344), built against

--- a/docs/design/mockups/fleet-bulk.html
+++ b/docs/design/mockups/fleet-bulk.html
@@ -1,0 +1,205 @@
+<style>
+  :root {
+    --bg:#f7f4ef; --chrome:#f0ebe4; --chrome-2:#ffffff; --border:#d4cfc4;
+    --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff;
+    --shadow:0 18px 50px -22px rgba(60,45,30,.4); --radius:14px;
+  }
+  @media (prefers-color-scheme: dark){ :root{
+    --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
+    --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a;
+    --shadow:0 22px 60px -26px rgba(0,0,0,.8); } }
+  :root[data-theme="light"]{ --bg:#f7f4ef; --chrome:#f0ebe4; --chrome-2:#ffffff; --border:#d4cfc4;
+    --text:#6b5a4a; --text-dim:#7a6a5a; --accent:#4a6b7c; --accent-ink:#ffffff; --shadow:0 18px 50px -22px rgba(60,45,30,.4); }
+  :root[data-theme="dark"]{ --bg:#181817; --chrome:#1e1e1e; --chrome-2:#252526; --border:#3c3c3c;
+    --text:#c4b4a4; --text-dim:#a89888; --accent:#7b9fb0; --accent-ink:#16202a; --shadow:0 22px 60px -26px rgba(0,0,0,.8); }
+  *{box-sizing:border-box;}
+  body{margin:0; min-height:100dvh; background:var(--bg); color:var(--text); display:flex; flex-direction:column;
+    font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased;}
+  .topbar{display:flex; align-items:center; gap:14px; flex-wrap:wrap; padding:11px 16px; background:var(--chrome);
+    border-bottom:1px solid var(--border); position:sticky; top:0; z-index:5;}
+  .brand{display:flex; align-items:baseline; gap:8px; margin-right:auto;}
+  .brand b{font-size:14px; letter-spacing:.13em; text-transform:uppercase; font-weight:700;}
+  .brand span{font-size:11px; color:var(--text-dim); letter-spacing:.04em;}
+  .seg{display:inline-flex; position:relative; background:var(--chrome-2); border:1px solid var(--border); border-radius:10px; padding:3px;}
+  .seg button{position:relative; z-index:1; appearance:none; border:0; background:transparent; color:var(--text-dim);
+    font:inherit; font-size:12.5px; font-weight:600; padding:6px 13px; border-radius:7px; cursor:pointer; transition:color .18s ease;}
+  .seg button[aria-pressed="true"]{color:var(--accent-ink);}
+  .seg .thumb{position:absolute; top:3px; left:3px; height:calc(100% - 6px); background:var(--accent); border-radius:7px;
+    transition:transform .22s cubic-bezier(.4,.9,.3,1), width .22s cubic-bezier(.4,.9,.3,1); z-index:0;}
+  .seg button:focus-visible{outline:2px solid var(--accent); outline-offset:2px;}
+  .dims{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace; font-size:12px; color:var(--text-dim);
+    font-variant-numeric:tabular-nums; white-space:nowrap;}
+  .stage{flex:1; display:flex; align-items:flex-start; justify-content:center; padding:22px 16px 30px; overflow:auto;}
+  .frame-wrap{position:relative; margin:0 auto; border-radius:var(--radius); overflow:hidden; box-shadow:var(--shadow);
+    border:1px solid var(--border); background:var(--chrome); transition:width .22s ease, height .22s ease;}
+  .frame{display:block; border:0; transform-origin:0 0; background:transparent;}
+  .hint{text-align:center; color:var(--text-dim); font-size:12.5px; line-height:1.6; padding:0 20px 30px; max-width:700px; margin:0 auto;}
+</style>
+
+<div class="topbar">
+  <div class="brand"><b>CFGMS</b><span>fleet · bulk selection</span></div>
+  <div class="seg" role="group" aria-label="Preview viewport">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-dev="desktop" aria-pressed="true">Desktop</button>
+    <button data-dev="tablet" aria-pressed="false">Tablet</button>
+    <button data-dev="mobile" aria-pressed="false">Mobile</button>
+  </div>
+  <div class="seg themeseg" role="group" aria-label="Theme">
+    <span class="thumb" aria-hidden="true"></span>
+    <button data-theme-mode="auto" aria-pressed="true">Auto</button>
+    <button data-theme-mode="light" aria-pressed="false">Light</button>
+    <button data-theme-mode="dark" aria-pressed="false">Dark</button>
+  </div>
+  <div class="dims" id="dims">—</div>
+</div>
+
+<div class="stage">
+  <div class="frame-wrap" id="wrap"><iframe class="frame" id="frame" title="CFGMS fleet bulk mockup"></iframe></div>
+</div>
+
+<p class="hint">
+  Fleet <b>bulk selection + actions</b> (Epic #2931 · #2939) — a checkbox column + select-all-on-page layered on the
+  existing fleet table, and a <b>bulk-action bar</b> that appears when ≥1 row is selected. <b>Edit tags</b> ships now
+  (issued as one authorized call <b>per steward</b> — no batch endpoint bypassing tenant checks); <b>Decommission</b>
+  is drawn deferred ("SOON"). Selection clears on page / filter / sort change. Both themes.
+</p>
+
+<script>
+  const DEVICES = { desktop:{w:1320,h:760}, tablet:{w:900,h:940}, mobile:{w:390,h:880} };
+  let current = "desktop", themeMode = "auto";
+  const frame = document.getElementById("frame"), wrap = document.getElementById("wrap");
+  const stage = document.querySelector(".stage"), dims = document.getElementById("dims");
+  const devSeg = document.querySelector(".seg:not(.themeseg)"), themeSeg = document.querySelector(".themeseg");
+  const devBtns = [...devSeg.querySelectorAll("button")], themeBtns = [...themeSeg.querySelectorAll("button")];
+  function posThumb(seg){ const t=seg.querySelector(".thumb"); const a=seg.querySelector('button[aria-pressed="true"]')||seg.querySelector("button"); t.style.width=a.offsetWidth+"px"; t.style.transform="translateX("+(a.offsetLeft-3)+"px)"; }
+
+  const MOCK_CSS = `
+    :root{
+      --bg-primary:#f7f4ef; --bg-surface:#ffffff; --bg-elevated:#f0ebe4; --bg-sunk:#f0ebe4; --border:#d4cfc4;
+      --text-primary:#6b5a4a; --text-secondary:#7a6a5a; --text-faint:#8f7d66;
+      --accent:#4a6b7c; --accent-ink:#ffffff;
+      --ok:#507055; --ok-bg:#e8f0e9; --warn:#a05a35; --warn-bg:#f7e8db; --crit:#b56a5a; --crit-bg:#f2e5e3; --neutral:#7a6a5a; --neutral-bg:#e8e0d8;
+    }
+    :root[data-theme="dark"]{
+      --bg-primary:#1e1e1e; --bg-surface:#252526; --bg-elevated:#2d2d2d; --bg-sunk:#1a1a1a; --border:#3c3c3c;
+      --text-primary:#c4b4a4; --text-secondary:#a89888; --text-faint:#8a7a68;
+      --accent:#7b9fb0; --accent-ink:#16202a;
+      --ok:#6d9472; --ok-bg:#1a2e1d; --warn:#d4864f; --warn-bg:#332518; --crit:#c97a6a; --crit-bg:#2d1f1c; --neutral:#a89888; --neutral-bg:#2a2520;
+    }
+    *{box-sizing:border-box;}
+    html,body{margin:0; height:100%;}
+    body{background:var(--bg-primary); color:var(--text-primary); font-size:13.5px; line-height:1.45;
+      font-family:'Inter',ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; -webkit-font-smoothing:antialiased; padding:26px 24px;}
+    .mono{font-family:'JetBrains Mono',ui-monospace,"SF Mono",Menlo,monospace;}
+    .page{max-width:1040px; margin:0 auto;}
+    .page-head{margin-bottom:14px;}
+    .page-head h1{font-size:21px; font-weight:700; margin:0 0 4px;}
+    .page-head .sub{margin:0; font-size:13px; color:var(--text-secondary);}
+
+    /* bulk action bar — appears when ≥1 selected */
+    .bulkbar{display:flex; align-items:center; gap:12px; padding:11px 16px; border-radius:10px; margin-bottom:12px;
+      background:color-mix(in srgb, var(--accent) 12%, var(--bg-surface)); border:1px solid color-mix(in srgb, var(--accent) 40%, var(--border));}
+    .bulkbar .n{font-weight:700; color:var(--accent);}
+    .bulkbar .sel{font-size:13px; color:var(--text-primary);}
+    .bulkbar .grow{flex:1;}
+    .bulkbar .clear{font-size:12px; color:var(--accent); font-weight:600; cursor:pointer;}
+    .bbtn{appearance:none; border:1px solid var(--border); background:var(--bg-surface); color:var(--text-primary);
+      font:inherit; font-size:12.5px; font-weight:600; padding:7px 13px; border-radius:8px; cursor:pointer; display:inline-flex; align-items:center; gap:7px;}
+    .bbtn.primary{background:var(--accent); color:var(--accent-ink); border-color:var(--accent);}
+    .bbtn.deferred{cursor:not-allowed; color:var(--text-secondary)!important; background:var(--bg-elevated)!important; border-color:var(--border)!important;}
+    .soon{font-size:9px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; padding:1px 6px; border-radius:20px;
+      background:var(--neutral-bg); color:var(--text-faint); border:1px solid var(--border);}
+
+    .panel{background:var(--bg-surface); border:1px solid var(--border); border-radius:12px; overflow:hidden; box-shadow:var(--shadow);}
+    .grid{display:grid; align-items:center; grid-template-columns:44px 1.5fr .9fr 1.1fr .9fr 1.2fr .9fr;}
+    .thead{color:var(--text-faint); font-size:10px; letter-spacing:.09em; text-transform:uppercase; font-weight:600;
+      padding:11px 16px; border-bottom:1px solid var(--border); background:var(--bg-elevated);}
+    .row{padding:12px 16px; border-bottom:1px solid var(--border); font-size:13px;}
+    .row:last-child{border-bottom:0;}
+    .row.sel{background:color-mix(in srgb, var(--accent) 7%, var(--bg-surface));}
+    .row .nm{font-weight:600;}
+    .cell{color:var(--text-secondary); font-family:'JetBrains Mono',Menlo,monospace; font-size:12.5px;}
+    .cbx{width:17px; height:17px; border-radius:5px; border:1px solid var(--border); background:var(--bg-sunk);
+      display:grid; place-items:center; color:var(--accent-ink); cursor:pointer;}
+    .cbx svg{opacity:0;}
+    .cbx.on{background:var(--accent); border-color:var(--accent);} .cbx.on svg{opacity:1;}
+    .cbx.ind{background:var(--accent); border-color:var(--accent);} .cbx.ind .bar{display:block; width:9px; height:2.4px; border-radius:2px; background:var(--accent-ink);} .cbx.ind svg{display:none;}
+    .cbx .bar{display:none;}
+    .badge{display:inline-flex; align-items:center; gap:5px; padding:2px 9px; border-radius:20px; font-size:11px; font-weight:600;}
+    .badge .dot{width:6px; height:6px; border-radius:50%; background:currentColor;}
+    .b-ok{background:var(--ok-bg); color:var(--ok);} .b-warn{background:var(--warn-bg); color:var(--warn);} .b-neutral{background:var(--neutral-bg); color:var(--neutral);}
+    .tags{display:flex; gap:5px; flex-wrap:wrap;}
+    .tag{font-size:11px; padding:1px 8px; border-radius:20px; background:var(--bg-sunk); border:1px solid var(--border); color:var(--text-secondary); font-family:'JetBrains Mono',Menlo,monospace;}
+  `;
+
+  const CHK = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M5 12.5l4.2 4.2L19 7" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+  const TAGI = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.6 3H7a4 4 0 0 0-4 4v5.6a2 2 0 0 0 .6 1.4l7 7a2 2 0 0 0 2.8 0l5.6-5.6a2 2 0 0 0 0-2.8l-7-7A2 2 0 0 0 12.6 3Z"/><circle cx="8" cy="8" r="1.2" fill="currentColor"/></svg>';
+  const TRASH = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>';
+
+  const MOCK_HTML = `
+    <div class="page">
+      <div class="page-head">
+        <h1>Fleet</h1>
+        <p class="sub">128 stewards in <b>root/msp-a</b> and below.</p>
+      </div>
+
+      <div class="bulkbar">
+        <span class="cbx ind"><span class="bar"></span></span>
+        <span class="sel"><span class="n">3</span> selected</span>
+        <span class="grow"></span>
+        <button class="bbtn primary">${TAGI} Edit tags</button>
+        <button class="bbtn deferred">${TRASH} Decommission <span class="soon">soon</span></button>
+        <span class="clear">Clear</span>
+      </div>
+
+      <div class="panel">
+        <div class="thead grid"><span class="cbx ind"><span class="bar"></span></span><span>Steward</span><span>Status</span><span>Tenant</span><span>OS</span><span>Tags</span><span>Last seen</span></div>
+        <div class="row grid sel">
+          <span class="cbx on">${CHK}</span><div class="nm">web-07.msp-a.lan</div>
+          <span><span class="badge b-ok"><span class="dot"></span>Converged</span></span><span class="cell">root/msp-a/prod</span><span class="cell">Ubuntu 24.04</span>
+          <span class="tags"><span class="tag">prod</span><span class="tag">web</span></span><span class="cell">2 min ago</span>
+        </div>
+        <div class="row grid sel">
+          <span class="cbx on">${CHK}</span><div class="nm">db-02.msp-a.lan</div>
+          <span><span class="badge b-warn"><span class="dot"></span>Drift</span></span><span class="cell">root/msp-a/prod</span><span class="cell">Ubuntu 24.04</span>
+          <span class="tags"><span class="tag">prod</span><span class="tag">db</span></span><span class="cell">5 min ago</span>
+        </div>
+        <div class="row grid sel">
+          <span class="cbx on">${CHK}</span><div class="nm">cache-01.msp-a.lan</div>
+          <span><span class="badge b-ok"><span class="dot"></span>Converged</span></span><span class="cell">root/msp-a/prod</span><span class="cell">Debian 12</span>
+          <span class="tags"><span class="tag">prod</span></span><span class="cell">1 min ago</span>
+        </div>
+        <div class="row grid">
+          <span class="cbx">${CHK}</span><div class="nm">kiosk-11.client-1.lan</div>
+          <span><span class="badge b-ok"><span class="dot"></span>Converged</span></span><span class="cell">root/msp-a/client-1</span><span class="cell">Win 11 23H2</span>
+          <span class="tags"><span class="tag">kiosk</span></span><span class="cell">12 min ago</span>
+        </div>
+        <div class="row grid">
+          <span class="cbx">${CHK}</span><div class="nm">edge-03.client-1.lan</div>
+          <span><span class="badge b-neutral"><span class="dot"></span>Offline</span></span><span class="cell">root/msp-a/client-1</span><span class="cell">Win 11 22H2</span>
+          <span class="tags"><span class="tag">edge</span></span><span class="cell">3 hr ago</span>
+        </div>
+      </div>
+    </div>
+  `;
+
+  function currentTheme(){ if(themeMode!=="auto") return themeMode; const d=document.documentElement.getAttribute("data-theme"); return d || (matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"); }
+  function srcdoc(t){ return '<!doctype html><html lang="en" data-theme="'+t+'"><head><meta charset="utf-8">'+
+    '<meta name="viewport" content="width=device-width,initial-scale=1"><style>'+MOCK_CSS+'</style></head><body>'+
+    MOCK_HTML+'</body></html>'; }
+  function layout(){ const d=DEVICES[current]; frame.style.width=d.w+"px"; frame.style.height=d.h+"px";
+    const avail=stage.clientWidth-32; const s=Math.min(1,avail/d.w); frame.style.transform="scale("+s+")";
+    wrap.style.width=(d.w*s)+"px"; wrap.style.height=(d.h*s)+"px"; dims.textContent=d.w+" × "+d.h+" · "+Math.round(s*100)+"%"; }
+  function render(){ frame.srcdoc=srcdoc(currentTheme()); layout(); }
+  devBtns.forEach(b=>b.addEventListener("click",()=>{ current=b.dataset.dev;
+    devBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(devSeg); layout(); }));
+  themeBtns.forEach(b=>b.addEventListener("click",()=>{ themeMode=b.dataset.themeMode;
+    themeBtns.forEach(x=>x.setAttribute("aria-pressed",x===b?"true":"false")); posThumb(themeSeg);
+    if(themeMode==="auto"){ document.documentElement.removeAttribute("data-theme"); render(); }
+    else { document.documentElement.setAttribute("data-theme",themeMode); } }));
+  new MutationObserver(render).observe(document.documentElement,{attributes:true,attributeFilter:["data-theme"]});
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change",()=>{ if(themeMode==="auto") render(); });
+  window.addEventListener("resize",()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); });
+  window.addEventListener("orientationchange",()=>setTimeout(()=>{ layout(); posThumb(devSeg); posThumb(themeSeg); },200));
+  render(); posThumb(devSeg); posThumb(themeSeg);
+</script>


### PR DESCRIPTION
Docs-only. Adds `docs/design/mockups/fleet-bulk.html` — a **checkbox column** (row + select-all-on-page, indeterminate when partial) and a **bulk-action bar** layered on the fleet table (Epic #2931).

- Bar shows the selection count with **Edit tags** (live — one authorized call **per steward**, no batch endpoint bypassing per-steward tenant checks) and **Decommission** drawn deferred ("SOON").
- Selection clears on page / filter / sort change. Both themes.

Founder-approved 2026-07-24. Clears the design gate on **#2939** — completing the registration-console mockup group (#2934/2935/2936 + #2941 + #2939).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAr3HLU7SoNtaMmzvJX6Hv