### PR TITLE
ci: bump actions/upload-artifact straggler to v7.0.1 (Issue #3070)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload crash corpora
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crash-corpora
           # Each target writes crashes to testdata/fuzz/<FuzzName>/ under its package.


### PR DESCRIPTION
## Summary

Bumps the last straggler `actions/upload-artifact` pin from `v4.6.2` (SHA `ea165f8d65b6e75b540449e92b4886f43607fa02`) to `v7.0.1` (SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`) in `.github/workflows/fuzz-nightly.yml:40`, bringing it into lockstep with the other 16 locations already at v7.0.1.

The fuzz-nightly job's inputs (`name`, `path`, `if-no-files-found`, `retention-days`) are all present and semantically unchanged in v7. The pin was over 100 days past the 3-day cooldown.

Fixes #3070

## Specialist Review Results

- **Code Review:** PASS
- **Test Quality:** PASS (1 fix round; tests passed on round 2)
- **Security:** PASS
- **Remaining findings:** none

## Test plan

- [x] `make test` passes locally (exit 0)
- [x] AC1: `.github/workflows/fuzz-nightly.yml:40` uses `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
- [x] AC2: old SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` returns 0 matches
- [x] AC3: new SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` returns 1 match
- [ ] CI required checks pass (unit-tests, integration-tests, Build Gate, security-deployment-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)