### PR TITLE
fix: agents bind-mount host credentials instead of a frozen volume copy

### DIFF
--- a/.claude/commands/agent-setup.md
+++ b/.claude/commands/agent-setup.md
@@ -20,11 +20,7 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
    ```
    If either fails, provide specific fix instructions and stop.
 
-2. **If `$ARGUMENTS` is 'creds'**: Tell the user to run the refresh script directly in their terminal:
-   ```
-   ./.claude/scripts/refresh-agent-creds.sh
-   ```
-   This script handles Docker volume creation, OAuth login, workspace trust, and remote-control consent interactively. It requires a TTY and cannot be run via the Bash tool. After the user confirms completion, verify credentials with `./.claude/scripts/agent-dispatch.sh check-creds` and stop (skip all other steps).
+2. **If `$ARGUMENTS` is 'creds'**: Agent containers bind-mount the host's live `~/.claude/.credentials.json` directly — there is no separate setup step. Tell the user: if `claude` is authenticated on this host (i.e. this session works), dispatch credentials are already in place. If missing, run `claude` normally on the host to log in. Verify with `./.claude/scripts/agent-dispatch.sh check-creds` and stop (skip all other steps).
 
 3. **Health check** (runs when image already exists and `$ARGUMENTS` is NOT 'rebuild'):
    ```bash
@@ -48,16 +44,14 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
 
    While waiting, proceed with steps 6-8 (they're independent).
 
-6. **Set up Claude credentials and workspace trust**:
-   **IMPORTANT**: This step requires a real TTY. Do NOT attempt to run it via the Bash tool.
+6. **Verify Claude credentials**: Agent containers bind-mount the host's `~/.claude/.credentials.json` directly, so no separate container-side login is needed.
 
-   - Check if credentials already exist:
+   - Check if credentials already exist on the host:
      ```bash
-     docker run --rm -v claude-creds:/persist --entrypoint test cfg-agent:latest \
-       -f /persist/.credentials.json && echo "exists"
+     test -f "$HOME/.claude/.credentials.json" && echo "exists"
      ```
    - If credentials exist and `$ARGUMENTS` is not 'creds': skip
-   - If credentials missing: tell the user to run `./.claude/scripts/refresh-agent-creds.sh` in their terminal, then confirm when done.
+   - If credentials missing: tell the user to run `claude` normally on this host to log in, then confirm when done.
 
 7. **Create directories**:
    ```bash
@@ -102,5 +96,5 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
 - **Docker not installed**: Provide install link, stop
 - **GitHub not authenticated**: Tell user to run `gh auth login`, stop
 - **Image build fails**: Show build output, suggest checking Dockerfile
-- **OAuth flow fails**: Tell user to retry with `./.claude/scripts/refresh-agent-creds.sh`
+- **OAuth flow fails**: Tell user to retry by running `claude` normally on the host to re-authenticate
 - **Network issues during build**: Suggest checking internet connection

--- a/.claude/metrics/README.md
+++ b/.claude/metrics/README.md
@@ -198,5 +198,6 @@ Docker creates a bind mount's missing parent as root and the image ships no
 `~/.claude`, so mounting inside it leaves `~/.claude` root-owned and breaks the
 credential symlink — which fails authentication for every agent. `setup-env.sh`
 symlinks `~/.claude/projects -> /agent-sessions` instead, which needs no image
-rebuild. `~/.claude` itself is never mounted: it holds `.credentials.json` from
-the `claude-creds` volume and must stay off the host filesystem.
+rebuild. The session mount targets `/agent-sessions`, never `~/.claude`
+directly — `~/.claude/.credentials.json` is bind-mounted separately from the
+host's live credentials file, and the session mount must never collide with it.

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -36,10 +36,9 @@ AGENT_CRED_BASE="${CFGMS_TEST_CRED_BASE:-/run/cfgms/agent-cred}"
 # Mounted at /agent-sessions, NOT directly at ~/.claude/projects. Docker
 # creates a bind mount's missing parent as root, and the image ships no
 # ~/.claude -- mounting inside it would leave ~/.claude root-owned and break
-# setup-env.sh's credential symlink, failing authentication for every agent.
-# setup-env.sh symlinks ~/.claude/projects -> /agent-sessions instead, which
-# needs no image rebuild. ~/.claude itself is never mounted: it holds
-# .credentials.json from the claude-creds volume and must stay off the host.
+# the bind-mounted ~/.claude/.credentials.json below, failing authentication
+# for every agent. setup-env.sh symlinks ~/.claude/projects -> /agent-sessions
+# instead, which needs no image rebuild.
 AGENT_SESSIONS_BASE="${CFGMS_AGENT_SESSIONS_BASE:-${HOME}/.cache/cfgms-agent-sessions}"
 AGENT_SESSIONS_RETENTION_DAYS="${CFGMS_AGENT_SESSIONS_RETENTION_DAYS:-30}"
 AGENT_SESSIONS_MOUNT="/agent-sessions"

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -705,24 +705,6 @@ check_existing_prs_for_issue() {
   return 0
 }
 
-# Refresh agent credentials from the host's Claude session.
-# Copies ~/.claude/.credentials.json into the claude-creds Docker volume
-# so agents always start with a fresh token. No interactive OAuth needed.
-refresh_creds_from_host() {
-  local host_creds="$HOME/.claude/.credentials.json"
-  if [ ! -f "$host_creds" ]; then
-    echo "WARN: No host credentials at $host_creds — agents may fail auth"
-    return 0
-  fi
-  docker run --rm --entrypoint bash \
-    -v claude-creds:/persist \
-    -v "$host_creds:/host-creds.json:ro" \
-    cfg-agent:latest \
-    -c "cp /host-creds.json /persist/.credentials.json" 2>/dev/null \
-    && echo "Refreshed agent credentials from host session" \
-    || echo "WARN: Failed to refresh credentials from host"
-}
-
 # ---------------------------------------------------------------------------
 # External-author trust gate helpers (Issue #1786)
 # ---------------------------------------------------------------------------
@@ -807,10 +789,19 @@ _post_quarantine_comment() {
     2>/dev/null || true
 }
 
-# Gate on credential validity before launching any agent container.
-# Threshold: 30 minutes (raised from 15; a 401 was observed at 27 min remaining).
+# Gate on credential availability before launching any agent container.
+#
+# Agent containers bind-mount the host's live ~/.claude/.credentials.json
+# (see the launch paths) — the same file the host and po-live use. They track
+# host token rotations live and refresh the token in place, exactly like an
+# interactive session. So a LOW or even EXPIRED token is NOT a launch blocker:
+# the agent's entrypoint refreshes it on startup and stays current thereafter.
+# Only a genuinely missing or unparseable creds file actually blocks a launch.
+#
+# This replaces the old copy-into-claude-creds-volume model, where a launched
+# agent held a frozen copy that the host's next token rotation silently
+# invalidated — the 401s observed on cfg-agent-1570 / review-pr-1589 (#1594).
 # Sets CFGMS_TEST_CREDS_STATUS to inject a synthetic result in hermetic tests.
-# Exits 10 with DISPATCH_DEFERRED:creds_low:<result> if creds are insufficient.
 gate_credentials_for_launch() {
   local creds_status
   if [[ -n "${CFGMS_TEST_CREDS_STATUS:-}" ]]; then
@@ -819,13 +810,13 @@ gate_credentials_for_launch() {
     creds_status=$(bash "$0" check-creds 2>/dev/null)
   fi
   case "$creds_status" in
-    CREDS_OK:*) ;;
-    CREDS_LOW:*|CREDS_EXPIRED:*|CREDS_MISSING:*|CREDS_ERROR:*)
-      echo "DISPATCH_DEFERRED:creds_low:${creds_status}"
+    CREDS_OK:*|CREDS_LOW:*|CREDS_EXPIRED:*) ;;
+    CREDS_MISSING:*|CREDS_ERROR:*)
+      echo "DISPATCH_DEFERRED:creds_missing:${creds_status}"
       exit 10
       ;;
     *)
-      echo "DISPATCH_DEFERRED:creds_low:check_creds_unknown:${creds_status}"
+      echo "DISPATCH_DEFERRED:creds_missing:check_creds_unknown:${creds_status}"
       exit 10
       ;;
   esac
@@ -1162,7 +1153,7 @@ case "$cmd" in
       --cpus=4 \
       --stop-timeout=3600 \
       -v "${real_path}:/workspace" \
-      -v "claude-creds:/persist" \
+      -v "${HOME}/.claude/.credentials.json:/home/agent/.claude/.credentials.json" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -v "${cred_dir}:/run/cfgms/agent-cred:ro" \
@@ -1250,7 +1241,7 @@ case "$cmd" in
       --cpus=4 \
       --stop-timeout=3600 \
       -v "${real_path}:/workspace" \
-      -v "claude-creds:/persist" \
+      -v "${HOME}/.claude/.credentials.json:/home/agent/.claude/.credentials.json" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       "${AGENT_METRICS_MOUNT_ARGS[@]}" \
@@ -1335,7 +1326,6 @@ case "$cmd" in
     fi
 
     real_path=$(realpath "$clone_dir")
-    refresh_creds_from_host
     gh_token=$(gh auth token)
 
     # Remove stale container with the same name if it exists
@@ -1438,7 +1428,6 @@ case "$cmd" in
     fi
 
     real_path=$(realpath "$clone_dir")
-    refresh_creds_from_host
     gh_token=$(gh auth token)
 
     # Remove stale container with the same name (only one PO live at a time)
@@ -1553,7 +1542,6 @@ case "$cmd" in
     sanitized=$(sanitize_branch "$branch")
     clone_dir="${2:-${WORKTREE_BASE}/${sanitized}}"
     real_path=$(realpath "$clone_dir")
-    refresh_creds_from_host
     gh_token=$(gh auth token)
     container_name="cfg-agent-interactive-${sanitized}"
 
@@ -1582,7 +1570,7 @@ case "$cmd" in
       --cpus=4 \
       --stop-timeout=3600 \
       -v "${real_path}:/workspace" \
-      -v "claude-creds:/persist" \
+      -v "${HOME}/.claude/.credentials.json:/home/agent/.claude/.credentials.json" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -e "GH_TOKEN=${gh_token}" \
@@ -1612,29 +1600,26 @@ case "$cmd" in
     ;;
 
   wait-for-auth)
-    # Deprecated: credentials are now pre-validated via check-creds and copied
-    # from the host via refresh_creds_from_host before launch. This no-op
-    # preserves backward compatibility for any callers that still invoke it.
+    # Deprecated no-op. Credentials are no longer copied per-agent — containers
+    # bind-mount the host credentials file directly. Kept for backward compat.
     echo "WAIT_DONE"
     ;;
 
   check-creds)
-    # Refresh from host session first so we check what agents will actually use
-    refresh_creds_from_host >/dev/null 2>&1
-    # Then check OAuth credential validity in the shared volume
-    if ! docker volume inspect claude-creds >/dev/null 2>&1; then
-      echo "CREDS_MISSING:no claude-creds volume"
-    elif ! docker run --rm -v claude-creds:/persist --entrypoint test cfg-agent:latest -f /persist/.credentials.json 2>/dev/null; then
-      echo "CREDS_MISSING:no credentials file"
+    # Report OAuth token validity by reading the host credentials file directly
+    # — agent containers bind-mount this exact file, so it is what they use.
+    # CREDS_LOW / CREDS_EXPIRED are advisory only: agents refresh the live file
+    # in place (see gate_credentials_for_launch). Only MISSING / ERROR block.
+    host_creds="$HOME/.claude/.credentials.json"
+    if [[ ! -f "$host_creds" ]]; then
+      echo "CREDS_MISSING:no host credentials file at ${host_creds}"
     else
-      result=$(docker run --rm -v claude-creds:/persist --entrypoint python3 cfg-agent:latest -c "
-import json, time
-d = json.load(open('/persist/.credentials.json'))
+      result=$(CFGMS_HOST_CREDS="$host_creds" python3 -c "
+import json, os, time
+d = json.load(open(os.environ['CFGMS_HOST_CREDS']))
 oauth = d.get('claudeAiOauth', {})
 exp_ms = oauth.get('expiresAt', 0)
-exp_s = exp_ms / 1000
-now = time.time()
-remaining_min = int((exp_s - now) / 60)
+remaining_min = int((exp_ms / 1000 - time.time()) / 60)
 if remaining_min < 0:
     print(f'CREDS_EXPIRED:{remaining_min}')
 elif remaining_min < 30:
@@ -1923,9 +1908,9 @@ PYEOF
       warnings=$((warnings + 1))
     fi
 
-    # Credentials check
-    if docker run --rm -v claude-creds:/persist --entrypoint test cfg-agent:latest -f /persist/.credentials.json 2>/dev/null; then
-      echo "INFO:creds:Credentials present in claude-creds volume"
+    # Credentials check — agents bind-mount the host credentials file directly.
+    if [[ -f "$HOME/.claude/.credentials.json" ]]; then
+      echo "INFO:creds:Host credentials file present (bind-mounted into agents)"
     else
       echo "WARN:creds:No credentials found — run /agent-setup creds"
       warnings=$((warnings + 1))
@@ -2221,7 +2206,7 @@ PROMPT_EOF
       --cpus=4 \
       --stop-timeout=1800 \
       -v "${real_path}:/workspace" \
-      -v "claude-creds:/persist" \
+      -v "${HOME}/.claude/.credentials.json:/home/agent/.claude/.credentials.json" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -v "${REPO_ROOT}/.devcontainer/scripts/setup-env.sh:/usr/local/bin/setup-env.sh:ro" \

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -563,15 +563,6 @@ except Exception: print('')" 2>/dev/null || echo "")
     # Inlined from agent-dispatch.sh launch to pass the extra env var without editing
     # that file.
     real_path=$(realpath "$clone_path")
-    # Refresh credentials from host session (mirrors refresh_creds_from_host in agent-dispatch.sh).
-    host_creds="$HOME/.claude/.credentials.json"
-    if [ -f "$host_creds" ]; then
-      docker run --rm --entrypoint bash \
-        -v claude-creds:/persist \
-        -v "${host_creds}:/host-creds.json:ro" \
-        cfg-agent:latest \
-        -c "cp /host-creds.json /persist/.credentials.json" 2>/dev/null || true
-    fi
     gh_token=$(gh auth token)
 
     # Persist this run's transcript to the host so its token spend survives the
@@ -595,7 +586,7 @@ except Exception: print('')" 2>/dev/null || echo "")
       --cpus=4 \
       --stop-timeout=3600 \
       -v "${real_path}:/workspace" \
-      -v "claude-creds:/persist" \
+      -v "${HOME}/.claude/.credentials.json:/home/agent/.claude/.credentials.json" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       "${session_mount[@]}" \

--- a/.claude/scripts/tests/creds_gate.test.sh
+++ b/.claude/scripts/tests/creds_gate.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Hermetic tests for the agent credentials model: bind-mount the host's live
+# ~/.claude/.credentials.json into agent containers instead of copying a
+# frozen snapshot into the claude-creds volume at dispatch time (the frozen
+# copy silently went stale on the host's next token rotation, causing 401s
+# mid-run — cfg-agent-1570, review-pr-1589, #1594).
+#
+# gate_credentials_for_launch is not a standalone CLI subcommand (it runs
+# inline at the top of launch/launch-generic/health-check), and exercising it
+# live would mean driving a real `launch` through gh auth + tenant mint with
+# no controller present. These tests instead assert on the script's own
+# structure — the same style session_persistence.test.sh and capacity.test.sh
+# use for docker-run wiring.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCH="${SCRIPT_DIR}/../agent-dispatch.sh"
+PO_ACT="${SCRIPT_DIR}/../po-act.sh"
+[[ -f "$DISPATCH" ]] || { printf 'FAIL: agent-dispatch.sh not found at %s\n' "$DISPATCH" >&2; exit 1; }
+[[ -f "$PO_ACT" ]] || { printf 'FAIL: po-act.sh not found at %s\n' "$PO_ACT" >&2; exit 1; }
+
+fail=0; ran=0
+ok()   { ran=$((ran + 1)); printf '  ok    %s\n' "$1"; }
+bad()  { ran=$((ran + 1)); fail=$((fail + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+check_contains() {
+  local desc="$1" hay="$2" needle="$3"
+  if [[ "$hay" == *"$needle"* ]]; then ok "$desc"
+  else bad "$desc" "want substring: ${needle}"; fi
+}
+check_not_contains() {
+  local desc="$1" hay="$2" needle="$3"
+  if [[ "$hay" != *"$needle"* ]]; then ok "$desc"
+  else bad "$desc" "must NOT contain: ${needle}"; fi
+}
+
+dispatch_src="$(cat "$DISPATCH")"
+po_act_src="$(cat "$PO_ACT")"
+
+echo ""
+echo "creds_gate.test.sh — host credentials bind-mount"
+echo "-------------------------------------------------"
+
+echo ""
+echo "== gate_credentials_for_launch: LOW/EXPIRED are advisory, not blocking =="
+gate_body="$(sed -n '/^gate_credentials_for_launch()/,/^}/p' "$DISPATCH")"
+check_contains "CREDS_OK/LOW/EXPIRED share the pass-through branch" "$gate_body" \
+  'CREDS_OK:*|CREDS_LOW:*|CREDS_EXPIRED:*) ;;'
+check_contains "CREDS_MISSING/ERROR still gate the launch" "$gate_body" \
+  'CREDS_MISSING:*|CREDS_ERROR:*)'
+check_contains "gate emits DISPATCH_DEFERRED:creds_missing on block" "$gate_body" \
+  'DISPATCH_DEFERRED:creds_missing:'
+check_contains "gate exits 10 on block" "$gate_body" 'exit 10'
+
+echo ""
+echo "== no launch path copies a frozen credential snapshot =="
+check_not_contains "agent-dispatch.sh defines no refresh_creds_from_host" "$dispatch_src" \
+  'refresh_creds_from_host()'
+check_not_contains "agent-dispatch.sh never mounts the claude-creds volume" "$dispatch_src" \
+  'claude-creds:/persist'
+check_not_contains "po-act.sh never mounts the claude-creds volume" "$po_act_src" \
+  'claude-creds:/persist'
+check_not_contains "po-act.sh no longer copies creds into a volume before launch" "$po_act_src" \
+  'cp /host-creds.json /persist/.credentials.json'
+
+echo ""
+echo "== every dispatch launch path bind-mounts the host's live credentials file =="
+cred_mount='.claude/.credentials.json:/home/agent/.claude/.credentials.json'
+dispatch_mount_count=$(grep -c "$cred_mount" "$DISPATCH")
+check_contains "agent-dispatch.sh bind-mounts host creds at least 4x (launch/launch-generic/launch-interactive/po-live)" \
+  "$dispatch_mount_count" "4"
+check_contains "po-act.sh bind-mounts host creds for its inlined launch" "$po_act_src" "$cred_mount"
+
+echo ""
+echo "== check-creds reads the host file directly, no docker run needed =="
+check_contains "check-creds reads \$HOME/.claude/.credentials.json" "$dispatch_src" \
+  'host_creds="$HOME/.claude/.credentials.json"'
+check_not_contains "check-creds no longer docker-runs into claude-creds to read the file" "$dispatch_src" \
+  "docker run --rm -v claude-creds:/persist --entrypoint python3"
+
+echo ""
+echo "-----------------------------------------"
+printf 'PASS: %d checks\n' "$ran"
+if [[ $fail -gt 0 ]]; then
+  printf '%d FAILED\n' "$fail"
+  exit 1
+fi

--- a/.claude/scripts/tests/session_persistence.test.sh
+++ b/.claude/scripts/tests/session_persistence.test.sh
@@ -120,9 +120,10 @@ else
   bad "setup-env still creates ~/.claude itself" "credential symlink target missing"
 fi
 
-# Credentials must never reach the host: .credentials.json is symlinked into
-# ~/.claude from the claude-creds volume, so no mount may target that directory
-# by any spelling.
+# The session-persistence mount (sessions_dir, Issue #3051) must never target
+# ~/.claude by any spelling: ~/.claude/.credentials.json is a separate,
+# deliberate bind-mount of the host's live credentials file, and a session
+# mount landing there would clobber it.
 if grep -qE -- '-v "[^"]*sessions_dir[^"]*:[^"]*\.claude' "$DISPATCH"; then
   bad "no mount targets ~/.claude by any path" "a session mount points inside the credential directory"
 else

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -139,7 +139,8 @@ RUN useradd -m -s /bin/bash agent \
     && echo "agent ALL=(root) NOPASSWD: /usr/sbin/iptables, /usr/sbin/ip6tables, /usr/sbin/dnsmasq, /usr/bin/tee /etc/resolv.conf" > /etc/sudoers.d/agent \
     && mkdir -p /persist && chown agent:agent /persist \
     && mkdir -p /home/agent/.cache/go-build /home/agent/go/pkg/mod \
-    && chown -R agent:agent /home/agent/.cache /home/agent/go
+    && chown -R agent:agent /home/agent/.cache /home/agent/go \
+    && mkdir -p /home/agent/.claude && chown agent:agent /home/agent/.claude
 
 # Pre-download Trivy vulnerability DB (avoids runtime download behind firewall)
 RUN trivy fs --download-db-only --cache-dir /home/agent/.cache/trivy 2>/dev/null || true

--- a/docs/development/agent-dispatch.md
+++ b/docs/development/agent-dispatch.md
@@ -32,7 +32,7 @@ Developer (architect)
 │     │     └── git worktree add -b feature/story-N-agent ../worktrees/story-N develop
 │     └── .claude/scripts/agent-dispatch.sh launch <N>
 │           └── docker run --detach cfg-agent:latest
-│                 ├── Mounts: worktree (rw), claude-creds (ro), gh-creds (ro)
+│                 ├── Mounts: worktree (rw), host ~/.claude/.credentials.json (rw), gh-creds (ro)
 │                 ├── Firewall: GitHub + Anthropic API + Go proxy only
 │                 ├── entrypoint: gh issue view N → agent prompt
 │                 ├── claude --dangerously-skip-permissions
@@ -65,16 +65,9 @@ Developer (architect)
 
 ## Credential Management
 
-### Refresh Claude OAuth Token
+### Claude OAuth Token
 
-Claude credentials expire periodically. If `/dispatch` reports `CREDS_EXPIRED`:
-
-```bash
-# Run in a real terminal (requires TTY — not in Claude session)
-./.claude/scripts/refresh-agent-creds.sh
-```
-
-Then verify: `/agent-setup creds`
+Agent containers bind-mount the host's live `~/.claude/.credentials.json` directly (the same file the host and `po-live` use), so they track host token rotations in place — a `LOW` or `EXPIRED` token is not a dispatch blocker; the agent's own entrypoint refreshes it exactly like an interactive session would. Only a genuinely missing or unparseable credentials file blocks a launch (`CREDS_MISSING`). If `/dispatch` reports `CREDS_MISSING`, run `claude` normally on the host to (re-)authenticate, then verify: `/agent-setup creds`.
 
 ### Rotate GitHub PAT
 
@@ -91,9 +84,9 @@ Then verify: `/agent-setup creds`
 ```bash
 ./.claude/scripts/agent-dispatch.sh check-creds
 # CREDS_OK:<minutes>     — valid, minutes until expiry
-# CREDS_LOW:<minutes>    — valid but expiring soon, refresh recommended
-# CREDS_EXPIRED:<N>      — run ./.claude/scripts/refresh-agent-creds.sh
-# CREDS_MISSING:*        — run /agent-setup
+# CREDS_LOW:<minutes>    — expiring soon, advisory only (agent refreshes the live file in place)
+# CREDS_EXPIRED:<N>      — advisory only; the host's own token rotation covers it
+# CREDS_MISSING:*        — run `claude` on the host to authenticate, then /agent-setup
 ```
 
 ## Writing Good Agent Stories
@@ -205,11 +198,6 @@ git push origin feature/story-N-agent
 
 **Cause**: Agent hit max fix iterations and created a draft PR, OR dispatch itself failed.
 **Fix**: `docker logs cfg-agent-story-N` — look for the draft PR URL or the failure reason.
-
-### Credential check passes but agent still fails auth mid-run
-
-**Cause**: Token valid at dispatch time but expired during the ~45 min run.
-**Fix**: Refresh credentials before dispatching long-running stories. Credentials with <60 min remaining trigger a `CREDS_LOW` warning.
 
 ## Relationship to Interactive Workflow
 

--- a/docs/operations/agent-dispatch.md
+++ b/docs/operations/agent-dispatch.md
@@ -173,7 +173,9 @@ When `agent-dispatch.sh launch <N>` runs:
    | `CFGMS_TIER1_URL` | Tier 1 controller base URL |
 
    **The key value is never in a container env var.** `docker inspect` shows
-   only the file path. The key is never in the `claude-creds` volume.
+   only the file path. The key is never in the bind-mounted Claude credentials
+   file (`~/.claude/.credentials.json`) — the two credentials are injected
+   through entirely separate mounts.
 
 **Mint failure** — if the sub-tenant creation or key issuance fails, the
 dispatcher emits `CRED_MINT_FAILED:<reason>`, removes any partial cred dir,
@@ -204,7 +206,7 @@ The revoke sequence:
 ### Security properties
 
 - Key value never appears in `docker inspect` env output.
-- Key value never enters the `claude-creds` Docker volume.
+- Key value never enters the bind-mounted Claude credentials file.
 - Key value never appears in the image.
 - Credentials live in RAM only (Linux `/run` tmpfs) and are destroyed on host
   reboot even if cleanup is skipped.

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -2628,7 +2628,7 @@ FAILPQEOF
 }
 
 test_dispatch_creds_gate() {
-    log_test "Testing agent-dispatch.sh: launch/review-pr gate on CREDS_LOW/EXPIRED, emit DISPATCH_DEFERRED..."
+    log_test "Testing agent-dispatch.sh: launch/review-pr/launch-generic pass through CREDS_LOW/EXPIRED, still defer on CREDS_MISSING/ERROR..."
 
     local dispatch_script
     dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
@@ -2638,60 +2638,70 @@ test_dispatch_creds_gate() {
         return
     fi
 
-    # CREDS_LOW causes launch to exit non-zero with DISPATCH_DEFERRED token
+    # Agent containers bind-mount the host's live ~/.claude/.credentials.json and
+    # track token rotations in place, so CREDS_LOW/EXPIRED are advisory only —
+    # the gate must NOT defer on them. Downstream execution past the gate is
+    # environment-dependent (gh auth, worktree existence, network), so we only
+    # assert the gate itself did not defer, not what happens after it.
     local output exit_code=0
     output=$(CFGMS_TEST_CREDS_STATUS="CREDS_LOW:5" bash "$dispatch_script" launch 99 2>&1) || exit_code=$?
-    if [[ $exit_code -ne 0 ]]; then
-        log_pass "dispatch_creds_gate launch CREDS_LOW: exits non-zero"
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_missing:"; then
+        log_fail "dispatch_creds_gate launch CREDS_LOW: gate deferred, expected pass-through: ${output}"
     else
-        log_fail "dispatch_creds_gate launch CREDS_LOW: expected non-zero exit, got 0: ${output}"
-    fi
-    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_LOW:5"; then
-        log_pass "dispatch_creds_gate launch CREDS_LOW: emits DISPATCH_DEFERRED:creds_low:CREDS_LOW:5"
-    else
-        log_fail "dispatch_creds_gate launch CREDS_LOW: expected DISPATCH_DEFERRED:creds_low:CREDS_LOW:5 in output: ${output}"
+        log_pass "dispatch_creds_gate launch CREDS_LOW: gate does not defer (advisory only)"
     fi
 
-    # CREDS_EXPIRED causes launch to exit non-zero with DISPATCH_DEFERRED token
     exit_code=0
     output=$(CFGMS_TEST_CREDS_STATUS="CREDS_EXPIRED:-3" bash "$dispatch_script" launch 99 2>&1) || exit_code=$?
-    if [[ $exit_code -ne 0 ]]; then
-        log_pass "dispatch_creds_gate launch CREDS_EXPIRED: exits non-zero"
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_missing:"; then
+        log_fail "dispatch_creds_gate launch CREDS_EXPIRED: gate deferred, expected pass-through: ${output}"
     else
-        log_fail "dispatch_creds_gate launch CREDS_EXPIRED: expected non-zero exit, got 0: ${output}"
-    fi
-    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_EXPIRED:-3"; then
-        log_pass "dispatch_creds_gate launch CREDS_EXPIRED: emits DISPATCH_DEFERRED:creds_low:CREDS_EXPIRED:-3"
-    else
-        log_fail "dispatch_creds_gate launch CREDS_EXPIRED: expected DISPATCH_DEFERRED:creds_low:CREDS_EXPIRED:-3 in output: ${output}"
+        log_pass "dispatch_creds_gate launch CREDS_EXPIRED: gate does not defer (advisory only)"
     fi
 
-    # CREDS_LOW causes review-pr to exit non-zero with DISPATCH_DEFERRED token
     exit_code=0
     output=$(CFGMS_TEST_CREDS_STATUS="CREDS_LOW:2" bash "$dispatch_script" review-pr 1589 2>&1) || exit_code=$?
-    if [[ $exit_code -ne 0 ]]; then
-        log_pass "dispatch_creds_gate review-pr CREDS_LOW: exits non-zero"
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_missing:"; then
+        log_fail "dispatch_creds_gate review-pr CREDS_LOW: gate deferred, expected pass-through: ${output}"
     else
-        log_fail "dispatch_creds_gate review-pr CREDS_LOW: expected non-zero exit, got 0: ${output}"
-    fi
-    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_LOW:2"; then
-        log_pass "dispatch_creds_gate review-pr CREDS_LOW: emits DISPATCH_DEFERRED:creds_low:CREDS_LOW:2"
-    else
-        log_fail "dispatch_creds_gate review-pr CREDS_LOW: expected DISPATCH_DEFERRED:creds_low:CREDS_LOW:2 in output: ${output}"
+        log_pass "dispatch_creds_gate review-pr CREDS_LOW: gate does not defer (advisory only)"
     fi
 
-    # CREDS_LOW causes launch-generic to exit non-zero with DISPATCH_DEFERRED token
     exit_code=0
     output=$(CFGMS_TEST_CREDS_STATUS="CREDS_LOW:8" bash "$dispatch_script" launch-generic "cfg-agent-test" "/tmp/nonexistent" 2>&1) || exit_code=$?
-    if [[ $exit_code -ne 0 ]]; then
-        log_pass "dispatch_creds_gate launch-generic CREDS_LOW: exits non-zero"
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_missing:"; then
+        log_fail "dispatch_creds_gate launch-generic CREDS_LOW: gate deferred, expected pass-through: ${output}"
     else
-        log_fail "dispatch_creds_gate launch-generic CREDS_LOW: expected non-zero exit, got 0: ${output}"
+        log_pass "dispatch_creds_gate launch-generic CREDS_LOW: gate does not defer (advisory only)"
     fi
-    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_LOW:8"; then
-        log_pass "dispatch_creds_gate launch-generic CREDS_LOW: emits DISPATCH_DEFERRED:creds_low:CREDS_LOW:8"
+
+    # CREDS_MISSING/CREDS_ERROR are the only genuine launch blockers left — no
+    # usable credentials file at all. These still exit at the gate, hermetically,
+    # before any real work happens.
+    exit_code=0
+    output=$(CFGMS_TEST_CREDS_STATUS="CREDS_MISSING:no host credentials" bash "$dispatch_script" launch 99 2>&1) || exit_code=$?
+    if [[ $exit_code -eq 10 ]]; then
+        log_pass "dispatch_creds_gate launch CREDS_MISSING: exits 10"
     else
-        log_fail "dispatch_creds_gate launch-generic CREDS_LOW: expected DISPATCH_DEFERRED:creds_low:CREDS_LOW:8 in output: ${output}"
+        log_fail "dispatch_creds_gate launch CREDS_MISSING: expected exit 10, got ${exit_code}: ${output}"
+    fi
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_missing:CREDS_MISSING:"; then
+        log_pass "dispatch_creds_gate launch CREDS_MISSING: emits DISPATCH_DEFERRED:creds_missing:CREDS_MISSING:"
+    else
+        log_fail "dispatch_creds_gate launch CREDS_MISSING: expected DISPATCH_DEFERRED:creds_missing:CREDS_MISSING: in output: ${output}"
+    fi
+
+    exit_code=0
+    output=$(CFGMS_TEST_CREDS_STATUS="CREDS_ERROR:docker unreachable" bash "$dispatch_script" launch 99 2>&1) || exit_code=$?
+    if [[ $exit_code -eq 10 ]]; then
+        log_pass "dispatch_creds_gate launch CREDS_ERROR: exits 10"
+    else
+        log_fail "dispatch_creds_gate launch CREDS_ERROR: expected exit 10, got ${exit_code}: ${output}"
+    fi
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_missing:CREDS_ERROR:"; then
+        log_pass "dispatch_creds_gate launch CREDS_ERROR: emits DISPATCH_DEFERRED:creds_missing:CREDS_ERROR:"
+    else
+        log_fail "dispatch_creds_gate launch CREDS_ERROR: expected DISPATCH_DEFERRED:creds_missing:CREDS_ERROR: in output: ${output}"
     fi
 }
 


### PR DESCRIPTION
## Summary

- Autonomous agent containers (launch, launch-generic, launch-interactive, review-pr, and po-act.sh's inlined launch) copied the host's OAuth credentials into the `claude-creds` Docker volume at dispatch time. A launched agent then ran on a *frozen copy*: when the host rotated its token mid-run, the copy silently went stale and the agent's next API call 401'd (observed on cfg-agent-1570 with 27 min of nominal token life remaining, and review-pr-1589, #1594). A 30-minute dispatch gate papered over this and is the source of the recurring `CREDS_LOW` deferral / credit-stall cycles.
- Fix: bind-mount the host's live `~/.claude/.credentials.json` file directly into every launch path, the same model `po-live` / interactive sessions already used. Agents now track host token rotations in place. `gate_credentials_for_launch` only blocks on a genuinely missing/unparseable file (`CREDS_MISSING`/`CREDS_ERROR`) — `CREDS_LOW`/`CREDS_EXPIRED` are advisory only.
- This picks up and completes an unmerged local branch (`fix/agent-creds-bind-mount`, single commit from 2026-05-22) that only touched `agent-dispatch.sh`. Since then `po-act.sh` grew its own independent copy of the same frozen-copy pattern for its inlined launch path — fixed identically here — and several docs/test comments still described the old volume-based model.
- `.claude/scripts/refresh-agent-creds.sh` is intentionally untouched: it still populates the `claude-creds` volume for the separate, still-valid `.devcontainer/devcontainer.json` interactive VS Code use case (different lifecycle — persists across container rebuilds). Only the autonomous dispatch paths and the docs describing *them* changed.

## Test plan

- [x] `bash -n` on `agent-dispatch.sh` and `po-act.sh`
- [x] `.claude/scripts/tests/session_persistence.test.sh` — 55/55 pass
- [x] `.claude/scripts/tests/agent-apikey-injection.test.sh` — 28/28 pass
- [x] `.claude/scripts/tests/capacity.test.sh` — 14/14 pass
- [x] New `.claude/scripts/tests/creds_gate.test.sh` (added — the LOW/EXPIRED pass-through behavior had no prior regression coverage) — 12/12 pass
- [x] Verified no remaining `claude-creds`/`refresh_creds_from_host` references outside the intentionally-untouched devcontainer/refresh-script path and the archived PRD doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbRjuJsa3J4g9vCrM4SRES