### PR TITLE
ci: bump github/codeql-action to v4.37.3 (Issue #3071)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -120,7 +120,7 @@ jobs:
     # run that workflow manually with `--ref <branch>` before re-running
     # this one.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -145,7 +145,7 @@ jobs:
 
     # Perform CodeQL Analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         category: "/language:${{ matrix.language }}"
         # Upload results to GitHub Security tab (SARIF format)

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -98,7 +98,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       if: always()
       with:
         sarif_file: 'trivy-controller-results.sarif'
@@ -188,7 +188,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       if: always()
       with:
         sarif_file: 'trivy-steward-results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: always() && hashFiles('scorecard.sarif') != ''
         with:
           sarif_file: scorecard.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -112,7 +112,7 @@ jobs:
         fi
     
     - name: Upload Trivy SARIF
-      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       if: always() && hashFiles('sarif-results/trivy.sarif') != ''
       with:
         sarif_file: sarif-results/trivy.sarif
@@ -245,7 +245,7 @@ jobs:
     # configuration, and results are still available via workflow artifacts.
     #
     # - name: Upload gosec SARIF
-    #   uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+    #   uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
     #   if: always() && hashFiles('sarif-results/gosec.sarif') != ''
     #   with:
     #     sarif_file: sarif-results/gosec.sarif


### PR DESCRIPTION
## Summary

Bump `github/codeql-action` (init/analyze/upload-sarif) from v4.36.3 to v4.37.3 across all 7 occurrences in `.github/workflows/`.

- v4.37.3 published 2026-07-22 (7 days ago, past the 3-day cooldown threshold)
- Routine refresh — not CVE-driven (GHSA-vqf5-2xx6-9wfm affects ranges below our current v4.36.3 pin)
- All three sub-actions (init, analyze, upload-sarif) moved together (lockstep required)
- Commented-out line in security-scan.yml:248 updated so repo-wide SHA grep returns 0 old matches

**SHA used:** `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (v4.37.3) — verified by adversarial review; the story originally specified `c54b30b7df092240050e69945842bc67aee0f0f4` but the review team independently confirmed the correct SHA is `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`.

## Files changed (7 occurrences)

| File | Line | Sub-action |
|------|------|-----------|
| `.github/workflows/codeql-analysis.yml` | 123 | init |
| `.github/workflows/codeql-analysis.yml` | 148 | analyze |
| `.github/workflows/docker-security.yml` | 101 | upload-sarif |
| `.github/workflows/docker-security.yml` | 191 | upload-sarif |
| `.github/workflows/scorecard.yml` | 56 | upload-sarif |
| `.github/workflows/security-scan.yml` | 115 | upload-sarif |
| `.github/workflows/security-scan.yml` | 248 | upload-sarif (commented-out) |

## Acceptance criteria verification

- AC2 (old SHA absent): `grep -rE "github/codeql-action/[a-z-]+@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a" .github/workflows/` → **0 matches** ✓
- AC4: `make test` → **PASS** (215/215 script tests + all Go package tests) ✓

## Specialist review results

Story-review workflow: **PASS** (3 rounds, 2 fix rounds, 0 remaining findings)
- Code review: PASS
- Test quality: PASS
- Security: PASS

## Test plan

- [ ] Confirm CI required checks pass (unit-tests, integration-tests, Build Gate, security-deployment-gate)
- [ ] Confirm CodeQL workflow runs green post-bump (primary functional verification for this pin)
- [ ] Verify `grep -rE "github/codeql-action/[a-z-]+@54f647b7" .github/workflows/` returns 0

Fixes #3071