### PR TITLE
metrics: per-cycle manifest and step-level cost attribution (Issue #3053)

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -319,14 +319,26 @@ separate call needed.
   - `merge-queue` — queue state as JSON
   - `block <ISSUE> <reason>` — set project status Blocked, post escalation comment
   - `release-story <ITEM_ID>` — release a §7 self-dispatch story lease after the PR is up
+  - `cycle-start [cron|cycle]` / `cycle-end` — bracket a cycle's per-step manifest (Issue #3053); see §4.0/§4.1 Step 11 below. Every other subcommand above auto-records a step into it while a cycle is open — nothing else to call.
+  - `cycle-report [N]` — average cost per cycle step across the last N completed cycles
 - `./scripts/pipeline-helper.sh lease-{acquire,release,status,list,gc}` — distributed-lease primitive (multi-host coordination, §4.-1). `lease-acquire <key> [ttl]` prints `ACQUIRED`/`RECLAIMED` (rc0), `HELD` (rc1), or `ACQUIRE_ERROR` (rc2). Used directly only for the inline-op leases below; container-op leases are managed by the dispatch helpers.
 - `./.claude/scripts/po-cycle-preflight.py` — the underlying preflight (called by `po-act.sh preflight`). Accepts `--stdout` for raw JSON or `--path` for the cache path.
 - `./.claude/scripts/agent-dispatch.sh` — lower-level primitives (called by `po-act.sh`)
 
 ### 4.0 Pre-Flight
 
-First fast-forward the local checkout so the cycle runs current pipeline
-scripts, then run preflight:
+Open this cycle's step manifest first (Issue #3053) — every `po-act.sh`
+subcommand from here through Step 11's `cycle-end` auto-records itself into
+it, so cost becomes attributable per step instead of only to the cycle as a
+whole. Pass `cron` for `/po cron`, `cycle` for `/po cycle`:
+
+```bash
+./.claude/scripts/po-act.sh cycle-start cron
+```
+
+Best-effort — a failed `cycle-start` never blocks the cycle, it just runs
+unmeasured (same as before this existed). Then fast-forward the local
+checkout so the cycle runs current pipeline scripts, and run preflight:
 
 ```bash
 ./.claude/scripts/po-act.sh sync
@@ -884,6 +896,17 @@ Post timestamped summary on each active epic. Skip if no actions taken.
 
 **Step 10 — (no reap needed):**
 Nested `Agent` spawns are now **synchronous** (§4): they complete and are consumed on the same turn, leaving no orphaned task-registry entries. There is nothing to `TaskStop`. Do **not** re-introduce a background-spawn + reap step — that was a workaround for the abandoned async-spawn model that caused the cron subagent to stall.
+
+**Step 11 — Close the cycle manifest (Issue #3053):**
+Always run this last, even if an earlier step failed or was skipped — a
+partial manifest describing how far the cycle got is the point, not a
+completed one:
+```bash
+./.claude/scripts/po-act.sh cycle-end
+```
+Correlates measured (never self-reported) cost per step and folds in this
+cycle's dispatch-ledger launches, then closes the manifest. Best-effort —
+never blocks the cycle from finishing.
 
 ### 4.2 Idempotency
 

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -319,8 +319,8 @@ separate call needed.
   - `merge-queue` — queue state as JSON
   - `block <ISSUE> <reason>` — set project status Blocked, post escalation comment
   - `release-story <ITEM_ID>` — release a §7 self-dispatch story lease after the PR is up
-  - `cycle-start [cron|cycle]` / `cycle-end` — bracket a cycle's per-step manifest (Issue #3053); see §4.0/§4.1 Step 11 below. Every other subcommand above auto-records a step into it while a cycle is open — nothing else to call.
-  - `cycle-report [N]` — average cost per cycle step across the last N completed cycles
+  - `cycle-start [cron|cycle]` / `cycle-end` — bracket a cycle's per-step manifest (Issue #3053); see §4.0/§4.1 Step 11 below. Every other subcommand above auto-records a step into it — with the work/no-op/error outcome it actually produced, classified from its own status markers — while a cycle is open. Nested `Agent`/`Skill` spawns (Tech Lead, BA, pin-refresh-runner, pipeline-sweep-runner, reviewers) are read out of this session's transcript by `cycle-end` and land in the manifest's `agents[]` with their roles and measured cost. **Nothing else to call, and nothing to narrate:** never report step outcomes, spawned agents or token counts into the manifest by hand — self-reported numbers were measured 31.5x low, which is why the record is taken from transcripts instead.
+  - `cycle-report [N]` — average cost per cycle step (with its work/no-op split) and per nested agent role, across the last N completed cycles
 - `./scripts/pipeline-helper.sh lease-{acquire,release,status,list,gc}` — distributed-lease primitive (multi-host coordination, §4.-1). `lease-acquire <key> [ttl]` prints `ACQUIRED`/`RECLAIMED` (rc0), `HELD` (rc1), or `ACQUIRE_ERROR` (rc2). Used directly only for the inline-op leases below; container-op leases are managed by the dispatch helpers.
 - `./.claude/scripts/po-cycle-preflight.py` — the underlying preflight (called by `po-act.sh preflight`). Accepts `--stdout` for raw JSON or `--path` for the cache path.
 - `./.claude/scripts/agent-dispatch.sh` — lower-level primitives (called by `po-act.sh`)
@@ -904,9 +904,11 @@ completed one:
 ```bash
 ./.claude/scripts/po-act.sh cycle-end
 ```
-Correlates measured (never self-reported) cost per step and folds in this
-cycle's dispatch-ledger launches, then closes the manifest. Best-effort —
-never blocks the cycle from finishing.
+Correlates measured (never self-reported) cost per step, records the nested
+agents this cycle spawned with their roles — read from this session's own
+transcript rows (`Agent` tool calls carry `subagent_type`), not from anything
+you declare — and folds in this cycle's dispatch-ledger launches, then closes
+the manifest. Best-effort — never blocks the cycle from finishing.
 
 ### 4.2 Idempotency
 

--- a/.claude/metrics/tests/test_token_report.py
+++ b/.claude/metrics/tests/test_token_report.py
@@ -28,6 +28,7 @@ from token_report import (  # noqa: E402
     collect,
     compute_cost,
     correlate_cycle_manifest,
+    extract_agent_spawns,
     parse_transcript,
     totals,
     split_cache_write,
@@ -521,6 +522,199 @@ class TestCycleManifestCorrelation(unittest.TestCase):
         correlate_cycle_manifest(manifest_path, [root], Pricing.load())
         result = json.loads(manifest_path.read_text())
         self.assertIsNotNone(result["cycle_cost_usd"])
+
+
+def agent_spawn_rows(
+    tool_use_id: str,
+    role: str,
+    agent_id: str,
+    ts: str,
+    description: str = "do the thing",
+    tool: str = "Agent",
+    model: str = "claude-sonnet-5",
+) -> list[str]:
+    """The two transcript rows Claude Code writes for one nested agent spawn."""
+    use_input = {"description": description, "subagent_type": role}
+    if tool == "Skill":
+        use_input = {"skill": role, "args": description}
+    return [
+        json.dumps({
+            "type": "assistant",
+            "timestamp": ts,
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": tool_use_id, "name": tool, "input": use_input}
+                ],
+            },
+        }),
+        json.dumps({
+            "type": "user",
+            "timestamp": ts,
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": tool_use_id, "content": "launched"}
+                ],
+            },
+            "toolUseResult": {
+                "agentId": agent_id,
+                "description": description,
+                "resolvedModel": model,
+                "status": "async_launched",
+                "commandName": role,
+            },
+        }),
+    ]
+
+
+class TestNestedAgentSpawns(unittest.TestCase):
+    """AC1: the manifest records nested agents spawned, with their roles.
+
+    A cron cycle's nested agents (Tech Lead, BA, pin-refresh-runner,
+    pipeline-sweep-runner, reviewers) are spawned by the orchestrator's own
+    tool calls, so no helper script sees that boundary -- but the transcript
+    records both the role (`subagent_type`) and the agentId naming the nested
+    transcript, which is what makes the role's cost measurable rather than
+    narrated.
+    """
+
+    def _corpus(self, session: str = "cycle-session") -> Path:
+        root = Path(tempfile.mkdtemp())
+        project = root / "-workspace"
+        project.mkdir()
+        rows = [
+            assistant_row("req_main", timestamp="2026-07-28T10:01:00.000Z"),
+            *agent_spawn_rows(
+                "toolu_tl", "tech-lead", "aaa111", "2026-07-28T10:02:00.000Z",
+                description="Draft tech notes for 3053",
+            ),
+            *agent_spawn_rows(
+                "toolu_ba", "business-analyst", "bbb222", "2026-07-28T10:06:00.000Z",
+                description="Groom the backlog",
+            ),
+        ]
+        (project / f"{session}.jsonl").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+        nested = project / session / "subagents"
+        nested.mkdir(parents=True)
+        (nested / "agent-aaa111.jsonl").write_text(
+            assistant_row(
+                "req_tl", timestamp="2026-07-28T10:02:30.000Z", usage=usage(inp=5000, out=900)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (nested / "agent-bbb222.jsonl").write_text(
+            assistant_row(
+                "req_ba", timestamp="2026-07-28T10:06:30.000Z", usage=usage(inp=1000, out=100)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return root
+
+    def _manifest(self, root: Path, **overrides) -> Path:
+        manifest = {
+            "cycle_id": "cycle-test",
+            "mode": "cron",
+            "session": "cycle-session",
+            "host": "test-host",
+            "start": "2026-07-28T10:00:00Z",
+            "end": "2026-07-28T10:10:00Z",
+            "steps": [
+                {"ts": "2026-07-28T10:01:00Z", "subcommand": "preflight", "args": ""},
+                {"ts": "2026-07-28T10:05:00Z", "subcommand": "state", "args": ""},
+            ],
+            "leases": [],
+            "containers": [],
+            "agents": [],
+        }
+        manifest.update(overrides)
+        path = root / "manifest.json"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        return path
+
+    def test_extract_reads_role_and_agent_id(self):
+        root = self._corpus()
+        spawns = extract_agent_spawns(root / "-workspace" / "cycle-session.jsonl")
+        self.assertEqual(
+            [(s["role"], s["agent_id"]) for s in spawns],
+            [("tech-lead", "aaa111"), ("business-analyst", "bbb222")],
+        )
+
+    def test_skill_fork_records_the_skill_as_the_role(self):
+        root = Path(tempfile.mkdtemp())
+        path = root / "s.jsonl"
+        path.write_text(
+            "\n".join(
+                agent_spawn_rows(
+                    "toolu_sk", "pipeline-sweep", "ccc333", "2026-07-28T10:02:00.000Z",
+                    tool="Skill",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        spawns = extract_agent_spawns(path)
+        self.assertEqual([(s["tool"], s["role"]) for s in spawns], [("Skill", "pipeline-sweep")])
+
+    def test_inline_tool_call_is_not_a_spawn(self):
+        # A Skill that ran inline (no agentId in its result) never became a
+        # nested agent and must not appear as one.
+        root = Path(tempfile.mkdtemp())
+        path = root / "s.jsonl"
+        rows = agent_spawn_rows(
+            "toolu_inline", "story-start", "unused", "2026-07-28T10:02:00.000Z", tool="Skill"
+        )
+        result_row = json.loads(rows[1])
+        result_row["toolUseResult"] = {"success": True, "commandName": "story-start"}
+        path.write_text(rows[0] + "\n" + json.dumps(result_row) + "\n", encoding="utf-8")
+        self.assertEqual(extract_agent_spawns(path), [])
+
+    def test_manifest_records_agents_with_roles_and_measured_cost(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        roles = [a["role"] for a in result["agents"]]
+        self.assertEqual(roles, ["tech-lead", "business-analyst"])
+        tech_lead = result["agents"][0]
+        self.assertEqual(tech_lead["agent_id"], "aaa111")
+        self.assertEqual(tech_lead["model"], "claude-sonnet-5")
+        self.assertEqual(tech_lead["calls"], 1)
+        # Measured from the nested transcript's own usage rows: the Tech Lead
+        # fixture spends 5x the BA's input tokens, so its cost must be larger.
+        self.assertGreater(tech_lead["cost_usd"], result["agents"][1]["cost_usd"])
+
+    def test_agent_is_attributed_to_the_step_that_spawned_it(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        # 10:02 falls in step 0 [10:01, 10:05); 10:06 falls in step 1.
+        self.assertEqual([a["step"] for a in result["agents"]], [0, 1])
+
+    def test_spawns_outside_the_cycle_window_are_excluded(self):
+        # One long-lived session can run several cycles back to back; each
+        # cycle must claim only the agents it actually spawned.
+        root = self._corpus()
+        manifest_path = self._manifest(
+            root, start="2026-07-28T10:04:00Z", end="2026-07-28T10:10:00Z",
+            steps=[{"ts": "2026-07-28T10:05:00Z", "subcommand": "state", "args": ""}],
+        )
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        self.assertEqual([a["role"] for a in result["agents"]], ["business-analyst"])
+
+    def test_nested_agent_cost_rolls_into_the_cycle_total(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        agent_cost = sum(a["cost_usd"] for a in result["agents"])
+        self.assertGreater(agent_cost, 0)
+        self.assertGreaterEqual(result["cycle_cost_usd"], agent_cost)
 
 
 if __name__ == "__main__":

--- a/.claude/metrics/tests/test_token_report.py
+++ b/.claude/metrics/tests/test_token_report.py
@@ -27,6 +27,7 @@ from token_report import (  # noqa: E402
     TranscriptRef,
     collect,
     compute_cost,
+    correlate_cycle_manifest,
     parse_transcript,
     totals,
     split_cache_write,
@@ -375,6 +376,151 @@ class TestCollect(unittest.TestCase):
         calls, _ = collect([root], Pricing.load(), None, ["proj-a"])
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0][0].project, "proj-a")
+
+
+class TestCycleManifestCorrelation(unittest.TestCase):
+    """Bucketing a cycle's measured calls into its recorded step boundaries.
+
+    The core claim under test (Issue #3053): every dollar attributed to a step
+    comes from parse_transcript's per-message usage accounting, never from a
+    step's own self-reported count -- the story exists because self-reporting
+    understated real cost by 31.5x on a real cycle.
+    """
+
+    def _corpus(self, session: str = "cycle-session") -> Path:
+        # A session is identified by its transcript's FILE NAME (see
+        # TranscriptRef.classify), not by any `sessionId` field inside a row --
+        # so the "different session" fixture below must live in its own file.
+        root = Path(tempfile.mkdtemp())
+        project = root / "-workspace"
+        project.mkdir()
+        rows = "\n".join(
+            [
+                # Before any step boundary -> unattributed.
+                assistant_row("req_pre", timestamp="2026-07-28T10:00:00.000Z"),
+                # Falls in step 0 [10:01, 10:05).
+                assistant_row("req_s0a", timestamp="2026-07-28T10:01:00.000Z"),
+                assistant_row("req_s0b", timestamp="2026-07-28T10:03:00.000Z"),
+                # Falls in step 1 [10:05, end).
+                assistant_row("req_s1a", timestamp="2026-07-28T10:06:00.000Z"),
+            ]
+        )
+        (project / f"{session}.jsonl").write_text(rows + "\n", encoding="utf-8")
+        # A different session, in its own transcript file, inside the same
+        # project directory -- must never be counted for this cycle.
+        (project / "other-session.jsonl").write_text(
+            assistant_row("req_other", timestamp="2026-07-28T10:02:00.000Z") + "\n",
+            encoding="utf-8",
+        )
+        return root
+
+    def _manifest(self, tmp_path: Path, session: str = "cycle-session") -> Path:
+        manifest = {
+            "cycle_id": "cycle-test",
+            "mode": "cron",
+            "session": session,
+            "host": "test-host",
+            "start": "2026-07-28T09:59:00Z",
+            "end": "2026-07-28T10:10:00Z",
+            "steps": [
+                {"ts": "2026-07-28T10:01:00Z", "subcommand": "dispatch", "args": "3060"},
+                {"ts": "2026-07-28T10:05:00Z", "subcommand": "enqueue", "args": "3061 3053"},
+            ],
+            "leases": [],
+            "containers": [],
+        }
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        return path
+
+    def test_calls_bucket_into_the_right_step(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        self.assertEqual(result["steps"][0]["calls"], 2)  # req_s0a, req_s0b
+        self.assertEqual(result["steps"][1]["calls"], 1)  # req_s1a
+
+    def test_calls_before_first_boundary_are_unattributed(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        self.assertEqual(result["unattributed"]["calls"], 1)  # req_pre
+
+    def test_other_sessions_never_counted(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        total_calls = (
+            result["steps"][0]["calls"] + result["steps"][1]["calls"] + result["unattributed"]["calls"]
+        )
+        self.assertEqual(total_calls, 4)  # req_pre + 2 in step0 + 1 in step1, never req_other/req_other2
+
+    def test_step_and_unattributed_cost_sums_to_cycle_cost(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        summed = (
+            result["steps"][0]["cost_usd"] + result["steps"][1]["cost_usd"] + result["unattributed"]["cost_usd"]
+        )
+        # Each bucket rounds independently, so the sum of rounded buckets can
+        # drift from the once-rounded cycle total by a unit in the last
+        # decimal place -- that's float rounding, not a mis-attributed call.
+        self.assertAlmostEqual(summed, result["cycle_cost_usd"], places=3)
+        self.assertGreater(result["cycle_cost_usd"], 0)
+
+    def test_cost_is_measured_not_self_reported(self):
+        # The whole point of this story: a step's cost_usd comes from real
+        # per-message usage accounting on the transcript, not from any field
+        # an agent wrote into the manifest itself. Assert the input manifest
+        # carried no cost data at all, and the output carries real numbers
+        # derived purely from the fixture transcript's usage tokens.
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        before = json.loads(manifest_path.read_text())
+        self.assertNotIn("cost_usd", before["steps"][0])
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        after = json.loads(manifest_path.read_text())
+        self.assertIn("cost_usd", after["steps"][0])
+        self.assertIn("total_tokens", after["steps"][0])
+        self.assertGreater(after["steps"][0]["total_tokens"], 0)
+
+    def test_missing_session_skips_without_writing(self):
+        root = self._corpus()
+        manifest_path = self._manifest(root, session="")
+        # No "session" recorded (e.g. a cycle started outside Claude Code) --
+        # correlation must decline rather than guess, and must not touch the
+        # file (a human can still read the raw steps by hand).
+        manifest = json.loads(manifest_path.read_text())
+        manifest["session"] = None
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        before_mtime = manifest_path.stat().st_mtime_ns
+        call_count, note = correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        self.assertEqual(call_count, 0)
+        self.assertIn("no session", note)
+        self.assertEqual(manifest_path.stat().st_mtime_ns, before_mtime)
+
+    def test_malformed_manifest_raises_for_caller_to_handle(self):
+        root = self._corpus()
+        path = root / "bad-manifest.json"
+        path.write_text("{not valid json", encoding="utf-8")
+        with self.assertRaises(json.JSONDecodeError):
+            correlate_cycle_manifest(path, [root], Pricing.load())
+
+    def test_incomplete_cycle_manifest_still_correlates(self):
+        # AC4: a cycle that fails partway leaves a manifest describing how far
+        # it got. Correlation must not require "end" to be set.
+        root = self._corpus()
+        manifest_path = self._manifest(root)
+        manifest = json.loads(manifest_path.read_text())
+        manifest["end"] = None
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        correlate_cycle_manifest(manifest_path, [root], Pricing.load())
+        result = json.loads(manifest_path.read_text())
+        self.assertIsNotNone(result["cycle_cost_usd"])
 
 
 if __name__ == "__main__":

--- a/.claude/metrics/token_report.py
+++ b/.claude/metrics/token_report.py
@@ -540,6 +540,95 @@ def collect(
 # --------------------------------------------------------------------------
 
 
+#: Tool calls that spawn a nested agent. ``Agent``/``Task`` carry the role in
+#: ``subagent_type``; a ``Skill`` call carries it in ``skill`` and only counts
+#: as a spawn when its result says the skill forked into its own agent.
+_SPAWN_TOOLS = ("Agent", "Task", "Skill")
+
+
+def extract_agent_spawns(path: Path) -> list[dict[str, Any]]:
+    """Nested agents a session spawned, with their roles, from its transcript.
+
+    A cron cycle's expensive work happens inside nested agents (Tech Lead, BA,
+    pin-refresh-runner, pipeline-sweep-runner, reviewers), and the orchestrator
+    is the only thing that knows it spawned them -- no helper script sees that
+    boundary. The transcript does record it, though, in two rows:
+
+        assistant  content[] tool_use {name: "Agent",
+                                       input: {subagent_type, description}}
+        user       toolUseResult {agentId, resolvedModel, ...}
+
+    ``subagent_type`` is the role verbatim, and ``agentId`` names the nested
+    transcript (``<session>/subagents/agent-<agentId>.jsonl``), which is how a
+    role gets its measured cost. Reading it here keeps the record measured
+    rather than narrated -- the same reason step cost is not self-reported.
+
+    Returns one dict per spawn: ts, role, description, agent_id, model, tool.
+    """
+    pending: dict[str, dict[str, Any]] = {}
+    spawns: list[dict[str, Any]] = []
+
+    with path.open("rb") as handle:
+        for raw in handle:
+            if b'"tool_use"' not in raw and b'"toolUseResult"' not in raw:
+                continue
+            try:
+                row = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(row, dict):
+                continue
+
+            message = row.get("message")
+            content = message.get("content") if isinstance(message, dict) else None
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") != "tool_use" or block.get("name") not in _SPAWN_TOOLS:
+                        continue
+                    tool_input = block.get("input")
+                    tool_input = tool_input if isinstance(tool_input, dict) else {}
+                    pending[str(block.get("id"))] = {
+                        "ts": row.get("timestamp"),
+                        "tool": block.get("name"),
+                        "role": tool_input.get("subagent_type") or tool_input.get("skill"),
+                        "description": tool_input.get("description") or tool_input.get("args"),
+                    }
+                # A tool_result row identifies WHICH pending spawn it answers.
+                for block in content:
+                    if not isinstance(block, dict) or block.get("type") != "tool_result":
+                        continue
+                    spawn = pending.pop(str(block.get("tool_use_id")), None)
+                    if spawn is None:
+                        continue
+                    result = row.get("toolUseResult")
+                    result = result if isinstance(result, dict) else {}
+                    agent_id = result.get("agentId")
+                    if not agent_id:
+                        # A Skill that ran inline never became an agent.
+                        continue
+                    spawn["agent_id"] = agent_id
+                    spawn["model"] = result.get("resolvedModel")
+                    spawn["role"] = spawn["role"] or result.get("commandName")
+                    spawn["description"] = spawn["description"] or result.get("description")
+                    spawns.append(spawn)
+
+    return spawns
+
+
+def _find_session_transcript(session: str, roots: list[Path]) -> Path | None:
+    """The top-level transcript for a session id, across every project dir."""
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for project_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+            candidate = project_dir / f"{session}.jsonl"
+            if candidate.is_file():
+                return candidate
+    return None
+
+
 def correlate_cycle_manifest(
     manifest_path: Path, roots: list[Path], pricing: Pricing
 ) -> tuple[int, str]:
@@ -554,11 +643,12 @@ def correlate_cycle_manifest(
     not a substitute for this.
 
     Writes cycle_cost_usd, cycle_total_tokens, per-step cost_usd/total_tokens/
-    calls, and an "unattributed" bucket (calls before the first step boundary,
-    or with no timestamp) back into the same manifest file. Returns
-    (call_count, note) for the caller to log; never raises on a malformed or
-    half-written manifest -- a cycle that failed partway still has one to
-    read, and correlation failing must not destroy it.
+    calls, the nested agents spawned during the cycle with their roles and
+    their own measured cost, and an "unattributed" bucket (calls before the
+    first step boundary, or with no timestamp) back into the same manifest
+    file. Returns (call_count, note) for the caller to log; never raises on a
+    malformed or half-written manifest -- a cycle that failed partway still has
+    one to read, and correlation failing must not destroy it.
     """
     manifest = json.loads(manifest_path.read_text())
 
@@ -608,6 +698,45 @@ def correlate_cycle_manifest(
         step["total_tokens"] = step_total["total_tokens"]
         step["calls"] = step_total["calls"]
 
+    # Nested agents spawned with their roles. Bounded to the cycle window so a
+    # session that runs several cycles back to back attributes each spawn to
+    # the cycle that made it, and tagged with the step it was spawned under so
+    # "which agent ran in which role, in which step" is queryable.
+    by_transcript: dict[str, dict[str, Any]] = {}
+    for call in session_calls:
+        bucket = by_transcript.setdefault(
+            call.transcript, {"calls": 0, "cost_usd": 0.0, "total_tokens": 0}
+        )
+        bucket["calls"] += 1
+        bucket["cost_usd"] += call.cost_usd or 0.0
+        bucket["total_tokens"] += call.total_tokens
+
+    cycle_start = _parse_time(manifest.get("start"))
+    cycle_end = _parse_time(manifest.get("end"))
+    main_transcript = _find_session_transcript(session, roots)
+    agents: list[dict[str, Any]] = []
+    if main_transcript is not None:
+        for spawn in extract_agent_spawns(main_transcript):
+            when = _parse_time(spawn.get("ts"))
+            if cycle_start is not None and (when is None or when < cycle_start):
+                continue
+            if cycle_end is not None and when is not None and when > cycle_end:
+                continue
+            measured = by_transcript.get(f"agent-{spawn['agent_id']}")
+            agents.append({
+                "ts": spawn.get("ts"),
+                "role": spawn.get("role") or "unknown",
+                "description": spawn.get("description"),
+                "agent_id": spawn.get("agent_id"),
+                "model": spawn.get("model"),
+                "tool": spawn.get("tool"),
+                "step": bucket_for(when),
+                "calls": measured["calls"] if measured else 0,
+                "cost_usd": round(measured["cost_usd"], 4) if measured else 0.0,
+                "total_tokens": measured["total_tokens"] if measured else 0,
+            })
+    manifest["agents"] = agents
+
     manifest["cycle_cost_usd"] = round(cycle_cost, 4)
     manifest["cycle_total_tokens"] = cycle_tokens
     manifest["unattributed"] = {
@@ -617,7 +746,10 @@ def correlate_cycle_manifest(
     }
 
     manifest_path.write_text(json.dumps(manifest, indent=2))
-    return len(session_calls), f"${cycle_cost:.2f} across {len(steps)} steps"
+    return (
+        len(session_calls),
+        f"${cycle_cost:.2f} across {len(steps)} steps, {len(agents)} nested agents",
+    )
 
 
 # --------------------------------------------------------------------------

--- a/.claude/metrics/token_report.py
+++ b/.claude/metrics/token_report.py
@@ -536,6 +536,91 @@ def collect(
 
 
 # --------------------------------------------------------------------------
+# Cycle-manifest correlation (Issue #3053)
+# --------------------------------------------------------------------------
+
+
+def correlate_cycle_manifest(
+    manifest_path: Path, roots: list[Path], pricing: Pricing
+) -> tuple[int, str]:
+    """Bucket a po-act.sh cycle's measured calls into its recorded step boundaries.
+
+    Every number here comes from parse_transcript's per-message usage
+    accounting -- never from a cycle's own narration. Measured on the
+    2026-07-25 cycle: the orchestrator's summary put its three nested agents
+    at ~302K tokens; the reporter measured 9,502,304 billed tokens for the
+    same transcripts, a 31.5x understatement (agents see their own context and
+    output but not cache-read traffic, ~95% of the bill). Self-reporting is
+    not a substitute for this.
+
+    Writes cycle_cost_usd, cycle_total_tokens, per-step cost_usd/total_tokens/
+    calls, and an "unattributed" bucket (calls before the first step boundary,
+    or with no timestamp) back into the same manifest file. Returns
+    (call_count, note) for the caller to log; never raises on a malformed or
+    half-written manifest -- a cycle that failed partway still has one to
+    read, and correlation failing must not destroy it.
+    """
+    manifest = json.loads(manifest_path.read_text())
+
+    session = manifest.get("session")
+    steps: list[dict[str, Any]] = manifest.get("steps") or []
+    if not session or session == "unknown":
+        return 0, "no session recorded, skipping correlation"
+
+    step_bounds: list[tuple[datetime, int]] = []
+    for i, step in enumerate(steps):
+        ts = _parse_time(step.get("ts"))
+        if ts is not None:
+            step_bounds.append((ts, i))
+    step_bounds.sort()
+
+    calls, _stats = collect(roots, pricing, None, None)
+    session_calls = [c for c, _ in calls if c.session == session]
+
+    def bucket_for(ts: datetime | None) -> int | None:
+        if ts is None:
+            return None
+        chosen = None
+        for boundary_ts, idx in step_bounds:
+            if boundary_ts <= ts:
+                chosen = idx
+            else:
+                break
+        return chosen
+
+    step_totals = [{"calls": 0, "cost_usd": 0.0, "total_tokens": 0} for _ in steps]
+    unattributed = {"calls": 0, "cost_usd": 0.0, "total_tokens": 0}
+    cycle_cost = 0.0
+    cycle_tokens = 0
+
+    for call in session_calls:
+        cost = call.cost_usd or 0.0
+        cycle_cost += cost
+        cycle_tokens += call.total_tokens
+        idx = bucket_for(call.timestamp)
+        bucket = step_totals[idx] if idx is not None else unattributed
+        bucket["calls"] += 1
+        bucket["cost_usd"] += cost
+        bucket["total_tokens"] += call.total_tokens
+
+    for step, step_total in zip(steps, step_totals):
+        step["cost_usd"] = round(step_total["cost_usd"], 4)
+        step["total_tokens"] = step_total["total_tokens"]
+        step["calls"] = step_total["calls"]
+
+    manifest["cycle_cost_usd"] = round(cycle_cost, 4)
+    manifest["cycle_total_tokens"] = cycle_tokens
+    manifest["unattributed"] = {
+        "calls": unattributed["calls"],
+        "cost_usd": round(unattributed["cost_usd"], 4),
+        "total_tokens": unattributed["total_tokens"],
+    }
+
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return len(session_calls), f"${cycle_cost:.2f} across {len(steps)} steps"
+
+
+# --------------------------------------------------------------------------
 # Output
 # --------------------------------------------------------------------------
 
@@ -727,6 +812,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Break spend into fresh input / cache write / cache read / output.",
     )
     parser.add_argument("--quiet", action="store_true", help="Suppress the parse-stats footer.")
+    parser.add_argument(
+        "--cycle-manifest",
+        type=Path,
+        help=(
+            "Correlate measured per-call cost against a po-act.sh cycle manifest's "
+            "step boundaries (Issue #3053) and write cycle_cost_usd + per-step "
+            "cost/tokens back into that file, instead of the normal report."
+        ),
+    )
     return parser
 
 
@@ -739,6 +833,17 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     pricing = Pricing.load(args.pricing)
+
+    if args.cycle_manifest is not None:
+        try:
+            call_count, note = correlate_cycle_manifest(args.cycle_manifest, roots, pricing)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"cycle-manifest: could not read/write {args.cycle_manifest}: {exc}", file=sys.stderr)
+            return 1
+        if not args.quiet:
+            print(f"cycle-manifest: {call_count} calls, {note}", file=sys.stderr)
+        return 0
+
     since = (
         datetime.now(timezone.utc) - timedelta(days=args.since) if args.since is not None else None
     )

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -25,9 +25,11 @@
 #   preflight                       Run preflight (writes ~/.cache/cfgms-po/preflight.json, prints summary)
 #   state [jq_filter]               Read cached preflight and apply optional jq filter
 #   cycle-start [MODE]              Open a per-cycle manifest (Issue #3053); every other subcommand
-#                                   below auto-records a step into it until cycle-end closes it
+#                                   below auto-records a step into it -- with its work/no-op/error
+#                                   outcome -- until cycle-end closes it
 #   cycle-end                       Close the current cycle: correlate measured cost per step via
-#                                   token_report.py, fold in this cycle's dispatch-ledger launches
+#                                   token_report.py, record the nested agents spawned with their
+#                                   roles, fold in this cycle's dispatch-ledger launches
 #   cycle-report [N]                Average cost per cycle step across the last N completed cycles
 
 set -euo pipefail
@@ -125,12 +127,28 @@ _cycle_manifest_path() {
 # _cycle_append_step <subcommand> [args...]
 # Best-effort, lock-guarded read-modify-write onto the open cycle's manifest
 # steps[]. Silent no-op with no cycle open. Never blocks or fails the caller.
+#
+# The record opens with outcome="incomplete" -- the honest state for a step
+# whose process is killed before it can classify itself (AC4: a cycle that
+# fails partway still describes how far it got) -- and _cycle_finalize_step
+# below rewrites it to work / no-op / error once the subcommand returns.
+# Exports the manifest path and the record's index so the finalizer updates
+# THIS step rather than guessing at the last one (a concurrent po-act.sh call
+# from another shell can append in between).
+CYCLE_STEP_MANIFEST=""
+CYCLE_STEP_INDEX=""
+CYCLE_STEP_OUTFILE=""
+CYCLE_STEP_TEE_PID=""
 _cycle_append_step() {
   local subcommand="$1"; shift
-  local manifest
+  local manifest idx
   manifest=$(_cycle_manifest_path) || return 0
   [[ -n "$manifest" ]] && [[ -f "$manifest" ]] || return 0
-  (
+  idx=$(
+    # stderr first: a command substitution runs before any redirection on the
+    # assignment itself could suppress it, so this subshell must silence its
+    # own noise (best-effort recording never speaks over a subcommand).
+    exec 2>/dev/null 201>>"${manifest}.lock"
     flock -w 2 201 || exit 0
     python3 - "$manifest" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$subcommand" "$*" <<'PYEOF'
 import json, sys
@@ -140,11 +158,125 @@ try:
         manifest = json.load(f)
 except Exception:
     sys.exit(0)
-manifest.setdefault("steps", []).append({"ts": ts, "subcommand": subcommand, "args": args})
+steps = manifest.setdefault("steps", [])
+steps.append({
+    "ts": ts, "subcommand": subcommand, "args": args,
+    "outcome": "incomplete", "exit_code": None, "result": None,
+})
+with open(path, "w") as f:
+    json.dump(manifest, f, indent=2)
+print(len(steps) - 1)
+PYEOF
+  ) || idx=""
+  [[ "$idx" =~ ^[0-9]+$ ]] || return 0
+  CYCLE_STEP_MANIFEST="$manifest"
+  CYCLE_STEP_INDEX="$idx"
+}
+
+# _cycle_arm_step_outcome
+# Arms per-step work-or-no-op outcome recording (AC1) for the step
+# _cycle_append_step just opened. The invocation ARGS alone cannot answer "did
+# this step do work": a `dispatch` deferred on capacity, a lease found HELD, an
+# `enqueue` refused and a real launch are the same invocation shape and differ
+# only in the verdict the subcommand prints. Those verdicts are this script's
+# own marker convention (DISPATCHED:/DISPATCH_SKIPPED:/CLAIM_LOST:/ENQUEUED:
+# ...), so the outcome is classified from the subcommand's REAL stdout and exit
+# status -- measured the same way step cost is, never self-declared.
+#
+# stdout is tee'd rather than buffered, so the caller still sees output as it
+# is produced; the copy is what the finalizer classifies. fd 210 holds the real
+# stdout (kept well clear of the 201/202 lock fds and of any fd the sourced
+# agent-dispatch.sh uses).
+_cycle_arm_step_outcome() {
+  [[ -n "$CYCLE_STEP_INDEX" ]] && [[ -n "$CYCLE_STEP_MANIFEST" ]] || return 0
+  command -v tee >/dev/null 2>&1 || return 0
+  CYCLE_STEP_OUTFILE="${CYCLE_STEP_MANIFEST}.step-${CYCLE_STEP_INDEX}.$$.out"
+  : >"$CYCLE_STEP_OUTFILE" 2>/dev/null || { CYCLE_STEP_OUTFILE=""; return 0; }
+  exec 210>&1
+  exec 1> >(tee "$CYCLE_STEP_OUTFILE" >&210)
+  CYCLE_STEP_TEE_PID="$!"
+  trap '_cycle_finalize_step "$?"' EXIT
+}
+
+# _cycle_finalize_step <exit_code>
+# EXIT-trap half of the above: classifies the step's outcome and writes it back
+# onto the step record. Never changes the caller's exit status or output.
+_cycle_finalize_step() {
+  local rc="${1:-0}" i=0
+  trap - EXIT
+  if [[ -n "$CYCLE_STEP_TEE_PID" ]]; then
+    # Closing the tee pipe is what makes tee flush and exit, so restore the
+    # real stdout FIRST, then wait for it -- bounded (~1s) rather than `wait`
+    # so a subcommand that left a child holding the pipe can never hang a
+    # cron cycle. Whatever tee has written by then is what gets classified.
+    exec 1>&210 210>&-
+    while kill -0 "$CYCLE_STEP_TEE_PID" 2>/dev/null && [[ "$i" -lt 10 ]]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+  fi
+  (
+    exec 203>>"${CYCLE_STEP_MANIFEST}.lock" 2>/dev/null
+    flock -w 2 203 || exit 0
+    python3 - "$CYCLE_STEP_MANIFEST" "$CYCLE_STEP_INDEX" "$rc" "${CYCLE_STEP_OUTFILE:-}" <<'PYEOF'
+import json, re, sys
+path, idx_raw, rc_raw, out_path = sys.argv[1:5]
+
+# This script's status markers, by what they mean about the step's outcome.
+NOOP_HINTS = ("SKIP", "DEFER", "REFUS", "LOST", "ALREADY", "FULL")
+ERROR_HINTS = ("FAIL", "ERROR", "ROLLED_BACK")
+# Paths that report "nothing to do" without a marker-shaped line.
+NOOP_PLAIN = ("no_failing_jobs", "no_failing_runs", "No cycles recorded yet")
+MARKER_RE = re.compile(r"^[A-Z][A-Z0-9_]*(?::|$)")
+
+text = ""
+if out_path:
+    try:
+        with open(out_path, errors="replace") as f:
+            text = f.read()
+    except OSError:
+        text = ""
+
+lines = [line.strip() for line in text.splitlines() if line.strip()]
+# Last marker wins: each path's final marker is its verdict (e.g. dispatch
+# prints RESOLVED_ITEM: then CLAIMED: then DISPATCHED:).
+marker = ""
+for line in lines:
+    if MARKER_RE.match(line):
+        marker = line
+token = marker.split(":", 1)[0]
+
+try:
+    rc = int(rc_raw)
+except ValueError:
+    rc = 0
+
+if rc != 0:
+    outcome = "error"
+elif token and any(hint in token for hint in NOOP_HINTS):
+    outcome = "no-op"
+elif token and any(hint in token for hint in ERROR_HINTS):
+    outcome = "error"
+elif any(line.startswith(plain) for plain in NOOP_PLAIN for line in lines):
+    outcome = "no-op"
+else:
+    outcome = "work"
+
+try:
+    with open(path) as f:
+        manifest = json.load(f)
+    step = manifest["steps"][int(idx_raw)]
+except Exception:
+    sys.exit(0)
+step["outcome"] = outcome
+step["exit_code"] = rc
+step["result"] = marker[:200] or None
 with open(path, "w") as f:
     json.dump(manifest, f, indent=2)
 PYEOF
-  ) 201>>"${manifest}.lock" 2>/dev/null || true
+  ) >/dev/null 2>&1 || true
+  [[ -n "$CYCLE_STEP_OUTFILE" ]] && rm -f "$CYCLE_STEP_OUTFILE"
+  return 0
 }
 
 # _cycle_append_lease <action> <key> <result>
@@ -284,10 +416,13 @@ shift || true
 
 # Deterministic step boundary (Issue #3053): every subcommand except the
 # cycle bracket itself auto-records a step into the open cycle's manifest, if
-# any is open. Silent no-op outside a cycle (_cycle_append_step's own
-# contract) -- never changes what the subcommand below actually does.
+# any is open, and arms outcome classification for it so the step reads back as
+# work / no-op / error once it returns. Silent no-op outside a cycle
+# (_cycle_append_step's own contract) -- never changes what the subcommand
+# below actually does, and never changes its output or exit status.
 if [[ "$cmd" != "cycle-start" && "$cmd" != "cycle-end" ]]; then
   _cycle_append_step "$cmd" "$@"
+  _cycle_arm_step_outcome
 fi
 
 case "$cmd" in
@@ -816,6 +951,11 @@ path, cycle_id, mode, session, ts, host = sys.argv[1:7]
 manifest = {
     "cycle_id": cycle_id, "mode": mode, "session": session, "host": host,
     "start": ts, "end": None, "steps": [], "leases": [], "containers": [],
+    # Nested Agent/Skill spawns (Tech Lead, BA, pin-refresh-runner,
+    # pipeline-sweep-runner, reviewers ...) with their roles. Filled at
+    # cycle-end from the session's own transcript rows -- see the cycle-end
+    # case below for why the agent is not asked to declare them.
+    "agents": [],
     "cycle_cost_usd": None,
 }
 with open(path, "w") as f:
@@ -831,9 +971,20 @@ PYEOF
 
   cycle-end)
     # Closes the current cycle's manifest: sets the end timestamp, correlates
-    # MEASURED (never self-reported) cost per step via token_report.py, and
-    # folds in this cycle's #3052 dispatch-ledger launches/exits so "containers
-    # launched by mode with names" doesn't re-implement container tracking.
+    # MEASURED (never self-reported) cost per step via token_report.py, records
+    # the nested agents this cycle spawned with their roles, and folds in this
+    # cycle's #3052 dispatch-ledger launches/exits so "containers launched by
+    # mode with names" doesn't re-implement container tracking.
+    #
+    # Nested agents (Tech Lead, BA, pin-refresh-runner, pipeline-sweep-runner,
+    # reviewers) are spawned by the ORCHESTRATOR's Agent/Skill tool calls, not
+    # by this script, so there is no shell boundary to hook. They are read out
+    # of the session transcript instead (token_report.py's
+    # extract_agent_spawns): the Agent tool_use row carries the role verbatim
+    # as `subagent_type`, and its result row carries the agentId that names the
+    # nested transcript, which is how each role also gets its measured cost.
+    # Asking the agent to declare its own spawns would put the record back on
+    # self-reporting, which this story exists to stop.
     # Best-effort throughout -- a broken correlation still leaves the raw
     # step/lease record behind (AC4 applies here too: a cycle that fails
     # partway leaves a manifest describing how far it got).
@@ -888,13 +1039,17 @@ PYEOF
     fi
 
     cost=$(python3 -c "import json; print(json.load(open('${manifest}')).get('cycle_cost_usd'))" 2>/dev/null || echo "unknown")
+    # Scratch capture files from steps that were killed before their outcome
+    # could be classified (the step record itself stays, honestly "incomplete").
+    rm -f "${manifest}".step-*.out
     rm -f "$CYCLE_CURRENT_PTR"
     echo "CYCLE_ENDED:$(basename "$manifest" .json):cost=${cost}"
     ;;
 
   cycle-report)
     # Documented one-line command (Issue #3053 AC6): average cost per cycle
-    # step across the last N completed cycles.
+    # step across the last N completed cycles, with each step's work/no-op
+    # split and the nested agent roles those cycles spawned.
     #   ./.claude/scripts/po-act.sh cycle-report [N]
     n="${1:-10}"
     if [[ ! -d "$CYCLE_DIR" ]]; then
@@ -912,6 +1067,7 @@ manifests = sorted(
 )[:n]
 
 by_step = {}
+by_role = {}
 cycle_count = 0
 total_cost = 0.0
 incomplete = 0
@@ -929,15 +1085,33 @@ for path in manifests:
     total_cost += manifest.get("cycle_cost_usd") or 0.0
     for step in manifest.get("steps") or []:
         name = step.get("subcommand") or "unknown"
-        bucket = by_step.setdefault(name, {"runs": 0, "cost_usd": 0.0})
+        bucket = by_step.setdefault(name, {"runs": 0, "work": 0, "noop": 0, "cost_usd": 0.0})
         bucket["runs"] += 1
+        # Recorded per step by po-act.sh's own outcome classifier: a run that
+        # skipped/deferred/refused is not the same unit of work as one that
+        # dispatched, and averaging them together hides that.
+        outcome = step.get("outcome")
+        if outcome == "no-op":
+            bucket["noop"] += 1
+        elif outcome == "work":
+            bucket["work"] += 1
         bucket["cost_usd"] += step.get("cost_usd") or 0.0
+    for agent in manifest.get("agents") or []:
+        role = agent.get("role") or "unknown"
+        rb = by_role.setdefault(role, {"spawns": 0, "cost_usd": 0.0})
+        rb["spawns"] += 1
+        rb["cost_usd"] += agent.get("cost_usd") or 0.0
 
 print(f"Cycle report -- last {cycle_count} completed cycles (of {len(manifests)} found, {incomplete} incomplete)")
-print(f"{'step':<20} {'runs':>5} {'avg_cost_usd':>13} {'total_cost_usd':>15}")
+print(f"{'step':<20} {'runs':>5} {'work':>5} {'no-op':>6} {'avg_cost_usd':>13} {'total_cost_usd':>15}")
 for name, b in sorted(by_step.items(), key=lambda kv: -kv[1]["cost_usd"]):
     avg = b["cost_usd"] / b["runs"] if b["runs"] else 0.0
-    print(f"{name:<20} {b['runs']:>5} {avg:>13.4f} {b['cost_usd']:>15.2f}")
+    print(f"{name:<20} {b['runs']:>5} {b['work']:>5} {b['noop']:>6} {avg:>13.4f} {b['cost_usd']:>15.2f}")
+if by_role:
+    print(f"\n{'nested agent role':<28} {'spawns':>6} {'avg_cost_usd':>13} {'total_cost_usd':>15}")
+    for role, b in sorted(by_role.items(), key=lambda kv: -kv[1]["cost_usd"]):
+        avg = b["cost_usd"] / b["spawns"] if b["spawns"] else 0.0
+        print(f"{role:<28} {b['spawns']:>6} {avg:>13.4f} {b['cost_usd']:>15.2f}")
 avg_cycle = total_cost / cycle_count if cycle_count else 0.0
 print(f"\nAverage cost per cycle: ${avg_cycle:.2f}  (total across {cycle_count} cycles: ${total_cost:.2f})")
 PYEOF

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -24,6 +24,11 @@
 #   sync                            Fast-forward local develop checkout (keeps cron scripts current)
 #   preflight                       Run preflight (writes ~/.cache/cfgms-po/preflight.json, prints summary)
 #   state [jq_filter]               Read cached preflight and apply optional jq filter
+#   cycle-start [MODE]              Open a per-cycle manifest (Issue #3053); every other subcommand
+#                                   below auto-records a step into it until cycle-end closes it
+#   cycle-end                       Close the current cycle: correlate measured cost per step via
+#                                   token_report.py, fold in this cycle's dispatch-ledger launches
+#   cycle-report [N]                Average cost per cycle step across the last N completed cycles
 
 set -euo pipefail
 
@@ -75,6 +80,100 @@ else
 fi
 CACHE_FILE="$CACHE_DIR/preflight.json"
 
+# ── Per-cycle step manifest (Issue #3053) ───────────────────────────────────
+# A cron cycle is one long-running agent session, so token_report.py attributes
+# its entire cost to a single segment -- what the Tech Lead pass costs versus
+# the pin sweep versus acceptance review is not derivable at any effort,
+# because nothing marks where one step ends and the next begins.
+#
+# Design decision (flagged in the issue as needing to be settled before
+# coding): who emits step boundaries. Not the agent -- self-reporting is not a
+# substitute (measured 2026-07-25: a cycle's own summary put its nested agents
+# at ~302K tokens; the reporter measured 9,502,304 billed tokens for the same
+# transcripts, a 31.5x understatement — agents see their own context and
+# output but not cache-read traffic, ~95% of the bill; the same failure mode
+# would make self-marked step boundaries unreliable). Instead this script
+# marks them deterministically: cycle-start opens a manifest, every other
+# subcommand below appends a step record to it as a side effect of running
+# (near the bottom of this file, right after argument parsing), and cycle-end
+# closes it and correlates MEASURED cost per step via token_report.py. A step
+# with no matching subcommand call (pure agent reasoning, e.g. "which of 5
+# eligible PRs to review first") has no boundary of its own and folds into
+# whichever step ran next -- imprecise but honest, and still strictly more
+# attributable than one undifferentiated whole-cycle bucket.
+#
+# Lives beside CACHE_DIR (durable, survives session-transcript retention —
+# distinct from AGENT_LEDGER_DIR/AGENT_SESSIONS_BASE, never pruned by either).
+CYCLE_DIR="${CFGMS_CYCLE_DIR:-${CACHE_DIR}/cycles}"
+CYCLE_CURRENT_PTR="${CYCLE_DIR}/current"
+
+# _cycle_manifest_path [cycle_id]
+# Prints the manifest path for the given (or currently open) cycle. Empty
+# output means no cycle is open -- callers must treat that as a silent no-op,
+# never an error: a human running a one-off `po-act.sh enqueue` outside a
+# cycle must not fail just because no cycle-start ever ran.
+_cycle_manifest_path() {
+  local cycle_id="${1:-}"
+  if [[ -z "$cycle_id" ]]; then
+    [[ -f "$CYCLE_CURRENT_PTR" ]] || return 0
+    cycle_id=$(cat "$CYCLE_CURRENT_PTR" 2>/dev/null) || return 0
+  fi
+  [[ -n "$cycle_id" ]] || return 0
+  echo "${CYCLE_DIR}/${cycle_id}.json"
+}
+
+# _cycle_append_step <subcommand> [args...]
+# Best-effort, lock-guarded read-modify-write onto the open cycle's manifest
+# steps[]. Silent no-op with no cycle open. Never blocks or fails the caller.
+_cycle_append_step() {
+  local subcommand="$1"; shift
+  local manifest
+  manifest=$(_cycle_manifest_path) || return 0
+  [[ -n "$manifest" ]] && [[ -f "$manifest" ]] || return 0
+  (
+    flock -w 2 201 || exit 0
+    python3 - "$manifest" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$subcommand" "$*" <<'PYEOF'
+import json, sys
+path, ts, subcommand, args = sys.argv[1:5]
+try:
+    with open(path) as f:
+        manifest = json.load(f)
+except Exception:
+    sys.exit(0)
+manifest.setdefault("steps", []).append({"ts": ts, "subcommand": subcommand, "args": args})
+with open(path, "w") as f:
+    json.dump(manifest, f, indent=2)
+PYEOF
+  ) 201>>"${manifest}.lock" 2>/dev/null || true
+}
+
+# _cycle_append_lease <action> <key> <result>
+# Same best-effort contract as _cycle_append_step, for AC1's "leases acquired
+# and released" -- hooked into _acquire_lease/_release_lease below rather than
+# every call site, since those two functions are the only path lease activity
+# takes in this script.
+_cycle_append_lease() {
+  local action="$1" key="$2" result="$3"
+  local manifest
+  manifest=$(_cycle_manifest_path) || return 0
+  [[ -n "$manifest" ]] && [[ -f "$manifest" ]] || return 0
+  (
+    flock -w 2 202 || exit 0
+    python3 - "$manifest" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$action" "$key" "$result" <<'PYEOF'
+import json, sys
+path, ts, action, key, result = sys.argv[1:6]
+try:
+    with open(path) as f:
+        manifest = json.load(f)
+except Exception:
+    sys.exit(0)
+manifest.setdefault("leases", []).append({"ts": ts, "action": action, "key": key, "result": result})
+with open(path, "w") as f:
+    json.dump(manifest, f, indent=2)
+PYEOF
+  ) 202>>"${manifest}.lock" 2>/dev/null || true
+}
+
 # ── Shared claim / routing helpers ──────────────────────────────────────────
 # The pipeline can run `/po cron` on MORE THAN ONE host concurrently, including
 # homogeneous (e.g. multiple Linux) hosts. Cross-host mutual exclusion is provided
@@ -93,9 +192,9 @@ _acquire_lease() {
   local key="$1" ttl="$2" label="$3" out
   out=$(bash "$PIPELINE_HELPER" lease-acquire "$key" "$ttl" 2>/dev/null || true)
   case "$out" in
-    ACQUIRED:*|RECLAIMED:*) LEASE_HELD="$key"; return 0 ;;
-    HELD:*)  echo "DISPATCH_SKIPPED:${label}:lease_held (${out})"; return 1 ;;
-    *)       echo "DISPATCH_SKIPPED:${label}:lease_error (${out:-no output})"; return 1 ;;
+    ACQUIRED:*|RECLAIMED:*) LEASE_HELD="$key"; _cycle_append_lease "acquire" "$key" "$out"; return 0 ;;
+    HELD:*)  echo "DISPATCH_SKIPPED:${label}:lease_held (${out})"; _cycle_append_lease "acquire" "$key" "$out"; return 1 ;;
+    *)       echo "DISPATCH_SKIPPED:${label}:lease_error (${out:-no output})"; _cycle_append_lease "acquire" "$key" "${out:-error}"; return 1 ;;
   esac
 }
 
@@ -108,6 +207,7 @@ _release_lease() {
   local key="${1:-$LEASE_HELD}"
   [ -n "$key" ] || return 0
   bash "$PIPELINE_HELPER" lease-release "$key" >/dev/null 2>&1 || true
+  _cycle_append_lease "release" "$key" "released"
 }
 
 # _capacity_ok
@@ -181,6 +281,14 @@ _host_serves_env() {
 
 cmd="${1:-}"
 shift || true
+
+# Deterministic step boundary (Issue #3053): every subcommand except the
+# cycle bracket itself auto-records a step into the open cycle's manifest, if
+# any is open. Silent no-op outside a cycle (_cycle_append_step's own
+# contract) -- never changes what the subcommand below actually does.
+if [[ "$cmd" != "cycle-start" && "$cmd" != "cycle-end" ]]; then
+  _cycle_append_step "$cmd" "$@"
+fi
 
 case "$cmd" in
   dispatch)
@@ -682,6 +790,157 @@ except Exception: print('')" 2>/dev/null || echo "")
       bash "$PROJECT_QUEUE" update-field "$arg" status "$new_status" >/dev/null 2>&1 || true
     fi
     echo "UNBLOCKED:$arg${mode:+ ($mode)}"
+    ;;
+
+  cycle-start)
+    # Opens a new per-cycle manifest (Issue #3053) so step attribution below
+    # has a boundary to bucket against. Bracketing only -- does not change
+    # cron orchestration; po.md's §4.0 Pre-Flight calls this as its first
+    # action, §4.1 Step 10 calls cycle-end as its last. Never fails the
+    # caller: measurement infra must not be able to block a cron cycle.
+    mode="${1:-cron}"
+    if ! mkdir -p "$CYCLE_DIR" 2>/dev/null; then
+      echo "CYCLE_START_FAILED:mkdir"
+      exit 0
+    fi
+    cycle_id="cycle-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+    manifest="${CYCLE_DIR}/${cycle_id}.json"
+    # CLAUDE_CODE_SESSION_ID is set by the harness for every command the
+    # running agent invokes -- this is how the manifest knows which
+    # transcript is "this cycle" without the agent narrating its own identity.
+    session="${CLAUDE_CODE_SESSION_ID:-unknown}"
+    host="$(hostname 2>/dev/null || echo unknown)"
+    if ! python3 - "$manifest" "$cycle_id" "$mode" "$session" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$host" <<'PYEOF' 2>/dev/null
+import json, sys
+path, cycle_id, mode, session, ts, host = sys.argv[1:7]
+manifest = {
+    "cycle_id": cycle_id, "mode": mode, "session": session, "host": host,
+    "start": ts, "end": None, "steps": [], "leases": [], "containers": [],
+    "cycle_cost_usd": None,
+}
+with open(path, "w") as f:
+    json.dump(manifest, f, indent=2)
+PYEOF
+    then
+      echo "CYCLE_START_FAILED:write"
+      exit 0
+    fi
+    echo "$cycle_id" > "$CYCLE_CURRENT_PTR"
+    echo "CYCLE_STARTED:${cycle_id}"
+    ;;
+
+  cycle-end)
+    # Closes the current cycle's manifest: sets the end timestamp, correlates
+    # MEASURED (never self-reported) cost per step via token_report.py, and
+    # folds in this cycle's #3052 dispatch-ledger launches/exits so "containers
+    # launched by mode with names" doesn't re-implement container tracking.
+    # Best-effort throughout -- a broken correlation still leaves the raw
+    # step/lease record behind (AC4 applies here too: a cycle that fails
+    # partway leaves a manifest describing how far it got).
+    manifest=$(_cycle_manifest_path) || true
+    if [[ -z "${manifest:-}" ]] || [[ ! -f "$manifest" ]]; then
+      echo "CYCLE_END_SKIPPED:no_open_cycle"
+      exit 0
+    fi
+    end_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    python3 - "$manifest" "$end_ts" <<'PYEOF' 2>/dev/null || true
+import json, sys
+path, end_ts = sys.argv[1:3]
+with open(path) as f:
+    manifest = json.load(f)
+manifest["end"] = end_ts
+with open(path, "w") as f:
+    json.dump(manifest, f, indent=2)
+PYEOF
+
+    TOKEN_REPORT="${REPO_ROOT}/.claude/metrics/token_report.py"
+    if [[ -f "$TOKEN_REPORT" ]]; then
+      # CFGMS_TEST_TRANSCRIPTS_DIR lets a hermetic test point correlation at a
+      # fixture corpus instead of the real ~/.claude/projects.
+      projects_dir_args=()
+      [[ -n "${CFGMS_TEST_TRANSCRIPTS_DIR:-}" ]] && projects_dir_args=(--projects-dir "$CFGMS_TEST_TRANSCRIPTS_DIR")
+      python3 "$TOKEN_REPORT" --cycle-manifest "$manifest" "${projects_dir_args[@]}" --quiet 2>/dev/null || \
+        echo "WARN: cycle cost correlation failed — manifest still has raw steps"
+    fi
+
+    if [[ -n "${AGENT_LEDGER_FILE:-}" ]] && [[ -f "$AGENT_LEDGER_FILE" ]]; then
+      python3 - "$manifest" "$AGENT_LEDGER_FILE" <<'PYEOF' 2>/dev/null || true
+import json, sys
+manifest_path, ledger_path = sys.argv[1:3]
+with open(manifest_path) as f:
+    manifest = json.load(f)
+start, end = manifest.get("start"), manifest.get("end")
+containers = []
+if start and end:
+    with open(ledger_path) as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            ts = rec.get("ts")
+            if ts and start <= ts <= end:
+                containers.append(rec)
+manifest["containers"] = containers
+with open(manifest_path, "w") as f:
+    json.dump(manifest, f, indent=2)
+PYEOF
+    fi
+
+    cost=$(python3 -c "import json; print(json.load(open('${manifest}')).get('cycle_cost_usd'))" 2>/dev/null || echo "unknown")
+    rm -f "$CYCLE_CURRENT_PTR"
+    echo "CYCLE_ENDED:$(basename "$manifest" .json):cost=${cost}"
+    ;;
+
+  cycle-report)
+    # Documented one-line command (Issue #3053 AC6): average cost per cycle
+    # step across the last N completed cycles.
+    #   ./.claude/scripts/po-act.sh cycle-report [N]
+    n="${1:-10}"
+    if [[ ! -d "$CYCLE_DIR" ]]; then
+      echo "No cycles recorded yet at ${CYCLE_DIR}"
+      exit 0
+    fi
+    python3 - "$CYCLE_DIR" "$n" <<'PYEOF'
+import json, sys
+from pathlib import Path
+
+cycle_dir, n = Path(sys.argv[1]), int(sys.argv[2])
+manifests = sorted(
+    (p for p in cycle_dir.glob("cycle-*.json")),
+    key=lambda p: p.stat().st_mtime, reverse=True,
+)[:n]
+
+by_step = {}
+cycle_count = 0
+total_cost = 0.0
+incomplete = 0
+for path in manifests:
+    try:
+        manifest = json.loads(path.read_text())
+    except Exception:
+        continue
+    if manifest.get("end") is None:
+        # A cycle that failed partway is still on disk (AC4) but excluded
+        # from the average -- its cost was never correlated.
+        incomplete += 1
+        continue
+    cycle_count += 1
+    total_cost += manifest.get("cycle_cost_usd") or 0.0
+    for step in manifest.get("steps") or []:
+        name = step.get("subcommand") or "unknown"
+        bucket = by_step.setdefault(name, {"runs": 0, "cost_usd": 0.0})
+        bucket["runs"] += 1
+        bucket["cost_usd"] += step.get("cost_usd") or 0.0
+
+print(f"Cycle report -- last {cycle_count} completed cycles (of {len(manifests)} found, {incomplete} incomplete)")
+print(f"{'step':<20} {'runs':>5} {'avg_cost_usd':>13} {'total_cost_usd':>15}")
+for name, b in sorted(by_step.items(), key=lambda kv: -kv[1]["cost_usd"]):
+    avg = b["cost_usd"] / b["runs"] if b["runs"] else 0.0
+    print(f"{name:<20} {b['runs']:>5} {avg:>13.4f} {b['cost_usd']:>15.2f}")
+avg_cycle = total_cost / cycle_count if cycle_count else 0.0
+print(f"\nAverage cost per cycle: ${avg_cycle:.2f}  (total across {cycle_count} cycles: ${total_cost:.2f})")
+PYEOF
     ;;
 
   ""|-h|--help|help)

--- a/.claude/scripts/tests/cycle_manifest.test.sh
+++ b/.claude/scripts/tests/cycle_manifest.test.sh
@@ -68,24 +68,55 @@ export CLAUDE_CODE_SESSION_ID="$SESSION"
 
 # A real transcript for this session so cycle-end's correlation pulls actual
 # measured cost through the full path (bash -> token_report.py -> parsed
-# usage), not just "did it crash on an empty corpus".
+# usage), not just "did it crash on an empty corpus". It also carries a real
+# nested-agent spawn (the two rows Claude Code writes for one `Agent` call)
+# plus that agent's own nested transcript, so the "nested agents spawned with
+# their roles" record is exercised end to end rather than asserted as an empty
+# list. Every fixture timestamp is relative to the real clock: the cycle's
+# start and end come from the real clock when cycle-start/cycle-end run, and a
+# spawn only belongs to the cycle whose [start, end] window contains it.
 PROJECTS_ROOT="${SANDBOX}/claude-projects"
 PROJECT_DIR="${PROJECTS_ROOT}/-workspace"
-mkdir -p "$PROJECT_DIR"
+mkdir -p "${PROJECT_DIR}/${SESSION}/subagents"
 python3 - "$PROJECT_DIR" "$SESSION" <<'PYEOF'
 import json, sys
+from datetime import datetime, timedelta, timezone
 project_dir, session = sys.argv[1], sys.argv[2]
-def row(request_id, ts):
+def row(request_id, ts, inp=1000, out=500):
     return json.dumps({
         "type": "assistant", "requestId": request_id, "timestamp": ts,
         "gitBranch": "develop", "cwd": "/workspace", "isSidechain": False,
         "message": {"model": "claude-sonnet-4-6", "usage": {
-            "input_tokens": 1000, "cache_read_input_tokens": 0, "output_tokens": 500,
+            "input_tokens": inp, "cache_read_input_tokens": 0, "output_tokens": out,
         }},
     })
+def ago(seconds):
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%SZ")
+# 300s: before the step boundary (pinned to 240s ago below) -> unattributed.
+# 180s: after it -> attributed to the merge-queue step, as is the nested
+# agent's own call at 30s ago.
+pre_ts, post_ts, spawn_ts = ago(300), ago(180), ago(30)
+spawn_use = json.dumps({
+    "type": "assistant", "timestamp": spawn_ts,
+    "message": {"role": "assistant", "content": [{
+        "type": "tool_use", "id": "toolu_tl", "name": "Agent",
+        "input": {"description": "Tech Lead pass", "subagent_type": "tech-lead"},
+    }]},
+})
+spawn_result = json.dumps({
+    "type": "user", "timestamp": spawn_ts,
+    "message": {"role": "user", "content": [
+        {"type": "tool_result", "tool_use_id": "toolu_tl", "content": "launched"}]},
+    "toolUseResult": {"agentId": "tl123", "description": "Tech Lead pass",
+                      "resolvedModel": "claude-sonnet-5", "status": "async_launched"},
+})
 with open(f"{project_dir}/{session}.jsonl", "w") as f:
-    f.write(row("req_a", "2026-07-28T11:00:30Z") + "\n")  # before any step -> unattributed
-    f.write(row("req_b", "2026-07-28T11:02:00Z") + "\n")  # after merge-queue's step
+    f.write(row("req_a", pre_ts) + "\n")   # before any step -> unattributed
+    f.write(row("req_b", post_ts) + "\n")  # after merge-queue's step
+    f.write(spawn_use + "\n")
+    f.write(spawn_result + "\n")
+with open(f"{project_dir}/{session}/subagents/agent-tl123.jsonl", "w") as f:
+    f.write(row("req_tl", spawn_ts, inp=8000, out=2000) + "\n")
 PYEOF
 
 out="$(bash "$POACT" cycle-start cron 2>&1)"
@@ -95,25 +126,30 @@ manifest="${CYCLE_DIR}/${cycle_id}.json"
 [[ -f "$manifest" ]] && ok "manifest file created" || bad "manifest file created" "missing: $manifest"
 check_eq "manifest records the harness session id" "$(jf "$manifest" 'd["session"]')" "$SESSION"
 check_eq "manifest starts with end=null (AC4: describable mid-run)" "$(jf "$manifest" 'd["end"]')" "None"
+check_eq "manifest opens an agents[] for nested spawns (AC1)" "$(jf "$manifest" 'len(d["agents"])')" "0"
 
-# Backdate the manifest's start + this step's ts so they land before req_a/req_b's fixed
-# fixture timestamps (2026-07-28T11:00:30Z / 11:02:00Z) -- cycle-start/step marking use
-# the real clock, which is not 2026-07-28T11:00 at test-run time.
+# Backdate the manifest's start so it precedes the fixture's oldest row (300s
+# ago). cycle-start stamps the real clock, so without this every fixture row
+# would sit before the cycle even began.
 python3 - "$manifest" <<PYEOF
 import json
+from datetime import datetime, timedelta, timezone
 with open("$manifest") as f:
     m = json.load(f)
-m["start"] = "2026-07-28T11:00:00Z"
+m["start"] = (datetime.now(timezone.utc) - timedelta(seconds=360)).strftime("%Y-%m-%dT%H:%M:%SZ")
 with open("$manifest", "w") as f:
     json.dump(m, f)
 PYEOF
 
 bash "$POACT" merge-queue >/dev/null 2>&1 || true
+# Pin the step boundary between the fixture's pre (300s ago) and post (180s
+# ago) rows; step marking stamps the real clock, which is later than both.
 python3 - "$manifest" <<PYEOF
 import json
+from datetime import datetime, timedelta, timezone
 with open("$manifest") as f:
     m = json.load(f)
-m["steps"][-1]["ts"] = "2026-07-28T11:01:00Z"
+m["steps"][-1]["ts"] = (datetime.now(timezone.utc) - timedelta(seconds=240)).strftime("%Y-%m-%dT%H:%M:%SZ")
 with open("$manifest", "w") as f:
     json.dump(m, f)
 PYEOF
@@ -134,8 +170,11 @@ out="$(CFGMS_TEST_TRANSCRIPTS_DIR="$PROJECTS_ROOT" bash "$POACT" cycle-end 2>&1)
 check_contains "cycle-end reports CYCLE_ENDED" "$out" "CYCLE_ENDED:"
 check_eq "current-cycle pointer cleared after cycle-end" "$([[ -f "${CYCLE_DIR}/current" ]] && echo present || echo cleared)" "cleared"
 check_eq "manifest end timestamp is set" "$([[ "$(jf "$manifest" 'd["end"]')" != "None" ]] && echo set || echo unset)" "set"
-check_eq "correlation attributes the merge-queue step's own call" \
-  "$(jf "$manifest" 'd["steps"][0]["calls"]')" "1"
+# The step's own call (req_b) plus the nested Tech Lead agent's call, which is
+# spend the cycle incurred inside that step -- nested transcripts roll up to
+# the session that spawned them, so they land in the step that was open.
+check_eq "correlation attributes the merge-queue step's own call and its nested agent's" \
+  "$(jf "$manifest" 'd["steps"][0]["calls"]')" "2"
 check_eq "the call before the step boundary is unattributed" \
   "$(jf "$manifest" 'd["unattributed"]["calls"]')" "1"
 if [[ "$(jf "$manifest" 'd["cycle_cost_usd"]')" != "0.0" ]] && [[ "$(jf "$manifest" 'd["cycle_cost_usd"]')" != "None" ]]; then
@@ -143,6 +182,85 @@ if [[ "$(jf "$manifest" 'd["cycle_cost_usd"]')" != "0.0" ]] && [[ "$(jf "$manife
 else
   bad "cycle_cost_usd is real measured dollars, not zero or null" "got: $(jf "$manifest" 'd["cycle_cost_usd"]')"
 fi
+
+printf '\n== nested agents spawned, with their roles (AC1) ==\n'
+check_eq "the cycle's nested Agent spawn is recorded" "$(jf "$manifest" 'len(d["agents"])')" "1"
+check_eq "the spawn is recorded under its role, not an opaque id" \
+  "$(jf "$manifest" 'd["agents"][0]["role"]')" "tech-lead"
+check_eq "the role is linked to the nested transcript that measured it" \
+  "$(jf "$manifest" 'd["agents"][0]["agent_id"]')" "tl123"
+check_eq "the nested agent's own calls are counted" "$(jf "$manifest" 'd["agents"][0]["calls"]')" "1"
+check_eq "the spawn is attributed to the step that was open when it happened" \
+  "$(jf "$manifest" 'd["agents"][0]["step"]')" "0"
+if [[ "$(jf "$manifest" 'd["agents"][0]["cost_usd"] > 0')" == "True" ]]; then
+  ok "the role carries its own measured dollars (not self-reported)"
+else
+  bad "the role carries its own measured dollars (not self-reported)" \
+    "got: $(jf "$manifest" 'd["agents"][0]["cost_usd"]')"
+fi
+
+printf '\n== per-step work-or-no-op outcome (AC1) ==\n'
+export CLAUDE_CODE_SESSION_ID="outcome-test-session"
+bash "$POACT" cycle-start cron >/dev/null 2>&1
+oc_id="$(cat "${CYCLE_DIR}/current")"
+oc="${CYCLE_DIR}/${oc_id}.json"
+
+# A real no-op path through the real code: the capacity gate refuses, so
+# dispatch defers before any side effect. CFGMS_TEST_DISPATCH is the script's
+# existing hook for the lower-level dispatch helper.
+STUB="${SANDBOX}/dispatch-stub.sh"
+cat > "$STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+[ "${1:-}" = "capacity" ] && { echo "CAPACITY_FULL:ram 94%"; exit 1; }
+exit 0
+STUBEOF
+chmod +x "$STUB"
+noop_out="$(CFGMS_TEST_DISPATCH="$STUB" bash "$POACT" dispatch 999999 2>&1)"
+check_contains "deferred dispatch still prints its own verdict" "$noop_out" "DISPATCH_DEFERRED:"
+check_eq "a deferred dispatch reads back as a no-op" "$(jf "$oc" 'd["steps"][-1]["outcome"]')" "no-op"
+check_eq "the no-op step keeps the verdict that classified it" \
+  "$(jf "$oc" 'd["steps"][-1]["result"].split(":")[0]')" "DISPATCH_DEFERRED"
+
+# A subcommand that did work: cycle-report renders a report and exits 0.
+work_out="$(bash "$POACT" cycle-report 5 2>&1)"
+check_eq "a subcommand that produced output reads back as work" \
+  "$(jf "$oc" 'd["steps"][-1]["outcome"]')" "work"
+check_contains "output is passed through unchanged while being classified" \
+  "$work_out" "Average cost per cycle"
+
+# A failure: `state` with no preflight cache exits 1.
+set +e
+bash "$POACT" state >/dev/null 2>&1
+state_rc=$?
+set -e
+check_eq "a failing subcommand's exit status is not swallowed" "$state_rc" "1"
+check_eq "a failing subcommand reads back as an error" "$(jf "$oc" 'd["steps"][-1]["outcome"]')" "error"
+check_eq "the failing step records its exit code" "$(jf "$oc" 'd["steps"][-1]["exit_code"]')" "1"
+
+# Distinct outcomes for the same shape of invocation is the whole point: args
+# alone cannot tell a deferred dispatch from a real one.
+check_eq "the three steps are distinguishable by outcome" \
+  "$(jf "$oc" '",".join(s["outcome"] for s in d["steps"])')" "no-op,work,error"
+
+printf '\n== a killed step stays honestly incomplete (AC4) ==\n'
+FIFO="${SANDBOX}/stdin.fifo"
+mkfifo "$FIFO"
+bash "$POACT" unblock 999999 - < "$FIFO" >/dev/null 2>&1 &
+killed_pid=$!
+exec 9>"$FIFO"   # open the write end so the subcommand blocks on read, not on open()
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [[ "$(jf "$oc" 'd["steps"][-1]["subcommand"]')" == "unblock" ]] && break
+  sleep 0.5
+done
+kill -9 "$killed_pid" 2>/dev/null || true
+wait "$killed_pid" 2>/dev/null || true
+exec 9>&-
+check_eq "the killed step is on disk" "$(jf "$oc" 'd["steps"][-1]["subcommand"]')" "unblock"
+check_eq "a step killed before it finished is not claimed as work" \
+  "$(jf "$oc" 'd["steps"][-1]["outcome"]')" "incomplete"
+
+rm -f "${CYCLE_DIR}/current"
+export CLAUDE_CODE_SESSION_ID="$SESSION"
 
 printf '\n== cycle-report ==\n'
 report="$(bash "$POACT" cycle-report 5 2>&1)"
@@ -171,6 +289,17 @@ check_contains "hook runs right after cmd parsing, before the case statement" "$
   'if [[ "$cmd" != "cycle-start" && "$cmd" != "cycle-end" ]]; then'
 check_contains "hook calls _cycle_append_step with the real subcommand and args" "$poact_src" \
   '_cycle_append_step "$cmd" "$@"'
+check_contains "hook arms outcome classification for the step it just opened" "$poact_src" \
+  '_cycle_arm_step_outcome'
+
+printf '\n== structural: agent roles come from transcripts, not from the agent ==\n'
+report_src="$(cat "$TOKEN_REPORT")"
+check_contains "the reporter reads spawns out of the transcript" "$report_src" \
+  "def extract_agent_spawns"
+check_contains "the role is the tool call's own subagent_type" "$report_src" \
+  'tool_input.get("subagent_type")'
+check_contains "correlation writes the roles into the manifest" "$report_src" \
+  'manifest["agents"] = agents'
 
 printf '\n== durability: cycle manifests live outside the ledger/session-transcript trees ==\n'
 check_eq "CYCLE_DIR is distinct from the dispatch ledger dir" \

--- a/.claude/scripts/tests/cycle_manifest.test.sh
+++ b/.claude/scripts/tests/cycle_manifest.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Regression test for per-cycle step manifests (Issue #3053).
+#
+# A `/po cron` cycle is one long agent session, so token_report.py attributes
+# its whole cost to a single segment -- what the Tech Lead pass costs versus
+# the pin sweep versus acceptance review was not derivable at any effort.
+# Covers: cycle-start/cycle-end/cycle-report end to end against a real
+# fixture transcript (real measured cost flows through, not a zero-value
+# happy path), the deterministic step-boundary hook (every subcommand except
+# the cycle bracket itself auto-marks a step), the no-cycle-open no-op
+# contract, lease events, and durability against the same retention/cleanup
+# paths #3052's ledger already proved itself isolated from.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+POACT="${REPO_ROOT}/.claude/scripts/po-act.sh"
+TOKEN_REPORT="${REPO_ROOT}/.claude/metrics/token_report.py"
+
+for f in "$POACT" "$TOKEN_REPORT"; do
+  [[ -f "$f" ]] || { printf 'FAIL: expected file not found: %s\n' "$f" >&2; exit 1; }
+done
+
+fail=0; ran=0
+ok()   { ran=$((ran + 1)); printf '  ok    %s\n' "$1"; }
+bad()  { ran=$((ran + 1)); fail=$((fail + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+check_eq() {
+  local desc="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then ok "$desc"
+  else bad "$desc" "want: ${expected}  actual: ${actual}"; fi
+}
+check_contains() {
+  local desc="$1" hay="$2" needle="$3"
+  if [[ "$hay" == *"$needle"* ]]; then ok "$desc"
+  else bad "$desc" "want substring: ${needle}"; fi
+}
+jf() {
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print($2)" "$1" 2>/dev/null
+}
+
+echo "cycle_manifest.test.sh"
+echo "-----------------------"
+
+printf '\n== bash -n parses ==\n'
+if bash -n "$POACT" 2>/dev/null; then ok "po-act.sh parses"; else bad "po-act.sh parses" "bash -n failed"; fi
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+export CFGMS_TEST_REPO_ROOT="$REPO_ROOT"
+export PO_CACHE_DIR="${SANDBOX}/po"
+export CFGMS_AGENT_LEDGER_DIR="${SANDBOX}/ledger"
+CYCLE_DIR="${PO_CACHE_DIR}/cycles"
+
+printf '\n== no cycle open: a subcommand call is a silent no-op ==\n'
+out="$(bash "$POACT" merge-queue 2>&1)"
+rc=$?
+check_eq "merge-queue still runs normally with no cycle open" "$rc" "0"
+if [[ -d "$CYCLE_DIR" ]]; then
+  bad "no manifest directory created with no cycle open" "found ${CYCLE_DIR}"
+else
+  ok "no manifest directory created with no cycle open"
+fi
+
+printf '\n== cycle-start / auto step-marking / cycle-end / cycle-report, real measured cost ==\n'
+SESSION="cycle-test-session"
+export CLAUDE_CODE_SESSION_ID="$SESSION"
+
+# A real transcript for this session so cycle-end's correlation pulls actual
+# measured cost through the full path (bash -> token_report.py -> parsed
+# usage), not just "did it crash on an empty corpus".
+PROJECTS_ROOT="${SANDBOX}/claude-projects"
+PROJECT_DIR="${PROJECTS_ROOT}/-workspace"
+mkdir -p "$PROJECT_DIR"
+python3 - "$PROJECT_DIR" "$SESSION" <<'PYEOF'
+import json, sys
+project_dir, session = sys.argv[1], sys.argv[2]
+def row(request_id, ts):
+    return json.dumps({
+        "type": "assistant", "requestId": request_id, "timestamp": ts,
+        "gitBranch": "develop", "cwd": "/workspace", "isSidechain": False,
+        "message": {"model": "claude-sonnet-4-6", "usage": {
+            "input_tokens": 1000, "cache_read_input_tokens": 0, "output_tokens": 500,
+        }},
+    })
+with open(f"{project_dir}/{session}.jsonl", "w") as f:
+    f.write(row("req_a", "2026-07-28T11:00:30Z") + "\n")  # before any step -> unattributed
+    f.write(row("req_b", "2026-07-28T11:02:00Z") + "\n")  # after merge-queue's step
+PYEOF
+
+out="$(bash "$POACT" cycle-start cron 2>&1)"
+check_contains "cycle-start reports CYCLE_STARTED" "$out" "CYCLE_STARTED:"
+cycle_id="$(cat "${CYCLE_DIR}/current")"
+manifest="${CYCLE_DIR}/${cycle_id}.json"
+[[ -f "$manifest" ]] && ok "manifest file created" || bad "manifest file created" "missing: $manifest"
+check_eq "manifest records the harness session id" "$(jf "$manifest" 'd["session"]')" "$SESSION"
+check_eq "manifest starts with end=null (AC4: describable mid-run)" "$(jf "$manifest" 'd["end"]')" "None"
+
+# Backdate the manifest's start + this step's ts so they land before req_a/req_b's fixed
+# fixture timestamps (2026-07-28T11:00:30Z / 11:02:00Z) -- cycle-start/step marking use
+# the real clock, which is not 2026-07-28T11:00 at test-run time.
+python3 - "$manifest" <<PYEOF
+import json
+with open("$manifest") as f:
+    m = json.load(f)
+m["start"] = "2026-07-28T11:00:00Z"
+with open("$manifest", "w") as f:
+    json.dump(m, f)
+PYEOF
+
+bash "$POACT" merge-queue >/dev/null 2>&1 || true
+python3 - "$manifest" <<PYEOF
+import json
+with open("$manifest") as f:
+    m = json.load(f)
+m["steps"][-1]["ts"] = "2026-07-28T11:01:00Z"
+with open("$manifest", "w") as f:
+    json.dump(m, f)
+PYEOF
+
+step_count_before_end="$(jf "$manifest" 'len(d["steps"])')"
+check_eq "one step auto-recorded for the merge-queue call" "$step_count_before_end" "1"
+check_eq "the recorded step names the real subcommand" "$(jf "$manifest" 'd["steps"][0]["subcommand"]')" "merge-queue"
+if [[ "$(jf "$manifest" 'd["steps"][0]')" == *'"cost_usd"'* ]]; then
+  bad "step has no cost yet before cycle-end" "cost_usd present pre-correlation"
+else
+  ok "step has no cost yet before cycle-end (proves cycle-end, not cycle-start, computes it)"
+fi
+
+# Exercise the REAL cycle-end subcommand end to end -- CFGMS_TEST_TRANSCRIPTS_DIR
+# points its internal token_report.py call at the fixture corpus instead of the
+# real ~/.claude/projects, so this stays hermetic without faking the code path.
+out="$(CFGMS_TEST_TRANSCRIPTS_DIR="$PROJECTS_ROOT" bash "$POACT" cycle-end 2>&1)"
+check_contains "cycle-end reports CYCLE_ENDED" "$out" "CYCLE_ENDED:"
+check_eq "current-cycle pointer cleared after cycle-end" "$([[ -f "${CYCLE_DIR}/current" ]] && echo present || echo cleared)" "cleared"
+check_eq "manifest end timestamp is set" "$([[ "$(jf "$manifest" 'd["end"]')" != "None" ]] && echo set || echo unset)" "set"
+check_eq "correlation attributes the merge-queue step's own call" \
+  "$(jf "$manifest" 'd["steps"][0]["calls"]')" "1"
+check_eq "the call before the step boundary is unattributed" \
+  "$(jf "$manifest" 'd["unattributed"]["calls"]')" "1"
+if [[ "$(jf "$manifest" 'd["cycle_cost_usd"]')" != "0.0" ]] && [[ "$(jf "$manifest" 'd["cycle_cost_usd"]')" != "None" ]]; then
+  ok "cycle_cost_usd is real measured dollars, not zero or null"
+else
+  bad "cycle_cost_usd is real measured dollars, not zero or null" "got: $(jf "$manifest" 'd["cycle_cost_usd"]')"
+fi
+
+printf '\n== cycle-report ==\n'
+report="$(bash "$POACT" cycle-report 5 2>&1)"
+check_contains "cycle-report names the step" "$report" "merge-queue"
+check_contains "cycle-report shows a totals row" "$report" "Average cost per cycle"
+
+printf '\n== incomplete cycles are excluded from the average but stay on disk (AC4) ==\n'
+bash "$POACT" cycle-start cron >/dev/null 2>&1
+incomplete_id="$(cat "${CYCLE_DIR}/current")"
+bash "$POACT" merge-queue >/dev/null 2>&1 || true
+rm -f "${CYCLE_DIR}/current"  # simulate a crash: never reached cycle-end
+[[ -f "${CYCLE_DIR}/${incomplete_id}.json" ]] && ok "crashed cycle's manifest survives on disk" \
+  || bad "crashed cycle's manifest survives on disk" "missing"
+report2="$(bash "$POACT" cycle-report 5 2>&1)"
+check_contains "cycle-report notes the incomplete cycle" "$report2" "incomplete"
+
+printf '\n== structural: lease events wired into the actual acquire/release helpers ==\n'
+poact_src="$(cat "$POACT")"
+acquire_body="$(awk '/^_acquire_lease\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$POACT")"
+release_body="$(awk '/^_release_lease\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$POACT")"
+check_contains "_acquire_lease records a cycle lease event" "$acquire_body" "_cycle_append_lease"
+check_contains "_release_lease records a cycle lease event" "$release_body" "_cycle_append_lease"
+
+printf '\n== structural: every subcommand auto-marks a step except the cycle bracket itself ==\n'
+check_contains "hook runs right after cmd parsing, before the case statement" "$poact_src" \
+  'if [[ "$cmd" != "cycle-start" && "$cmd" != "cycle-end" ]]; then'
+check_contains "hook calls _cycle_append_step with the real subcommand and args" "$poact_src" \
+  '_cycle_append_step "$cmd" "$@"'
+
+printf '\n== durability: cycle manifests live outside the ledger/session-transcript trees ==\n'
+check_eq "CYCLE_DIR is distinct from the dispatch ledger dir" \
+  "$([[ "$CYCLE_DIR" != "$CFGMS_AGENT_LEDGER_DIR"* ]] && echo distinct || echo same)" "distinct"
+check_contains "CYCLE_DIR sits beside CACHE_DIR, not under it via retention pruning" "$poact_src" \
+  'CYCLE_DIR="${CFGMS_CYCLE_DIR:-${CACHE_DIR}/cycles}"'
+
+printf '\n%s\n' "-----------------------------------------"
+if [[ "$fail" -eq 0 ]]; then
+  printf 'PASS: %d checks\n' "$ran"; exit 0
+else
+  printf 'FAIL: %d of %d checks failed\n' "$fail" "$ran"; exit 1
+fi


### PR DESCRIPTION
## Summary

A `/po cron` cycle is one agent session, so `token_report.py` attributed its entire cost to a single segment — what the Tech Lead pass costs versus the pin sweep versus acceptance review was not derivable at any effort, because nothing marked where one step ends and the next begins. Measured on the 2026-07-25 cycle: the orchestrator's own summary put its three nested agents at ~302K tokens; the reporter measured 9,502,304 billed tokens for the same transcripts, a **31.5x understatement** (agents see their own context and output but not cache-read traffic, ~95% of the bill) — self-reporting is not a substitute for measured attribution.

## Design decision (explicitly flagged in the issue as needing to be settled before coding)

**Who emits step boundaries:** `po-act.sh` does, deterministically, at its own subcommand-call boundaries — not the agent narrating its own steps. `po-act.sh` already bundles nearly every cycle action into one subcommand each ("bundle common PO cycle actions into single invocations", its own stated design), so this covers the overwhelming majority of real work. A step with no matching subcommand call (pure agent reasoning) has no boundary of its own and folds into whichever step ran next — imprecise but honest, and strictly more attributable than one undifferentiated whole-cycle bucket.

## Changes made

- **`po-act.sh`**: `cycle-start` opens a per-cycle manifest keyed by `CLAUDE_CODE_SESSION_ID` (the harness-set env var identifying the running agent's own transcript — never self-reported); every other subcommand auto-records a step via a single hook right after argument parsing, and **tees each step's real stdout** to classify its outcome (work / no-op / error) from this script's own status markers (`DISPATCHED:`/`DISPATCH_SKIPPED:`/`CLAIM_LOST:`/...) and exit code, via an EXIT trap so a step killed mid-run stays honestly "incomplete" rather than silently missing; `_acquire_lease`/`_release_lease` record lease events; `cycle-end` closes the manifest, correlates measured cost per step via `token_report.py`, records the nested agents spawned with their roles, and folds in this cycle's #3052 dispatch-ledger launches (reusing it rather than re-implementing container tracking); `cycle-report` is the documented one-line command for average cost per step (with work/no-op split) and per nested-agent-role spend, across the last N cycles.
- **`token_report.py`**: new `correlate_cycle_manifest()` + `--cycle-manifest` flag buckets a session's real per-call usage into the manifest's step boundaries by timestamp; new `extract_agent_spawns()` reads nested-agent roles straight out of the session's transcript (`Agent`/`Skill` tool_use rows carry the role verbatim in `subagent_type`, and the result row's `agentId` names the nested transcript, which is how each role also gets its own measured cost) — never asks the orchestrator to declare its own spawns.
- **`po.md`**: brackets §4 with `cycle-start` (first action of §4.0 Pre-Flight) and `cycle-end` (new Step 11, always run last even on partial failure) — no change to existing step order or content — and tells the agent explicitly: **never report step outcomes, spawned agents, or token counts by hand; the record comes from transcripts.**

## Verified independently, not just via the automated suite

- Ran `extract_agent_spawns` against **this session's own real transcript** and got back the actual `pr-reviewer`/`qa-test-runner`/`doc-review` spawns from this conversation with correct roles and agent IDs.
- Ran a **live multi-step cycle** through the real tee/EXIT-trap mechanism (`cycle-start`, three real subcommands, `cycle-end`) and confirmed no hangs, no leaked `tee` processes, no stray capture files left behind, and accurate work/no-op/error classification against real subcommand output.
- A first `git push` hit a 3-test flake in the pre-push script suite under concurrent background load; two clean standalone re-runs (215/0) and a clean re-push confirmed it was transient, not a regression.

## Test plan

- [x] `.claude/scripts/tests/cycle_manifest.test.sh` — 48 checks: real end-to-end cycle-start/step-marking/cycle-end/cycle-report against a fixture transcript, outcome classification for deferred/successful/failing/killed steps, nested-agent-role attribution, idempotency, durability
- [x] `.claude/metrics/tests/test_token_report.py` — 50 tests (was 43): step bucketing, measured-vs-self-reported distinction, `extract_agent_spawns` parsing, missing/malformed manifests, AC4 (incomplete cycle still correlates and stays on disk)
- [x] Full existing `.claude/scripts/tests/*.test.sh` suite (11 other files) — no regressions
- [x] `make test` / `make lint` / `make security-precommit` / `make check-architecture` / `make security-scan` all pass
- [x] `/story-complete` adversarial review — round 1 acceptance lens flagged the missing outcome-classification and nested-agent-role ACs, developer fix round addressed both, round 2 passed clean

Fixes #3053

Co-Authored-By: Claude <noreply@anthropic.com>