### PR TITLE
tooling: refresh-pins dedup by pin identifier, discover Dockerfile-baked MCP pins

### DIFF
--- a/.claude/skills/refresh-pins/SKILL.md
+++ b/.claude/skills/refresh-pins/SKILL.md
@@ -114,10 +114,32 @@ For each pin with verdict BUMP or BUMP NOW:
    ```
 5. Capture the returned `item_id` for the report.
 
-If a draft for the same pin+version already exists (scan the project's Draft and
-Ready buckets via `project-queue.sh list-by-status` and match on title), update
-its body via `project-queue.sh` / `pipeline-helper.sh` rather than duplicating —
-do not create a public issue.
+**Before creating a story, check for an existing open one for the same pin.**
+Title text is not a reliable match key — story titles have drifted across
+sweeps (`deps: bump X ... (Issue #2675)` vs `ci: bump X ...`), so two stories
+for the identical pin+SHA bump can have completely different titles. Instead:
+
+1. List every open issue for the repo (`gh issue list --state open --json
+   number,title,body --limit 200`) plus `project-queue.sh list-by-status
+   Draft` and `list-by-status Ready` for undispatched drafts.
+2. Match on the pin's **canonical identifier** appearing in the body/scope —
+   e.g. the `uses:` action path (`actions/checkout`, `github/codeql-action`),
+   the binary/package name (`trufflehog`), or the pin's current SHA/version
+   string — not the free-text title.
+3. If a match is found: diff the two stories' "Files In Scope" lists against
+   the live discovery-script inventory. Keep whichever is a superset /
+   more accurate (a later sweep may have found locations, including
+   commented-out lines, that an earlier one missed); update that story's body
+   in place via `project-queue.sh` / `pipeline-helper.sh` rather than creating
+   a new one, and close the other as superseded if it's already a public
+   issue, or delete the draft if it never materialized.
+4. Only create a new story once you've confirmed no open issue already
+   targets this pin.
+
+Do not create a public issue for a pin that already has one open — this
+produces duplicate stories racing two dev agents onto the same workflow
+lines (observed 2026-07-29: 4 of 6 stories in a sweep duplicated already-open
+`Ready` stories from a prior sweep, undetected by title matching).
 
 ## Phase 5: Cooldown override audit (if any BUMP NOW)
 

--- a/.claude/skills/refresh-pins/scripts/discover-pins.py
+++ b/.claude/skills/refresh-pins/scripts/discover-pins.py
@@ -316,7 +316,28 @@ def discover_mcp_pins(root: Path) -> list[dict]:
             for i, line in enumerate(raw_lines, 1)
             if git_ref.search(line)
         ]
-        pins.append({
+        # An MCP server's git ref can be pinned a second time, independently, in
+        # a Dockerfile that bakes it into the agent image (e.g. `uv tool install
+        # --from git+https://github.com/<owner>/<repo>@<tag> <name>`). setup-env.sh
+        # repoints .mcp.json at that baked binary at container startup, so a bump
+        # that only touches .mcp.json is a no-op — both locations must move
+        # together. Missing this cost story #3074 a manual scope correction.
+        drift_tag = None
+        for dockerfile in sorted(root.glob("**/Dockerfile*")):
+            if ".git" in dockerfile.parts:
+                continue
+            try:
+                docker_lines = dockerfile.read_text().splitlines()
+            except (UnicodeDecodeError, OSError):
+                continue
+            rel = str(dockerfile.relative_to(root))
+            for i, line in enumerate(docker_lines, 1):
+                dmatch = git_ref.search(line)
+                if dmatch and dmatch.group(1) == owner and dmatch.group(2) == repo:
+                    locations.append({"file": rel, "line": i, "match": line.strip()})
+                    if dmatch.group(3) != tag:
+                        drift_tag = dmatch.group(3)
+        pin = {
             "name": name,
             "kind": "mcp",
             "current": tag,
@@ -324,7 +345,13 @@ def discover_mcp_pins(root: Path) -> list[dict]:
             "ecosystem": None,  # git-installed; GHSA rarely resolves — Phase 2 falls back to release notes
             "package": None,
             "locations": locations,
-        })
+        }
+        if drift_tag:
+            # Two divergent pins of the same server — surface it like the
+            # actions/checkout "mixed pins" case so Phase 3's justification
+            # calls out unifying them, not just bumping .mcp.json's tag.
+            pin["drift_current"] = drift_tag
+        pins.append(pin)
     return pins
 
 


### PR DESCRIPTION
## Summary
- The `refresh-pins` skill's duplicate-story check matched on title text, which missed 4 duplicate stories between the 2026-07-25 and 2026-07-29 sweeps (title conventions changed between runs: `deps: bump X ... (Issue #2675)` vs `ci:`/`security:`/`tooling: bump X ...`). Now matches on the pin's canonical identifier (action path / package name / SHA) instead of title text.
- `discover_mcp_pins` only scanned `.mcp.json`, missing a server pinned a second time independently in a Dockerfile (serena's `uv tool install` line in `.devcontainer/Dockerfile`) — a bump touching only `.mcp.json` would have been a no-op since `setup-env.sh` repoints agent containers from the Dockerfile-baked binary. Now scans `Dockerfile*` for the same git ref and flags version drift between locations if found.

Found during tech-lead review of stories #3069-3074 (2026-07-29 pin sweep): 4 of those 6 stories duplicated already-open `Ready` stories (#3044-3047) from the prior sweep — closed as superseded, board synced to Done.

## Test plan
- [x] `make test` passes (215/215 script tests)
- [x] `python3 -m py_compile discover-pins.py` clean
- [x] Ran `discover-pins.py` end-to-end; confirmed the serena pin entry now includes both `.mcp.json:8` and `.devcontainer/Dockerfile:262`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>