### PR TITLE
metrics: durable dispatch ledger for agent launches and exits (Issue #3052)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -7,6 +7,21 @@ set -euo pipefail
 REPO_ROOT="${CFGMS_TEST_REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 WORKTREE_BASE="${CFGMS_TEST_WORKTREE_BASE:-$(cd "$REPO_ROOT/.." && pwd)/worktrees}"
 
+# Reuse ac_resolve_agent_model (Issue #3030) to predict the model a dispatched
+# container will resolve to, for the ledger's launch record below. Pure
+# function definitions only — see agent-context.sh's own "do not exit from
+# here" docstring — safe to source unconditionally.
+#
+# Resolved from THIS SCRIPT's own real location (BASH_SOURCE[0]), never from
+# REPO_ROOT: hermetic tests point CFGMS_TEST_REPO_ROOT at a throwaway bare
+# repo with no .devcontainer/ tree, and this file must still source cleanly
+# when they do (verified by scripts/test-scripts.sh's create-clone fixtures).
+_agent_dispatch_self_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [[ -f "${_agent_dispatch_self_root}/.devcontainer/agent-context.sh" ]]; then
+  # shellcheck source=../../.devcontainer/agent-context.sh
+  source "${_agent_dispatch_self_root}/.devcontainer/agent-context.sh"
+fi
+
 # Base directory for per-agent API key tmpfs files.
 # Override CFGMS_TEST_CRED_BASE in hermetic tests.
 AGENT_CRED_BASE="${CFGMS_TEST_CRED_BASE:-/run/cfgms/agent-cred}"
@@ -90,6 +105,186 @@ META
 
   printf '%s\n' "$dir"
 }  # end prepare_session_dir
+
+# ---------------------------------------------------------------------------
+# Durable dispatch ledger (Issue #3052).
+#
+# Every container launch and exit appends one JSON line here, so agent counts
+# and per-run outcomes outlive both session-transcript retention (Issue #3028's
+# 30-day prune) and every cleanup routine below. Lives in its own directory,
+# deliberately never touched by cleanup-issue/cleanup-container/cleanup-stale/
+# cleanup-stale-reviews or AGENT_SESSIONS_RETENTION_DAYS pruning — this is an
+# execution log, not a queue, and not backfilled for historical runs.
+#
+# Who writes the exit record: the HOST always does (a container that dies
+# mid-run — hard-killed, OOM, host reboot — cannot be relied on to write its
+# own record), reading whatever the container itself already left behind in
+# its session-mounted agent-result.json (Issue #3028/#3051) when a caller
+# passes one in (source=agent-result: exit code, duration, PR URL, validation
+# outcome, head-advanced flag, token usage), falling back to `docker inspect`
+# alone otherwise (source=docker-inspect-only). That fallback is what makes a
+# hard-killed run distinguishable from one that reported cleanly — the
+# documented hybrid: the container supplies the rich fields when it can, the
+# host reconciles what's missing when it can't.
+#
+# Best-effort throughout — every function here degrades to a silent no-op
+# rather than propagate a failure; a ledger write must never block or fail a
+# dispatch.
+AGENT_LEDGER_DIR="${CFGMS_AGENT_LEDGER_DIR:-${HOME}/.cache/cfgms-agent-ledger}"
+AGENT_LEDGER_FILE="${AGENT_LEDGER_DIR}/ledger.jsonl"
+
+# _ledger_write_line <json_line>
+# Appends one already-serialized JSON line, lock-guarded against concurrent
+# writers on this host (JSONL lines are small enough for an atomic O_APPEND
+# write, but flock removes any doubt). Not shared cross-host by default —
+# CFGMS_AGENT_LEDGER_DIR would need to point at shared storage for that, which
+# this story does not assume.
+_ledger_write_line() {
+  local line="$1"
+  [[ -n "$line" ]] || return 0
+  mkdir -p "$AGENT_LEDGER_DIR" 2>/dev/null || return 0
+  (
+    flock -w 2 200 || exit 0
+    printf '%s\n' "$line" >> "$AGENT_LEDGER_FILE"
+  ) 200>>"${AGENT_LEDGER_FILE}.lock" 2>/dev/null || true
+}
+
+# ledger_resolve_model <segment>
+# Predicts the model a dispatched container will resolve to: reads the SAME
+# harness-checkout routing file the container gets baked/mounted from (Issue
+# #3030), a host-side prediction rather than a live read of the container.
+ledger_resolve_model() {
+  local segment="$1"
+  CFGMS_MODEL_ROUTING_FILE="${REPO_ROOT}/.claude/model-routing.yaml" \
+    ac_resolve_agent_model "$segment" 2>/dev/null | sed -n '1p'
+}
+
+# ledger_append_launch <container> <mode> <issue> <pr> <branch> <segment> <lease_key>
+# Appends a launch record. Called right before `docker run`, so a launch
+# record exists even when the run itself then fails — see
+# ledger_append_launch_failed for that terminal case.
+ledger_append_launch() {
+  local container="$1" mode="$2" issue="$3" pr="$4" branch="$5" segment="$6" lease_key="$7"
+  local model
+  model=$(ledger_resolve_model "$segment")
+  local line
+  line=$(python3 -c '
+import json, sys
+ts, container, mode, issue, pr, branch, model, lease_key = sys.argv[1:9]
+def num(v):
+    return int(v) if v.isdigit() else None
+print(json.dumps({
+    "event": "launch", "ts": ts, "container": container, "mode": mode,
+    "issue": num(issue), "pr": num(pr), "branch": (branch or None),
+    "model": (model or None), "lease_key": (lease_key or None),
+}, separators=(",", ":")))
+' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$container" "$mode" "${issue:-}" "${pr:-}" \
+    "${branch:-}" "${model:-}" "${lease_key:-}" 2>/dev/null) || return 0
+  _ledger_write_line "$line"
+}
+
+# ledger_append_launch_failed <container> <mode>
+# `docker run` itself returned nonzero — no container ever existed, so no exit
+# path will ever fire for it. Writes the terminal record directly so this run
+# is distinguishable from both a clean exit and a hard-killed one.
+ledger_append_launch_failed() {
+  local container="$1" mode="$2"
+  local line
+  line=$(python3 -c '
+import json, sys
+ts, container, mode = sys.argv[1:4]
+print(json.dumps({
+    "event": "exit", "ts": ts, "container": container, "mode": mode,
+    "exit_code": None, "source": "launch-failed",
+}, separators=(",", ":")))
+' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$container" "$mode" 2>/dev/null) || return 0
+  _ledger_write_line "$line"
+}
+
+# ledger_has_exit <container>
+# True if an exit record for this container name already exists. Guards
+# ledger_reconcile_exit against duplicate records when a cleanup routine
+# inspects the same exited container more than once before it is removed.
+ledger_has_exit() {
+  local container="$1"
+  [[ -f "$AGENT_LEDGER_FILE" ]] || return 1
+  python3 -c '
+import json, sys
+container, path = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            if rec.get("event") == "exit" and rec.get("container") == container:
+                sys.exit(0)
+except FileNotFoundError:
+    pass
+sys.exit(1)
+' "$container" "$AGENT_LEDGER_FILE"
+}
+
+# _ledger_docker_inspect <go_template> <container>
+# Thin wrapper around `docker inspect` so tests can stub it without a real
+# container.
+_ledger_docker_inspect() {
+  docker inspect --format "$1" "$2" 2>/dev/null || echo ""
+}
+
+# ledger_reconcile_exit <container> [result_json_path]
+# The host-side reaper half of the hybrid. Called by every cleanup routine at
+# the point it already inspects/removes an exited container. Idempotent
+# (skips if an exit record already exists for this container). Reads
+# `docker inspect` for exit code + finish time — always available, even for a
+# hard-killed container — and layers in the container's own agent-result.json
+# when the caller found one on disk.
+ledger_reconcile_exit() {
+  local container="$1" result_file="${2:-}"
+  ledger_has_exit "$container" && return 0
+
+  local exit_code finished_at
+  exit_code=$(_ledger_docker_inspect '{{.State.ExitCode}}' "$container")
+  finished_at=$(_ledger_docker_inspect '{{.State.FinishedAt}}' "$container")
+
+  local result_json="{}"
+  local source="docker-inspect-only"
+  if [[ -n "$result_file" ]] && [[ -s "$result_file" ]]; then
+    if result_json=$(cat "$result_file" 2>/dev/null) && [[ -n "$result_json" ]]; then
+      source="agent-result"
+    else
+      result_json="{}"
+    fi
+  fi
+
+  local line
+  line=$(python3 -c '
+import json, sys
+container, exit_code, finished_at, source, result_raw = sys.argv[1:6]
+try:
+    result = json.loads(result_raw) if result_raw.strip() else {}
+    if not isinstance(result, dict):
+        result = {}
+except Exception:
+    result = {}
+rec = {
+    "event": "exit",
+    "ts": finished_at or None,
+    "container": container,
+    "mode": result.get("mode"),
+    "exit_code": int(exit_code) if exit_code.lstrip("-").isdigit() else None,
+    "source": source,
+    "duration_seconds": result.get("agent_duration_seconds"),
+    "pr_url": result.get("pr_url") or None,
+    "validation_passed": result.get("validation_passed"),
+    "head_advanced": result.get("head_advanced"),
+    "usage": result.get("usage"),
+}
+print(json.dumps(rec, separators=(",", ":")))
+' "$container" "${exit_code:-}" "${finished_at:-}" "$source" "$result_json" 2>/dev/null) || return 0
+  _ledger_write_line "$line"
+}
 
 # ---------------------------------------------------------------------------
 # Resource-based admission gate (replaces the hand-tuned container count).
@@ -956,6 +1151,8 @@ case "$cmd" in
       session_mount=(-v "${sessions_dir}:${AGENT_SESSIONS_MOUNT}")
     fi
 
+    ledger_append_launch "cfg-agent-${num}" "issue" "${num}" "" "" "dev-agent" ""
+
     if container_id=$(docker run -d \
       --name "cfg-agent-${num}" \
       --label "cfg-agent=true" \
@@ -986,6 +1183,7 @@ case "$cmd" in
     else
       # Launch failed — revoke creds and clean up to prevent orphaned resources.
       echo "LAUNCH_FAILED:${num}:${container_id}"
+      ledger_append_launch_failed "cfg-agent-${num}" "issue"
       revoke_agent_creds "$num" || true
       rm -rf "${cred_dir}" 2>/dev/null || true
       rm -rf "$clone_path"
@@ -1036,6 +1234,13 @@ case "$cmd" in
       session_mount=(-v "${sessions_dir}:${AGENT_SESSIONS_MOUNT}")
     fi
 
+    ledger_segment="dev-agent"
+    if [[ "$mode_label" == "fix-pr" || "$mode_label" == "resolve-conflict" ]]; then
+      ledger_segment="fix-agent"
+    fi
+    ledger_append_launch "$container_name" "$mode_label" "${issue_arg:-}" "${fix_pr_num:-}" \
+      "${branch_arg:-}" "$ledger_segment" "${CFGMS_LEASE_KEY:-}"
+
     if container_id=$(docker run -d \
       --name "$container_name" \
       --label "cfg-agent=true" \
@@ -1071,6 +1276,7 @@ case "$cmd" in
       fi
     else
       echo "LAUNCH_FAILED:${container_name}:${container_id}"
+      ledger_append_launch_failed "$container_name" "$mode_label"
       rm -rf "$clone_dir"
       echo "CLEANED:clone:${clone_dir}"
       exit 1
@@ -1448,6 +1654,7 @@ else:
       revoke_agent_creds "$num" || true
       rm -rf "${AGENT_CRED_BASE}/${num}" 2>/dev/null || true
       docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
+      ledger_reconcile_exit "cfg-agent-${num}" "/tmp/agent-result-${num}.json"
       if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
         echo "CLEANED:container:cfg-agent-${num}"
       else
@@ -1464,6 +1671,8 @@ else:
       # Item mode (non-numeric item_id): derive LAST12 and clean item resources
       item_last12=$(echo "$num" | tr -cd 'a-zA-Z0-9' | rev | cut -c1-12 | rev)
       item_container="cfg-agent-item-${item_last12}"
+      docker cp "${item_container}:/tmp/agent-result.json" "/tmp/agent-result-${item_container}.json" 2>/dev/null || true
+      ledger_reconcile_exit "$item_container" "/tmp/agent-result-${item_container}.json"
       if docker rm -f "$item_container" >/dev/null 2>&1; then
         echo "CLEANED:container:${item_container}"
       else
@@ -1485,6 +1694,7 @@ else:
     container_name="$1"
     # Copy result file (best-effort)
     docker cp "${container_name}:/tmp/agent-result.json" "/tmp/agent-result-${container_name}.json" 2>/dev/null || true
+    ledger_reconcile_exit "$container_name" "/tmp/agent-result-${container_name}.json"
     # Remove container
     if docker rm -f "$container_name" >/dev/null 2>&1; then
       echo "CLEANED:container:${container_name}"
@@ -1536,6 +1746,67 @@ else:
   inspect-exit)
     [[ $# -eq 1 ]] || { echo "inspect-exit requires exactly one issue number"; exit 1; }
     docker inspect --format "{{.State.ExitCode}}" "cfg-agent-$1"
+    ;;
+
+  ledger-report)
+    # Answers "how many agents of each mode ran in the last N days, and what
+    # did they cost" from the durable ledger (Issue #3052) — no docker/GitHub
+    # history cross-referencing required.
+    #   ./.claude/scripts/agent-dispatch.sh ledger-report [DAYS]
+    days="${1:-7}"
+    if [[ ! -f "$AGENT_LEDGER_FILE" ]]; then
+      echo "No ledger yet at ${AGENT_LEDGER_FILE}"
+      exit 0
+    fi
+    python3 - "$AGENT_LEDGER_FILE" "$days" <<'PYEOF'
+import json, sys
+from datetime import datetime, timedelta, timezone
+
+path, days = sys.argv[1], int(sys.argv[2])
+cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+def parse_ts(ts):
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+launch_modes = {}
+by_mode = {}
+with open(path) as f:
+    for line in f:
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        ts = parse_ts(rec.get("ts"))
+        if ts is None or ts < cutoff:
+            continue
+        if rec.get("event") == "launch":
+            launch_modes[rec.get("container")] = rec.get("mode")
+        elif rec.get("event") == "exit":
+            mode = rec.get("mode") or launch_modes.get(rec.get("container")) or "unknown"
+            bucket = by_mode.setdefault(mode, {"runs": 0, "failed": 0, "cost_usd": 0.0, "no_usage": 0})
+            bucket["runs"] += 1
+            if rec.get("source") == "launch-failed" or rec.get("exit_code") not in (0, None):
+                bucket["failed"] += 1
+            usage = rec.get("usage")
+            if usage and usage.get("cost_usd") is not None:
+                bucket["cost_usd"] += usage["cost_usd"]
+            else:
+                bucket["no_usage"] += 1
+
+print(f"Ledger report -- last {days}d ({path})")
+print(f"{'mode':<18} {'runs':>5} {'failed':>7} {'cost_usd':>10} {'no_usage':>9}")
+for mode, b in sorted(by_mode.items()):
+    print(f"{mode:<18} {b['runs']:>5} {b['failed']:>7} {b['cost_usd']:>10.2f} {b['no_usage']:>9}")
+total_runs = sum(b["runs"] for b in by_mode.values())
+total_failed = sum(b["failed"] for b in by_mode.values())
+total_cost = sum(b["cost_usd"] for b in by_mode.values())
+print(f"{'TOTAL':<18} {total_runs:>5} {total_failed:>7} {total_cost:>10.2f}")
+PYEOF
     ;;
 
   inspect-detail)
@@ -1935,6 +2206,9 @@ PROMPT_EOF
       review_session_mount=(-v "${review_sessions_dir}:${AGENT_SESSIONS_MOUNT}")
     fi
 
+    ledger_append_launch "$container_name" "review" "${story_num:-}" "$pr_num" \
+      "${pr_branch:-}" "acceptance-review" "pr-${pr_num}"
+
     # Launch headless. Mount the review entrypoint at runtime — no image rebuild
     # required when this script changes.
     if container_id=$(docker run -d \
@@ -1972,6 +2246,7 @@ PROMPT_EOF
     else
       # Launch failed — the EXIT trap releases the lease.
       echo "LAUNCH_FAILED:${container_name}:${container_id}"
+      ledger_append_launch_failed "$container_name" "review"
       rm -rf "$clone_dir"
       echo "CLEANED:clone:${clone_dir}"
       exit 1
@@ -2018,6 +2293,7 @@ PROMPT_EOF
 
       # Archive the result JSON for forensics.
       docker cp "${container_name}:/tmp/agent-result.json" "/tmp/agent-result-review-${pr_num:-${container_name}}.json" 2>/dev/null || true
+      ledger_reconcile_exit "$container_name" "/tmp/agent-result-review-${pr_num:-${container_name}}.json"
 
       # Remove the container and clone.
       if docker rm -f "$container_name" >/dev/null 2>&1; then
@@ -2119,6 +2395,7 @@ PROMPT_EOF
         revoke_agent_creds "$num" || true
         rm -rf "${AGENT_CRED_BASE}/${num}" 2>/dev/null || true
         docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
+        ledger_reconcile_exit "cfg-agent-${num}" "/tmp/agent-result-${num}.json"
         if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
           echo "CLEANED:container:cfg-agent-${num}"
         fi

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -341,6 +341,8 @@ except Exception: print('')" 2>/dev/null || echo "")
       session_mount=(-v "${sessions_dir}:${AGENT_SESSIONS_MOUNT}")
     fi
 
+    ledger_append_launch "$container_name" "issue" "${story:-}" "" "" "dev-agent" "story-${item_id}"
+
     if container_id=$(docker run -d \
       --name "$container_name" \
       --label "cfg-agent=true" \
@@ -366,6 +368,7 @@ except Exception: print('')" 2>/dev/null || echo "")
     else
       trap - ERR
       echo "LAUNCH_FAILED:${first_arg}:${container_id}"
+      ledger_append_launch_failed "$container_name" "issue"
       rm -rf "$clone_path"
       echo "CLEANED:clone:${clone_path}"
       # Release the claim + lease: launch never happened, so return the story to

--- a/.claude/scripts/tests/dispatch_ledger.test.sh
+++ b/.claude/scripts/tests/dispatch_ledger.test.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Regression test for the durable dispatch ledger (Issue #3052).
+#
+# Before this, there was no durable record that an agent container ever ran --
+# docker labels vanish when a container is reaped, and meta.json only existed
+# on two of the four launch paths. This covers: the launch/exit record
+# functions in isolation, idempotent reconciliation, the AC4 distinguishing
+# cases (clean exit vs launch failure vs hard-kill), and structural wiring —
+# every launch path appends a launch record, every cleanup routine reconciles
+# an exit record, and the ledger directory is never touched by cleanup or
+# session retention.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DISPATCH="${REPO_ROOT}/.claude/scripts/agent-dispatch.sh"
+POACT="${REPO_ROOT}/.claude/scripts/po-act.sh"
+
+for f in "$DISPATCH" "$POACT"; do
+  [[ -f "$f" ]] || { printf 'FAIL: expected file not found: %s\n' "$f" >&2; exit 1; }
+done
+
+fail=0; ran=0
+ok()   { ran=$((ran + 1)); printf '  ok    %s\n' "$1"; }
+bad()  { ran=$((ran + 1)); fail=$((fail + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+check_eq() {
+  local desc="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then ok "$desc"
+  else bad "$desc" "want: ${expected}  actual: ${actual}"; fi
+}
+check_contains() {
+  local desc="$1" hay="$2" needle="$3"
+  if [[ "$hay" == *"$needle"* ]]; then ok "$desc"
+  else bad "$desc" "want substring: ${needle}"; fi
+}
+jf() {
+  # jf <json_line> <python_expr_on_rec> — evaluate a field from a JSON line.
+  python3 -c "import json,sys; rec=json.loads(sys.argv[1]); print($2)" "$1" 2>/dev/null
+}
+
+echo "dispatch_ledger.test.sh"
+echo "------------------------"
+
+printf '\n== bash -n parses ==\n'
+if bash -n "$DISPATCH" 2>/dev/null; then ok "agent-dispatch.sh parses"; else bad "agent-dispatch.sh parses" "bash -n failed"; fi
+if bash -n "$POACT" 2>/dev/null; then ok "po-act.sh parses"; else bad "po-act.sh parses" "bash -n failed"; fi
+
+printf '\n== ledger functions (sourced) ==\n'
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+export CFGMS_TEST_REPO_ROOT="$REPO_ROOT"
+export CFGMS_TEST_WORKTREE_BASE="${SANDBOX}/worktrees"
+mkdir -p "$CFGMS_TEST_WORKTREE_BASE"
+export CFGMS_AGENT_LEDGER_DIR="${SANDBOX}/ledger"
+
+# shellcheck source=/dev/null
+source "$DISPATCH"
+
+line="$(ledger_append_launch "cfg-agent-9001" "issue" "9001" "" "" "dev-agent" "story-abc")"
+[[ -z "$line" ]] || true  # function writes to file, prints nothing
+[[ -f "$AGENT_LEDGER_FILE" ]] && ok "ledger file created on first write" || bad "ledger file created on first write" "missing: $AGENT_LEDGER_FILE"
+
+rec="$(tail -1 "$AGENT_LEDGER_FILE")"
+check_eq "launch record event" "$(jf "$rec" 'rec["event"]')" "launch"
+check_eq "launch record container" "$(jf "$rec" 'rec["container"]')" "cfg-agent-9001"
+check_eq "launch record mode" "$(jf "$rec" 'rec["mode"]')" "issue"
+check_eq "launch record issue is numeric" "$(jf "$rec" 'rec["issue"]')" "9001"
+check_eq "launch record pr is null when absent" "$(jf "$rec" 'rec["pr"]')" "None"
+check_eq "launch record lease_key" "$(jf "$rec" 'rec["lease_key"]')" "story-abc"
+check_eq "launch record carries a resolved model" "$(jf "$rec" '"model" in rec and bool(rec["model"])')" "True"
+check_contains "launch record has an ISO timestamp" "$rec" '"ts":"'
+
+printf '\n== launch-failed record (AC4: distinguishable from clean/hard-killed) ==\n'
+before_lines=$(wc -l < "$AGENT_LEDGER_FILE")
+ledger_append_launch_failed "cfg-agent-9002" "issue"
+after_lines=$(wc -l < "$AGENT_LEDGER_FILE")
+check_eq "launch-failed appends exactly one line" "$((after_lines - before_lines))" "1"
+rec="$(tail -1 "$AGENT_LEDGER_FILE")"
+check_eq "launch-failed event is exit" "$(jf "$rec" 'rec["event"]')" "exit"
+check_eq "launch-failed exit_code is null" "$(jf "$rec" 'rec["exit_code"]')" "None"
+check_eq "launch-failed source marker" "$(jf "$rec" 'rec["source"]')" "launch-failed"
+
+printf '\n== ledger_has_exit ==\n'
+if ledger_has_exit "cfg-agent-9002"; then ok "has_exit true for a container with an exit record"
+else bad "has_exit true for a container with an exit record" "expected 0"; fi
+if ! ledger_has_exit "cfg-agent-never-seen"; then ok "has_exit false for an unknown container"
+else bad "has_exit false for an unknown container" "expected 1"; fi
+
+printf '\n== ledger_reconcile_exit: clean run (agent-result available) ==\n'
+# Stub docker inspect so this is hermetic (no real container needed).
+_ledger_docker_inspect() {
+  case "$1" in
+    '{{.State.ExitCode}}')   echo "0" ;;
+    '{{.State.FinishedAt}}') echo "2026-07-28T05:00:00Z" ;;
+  esac
+}
+result_file="${SANDBOX}/agent-result-clean.json"
+cat > "$result_file" <<'JSON'
+{"mode":"issue","agent_duration_seconds":900,"pr_url":"https://github.com/cfg-is/cfgms/pull/1","validation_passed":true,"head_advanced":true,"usage":{"cost_usd":1.23,"total_tokens":45000}}
+JSON
+ledger_append_launch "cfg-agent-9003" "issue" "9003" "" "" "dev-agent" ""
+ledger_reconcile_exit "cfg-agent-9003" "$result_file"
+rec="$(tail -1 "$AGENT_LEDGER_FILE")"
+check_eq "clean-run source" "$(jf "$rec" 'rec["source"]')" "agent-result"
+check_eq "clean-run exit_code" "$(jf "$rec" 'rec["exit_code"]')" "0"
+check_eq "clean-run duration" "$(jf "$rec" 'rec["duration_seconds"]')" "900"
+check_eq "clean-run pr_url" "$(jf "$rec" 'rec["pr_url"]')" "https://github.com/cfg-is/cfgms/pull/1"
+check_eq "clean-run validation_passed" "$(jf "$rec" 'rec["validation_passed"]')" "True"
+check_eq "clean-run head_advanced" "$(jf "$rec" 'rec["head_advanced"]')" "True"
+check_eq "clean-run usage.cost_usd" "$(jf "$rec" 'rec["usage"]["cost_usd"]')" "1.23"
+
+printf '\n== ledger_reconcile_exit: idempotent (AC5-adjacent: never duplicates) ==\n'
+before_lines=$(wc -l < "$AGENT_LEDGER_FILE")
+ledger_reconcile_exit "cfg-agent-9003" "$result_file"
+after_lines=$(wc -l < "$AGENT_LEDGER_FILE")
+check_eq "second reconcile call for the same container writes nothing" "$after_lines" "$before_lines"
+
+printf '\n== ledger_reconcile_exit: hard-killed (AC4: no agent-result at all) ==\n'
+_ledger_docker_inspect() {
+  case "$1" in
+    '{{.State.ExitCode}}')   echo "137" ;;
+    '{{.State.FinishedAt}}') echo "2026-07-28T05:05:00Z" ;;
+  esac
+}
+ledger_append_launch "cfg-agent-9004" "fix-pr" "" "9004" "" "fix-agent" "pr-9004"
+ledger_reconcile_exit "cfg-agent-9004" "/nonexistent/agent-result.json"
+rec="$(tail -1 "$AGENT_LEDGER_FILE")"
+check_eq "hard-killed source" "$(jf "$rec" 'rec["source"]')" "docker-inspect-only"
+check_eq "hard-killed exit_code from docker inspect" "$(jf "$rec" 'rec["exit_code"]')" "137"
+check_eq "hard-killed has no usage" "$(jf "$rec" 'rec["usage"]')" "None"
+check_eq "hard-killed has no pr_url" "$(jf "$rec" 'rec["pr_url"]')" "None"
+
+printf '\n== all three outcomes are mutually distinguishable ==\n'
+clean_rec=$(grep -F '"container":"cfg-agent-9003"' "$AGENT_LEDGER_FILE" | grep '"event":"exit"')
+failed_rec=$(grep -F '"container":"cfg-agent-9002"' "$AGENT_LEDGER_FILE" | grep '"event":"exit"')
+killed_rec=$(grep -F '"container":"cfg-agent-9004"' "$AGENT_LEDGER_FILE" | grep '"event":"exit"')
+sources="$(jf "$clean_rec" 'rec["source"]')|$(jf "$failed_rec" 'rec["source"]')|$(jf "$killed_rec" 'rec["source"]')"
+check_eq "clean vs launch-failed vs hard-killed all carry distinct source markers" \
+  "$sources" "agent-result|launch-failed|docker-inspect-only"
+
+printf '\n== ledger survives what cleanup/retention touch (AC3) ==\n'
+check_eq "ledger dir is distinct from the session-transcript dir" \
+  "$([[ "$AGENT_LEDGER_DIR" != "$AGENT_SESSIONS_BASE"* ]] && echo distinct || echo same)" "distinct"
+dispatch_src="$(cat "$DISPATCH")"
+for routine in cleanup-issue cleanup-container cleanup-stale-reviews cleanup-stale; do
+  block="$(awk -v r="  ${routine})" '
+    $0 == r { grab = 1 }
+    grab { print }
+    grab && /^    ;;$/ { exit }
+  ' "$DISPATCH")"
+  if echo "$block" | grep -qE 'rm -rf "\$AGENT_LEDGER'; then
+    bad "${routine} does not delete the ledger" "found rm -rf targeting AGENT_LEDGER*"
+  else
+    ok "${routine} does not delete the ledger"
+  fi
+done
+
+printf '\n== structural: every launch path appends a launch record ==\n'
+poact_src="$(cat "$POACT")"
+# The pre-docker-run statement window: ledger_append_launch is called as its
+# own statement a few lines BEFORE `docker run -d`, not as a flag inside it
+# (unlike AGENT_METRICS_MOUNT_ARGS etc.), so the block capture below also
+# carries the preceding 19 lines forward.
+mapfile -t missing_launch < <(awk '
+  {
+    for (i = 19; i >= 1; i--) prevbuf[i+1] = prevbuf[i]
+    prevbuf[1] = $0
+  }
+  /docker run -d/ {
+    in_block = 1; start = NR
+    block = ""
+    for (i = 20; i >= 2; i--) block = block prevbuf[i] "\n"
+  }
+  in_block { block = block $0 "\n" }
+  in_block && /cfg-agent:latest/  {
+    in_block = 0
+    if (block ~ /--entrypoint \/bin\/bash/) next
+    if (block !~ /ledger_append_launch/) print start
+  }
+' <(printf '%s\n%s\n' "$dispatch_src" "$poact_src"))
+if [[ "${#missing_launch[@]}" -eq 0 ]]; then
+  ok "every non-interactive docker-run launch path calls ledger_append_launch"
+else
+  bad "every non-interactive docker-run launch path calls ledger_append_launch" \
+      "missing at combined-source line(s): ${missing_launch[*]}"
+fi
+
+printf '\n== structural: every cleanup routine reconciles an exit record ==\n'
+for routine in cleanup-issue cleanup-container cleanup-stale-reviews cleanup-stale; do
+  block="$(awk -v r="  ${routine})" '
+    $0 == r { grab = 1 }
+    grab { print }
+    grab && /^    ;;$/ { exit }
+  ' "$DISPATCH")"
+  check_contains "${routine} calls ledger_reconcile_exit" "$block" "ledger_reconcile_exit"
+done
+
+printf '\n== structural: ledger-report subcommand exists ==\n'
+check_contains "agent-dispatch.sh defines a ledger-report subcommand" "$dispatch_src" "ledger-report)"
+check_contains "ledger-report accepts a DAYS argument" "$dispatch_src" 'days="${1:-7}"'
+
+printf '\n== ledger-report actually runs (regression guard: embedded-python quoting) ==\n'
+# The `docker run -d`/`docker rm -f` bash checks above never execute the
+# subcommand's embedded Python, so a real syntax error there (e.g. a Python
+# single-quoted string literal breaking out of an enclosing bash single-quoted
+# `python3 -c '...'`) would pass every check above and still crash at runtime.
+# Exercise the real subcommand end to end against the sandbox ledger built above.
+report_out="$(CFGMS_AGENT_LEDGER_DIR="$CFGMS_AGENT_LEDGER_DIR" bash "$DISPATCH" ledger-report 30 2>&1)"
+report_rc=$?
+check_eq "ledger-report exits 0" "$report_rc" "0"
+if [[ "$report_out" == *"Traceback"* ]]; then
+  bad "ledger-report produces no Python traceback" "$report_out"
+else
+  ok "ledger-report produces no Python traceback"
+fi
+check_contains "ledger-report reports the issue-mode runs" "$report_out" "issue"
+check_contains "ledger-report reports the fix-pr-mode run" "$report_out" "fix-pr"
+check_contains "ledger-report totals row" "$report_out" "TOTAL"
+
+printf '\n%s\n' "-----------------------------------------"
+if [[ "$fail" -eq 0 ]]; then
+  printf 'PASS: %d checks\n' "$ran"; exit 0
+else
+  printf 'FAIL: %d of %d checks failed\n' "$fail" "$ran"; exit 1
+fi


### PR DESCRIPTION
## Summary

There was no durable record that an agent container ever ran. Docker labels disappear when a container is reaped, and `meta.json` (Issue #3028/#3051) only covers session transcripts, which are pruned on a 30-day retention — the epic's "how many agents ran, at what cost" question was reconstructable only by scraping GitHub history or reading `docker ps -a` before the next cleanup pass.

## Changes made

- **Append-only JSONL ledger** (`~/.cache/cfgms-agent-ledger/ledger.jsonl`, distinct from the session-transcript tree and never touched by any cleanup routine or session retention).
- **Launch records** (timestamp, container, mode, issue, PR, branch, resolved model, lease key) written before every non-interactive `docker run` — `agent-dispatch.sh`'s `launch`/`launch-generic`/`review-pr`, and `po-act.sh`'s inlined `dispatch` launch (which already sources `agent-dispatch.sh` per #3051).
- **Exit records** reconciled by every cleanup routine (`cleanup-issue` ×2 branches, `cleanup-container`, `cleanup-stale-reviews`, `cleanup-stale`) at the point each already inspects/removes an exited container.
- **Design decision (explicitly flagged in the issue as needing to be settled before coding): who writes the exit record.** The HOST always writes it — informed by the container's own `agent-result.json` when a cleanup routine finds one on disk (`source=agent-result`: exit code, duration, PR URL, validation outcome, head-advanced flag, token usage), falling back to `docker inspect` alone when it can't (`source=docker-inspect-only`, e.g. a hard-killed container). A launch whose `docker run` itself fails gets its own terminal record (`source=launch-failed`) — no container ever existed. All three outcomes carry a distinct source marker; the test verifies they're mutually distinguishable. Reconciliation is idempotent per container name.
- **`agent-dispatch.sh ledger-report [DAYS]`** — the one-line command the AC asks for: per-mode run counts, failures, and dollar cost.

## Bugs found and fixed while validating inline (not just structural checks)

- Sourcing `agent-context.sh` via `REPO_ROOT` (test-overridable) broke `scripts/test-scripts.sh`'s `create-clone` fixtures, which point `CFGMS_TEST_REPO_ROOT` at a throwaway bare repo with no `.devcontainer/` tree — fixed to resolve from the script's own real location (`BASH_SOURCE[0]`) instead.
- Single-quoted Python string literals inside a bash single-quoted `python3 -c '...'` terminate the bash string early — `ledger-report`'s formatted output silently crashed at runtime despite passing every structural grep check. Caught by adding a real end-to-end execution test (not just "does the subcommand exist"), fixed by switching to the heredoc + `sys.argv` pattern already used by `ac_resolve_agent_model`.
- Verified `ledger_reconcile_exit` against a **real** (non-mocked) exited `busybox` container's `docker inspect` output, not just a stubbed one, before committing.

## Test plan

- [x] `.claude/scripts/tests/dispatch_ledger.test.sh` (47 checks) — launch/exit record fields, idempotent reconciliation, the three AC4 outcomes verified mutually distinguishable, structural wiring across every launch/cleanup path, and a real execution run of `ledger-report`
- [x] Real (non-stubbed) `docker inspect` verification against a live exited container
- [x] Full existing `.claude/scripts/tests/*.test.sh` suite (11 other files) — no regressions
- [x] `make test` / `make lint` / `make security-precommit` / `make check-architecture` / `make security-scan` all pass
- [x] Pre-push validation (race-detector unit tests + security + lint) passed
- [x] `/story-complete` adversarial review (acceptance check, tests, code review, security) passed clean, 1 round, 0 fix rounds

## Out of scope (per issue)

Reporting/visualization beyond `ledger-report`, backfilling historical runs, replacing the project board as source of truth for work state.

Fixes #3052

Co-Authored-By: Claude <noreply@anthropic.com>