### PR TITLE
dispatch: persist the dev-agent session directory and manifest (Issue #3051)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -688,6 +688,13 @@ EOF
   exit 1
 }
 
+# Guard so po-act.sh can `source` this file to reuse prepare_session_dir and
+# the AGENT_SESSIONS_* config (Issue #3051) without also executing this
+# script's own command dispatch against po-act.sh's positional args.
+# BASH_SOURCE[0] is this file whenever it's sourced; $0 stays the top-level
+# script (po-act.sh) — they match only when agent-dispatch.sh is run directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+
 [[ $# -ge 1 ]] || usage
 
 cmd="$1"; shift
@@ -939,6 +946,16 @@ case "$cmd" in
 
     tier1_url="${CFGMS_TIER1_URL:-}"
 
+    # Persist this run's transcript to the host so its token spend survives the
+    # container's --rm (Issue #3028; extended to this launch path in #3051 —
+    # `launch` was the one dev-agent path prepare_session_dir never reached).
+    # Degrades to no mount if the dir can't be created; telemetry never blocks
+    # dispatch.
+    session_mount=()
+    if sessions_dir=$(prepare_session_dir "cfg-agent-${num}" "issue" "${num}" "" ""); then
+      session_mount=(-v "${sessions_dir}:${AGENT_SESSIONS_MOUNT}")
+    fi
+
     if container_id=$(docker run -d \
       --name "cfg-agent-${num}" \
       --label "cfg-agent=true" \
@@ -954,6 +971,7 @@ case "$cmd" in
       -v "${cred_dir}:/run/cfgms/agent-cred:ro" \
       "${AGENT_METRICS_MOUNT_ARGS[@]}" \
       "${AGENT_MODEL_ROUTING_MOUNT_ARGS[@]}" \
+      "${session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AUTONOMOUS=true" \
       -e "CFGMS_API_KEY_FILE=/run/cfgms/agent-cred/api.key" \
@@ -2202,3 +2220,5 @@ PROMPT_EOF
     usage
     ;;
 esac
+
+fi  # BASH_SOURCE[0] == $0

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -28,12 +28,28 @@
 set -euo pipefail
 
 REPO="cfg-is/cfgms"
+DISPATCH="${CFGMS_TEST_DISPATCH:-$(dirname "$0")/agent-dispatch.sh}"
+
+# Reuse prepare_session_dir + AGENT_SESSIONS_* config from agent-dispatch.sh
+# (Issue #3051) instead of duplicating the session-dir logic for the docker run
+# this script inlines below. Sourcing (not shelling out) is required because
+# the dispatch case below builds its own `docker run` rather than calling
+# agent-dispatch.sh launch — see the "Inlined from agent-dispatch.sh launch"
+# comment there. agent-dispatch.sh guards its own command dispatch behind a
+# BASH_SOURCE[0]==$0 check, so sourcing it only defines functions/vars and does
+# not execute its case statement against our args. Deliberately sources the
+# REAL file, not "$DISPATCH": tests set CFGMS_TEST_DISPATCH to a throwaway mock
+# with no such guard, and sourcing that would run the mock's case statement
+# against po-act.sh's own args instead. Source BEFORE setting WORKTREE_BASE
+# below so this script's own value (not agent-dispatch.sh's) wins.
+# shellcheck source=agent-dispatch.sh
+source "$(dirname "$0")/agent-dispatch.sh"
+
 WORKTREE_BASE="${CFGMS_TEST_WORKTREE_BASE:-}"
 if [[ -z "$WORKTREE_BASE" ]]; then
   WORKTREE_BASE="$(cd "$(dirname "$0")/../.." && pwd)/../worktrees"
   WORKTREE_BASE="$(cd "$WORKTREE_BASE" 2>/dev/null && pwd || echo "/home/jrdn/git/cfg.is/worktrees")"
 fi
-DISPATCH="${CFGMS_TEST_DISPATCH:-$(dirname "$0")/agent-dispatch.sh}"
 PREFLIGHT="$(dirname "$0")/po-cycle-preflight.py"
 PROJECT_QUEUE="$(cd "$(dirname "$0")/../.." && pwd)/scripts/project-queue.sh"
 PIPELINE_HELPER="${CFGMS_TEST_PIPELINE_HELPER:-$(cd "$(dirname "$0")/../.." && pwd)/scripts/pipeline-helper.sh}"
@@ -314,6 +330,17 @@ except Exception: print('')" 2>/dev/null || echo "")
         -c "cp /host-creds.json /persist/.credentials.json" 2>/dev/null || true
     fi
     gh_token=$(gh auth token)
+
+    # Persist this run's transcript to the host so its token spend survives the
+    # container's --rm (Issue #3028; extended to this dispatch path in #3051 —
+    # this inlined docker run was the dev-agent path prepare_session_dir never
+    # reached). Degrades to no mount if the dir can't be created; telemetry
+    # never blocks dispatch.
+    session_mount=()
+    if sessions_dir=$(prepare_session_dir "$container_name" "issue" "${story:-}" "" ""); then
+      session_mount=(-v "${sessions_dir}:${AGENT_SESSIONS_MOUNT}")
+    fi
+
     if container_id=$(docker run -d \
       --name "$container_name" \
       --label "cfg-agent=true" \
@@ -326,6 +353,7 @@ except Exception: print('')" 2>/dev/null || echo "")
       -v "claude-creds:/persist" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
+      "${session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_PROJECT_ITEM_ID=${item_id}" \
       -e "CFGMS_LEASE_KEY=story-${item_id}" \

--- a/.claude/scripts/tests/session_persistence.test.sh
+++ b/.claude/scripts/tests/session_persistence.test.sh
@@ -132,6 +132,79 @@ fi
 check_contains "sessions base is under \$HOME/.cache, not /tmp" "$dispatch_src" \
   'AGENT_SESSIONS_BASE="${CFGMS_AGENT_SESSIONS_BASE:-${HOME}/.cache/cfgms-agent-sessions}"'
 
+printf '\n== docker run enumeration (Issue #3051) ==\n'
+
+# Enumerate every detached `docker run -d ... cfg-agent:latest` block in BOTH
+# scripts and assert each one bind-mounts the session dir, rather than
+# asserting the mount string appears somewhere in the file. A file-wide
+# substring check (as used above for launch-generic/review-pr) would have
+# stayed green while `po-act.sh dispatch` and `agent-dispatch.sh launch` had
+# no mount at all -- launch-generic's own mount was enough to satisfy a
+# "contains somewhere" check on the whole file. That blind spot is exactly how
+# the regression this story fixes went undetected.
+#
+# mode=interactive (launch-interactive) is deliberately exempt: it is a
+# human-attached remote-control session, not an autonomous dev-agent run, so
+# it never runs the manifest-writing entrypoint.sh and has nothing to persist.
+enum_out="$(python3 - "$DISPATCH" "${SCRIPT_DIR}/../po-act.sh" <<'PY'
+import sys
+
+# The docker run block itself references the *array* built from
+# prepare_session_dir's output ("${session_mount[@]}" / "${review_session_mount[@]}"),
+# not the literal AGENT_SESSIONS_MOUNT constant -- that only appears where the
+# array is assigned, outside the block. "session_mount[@]" is a substring of
+# both array names, so one marker covers both.
+MOUNT_MARKER = "session_mount[@]"
+EXEMPT_MARKER = 'mode=interactive'
+
+fails = []
+total = 0
+for path in sys.argv[1:]:
+    lines = open(path).read().splitlines()
+    for i, line in enumerate(lines):
+        if line.strip().startswith('#') or 'docker run -d' not in line:
+            continue
+        # Block runs from this line through the one naming the image -- every
+        # session-mount `-v` arg (if present) sits somewhere in between.
+        block = [line]
+        j = i
+        while j < len(lines) - 1 and 'cfg-agent:latest' not in lines[j]:
+            j += 1
+            block.append(lines[j])
+        block_text = '\n'.join(block)
+        total += 1
+        label = f"{path}:{i + 1}"
+        if EXEMPT_MARKER in block_text:
+            continue
+        if MOUNT_MARKER not in block_text:
+            fails.append(label)
+
+print(f"TOTAL:{total}")
+for f in fails:
+    print(f"MISSING:{f}")
+PY
+)"
+
+total_blocks="$(echo "$enum_out" | grep -oP '^TOTAL:\K[0-9]+' || echo 0)"
+missing_blocks="$(echo "$enum_out" | grep '^MISSING:' || true)"
+
+# Sanity floor on the enumeration itself: 5 known blocks exist today (po-act.sh
+# dispatch, agent-dispatch.sh launch, launch-generic, launch-interactive,
+# review-pr). Fewer than that means the parser silently stopped matching a
+# call site -- e.g. a `docker run -d` rewritten to a different form -- which
+# would make the assertion below vacuously pass.
+if [[ "$total_blocks" -ge 5 ]]; then
+  ok "enumeration found ${total_blocks} docker run -d cfg-agent:latest blocks (>=5 expected)"
+else
+  bad "enumeration found docker run -d cfg-agent:latest blocks" "expected >=5, found ${total_blocks} -- a launch call site may have gone undetected"
+fi
+
+if [[ -z "$missing_blocks" ]]; then
+  ok "every non-interactive docker run -d block mounts the session dir"
+else
+  bad "every non-interactive docker run -d block mounts the session dir" "$missing_blocks"
+fi
+
 printf '\n== retention sweep ==\n'
 
 mkdir -p "${AGENT_SESSIONS_BASE}/old-run" "${AGENT_SESSIONS_BASE}/fresh-run"


### PR DESCRIPTION
## Summary

- `po-act.sh dispatch` and `agent-dispatch.sh launch` each inline their own `docker run cfg-agent:latest` rather than sharing `launch-generic`'s launcher, so neither called `prepare_session_dir` (#3028) — every dev-agent container's transcript and `agent-result.json` died with `docker rm -f`. Both now call the same `prepare_session_dir` + `AGENT_SESSIONS_MOUNT` pattern `launch-generic`/`review-pr` already use.
- `po-act.sh` sources `agent-dispatch.sh` to reuse the function rather than duplicating it; `agent-dispatch.sh` gates its own command dispatch behind a `BASH_SOURCE[0]==$0` check so sourcing only defines functions/vars, never executing its case statement against `po-act.sh`'s own args (or a test's mock stand-in for `$DISPATCH`).
- Added a docker-run enumeration test to `session_persistence.test.sh` that scans both scripts for every `docker run -d cfg-agent:latest` block and fails if any (non-interactive) one lacks the session mount. Replaces a file-wide substring check that stayed green with the mount missing entirely from these two call sites — confirmed by running the new enumeration against the pre-fix source, where it correctly flags exactly those two lines.
- Telemetry failure still never blocks dispatch — unchanged best-effort behavior of `prepare_session_dir`.

## Verification

- Ran a real (non-mocked) container with the exact fixed mount pattern: `prepare_session_dir` created the host session dir + `meta.json`, `setup-env.sh` symlinked `~/.claude/projects` → `/agent-sessions`, and a write inside the container (plus the real `entrypoint.sh` `agent-result.json` copy path) round-tripped to the host directory and survived container removal.
- All `.claude/scripts/tests/*.test.sh` pass (11 files).
- `make test` (pre-push, race detection) passed in full.

## Test plan

- [x] `.claude/scripts/tests/session_persistence.test.sh` passes, including the new enumeration section
- [x] All other `.claude/scripts/tests/*.test.sh` pass
- [x] `go build ./...` and pre-push `make test` pass
- [x] Real-container verification of the mount/symlink/manifest round trip
- [ ] Natural confirmation on the next cron-dispatched dev agent that its host session dir contains a transcript + populated `agent-result.json` (not exercisable safely from this inline session without a real GitHub issue + API spend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbRjuJsa3J4g9vCrM4SRES

Fixes #3051