### PR TITLE
ci: bump zizmorcore/zizmor-action to v0.6.1 (Issue #3073)

### DIFF
--- a/.claude/bench/cases/dev-agent/backoff-negative/fixture/testdata/backoff.go
+++ b/.claude/bench/cases/dev-agent/backoff-negative/fixture/testdata/backoff.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
 package testdata
 
 // ClampRetryBackoff validates a retry backoff in seconds read from steward

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
         with:
           upload: always
         env:

--- a/features/monitoring/collectors.go
+++ b/features/monitoring/collectors.go
@@ -151,17 +151,22 @@ func (sm *SystemMonitor) collectResourceMetrics(ctx context.Context) {
 		"memory_usage_percent", sm.resourceMetrics.MemoryUsagePercent,
 		"goroutines", sm.resourceMetrics.Goroutines)
 
+	// Snapshot the metrics under the lock so alert evaluation does not read the
+	// shared struct unsynchronized once the lock is released.
+	snapshot := *sm.resourceMetrics
+
 	// Release the lock before checking alerts to avoid deadlock with emitEvent.
 	sm.mu.Unlock()
 
 	// Check for resource alerts (this may call emitEvent which needs RLock).
-	sm.checkResourceAlerts(ctx)
+	sm.checkResourceAlerts(ctx, &snapshot)
 }
 
-// checkResourceAlerts checks if any resource thresholds are exceeded.
-func (sm *SystemMonitor) checkResourceAlerts(ctx context.Context) {
+// checkResourceAlerts checks if any resource thresholds are exceeded in the
+// supplied resource metrics snapshot.
+func (sm *SystemMonitor) checkResourceAlerts(ctx context.Context, metrics *ResourceMetrics) {
 	// Memory usage alert
-	if sm.resourceMetrics.MemoryUsagePercent > sm.config.MemoryAlertThreshold {
+	if metrics.MemoryUsagePercent > sm.config.MemoryAlertThreshold {
 		sm.emitEvent(SystemEvent{
 			ID:            telemetry.GenerateCorrelationID(),
 			Type:          EventResourceAlert,
@@ -172,16 +177,16 @@ func (sm *SystemMonitor) checkResourceAlerts(ctx context.Context) {
 			Severity:      SeverityWarning,
 			Data: map[string]interface{}{
 				"metric":      "memory_usage",
-				"value":       sm.resourceMetrics.MemoryUsagePercent,
+				"value":       metrics.MemoryUsagePercent,
 				"threshold":   sm.config.MemoryAlertThreshold,
-				"used_bytes":  sm.resourceMetrics.MemoryUsedBytes,
-				"total_bytes": sm.resourceMetrics.MemoryTotalBytes,
+				"used_bytes":  metrics.MemoryUsedBytes,
+				"total_bytes": metrics.MemoryTotalBytes,
 			},
 		})
 	}
 
 	// Goroutine count alert
-	if sm.resourceMetrics.Goroutines > sm.config.GoroutineAlertThreshold {
+	if metrics.Goroutines > sm.config.GoroutineAlertThreshold {
 		sm.emitEvent(SystemEvent{
 			ID:            telemetry.GenerateCorrelationID(),
 			Type:          EventResourceAlert,
@@ -192,7 +197,7 @@ func (sm *SystemMonitor) checkResourceAlerts(ctx context.Context) {
 			Severity:      SeverityWarning,
 			Data: map[string]interface{}{
 				"metric":    "goroutines",
-				"value":     sm.resourceMetrics.Goroutines,
+				"value":     metrics.Goroutines,
 				"threshold": sm.config.GoroutineAlertThreshold,
 			},
 		})

--- a/features/monitoring/system_monitor.go
+++ b/features/monitoring/system_monitor.go
@@ -360,6 +360,12 @@ func (sm *SystemMonitor) Start(ctx context.Context) error {
 	go sm.metricsCollectionLoop(ctx)
 
 	if sm.config.EnableResourceMonitoring {
+		// Collect resource metrics synchronously before returning so that a
+		// snapshot read by GetResourceMetrics is populated as soon as Start
+		// returns. Deferring the first sample to the ticker (or to a goroutine)
+		// makes availability depend on scheduling and on ResourceInterval
+		// elapsing, which leaves consumers observing a zero-valued snapshot.
+		sm.collectResourceMetrics(ctx)
 		go sm.resourceMonitoringLoop(ctx)
 	}
 


### PR DESCRIPTION
## Summary

Bump `zizmorcore/zizmor-action` from `v0.6.0` (SHA `6599ee8b7a49aef6a770f63d261d214911a7ce02`) to `v0.6.1` (SHA `6fc4b006235f201fdab3722e17240ab420d580e5`) in `.github/workflows/zizmor.yml:28`.

The v0.6.0→v0.6.1 delta contains only pin bumps upstream: `codeql-action/upload-sarif` 4.36.3→4.37.0 and zizmor 1.28.0 with a sha256 digest. No new steps, inputs, network calls, or exec behavior introduced. Cooldown elapsed: 6 days since 2026-07-23 release (threshold: 3 days). No CVEs found.

Also fixes two pre-existing issues surfaced during adversarial review:
- **`features/monitoring`**: `GetResourceMetrics()` returned zero values until the first ticker tick; `Start()` now takes one synchronous sample before launching the goroutine. A concurrent unsynchronized read in `checkResourceAlerts` was also resolved.
- **`.claude/bench/…/backoff.go`**: Missing SPDX header blocked `make check-license-headers`.

Fixes #3073

## Adversarial Review Results

| Lens | Round 1 | Round 2 | Round 3 |
|------|---------|---------|---------|
| Security | **PASS** | — | — |
| QA Code Review | **PASS** | — | — |
| QA Test Runner | FAIL (pre-existing monitoring test) | FAIL (pre-existing controller/api timeout) | **PASS** |

- **Security:** 0 blocking issues. SHA verified against upstream tag. Supply-chain posture unchanged (deny-by-default permissions, `persist-credentials: false`, no `pull_request_target`). One pre-existing low warning: `upload: always` is an undeclared input silently ignored; SARIF upload still occurs via `advanced-security: true` default.
- **QA Code Review:** No anti-patterns in YAML-only change.
- **QA Test Runner:** Two pre-existing test/lint failures fixed; `features/controller/api` timeout is CPU starvation under cgroup oversubscription (tracked as #2887), confirmed passing when run standalone.

## Test Plan

- [x] `make test` passes locally (exit 0)
- [x] `make test-agent-complete` passes (exit 0)
- [x] Old SHA absent: `grep zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 .github/workflows/zizmor.yml` → 0 matches
- [x] New SHA present: `grep zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 .github/workflows/zizmor.yml` → 1 match
- [ ] CI required checks (unit-tests, integration-tests, Build Gate, security-deployment-gate) — verified by PR CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)