### PR TITLE
security: bump trufflehog to v3.96.0 (Issue #3072)

### DIFF
--- a/.claude/bench/cases/dev-agent/backoff-negative/fixture/testdata/backoff.go
+++ b/.claude/bench/cases/dev-agent/backoff-negative/fixture/testdata/backoff.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
 package testdata
 
 // ClampRetryBackoff validates a retry backoff in seconds read from steward

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -122,7 +122,7 @@ RUN set -eu; \
     && chmod +x "$GOPATH/bin/nancy"
 
 # truffleHog (optional, best-effort secret scanning — pinned version, not @main)
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.9/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.9 || true
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.96.0/scripts/install.sh | sh -s -- -b /usr/local/bin v3.96.0 || true
 
 # Claude Code — pinned, never @latest (same supply-chain rule as every other
 # tool here; see dependency-pin-check.yml). An unpinned install also froze

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -120,7 +120,7 @@ jobs:
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.1.0"
-        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.9"
+        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.96.0"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.72.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"


### PR DESCRIPTION
## Summary

Bumps trufflehog from v3.95.9 to v3.96.0 in both pin locations (lockstep required):
- `.devcontainer/Dockerfile:125` — curl install line
- `.github/workflows/dependency-pin-check.yml:123` — freshness check reference

Cooldown elapsed: v3.96.0 published 2026-07-24 (5 days, threshold 3 days). No CVE affecting v3.95.9 found in GHSA. The upstream release includes a go-git v5.19.1 security fix, making this a net security gain.

Also fixes a pre-existing missing SPDX license header in `.claude/bench/cases/dev-agent/backoff-negative/fixture/testdata/backoff.go` (caught by the check-license-headers gate in `test-agent-complete`).

Fixes #3072

## Specialist Review Results

| Lens | Result | Notes |
|------|--------|-------|
| Code Review | **PASS** | No Go code changed; infrastructure/CI artifacts only; no mocks, no empty assertions |
| Security Review | **PASS** | v3.96.0 verified as real non-draft release; both pin sites consistent; net security gain; `make security-scan` exit 0; no leaks found in changed files. Three pre-existing LOW warnings (non-blocking, not regressions). Note: run `./scripts/pr-security-findings.sh <PR_NUM>` post-merge to clear CodeQL GHAS review. |
| QA / Test Runner | **PASS** | `make test`: 215 script tests passed, 194 Go packages passed, 0 failures. Full gate passed after license-header fix. |

## Acceptance Criteria Verification

```
# AC 2: old version absent
grep -rE "v3\.95\.9" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile
# → 0 matches ✓

# AC 3: new version present
grep -rE "v3\.96\.0" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile
# → 2 matches ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)