### PR TITLE
metrics: cost per merged story, PR, and fix round (Issue #3055)

### DIFF
--- a/.claude/metrics/README.md
+++ b/.claude/metrics/README.md
@@ -25,10 +25,32 @@ Part of epic #3026 (pipeline cost engineering); this directory is story #3027.
 
 # One record per API call, for downstream tooling and benchmarks
 .claude/metrics/token_report.py --format jsonl --out facts.jsonl
+
+# What did delivered work actually cost -- per story, dev vs fix vs review
+.claude/metrics/token_report.py --story-report
+.claude/metrics/token_report.py --story-report --format jsonl --out stories.jsonl
 ```
 
 Group keys: `model`, `segment`, `session`, `day`, `skill`, `agent`, `project`,
 `workflow`, `role`.
+
+`--story-report` (story #3055) answers the epic's own framing question's
+denominator — cost per story and per PR, dev cost separated from fix-round
+cost so the price of rework is visible on its own. Joined on the issue
+number in each persisted container's `meta.json` (`~/.cache/cfgms-agent-sessions`
+by default, `--sessions-dir` to override), falling back to the story number
+in `feature/story-<N>-*` when `meta.json` has none — never from a filename
+elsewhere or from `agent-result.json`'s own totals: every dollar is computed
+fresh from that container's own persisted transcript, the same measured
+accounting as every other report here. Explicitly excludes the cron
+orchestration's own share of a story's cost (an inherently arbitrary split
+across however many stories one cycle happened to touch) — every row's
+`excludes` field says so. A story is `partial` when its transcript is
+missing, its story number couldn't be resolved, or — the common case for
+anything dispatched before dev-agent session persistence (story #3051)
+landed — no dev-mode launch was ever found for it, so the largest component
+of its cost is silently absent rather than genuinely zero. Never reported as
+though the figure were complete.
 
 `role` (story #3054) is who a call ran *as* — `acceptance-checker`,
 `developer`, `security-engineer`, `tech-lead`, a Skill name like

--- a/.claude/metrics/tests/test_token_report.py
+++ b/.claude/metrics/tests/test_token_report.py
@@ -33,6 +33,7 @@ from token_report import (  # noqa: E402
     extract_agent_spawns,
     group_key,
     parse_transcript,
+    story_cost_report,
     totals,
     split_cache_write,
 )
@@ -816,6 +817,155 @@ class TestNestedAgentSpawns(unittest.TestCase):
         agent_cost = sum(a["cost_usd"] for a in result["agents"])
         self.assertGreater(agent_cost, 0)
         self.assertGreaterEqual(result["cycle_cost_usd"], agent_cost)
+
+
+class TestStoryCostReport(unittest.TestCase):
+    """Cost per story: dev vs fix-round vs review (Issue #3055).
+
+    The join is issue number (or branch-parsed story number) from meta.json
+    (Issue #3051), written host-side at launch -- never self-reported. Cost
+    itself is always computed fresh from the container's own persisted
+    transcript, the same measured accounting every other report in this tool
+    uses, even when agent-result.json already carries a pre-baked number.
+    """
+
+    def _container(
+        self,
+        sessions_base: Path,
+        name: str,
+        mode: str,
+        issue=None,
+        pr=None,
+        branch="",
+        started_at="2026-07-28T10:00:00Z",
+        usage_tokens: int | None = 1000,
+        write_transcript: bool = True,
+    ) -> Path:
+        container_dir = sessions_base / name
+        container_dir.mkdir(parents=True)
+        meta = {"container": name, "mode": mode, "issue": issue, "pr": pr, "branch": branch, "started_at": started_at}
+        (container_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+        # agent-result.json deliberately claims an absurd, wrong cost -- the
+        # report must never trust it; only the transcript's own measured
+        # usage may produce a dollar figure.
+        (container_dir / "agent-result.json").write_text(
+            json.dumps({"mode": mode, "usage": {"cost_usd": 99999.0}}), encoding="utf-8"
+        )
+        if write_transcript:
+            workspace = container_dir / "-workspace"
+            workspace.mkdir()
+            (workspace / "sess.jsonl").write_text(
+                assistant_row("req_1", usage=usage(inp=usage_tokens, out=usage_tokens)) + "\n",
+                encoding="utf-8",
+            )
+        return container_dir
+
+    def test_dev_fix_review_sum_into_separate_buckets(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-42", "issue", issue=42)
+        self._container(sessions, "cfg-agent-pr-fix-42", "fix-pr", issue=42, pr=100)
+        self._container(sessions, "cfg-agent-review-pr-42", "review", issue=42, pr=100)
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertEqual(len(stories), 1)
+        story = stories[0]
+        self.assertEqual(story["story"], 42)
+        self.assertEqual(story["pr"], 100)
+        self.assertGreater(story["dev_cost_usd"], 0)
+        self.assertGreater(story["fix_cost_usd"], 0)
+        self.assertGreater(story["review_cost_usd"], 0)
+        self.assertAlmostEqual(
+            story["total_cost_usd"],
+            story["dev_cost_usd"] + story["fix_cost_usd"] + story["review_cost_usd"],
+            places=4,
+        )
+
+    def test_cost_is_measured_not_taken_from_agent_result(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-7", "issue", issue=7)
+        stories = story_cost_report(sessions, Pricing.load())
+        # agent-result.json claimed cost_usd=99999.0; the real transcript's
+        # usage is tiny by comparison.
+        self.assertLess(stories[0]["dev_cost_usd"], 100.0)
+        self.assertGreater(stories[0]["dev_cost_usd"], 0.0)
+
+    def test_story_resolved_from_branch_when_issue_field_absent(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(
+            sessions, "cfg-agent-branch-x", "branch", issue=None, branch="feature/story-88-x"
+        )
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertEqual(stories[0]["story"], 88)
+
+    def test_multiple_fix_rounds_counted_and_summed(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-pr-fix-9-a", "fix-pr", issue=9, pr=200)
+        self._container(sessions, "cfg-agent-pr-fix-9-b", "fix-pr", issue=9, pr=200)
+        self._container(sessions, "cfg-agent-resolve-conflict-9", "resolve-conflict", issue=9, pr=200)
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertEqual(stories[0]["fix_rounds"], 3)
+
+    def test_missing_dev_container_is_flagged_partial(self):
+        # AC4: the largest cost component is silently missing, not zero.
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-review-pr-5", "review", issue=5, pr=50)
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertTrue(stories[0]["partial"])
+        self.assertEqual(stories[0]["dev_cost_usd"], 0.0)
+
+    def test_dev_container_present_is_not_flagged_partial_for_that_reason(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-6", "issue", issue=6)
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertFalse(stories[0]["partial"])
+
+    def test_session_dir_with_no_transcript_is_flagged_partial(self):
+        # meta.json exists (a launch was recorded) but the transcript was
+        # never captured -- a crash before persistence, or a pruned session.
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-11", "issue", issue=11, write_transcript=False)
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertTrue(stories[0]["partial"])
+        self.assertEqual(stories[0]["dev_cost_usd"], 0.0)
+
+    def test_unresolvable_story_is_grouped_by_container_and_flagged_partial(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-interactive-scratch", "branch", issue=None, branch="")
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertEqual(len(stories), 1)
+        self.assertIsNone(stories[0]["story"])
+        self.assertTrue(stories[0]["partial"])
+
+    def test_since_filters_by_launch_time(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-old", "issue", issue=1, started_at="2020-01-01T00:00:00Z")
+        self._container(sessions, "cfg-agent-new", "issue", issue=2, started_at="2026-07-28T00:00:00Z")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        stories = story_cost_report(sessions, Pricing.load(), since=since)
+        self.assertEqual({s["story"] for s in stories}, {2})
+
+    def test_excludes_field_names_cron_orchestration(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-3", "issue", issue=3)
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertIn("cron-orchestration-share", stories[0]["excludes"])
+
+    def test_missing_sessions_dir_returns_empty_not_an_error(self):
+        stories = story_cost_report(Path("/nonexistent/path"), Pricing.load())
+        self.assertEqual(stories, [])
+
+    def test_sorted_by_total_cost_descending(self):
+        sessions = Path(tempfile.mkdtemp())
+        self._container(sessions, "cfg-agent-small", "issue", issue=1, usage_tokens=10)
+        self._container(sessions, "cfg-agent-big", "issue", issue=2, usage_tokens=100000)
+        stories = story_cost_report(sessions, Pricing.load())
+        self.assertEqual(stories[0]["story"], 2)
+        self.assertEqual(stories[1]["story"], 1)
+
+    def test_cli_flags_exist(self):
+        parser = build_parser()
+        args = parser.parse_args(["--story-report", "--sessions-dir", "/tmp/x"])
+        self.assertTrue(args.story_report)
+        self.assertEqual(str(args.sessions_dir), "/tmp/x")
 
 
 if __name__ == "__main__":

--- a/.claude/metrics/token_report.py
+++ b/.claude/metrics/token_report.py
@@ -778,6 +778,145 @@ def correlate_cycle_manifest(
 
 
 # --------------------------------------------------------------------------
+# Per-story cost (Issue #3055)
+# --------------------------------------------------------------------------
+
+DEFAULT_SESSIONS_DIR = Path.home() / ".cache" / "cfgms-agent-sessions"
+
+#: Dispatch mode (Issue #3052's launch ledger / #3051's meta.json) -> cost bucket.
+_MODE_BUCKET = {
+    "issue": "dev",
+    "branch": "dev",
+    "fix-pr": "fix",
+    "resolve-conflict": "fix",
+    "review": "review",
+}
+
+
+def story_cost_report(
+    sessions_base: Path, pricing: Pricing, since: datetime | None = None
+) -> list[dict[str, Any]]:
+    """Cost per story: dev vs fix-round vs review, from real container sessions.
+
+    Answers the epic's own framing question's denominator -- "which segment
+    consumes the most tokens per unit of DELIVERED WORK" needs a dollar figure
+    per story, not just per segment. Every fact record already carries
+    git_branch, and dev branches follow feature/story-<N>-*, so joining a
+    container to its story is mechanically the story number in that branch
+    name -- confirmed here against meta.json (Issue #3051), which records it
+    host-side at launch time, never self-reported by the agent.
+
+    Cost per container is computed FRESH from that container's own persisted
+    transcript (the same session mount Issue #3051 added) via this reporter's
+    normal per-call accounting -- never agent-result.json's own pre-baked
+    cost_usd, even though that number was computed the same way. Reusing a
+    downstream artifact's number is not "measuring it here", and this story's
+    entire premise is the same one every story in this epic shares: figures
+    must be measured, not narrated or trusted secondhand.
+
+    Explicitly excludes the cron orchestration's own share of a story's cost
+    (AC3 allows stating exclusions instead of attributing an inherently
+    arbitrary split across however many stories one cycle happened to touch
+    on a given run) -- every returned record carries this in `excludes`.
+
+    A story is "partial" when: a container's session directory exists (so a
+    launch was recorded) but no transcript was ever captured for it -- a
+    crash before persistence, or a pruned session; no story number could be
+    resolved at all; or the story has fix and/or review cost but no dev
+    launch was ever found for it -- the single largest component of a
+    story's cost is then silently absent rather than genuinely zero (this is
+    the common case for every story dispatched before #3051's session
+    persistence landed: fix/review costs are measured, dev cost reads $0.00
+    but is not $0.00). Flagged explicitly in every such case, never reported
+    as though the figure were complete (AC4).
+    """
+    stories: dict[str, dict[str, Any]] = {}
+    if not sessions_base.is_dir():
+        return []
+
+    for container_dir in sorted(p for p in sessions_base.iterdir() if p.is_dir()):
+        meta_path = container_dir / "meta.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        result: dict[str, Any] = {}
+        result_path = container_dir / "agent-result.json"
+        if result_path.is_file():
+            try:
+                result = json.loads(result_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                result = {}
+
+        started_at = _parse_time(meta.get("started_at"))
+        if since is not None and started_at is not None and started_at < since:
+            continue
+
+        mode = meta.get("mode") or result.get("mode")
+        branch = meta.get("branch") or result.get("branch") or ""
+        issue = meta.get("issue") or result.get("issue")
+        if not issue:
+            match = _STORY_BRANCH_RE.search(branch)
+            if match:
+                issue = int(match.group(1))
+        pr = meta.get("pr") or result.get("pr_num")
+
+        # Measured, not self-reported: scan this container's own persisted
+        # transcript directory the same way every other report in this tool
+        # does, rather than trusting agent-result.json's own totals.
+        container_calls, _ = collect([container_dir], pricing, None, None)
+        cost = sum((c.cost_usd or 0.0) for c, _ in container_calls)
+        has_transcript = len(container_calls) > 0
+
+        key = str(issue) if issue else (f"pr-{pr}" if pr else f"container:{container_dir.name}")
+        story = stories.setdefault(
+            key,
+            {
+                "story": issue,
+                "pr": pr,
+                "dev_cost_usd": 0.0,
+                "fix_cost_usd": 0.0,
+                "review_cost_usd": 0.0,
+                "fix_rounds": 0,
+                "containers": 0,
+                "has_dev": False,
+                "partial": False,
+                "excludes": ["cron-orchestration-share"],
+            },
+        )
+        if pr and not story["pr"]:
+            story["pr"] = pr
+        story["containers"] += 1
+        if not has_transcript:
+            story["partial"] = True
+
+        bucket = _MODE_BUCKET.get(mode, "fix")
+        story[f"{bucket}_cost_usd"] = round(story[f"{bucket}_cost_usd"] + cost, 4)
+        if bucket == "dev":
+            story["has_dev"] = True
+        if bucket == "fix":
+            story["fix_rounds"] += 1
+
+    for story in stories.values():
+        story["total_cost_usd"] = round(
+            story["dev_cost_usd"] + story["fix_cost_usd"] + story["review_cost_usd"], 4
+        )
+        if story["story"] is None:
+            # No issue number resolvable at all -- reported under its PR (or
+            # container name) rather than dropped, but the figure can't be
+            # trusted as "this story's cost" without one.
+            story["partial"] = True
+        if not story.pop("has_dev"):
+            # The largest component of a story's cost is missing, not zero.
+            story["partial"] = True
+
+    return sorted(stories.values(), key=lambda s: -s["total_cost_usd"])
+
+
+# --------------------------------------------------------------------------
 # Output
 # --------------------------------------------------------------------------
 
@@ -883,6 +1022,29 @@ def render_composition(calls: list[tuple[Call, str]], pricing: Pricing, out) -> 
     print(f"{'TOTAL':<16}  {_fmt_tokens(sum(tokens.values())):>9}  {total:>9.2f}  100.0%", file=out)
 
 
+def render_story_report(stories: list[dict[str, Any]], out) -> None:
+    """Human-readable form of story_cost_report's output (Issue #3055)."""
+    print(
+        f"\n{'story':>7}  {'pr':>7}  {'dev $':>8}  {'fix $':>8}  {'review $':>9}  "
+        f"{'total $':>8}  {'rounds':>6}  {'partial':>7}",
+        file=out,
+    )
+    print("-" * 76, file=out)
+    for story in stories:
+        print(
+            f"{str(story['story'] or '-'):>7}  {str(story['pr'] or '-'):>7}  "
+            f"{story['dev_cost_usd']:>8.2f}  {story['fix_cost_usd']:>8.2f}  "
+            f"{story['review_cost_usd']:>9.2f}  {story['total_cost_usd']:>8.2f}  "
+            f"{story['fix_rounds']:>6}  {('yes' if story['partial'] else ''):>7}",
+            file=out,
+        )
+    print("-" * 76, file=out)
+    total = sum(s["total_cost_usd"] for s in stories)
+    partial_count = sum(1 for s in stories if s["partial"])
+    print(f"{len(stories)} stories, ${total:.2f} total, {partial_count} partial", file=out)
+    print("excludes: cron orchestration's own share of cost", file=out)
+
+
 def totals(calls: list[tuple[Call, str]]) -> dict[str, Any]:
     """Aggregate every call into one record.
 
@@ -979,18 +1141,51 @@ def build_parser() -> argparse.ArgumentParser:
             "cost/tokens back into that file, instead of the normal report."
         ),
     )
+    parser.add_argument(
+        "--story-report",
+        action="store_true",
+        help=(
+            "Report cost per story: dev vs fix-round vs review, joined from "
+            "persisted dev-agent container sessions (Issue #3055), instead of "
+            "the normal per-call report. --format jsonl for machine-readable "
+            "output, otherwise a table."
+        ),
+    )
+    parser.add_argument(
+        "--sessions-dir",
+        type=Path,
+        default=DEFAULT_SESSIONS_DIR,
+        help=f"Persisted dev-agent session root for --story-report. Default: {DEFAULT_SESSIONS_DIR}",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    pricing = Pricing.load(args.pricing)
+
+    if args.story_report:
+        since = (
+            datetime.now(timezone.utc) - timedelta(days=args.since) if args.since is not None else None
+        )
+        stories = story_cost_report(args.sessions_dir, pricing, since)
+        out = args.out.open("w", encoding="utf-8") if args.out else sys.stdout
+        try:
+            if args.format == "jsonl":
+                for story in stories:
+                    json.dump(story, out)
+                    out.write("\n")
+            else:
+                render_story_report(stories, out)
+        finally:
+            if args.out:
+                out.close()
+        return 0
 
     roots = args.projects_dir or [DEFAULT_PROJECTS_DIR]
     if not any(root.is_dir() for root in roots):
         print(f"No transcript directory found in: {[str(r) for r in roots]}", file=sys.stderr)
         return 2
-
-    pricing = Pricing.load(args.pricing)
 
     if args.cycle_manifest is not None:
         try:


### PR DESCRIPTION
## Summary

The epic's first framing question is "which pipeline segment consumes the most tokens per unit of delivered work" — the reporter answered the numerator (spend by model/segment/session/day) but nothing supplied the denominator, so no dollar figure existed for what a merged story actually cost.

Every fact record already carries `git_branch`, and dev branches follow `feature/story-<N>-*`, so the join to a story is mechanically the story number — confirmed against `meta.json` (Issue #3051), written host-side at launch time, never self-reported by the agent. Cost per container is computed **fresh from that container's own persisted transcript** via this reporter's normal measured accounting, never `agent-result.json`'s own pre-baked `cost_usd`, even though that number was computed the same way — reusing a downstream artifact's figure is not "measuring it here," and this story shares the same premise every story in this epic does.

## Changes made

- `story_cost_report()` walks `~/.cache/cfgms-agent-sessions/*/` (`--sessions-dir` to override), buckets each container's measured cost into dev / fix / review by its launch mode, and sums per story.
- Explicitly excludes the cron orchestration's own share of a story's cost in every row's `excludes` field — an inherently arbitrary split across however many stories one cycle happened to touch, which AC3 allows stating rather than attributing.
- A story is flagged `partial` when: its transcript is missing though a launch was recorded, its story number can't be resolved, or — **caught by running this against the real corpus on this host**, where it silently under-reported every story's cost as `dev=$0.00` before this fix — no dev-mode launch was ever found for it (the common case for every story dispatched before #3051's session persistence landed).
- `--story-report` (table, or `--format jsonl` for machine-readable output) and `--sessions-dir` wired into the CLI.

## Verified against real data, not just fixtures

Ran against every real dispatched-container session on this host: real dollar figures per story (e.g. PR #3021's **$7.93 total**: $6.56 fix + $1.37 review — the $1.37 matches the issue's own independently-measured reviewer figure cited in its Context section), with all 10 correctly flagged `partial` for the missing-dev reason above rather than silently reporting an incomplete total as if it were final.

## Test plan

- [x] `.claude/metrics/tests/test_token_report.py` — 13 new tests (71 total): bucket split, measured-vs-agent-result precedence (agent-result.json plants an absurd wrong cost, test confirms the transcript wins), branch-parsed story resolution, multiple fix rounds, every partial-flag trigger, `--since` filtering, sort order
- [x] `.claude/scripts/tests/cycle_manifest.test.sh` — 48 checks, confirms no regression to #3053's `--cycle-manifest` path
- [x] Real end-to-end run of `--story-report` against every real session directory on this host
- [x] `make test` / `make lint` / `make security-precommit` / `make check-architecture` / `make security-scan` all pass
- [x] Pre-push validation (race-detector unit tests + security + lint) passed

## Out of scope (per issue)

Acting on the results (including any model/prompt change), backfilling stories that merged before telemetry existed, forecasting or budgeting.

Fixes #3055

Co-Authored-By: Claude <noreply@anthropic.com>