### PR TITLE
dispatch: source the token reporter from the harness, not the PR checkout (Issue #3041)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -29,6 +29,24 @@ AGENT_SESSIONS_BASE="${CFGMS_AGENT_SESSIONS_BASE:-${HOME}/.cache/cfgms-agent-ses
 AGENT_SESSIONS_RETENTION_DAYS="${CFGMS_AGENT_SESSIONS_RETENTION_DAYS:-30}"
 AGENT_SESSIONS_MOUNT="/agent-sessions"
 
+# Token reporter mount (Issue #3041). Every entrypoint resolves the reporter
+# from ${AGENT_METRICS_MOUNT} only, never from /workspace: the branch under
+# dispatch or review must not be able to disable its own accounting by lacking,
+# editing or deleting .claude/metrics.
+#
+# The image bakes a copy at the same path (.devcontainer/Dockerfile), so this
+# bind mount is not what makes the control exist -- it is what keeps every
+# dispatch path on the *harness checkout's* reporter without waiting for an
+# image rebuild, the same no-rebuild pattern already used for setup-env.sh and
+# review-entrypoint.sh. Mounting is conditional on the source existing: Docker
+# would otherwise create an empty host directory and shadow the baked copy with
+# nothing, turning a working control into reporter_missing.
+AGENT_METRICS_MOUNT="/usr/local/share/cfgms-metrics"
+AGENT_METRICS_MOUNT_ARGS=()
+if [ -d "${REPO_ROOT}/.claude/metrics" ]; then
+  AGENT_METRICS_MOUNT_ARGS=(-v "${REPO_ROOT}/.claude/metrics:${AGENT_METRICS_MOUNT}:ro")
+fi
+
 # Prepare the host-side transcript directory for a container and record what the
 # run was for. meta.json is written *before* launch so a container that dies
 # early is still attributable; container labels are gone once it is pruned.
@@ -917,6 +935,7 @@ case "$cmd" in
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -v "${cred_dir}:/run/cfgms/agent-cred:ro" \
+      "${AGENT_METRICS_MOUNT_ARGS[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AUTONOMOUS=true" \
       -e "CFGMS_API_KEY_FILE=/run/cfgms/agent-cred/api.key" \
@@ -992,6 +1011,7 @@ case "$cmd" in
       -v "claude-creds:/persist" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
+      "${AGENT_METRICS_MOUNT_ARGS[@]}" \
       "${session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AUTONOMOUS=true" \
@@ -1893,7 +1913,7 @@ PROMPT_EOF
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -v "${REPO_ROOT}/.devcontainer/scripts/setup-env.sh:/usr/local/bin/setup-env.sh:ro" \
       -v "${REPO_ROOT}/.devcontainer/scripts/review-entrypoint.sh:/usr/local/bin/review-entrypoint.sh:ro" \
-      -v "${REPO_ROOT}/.claude/metrics:/usr/local/share/cfgms-metrics:ro" \
+      "${AGENT_METRICS_MOUNT_ARGS[@]}" \
       "${review_session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AGENT_MODE=true" \

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -1893,6 +1893,7 @@ PROMPT_EOF
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -v "${REPO_ROOT}/.devcontainer/scripts/setup-env.sh:/usr/local/bin/setup-env.sh:ro" \
       -v "${REPO_ROOT}/.devcontainer/scripts/review-entrypoint.sh:/usr/local/bin/review-entrypoint.sh:ro" \
+      -v "${REPO_ROOT}/.claude/metrics:/usr/local/share/cfgms-metrics:ro" \
       "${review_session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AGENT_MODE=true" \

--- a/.claude/scripts/tests/session_persistence.test.sh
+++ b/.claude/scripts/tests/session_persistence.test.sh
@@ -159,7 +159,34 @@ for entry in "${SCRIPT_DIR}/../../../.devcontainer/entrypoint.sh" \
   check_contains "${name} copies the manifest to the mount" "$src" \
     'cp /tmp/agent-result.json "${CLAUDE_PROJECTS_DIR}/agent-result.json"'
   if bash -n "$entry" 2>/dev/null; then ok "${name} parses"; else bad "${name} parses" "bash -n failed"; fi
+
+  # Regression guard for #3041: the reporter must resolve from the harness,
+  # never from the PR checkout under /workspace -- a branch that lacks, edits,
+  # or deletes .claude/metrics must not be able to disable its own accounting.
+  if grep -qE 'TOKEN_REPORT="/workspace' "$entry"; then
+    bad "${name} reporter never resolved from /workspace" "found a /workspace-rooted TOKEN_REPORT assignment"
+  else
+    ok "${name} reporter never resolved from /workspace"
+  fi
+  check_contains "${name} reporter resolves from the harness path" "$src" \
+    'TOKEN_REPORT="/usr/local/share/cfgms-metrics/token_report.py"'
+
+  # A failure to record usage must be loud, never a silently-absent key.
+  check_contains "${name} records an explicit marker on accounting failure" "$src" '"usage_error"'
+  check_contains "${name} warns on stdout when the reporter is missing" "$src" \
+    'WARN: token reporter not found'
 done
+
+printf '\n== harness-baked reporter (image + Dockerfile) ==\n'
+
+dockerfile_src="$(cat "${SCRIPT_DIR}/../../../.devcontainer/Dockerfile")"
+check_contains "Dockerfile bakes token_report.py into the harness path" "$dockerfile_src" \
+  '/usr/local/share/cfgms-metrics/'
+check_contains "Dockerfile bakes pricing.json alongside it" "$dockerfile_src" \
+  '.claude/metrics/pricing.json'
+
+check_contains "review-pr dispatch bind-mounts .claude/metrics fresh from host" "$dispatch_src" \
+  '.claude/metrics:/usr/local/share/cfgms-metrics:ro'
 
 printf '\n%s\n' "-----------------------------------------"
 if [[ "$fail" -eq 0 ]]; then

--- a/.claude/scripts/tests/session_persistence.test.sh
+++ b/.claude/scripts/tests/session_persistence.test.sh
@@ -179,14 +179,79 @@ done
 
 printf '\n== harness-baked reporter (image + Dockerfile) ==\n'
 
-dockerfile_src="$(cat "${SCRIPT_DIR}/../../../.devcontainer/Dockerfile")"
+DOCKERFILE="${SCRIPT_DIR}/../../../.devcontainer/Dockerfile"
+DOCKERIGNORE="${SCRIPT_DIR}/../../../.dockerignore"
+dockerfile_src="$(cat "$DOCKERFILE")"
 check_contains "Dockerfile bakes token_report.py into the harness path" "$dockerfile_src" \
   '/usr/local/share/cfgms-metrics/'
 check_contains "Dockerfile bakes pricing.json alongside it" "$dockerfile_src" \
   '.claude/metrics/pricing.json'
 
-check_contains "review-pr dispatch bind-mounts .claude/metrics fresh from host" "$dispatch_src" \
-  '.claude/metrics:/usr/local/share/cfgms-metrics:ro'
+# The bake COPYs out of .claude, which .dockerignore excludes wholesale for
+# every image in the repo. Without a per-file negation BuildKit warns
+# CopyIgnoredFile and then fails the build ("failed to compute cache key: not
+# found"), so cfg-agent:latest cannot be rebuilt at all -- and that rebuild is
+# the path that ships harness security updates (entrypoint.sh, init-firewall.sh,
+# pinned tool versions). Assert every .claude source the Dockerfile copies is
+# re-included.
+mapfile -t baked_sources < <(grep -E '^COPY ' "$DOCKERFILE" \
+  | grep -oE '\.claude/[^[:space:]]+' | sort -u)
+check_eq "Dockerfile bakes exactly the two reporter files" "${#baked_sources[@]}" "2"
+for baked in "${baked_sources[@]}"; do
+  if grep -qxF -- "!${baked}" "$DOCKERIGNORE"; then
+    ok ".dockerignore re-includes ${baked} into the build context"
+  else
+    bad ".dockerignore re-includes ${baked} into the build context" \
+        "COPY source is excluded by .dockerignore — the agent image cannot build"
+  fi
+done
+
+# ...but only those files. Stage 0 does `COPY . .`, so un-ignoring .claude
+# wholesale would bake session transcripts, worktree checkouts and
+# credential-adjacent state into an image layer.
+if grep -qxF -- '.claude' "$DOCKERIGNORE"; then
+  ok ".dockerignore still excludes the .claude tree itself"
+else
+  bad ".dockerignore still excludes the .claude tree itself" \
+      "agent state would be baked into the image by stage 0's COPY . ."
+fi
+if grep -qxE -- '!\.claude/?' "$DOCKERIGNORE"; then
+  bad "no blanket re-include of .claude" \
+      "a bare '!.claude' negation bakes the whole agent-state tree into a layer"
+else
+  ok "no blanket re-include of .claude"
+fi
+
+printf '\n== harness reporter mount (all accounting dispatch paths) ==\n'
+
+check_contains "harness mount targets the image's baked reporter path" "$dispatch_src" \
+  'AGENT_METRICS_MOUNT="/usr/local/share/cfgms-metrics"'
+check_contains "dispatch bind-mounts .claude/metrics from the harness checkout" "$dispatch_src" \
+  '-v "${REPO_ROOT}/.claude/metrics:${AGENT_METRICS_MOUNT}:ro"'
+# An absent source must fall through to the baked copy: Docker would otherwise
+# create an empty host dir and shadow a working reporter with nothing.
+check_contains "mount is skipped when the harness copy is absent" "$dispatch_src" \
+  'if [ -d "${REPO_ROOT}/.claude/metrics" ]; then'
+
+# Baking alone leaves the control inoperative until someone rebuilds a ~10GB
+# image, so every container that runs an accounting entrypoint must also carry
+# the mount. Interactive sessions are exempt: they override the entrypoint with
+# a bash shell that writes no result manifest.
+mapfile -t unmounted < <(awk '
+  /docker run -d/                 { in_block = 1; block = ""; start = NR }
+  in_block                        { block = block $0 "\n" }
+  in_block && /cfg-agent:latest/  {
+    in_block = 0
+    if (block ~ /--entrypoint \/bin\/bash/) next
+    if (block !~ /AGENT_METRICS_MOUNT_ARGS/) print start
+  }
+' "$DISPATCH")
+if [[ "${#unmounted[@]}" -eq 0 ]]; then
+  ok "every accounting dispatch path mounts the harness reporter"
+else
+  bad "every accounting dispatch path mounts the harness reporter" \
+      "docker run at line(s) ${unmounted[*]} would record usage_error=reporter_missing"
+fi
 
 printf '\n%s\n' "-----------------------------------------"
 if [[ "$fail" -eq 0 ]]; then

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -194,6 +194,16 @@ COPY .devcontainer/agent-context.sh /usr/local/bin/agent-context.sh
 COPY .devcontainer/dnsmasq-allowlist.conf /etc/dnsmasq-allowlist.conf
 RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/setup-env.sh /usr/local/bin/entrypoint.sh
 
+# Token reporter (Issue #3028/#3041) — baked into the harness so accounting is a
+# property of the image, never of the branch under dispatch/review. A PR branch
+# that predates this reporter (or edits/deletes it) must not disable its own
+# telemetry. The review dispatch path additionally bind-mounts .claude/metrics
+# fresh from the host at runtime (see agent-dispatch.sh review-pr), the same
+# no-rebuild-required pattern already used for review-entrypoint.sh; this bake
+# covers the entrypoint.sh dev/fix/branch paths, which only pick up script
+# changes on image rebuild anyway.
+COPY .claude/metrics/token_report.py .claude/metrics/pricing.json /usr/local/share/cfgms-metrics/
+
 # Agent environment — 4GB RAM is sufficient for go test/build + Claude API calls
 ENV CFGMS_AGENT_MODE=true
 ENV TRIVY_CACHE_DIR=/home/agent/.cache/trivy

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -921,21 +921,37 @@ cat > /tmp/agent-result.json <<RESULT_EOF
 }
 RESULT_EOF
 
-# --- Token accounting (Issue #3028) ---
+# --- Token accounting (Issue #3028, harness-sourced per #3041) ---
 # Stamp this run's own spend into the result manifest and drop a copy next to
 # the transcript on the host, so the run stays attributable even after the
 # transcript is pruned. Reuses the reporter's cost model rather than
 # duplicating the cache-TTL pricing rules.
 #
-# Entirely best-effort: an older branch may predate .claude/metrics, and no
-# telemetry failure may ever change the agent's exit code.
+# The reporter is baked into the image at /usr/local/share/cfgms-metrics (see
+# Dockerfile) rather than read from /workspace — the PR branch under dispatch
+# must never be able to disable its own accounting by lacking, editing, or
+# deleting the reporter. Entirely best-effort: no telemetry failure may ever
+# change the agent's exit code, but a failure to record usage must be loud
+# (stdout WARN + an explicit usage_error marker in the manifest), never a
+# silently-absent "usage" key.
 CLAUDE_PROJECTS_DIR="${HOME}/.claude/projects"
-TOKEN_REPORT="/workspace/.claude/metrics/token_report.py"
+TOKEN_REPORT="/usr/local/share/cfgms-metrics/token_report.py"
 
-if [ -f "$TOKEN_REPORT" ] && [ -d "$CLAUDE_PROJECTS_DIR" ]; then
-    if python3 "$TOKEN_REPORT" --projects-dir "$CLAUDE_PROJECTS_DIR" \
-            --format totals --quiet > /tmp/agent-usage.json 2>/dev/null; then
-        python3 - <<'USAGE_MERGE' || echo "WARN: could not merge token usage into result"
+usage_status="ok"
+if [ ! -f "$TOKEN_REPORT" ]; then
+    usage_status="reporter_missing"
+    echo "WARN: token reporter not found at ${TOKEN_REPORT} — result manifest carries no usage"
+elif [ ! -d "$CLAUDE_PROJECTS_DIR" ]; then
+    usage_status="no_projects_dir"
+    echo "WARN: no persisted session directory at ${CLAUDE_PROJECTS_DIR} — result manifest carries no usage"
+elif ! python3 "$TOKEN_REPORT" --projects-dir "$CLAUDE_PROJECTS_DIR" \
+        --format totals --quiet > /tmp/agent-usage.json 2>/dev/null; then
+    usage_status="reporter_failed"
+    echo "WARN: token report failed — result manifest carries no usage"
+fi
+
+if [ "$usage_status" = "ok" ]; then
+    if ! python3 - <<'USAGE_MERGE'
 import json
 
 with open("/tmp/agent-result.json") as handle:
@@ -945,11 +961,23 @@ with open("/tmp/agent-usage.json") as handle:
 with open("/tmp/agent-result.json", "w") as handle:
     json.dump(result, handle, indent=2)
 USAGE_MERGE
-    else
-        echo "WARN: token report failed — result manifest carries no usage"
+    then
+        usage_status="merge_failed"
+        echo "WARN: could not merge token usage into result"
     fi
-else
-    echo "INFO: token reporter unavailable — skipping usage accounting"
+fi
+
+if [ "$usage_status" != "ok" ]; then
+    python3 - "$usage_status" <<'USAGE_MARK' || echo "WARN: could not write usage_error marker into result"
+import json, sys
+
+with open("/tmp/agent-result.json") as handle:
+    result = json.load(handle)
+result["usage"] = None
+result["usage_error"] = sys.argv[1]
+with open("/tmp/agent-result.json", "w") as handle:
+    json.dump(result, handle, indent=2)
+USAGE_MARK
 fi
 
 # Copy the manifest beside the transcript. When the host bind-mounts a session

--- a/.devcontainer/scripts/review-entrypoint.sh
+++ b/.devcontainer/scripts/review-entrypoint.sh
@@ -105,17 +105,37 @@ cat > /tmp/agent-result.json <<RESULT_EOF
 }
 RESULT_EOF
 
-# --- Token accounting (Issue #3028) ---
+# --- Token accounting (Issue #3028, harness-sourced per #3041) ---
 # Reviewers were previously unmeasured: the container is --rm, so its transcript
 # and spend vanished on exit. Best-effort throughout; no telemetry failure may
 # change the reviewer's exit code.
+#
+# The reporter resolves from the harness, never from /workspace (the PR branch
+# under review) — a branch that predates, edits, or deletes the reporter must
+# not be able to disable its own accounting. agent-dispatch.sh review-pr
+# bind-mounts .claude/metrics from the host at runtime, the same no-rebuild
+# pattern already used for this script and setup-env.sh; entrypoint.sh's own
+# copy is baked into the image (see Dockerfile) as a fallback path. A failure
+# to record usage must be loud (stdout WARN + an explicit usage_error marker
+# in the manifest), never a silently-absent "usage" key.
 CLAUDE_PROJECTS_DIR="${HOME}/.claude/projects"
-TOKEN_REPORT="/workspace/.claude/metrics/token_report.py"
+TOKEN_REPORT="/usr/local/share/cfgms-metrics/token_report.py"
 
-if [ -f "$TOKEN_REPORT" ] && [ -d "$CLAUDE_PROJECTS_DIR" ]; then
-    if python3 "$TOKEN_REPORT" --projects-dir "$CLAUDE_PROJECTS_DIR" \
-            --format totals --quiet > /tmp/agent-usage.json 2>/dev/null; then
-        python3 - <<'USAGE_MERGE' || echo "WARN: could not merge token usage into result"
+usage_status="ok"
+if [ ! -f "$TOKEN_REPORT" ]; then
+    usage_status="reporter_missing"
+    echo "WARN: token reporter not found at ${TOKEN_REPORT} — result manifest carries no usage"
+elif [ ! -d "$CLAUDE_PROJECTS_DIR" ]; then
+    usage_status="no_projects_dir"
+    echo "WARN: no persisted session directory at ${CLAUDE_PROJECTS_DIR} — result manifest carries no usage"
+elif ! python3 "$TOKEN_REPORT" --projects-dir "$CLAUDE_PROJECTS_DIR" \
+        --format totals --quiet > /tmp/agent-usage.json 2>/dev/null; then
+    usage_status="reporter_failed"
+    echo "WARN: token report failed — result manifest carries no usage"
+fi
+
+if [ "$usage_status" = "ok" ]; then
+    if ! python3 - <<'USAGE_MERGE'
 import json
 
 with open("/tmp/agent-result.json") as handle:
@@ -125,7 +145,23 @@ with open("/tmp/agent-usage.json") as handle:
 with open("/tmp/agent-result.json", "w") as handle:
     json.dump(result, handle, indent=2)
 USAGE_MERGE
+    then
+        usage_status="merge_failed"
+        echo "WARN: could not merge token usage into result"
     fi
+fi
+
+if [ "$usage_status" != "ok" ]; then
+    python3 - "$usage_status" <<'USAGE_MARK' || echo "WARN: could not write usage_error marker into result"
+import json, sys
+
+with open("/tmp/agent-result.json") as handle:
+    result = json.load(handle)
+result["usage"] = None
+result["usage_error"] = sys.argv[1]
+with open("/tmp/agent-result.json", "w") as handle:
+    json.dump(result, handle, indent=2)
+USAGE_MARK
 fi
 
 cp /tmp/agent-result.json "${CLAUDE_PROJECTS_DIR}/agent-result.json" 2>/dev/null || true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,21 @@
 # Build-context exclusions for every image in this repo (all Dockerfiles use
-# `COPY . .` builders). Nothing here is read by any Dockerfile.
+# `COPY . .` builders). Nothing excluded here is read by any Dockerfile; a
+# Dockerfile that does name an excluded path must re-include exactly that path
+# with a `!` negation below, or its COPY fails the build.
 # NOTE: web/dist is NOT excluded — the controller embeds it (web/embed.go).
 
 # VCS metadata (~140MB) — builds never run git against the repo
 .git
 
-# Claude Code agent state, incl. worktree checkouts (~400MB+)
+# Claude Code agent state, incl. worktree checkouts (~400MB+).
+# Exception: the agent image bakes the token reporter into the harness so a
+# dispatched branch cannot disable its own accounting (.devcontainer/Dockerfile,
+# Issue #3041). Re-include exactly those two files — never `.claude` wholesale,
+# since every builder here does `COPY . .` and would bake session transcripts,
+# worktree checkouts and credential-adjacent state into an image layer.
 .claude
+!.claude/metrics/token_report.py
+!.claude/metrics/pricing.json
 
 # Frontend toolchain artifacts — images build Go only; node_modules exists
 # wherever the frontend CI lane or a local npm ci ran (~180MB, 14k files)


### PR DESCRIPTION
## Summary

Per-run token accounting (#3028) silently produced no usage data for any dispatched or reviewed agent whose branch predated `.claude/metrics` or edited/deleted it — `review-entrypoint.sh` and `entrypoint.sh` both resolved `token_report.py` from `/workspace` (the checked-out branch under dispatch/review) rather than from the harness. Every open PR branch at the time predated #3027, so the entire review backlog was unmeasurable, and a branch could disable its own accounting by omission.

## Changes made

- Bake `token_report.py` + `pricing.json` into the Docker image at `/usr/local/share/cfgms-metrics/` (`.devcontainer/Dockerfile`), re-including exactly those two files past the wholesale `.claude` exclusion in `.dockerignore` (never the whole tree — stage 0's `COPY . .` would otherwise bake session transcripts, worktree checkouts, and credential-adjacent state into an image layer).
- `agent-dispatch.sh`: a shared, existence-guarded `AGENT_METRICS_MOUNT_ARGS` bind-mounts `.claude/metrics` fresh from the host checkout into the same harness path on every dispatch mode that writes a manifest — `launch` (issue mode), `launch-generic` (branch/fix-pr/resolve-conflict), and `review-pr` — so accounting works on already-built images without waiting for a rebuild. `launch-interactive` is untouched: it overrides the entrypoint with a bash shell and writes no result manifest.
- Both entrypoints resolve `TOKEN_REPORT` from the harness path only, never `/workspace`.
- Absent or failed accounting no longer disappears silently: it emits a stdout `WARN` and records an explicit `usage_error` marker (with `usage: null`) in `agent-result.json`, distinguishing `reporter_missing` / `no_projects_dir` / `reporter_failed` / `merge_failed`. Best-effort throughout — no telemetry failure changes the agent's exit code.
- New/mutation-tested regression guards in `session_persistence.test.sh`: the reporter is never resolved from `/workspace`; every `.claude` source a Dockerfile `COPY`s has a matching `.dockerignore` negation (and `.claude` itself stays excluded, no blanket re-include); every accounting `docker run` block carries the mount.

## Test results

- `session_persistence.test.sh`: 52/52 checks pass
- All 14 suites under `.claude/scripts/tests/`: pass
- `make test`: 215/215 script/HA checks pass, full Go suite green
- `make lint`, `make check-architecture`, `make security-scan`: clean
- Pre-push validation (full `make test` + security + lint): PASSED

## QA / Security review summary (adversarial story-review workflow)

First round found one HIGH-severity blocking issue: the Dockerfile's new `COPY .claude/metrics/*` could not actually build, because `.dockerignore` excludes `.claude` wholesale from every image's build context — this would have bricked `cfg-agent:latest` rebuilds entirely and left the accounting control inoperative outside the review path. Fixed in a follow-up commit (`.dockerignore` negations for exactly the two reporter files + extending the bind-mount to every dispatch path, not just review). A pre-existing, unrelated local environment issue (stale gitignored `.env.test` pointing `test-integration-docker` at a non-running Postgres container) was also found and resolved (file moved aside, not deleted; not a repo change). Second round: all lenses passed, 0 remaining findings.

**Verified against a real dispatch** (not just the unit test): ran the actual token-accounting block extracted from `review-entrypoint.sh` inside the real `cfg-agent:latest` container, with a fake `/workspace` lacking `.claude/metrics` — confirmed a populated `usage` object when the harness mount is present, and an explicit `usage_error: "reporter_missing"` + stdout `WARN` when it is not.

Fixes #3041

Co-Authored-By: Claude <noreply@anthropic.com>