### PR TITLE
web: script/job execution UI (Issue #2988)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,7 @@ import ConfigListView from './config/ConfigListView.tsx'
 import WorkflowListView from './workflow/WorkflowListView.tsx'
 import AccountsView from './accounts/AccountsView.tsx'
 import ModuleReviewQueue from './modules/ModuleReviewQueue.tsx'
+import ScriptsView from './scripts/ScriptsView.tsx'
 
 function App() {
   return (
@@ -44,6 +45,7 @@ function App() {
             <Route path="modules" element={<ModuleReviewQueue />} />
             <Route path="workflows" element={<WorkflowListView />} />
             <Route path="accounts" element={<AccountsView />} />
+            <Route path="scripts" element={<ScriptsView />} />
           </Route>
         </Routes>
       </RequireAuth>

--- a/web/src/scripts/RunPanel.test.tsx
+++ b/web/src/scripts/RunPanel.test.tsx
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * RunPanel test suite (Issue #2988, AC: confirm-before-run gate).
+ *
+ * Key invariants tested:
+ * 1. POST /api/v1/runs/script is never called without an explicit confirm step.
+ * 2. The confirm dialog shows the resolved target count before committing [REQUIRED].
+ * 3. Cancelling the confirm dialog prevents the POST.
+ * 4. Confirming fires the POST with the correct body.
+ * 5. Param inputs are rendered for scripts with parameters.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import RunPanel from './RunPanel.tsx'
+import type { ScriptMetadata } from './useScripts.ts'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeScript(overrides: Partial<ScriptMetadata> = {}): ScriptMetadata {
+  return {
+    id: 'script-1',
+    name: 'Test Script',
+    description: 'A test script',
+    version: { major: 1, minor: 0, patch: 0, prerelease: '', build_meta: '' },
+    author: 'test-author',
+    tags: [],
+    category: 'maintenance',
+    platform: ['linux'],
+    shell: 'bash',
+    parameters: [],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    idempotent: true,
+    ...overrides,
+  }
+}
+
+function makeFleetResponse(total: number) {
+  return new Response(
+    JSON.stringify({
+      data: { stewards: [], total, limit: 1, offset: 0 },
+      timestamp: new Date().toISOString(),
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeRunScriptResponse(runId: string) {
+  return new Response(
+    JSON.stringify({ data: { run_id: runId }, timestamp: new Date().toISOString() }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeRunStatusResponse(runId: string, status: string) {
+  return new Response(
+    JSON.stringify({
+      data: {
+        run_id: runId,
+        tenant_id: 'root',
+        created_by: 'admin',
+        created_at: new Date().toISOString(),
+        status,
+        script_ref: 'script-1',
+        shell: 'bash',
+        job_count: 1,
+        completed_jobs: status === 'completed' ? 1 : 0,
+        failed_jobs: 0,
+      },
+      timestamp: new Date().toISOString(),
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function renderRunPanel(script = makeScript(), onClose = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <RunPanel script={script} onClose={onClose} />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+// ── Resolve and confirm-before-run gate [REQUIRED] ────────────────────────────
+
+describe('RunPanel — confirm-before-run gate [REQUIRED]', () => {
+  it('shows the resolve button and disables Run script until count is resolved', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderRunPanel()
+    expect(screen.getByTestId('resolve-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('run-btn')).toBeDisabled()
+  })
+
+  it('shows the resolved target count after resolving', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(7))
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'name:web*' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('run-target-count')).toHaveTextContent('7 stewards match'),
+    )
+  })
+
+  it('enables Run script only after resolve completes', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(3))
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'os:linux' },
+    })
+    expect(screen.getByTestId('run-btn')).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    expect(screen.getByTestId('run-btn')).not.toBeDisabled()
+  })
+
+  it('shows confirm dialog with resolved count when Run script is clicked [REQUIRED]', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(5))
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'tag:prod' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+
+    // Confirm dialog must be visible
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // The dialog must show the resolved target count
+    expect(screen.getByTestId('run-confirm-count')).toHaveTextContent('5 stewards')
+    // POST must NOT have been called yet at this point
+    expect(fetchMock).toHaveBeenCalledTimes(1) // only the resolve fleet call
+  })
+
+  it('does NOT fire POST when the confirm dialog is cancelled', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(4))
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'name:api*' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Cancel the dialog — scope to the dialog to avoid matching the panel Cancel button
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /cancel/i }))
+
+    // Dialog dismissed
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // POST never called
+    expect(fetchMock).toHaveBeenCalledTimes(1) // only the resolve call
+  })
+
+  it('fires POST to /api/v1/runs/script only after confirm click', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(2))
+    fetchMock.mockResolvedValueOnce(makeRunScriptResponse('run-abc'))
+    // Run status and jobs polls after POST
+    fetchMock.mockResolvedValue(makeRunStatusResponse('run-abc', 'completed'))
+
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'id:steward-1' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1) // only resolve, no POST yet
+
+    fireEvent.click(screen.getByTestId('run-confirm-btn'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    // Verify the POST call
+    const postCall = fetchMock.mock.calls[1]!
+    expect(postCall[0]).toBe('/api/v1/runs/script')
+    const init = postCall[1]!
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body.script_id).toBe('script-1')
+    expect(body.target).toBe('id:steward-1')
+  })
+
+  it('posts correct params in request body', async () => {
+    const scriptWithParams = makeScript({
+      parameters: [
+        { name: 'timeout', description: 'Timeout', type: 'int', required: true },
+        { name: 'env', description: 'Environment', type: 'string', required: false },
+      ],
+    })
+
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(1))
+    fetchMock.mockResolvedValueOnce(makeRunScriptResponse('run-xyz'))
+    fetchMock.mockResolvedValue(makeRunStatusResponse('run-xyz', 'completed'))
+
+    renderRunPanel(scriptWithParams)
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'name:api*' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: /^timeout$/i }), {
+      target: { value: '30' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: /^env$/i }), {
+      target: { value: 'production' },
+    })
+
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+    fireEvent.click(screen.getByTestId('run-confirm-btn'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    const postCall = fetchMock.mock.calls[1]!
+    const body = JSON.parse((postCall[1] as RequestInit).body as string) as Record<string, unknown>
+    expect(body.params).toEqual({ timeout: '30', env: 'production' })
+  })
+
+  it('clears resolved count when selector changes', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(5))
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'tag:prod' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    // Change the selector
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'tag:staging' },
+    })
+
+    // Count should be cleared; Run script should be disabled again
+    expect(screen.queryByTestId('run-target-count')).not.toBeInTheDocument()
+    expect(screen.getByTestId('run-btn')).toBeDisabled()
+  })
+
+  it('shows singular "steward" when count is 1', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(1))
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'id:single-steward' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+    expect(screen.getByTestId('run-confirm-count')).toHaveTextContent('1 steward will')
+  })
+})
+
+// ── Structure ─────────────────────────────────────────────────────────────────
+
+describe('RunPanel — structure', () => {
+  it('renders the panel container', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderRunPanel()
+    expect(screen.getByTestId('run-panel')).toBeInTheDocument()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const onClose = vi.fn()
+    renderRunPanel(makeScript(), onClose)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders param inputs for scripts with parameters', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const scriptWithParams = makeScript({
+      parameters: [
+        { name: 'timeout', description: 'Timeout seconds', type: 'int', required: true },
+        { name: 'env', description: 'Environment', type: 'string', required: false },
+      ],
+    })
+    renderRunPanel(scriptWithParams)
+    expect(screen.getByTestId('param-input-timeout')).toBeInTheDocument()
+    expect(screen.getByTestId('param-input-env')).toBeInTheDocument()
+  })
+
+  it('does not render param inputs for scripts without parameters', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderRunPanel(makeScript({ parameters: [] }))
+    expect(screen.queryByTestId(/param-input-/)).not.toBeInTheDocument()
+  })
+
+  it('shows resolve error when fleet query fails', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 500 }),
+    )
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'name:web*' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('run-resolve-error')).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('run-target-count')).not.toBeInTheDocument()
+  })
+
+  it('shows run error when POST fails', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(3))
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'service unavailable' }), {
+        status: 503,
+      }),
+    )
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'name:web*' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+    fireEvent.click(screen.getByTestId('run-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('run-error')).toBeInTheDocument(),
+    )
+  })
+
+  it('shows run status after successful POST', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(2))
+    fetchMock.mockResolvedValueOnce(makeRunScriptResponse('run-live'))
+    fetchMock.mockResolvedValue(makeRunStatusResponse('run-live', 'running'))
+
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'tag:prod' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+    fireEvent.click(screen.getByTestId('run-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('run-status')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('run-status')).toHaveTextContent('run-live')
+  })
+
+  it('shows run jobs table when jobs are returned', async () => {
+    fetchMock.mockResolvedValueOnce(makeFleetResponse(1))
+    fetchMock.mockResolvedValueOnce(makeRunScriptResponse('run-jobs'))
+    // Run status response
+    fetchMock.mockResolvedValueOnce(makeRunStatusResponse('run-jobs', 'running'))
+    // Run jobs response
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              job_id: 'job-1',
+              run_id: 'run-jobs',
+              device_id: 'steward-1',
+              execution_id: 'exec-1',
+              status: 'completed',
+              created_at: '2026-01-01T00:00:00Z',
+              exit_code: 0,
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    renderRunPanel()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /target selector/i }), {
+      target: { value: 'tag:prod' },
+    })
+    fireEvent.click(screen.getByTestId('resolve-btn'))
+    await waitFor(() => expect(screen.getByTestId('run-target-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('run-btn'))
+    fireEvent.click(screen.getByTestId('run-confirm-btn'))
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('run-jobs-table')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('run-job-row')).toBeInTheDocument()
+  })
+})

--- a/web/src/scripts/RunPanel.tsx
+++ b/web/src/scripts/RunPanel.tsx
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Run panel (Issue #2988): selector-targeted script run with a confirm step
+ * that shows the resolved steward count before committing.
+ *
+ * POST /api/v1/runs/script returns { data: { run_id } }; useRunStatus then
+ * polls GET /api/v1/runs/{run_id} and GET /api/v1/runs/{run_id}/jobs until
+ * the run reaches a terminal state.
+ *
+ * Security A9.1: script names, params, run/job output, and status strings are
+ * untrusted-origin data — rendered as JSX text nodes only, never
+ * dangerouslySetInnerHTML.
+ *
+ * Destructive-action confirm gate (AC): the Run button only fires after the
+ * user sees the resolved steward count and explicitly clicks "Confirm run" —
+ * matching the PushPanel pattern (cfg-overlay/cfg-modal).
+ */
+import { useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+import SelectorInput from '../shell/SelectorInput.tsx'
+import { useRunStatus, useRunJobs, type ScriptMetadata } from './useScripts.ts'
+
+interface RunPanelProps {
+  script: ScriptMetadata
+  onClose: () => void
+}
+
+interface ConfirmState {
+  targetCount: number
+  selector: string
+  params: Record<string, string>
+}
+
+function runStatusTone(status: string): string {
+  switch (status) {
+    case 'completed':
+      return 'ok'
+    case 'failed':
+    case 'cancelled':
+      return 'crit'
+    case 'running':
+    case 'pending':
+      return 'warn'
+    default:
+      return 'neutral'
+  }
+}
+
+const RUN_TERMINAL_SET = new Set(['completed', 'failed', 'cancelled'])
+
+export default function RunPanel({ script, onClose }: RunPanelProps) {
+  const [selector, setSelector] = useState('')
+  const [params, setParams] = useState<Record<string, string>>(() =>
+    Object.fromEntries(script.parameters.map((p) => [p.name, '']))
+  )
+
+  const [resolving, setResolving] = useState(false)
+  const [resolveError, setResolveError] = useState<string | null>(null)
+  const [resolvedCount, setResolvedCount] = useState<number | null>(null)
+
+  const [confirm, setConfirm] = useState<ConfirmState | null>(null)
+  const [running, setRunning] = useState(false)
+  const [runError, setRunError] = useState<string | null>(null)
+  const [activeRunId, setActiveRunId] = useState<string | null>(null)
+
+  const { run: runStatus } = useRunStatus(activeRunId)
+  const isRunTerminal = runStatus !== null && RUN_TERMINAL_SET.has(runStatus.status)
+  const { jobs: runJobs } = useRunJobs(activeRunId, isRunTerminal)
+
+  async function handleResolve() {
+    if (!selector.trim()) {
+      setResolveError('Selector is required')
+      return
+    }
+    setResolving(true)
+    setResolveError(null)
+    setResolvedCount(null)
+    try {
+      const qp = new URLSearchParams()
+      qp.set('limit', '1')
+      qp.set('q', selector.trim())
+      const response = await apiFetch(`/api/v1/stewards?${qp.toString()}`)
+      if (!response.ok) throw new Error(`Fleet query failed — ${response.status}`)
+      const body = (await response.json()) as Record<string, unknown>
+      const data = body?.data as Record<string, unknown> | undefined
+      const total = typeof data?.total === 'number' ? data.total : 0
+      setResolvedCount(total)
+    } catch (cause: unknown) {
+      setResolveError(
+        cause instanceof Error && cause.message ? cause.message : 'Fleet query failed',
+      )
+    } finally {
+      setResolving(false)
+    }
+  }
+
+  function handleRequestRun() {
+    if (!selector.trim()) {
+      setRunError('Selector is required')
+      return
+    }
+    if (resolvedCount === null) {
+      setRunError('Resolve target count first')
+      return
+    }
+    setRunError(null)
+    const activeParams = Object.fromEntries(
+      Object.entries(params).filter(([, v]) => v.trim()).map(([k, v]) => [k, v.trim()])
+    )
+    setConfirm({
+      targetCount: resolvedCount,
+      selector: selector.trim(),
+      params: activeParams,
+    })
+  }
+
+  async function handleConfirmRun() {
+    if (!confirm) return
+    setRunning(true)
+    setRunError(null)
+    setActiveRunId(null)
+    setConfirm(null)
+    try {
+      const body = {
+        target: confirm.selector,
+        script_id: script.id,
+        params: confirm.params,
+      }
+      const response = await apiFetch('/api/v1/runs/script', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        const errBody = (await response.json().catch(() => ({}))) as Record<string, unknown>
+        throw new Error(
+          (errBody?.error as string) || `Run failed — ${response.status}`,
+        )
+      }
+      const result = (await response.json()) as Record<string, unknown>
+      const data = result?.data as Record<string, unknown> | undefined
+      setActiveRunId((data?.run_id as string) || null)
+    } catch (cause: unknown) {
+      setRunError(
+        cause instanceof Error && cause.message ? cause.message : 'Run failed',
+      )
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const canResolve = selector.trim().length > 0 && !resolving
+  const canRequestRun =
+    selector.trim().length > 0 &&
+    resolvedCount !== null &&
+    !running &&
+    !activeRunId
+
+  return (
+    <div className="cfg-push-panel" data-testid="run-panel">
+      <div className="cfg-push-form">
+        <div className="cfg-push-row">
+          <div className="cfg-push-field">
+            <span className="cfg-push-label">Target selector</span>
+            <SelectorInput
+              value={selector}
+              onChange={(next) => {
+                setSelector(next)
+                setResolvedCount(null)
+              }}
+              className="wide"
+              ariaLabel="Target selector"
+              placeholder="name:web* os:linux tag:prod"
+              hintId="run-selector-hint"
+              hintTestId="run-selector-syntax"
+            />
+          </div>
+        </div>
+
+        {script.parameters.length > 0 && (
+          <div className="cfg-push-row">
+            {script.parameters.map((p) => (
+              <div key={p.name} className="cfg-push-field">
+                <span className="cfg-push-label">
+                  {p.name}{p.required ? ' *' : ''}
+                </span>
+                <input
+                  type="text"
+                  aria-label={p.name}
+                  placeholder={p.description || p.name}
+                  value={params[p.name] ?? ''}
+                  onChange={(e) =>
+                    setParams((prev) => ({ ...prev, [p.name]: e.target.value }))
+                  }
+                  data-testid={`param-input-${p.name}`}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="cfg-push-actions">
+          <button
+            type="button"
+            className="cfg-btn-secondary"
+            disabled={!canResolve}
+            onClick={handleResolve}
+            data-testid="resolve-btn"
+          >
+            {resolving ? 'Resolving…' : 'Resolve targets'}
+          </button>
+
+          {resolvedCount !== null && (
+            <span className="cfg-push-count" data-testid="run-target-count">
+              {resolvedCount} steward{resolvedCount !== 1 ? 's' : ''} match
+            </span>
+          )}
+
+          {resolveError && (
+            <span className="cfg-validation-err" data-testid="run-resolve-error">
+              {resolveError}
+            </span>
+          )}
+
+          <button
+            type="button"
+            className="cfg-btn"
+            disabled={!canRequestRun}
+            onClick={handleRequestRun}
+            data-testid="run-btn"
+          >
+            Run script
+          </button>
+
+          <button
+            type="button"
+            className="cfg-btn-secondary"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+        </div>
+
+        {runError && (
+          <div className="cfg-validation-err" data-testid="run-error">
+            {runError}
+          </div>
+        )}
+
+        {activeRunId !== null && runStatus !== null && (
+          <div className="cfg-push-status" data-testid="run-status">
+            <span className={`pill ${runStatusTone(runStatus.status)}`}>
+              <span className="dot" />
+              {runStatus.status}
+            </span>
+            <span className="mono2">
+              Run ID: {activeRunId}
+            </span>
+            <span className="mono2">
+              Jobs: {runStatus.completed_jobs}/{runStatus.job_count}
+              {runStatus.failed_jobs > 0
+                ? ` (${runStatus.failed_jobs} failed)`
+                : ''}
+            </span>
+          </div>
+        )}
+
+        {runJobs.length > 0 && (
+          <div className="cfg-deployment-breakdown" data-testid="run-jobs-table-container">
+            <table className="tbl" data-testid="run-jobs-table">
+              <thead>
+                <tr>
+                  <th>Steward</th>
+                  <th>Status</th>
+                  <th>Exit code</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runJobs.map((j) => (
+                  <tr key={j.job_id} data-testid="run-job-row">
+                    <td><span className="mono2">{j.device_id}</span></td>
+                    <td>
+                      <span className={`pill ${runStatusTone(j.status)}`}>
+                        <span className="dot" />
+                        {j.status}
+                      </span>
+                    </td>
+                    <td><span className="mono2">{j.exit_code}</span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {confirm !== null && (
+        <div
+          className="cfg-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="run-confirm-title"
+        >
+          <div className="cfg-modal">
+            <h3 id="run-confirm-title">Confirm script run</h3>
+            <p>
+              This will run script <b>{script.name}</b> against stewards matching{' '}
+              <code>{confirm.selector}</code>.
+            </p>
+            <div className="cfg-modal-count" data-testid="run-confirm-count">
+              {confirm.targetCount} steward{confirm.targetCount !== 1 ? 's' : ''} will
+              execute this script
+            </div>
+            <p>This action will run against active endpoints. Proceed?</p>
+            <div className="cfg-modal-actions">
+              <button
+                type="button"
+                className="cfg-btn-secondary"
+                onClick={() => setConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="cfg-btn-danger"
+                onClick={handleConfirmRun}
+                data-testid="run-confirm-btn"
+              >
+                Confirm run
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/scripts/RunsView.test.tsx
+++ b/web/src/scripts/RunsView.test.tsx
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * RunsView test suite (Issue #2988).
+ *
+ * Covers: loading, error, empty, and table states for both the script-runs
+ * section (GET /api/v1/runs) and the batch-jobs section (GET /api/v1/jobs).
+ * Security A9.1: run IDs, script refs, job selectors, and status strings are
+ * rendered as text nodes — never dangerouslySetInnerHTML.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import RunsView from './RunsView.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeRunRecord(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    run_id: 'run-1',
+    tenant_id: 'root',
+    created_by: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+    status: 'completed',
+    script_ref: 'patch-system',
+    shell: 'bash',
+    job_count: 3,
+    completed_jobs: 3,
+    failed_jobs: 0,
+    ...overrides,
+  }
+}
+
+function makeBatchJob(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'bjob-1',
+    tenant_id: 'root',
+    selector: 'name:web*',
+    status: 'completed',
+    targets: ['s-1', 's-2'],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:01:00Z',
+    initiated_by: 'admin',
+    ...overrides,
+  }
+}
+
+function makeRunsResponse(runs: object[], status = 200) {
+  return new Response(
+    JSON.stringify({ data: runs, timestamp: new Date().toISOString() }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeJobsResponse(jobs: object[], status = 200) {
+  return new Response(
+    JSON.stringify({ data: jobs, timestamp: new Date().toISOString() }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function renderRunsView() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <RunsView />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+// ── Container ─────────────────────────────────────────────────────────────────
+
+describe('RunsView — container', () => {
+  it('renders the runs-view container', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderRunsView()
+    expect(screen.getByTestId('runs-view')).toBeInTheDocument()
+  })
+
+  it('shows both section headings', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderRunsView()
+    expect(screen.getByRole('heading', { name: /script runs/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /batch jobs/i })).toBeInTheDocument()
+  })
+})
+
+// ── Script runs section ───────────────────────────────────────────────────────
+
+describe('RunsView — script runs section', () => {
+  it('shows loading skeleton while runs are loading', () => {
+    // Runs never resolves; jobs resolves immediately
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/runs')) return new Promise(() => {})
+      return Promise.resolve(makeJobsResponse([]))
+    })
+    renderRunsView()
+    expect(screen.getByTestId('runs-loading')).toBeInTheDocument()
+  })
+
+  it('shows error card when the runs API returns non-ok', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/jobs')) return Promise.resolve(makeJobsResponse([]))
+      return Promise.resolve(makeRunsResponse([], 500))
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /couldn't load runs/i })).toBeInTheDocument(),
+    )
+  })
+
+  it('shows empty state when there are no script runs', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/jobs')) return Promise.resolve(makeJobsResponse([]))
+      return Promise.resolve(makeRunsResponse([]))
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-empty')).toBeInTheDocument(),
+    )
+  })
+
+  it('renders the runs table with run rows', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/jobs')) return Promise.resolve(makeJobsResponse([]))
+      return Promise.resolve(makeRunsResponse([makeRunRecord()]))
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-table')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('run-row')).toBeInTheDocument()
+  })
+
+  it('renders run status as a text node (security A9.1)', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/jobs')) return Promise.resolve(makeJobsResponse([]))
+      return Promise.resolve(
+        makeRunsResponse([makeRunRecord({ run_id: 'run-xss', status: '<script>bad()</script>' })])
+      )
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('run-row')).toBeInTheDocument(),
+    )
+    expect(document.querySelector('script[src]')).toBeNull()
+    expect(screen.getByText('<script>bad()</script>')).toBeInTheDocument()
+  })
+
+  it('retries the runs fetch when the retry button is clicked', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/jobs')) return Promise.resolve(makeJobsResponse([]))
+      return Promise.resolve(makeRunsResponse([], 503))
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /retry/i })[0]).toBeInTheDocument(),
+    )
+
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/jobs')) return Promise.resolve(makeJobsResponse([]))
+      return Promise.resolve(makeRunsResponse([makeRunRecord()]))
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: /retry/i })[0]!)
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-table')).toBeInTheDocument(),
+    )
+  })
+})
+
+// ── Batch jobs section ────────────────────────────────────────────────────────
+
+describe('RunsView — batch jobs section', () => {
+  it('shows loading skeleton while jobs are loading', () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/runs')) return Promise.resolve(makeRunsResponse([]))
+      return new Promise(() => {})
+    })
+    renderRunsView()
+    expect(screen.getByTestId('jobs-loading')).toBeInTheDocument()
+  })
+
+  it('shows error card when the jobs API returns non-ok', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/runs') && !input.toString().includes('/jobs'))
+        return Promise.resolve(makeRunsResponse([]))
+      return Promise.resolve(makeJobsResponse([], 500))
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /couldn't load batch jobs/i })).toBeInTheDocument(),
+    )
+  })
+
+  it('shows empty state when there are no batch jobs', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/runs') && !input.toString().includes('/jobs'))
+        return Promise.resolve(makeRunsResponse([]))
+      return Promise.resolve(makeJobsResponse([]))
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('jobs-empty')).toBeInTheDocument(),
+    )
+  })
+
+  it('renders the jobs table with job rows', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/runs') && !input.toString().includes('/jobs'))
+        return Promise.resolve(makeRunsResponse([]))
+      return Promise.resolve(makeJobsResponse([makeBatchJob()]))
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('jobs-table')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('job-row')).toBeInTheDocument()
+  })
+
+  it('renders job selector as a text node (security A9.1)', async () => {
+    fetchMock.mockImplementation((input) => {
+      if (String(input).includes('/api/v1/runs') && !input.toString().includes('/jobs'))
+        return Promise.resolve(makeRunsResponse([]))
+      return Promise.resolve(
+        makeJobsResponse([makeBatchJob({ selector: '<b>inject</b>' })])
+      )
+    })
+    renderRunsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('job-row')).toBeInTheDocument(),
+    )
+    expect(document.querySelector('b')).toBeNull()
+    expect(screen.getByText('<b>inject</b>')).toBeInTheDocument()
+  })
+})

--- a/web/src/scripts/RunsView.tsx
+++ b/web/src/scripts/RunsView.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Run/job history view (Issue #2988).
+ * Consumes GET /api/v1/runs (script-library-backed runs) and GET /api/v1/jobs
+ * (batch jobs) from the list endpoints added in Issue #2987.
+ *
+ * Security A9.1: run IDs, script refs, job IDs, selectors, and status strings
+ * are untrusted-origin data — rendered as JSX text nodes only, never
+ * dangerouslySetInnerHTML.
+ */
+import { useRunList, useJobList } from './useScripts.ts'
+import ErrorCard from '../shell/ErrorCard.tsx'
+
+function statusTone(status: string): string {
+  switch (status) {
+    case 'completed':
+    case 'rolled_back':
+      return 'ok'
+    case 'failed':
+    case 'cancelled':
+      return 'crit'
+    case 'running':
+    case 'pending':
+    case 'paused':
+      return 'warn'
+    default:
+      return 'neutral'
+  }
+}
+
+export default function RunsView() {
+  const {
+    runs,
+    loading: runsLoading,
+    error: runsError,
+    retry: retryRuns,
+  } = useRunList()
+  const {
+    jobs,
+    loading: jobsLoading,
+    error: jobsError,
+    retry: retryJobs,
+  } = useJobList()
+
+  return (
+    <div data-testid="runs-view">
+      <h3>Script runs</h3>
+
+      {runsLoading ? (
+        <div data-testid="runs-loading" aria-label="Loading runs">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div className="skrow" key={i}>
+              <span className="skel" style={{ width: '50%' }} />
+              <span className="skel" style={{ width: '30%' }} />
+              <span className="skel" style={{ width: '40%' }} />
+            </div>
+          ))}
+        </div>
+      ) : runsError !== null ? (
+        <ErrorCard
+          heading="Couldn't load runs"
+          detail={runsError}
+          onRetry={retryRuns}
+        />
+      ) : runs.length === 0 ? (
+        <div className="notice empty" data-testid="runs-empty">
+          <div className="ic">◍</div>
+          <p>No script runs found.</p>
+        </div>
+      ) : (
+        <table className="tbl" data-testid="runs-table">
+          <thead>
+            <tr>
+              <th>Run ID</th>
+              <th>Script</th>
+              <th>Status</th>
+              <th>Jobs</th>
+              <th>Created</th>
+              <th className="c-spacer" aria-hidden="true" />
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((r) => (
+              <tr key={r.run_id} data-testid="run-row">
+                <td>
+                  <span className="mono2">{r.run_id}</span>
+                </td>
+                <td>
+                  <span className="nm">{r.script_ref || '—'}</span>
+                </td>
+                <td>
+                  <span className={`pill ${statusTone(r.status)}`}>
+                    <span className="dot" />
+                    {r.status}
+                  </span>
+                </td>
+                <td>
+                  <span className="mono2">
+                    {r.completed_jobs}/{r.job_count}
+                    {r.failed_jobs > 0 ? ` (${r.failed_jobs} failed)` : ''}
+                  </span>
+                </td>
+                <td>
+                  <span className="mono2">{r.created_at}</span>
+                </td>
+                <td className="c-spacer" />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <h3>Batch jobs</h3>
+
+      {jobsLoading ? (
+        <div data-testid="jobs-loading" aria-label="Loading jobs">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div className="skrow" key={i}>
+              <span className="skel" style={{ width: '50%' }} />
+              <span className="skel" style={{ width: '30%' }} />
+              <span className="skel" style={{ width: '40%' }} />
+            </div>
+          ))}
+        </div>
+      ) : jobsError !== null ? (
+        <ErrorCard
+          heading="Couldn't load batch jobs"
+          detail={jobsError}
+          onRetry={retryJobs}
+        />
+      ) : jobs.length === 0 ? (
+        <div className="notice empty" data-testid="jobs-empty">
+          <div className="ic">◍</div>
+          <p>No batch jobs found.</p>
+        </div>
+      ) : (
+        <table className="tbl" data-testid="jobs-table">
+          <thead>
+            <tr>
+              <th>Job ID</th>
+              <th>Selector</th>
+              <th>Status</th>
+              <th>Targets</th>
+              <th>Created</th>
+              <th className="c-spacer" aria-hidden="true" />
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.map((j) => (
+              <tr key={j.id} data-testid="job-row">
+                <td>
+                  <span className="mono2">{j.id}</span>
+                </td>
+                <td>
+                  <span className="nm">{j.selector || '—'}</span>
+                </td>
+                <td>
+                  <span className={`pill ${statusTone(j.status)}`}>
+                    <span className="dot" />
+                    {j.status}
+                  </span>
+                </td>
+                <td>
+                  <span className="mono2">{j.targets.length}</span>
+                </td>
+                <td>
+                  <span className="mono2">{j.created_at}</span>
+                </td>
+                <td className="c-spacer" />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/web/src/scripts/ScriptsView.test.tsx
+++ b/web/src/scripts/ScriptsView.test.tsx
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * ScriptsView test suite (Issue #2988).
+ *
+ * Covers: loading, error, empty, and populated table states; row selection
+ * opens RunPanel and deselects on second click; history toggle mounts
+ * RunsView; script count label; Security A9.1 (no dangerouslySetInnerHTML).
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import ScriptsView from './ScriptsView.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeScript(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'script-1',
+    name: 'Patch System',
+    description: 'Apply OS patches',
+    version: { major: 1, minor: 2, patch: 0, prerelease: '', build_meta: '' },
+    author: 'test-author',
+    tags: ['patch'],
+    category: 'maintenance',
+    platform: ['linux'],
+    shell: 'bash',
+    parameters: [],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    idempotent: true,
+    ...overrides,
+  }
+}
+
+function makeScriptListResponse(scripts: object[], status = 200) {
+  return new Response(
+    JSON.stringify({ data: scripts, timestamp: new Date().toISOString() }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeRunListResponse(status = 200) {
+  return new Response(
+    JSON.stringify({ data: [], timestamp: new Date().toISOString() }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function renderScriptsView() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <ScriptsView />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+// ── Data states ───────────────────────────────────────────────────────────────
+
+describe('ScriptsView — data states', () => {
+  it('shows loading skeleton before the response arrives', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderScriptsView()
+    expect(screen.getByTestId('scripts-loading')).toBeInTheDocument()
+  })
+
+  it('shows error card when the API returns a non-ok status', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([], 503))
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /couldn't load scripts/i })).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('scripts-loading')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when the library is empty', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([]))
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('scripts-empty')).toBeInTheDocument(),
+    )
+  })
+
+  it('shows the scripts table when scripts are returned', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([makeScript()]))
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('scripts-table')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('script-row')).toBeInTheDocument()
+  })
+
+  it('renders the script name as a text node (security A9.1)', async () => {
+    fetchMock.mockResolvedValue(
+      makeScriptListResponse([makeScript({ name: '<script>alert(1)</script>' })]),
+    )
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('script-row')).toBeInTheDocument(),
+    )
+    // Must appear as escaped text, not injected HTML
+    expect(document.querySelector('script[src]')).toBeNull()
+    expect(screen.getByText('<script>alert(1)</script>')).toBeInTheDocument()
+  })
+
+  it('shows the script count label after loading', async () => {
+    fetchMock.mockResolvedValue(
+      makeScriptListResponse([makeScript(), makeScript({ id: 'script-2', name: 'Script 2' })]),
+    )
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('script-count')).toHaveTextContent('2 scripts'),
+    )
+  })
+
+  it('shows singular "script" when there is exactly one', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([makeScript()]))
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('script-count')).toHaveTextContent('1 script'),
+    )
+  })
+
+  it('retries the list fetch when the error card retry button is clicked', async () => {
+    fetchMock.mockResolvedValueOnce(makeScriptListResponse([], 500))
+    fetchMock.mockResolvedValueOnce(makeScriptListResponse([makeScript()]))
+    renderScriptsView()
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    await waitFor(() =>
+      expect(screen.getByTestId('scripts-table')).toBeInTheDocument(),
+    )
+  })
+})
+
+// ── Row selection → RunPanel ──────────────────────────────────────────────────
+
+describe('ScriptsView — row selection and RunPanel', () => {
+  it('opens RunPanel when a script row is clicked', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([makeScript()]))
+    renderScriptsView()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('script-row')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('script-row'))
+
+    expect(screen.getByTestId('run-panel')).toBeInTheDocument()
+  })
+
+  it('closes RunPanel when the same row is clicked again', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([makeScript()]))
+    renderScriptsView()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('script-row')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('script-row'))
+    expect(screen.getByTestId('run-panel')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('script-row'))
+    expect(screen.queryByTestId('run-panel')).not.toBeInTheDocument()
+  })
+
+  it('closes RunPanel when its Cancel button is clicked', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([makeScript()]))
+    renderScriptsView()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('script-row')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('script-row'))
+    expect(screen.getByTestId('run-panel')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByTestId('run-panel')).not.toBeInTheDocument()
+  })
+})
+
+// ── History toggle ────────────────────────────────────────────────────────────
+
+describe('ScriptsView — history toggle', () => {
+  it('shows the history toggle button', async () => {
+    fetchMock.mockResolvedValue(makeScriptListResponse([]))
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('toggle-history-btn')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('toggle-history-btn')).toHaveTextContent('Run history')
+  })
+
+  it('clicking the history button shows RunsView', async () => {
+    // Resolve scripts list, then handle runs and jobs endpoints
+    fetchMock.mockResolvedValueOnce(makeScriptListResponse([makeScript()]))
+    fetchMock.mockResolvedValue(makeRunListResponse())
+
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('toggle-history-btn')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('toggle-history-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-view')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('toggle-history-btn')).toHaveTextContent('Close history')
+  })
+
+  it('clicking the history button again hides RunsView', async () => {
+    fetchMock.mockResolvedValueOnce(makeScriptListResponse([]))
+    fetchMock.mockResolvedValue(makeRunListResponse())
+
+    renderScriptsView()
+    await waitFor(() =>
+      expect(screen.getByTestId('toggle-history-btn')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('toggle-history-btn'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-view')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('toggle-history-btn'))
+    expect(screen.queryByTestId('runs-view')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/scripts/ScriptsView.tsx
+++ b/web/src/scripts/ScriptsView.tsx
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Scripts view (Issue #2988) — the /scripts route entry point.
+ * Fetches GET /api/v1/scripts, renders a library table, and opens RunPanel
+ * when an operator selects a script row.
+ *
+ * Security A9.1: script names and descriptions are untrusted-origin data.
+ * Every value reaches the DOM as a JSX text node — never dangerouslySetInnerHTML.
+ */
+import { useState } from 'react'
+import { useScriptList, type ScriptMetadata } from './useScripts.ts'
+import RunPanel from './RunPanel.tsx'
+import RunsView from './RunsView.tsx'
+import ErrorCard from '../shell/ErrorCard.tsx'
+
+function LoadingRows() {
+  return (
+    <div data-testid="scripts-loading" aria-label="Loading scripts">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div className="skrow" key={i}>
+          <span className="skel" style={{ width: '45%' }} />
+          <span className="skel" style={{ width: '20%' }} />
+          <span className="skel" style={{ width: '55%' }} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ScriptsEmpty() {
+  return (
+    <div className="notice empty" data-testid="scripts-empty">
+      <div className="ic">◍</div>
+      <h3>No scripts in the library</h3>
+      <p>The script library is empty. Add scripts via the controller CLI.</p>
+    </div>
+  )
+}
+
+function scriptVersionLabel(script: ScriptMetadata): string {
+  const v = script.version
+  if (!v) return '—'
+  return `${v.major}.${v.minor}.${v.patch}${v.prerelease ? `-${v.prerelease}` : ''}`
+}
+
+function ScriptRow({
+  script,
+  selected,
+  onClick,
+}: {
+  script: ScriptMetadata
+  selected: boolean
+  onClick: () => void
+}) {
+  return (
+    <tr
+      className={selected ? 'selected' : ''}
+      onClick={onClick}
+      data-testid="script-row"
+    >
+      <td>
+        <span className="nm">{script.name}</span>
+      </td>
+      <td>
+        <span className="mono2">{scriptVersionLabel(script)}</span>
+      </td>
+      <td>
+        <span className="mut">{script.description || '—'}</span>
+      </td>
+      <td>
+        <span className="mono2">{script.shell || '—'}</span>
+      </td>
+      <td className="c-spacer" />
+    </tr>
+  )
+}
+
+export default function ScriptsView() {
+  const { scripts, loading, error, retry } = useScriptList()
+  const [selectedScript, setSelectedScript] = useState<ScriptMetadata | null>(null)
+  const [showHistory, setShowHistory] = useState(false)
+
+  function handleRowClick(script: ScriptMetadata) {
+    setSelectedScript((prev) => (prev?.id === script.id ? null : script))
+    setShowHistory(false)
+  }
+
+  return (
+    <>
+      <div className="htitle">
+        <h1>Scripts</h1>
+        <p>Browse the script library and run scripts against stewards or fleet selections.</p>
+      </div>
+
+      <section className="panel">
+        <div className="ptool">
+          <button
+            type="button"
+            className={showHistory ? 'wf-btn' : 'wf-btn-secondary'}
+            onClick={() => {
+              setShowHistory((v) => !v)
+              setSelectedScript(null)
+            }}
+            data-testid="toggle-history-btn"
+          >
+            {showHistory ? 'Close history' : 'Run history'}
+          </button>
+          {!loading && error === null && (
+            <span className="cnt" data-testid="script-count">
+              {scripts.length} script{scripts.length !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+
+        {showHistory && <RunsView />}
+
+        {loading ? (
+          <LoadingRows />
+        ) : error !== null ? (
+          <ErrorCard heading="Couldn't load scripts" detail={error} onRetry={retry} />
+        ) : scripts.length === 0 ? (
+          <ScriptsEmpty />
+        ) : (
+          <table className="tbl" data-testid="scripts-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Version</th>
+                <th>Description</th>
+                <th>Shell</th>
+                <th className="c-spacer" aria-hidden="true" />
+              </tr>
+            </thead>
+            <tbody>
+              {scripts.map((s) => (
+                <ScriptRow
+                  key={s.id}
+                  script={s}
+                  selected={selectedScript?.id === s.id}
+                  onClick={() => handleRowClick(s)}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {selectedScript !== null && (
+        <RunPanel
+          script={selectedScript}
+          onClose={() => setSelectedScript(null)}
+        />
+      )}
+    </>
+  )
+}

--- a/web/src/scripts/useScripts.test.ts
+++ b/web/src/scripts/useScripts.test.ts
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * useScripts test suite (Issue #2988).
+ *
+ * Key invariants tested:
+ *   - parseScriptMetadata coerces all fields correctly
+ *   - parseRunRecord coerces all fields correctly
+ *   - parseJobRecord coerces all fields correctly
+ *   - parseBatchJob coerces all fields correctly
+ *   - useScriptList fetches and parses the script library
+ *   - useRunList fetches and parses the run list
+ *   - useRunStatus polls GET /api/v1/runs/{id} until a terminal state [REQUIRED]
+ *   - useJobList fetches and parses batch jobs
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import {
+  parseScriptMetadata,
+  parseScriptList,
+  parseRunRecord,
+  parseRunList,
+  parseJobRecord,
+  parseJobList,
+  parseBatchJob,
+  parseBatchJobList,
+  useScriptList,
+  useRunList,
+  useRunStatus,
+  useRunJobs,
+  useJobList,
+  RUN_POLL_INTERVAL,
+  RUN_TERMINAL,
+} from './useScripts.ts'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  // Always restore real timers so fake-timer tests don't leak into subsequent ones
+  vi.useRealTimers()
+})
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeScript(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'script-1',
+    name: 'Test Script',
+    description: 'A test script',
+    version: { major: 1, minor: 0, patch: 0, prerelease: '', build_meta: '' },
+    author: 'test-author',
+    tags: ['tag1'],
+    category: 'maintenance',
+    platform: ['linux'],
+    shell: 'bash',
+    parameters: [],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    idempotent: true,
+    ...overrides,
+  }
+}
+
+function makeRunRecord(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    run_id: 'run-1',
+    tenant_id: 'root',
+    created_by: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+    status: 'running',
+    script_ref: 'script-1',
+    shell: 'bash',
+    job_count: 3,
+    completed_jobs: 1,
+    failed_jobs: 0,
+    ...overrides,
+  }
+}
+
+function makeJobRecord(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    job_id: 'job-1',
+    run_id: 'run-1',
+    device_id: 'steward-1',
+    execution_id: 'exec-1',
+    status: 'completed',
+    created_at: '2026-01-01T00:00:00Z',
+    completed_at: '2026-01-01T00:01:00Z',
+    output: 'ok',
+    stderr: '',
+    exit_code: 0,
+    ...overrides,
+  }
+}
+
+function makeBatchJob(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'bjob-1',
+    tenant_id: 'root',
+    selector: 'name:web*',
+    status: 'completed',
+    targets: ['s-1', 's-2'],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:01:00Z',
+    initiated_by: 'admin',
+    ...overrides,
+  }
+}
+
+function makeSuccessResponse(data: unknown, status = 200) {
+  return new Response(
+    JSON.stringify({ data, timestamp: '2026-01-01T00:00:00Z' }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+// ── parseScriptMetadata ───────────────────────────────────────────────────────
+
+describe('parseScriptMetadata', () => {
+  it('parses a valid script', () => {
+    const s = parseScriptMetadata(makeScript())
+    expect(s).not.toBeNull()
+    expect(s!.id).toBe('script-1')
+    expect(s!.name).toBe('Test Script')
+    expect(s!.description).toBe('A test script')
+    expect(s!.version?.major).toBe(1)
+    expect(s!.shell).toBe('bash')
+    expect(s!.idempotent).toBe(true)
+  })
+
+  it('returns null for non-object input', () => {
+    expect(parseScriptMetadata(null)).toBeNull()
+    expect(parseScriptMetadata('string')).toBeNull()
+    expect(parseScriptMetadata(42)).toBeNull()
+  })
+
+  it('returns null when id is missing', () => {
+    expect(parseScriptMetadata({ name: 'no-id' })).toBeNull()
+  })
+
+  it('coerces non-string fields to defaults', () => {
+    const s = parseScriptMetadata({ id: 'x', name: 42, description: null, shell: false })
+    expect(s!.name).toBe('')
+    expect(s!.description).toBe('')
+    expect(s!.shell).toBe('')
+  })
+
+  it('handles missing version gracefully', () => {
+    const s = parseScriptMetadata({ id: 'x' })
+    expect(s!.version).toBeNull()
+  })
+
+  it('handles missing parameters gracefully', () => {
+    const s = parseScriptMetadata({ id: 'x' })
+    expect(s!.parameters).toEqual([])
+  })
+
+  it('parses parameters with required and optional fields', () => {
+    const s = parseScriptMetadata(
+      makeScript({
+        parameters: [
+          { name: 'timeout', description: 'Timeout seconds', type: 'int', required: true },
+          { name: 'env', type: 'string', required: false },
+          { description: 'no-name-param' }, // should be skipped
+        ],
+      }),
+    )
+    expect(s!.parameters).toHaveLength(2)
+    expect(s!.parameters[0]!.name).toBe('timeout')
+    expect(s!.parameters[0]!.required).toBe(true)
+    expect(s!.parameters[1]!.name).toBe('env')
+    expect(s!.parameters[1]!.required).toBe(false)
+  })
+})
+
+// ── parseScriptList ───────────────────────────────────────────────────────────
+
+describe('parseScriptList', () => {
+  it('parses a valid array of scripts', () => {
+    const result = parseScriptList([makeScript(), makeScript({ id: 'script-2', name: 'Script 2' })])
+    expect(result).toHaveLength(2)
+    expect(result[0]!.id).toBe('script-1')
+    expect(result[1]!.id).toBe('script-2')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseScriptList([])).toEqual([])
+  })
+
+  it('throws on non-array input', () => {
+    expect(() => parseScriptList(null)).toThrow('unexpected response shape')
+    expect(() => parseScriptList({ scripts: [] })).toThrow('unexpected response shape')
+  })
+
+  it('skips items without an id', () => {
+    const result = parseScriptList([makeScript(), { name: 'no-id' }])
+    expect(result).toHaveLength(1)
+  })
+})
+
+// ── parseRunRecord ────────────────────────────────────────────────────────────
+
+describe('parseRunRecord', () => {
+  it('parses a valid run record', () => {
+    const r = parseRunRecord(makeRunRecord())
+    expect(r).not.toBeNull()
+    expect(r!.run_id).toBe('run-1')
+    expect(r!.status).toBe('running')
+    expect(r!.job_count).toBe(3)
+    expect(r!.completed_jobs).toBe(1)
+    expect(r!.failed_jobs).toBe(0)
+  })
+
+  it('returns null for non-object input', () => {
+    expect(parseRunRecord(null)).toBeNull()
+    expect(parseRunRecord('string')).toBeNull()
+  })
+
+  it('returns null when run_id is missing', () => {
+    expect(parseRunRecord({ status: 'running' })).toBeNull()
+  })
+
+  it('coerces non-number fields to zero', () => {
+    const r = parseRunRecord({ run_id: 'r-1', job_count: 'not-a-num', completed_jobs: null })
+    expect(r!.job_count).toBe(0)
+    expect(r!.completed_jobs).toBe(0)
+  })
+})
+
+// ── parseRunList ──────────────────────────────────────────────────────────────
+
+describe('parseRunList', () => {
+  it('parses a valid array of runs', () => {
+    const result = parseRunList([makeRunRecord(), makeRunRecord({ run_id: 'run-2' })])
+    expect(result).toHaveLength(2)
+    expect(result[0]!.run_id).toBe('run-1')
+    expect(result[1]!.run_id).toBe('run-2')
+  })
+
+  it('throws on non-array input', () => {
+    expect(() => parseRunList(null)).toThrow('unexpected response shape')
+  })
+
+  it('skips items without run_id', () => {
+    const result = parseRunList([makeRunRecord(), { status: 'running' }])
+    expect(result).toHaveLength(1)
+  })
+})
+
+// ── parseJobRecord ────────────────────────────────────────────────────────────
+
+describe('parseJobRecord', () => {
+  it('parses a valid job record', () => {
+    const j = parseJobRecord(makeJobRecord())
+    expect(j).not.toBeNull()
+    expect(j!.job_id).toBe('job-1')
+    expect(j!.device_id).toBe('steward-1')
+    expect(j!.status).toBe('completed')
+    expect(j!.exit_code).toBe(0)
+  })
+
+  it('returns null for non-object or missing job_id', () => {
+    expect(parseJobRecord(null)).toBeNull()
+    expect(parseJobRecord({ device_id: 'x' })).toBeNull()
+  })
+
+  it('coerces non-string stderr to empty string', () => {
+    const j = parseJobRecord({ job_id: 'j-1', stderr: 42 })
+    expect(j!.stderr).toBe('')
+  })
+})
+
+// ── parseJobList ──────────────────────────────────────────────────────────────
+
+describe('parseJobList', () => {
+  it('parses a valid array of jobs', () => {
+    const result = parseJobList([makeJobRecord(), makeJobRecord({ job_id: 'job-2' })])
+    expect(result).toHaveLength(2)
+  })
+
+  it('throws on non-array input', () => {
+    expect(() => parseJobList(null)).toThrow('unexpected response shape')
+  })
+})
+
+// ── parseBatchJob ─────────────────────────────────────────────────────────────
+
+describe('parseBatchJob', () => {
+  it('parses a valid batch job', () => {
+    const j = parseBatchJob(makeBatchJob())
+    expect(j).not.toBeNull()
+    expect(j!.id).toBe('bjob-1')
+    expect(j!.selector).toBe('name:web*')
+    expect(j!.targets).toEqual(['s-1', 's-2'])
+    expect(j!.status).toBe('completed')
+  })
+
+  it('returns null for non-object or missing id', () => {
+    expect(parseBatchJob(null)).toBeNull()
+    expect(parseBatchJob({ selector: 'all' })).toBeNull()
+  })
+
+  it('coerces non-array targets to empty array', () => {
+    const j = parseBatchJob({ id: 'j-1', targets: 'not-an-array' })
+    expect(j!.targets).toEqual([])
+  })
+})
+
+// ── parseBatchJobList ─────────────────────────────────────────────────────────
+
+describe('parseBatchJobList', () => {
+  it('parses a valid array', () => {
+    const result = parseBatchJobList([makeBatchJob(), makeBatchJob({ id: 'bjob-2' })])
+    expect(result).toHaveLength(2)
+  })
+
+  it('throws on non-array input', () => {
+    expect(() => parseBatchJobList(null)).toThrow('unexpected response shape')
+  })
+})
+
+// ── useScriptList ─────────────────────────────────────────────────────────────
+
+describe('useScriptList', () => {
+  it('starts in loading state', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useScriptList())
+    expect(result.current.loading).toBe(true)
+    expect(result.current.scripts).toEqual([])
+    expect(result.current.error).toBeNull()
+  })
+
+  it('returns parsed scripts on success', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse([makeScript()]))
+    const { result } = renderHook(() => useScriptList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.scripts).toHaveLength(1)
+    expect(result.current.scripts[0]!.id).toBe('script-1')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces an error on non-ok response', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse([], 503))
+    const { result } = renderHook(() => useScriptList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toContain('503')
+    expect(result.current.scripts).toEqual([])
+  })
+
+  it('refetches when retry is called', async () => {
+    fetchMock.mockResolvedValueOnce(makeSuccessResponse([], 500))
+    const { result } = renderHook(() => useScriptList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).not.toBeNull()
+
+    fetchMock.mockResolvedValueOnce(makeSuccessResponse([makeScript()]))
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.scripts).toHaveLength(1)
+    expect(result.current.error).toBeNull()
+  })
+})
+
+// ── useRunList ────────────────────────────────────────────────────────────────
+
+describe('useRunList', () => {
+  it('starts in loading state', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useRunList())
+    expect(result.current.loading).toBe(true)
+    expect(result.current.runs).toEqual([])
+  })
+
+  it('returns parsed runs on success', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse([makeRunRecord()]))
+    const { result } = renderHook(() => useRunList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.runs).toHaveLength(1)
+    expect(result.current.runs[0]!.run_id).toBe('run-1')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces an error on non-ok response', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse([], 500))
+    const { result } = renderHook(() => useRunList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toContain('500')
+  })
+
+  it('refetches when retry is called', async () => {
+    fetchMock.mockResolvedValueOnce(makeSuccessResponse([], 500))
+    const { result } = renderHook(() => useRunList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    fetchMock.mockResolvedValueOnce(makeSuccessResponse([makeRunRecord()]))
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.runs).toHaveLength(1)
+    expect(result.current.error).toBeNull()
+  })
+})
+
+// ── useRunStatus — polling to terminal state [REQUIRED] ───────────────────────
+
+describe('useRunStatus', () => {
+  it('returns null run and not-loading when runId is null', () => {
+    const { result } = renderHook(() => useRunStatus(null))
+    expect(result.current.run).toBeNull()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('starts loading when runId is provided', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useRunStatus('run-1'))
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('returns parsed run on success', async () => {
+    fetchMock.mockResolvedValue(
+      makeSuccessResponse(makeRunRecord({ status: 'completed' })),
+    )
+    const { result } = renderHook(() => useRunStatus('run-1'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.run?.run_id).toBe('run-1')
+    expect(result.current.run?.status).toBe('completed')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces an error on non-ok response', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse({}, 404))
+    const { result } = renderHook(() => useRunStatus('run-bad'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toContain('404')
+  })
+
+  it('polls to a terminal state then stops [REQUIRED]', async () => {
+    // shouldAdvanceTime lets waitFor's internal setTimeout tick with real time
+    // while vi.advanceTimersByTimeAsync() still controls the poll interval explicitly
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    // First fetch: run is still in progress
+    fetchMock.mockResolvedValueOnce(
+      makeSuccessResponse(makeRunRecord({ run_id: 'run-poll', status: 'running' })),
+    )
+
+    const { result } = renderHook(() => useRunStatus('run-poll'))
+
+    await waitFor(() => expect(result.current.run?.status).toBe('running'))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Second fetch: terminal state
+    fetchMock.mockResolvedValueOnce(
+      makeSuccessResponse(makeRunRecord({ run_id: 'run-poll', status: 'completed' })),
+    )
+
+    // Fire the poll interval timer and flush resulting Promises
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_POLL_INTERVAL)
+    })
+
+    await waitFor(() => expect(result.current.run?.status).toBe('completed'))
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // After terminal state, no more fetches should be made even if time advances
+    const callCountAfterTerminal = fetchMock.mock.calls.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_POLL_INTERVAL * 3)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(callCountAfterTerminal)
+  })
+
+  it('polls until "failed" terminal state', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    fetchMock.mockResolvedValueOnce(
+      makeSuccessResponse(makeRunRecord({ run_id: 'run-fail', status: 'pending' })),
+    )
+    fetchMock.mockResolvedValueOnce(
+      makeSuccessResponse(makeRunRecord({ run_id: 'run-fail', status: 'failed' })),
+    )
+
+    const { result } = renderHook(() => useRunStatus('run-fail'))
+
+    await waitFor(() => expect(result.current.run?.status).toBe('pending'))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_POLL_INTERVAL)
+    })
+    await waitFor(() => expect(result.current.run?.status).toBe('failed'))
+    expect(RUN_TERMINAL.has('failed')).toBe(true)
+  })
+
+  it('all terminal states are in RUN_TERMINAL', () => {
+    expect(RUN_TERMINAL.has('completed')).toBe(true)
+    expect(RUN_TERMINAL.has('failed')).toBe(true)
+    expect(RUN_TERMINAL.has('cancelled')).toBe(true)
+    expect(RUN_TERMINAL.has('running')).toBe(false)
+    expect(RUN_TERMINAL.has('pending')).toBe(false)
+  })
+})
+
+// ── useRunJobs ────────────────────────────────────────────────────────────────
+
+describe('useRunJobs', () => {
+  it('returns empty and not-loading when runId is null', () => {
+    const { result } = renderHook(() => useRunJobs(null, false))
+    expect(result.current.jobs).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('starts loading when runId is provided', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useRunJobs('run-1', false))
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('returns parsed jobs on success', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse([makeJobRecord()]))
+    const { result } = renderHook(() => useRunJobs('run-1', false))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.jobs).toHaveLength(1)
+    expect(result.current.jobs[0]!.job_id).toBe('job-1')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('does not start polling when isRunTerminal is true', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    fetchMock.mockResolvedValue(makeSuccessResponse([makeJobRecord()]))
+
+    const { result } = renderHook(() => useRunJobs('run-1', true))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    const callCountAfterInitial = fetchMock.mock.calls.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_POLL_INTERVAL * 3)
+    })
+    // Only the initial fetch should have fired
+    expect(fetchMock).toHaveBeenCalledTimes(callCountAfterInitial)
+  })
+})
+
+// ── useJobList ────────────────────────────────────────────────────────────────
+
+describe('useJobList', () => {
+  it('starts in loading state', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useJobList())
+    expect(result.current.loading).toBe(true)
+    expect(result.current.jobs).toEqual([])
+  })
+
+  it('returns parsed batch jobs on success', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse([makeBatchJob()]))
+    const { result } = renderHook(() => useJobList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.jobs).toHaveLength(1)
+    expect(result.current.jobs[0]!.id).toBe('bjob-1')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces an error on non-ok response', async () => {
+    fetchMock.mockResolvedValue(makeSuccessResponse([], 503))
+    const { result } = renderHook(() => useJobList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toContain('503')
+  })
+
+  it('refetches when retry is called', async () => {
+    fetchMock.mockResolvedValueOnce(makeSuccessResponse([], 500))
+    const { result } = renderHook(() => useJobList())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    fetchMock.mockResolvedValueOnce(makeSuccessResponse([makeBatchJob()]))
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.jobs).toHaveLength(1)
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/web/src/scripts/useScripts.ts
+++ b/web/src/scripts/useScripts.ts
@@ -1,0 +1,558 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Scripts, runs, and jobs fetch/mutation hooks (Issue #2988).
+ *
+ * Endpoints covered:
+ *   GET  /api/v1/scripts                        → useScriptList
+ *   GET  /api/v1/runs                           → useRunList
+ *   GET  /api/v1/runs/{run_id}                  → useRunStatus (polls)
+ *   GET  /api/v1/runs/{run_id}/jobs             → useRunJobs (polls while run is non-terminal)
+ *   GET  /api/v1/jobs                           → useJobList
+ *
+ * Security A9.1: script names, params, run/job output, and status strings are
+ * untrusted-origin data. Every string field is coerced via str(). Callers must
+ * render them as JSX text nodes only, never dangerouslySetInnerHTML.
+ *
+ * Response envelope: all endpoints use writeSuccessResponse → { data: ..., timestamp: ... }.
+ *
+ * Polling: useRunStatus and useRunJobs use a fixed RUN_POLL_INTERVAL ticker
+ * (same pattern as usePushStatus in useConfigs.ts) and stop when the run
+ * reaches a terminal state ("completed", "failed", "cancelled").
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+
+// ── Primitive coercers ────────────────────────────────────────────────────────
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function num(value: unknown): number {
+  return typeof value === 'number' ? value : 0
+}
+
+function bool(value: unknown): boolean {
+  return typeof value === 'boolean' ? value : false
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface ScriptVersion {
+  major: number
+  minor: number
+  patch: number
+  prerelease: string
+  build_meta: string
+}
+
+export interface ScriptParameter {
+  name: string
+  description: string
+  type: string
+  required: boolean
+  default?: unknown
+  allowed_values?: string[]
+  dna_path?: string
+}
+
+export interface ScriptMetadata {
+  id: string
+  name: string
+  description: string
+  version: ScriptVersion | null
+  author: string
+  tags: string[]
+  category: string
+  platform: string[]
+  shell: string
+  parameters: ScriptParameter[]
+  created_at: string
+  updated_at: string
+  idempotent: boolean
+}
+
+export interface RunRecord {
+  run_id: string
+  tenant_id: string
+  created_by: string
+  created_at: string
+  status: string
+  script_ref: string
+  shell: string
+  job_count: number
+  completed_jobs: number
+  failed_jobs: number
+}
+
+export interface JobRecord {
+  job_id: string
+  run_id: string
+  device_id: string
+  execution_id: string
+  status: string
+  created_at: string
+  completed_at: string
+  output: string
+  stderr: string
+  exit_code: number
+}
+
+export interface BatchJob {
+  id: string
+  tenant_id: string
+  selector: string
+  status: string
+  targets: string[]
+  created_at: string
+  updated_at: string
+  initiated_by: string
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+function parseScriptVersion(value: unknown): ScriptVersion | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  return {
+    major: num(r.major),
+    minor: num(r.minor),
+    patch: num(r.patch),
+    prerelease: str(r.prerelease),
+    build_meta: str(r.build_meta),
+  }
+}
+
+function parseScriptParameter(value: unknown): ScriptParameter | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const name = str(r.name)
+  if (!name) return null
+  return {
+    name,
+    description: str(r.description),
+    type: str(r.type),
+    required: bool(r.required),
+    default: r.default !== undefined ? r.default : undefined,
+    allowed_values: Array.isArray(r.allowed_values)
+      ? r.allowed_values.filter((v): v is string => typeof v === 'string')
+      : undefined,
+    dna_path: r.dna_path !== undefined ? str(r.dna_path) : undefined,
+  }
+}
+
+export function parseScriptMetadata(value: unknown): ScriptMetadata | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const id = str(r.id)
+  if (!id) return null
+  return {
+    id,
+    name: str(r.name),
+    description: str(r.description),
+    version: parseScriptVersion(r.version),
+    author: str(r.author),
+    tags: Array.isArray(r.tags)
+      ? r.tags.filter((t): t is string => typeof t === 'string')
+      : [],
+    category: str(r.category),
+    platform: Array.isArray(r.platform)
+      ? r.platform.filter((p): p is string => typeof p === 'string')
+      : [],
+    shell: str(r.shell),
+    parameters: Array.isArray(r.parameters)
+      ? r.parameters.flatMap((p) => {
+          const parsed = parseScriptParameter(p)
+          return parsed ? [parsed] : []
+        })
+      : [],
+    created_at: str(r.created_at),
+    updated_at: str(r.updated_at),
+    idempotent: bool(r.idempotent),
+  }
+}
+
+export function parseScriptList(data: unknown): ScriptMetadata[] {
+  if (!Array.isArray(data)) throw new Error('unexpected response shape')
+  const list: ScriptMetadata[] = []
+  for (const item of data) {
+    const s = parseScriptMetadata(item)
+    if (s !== null) list.push(s)
+  }
+  return list
+}
+
+export function parseRunRecord(value: unknown): RunRecord | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const run_id = str(r.run_id)
+  if (!run_id) return null
+  return {
+    run_id,
+    tenant_id: str(r.tenant_id),
+    created_by: str(r.created_by),
+    created_at: str(r.created_at),
+    status: str(r.status),
+    script_ref: str(r.script_ref),
+    shell: str(r.shell),
+    job_count: num(r.job_count),
+    completed_jobs: num(r.completed_jobs),
+    failed_jobs: num(r.failed_jobs),
+  }
+}
+
+export function parseRunList(data: unknown): RunRecord[] {
+  if (!Array.isArray(data)) throw new Error('unexpected response shape')
+  const list: RunRecord[] = []
+  for (const item of data) {
+    const r = parseRunRecord(item)
+    if (r !== null) list.push(r)
+  }
+  return list
+}
+
+export function parseJobRecord(value: unknown): JobRecord | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const job_id = str(r.job_id)
+  if (!job_id) return null
+  return {
+    job_id,
+    run_id: str(r.run_id),
+    device_id: str(r.device_id),
+    execution_id: str(r.execution_id),
+    status: str(r.status),
+    created_at: str(r.created_at),
+    completed_at: r.completed_at !== undefined ? str(r.completed_at) : '',
+    output: str(r.output),
+    stderr: str(r.stderr),
+    exit_code: num(r.exit_code),
+  }
+}
+
+export function parseJobList(data: unknown): JobRecord[] {
+  if (!Array.isArray(data)) throw new Error('unexpected response shape')
+  const list: JobRecord[] = []
+  for (const item of data) {
+    const j = parseJobRecord(item)
+    if (j !== null) list.push(j)
+  }
+  return list
+}
+
+export function parseBatchJob(value: unknown): BatchJob | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const id = str(r.id)
+  if (!id) return null
+  return {
+    id,
+    tenant_id: str(r.tenant_id),
+    selector: str(r.selector),
+    status: str(r.status),
+    targets: Array.isArray(r.targets)
+      ? r.targets.filter((t): t is string => typeof t === 'string')
+      : [],
+    created_at: str(r.created_at),
+    updated_at: str(r.updated_at),
+    initiated_by: str(r.initiated_by),
+  }
+}
+
+export function parseBatchJobList(data: unknown): BatchJob[] {
+  if (!Array.isArray(data)) throw new Error('unexpected response shape')
+  const list: BatchJob[] = []
+  for (const item of data) {
+    const j = parseBatchJob(item)
+    if (j !== null) list.push(j)
+  }
+  return list
+}
+
+// ── Generic fetch outcome ─────────────────────────────────────────────────────
+
+interface FetchOutcome<T> {
+  key: string
+  data?: T
+  error?: string
+  fetchedAtMs: number
+}
+
+// ── useScriptList ─────────────────────────────────────────────────────────────
+
+export interface UseScriptListResult {
+  scripts: ScriptMetadata[]
+  loading: boolean
+  error: string | null
+  fetchedAtMs: number
+  retry: () => void
+}
+
+export function useScriptList(): UseScriptListResult {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome<ScriptMetadata[]> | null>(null)
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+  const key = `scripts:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/scripts')
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`GET /api/v1/scripts — ${response.status}`)
+        const body: unknown = await response.json()
+        const parsed = parseScriptList((body as Record<string, unknown> | null)?.data)
+        if (cancelled) return
+        setOutcome({ key, data: parsed, fetchedAtMs: Date.now() })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/scripts — request failed',
+          fetchedAtMs: Date.now(),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, attempt])
+
+  const current = outcome?.key === key ? outcome : null
+  return {
+    scripts: current?.data ?? [],
+    loading: current === null,
+    error: current?.error ?? null,
+    fetchedAtMs: current?.fetchedAtMs ?? 0,
+    retry,
+  }
+}
+
+// ── useRunList ────────────────────────────────────────────────────────────────
+
+export interface UseRunListResult {
+  runs: RunRecord[]
+  loading: boolean
+  error: string | null
+  retry: () => void
+}
+
+export function useRunList(): UseRunListResult {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome<RunRecord[]> | null>(null)
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+  const key = `runs:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/runs')
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`GET /api/v1/runs — ${response.status}`)
+        const body: unknown = await response.json()
+        const parsed = parseRunList((body as Record<string, unknown> | null)?.data)
+        if (cancelled) return
+        setOutcome({ key, data: parsed, fetchedAtMs: Date.now() })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/runs — request failed',
+          fetchedAtMs: Date.now(),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, attempt])
+
+  const current = outcome?.key === key ? outcome : null
+  return {
+    runs: current?.data ?? [],
+    loading: current === null,
+    error: current?.error ?? null,
+    retry,
+  }
+}
+
+// ── useRunStatus (polls until terminal) ───────────────────────────────────────
+
+export const RUN_POLL_INTERVAL = 3000
+export const RUN_TERMINAL = new Set(['completed', 'failed', 'cancelled'])
+
+export interface UseRunStatusResult {
+  run: RunRecord | null
+  loading: boolean
+  error: string | null
+}
+
+export function useRunStatus(runId: string | null): UseRunStatusResult {
+  const [outcome, setOutcome] = useState<FetchOutcome<RunRecord> | null>(null)
+  const [pollTick, setPollTick] = useState(0)
+  const key = `run-status:${runId ?? ''}:${pollTick}`
+
+  const current = outcome?.key === key ? outcome : null
+  const isTerminal =
+    current?.data !== undefined && RUN_TERMINAL.has(current.data.status)
+
+  // Polling ticker — fires every RUN_POLL_INTERVAL while run is non-terminal
+  useEffect(() => {
+    if (!runId || isTerminal) return
+    const timer = setInterval(() => setPollTick((n) => n + 1), RUN_POLL_INTERVAL)
+    return () => clearInterval(timer)
+  }, [runId, isTerminal])
+
+  // Fetch on runId change or poll tick
+  useEffect(() => {
+    if (!runId) return
+    let cancelled = false
+    apiFetch(`/api/v1/runs/${encodeURIComponent(runId)}`)
+      .then(async (response) => {
+        if (!response.ok)
+          throw new Error(`GET /api/v1/runs/${runId} — ${response.status}`)
+        const body: unknown = await response.json()
+        const parsed = parseRunRecord((body as Record<string, unknown> | null)?.data)
+        if (cancelled) return
+        if (parsed !== null) {
+          setOutcome({ key, data: parsed, fetchedAtMs: Date.now() })
+        }
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'request failed',
+          fetchedAtMs: Date.now(),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, runId, pollTick])
+
+  return {
+    run: runId ? (current?.data ?? null) : null,
+    loading: runId !== null && current === null,
+    error: runId ? (current?.error ?? null) : null,
+  }
+}
+
+// ── useRunJobs (polls while run is non-terminal) ──────────────────────────────
+
+export interface UseRunJobsResult {
+  jobs: JobRecord[]
+  loading: boolean
+  error: string | null
+}
+
+export function useRunJobs(
+  runId: string | null,
+  isRunTerminal: boolean,
+): UseRunJobsResult {
+  const [outcome, setOutcome] = useState<FetchOutcome<JobRecord[]> | null>(null)
+  const [pollTick, setPollTick] = useState(0)
+  const key = `run-jobs:${runId ?? ''}:${pollTick}`
+
+  // Polling ticker — fires every RUN_POLL_INTERVAL while run is non-terminal
+  useEffect(() => {
+    if (!runId || isRunTerminal) return
+    const timer = setInterval(() => setPollTick((n) => n + 1), RUN_POLL_INTERVAL)
+    return () => clearInterval(timer)
+  }, [runId, isRunTerminal])
+
+  // Fetch on runId change or poll tick
+  useEffect(() => {
+    if (!runId) return
+    let cancelled = false
+    apiFetch(`/api/v1/runs/${encodeURIComponent(runId)}/jobs`)
+      .then(async (response) => {
+        if (!response.ok)
+          throw new Error(`GET /api/v1/runs/${runId}/jobs — ${response.status}`)
+        const body: unknown = await response.json()
+        const parsed = parseJobList((body as Record<string, unknown> | null)?.data)
+        if (cancelled) return
+        setOutcome({ key, data: parsed, fetchedAtMs: Date.now() })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'request failed',
+          fetchedAtMs: Date.now(),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, runId, pollTick])
+
+  const current = outcome?.key === key ? outcome : null
+  return {
+    jobs: current?.data ?? [],
+    loading: runId !== null && current === null,
+    error: runId ? (current?.error ?? null) : null,
+  }
+}
+
+// ── useJobList ────────────────────────────────────────────────────────────────
+
+export interface UseJobListResult {
+  jobs: BatchJob[]
+  loading: boolean
+  error: string | null
+  retry: () => void
+}
+
+export function useJobList(): UseJobListResult {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome<BatchJob[]> | null>(null)
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+  const key = `jobs:${attempt}`
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/jobs')
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`GET /api/v1/jobs — ${response.status}`)
+        const body: unknown = await response.json()
+        const parsed = parseBatchJobList((body as Record<string, unknown> | null)?.data)
+        if (cancelled) return
+        setOutcome({ key, data: parsed, fetchedAtMs: Date.now() })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/jobs — request failed',
+          fetchedAtMs: Date.now(),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, attempt])
+
+  const current = outcome?.key === key ? outcome : null
+  return {
+    jobs: current?.data ?? [],
+    loading: current === null,
+    error: current?.error ?? null,
+    retry,
+  }
+}

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -56,13 +56,14 @@ function renderShell() {
 }
 
 describe('AppShell', () => {
-  it('renders sidebar navigation with Fleet, Modules, Config, Workflows, Audit, and Accounts as links', () => {
+  it('renders sidebar navigation with Fleet, Modules, Config, Workflows, Scripts, Audit, and Accounts as links', () => {
     renderShell()
     expect(screen.getByRole('navigation')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /fleet/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /modules/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /config/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /workflows/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /scripts/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /audit/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
   })
@@ -74,6 +75,7 @@ describe('AppShell', () => {
     expect(screen.getByRole('link', { name: /modules/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /config/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /workflows/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /scripts/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /audit/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
   })

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -31,6 +31,7 @@ const NAV_ITEMS = [
   { label: 'Modules', to: '/modules', soon: false },
   { label: 'Config', to: '/config', soon: false },
   { label: 'Workflows', to: '/workflows', soon: false },
+  { label: 'Scripts', to: '/scripts', soon: false },
   { label: 'Audit', to: '/audit', soon: false },
   { label: 'Accounts', to: '/accounts', soon: false },
 ] as const


### PR DESCRIPTION
## Summary

- Adds `/scripts` route listing the script library from `GET /api/v1/scripts`
- Implements confirm-before-run gate: operator resolves fleet target count before `POST /api/v1/runs/script` fires
- Polls `GET /api/v1/runs/{id}` and `GET /api/v1/runs/{id}/jobs` for live run/job status
- Run/job history view consumes `GET /api/v1/runs` and `GET /api/v1/jobs` list endpoints
- Scripts nav entry added to AppShell; `/scripts` route added to App.tsx

## Changed files

| File | Change |
|------|--------|
| `web/src/scripts/useScripts.ts` | Fetch/mutation hooks with polling (new) |
| `web/src/scripts/ScriptsView.tsx` | Route entry point: library table + RunPanel + RunsView (new) |
| `web/src/scripts/RunPanel.tsx` | Confirm-before-run gate, param inputs, status polling (new) |
| `web/src/scripts/RunsView.tsx` | Run/job history tables (new) |
| `web/src/scripts/useScripts.test.ts` | 40 tests inc. required polling test (new) |
| `web/src/scripts/RunPanel.test.tsx` | 14 tests inc. required confirm-gate test (new) |
| `web/src/scripts/ScriptsView.test.tsx` | 12 tests: loading/error/empty/table/row/history (new) |
| `web/src/scripts/RunsView.test.tsx` | 12 tests: both sections, loading/error/empty/data (new) |
| `web/src/App.tsx` | Adds `<Route path="scripts" element={<ScriptsView />} />` |
| `web/src/shell/AppShell.tsx` | Adds Scripts nav entry to NAV_ITEMS |
| `web/src/shell/AppShell.test.tsx` | Updates nav link assertions to include Scripts |

## Specialist review results

- **QA code reviewer:** PASS (fix round applied: added ScriptsView.test.tsx and RunsView.test.tsx after initial review flagged their absence)
- **Security engineer:** PASS — no blocking findings; security A9.1 confirmed (all untrusted data renders as JSX text nodes)

## Test plan

- [ ] `make test-agent-complete` — 842 frontend tests pass (all Go tests pass)
- [ ] `npm run test` in `web/` — 842/842 pass
- [ ] `npx eslint src/scripts/` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] Required tests present: `useScripts.test.ts > polls to a terminal state then stops [REQUIRED]` and `RunPanel.test.tsx > shows confirm dialog with resolved count when Run script is clicked [REQUIRED]`

Fixes #2988

🤖 Generated with [Claude Code](https://claude.com/claude-code)