### PR TITLE
bench: multi-turn harness and fixtures for dev-agent and story-review segments (Issue #3056)

### DIFF
--- a/.claude/bench/README.md
+++ b/.claude/bench/README.md
@@ -53,6 +53,7 @@ cases/<segment>/<case-id>/
   case.yaml          # segment, description, repo_sha, prompt_file
   input/prompt.md    # the frozen input
   expect.yaml        # assertions[] + rubric
+  fixture/           # optional -- see "Multi-turn, tool-using cases" below
 ```
 
 Every case pins the `repo_sha` it was captured against, so a fixture does not
@@ -67,6 +68,37 @@ embed a specific trap:
 | `acceptance-review/pr-verdict` | acceptance-review | PR body claims 3 ACs met, diff meets 2 |
 | `pr-review/security-regression` | pr-review | SQL injection beside a cosmetic change |
 | `ba/epic-decomposition` | ba | epic states explicit out-of-scope work |
+| `dev-agent/backoff-negative` | dev-agent | fix clamps a negative value to zero instead of erroring |
+| `story-review/log-sanitize-claim` | story-review | criterion's threshold and suffix are both wrong; skimming it approves anyway |
+
+### Multi-turn, tool-using cases
+
+Set `checkout: true` and `allowed_tools: [...]` in `case.yaml` to run a case
+against a real, disposable git worktree checked out at `repo_sha` instead of
+only the prompt text. `bench.py run` then invokes the CLI with `cwd` set to
+that worktree and `--allowedTools` scoped to the case's list, so a dev-agent
+case can really `Edit` a file and a story-review case can really `Read` or
+`Grep` one -- this is what makes a case genuinely multi-turn: the CLI's own
+agentic loop runs as many tool-call turns as the model needs, all inside one
+scored run, and `bench.py` totals cost across the whole thing exactly as it
+already did for single-turn cases.
+
+A case that supplies a `fixture/` directory has that tree copied onto the
+worktree *after* checkout and staged as the diff baseline, so the file a
+dev-agent case edits does not need to already exist -- or stay unchanged --
+at the pinned `repo_sha`. Assertion kinds prefixed `diff_` (`diff_contains`,
+`diff_not_contains`, `diff_matches`, `diff_not_matches`) check `git diff` in
+the worktree afterward instead of the model's text output, so a fixture can
+fail an answer that *claims* success in prose but never actually made the
+edit, or made the wrong one.
+
+The worktree is always removed when the run ends, success or failure. Every
+case's tool access is explicit and scoped per-case via `allowed_tools` --
+nothing here runs with broad or bypassed permissions.
+
+`run` captures and persists the diff the same way it already persists the
+output, so `rescore` stays free for diff-based cases too. `replay` accepts an
+optional `--diff <path>` for scoring a diff alongside an existing transcript.
 
 ## Results
 
@@ -108,10 +140,10 @@ capability, not a routing recommendation.
 
 ## Known limitations
 
-- **Fixtures are single-turn.** Real segments run agentic loops with tool use;
-  a single prompt/response underestimates both cost and failure modes.
-- **No repo checkout yet.** `repo_sha` is recorded for provenance but the
-  runner does not check it out, so cases must be self-contained. Cases needing
-  real repo state will need that added.
+- **Most fixtures are still single-turn.** `dev-agent/backoff-negative` and
+  `story-review/log-sanitize-claim` now run multi-turn against a real
+  checkout (see "Multi-turn, tool-using cases" above); the four originals
+  remain self-contained prompt/response cases and were left that way
+  deliberately -- they don't need real repo state to discriminate.
 - **Judge is single-vote.** A stronger design runs several judges with distinct
   lenses and takes a majority.

--- a/.claude/bench/bench.py
+++ b/.claude/bench/bench.py
@@ -30,6 +30,7 @@ be used to evaluate models.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import re
 import shutil
@@ -61,9 +62,18 @@ except ImportError:  # pragma: no cover - only when metrics tooling is absent
 # --------------------------------------------------------------------------
 
 
+DIFF_KIND_PREFIX = "diff_"
+
+
 @dataclass
 class Assertion:
-    """One deterministic check against the segment's output."""
+    """One deterministic check against the segment's output.
+
+    A kind prefixed ``diff_`` checks the case's captured diff (what a
+    dev-agent style case actually changed on disk) instead of the model's
+    text output -- see ``diff_contains`` / ``diff_not_contains`` /
+    ``diff_matches`` / ``diff_not_matches``. Everything else is unchanged.
+    """
 
     kind: str
     value: str
@@ -79,15 +89,17 @@ class Assertion:
             description=raw.get("description", ""),
         )
 
-    def check(self, output: str) -> bool:
-        text = output
-        if self.kind == "contains":
+    def check(self, output: str, diff: str = "") -> bool:
+        against_diff = self.kind.startswith(DIFF_KIND_PREFIX)
+        text = diff if against_diff else output
+        base = self.kind[len(DIFF_KIND_PREFIX):] if against_diff else self.kind
+        if base == "contains":
             return self.value in text
-        if self.kind == "not_contains":
+        if base == "not_contains":
             return self.value not in text
-        if self.kind == "matches":
+        if base == "matches":
             return re.search(self.value, text, re.MULTILINE) is not None
-        if self.kind == "not_matches":
+        if base == "not_matches":
             return re.search(self.value, text, re.MULTILINE) is None
         if self.kind == "section":
             # A required markdown heading, at any level.
@@ -127,6 +139,8 @@ class Case:
     assertions: list[Assertion] = field(default_factory=list)
     rubric: str | None = None
     path: Path | None = None
+    checkout: bool = False
+    allowed_tools: list[str] = field(default_factory=list)
 
     @classmethod
     def load(cls, case_dir: Path) -> "Case":
@@ -147,6 +161,8 @@ class Case:
             assertions=[Assertion.parse(a) for a in (expect.get("assertions") or [])],
             rubric=expect.get("rubric"),
             path=case_dir,
+            checkout=bool(spec.get("checkout", False)),
+            allowed_tools=list(spec.get("allowed_tools") or []),
         )
 
 
@@ -181,12 +197,12 @@ class Score:
         return (self.weighted / self.weight_total) if self.weight_total else 1.0
 
 
-def score_deterministic(case: Case, output: str) -> Score:
+def score_deterministic(case: Case, output: str, diff: str = "") -> Score:
     passed = weighted = weight_total = 0
     failures: list[str] = []
     for assertion in case.assertions:
         weight_total += assertion.weight
-        if assertion.check(output):
+        if assertion.check(output, diff):
             passed += 1
             weighted += assertion.weight
         else:
@@ -255,17 +271,92 @@ def _usage_from_transcripts(projects_dir: Path) -> dict[str, Any]:
     return totals(collected)
 
 
+def _repo_root() -> Path:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=str(BENCH_DIR), capture_output=True, text=True, check=True,
+    )
+    return Path(completed.stdout.strip())
+
+
+@contextlib.contextmanager
+def checkout_worktree(repo_sha: str, repo_root: Path | None = None):
+    """Check out a case's pinned commit into an isolated, disposable worktree.
+
+    A case that needs real tool use (Read/Grep/Edit against actual files,
+    not a prompt-embedded excerpt) runs here instead of in the caller's own
+    working tree, so it cannot see or touch anything but the pinned commit.
+    Always removed on exit, even if the run inside it fails.
+    """
+    root = repo_root or _repo_root()
+    worktree = Path(tempfile.mkdtemp(prefix="bench-worktree-"))
+    shutil.rmtree(worktree)  # `git worktree add` creates the directory itself.
+    added = subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree), repo_sha],
+        cwd=str(root), capture_output=True, text=True,
+    )
+    if added.returncode != 0:
+        raise SystemExit(f"failed to check out {repo_sha}: {added.stderr.strip()}")
+    try:
+        yield worktree
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree)],
+            cwd=str(root), capture_output=True, text=True,
+        )
+        shutil.rmtree(worktree, ignore_errors=True)
+
+
+def apply_fixture_overlay(case: Case, worktree: Path) -> None:
+    """Copy a case's bundled fixture/ files on top of the checked-out worktree.
+
+    Lets a case pin the exact file it wants edited or inspected without that
+    file needing to already exist -- and stay unchanged -- at the pinned
+    repo_sha, so a dev-agent case does not depend on its own fixture having
+    been merged upstream first.
+    """
+    if case.path is None:
+        return
+    fixture_dir = case.path / "fixture"
+    if not fixture_dir.is_dir():
+        return
+    for src in fixture_dir.rglob("*"):
+        if src.is_dir():
+            continue
+        dest = worktree / src.relative_to(fixture_dir)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+
+def _stage_baseline(worktree: Path) -> None:
+    """Stage the checked-out(+overlaid) tree so a later diff shows only what
+    the case's run actually changed, not the checkout or overlay itself."""
+    subprocess.run(["git", "-C", str(worktree), "add", "-A"], capture_output=True, text=True)
+
+
+def _capture_diff(worktree: Path) -> str:
+    result = subprocess.run(["git", "-C", str(worktree), "diff"], capture_output=True, text=True)
+    return result.stdout
+
+
 def run_case(
     case: Case,
     model: str,
     effort: str | None = None,
     timeout: int = 1800,
     workdir: Path | None = None,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     """Execute a case live against a model and capture output plus usage.
 
     The transcript is written to an isolated projects directory so the run's
     token usage can be priced exactly, without picking up unrelated sessions.
+    A case with ``checkout: true`` runs inside a disposable git worktree
+    pinned to its ``repo_sha`` instead of the caller's cwd, with tool access
+    scoped to ``allowed_tools`` -- this is what makes multi-turn, tool-using
+    cases (a dev agent editing a real file, a reviewer reading one) possible.
+    The diff captured from that worktree, if any, is returned alongside the
+    output so diff-based assertions can grade what actually changed on disk.
     """
     if shutil.which("claude") is None:
         raise SystemExit("claude CLI not found on PATH — cannot run live mode")
@@ -286,26 +377,36 @@ def run_case(
     cmd = ["claude", "-p", case.prompt, "--model", model]
     if effort:
         cmd += ["--effort", effort]
+    if case.allowed_tools:
+        cmd += ["--allowedTools", *case.allowed_tools]
 
     import os
 
     env = dict(os.environ)
     env["CLAUDE_CONFIG_DIR"] = str(env_home / ".claude")
 
-    started = time.monotonic()
-    try:
-        completed = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=str(workdir or Path.cwd()),
-            env=env,
-        )
-        output, exit_code = completed.stdout, completed.returncode
-    except subprocess.TimeoutExpired:
-        output, exit_code = "", 124
-    elapsed = time.monotonic() - started
+    def _execute(cwd: Path) -> tuple[str, int, float]:
+        started = time.monotonic()
+        try:
+            completed = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, cwd=str(cwd), env=env,
+            )
+            out, code = completed.stdout, completed.returncode
+        except subprocess.TimeoutExpired:
+            out, code = "", 124
+        return out, code, time.monotonic() - started
+
+    diff = ""
+    if case.checkout:
+        if not case.repo_sha:
+            raise SystemExit(f"{case.case_id} sets checkout: true but has no repo_sha")
+        with checkout_worktree(case.repo_sha, repo_root) as worktree:
+            apply_fixture_overlay(case, worktree)
+            _stage_baseline(worktree)
+            output, exit_code, elapsed = _execute(worktree)
+            diff = _capture_diff(worktree)
+    else:
+        output, exit_code, elapsed = _execute(workdir or Path.cwd())
 
     usage = _usage_from_transcripts(projects)
     shutil.rmtree(sandbox, ignore_errors=True)
@@ -315,6 +416,7 @@ def run_case(
         "exit_code": exit_code,
         "wall_clock_s": round(elapsed, 1),
         "usage": usage,
+        "diff": diff,
     }
 
 
@@ -347,6 +449,22 @@ def save_output(run_id: str, case: Case, output: str, results_dir: Path = RESULT
     return path
 
 
+def save_diff(run_id: str, case: Case, diff: str, results_dir: Path = RESULTS_DIR) -> Path | None:
+    """Persist the graded diff verbatim, mirroring save_output.
+
+    A dev-agent style case is scored against what changed on disk, not just
+    text output. Without this, rescoring it later would mean re-running the
+    agent -- the same reason save_output exists.
+    """
+    if not diff:
+        return None
+    out_dir = results_dir / run_id / "diffs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{case.case_id.replace('/', '__')}.diff"
+    path.write_text(diff, encoding="utf-8")
+    return path
+
+
 def build_record(
     case: Case,
     mode: str,
@@ -357,6 +475,7 @@ def build_record(
     wall_clock: float | None,
     run_id: str,
     output_path: Path | None = None,
+    diff_path: Path | None = None,
 ) -> dict[str, Any]:
     cost = float(usage.get("cost_usd") or 0.0)
     record = {
@@ -379,6 +498,7 @@ def build_record(
         "cost_usd": round(cost, 4),
         "wall_clock_s": wall_clock,
         "output_path": str(output_path) if output_path else None,
+        "diff_path": str(diff_path) if diff_path else None,
     }
     # The metric the whole harness exists to produce. Undefined at zero cost
     # (replay mode), and left null rather than divided by zero.
@@ -475,6 +595,8 @@ def main(argv: list[str] | None = None) -> int:
                         help="Transcript .jsonl, or a text file holding the output to score.")
     replay.add_argument("--run-id", default="baseline")
     replay.add_argument("--judge-model", default=None, help="Enable rubric scoring with this model.")
+    replay.add_argument("--diff", default=None, type=Path,
+                        help="Diff file to score alongside the transcript, for diff_* assertions.")
 
     run = sub.add_parser("run", help="Execute a case live against a model. Spends tokens.")
     run.add_argument("--case", required=True)
@@ -510,11 +632,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "replay":
         case = load_case(args.case)
         output = extract_output(args.transcript)
-        deterministic = score_deterministic(case, output)
+        diff_text = args.diff.read_text(encoding="utf-8") if args.diff else ""
+        deterministic = score_deterministic(case, output, diff_text)
         rubric = score_rubric(case, output, args.judge_model) if args.judge_model else None
         saved = save_output(args.run_id, case, output)
+        diff_saved = save_diff(args.run_id, case, diff_text)
         record = build_record(
-            case, "replay", "(replayed)", deterministic, rubric, {}, None, args.run_id, saved
+            case, "replay", "(replayed)", deterministic, rubric, {}, None, args.run_id, saved, diff_saved
         )
         append_result(record)
         _print_result(record)
@@ -523,12 +647,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "run":
         case = load_case(args.case)
         outcome = run_case(case, args.model, args.effort, args.timeout)
-        deterministic = score_deterministic(case, outcome["output"])
+        deterministic = score_deterministic(case, outcome["output"], outcome.get("diff", ""))
         rubric = score_rubric(case, outcome["output"], args.judge_model) if args.judge_model else None
         saved = save_output(args.run_id, case, outcome["output"])
+        diff_saved = save_diff(args.run_id, case, outcome.get("diff", ""))
         record = build_record(
             case, "live", args.model, deterministic, rubric,
-            outcome["usage"], outcome["wall_clock_s"], args.run_id, saved,
+            outcome["usage"], outcome["wall_clock_s"], args.run_id, saved, diff_saved,
         )
         append_result(record)
         _print_result(record)
@@ -540,7 +665,9 @@ def main(argv: list[str] | None = None) -> int:
         if not stored.is_file():
             raise SystemExit(f"No stored output for {case.case_id} in run {args.from_run}")
         output = stored.read_text(encoding="utf-8")
-        deterministic = score_deterministic(case, output)
+        diff_path = RESULTS_DIR / args.from_run / "diffs" / f"{case.case_id.replace('/', '__')}.diff"
+        diff_text = diff_path.read_text(encoding="utf-8") if diff_path.is_file() else ""
+        deterministic = score_deterministic(case, output, diff_text)
         rubric = score_rubric(case, output, args.judge_model) if args.judge_model else None
         # Carry the original run's cost forward: re-scoring spends nothing, but
         # quality-per-dollar must still reflect what the output actually cost.
@@ -550,6 +677,7 @@ def main(argv: list[str] | None = None) -> int:
         record = build_record(
             case, "rescore", prior.get("model", "(unknown)"), deterministic, rubric,
             prior.get("usage", {}), prior.get("wall_clock_s"), args.run_id, stored,
+            diff_path if diff_path.is_file() else None,
         )
         append_result(record)
         _print_result(record)

--- a/.claude/bench/cases/dev-agent/backoff-negative/case.yaml
+++ b/.claude/bench/cases/dev-agent/backoff-negative/case.yaml
@@ -1,0 +1,16 @@
+segment: dev-agent
+description: >
+  Fix a real bug via real tool use against a real repo checkout, not a
+  prompt-embedded excerpt. ClampRetryBackoff's own doc comment requires
+  rejecting a negative backoff with an error; the implementation silently
+  accepts it instead. A plausible wrong answer clamps the value to zero --
+  it looks like a fix but violates the explicit no-silent-failure
+  requirement the comment states.
+# repo_sha pins the ambient repo state the agent can read around the fix;
+# the file actually being edited comes from fixture/, overlaid onto the
+# checkout at run time, so this case does not depend on that file having
+# been merged upstream first.
+repo_sha: "86a5a70f"
+checkout: true
+allowed_tools: [Read, Edit]
+prompt_file: input/prompt.md

--- a/.claude/bench/cases/dev-agent/backoff-negative/expect.yaml
+++ b/.claude/bench/cases/dev-agent/backoff-negative/expect.yaml
@@ -1,0 +1,23 @@
+assertions:
+  - kind: diff_matches
+    value: 'seconds\s*<\s*0'
+    description: adds a negative-value guard
+  - kind: diff_contains
+    value: fmt.Errorf
+    weight: 3
+    description: rejects with an error rather than silently clamping
+  - kind: diff_matches
+    value: '(?i)negative'
+    weight: 2
+    description: names the actual problem in the error message
+  - kind: diff_not_matches
+    value: 'seconds\s*=\s*0\b'
+    weight: 2
+    description: does not silently clamp to zero instead of erroring
+rubric: |
+  - root-cause: does the fix reject the invalid input rather than
+    normalizing it away?
+  - minimalism: does it touch only ClampRetryBackoff (and its import), not
+    unrelated code?
+  - clarity: would the error message tell an operator what config value was
+    wrong?

--- a/.claude/bench/cases/dev-agent/backoff-negative/fixture/testdata/backoff.go
+++ b/.claude/bench/cases/dev-agent/backoff-negative/fixture/testdata/backoff.go
@@ -1,0 +1,9 @@
+package testdata
+
+// ClampRetryBackoff validates a retry backoff in seconds read from steward
+// config. A negative value is invalid and must be rejected with a clear
+// error -- silently clamping it to zero would let a misconfigured steward
+// retry in a tight loop without anyone noticing.
+func ClampRetryBackoff(seconds int) (int, error) {
+	return seconds, nil
+}

--- a/.claude/bench/cases/dev-agent/backoff-negative/input/prompt.md
+++ b/.claude/bench/cases/dev-agent/backoff-negative/input/prompt.md
@@ -1,0 +1,8 @@
+You are the dev agent implementing a small, focused fix in this repository.
+Work directly against the checked-out working tree at your current working
+directory -- read the real file, make the real edit. Do not just describe a
+fix in prose.
+
+Fix `ClampRetryBackoff` in `testdata/backoff.go` so its behavior matches its
+own doc comment. Use the Read tool to see the current code, then the Edit
+tool to change it. Make no other changes and touch no other file.

--- a/.claude/bench/cases/story-review/log-sanitize-claim/case.yaml
+++ b/.claude/bench/cases/story-review/log-sanitize-claim/case.yaml
@@ -1,0 +1,13 @@
+segment: story-review
+description: >
+  Verify a claimed acceptance criterion against the real, checked-out
+  implementation rather than trusting the criterion's own wording. The
+  claim states two specific behaviors of SanitizeLogValue; only the
+  function's existence is true -- both the threshold and the truncation
+  suffix it names are wrong. A reviewer that skims the prose without
+  reading pkg/logging/sanitize.go approves a criterion the implementation
+  does not meet.
+repo_sha: "86a5a70f"
+checkout: true
+allowed_tools: [Read, Grep, Glob]
+prompt_file: input/prompt.md

--- a/.claude/bench/cases/story-review/log-sanitize-claim/expect.yaml
+++ b/.claude/bench/cases/story-review/log-sanitize-claim/expect.yaml
@@ -1,0 +1,28 @@
+assertions:
+  - kind: section
+    value: Verdict
+    description: emits a Verdict section
+  - kind: matches
+    value: '\bNOT_MET\b'
+    weight: 3
+    description: correctly refutes the criterion
+  - kind: not_matches
+    value: '##\s*Verdict\s*\n+\s*MET\b'
+    weight: 3
+    description: does not approve a criterion the code does not meet
+  - kind: section
+    value: Evidence
+    description: emits an Evidence section
+  - kind: matches
+    value: '1024'
+    weight: 2
+    description: names the actual threshold, not the claimed one
+  - kind: matches
+    value: '(?i)\[truncated\]'
+    weight: 2
+    description: names the actual suffix, not the claimed one
+rubric: |
+  - grounding: does the verdict cite the real file content rather than
+    restating the criterion's own wording?
+  - precision: does it name the specific numeric/string mismatch instead of
+    a vague "doesn't match"?

--- a/.claude/bench/cases/story-review/log-sanitize-claim/input/prompt.md
+++ b/.claude/bench/cases/story-review/log-sanitize-claim/input/prompt.md
@@ -1,0 +1,15 @@
+You are reviewing whether an implementation meets a story's acceptance
+criterion. Do not take the criterion's wording on faith -- open the real
+file in this checked-out repository and verify each claim against the
+actual code before you decide.
+
+--- ACCEPTANCE CRITERION ---
+`logging.SanitizeLogValue` (pkg/logging/sanitize.go) truncates values
+longer than 2048 characters and appends the suffix "...(truncated)" to the
+result.
+--- END CRITERION ---
+
+Read `pkg/logging/sanitize.go` and confirm or refute the criterion against
+what the function actually does. Respond in markdown with a `## Verdict`
+section containing exactly one of MET or NOT_MET, and an `## Evidence`
+section quoting the specific line(s) that support your verdict.

--- a/.claude/bench/tests/test_bench.py
+++ b/.claude/bench/tests/test_bench.py
@@ -13,6 +13,9 @@ endorse every regression.
 from __future__ import annotations
 
 import json
+import os
+import stat
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -24,10 +27,13 @@ from bench import (  # noqa: E402
     Assertion,
     Case,
     _extract_json,
+    apply_fixture_overlay,
+    checkout_worktree,
     compare,
     discover_cases,
     extract_output,
     load_case,
+    run_case,
     save_output,
     score_deterministic,
 )
@@ -35,17 +41,33 @@ from bench import (  # noqa: E402
 REAL_CASES = Path(__file__).resolve().parents[1] / "cases"
 
 
-def case_with(assertions: list[dict], rubric: str | None = None) -> Case:
+def case_with(
+    assertions: list[dict],
+    rubric: str | None = None,
+    path: Path | None = None,
+    checkout: bool = False,
+    allowed_tools: list[str] | None = None,
+    prompt: str = "",
+) -> Case:
     return Case(
         case_id="test/case",
         segment="test",
         description="",
-        prompt="",
+        prompt=prompt,
         repo_sha="abc123",
         model_default=None,
         assertions=[Assertion.parse(a) for a in assertions],
         rubric=rubric,
+        path=path,
+        checkout=checkout,
+        allowed_tools=allowed_tools or [],
     )
+
+
+def _init_git_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "--quiet"], cwd=str(root), check=True)
+    subprocess.run(["git", "config", "user.email", "bench@test.local"], cwd=str(root), check=True)
+    subprocess.run(["git", "config", "user.name", "bench-test"], cwd=str(root), check=True)
 
 
 class TestAssertions(unittest.TestCase):
@@ -75,6 +97,24 @@ class TestAssertions(unittest.TestCase):
     def test_unknown_kind_raises(self):
         with self.assertRaises(ValueError):
             Assertion("telepathy", "x").check("anything")
+
+    def test_diff_kinds_check_the_diff_not_the_output(self):
+        assertion = Assertion("diff_contains", "+added line")
+        self.assertTrue(assertion.check("output has no such text", "+added line"))
+        self.assertFalse(assertion.check("+added line", "output has no such text"))
+
+    def test_diff_not_contains(self):
+        self.assertTrue(Assertion("diff_not_contains", "seconds = 0").check("", "+return 0, err"))
+        self.assertFalse(Assertion("diff_not_contains", "seconds = 0").check("", "+seconds = 0"))
+
+    def test_diff_matches_and_not_matches(self):
+        self.assertTrue(Assertion("diff_matches", r"seconds\s*<\s*0").check("", "+if seconds < 0 {"))
+        self.assertTrue(Assertion("diff_not_matches", r"seconds\s*<\s*0").check("", "+unrelated change"))
+
+    def test_non_diff_kind_ignores_a_supplied_diff(self):
+        # A plain "contains" assertion must keep checking output even when a
+        # diff happens to be passed in -- only a diff_-prefixed kind reroutes.
+        self.assertTrue(Assertion("contains", "PASS").check("verdict: PASS", "+irrelevant diff text"))
 
 
 class TestExtractJson(unittest.TestCase):
@@ -133,13 +173,138 @@ class TestScoring(unittest.TestCase):
         score = score_deterministic(case_with([]), "anything")
         self.assertEqual((score.passed, score.total), (0, 0))
 
+    def test_diff_assertions_score_against_the_diff_argument(self):
+        case = case_with([
+            {"kind": "diff_contains", "value": "fmt.Errorf", "weight": 2},
+            {"kind": "diff_not_contains", "value": "seconds = 0"},
+        ])
+        good = score_deterministic(case, "", "+return 0, fmt.Errorf(\"negative\")")
+        bad = score_deterministic(case, "", "+seconds = 0")
+        self.assertEqual(good.ratio, 1.0)
+        self.assertEqual(bad.ratio, 0.0)
+
+    def test_diff_assertion_fails_closed_when_no_diff_was_captured(self):
+        # A case with diff_* assertions but no captured diff (e.g. replayed
+        # from a plain transcript) must fail those checks, not skip them.
+        case = case_with([{"kind": "diff_contains", "value": "fmt.Errorf"}])
+        self.assertEqual(score_deterministic(case, "some text output").ratio, 0.0)
+
+
+class TestCheckoutWorktree(unittest.TestCase):
+    """The multi-turn extension: a case can run against a real, pinned
+    checkout instead of only prompt-embedded text."""
+
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp(prefix="bench-test-repo-"))
+        _init_git_repo(self.repo)
+        (self.repo / "README.md").write_text("hello\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=str(self.repo), check=True)
+        subprocess.run(["git", "commit", "--quiet", "-m", "initial"], cwd=str(self.repo), check=True)
+        self.sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(self.repo), capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+    def test_checkout_exposes_the_pinned_commit_and_cleans_up(self):
+        with checkout_worktree(self.sha, repo_root=self.repo) as worktree:
+            self.assertTrue(worktree.is_dir())
+            self.assertEqual((worktree / "README.md").read_text(encoding="utf-8"), "hello\n")
+        self.assertFalse(worktree.exists())
+        listing = subprocess.run(
+            ["git", "worktree", "list"], cwd=str(self.repo), capture_output=True, text=True, check=True,
+        ).stdout
+        self.assertNotIn(str(worktree), listing)
+
+    def test_worktree_removed_even_when_the_body_raises(self):
+        try:
+            with checkout_worktree(self.sha, repo_root=self.repo) as worktree:
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        self.assertFalse(worktree.exists())
+
+    def test_unknown_sha_raises_a_clear_error(self):
+        with self.assertRaises(SystemExit):
+            with checkout_worktree("0" * 40, repo_root=self.repo):
+                pass
+
+
+class TestFixtureOverlay(unittest.TestCase):
+    def test_overlay_copies_nested_files_onto_the_worktree(self):
+        case_dir = Path(tempfile.mkdtemp(prefix="bench-test-case-"))
+        (case_dir / "fixture" / "testdata").mkdir(parents=True)
+        (case_dir / "fixture" / "testdata" / "backoff.go").write_text("package testdata\n", encoding="utf-8")
+
+        worktree = Path(tempfile.mkdtemp(prefix="bench-test-worktree-"))
+        case = case_with([], path=case_dir)
+        apply_fixture_overlay(case, worktree)
+
+        self.assertEqual(
+            (worktree / "testdata" / "backoff.go").read_text(encoding="utf-8"), "package testdata\n"
+        )
+
+    def test_overlay_is_a_no_op_without_a_fixture_dir(self):
+        case_dir = Path(tempfile.mkdtemp(prefix="bench-test-case-"))
+        worktree = Path(tempfile.mkdtemp(prefix="bench-test-worktree-"))
+        apply_fixture_overlay(case_with([], path=case_dir), worktree)
+        self.assertEqual(list(worktree.iterdir()), [])
+
+
+class TestRunCaseCheckout(unittest.TestCase):
+    """End-to-end: checkout + fixture overlay + tool-driven edit + diff
+    capture, using a fake `claude` binary so no tokens are spent."""
+
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp(prefix="bench-test-repo-"))
+        _init_git_repo(self.repo)
+        (self.repo / "README.md").write_text("hello\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=str(self.repo), check=True)
+        subprocess.run(["git", "commit", "--quiet", "-m", "initial"], cwd=str(self.repo), check=True)
+
+        self.case_dir = Path(tempfile.mkdtemp(prefix="bench-test-case-"))
+        (self.case_dir / "fixture").mkdir()
+        (self.case_dir / "fixture" / "greeting.txt").write_text("old\n", encoding="utf-8")
+
+        self.fakebin = Path(tempfile.mkdtemp(prefix="bench-test-fakebin-"))
+        fake_claude = self.fakebin / "claude"
+        fake_claude.write_text(
+            "#!/usr/bin/env bash\n"
+            "echo 'new' > greeting.txt\n"
+            "echo did-the-edit\n",
+            encoding="utf-8",
+        )
+        fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+
+        self._old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{self.fakebin}{os.pathsep}{self._old_path}"
+
+    def tearDown(self):
+        os.environ["PATH"] = self._old_path
+
+    def test_checkout_case_captures_the_agents_diff(self):
+        case = case_with([], path=self.case_dir, checkout=True, prompt="edit greeting.txt")
+        case.repo_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(self.repo), capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        outcome = run_case(case, model="fake", repo_root=self.repo)
+
+        self.assertEqual(outcome["exit_code"], 0)
+        self.assertIn("did-the-edit", outcome["output"])
+        self.assertIn("-old", outcome["diff"])
+        self.assertIn("+new", outcome["diff"])
+        # The worktree must be gone afterward, same as the direct contextmanager test.
+        listing = subprocess.run(
+            ["git", "worktree", "list"], cwd=str(self.repo), capture_output=True, text=True, check=True,
+        ).stdout
+        self.assertEqual(listing.count("bench-worktree-"), 0)
+
 
 class TestRealCases(unittest.TestCase):
     """The shipped fixtures must load and must actually discriminate."""
 
     def test_all_cases_load(self):
         cases = discover_cases(REAL_CASES)
-        self.assertGreaterEqual(len(cases), 4)
+        self.assertGreaterEqual(len(cases), 6)
         for case in cases:
             self.assertTrue(case.prompt.strip(), f"{case.case_id} has an empty prompt")
             self.assertTrue(case.assertions, f"{case.case_id} has no assertions")
@@ -147,7 +312,41 @@ class TestRealCases(unittest.TestCase):
 
     def test_every_segment_is_covered(self):
         segments = {c.segment for c in discover_cases(REAL_CASES)}
-        self.assertTrue({"tech-lead", "acceptance-review", "pr-review", "ba"} <= segments)
+        self.assertTrue(
+            {"tech-lead", "acceptance-review", "pr-review", "ba", "dev-agent", "story-review"} <= segments
+        )
+
+    def test_multi_turn_cases_declare_checkout_and_scoped_tools(self):
+        for case_id in ("dev-agent/backoff-negative", "story-review/log-sanitize-claim"):
+            case = load_case(case_id, REAL_CASES)
+            self.assertTrue(case.checkout, f"{case_id} should run against a real checkout")
+            self.assertTrue(case.allowed_tools, f"{case_id} should scope its tool access")
+
+    def test_dev_agent_case_rejects_a_silent_clamp(self):
+        case = load_case("dev-agent/backoff-negative", REAL_CASES)
+        correct_fix = (
+            '+\tif seconds < 0 {\n'
+            '+\t\treturn 0, fmt.Errorf("retry backoff must not be negative, got %d", seconds)\n'
+            '+\t}\n'
+        )
+        silent_clamp = (
+            '+\tif seconds < 0 {\n'
+            '+\t\tseconds = 0\n'
+            '+\t}\n'
+        )
+        self.assertEqual(score_deterministic(case, "", correct_fix).ratio, 1.0)
+        self.assertLess(score_deterministic(case, "", silent_clamp).ratio, 0.2)
+
+    def test_story_review_case_rejects_a_skim_approval(self):
+        case = load_case("story-review/log-sanitize-claim", REAL_CASES)
+        skim_approval = "## Verdict\nMET\n\n## Evidence\nLooks right.\n"
+        grounded_refutation = (
+            "## Verdict\nNOT_MET\n\n## Evidence\n"
+            'const maxLogValueLength = 1024 -- not 2048.\n'
+            'return s + "[truncated]" -- not "...(truncated)".\n'
+        )
+        self.assertLess(score_deterministic(case, skim_approval).ratio, 0.2)
+        self.assertEqual(score_deterministic(case, grounded_refutation).ratio, 1.0)
 
     def test_tech_lead_case_rejects_a_rubber_stamp(self):
         case = load_case("tech-lead/story-validation", REAL_CASES)


### PR DESCRIPTION
## Summary

- Adds `checkout: true` + `allowed_tools: [...]` to `case.yaml`, running a case's model invocation inside a disposable git worktree pinned to `repo_sha` (with an optional `fixture/` overlay so a case's editable file need not already exist upstream) instead of only the prompt text — this is what makes a case genuinely multi-turn, since the CLI's own agentic loop then runs real tool-call turns against real files, all inside one scored run.
- Adds `diff_contains` / `diff_not_contains` / `diff_matches` / `diff_not_matches` assertion kinds that grade `git diff` in the worktree after the run, instead of (or alongside) the model's text output, and persists the diff the same way output is already persisted so `rescore` stays free for diff-based cases too.
- Two new fixtures exercise it end-to-end: `dev-agent/backoff-negative` (a fix that silently clamps a negative value to zero instead of erroring fails the diff assertions) and `story-review/log-sanitize-claim` (an acceptance criterion whose threshold and truncation suffix are both wrong; approving it without reading the real file fails).
- The worktree is always removed on exit, success or failure; tool access is explicit and scoped per-case via `allowed_tools` — nothing runs with broad or bypassed permissions.

## Test plan

- [x] `python3 .claude/bench/tests/test_bench.py` — 40/40 passing, including new coverage for diff-based assertions, worktree checkout/cleanup (success, exception, and unknown-SHA paths), fixture overlay, and an end-to-end `run_case` test against a fake `claude` binary that verifies the captured diff and worktree cleanup.
- [x] Manually verified both new fixtures discriminate a correct fix/verdict from the documented trap (scores 1.0 vs ~0.13–0.17).
- [x] `make test` — full suite passes (pre-existing, unrelated to this change).
- [x] Pre-push validation passed.

Fixes #3056

https://claude.ai/code/session_01MbRjuJsa3J4g9vCrM4SRES