### PR TITLE
metrics: attribute spend to nested agent roles and review lenses (Issue #3054)

### DIFF
--- a/.claude/metrics/README.md
+++ b/.claude/metrics/README.md
@@ -20,12 +20,27 @@ Part of epic #3026 (pipeline cost engineering); this directory is story #3027.
 # Main loop vs subagents vs workflow agents
 .claude/metrics/token_report.py --group-by agent
 
+# Which review lens (or Tech Lead, BA, fix round...) actually costs what
+.claude/metrics/token_report.py --group-by role
+
 # One record per API call, for downstream tooling and benchmarks
 .claude/metrics/token_report.py --format jsonl --out facts.jsonl
 ```
 
 Group keys: `model`, `segment`, `session`, `day`, `skill`, `agent`, `project`,
-`workflow`.
+`workflow`, `role`.
+
+`role` (story #3054) is who a call ran *as* — `acceptance-checker`,
+`developer`, `security-engineer`, `tech-lead`, a Skill name like
+`doc-review`, or `main` for the top-level session. Sourced from transcript
+data only, never inferred from a filename or self-reported: an Agent/Task
+spawn stamps every row of its own transcript with `attributionAgent` set to
+the exact `subagent_type`; a Skill that forks into its own agent stamps
+`attributionSkill` instead. A nested call with neither field is `unknown` —
+reported explicitly, never dropped or folded into a neighbouring role.
+Combine with `--group-by workflow` or the `session`/`transcript` fields in
+`--format jsonl` to separate spend per review lens *and* per fix round for a
+single dev-agent run, or per role across a whole cron cycle.
 
 Prices live in `pricing.json`, not in code. A model absent from that table is
 reported as `UNPRICED`: its tokens are counted and its dollars are **not**

--- a/.claude/metrics/tests/test_token_report.py
+++ b/.claude/metrics/tests/test_token_report.py
@@ -25,10 +25,13 @@ from token_report import (  # noqa: E402
     Pricing,
     SessionMeta,
     TranscriptRef,
+    build_parser,
+    call_to_fact,
     collect,
     compute_cost,
     correlate_cycle_manifest,
     extract_agent_spawns,
+    group_key,
     parse_transcript,
     totals,
     split_cache_write,
@@ -377,6 +380,104 @@ class TestCollect(unittest.TestCase):
         calls, _ = collect([root], Pricing.load(), None, ["proj-a"])
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0][0].project, "proj-a")
+
+
+class TestRoleAttribution(unittest.TestCase):
+    """Every fact record carries a role, sourced from transcript data (Issue #3054).
+
+    Confirmed empirically against a real transcript tree before writing this
+    code (per the issue's own Implementation Notes -- "do not let an
+    implementer guess a field name"): `attributionAgent` carries the exact
+    subagent_type ("acceptance-checker", "developer", ...) on every row of an
+    Agent/Task-spawned nested transcript; a Skill that forks into its own
+    agent carries `attributionSkill` instead (the same field already read
+    into `call.skill`) with no `attributionAgent` at all. Both were observed
+    on real transcripts from this repo's own pipeline runs.
+    """
+
+    def _corpus(self) -> Path:
+        root = Path(tempfile.mkdtemp())
+        project = root / "-workspace"
+        (project / "sess1" / "subagents" / "workflows" / "wf_abc").mkdir(parents=True)
+        (project / "sess1.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "<command-name>/po</command-name>"},
+                }
+            )
+            + "\n"
+            + assistant_row("req_main")
+            + "\n",
+            encoding="utf-8",
+        )
+        # Agent/Task spawn: attributionAgent carries the role verbatim.
+        (project / "sess1" / "subagents" / "sub_role.jsonl").write_text(
+            assistant_row("req_sub_role", attributionAgent="acceptance-checker") + "\n",
+            encoding="utf-8",
+        )
+        # Skill fork: attributionAgent absent, attributionSkill carries it instead.
+        (project / "sess1" / "subagents" / "sub_skill.jsonl").write_text(
+            assistant_row("req_sub_skill", attributionSkill="doc-review") + "\n",
+            encoding="utf-8",
+        )
+        # Nested with neither field -- the genuine "cannot be determined" case.
+        (project / "sess1" / "subagents" / "sub_bare.jsonl").write_text(
+            assistant_row("req_sub_bare") + "\n", encoding="utf-8"
+        )
+        # Workflow-nested lens, same attributionAgent mechanism.
+        (project / "sess1" / "subagents" / "workflows" / "wf_abc" / "w1.jsonl").write_text(
+            assistant_row("req_wf", attributionAgent="security-engineer") + "\n",
+            encoding="utf-8",
+        )
+        return root
+
+    def test_agent_spawn_role_is_the_subagent_type(self):
+        calls, _ = collect([self._corpus()], Pricing.load(), None, None)
+        by_req = {c.request_id: c for c, _ in calls}
+        self.assertEqual(by_req["req_sub_role"].role, "acceptance-checker")
+
+    def test_skill_fork_role_falls_back_to_attribution_skill(self):
+        calls, _ = collect([self._corpus()], Pricing.load(), None, None)
+        by_req = {c.request_id: c for c, _ in calls}
+        self.assertEqual(by_req["req_sub_skill"].role, "doc-review")
+
+    def test_workflow_nested_lens_role(self):
+        calls, _ = collect([self._corpus()], Pricing.load(), None, None)
+        by_req = {c.request_id: c for c, _ in calls}
+        self.assertEqual(by_req["req_wf"].role, "security-engineer")
+
+    def test_main_loop_role_is_main_not_unknown(self):
+        calls, _ = collect([self._corpus()], Pricing.load(), None, None)
+        by_req = {c.request_id: c for c, _ in calls}
+        self.assertEqual(by_req["req_main"].role, "main")
+
+    def test_undeterminable_nested_role_is_unknown_not_dropped(self):
+        # AC4: never silently dropped, never merged into a neighbouring role.
+        calls, _ = collect([self._corpus()], Pricing.load(), None, None)
+        by_req = {c.request_id: c for c, _ in calls}
+        self.assertIn("req_sub_bare", by_req)
+        self.assertEqual(by_req["req_sub_bare"].role, "unknown")
+
+    def test_group_by_role_covers_a_full_tree(self):
+        # AC5: a transcript tree containing main, subagent, and workflow-agent
+        # calls, sliced by role in one pass.
+        calls, _ = collect([self._corpus()], Pricing.load(), None, None)
+        roles = sorted({group_key(call, segment, "role") for call, segment in calls})
+        self.assertEqual(
+            roles, ["acceptance-checker", "doc-review", "main", "security-engineer", "unknown"]
+        )
+
+    def test_role_is_in_the_fact_record(self):
+        calls, _ = collect([self._corpus()], Pricing.load(), None, None)
+        by_req = {c.request_id: c for c, _ in calls}
+        fact = call_to_fact(by_req["req_sub_role"], "some-segment")
+        self.assertEqual(fact["role"], "acceptance-checker")
+
+    def test_role_is_a_valid_group_by_choice(self):
+        parser = build_parser()
+        args = parser.parse_args(["--group-by", "role"])
+        self.assertEqual(args.group_by, "role")
 
 
 class TestCycleManifestCorrelation(unittest.TestCase):

--- a/.claude/metrics/token_report.py
+++ b/.claude/metrics/token_report.py
@@ -59,7 +59,7 @@ BUILTIN_COMMANDS = frozenset(
     }
 )
 
-GROUP_KEYS = ("model", "segment", "session", "day", "skill", "agent", "project", "workflow")
+GROUP_KEYS = ("model", "segment", "session", "day", "skill", "agent", "project", "workflow", "role")
 
 
 # --------------------------------------------------------------------------
@@ -170,6 +170,7 @@ class Call:
     model: str
     effort: str | None
     skill: str | None
+    attribution_agent: str | None
     is_sidechain: bool
     git_branch: str | None
     cwd: str | None
@@ -190,6 +191,27 @@ class Call:
             + self.cache_read
             + self.output_tokens
         )
+
+    @property
+    def role(self) -> str:
+        """Who this call ran as, sourced from transcript data (Issue #3054).
+
+        Never inferred from a filename or self-reported: Agent/Task spawns
+        stamp every row with `attributionAgent` set to the exact
+        `subagent_type` (e.g. "acceptance-checker", "developer"); a Skill
+        forked into its own agent stamps `attributionSkill` instead (the same
+        field this reporter already reads into `skill` for segment
+        attribution) -- confirmed empirically against a real transcript tree,
+        not assumed (see extract_agent_spawns' fixture and the epic's own
+        Implementation Notes, which required this before any code was
+        written). A main-loop call has neither field and is not nested, so it
+        is labeled "main" rather than falling into "unknown" -- only a nested
+        call with genuinely neither field earns that bucket, and it is never
+        merged into a neighbouring role.
+        """
+        if self.agent_kind == "main":
+            return "main"
+        return self.attribution_agent or self.skill or "unknown"
 
 
 @dataclass
@@ -407,6 +429,7 @@ def parse_transcript(
                 model=model,
                 effort=row.get("effort"),
                 skill=row.get("attributionSkill"),
+                attribution_agent=row.get("attributionAgent"),
                 is_sidechain=bool(row.get("isSidechain")),
                 git_branch=row.get("gitBranch") or meta.branch,
                 cwd=row.get("cwd") or meta.cwd,
@@ -489,6 +512,8 @@ def group_key(call: Call, segment: str, key: str) -> str:
         return call.project
     if key == "workflow":
         return call.workflow or "(none)"
+    if key == "role":
+        return call.role
     raise ValueError(f"unknown group key: {key}")
 
 
@@ -900,6 +925,7 @@ def call_to_fact(call: Call, segment: str) -> dict[str, Any]:
         "effort": call.effort,
         "skill": call.skill,
         "agent": call.agent_kind,
+        "role": call.role,
         "workflow": call.workflow,
         "git_branch": call.git_branch,
         "input_tokens": call.input_tokens,


### PR DESCRIPTION
## Summary

The reporter's `agent` field said what *layer* a call ran in (main/subagent/workflow) but not what it was *doing*. Nested transcripts are named by opaque hash on disk, so roles couldn't be recovered after the fact — inside a cron cycle, nested spend could only be attributed to the Tech Lead vs the pin sweep vs the pipeline sweep by reading the orchestrator's prose; inside dev containers, the `story-review` workflow's three review lenses plus up to three fix rounds were 56.3% of container spend with no way to tell which lens, or whether a third fix round ever earns its cost. That matters for routing: `developer` and `security-engineer` carry `model: opus`, so this is the mechanism by which opus reaches 31% of container spend.

## Field-existence verification (required before any code, per the issue's own Implementation Notes)

> "it is not yet established that a usable role label exists in nested transcript rows... do not let an implementer guess a field name."

Confirmed empirically against this repo's own real transcript tree — 28 nested transcripts spanning 10 bare subagents and three real `story-review` workflow runs from tonight's own epic work:

- **`attributionAgent`** carries the exact `subagent_type` verbatim (`acceptance-checker`, `developer`, `security-engineer`, `qa-code-reviewer`, `qa-test-runner`, `pr-reviewer`, ...) on every row of an Agent/Task-spawned transcript.
- **`attributionSkill`** carries the skill name (`doc-review`) on a Skill-forked transcript instead — the same field already read into the existing `skill` field — with no `attributionAgent` at all.
- Both fields are measured attribution data written by the harness, never a guess and never self-reported.

## Changes made

- `Call` gains `attribution_agent` (parsed the same way as the existing `skill` field) and a derived `role` property: `attribution_agent`, else `skill`, else `"main"` for non-nested calls, else `"unknown"` for a nested call with neither — reported explicitly, **never dropped or merged into a neighbouring role** (AC4).
- `role` added to `GROUP_KEYS` (`--group-by role`) and to `call_to_fact` (present on every `--format jsonl` fact record) — AC1/AC2.
- `README.md` documents the new dimension and how to combine it with `--group-by workflow` or the `session`/`transcript` fields in `--format jsonl` output to separate spend per review lens *and* per fix round for a dev-agent run, or per role across a whole cron cycle (AC3).
- `test_token_report.py`: 8 new tests (58 total) covering a transcript tree with main, bare-subagent, and workflow-nested calls, both attribution fields, and the undeterminable-role case (AC5).

## Verified against the full real corpus, not just fixtures

Ran `--group-by role` against every transcript this host has ever produced (43,189 real API calls) and got back a genuine, meaningful breakdown — `main`, `po`, `tech-lead`, `epic-review`, `pipeline-sweep`, `developer`, `security-engineer`, `pr-reviewer`, `acceptance-checker`, `acceptance-reviewer`, `ba`, and a real 9.4%-of-total-cost `unknown` bucket, correctly surfaced rather than silently dropped or folded elsewhere.

## Out of scope (per issue)

Changing which model any agent runs on; acting on the results; persisting dev-agent transcripts (tracked separately, precondition for the dev-container half of this).

## Test plan

- [x] `.claude/metrics/tests/test_token_report.py` — 58 tests (was 50), all pass
- [x] `.claude/scripts/tests/cycle_manifest.test.sh` — 48 checks, confirms the `Call` dataclass change doesn't break #3053's `--cycle-manifest` correlation path
- [x] Real end-to-end run of `--group-by role` against the full historical transcript corpus (43,189 calls) — meaningful, correctly-labeled output
- [x] `make test` / `make lint` / `make security-precommit` / `make check-architecture` / `make security-scan` all pass
- [x] Pre-push validation (race-detector unit tests + security + lint) passed

Fixes #3054

Co-Authored-By: Claude <noreply@anthropic.com>