### PR TITLE
config: move per-segment model selection out of hardcoded entrypoints (Issue #3030)

### DIFF
--- a/.claude/model-routing.yaml
+++ b/.claude/model-routing.yaml
@@ -1,12 +1,21 @@
 # Per-segment agent model/effort routing (Issue #3030).
 #
 # Read by .devcontainer/agent-context.sh's ac_resolve_agent_model() from inside
-# agent containers (mounted at /workspace/.claude/model-routing.yaml). A
-# missing or malformed file falls back to the hardcoded defaults baked into
+# agent containers, from the HARNESS path
+# /usr/local/share/cfgms-agent/model-routing.yaml only — baked into the image
+# (.devcontainer/Dockerfile) and bind-mounted read-only from the harness
+# checkout by agent-dispatch.sh. It is never read from /workspace: that is the
+# branch under dispatch/review, which must not be able to choose the model of
+# the acceptance reviewer that decides whether it merges. Editing this file in
+# the harness checkout takes effect on the next dispatch with no image rebuild;
+# editing it on a PR branch changes nothing for that branch's agents.
+#
+# A missing or malformed file falls back to the hardcoded defaults baked into
 # the resolver, so a parse failure degrades to prior behavior rather than
-# breaking dispatch. CFGMS_MODEL_OVERRIDE (forwarded by agent-dispatch.sh)
-# takes precedence over this file's model — used by the benchmark harness to
-# run a fixture across models without mutating committed config.
+# breaking dispatch. CFGMS_MODEL_OVERRIDE (forwarded by agent-dispatch.sh from
+# host operator env) takes precedence over this file's model — used by the
+# benchmark harness to run a fixture across models without mutating committed
+# config.
 #
 # Fixed two-level shape: do not add nesting beyond defaults:/segments: — the
 # resolver is a plain-stdlib parser, not a general YAML implementation.

--- a/.claude/model-routing.yaml
+++ b/.claude/model-routing.yaml
@@ -1,0 +1,20 @@
+# Per-segment agent model/effort routing (Issue #3030).
+#
+# Read by .devcontainer/agent-context.sh's ac_resolve_agent_model() from inside
+# agent containers (mounted at /workspace/.claude/model-routing.yaml). A
+# missing or malformed file falls back to the hardcoded defaults baked into
+# the resolver, so a parse failure degrades to prior behavior rather than
+# breaking dispatch. CFGMS_MODEL_OVERRIDE (forwarded by agent-dispatch.sh)
+# takes precedence over this file's model — used by the benchmark harness to
+# run a fixture across models without mutating committed config.
+#
+# Fixed two-level shape: do not add nesting beyond defaults:/segments: — the
+# resolver is a plain-stdlib parser, not a general YAML implementation.
+defaults:
+  model: claude-sonnet-4-6
+  effort: high
+segments:
+  dev-agent:          { model: claude-sonnet-4-6 }
+  fix-agent:          { model: claude-sonnet-4-6 }
+  pr-review:          { model: claude-sonnet-4-6 }
+  acceptance-review:  { model: claude-sonnet-4-6 }

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -47,6 +47,23 @@ if [ -d "${REPO_ROOT}/.claude/metrics" ]; then
   AGENT_METRICS_MOUNT_ARGS=(-v "${REPO_ROOT}/.claude/metrics:${AGENT_METRICS_MOUNT}:ro")
 fi
 
+# Model-routing mount (Issue #3030), same rule as the reporter above:
+# ac_resolve_agent_model reads ${AGENT_MODEL_ROUTING_MOUNT} only, never
+# /workspace. /workspace is a checkout of the branch under dispatch or review,
+# so reading routing from there would let a PR branch pick the model of the
+# acceptance reviewer deciding whether it merges, and dev/fix agents run on
+# untrusted issue/PR text. The image bakes a copy at the same path
+# (.devcontainer/Dockerfile); this bind mount keeps every dispatch path on the
+# *harness checkout's* routing config without waiting for an image rebuild.
+# Conditional on the source existing as a file: Docker would otherwise create an
+# empty host directory at that path and shadow the baked config, silently
+# dropping every dispatch to the hardcoded fallback.
+AGENT_MODEL_ROUTING_MOUNT="/usr/local/share/cfgms-agent/model-routing.yaml"
+AGENT_MODEL_ROUTING_MOUNT_ARGS=()
+if [ -f "${REPO_ROOT}/.claude/model-routing.yaml" ]; then
+  AGENT_MODEL_ROUTING_MOUNT_ARGS=(-v "${REPO_ROOT}/.claude/model-routing.yaml:${AGENT_MODEL_ROUTING_MOUNT}:ro")
+fi
+
 # Prepare the host-side transcript directory for a container and record what the
 # run was for. meta.json is written *before* launch so a container that dies
 # early is still attributable; container labels are gone once it is pruned.
@@ -936,6 +953,7 @@ case "$cmd" in
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -v "${cred_dir}:/run/cfgms/agent-cred:ro" \
       "${AGENT_METRICS_MOUNT_ARGS[@]}" \
+      "${AGENT_MODEL_ROUTING_MOUNT_ARGS[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AUTONOMOUS=true" \
       -e "CFGMS_API_KEY_FILE=/run/cfgms/agent-cred/api.key" \
@@ -1013,6 +1031,7 @@ case "$cmd" in
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       "${AGENT_METRICS_MOUNT_ARGS[@]}" \
+      "${AGENT_MODEL_ROUTING_MOUNT_ARGS[@]}" \
       "${session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AUTONOMOUS=true" \
@@ -1916,6 +1935,7 @@ PROMPT_EOF
       -v "${REPO_ROOT}/.devcontainer/scripts/setup-env.sh:/usr/local/bin/setup-env.sh:ro" \
       -v "${REPO_ROOT}/.devcontainer/scripts/review-entrypoint.sh:/usr/local/bin/review-entrypoint.sh:ro" \
       "${AGENT_METRICS_MOUNT_ARGS[@]}" \
+      "${AGENT_MODEL_ROUTING_MOUNT_ARGS[@]}" \
       "${review_session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AGENT_MODE=true" \

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -942,6 +942,7 @@ case "$cmd" in
       -e "CFGMS_TENANT=agent-test/${num}" \
       -e "CFGMS_TIER1_URL=${tier1_url}" \
       -e "CFGMS_ADMIN_BUNDLE=" \
+      -e "CFGMS_MODEL_OVERRIDE=${CFGMS_MODEL_OVERRIDE:-}" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
       "${num}" 2>&1); then
@@ -1015,6 +1016,7 @@ case "$cmd" in
       "${session_mount[@]}" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AUTONOMOUS=true" \
+      -e "CFGMS_MODEL_OVERRIDE=${CFGMS_MODEL_OVERRIDE:-}" \
       "${lease_env[@]}" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
@@ -1918,6 +1920,7 @@ PROMPT_EOF
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AGENT_MODE=true" \
       -e "CFGMS_LEASE_KEY=pr-${pr_num}" \
+      -e "CFGMS_MODEL_OVERRIDE=${CFGMS_MODEL_OVERRIDE:-}" \
       --cap-add NET_ADMIN \
       --entrypoint /usr/local/bin/review-entrypoint.sh \
       cfg-agent:latest 2>&1); then

--- a/.claude/scripts/tests/model_routing.test.sh
+++ b/.claude/scripts/tests/model_routing.test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Regression test for per-segment model routing (Issue #3030).
+#
+# Model selection used to be hardcoded in three places (entrypoint.sh,
+# review-entrypoint.sh, agent frontmatter) and could not be changed without a
+# code edit. This covers the config-driven resolver: .claude/model-routing.yaml
+# defaults + per-segment overrides, a hardcoded fallback on missing/malformed
+# config, and CFGMS_MODEL_OVERRIDE taking precedence over the file. Also
+# asserts the entrypoints and agent-dispatch.sh are actually wired to it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+AGENT_CONTEXT="${REPO_ROOT}/.devcontainer/agent-context.sh"
+ENTRYPOINT="${REPO_ROOT}/.devcontainer/entrypoint.sh"
+REVIEW_ENTRYPOINT="${REPO_ROOT}/.devcontainer/scripts/review-entrypoint.sh"
+DISPATCH="${REPO_ROOT}/.claude/scripts/agent-dispatch.sh"
+ROUTING_FILE="${REPO_ROOT}/.claude/model-routing.yaml"
+
+for f in "$AGENT_CONTEXT" "$ENTRYPOINT" "$REVIEW_ENTRYPOINT" "$DISPATCH" "$ROUTING_FILE"; do
+  [[ -f "$f" ]] || { printf 'FAIL: expected file not found: %s\n' "$f" >&2; exit 1; }
+done
+
+fail=0; ran=0
+ok()   { ran=$((ran + 1)); printf '  ok    %s\n' "$1"; }
+bad()  { ran=$((ran + 1)); fail=$((fail + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+check_eq() {
+  local desc="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then ok "$desc"
+  else bad "$desc" "want: ${expected}  actual: ${actual}"; fi
+}
+check_contains() {
+  local desc="$1" hay="$2" needle="$3"
+  if [[ "$hay" == *"$needle"* ]]; then ok "$desc"
+  else bad "$desc" "want substring: ${needle}"; fi
+}
+check_not_contains() {
+  local desc="$1" hay="$2" needle="$3"
+  if [[ "$hay" != *"$needle"* ]]; then ok "$desc"
+  else bad "$desc" "want NO substring: ${needle}"; fi
+}
+
+echo "model_routing.test.sh"
+echo "----------------------"
+
+printf '\n== .claude/model-routing.yaml ==\n'
+routing_src="$(cat "$ROUTING_FILE")"
+check_contains "declares defaults model" "$routing_src" "model: claude-sonnet-4-6"
+check_contains "declares defaults effort" "$routing_src" "effort: high"
+for seg in dev-agent fix-agent pr-review acceptance-review; do
+  check_contains "declares segment ${seg}" "$routing_src" "${seg}:"
+done
+
+printf '\n== ac_resolve_agent_model resolver ==\n'
+# shellcheck source=/dev/null
+source "$AGENT_CONTEXT"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+cat > "${SANDBOX}/routing.yaml" <<'YAML'
+defaults:
+  model: claude-sonnet-4-6
+  effort: high
+segments:
+  dev-agent:        { model: claude-sonnet-4-6 }
+  fix-agent:        { model: claude-sonnet-4-6 }
+  pr-review:        { model: claude-sonnet-4-6 }
+  acceptance-review: { model: claude-sonnet-4-6 }
+YAML
+
+unset CFGMS_MODEL_OVERRIDE
+resolved="$(CFGMS_MODEL_ROUTING_FILE="${SANDBOX}/routing.yaml" ac_resolve_agent_model "dev-agent")"
+mapfile -t lines <<< "$resolved"
+check_eq "known segment resolves configured model" "${lines[0]:-}" "claude-sonnet-4-6"
+check_eq "known segment resolves configured effort" "${lines[1]:-}" "high"
+
+# Segment override wins over defaults.
+cat > "${SANDBOX}/override.yaml" <<'YAML'
+defaults:
+  model: claude-sonnet-4-6
+  effort: high
+segments:
+  fix-agent:        { model: claude-opus-4-7 }
+YAML
+resolved="$(CFGMS_MODEL_ROUTING_FILE="${SANDBOX}/override.yaml" ac_resolve_agent_model "fix-agent")"
+mapfile -t lines <<< "$resolved"
+check_eq "segment-level model overrides defaults" "${lines[0]:-}" "claude-opus-4-7"
+
+# Unknown segment falls back to file defaults, not the hardcoded fallback.
+cat > "${SANDBOX}/unknown_seg.yaml" <<'YAML'
+defaults:
+  model: claude-sonnet-9-9
+  effort: medium
+segments:
+  dev-agent:        { model: claude-sonnet-4-6 }
+YAML
+resolved="$(CFGMS_MODEL_ROUTING_FILE="${SANDBOX}/unknown_seg.yaml" ac_resolve_agent_model "never-defined-segment")"
+mapfile -t lines <<< "$resolved"
+check_eq "unknown segment falls back to file defaults (model)" "${lines[0]:-}" "claude-sonnet-9-9"
+check_eq "unknown segment falls back to file defaults (effort)" "${lines[1]:-}" "medium"
+
+# Missing config file: hardcoded fallback, current production values.
+resolved="$(CFGMS_MODEL_ROUTING_FILE="${SANDBOX}/does-not-exist.yaml" ac_resolve_agent_model "dev-agent")"
+mapfile -t lines <<< "$resolved"
+check_eq "missing file falls back to hardcoded model" "${lines[0]:-}" "claude-sonnet-4-6"
+check_eq "missing file falls back to hardcoded effort" "${lines[1]:-}" "high"
+
+# Malformed config file: same hardcoded fallback, never a crash.
+printf 'not: [valid, yaml, {{{\n***\n' > "${SANDBOX}/malformed.yaml"
+set +e
+resolved="$(CFGMS_MODEL_ROUTING_FILE="${SANDBOX}/malformed.yaml" ac_resolve_agent_model "dev-agent" 2>/dev/null)"
+rc=$?
+set -e
+check_eq "malformed file does not abort resolution" "$rc" "0"
+mapfile -t lines <<< "$resolved"
+check_eq "malformed file falls back to hardcoded model" "${lines[0]:-}" "claude-sonnet-4-6"
+check_eq "malformed file falls back to hardcoded effort" "${lines[1]:-}" "high"
+
+# CFGMS_MODEL_OVERRIDE takes precedence over the file, even with a valid config.
+resolved="$(CFGMS_MODEL_ROUTING_FILE="${SANDBOX}/routing.yaml" CFGMS_MODEL_OVERRIDE="claude-opus-override" ac_resolve_agent_model "dev-agent")"
+mapfile -t lines <<< "$resolved"
+check_eq "CFGMS_MODEL_OVERRIDE wins over configured model" "${lines[0]:-}" "claude-opus-override"
+check_eq "CFGMS_MODEL_OVERRIDE does not affect effort" "${lines[1]:-}" "high"
+unset CFGMS_MODEL_OVERRIDE
+
+# CFGMS_MODEL_OVERRIDE also wins with a missing/malformed file (never blocked
+# by config state).
+resolved="$(CFGMS_MODEL_ROUTING_FILE="${SANDBOX}/does-not-exist.yaml" CFGMS_MODEL_OVERRIDE="claude-opus-override" ac_resolve_agent_model "dev-agent")"
+mapfile -t lines <<< "$resolved"
+check_eq "CFGMS_MODEL_OVERRIDE wins with missing file" "${lines[0]:-}" "claude-opus-override"
+unset CFGMS_MODEL_OVERRIDE
+
+printf '\n== entrypoint.sh wiring ==\n'
+entrypoint_src="$(cat "$ENTRYPOINT")"
+check_not_contains "no longer unconditionally hardcodes AGENT_MODEL" "$entrypoint_src" 'AGENT_MODEL="claude-sonnet-4-6"'
+check_contains "resolves model via ac_resolve_agent_model" "$entrypoint_src" "ac_resolve_agent_model"
+check_contains "routes fix-pr to the fix-agent segment" "$entrypoint_src" "fix-agent"
+check_contains "routes dev issue/branch to the dev-agent segment" "$entrypoint_src" "dev-agent"
+check_contains "result manifest records resolved model" "$entrypoint_src" '"model": "${AGENT_MODEL}"'
+check_contains "result manifest records resolved effort" "$entrypoint_src" '"effort": "${AGENT_EFFORT}"'
+if bash -n "$ENTRYPOINT" 2>/dev/null; then ok "entrypoint.sh parses"; else bad "entrypoint.sh parses" "bash -n failed"; fi
+
+printf '\n== review-entrypoint.sh wiring ==\n'
+review_src="$(cat "$REVIEW_ENTRYPOINT")"
+check_contains "sources agent-context.sh" "$review_src" "agent-context.sh"
+check_contains "resolves model via ac_resolve_agent_model" "$review_src" "ac_resolve_agent_model"
+check_contains "routes to the acceptance-review segment" "$review_src" "acceptance-review"
+check_not_contains "no longer hardcodes claude-sonnet-4-6 in the claude invocation" "$review_src" '--model claude-sonnet-4-6 -p'
+check_contains "result manifest records resolved model" "$review_src" '"model": "${AGENT_MODEL}"'
+check_contains "result manifest records resolved effort" "$review_src" '"effort": "${AGENT_EFFORT}"'
+if bash -n "$REVIEW_ENTRYPOINT" 2>/dev/null; then ok "review-entrypoint.sh parses"; else bad "review-entrypoint.sh parses" "bash -n failed"; fi
+
+printf '\n== agent-dispatch.sh forwards CFGMS_MODEL_OVERRIDE ==\n'
+dispatch_src="$(cat "$DISPATCH")"
+mapfile -t missing_override < <(awk '
+  /docker run -d/                 { in_block = 1; block = ""; start = NR }
+  in_block                        { block = block $0 "\n" }
+  in_block && /cfg-agent:latest/  {
+    in_block = 0
+    if (block ~ /--entrypoint \/bin\/bash/) next
+    if (block !~ /CFGMS_MODEL_OVERRIDE/) print start
+  }
+' "$DISPATCH")
+if [[ "${#missing_override[@]}" -eq 0 ]]; then
+  ok "every accounting dispatch path forwards CFGMS_MODEL_OVERRIDE"
+else
+  bad "every accounting dispatch path forwards CFGMS_MODEL_OVERRIDE" \
+      "docker run at line(s) ${missing_override[*]} does not forward it"
+fi
+
+printf '\n%s\n' "-----------------------------------------"
+if [[ "$fail" -eq 0 ]]; then
+  printf 'PASS: %d checks\n' "$ran"; exit 0
+else
+  printf 'FAIL: %d of %d checks failed\n' "$fail" "$ran"; exit 1
+fi

--- a/.claude/scripts/tests/model_routing.test.sh
+++ b/.claude/scripts/tests/model_routing.test.sh
@@ -16,8 +16,14 @@ ENTRYPOINT="${REPO_ROOT}/.devcontainer/entrypoint.sh"
 REVIEW_ENTRYPOINT="${REPO_ROOT}/.devcontainer/scripts/review-entrypoint.sh"
 DISPATCH="${REPO_ROOT}/.claude/scripts/agent-dispatch.sh"
 ROUTING_FILE="${REPO_ROOT}/.claude/model-routing.yaml"
+DOCKERFILE="${REPO_ROOT}/.devcontainer/Dockerfile"
+DOCKERIGNORE="${REPO_ROOT}/.dockerignore"
 
-for f in "$AGENT_CONTEXT" "$ENTRYPOINT" "$REVIEW_ENTRYPOINT" "$DISPATCH" "$ROUTING_FILE"; do
+# The one path the routing config may be read from inside a container. It is
+# harness-owned (baked + bind-mounted); /workspace is the branch under review.
+HARNESS_ROUTING_PATH="/usr/local/share/cfgms-agent/model-routing.yaml"
+
+for f in "$AGENT_CONTEXT" "$ENTRYPOINT" "$REVIEW_ENTRYPOINT" "$DISPATCH" "$ROUTING_FILE" "$DOCKERFILE" "$DOCKERIGNORE"; do
   [[ -f "$f" ]] || { printf 'FAIL: expected file not found: %s\n' "$f" >&2; exit 1; }
 done
 
@@ -167,6 +173,60 @@ if [[ "${#missing_override[@]}" -eq 0 ]]; then
 else
   bad "every accounting dispatch path forwards CFGMS_MODEL_OVERRIDE" \
       "docker run at line(s) ${missing_override[*]} does not forward it"
+fi
+
+printf '\n== routing config is harness-owned, never read from the branch ==\n'
+# A merge gate must not read its configuration from the artifact it gates.
+# /workspace is a checkout of the PR branch under review (agent-dispatch.sh
+# review-pr, -v "${real_path}:/workspace"), so a resolver defaulting there lets
+# a branch set `segments: acceptance-review: { model: <weak model> }` and choose
+# the model of the agent deciding whether that branch merges. Dev/fix agents
+# additionally run on untrusted issue and PR text. Same rule as the token
+# reporter (Issue #3041).
+resolver_body="$(awk '/^ac_resolve_agent_model\(\)/ { in_fn = 1 } in_fn { print } in_fn && /^}/ { exit }' "$AGENT_CONTEXT")"
+[[ -n "$resolver_body" ]] || { printf 'FAIL: could not extract ac_resolve_agent_model body\n' >&2; exit 1; }
+check_contains "resolver defaults to the harness routing path" "$resolver_body" \
+  "\${CFGMS_MODEL_ROUTING_FILE:-${HARNESS_ROUTING_PATH}}"
+check_not_contains "resolver never reads routing from /workspace" "$resolver_body" "/workspace"
+
+# Baking makes the control exist even with no mount; the mount is what keeps it
+# current without a ~10GB image rebuild.
+dockerfile_src="$(cat "$DOCKERFILE")"
+check_contains "Dockerfile bakes the routing config into the harness path" "$dockerfile_src" \
+  "COPY .claude/model-routing.yaml ${HARNESS_ROUTING_PATH}"
+# .dockerignore excludes .claude wholesale for every image in the repo; without
+# a per-file negation the COPY fails and cfg-agent:latest cannot be rebuilt.
+if grep -qxF -- '!.claude/model-routing.yaml' "$DOCKERIGNORE"; then
+  ok ".dockerignore re-includes the routing config into the build context"
+else
+  bad ".dockerignore re-includes the routing config into the build context" \
+      "COPY source is excluded by .dockerignore — the agent image cannot build"
+fi
+
+check_contains "dispatch mount targets the image's baked routing path" "$dispatch_src" \
+  "AGENT_MODEL_ROUTING_MOUNT=\"${HARNESS_ROUTING_PATH}\""
+check_contains "dispatch bind-mounts the routing config read-only from the harness checkout" "$dispatch_src" \
+  '-v "${REPO_ROOT}/.claude/model-routing.yaml:${AGENT_MODEL_ROUTING_MOUNT}:ro"'
+# An absent source must fall through to the baked copy: Docker would otherwise
+# create an empty host directory at that path and shadow the baked config,
+# silently dropping every dispatch to the hardcoded fallback.
+check_contains "mount is skipped when the harness copy is absent" "$dispatch_src" \
+  'if [ -f "${REPO_ROOT}/.claude/model-routing.yaml" ]; then'
+
+mapfile -t unrouted < <(awk '
+  /docker run -d/                 { in_block = 1; block = ""; start = NR }
+  in_block                        { block = block $0 "\n" }
+  in_block && /cfg-agent:latest/  {
+    in_block = 0
+    if (block ~ /--entrypoint \/bin\/bash/) next
+    if (block !~ /AGENT_MODEL_ROUTING_MOUNT_ARGS/) print start
+  }
+' "$DISPATCH")
+if [[ "${#unrouted[@]}" -eq 0 ]]; then
+  ok "every accounting dispatch path mounts the harness routing config"
+else
+  bad "every accounting dispatch path mounts the harness routing config" \
+      "docker run at line(s) ${unrouted[*]} would run on stale baked routing"
 fi
 
 printf '\n%s\n' "-----------------------------------------"

--- a/.claude/scripts/tests/session_persistence.test.sh
+++ b/.claude/scripts/tests/session_persistence.test.sh
@@ -196,7 +196,11 @@ check_contains "Dockerfile bakes pricing.json alongside it" "$dockerfile_src" \
 # re-included.
 mapfile -t baked_sources < <(grep -E '^COPY ' "$DOCKERFILE" \
   | grep -oE '\.claude/[^[:space:]]+' | sort -u)
-check_eq "Dockerfile bakes exactly the two reporter files" "${#baked_sources[@]}" "2"
+# Exactly the harness-owned config the image is allowed to bake: the two
+# reporter files (Issue #3041) plus the model-routing config (Issue #3030).
+# Any further .claude source added to a COPY is a deliberate decision that must
+# update this count — the tree holds session transcripts and worktree checkouts.
+check_eq "Dockerfile bakes exactly the harness-owned .claude files" "${#baked_sources[@]}" "3"
 for baked in "${baked_sources[@]}"; do
   if grep -qxF -- "!${baked}" "$DOCKERIGNORE"; then
     ok ".dockerignore re-includes ${baked} into the build context"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -204,6 +204,16 @@ RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/setup-env.sh /usr/lo
 # changes on image rebuild anyway.
 COPY .claude/metrics/token_report.py .claude/metrics/pricing.json /usr/local/share/cfgms-metrics/
 
+# Per-segment model routing (Issue #3030) — same rule as the reporter above:
+# baked into the harness so the model an agent runs on is a property of the
+# image, never of the branch under dispatch/review. Reading this from
+# /workspace would let a PR branch select the model of the acceptance reviewer
+# deciding whether that branch merges (self-weakening of a merge gate), and dev
+# and fix agents consume untrusted issue/PR text. The dispatch paths additionally
+# bind-mount the harness checkout's copy over this path at runtime
+# (agent-dispatch.sh) so routing edits need no image rebuild.
+COPY .claude/model-routing.yaml /usr/local/share/cfgms-agent/model-routing.yaml
+
 # Agent environment — 4GB RAM is sufficient for go test/build + Claude API calls
 ENV CFGMS_AGENT_MODE=true
 ENV TRIVY_CACHE_DIR=/home/agent/.cache/trivy

--- a/.devcontainer/agent-context.sh
+++ b/.devcontainer/agent-context.sh
@@ -334,13 +334,29 @@ ac_post_no_op_comment() {
 
 # ac_resolve_agent_model <segment>
 # Resolves the model + effort to run a container's `claude` invocation on,
-# reading .claude/model-routing.yaml (defaults + per-segment overrides).
+# reading model-routing.yaml (defaults + per-segment overrides).
 # stdout: two lines, "<model>\n<effort>".
+#
+# The config is read from the HARNESS path only, never from /workspace. The
+# branch under dispatch or review must not select the model of the agent that
+# reviews it: /workspace is a checkout of the PR branch (agent-dispatch.sh
+# review-pr), so a branch could otherwise set
+# `segments: acceptance-review: { model: <weak model> }` and weaken the merge
+# gate judging it. Dev and fix agents consume untrusted issue/PR text, so branch
+# content is never a trusted input to harness configuration (same rule as the
+# token reporter, Issue #3041). The image bakes this file
+# (.devcontainer/Dockerfile) and every dispatch path bind-mounts the harness
+# checkout's copy over it read-only, so routing edits need no image rebuild.
+#
+# CFGMS_MODEL_ROUTING_FILE is the host operator's escape hatch (used by the
+# tests below and by benchmark tooling); it is set from host env, not from the
+# repo under review.
 #
 # CFGMS_MODEL_OVERRIDE (forwarded into the container by agent-dispatch.sh)
 # takes precedence over the file's model regardless of config state — this is
 # what the benchmark harness uses to run a fixture across models without
-# mutating committed config. It never affects the resolved effort.
+# mutating committed config. It originates from host operator env, not the
+# branch. It never affects the resolved effort.
 #
 # A missing or malformed config file falls back to the hardcoded values below
 # (today's prior hardcoded defaults) so a parse failure degrades to previous
@@ -349,7 +365,7 @@ ac_post_no_op_comment() {
 # own header comment — it is a keyed lookup, not a general YAML implementation.
 ac_resolve_agent_model() {
     local segment="$1"
-    local routing_file="${CFGMS_MODEL_ROUTING_FILE:-/workspace/.claude/model-routing.yaml}"
+    local routing_file="${CFGMS_MODEL_ROUTING_FILE:-/usr/local/share/cfgms-agent/model-routing.yaml}"
     local fallback_model="claude-sonnet-4-6"
     local fallback_effort="high"
     local model="$fallback_model"

--- a/.devcontainer/agent-context.sh
+++ b/.devcontainer/agent-context.sh
@@ -327,3 +327,97 @@ ac_post_no_op_comment() {
     gh pr comment "$pr_num" --repo "${owner}/${repo}" --body "$body" >/dev/null 2>&1 || return 1
     return 0
 }
+
+# ----------------------------------------------------------------------------
+# Per-segment model routing (Issue #3030)
+# ----------------------------------------------------------------------------
+
+# ac_resolve_agent_model <segment>
+# Resolves the model + effort to run a container's `claude` invocation on,
+# reading .claude/model-routing.yaml (defaults + per-segment overrides).
+# stdout: two lines, "<model>\n<effort>".
+#
+# CFGMS_MODEL_OVERRIDE (forwarded into the container by agent-dispatch.sh)
+# takes precedence over the file's model regardless of config state — this is
+# what the benchmark harness uses to run a fixture across models without
+# mutating committed config. It never affects the resolved effort.
+#
+# A missing or malformed config file falls back to the hardcoded values below
+# (today's prior hardcoded defaults) so a parse failure degrades to previous
+# behavior instead of breaking dispatch. The parser only understands the
+# fixed two-level `defaults:`/`segments:` shape declared in the config file's
+# own header comment — it is a keyed lookup, not a general YAML implementation.
+ac_resolve_agent_model() {
+    local segment="$1"
+    local routing_file="${CFGMS_MODEL_ROUTING_FILE:-/workspace/.claude/model-routing.yaml}"
+    local fallback_model="claude-sonnet-4-6"
+    local fallback_effort="high"
+    local model="$fallback_model"
+    local effort="$fallback_effort"
+
+    if [[ -f "$routing_file" ]]; then
+        local resolved
+        resolved=$(python3 - "$routing_file" "$segment" "$fallback_model" "$fallback_effort" <<'PYEOF'
+import sys
+
+path, segment, fallback_model, fallback_effort = sys.argv[1:5]
+model, effort = fallback_model, fallback_effort
+try:
+    defaults = {}
+    segments = {}
+    section = None
+    with open(path) as f:
+        for raw in f:
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if line == "defaults:":
+                section = "defaults"
+                continue
+            if line == "segments:":
+                section = "segments"
+                continue
+            if not line.startswith(" "):
+                section = None
+                continue
+            if section == "defaults":
+                key, sep, val = stripped.partition(":")
+                if sep:
+                    defaults[key.strip()] = val.strip()
+            elif section == "segments":
+                seg_name, sep, rest = stripped.partition(":")
+                if not sep:
+                    continue
+                rest = rest.strip()
+                fields = {}
+                if rest.startswith("{") and rest.endswith("}"):
+                    for pair in rest[1:-1].split(","):
+                        k, psep, v = pair.partition(":")
+                        if psep:
+                            fields[k.strip()] = v.strip()
+                segments[seg_name.strip()] = fields
+    seg_fields = segments.get(segment, {})
+    model = seg_fields.get("model") or defaults.get("model") or fallback_model
+    effort = seg_fields.get("effort") or defaults.get("effort") or fallback_effort
+except Exception:
+    model, effort = fallback_model, fallback_effort
+print(model)
+print(effort)
+PYEOF
+        ) || resolved=""
+        if [[ -n "$resolved" ]]; then
+            local resolved_model resolved_effort
+            resolved_model=$(sed -n '1p' <<< "$resolved")
+            resolved_effort=$(sed -n '2p' <<< "$resolved")
+            [[ -n "$resolved_model" ]] && model="$resolved_model"
+            [[ -n "$resolved_effort" ]] && effort="$resolved_effort"
+        fi
+    fi
+
+    if [[ -n "${CFGMS_MODEL_OVERRIDE:-}" ]]; then
+        model="$CFGMS_MODEL_OVERRIDE"
+    fi
+
+    printf '%s\n%s\n' "$model" "$effort"
+}

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -820,15 +820,23 @@ rm -f /tmp/agent-validation-passed
 # Capture pre-run HEAD SHA so fix-pr mode can detect silent no-ops.
 PRE_FIX_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "")
 
-# All agent modes run on Sonnet 4.6. fix-pr briefly ran on Opus 4.7 (#1580) on
-# the hypothesis that stronger reasoning would compress multi-attempt fix loops,
-# but multi-round fix loops were already rare (~8% of fix-loop PRs) and the Opus
-# token cost was not justified once the pipeline was kept full ahead of the
-# cron. agent-result.json now records model + duration so this trade can be
-# revisited with real data rather than a hypothesis.
-AGENT_MODEL="claude-sonnet-4-6"
+# Model/effort is resolved per-segment from .claude/model-routing.yaml
+# (Issue #3030) rather than hardcoded, so a benchmarked change is a config
+# edit. fix-pr briefly ran on Opus 4.7 (#1580) on the hypothesis that stronger
+# reasoning would compress multi-attempt fix loops, but multi-round fix loops
+# were already rare (~8% of fix-loop PRs) and the Opus token cost was not
+# justified once the pipeline was kept full ahead of the cron. agent-result.json
+# records model + effort + duration so this trade can be revisited with real
+# data rather than a hypothesis.
+case "$MODE" in
+    fix-pr|resolve-conflict) MODEL_SEGMENT="fix-agent" ;;
+    *)                       MODEL_SEGMENT="dev-agent" ;;
+esac
+mapfile -t RESOLVED_MODEL < <(ac_resolve_agent_model "$MODEL_SEGMENT")
+AGENT_MODEL="${RESOLVED_MODEL[0]}"
+AGENT_EFFORT="${RESOLVED_MODEL[1]}"
 
-echo "Starting Claude agent (mode=${MODE}, model=${AGENT_MODEL})..."
+echo "Starting Claude agent (mode=${MODE}, segment=${MODEL_SEGMENT}, model=${AGENT_MODEL}, effort=${AGENT_EFFORT})..."
 EXIT_CODE=0
 # Wait indefinitely for background tasks (the story-complete / fix-pr review team
 # runs qa-test-runner etc. as background Task tool invocations). The CLI default
@@ -910,6 +918,7 @@ cat > /tmp/agent-result.json <<RESULT_EOF
   "pr_num": ${PR_NUM:-null},
   "exit_code": ${EXIT_CODE},
   "model": "${AGENT_MODEL}",
+  "effort": "${AGENT_EFFORT}",
   "agent_duration_seconds": ${AGENT_DURATION_SECONDS:-null},
   "pr_url": "${PR_URL}",
   "branch": "${CURRENT_BRANCH}",

--- a/.devcontainer/scripts/review-entrypoint.sh
+++ b/.devcontainer/scripts/review-entrypoint.sh
@@ -16,6 +16,19 @@
 
 set -euo pipefail
 
+# Helper library for prompt context assembly, incl. ac_resolve_agent_model
+# (Issue #3030). Layout differs between the source tree (this script lives
+# under .devcontainer/scripts/, agent-context.sh under .devcontainer/) and the
+# container (both flattened as siblings under /usr/local/bin/ — see Dockerfile
+# COPY + the runtime -v mount in agent-dispatch.sh) — try the flattened path
+# first since that's the hot path in production.
+_AC_DIR="$(dirname "${BASH_SOURCE[0]}")"
+if [[ -f "${_AC_DIR}/agent-context.sh" ]]; then
+    source "${_AC_DIR}/agent-context.sh"
+else
+    source "${_AC_DIR}/../agent-context.sh"
+fi
+
 PROMPT_FILE="/workspace/.acceptance-review-prompt.md"
 
 # Distributed-lease release (multi-host cron coordination). agent-dispatch.sh
@@ -72,11 +85,17 @@ PR_NUM=$(grep -oP 'pr:\K[0-9]+' "$PROMPT_FILE" | head -1 || echo "")
 STORY_NUM=$(grep -oP 'story:\K[0-9]+' "$PROMPT_FILE" | head -1 || echo "")
 ITEM_ID=$(grep -oP -- '--project-item \K\S+' "$PROMPT_FILE" | head -1 || echo "")
 PROJECT_QUEUE="/workspace/scripts/project-queue.sh"
-echo "Starting Acceptance Reviewer (pr=${PR_NUM} story=${STORY_NUM} item=${ITEM_ID})..."
+# Model/effort resolved from .claude/model-routing.yaml (Issue #3030) —
+# see ac_resolve_agent_model in agent-context.sh.
+mapfile -t RESOLVED_MODEL < <(ac_resolve_agent_model "acceptance-review")
+AGENT_MODEL="${RESOLVED_MODEL[0]}"
+AGENT_EFFORT="${RESOLVED_MODEL[1]}"
+
+echo "Starting Acceptance Reviewer (pr=${PR_NUM} story=${STORY_NUM} item=${ITEM_ID} model=${AGENT_MODEL} effort=${AGENT_EFFORT})..."
 
 EXIT_CODE=0
 PROMPT_CONTENT=$(cat "$PROMPT_FILE")
-claude --dangerously-skip-permissions --model claude-sonnet-4-6 -p "$PROMPT_CONTENT" || EXIT_CODE=$?
+claude --dangerously-skip-permissions --model "$AGENT_MODEL" -p "$PROMPT_CONTENT" || EXIT_CODE=$?
 
 # --- Phase 2: Failsafe project status reset ---
 # The agent is instructed to update project status before exiting.
@@ -100,7 +119,8 @@ cat > /tmp/agent-result.json <<RESULT_EOF
   "pr_num": ${PR_NUM:-null},
   "story_num": ${STORY_NUM:-null},
   "exit_code": ${EXIT_CODE},
-  "model": "claude-sonnet-4-6",
+  "model": "${AGENT_MODEL}",
+  "effort": "${AGENT_EFFORT}",
   "timestamp": "$(date -Iseconds)"
 }
 RESULT_EOF

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,14 +8,17 @@
 .git
 
 # Claude Code agent state, incl. worktree checkouts (~400MB+).
-# Exception: the agent image bakes the token reporter into the harness so a
-# dispatched branch cannot disable its own accounting (.devcontainer/Dockerfile,
-# Issue #3041). Re-include exactly those two files — never `.claude` wholesale,
-# since every builder here does `COPY . .` and would bake session transcripts,
-# worktree checkouts and credential-adjacent state into an image layer.
+# Exception: the agent image bakes harness-owned config into the image so a
+# dispatched branch can neither disable its own accounting (token reporter,
+# Issue #3041) nor choose the model its own reviewer runs on (model routing,
+# Issue #3030) — see .devcontainer/Dockerfile. Re-include exactly those files —
+# never `.claude` wholesale, since every builder here does `COPY . .` and would
+# bake session transcripts, worktree checkouts and credential-adjacent state
+# into an image layer.
 .claude
 !.claude/metrics/token_report.py
 !.claude/metrics/pricing.json
+!.claude/model-routing.yaml
 
 # Frontend toolchain artifacts — images build Go only; node_modules exists
 # wherever the frontend CI lane or a local npm ci ran (~180MB, 14k files)


### PR DESCRIPTION
## Summary

Model selection was hardcoded in three places (`entrypoint.sh`, `review-entrypoint.sh`, agent frontmatter) and could not be changed without a code edit — a benchmark result could never be applied without shipping a diff. Adds per-segment model/effort routing read from a single config file, with today's hardcoded values as defaults, so a benchmarked change is a config edit instead.

## Changes made

- **`.claude/model-routing.yaml`** — `defaults:`/`segments:` config keyed by segment (`dev-agent`, `fix-agent`, `pr-review`, `acceptance-review`), today's values (`claude-sonnet-4-6` / `high`) as defaults.
- **`ac_resolve_agent_model()`** (`.devcontainer/agent-context.sh`) — plain-stdlib `python3` resolver (no PyYAML in the devcontainer image) for the fixed two-level shape. Falls back to the hardcoded defaults on a missing or malformed file, so a parse failure degrades to prior behavior rather than breaking dispatch.
- **`entrypoint.sh`** routes `issue`/`branch` → `dev-agent`, `fix-pr`/`resolve-conflict` → `fix-agent`. **`review-entrypoint.sh`** now sources `agent-context.sh` and routes to `acceptance-review`.
- **`CFGMS_MODEL_OVERRIDE`** — forwarded by `agent-dispatch.sh` into all three `docker run` paths (`launch`, `launch-generic`, `review-pr`); takes precedence over the file, used by the benchmark harness to run a fixture across models without mutating committed config.
- **`/tmp/agent-result.json`** in both entrypoints now records the resolved `model` and `effort`.
- **Security hardening (found by the security lens during `/story-complete` review):** the resolver initially defaulted to `/workspace/.claude/model-routing.yaml` — but `/workspace` is a checkout of the branch under dispatch/review, so a PR branch could set `segments: acceptance-review: { model: <weak model> }` and choose the model of its own reviewer, self-weakening the merge gate. Fixed by applying the same pattern already used for the token reporter (#3041): bake the config into the harness image at `/usr/local/share/cfgms-agent/model-routing.yaml` and bind-mount the harness checkout's copy read-only over that path on every dispatch path, so `/workspace` is never consulted.
- No actual model-assignment change — every segment still resolves to `claude-sonnet-4-6`.

## Test plan

- [x] `.claude/scripts/tests/model_routing.test.sh` (42 checks) — resolver precedence/fallback behavior (known/unknown/missing/malformed config, `CFGMS_MODEL_OVERRIDE` precedence), entrypoint/dispatch wiring, harness-only routing-path enforcement
- [x] `.claude/scripts/tests/session_persistence.test.sh` (53 checks, extended) — Dockerfile bake + `.dockerignore` re-include coverage for the routing config
- [x] `make test` / `make lint` / `make security-precommit` / `make check-architecture` / `make security-scan` all pass
- [x] Pre-push validation (race-detector unit tests + security + lint) passed
- [x] `/story-complete` adversarial review (acceptance check, tests, QA code review, security) passed after 1 fix round

Fixes #3030

Co-Authored-By: Claude <noreply@anthropic.com>