### PR TITLE
web: registration token lifecycle tab (Issue #2935)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -190,6 +190,54 @@ search box doubles as its live filter).
   drawer opened by the hamburger button; a scrim covers the content and
   Escape or a scrim click closes it, matching the mockup harness.
 
+## Registration console (Stories #2934, #2935)
+
+[`src/registration/RegistrationConsolePage.tsx`](src/registration/RegistrationConsolePage.tsx)
+renders the steward enrollment console at `/registration`. The page opens on the
+**Pending** tab by default. The tab strip follows the same roving-tabindex +
+ArrowLeft/Right pattern as `StewardAssetPage.tsx`.
+
+Canonical design:
+[`docs/design/mockups/registration-console.html`](../docs/design/mockups/registration-console.html).
+
+No approve, approve-all, approve-by-CIDR, mint, rotate, revoke, or delete control
+is present — those are Section 2's follow-on epic.
+
+### Pending tab (Story #2934)
+
+[`src/registration/PendingQueueTab.tsx`](src/registration/PendingQueueTab.tsx)
+lists every pending registration in the caller's tenant scope and provides a
+functional **Deny** button per row.
+
+- **List endpoint:** `GET /api/v1/registration/pending` — bare-array response (no
+  `{data:...}` envelope). Shape-validated by `parsePendingRegistrations` before
+  any value reaches the DOM.
+- **Deny endpoint:** `POST /api/v1/registration/{id}/deny` — removes the row from
+  the list on success; surfaces a row-level error without crashing on failure.
+- All steward-supplied values (`pending_id`, `steward_id`, `source_ip`,
+  `registered_at`) render as JSX text nodes only (security A9.1).
+
+### Tokens tab (Story #2935)
+
+[`src/registration/TokensTab.tsx`](src/registration/TokensTab.tsx)
+is a read-only view of registration tokens for the caller's tenant scope.
+`token_prefix` (never the full secret) is the only token identifier rendered.
+The list endpoint contract (`handlers_registration_tokens.go`) omits the `token`
+field from list responses; `parseToken` enforces this client-side by not reading
+that field.
+
+- **List endpoint:** `GET /api/v1/registration/tokens` — `{tokens:[...], total:N}`
+  shape (no `{data:...}` envelope). Shape-validated by `parseTokenList`.
+- **Fields rendered:** `token_prefix`, `tenant_id`, `group`, `created_at`,
+  `expires_at`, computed status (Active / Expired / Revoked).
+- `expires_at` / `revoked_at` are optional (`omitempty` in Go) — renders `—`
+  when absent, matching the `columns.ts` em-dash convention.
+- No mint, rotate, revoke, or delete affordance of any kind.
+
+### IP Trust tab (Story #2936)
+
+Renders a "soon" placeholder — the IP-trust list tab is added by Story #2936.
+
 ## Fleet overview (Story #2497)
 
 [`src/fleet/FleetOverview.tsx`](src/fleet/FleetOverview.tsx) renders the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@
  *   /modules         → AppShell layout → ModuleReviewQueue
  *   /workflows       → AppShell layout → WorkflowListView
  *   /accounts        → AppShell layout → AccountsView
+ *   /registration    → AppShell layout → RegistrationConsolePage
  *
  * Session presence is inferred from API responses, never from reading
  * cookies (#2495). The fleet view's own data call (GET /api/v1/stewards,
@@ -31,6 +32,7 @@ import WorkflowListView from './workflow/WorkflowListView.tsx'
 import AccountsView from './accounts/AccountsView.tsx'
 import ModuleReviewQueue from './modules/ModuleReviewQueue.tsx'
 import ScriptsView from './scripts/ScriptsView.tsx'
+import RegistrationConsolePage from './registration/RegistrationConsolePage.tsx'
 
 function App() {
   return (
@@ -46,6 +48,7 @@ function App() {
             <Route path="workflows" element={<WorkflowListView />} />
             <Route path="accounts" element={<AccountsView />} />
             <Route path="scripts" element={<ScriptsView />} />
+            <Route path="registration" element={<RegistrationConsolePage />} />
           </Route>
         </Routes>
       </RequireAuth>

--- a/web/src/registration/PendingQueueTab.test.tsx
+++ b/web/src/registration/PendingQueueTab.test.tsx
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * PendingQueueTab test suite (Story #2934): list rendering, data states, and
+ * deny-remove / deny-error flows.
+ *
+ * Required AC: deny removes the row on success; surfaces a row-level error
+ * state on a failed deny request without crashing.
+ *
+ * Security A9.1: steward-supplied values (pending_id, steward_id, source_ip,
+ * registered_at) must render as text content, not markup. Tests assert on
+ * textContent only — never on innerHTML.
+ *
+ * The GET /api/v1/registration/pending response is a bare JSON array (no
+ * {data:...} envelope) — confirmed against handlers_registration.go line 133.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import PendingQueueTab, { parsePendingEntry, parsePendingRegistrations } from './PendingQueueTab.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+// ── Factories ─────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    pending_id: 'pend-abc123',
+    steward_id: 'stwd-xyz789',
+    source_ip: '10.0.0.1',
+    registered_at: '2026-07-25T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function makePendingResponse(entries: object[], status = 200) {
+  return new Response(JSON.stringify(entries), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderTab() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <PendingQueueTab />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+describe('parsePendingEntry', () => {
+  it('returns null for non-objects', () => {
+    expect(parsePendingEntry(null)).toBeNull()
+    expect(parsePendingEntry('string')).toBeNull()
+    expect(parsePendingEntry(42)).toBeNull()
+  })
+
+  it('returns null when pending_id is missing or empty', () => {
+    expect(parsePendingEntry({})).toBeNull()
+    expect(parsePendingEntry({ pending_id: '' })).toBeNull()
+  })
+
+  it('parses a valid entry', () => {
+    const entry = parsePendingEntry(makeEntry())
+    expect(entry).toEqual({
+      pending_id: 'pend-abc123',
+      steward_id: 'stwd-xyz789',
+      source_ip: '10.0.0.1',
+      registered_at: '2026-07-25T10:00:00Z',
+    })
+  })
+
+  it('coerces non-string fields to empty string', () => {
+    const entry = parsePendingEntry({
+      pending_id: 'pend-1',
+      steward_id: 99,
+      source_ip: null,
+      registered_at: undefined,
+    })
+    expect(entry).toEqual({
+      pending_id: 'pend-1',
+      steward_id: '',
+      source_ip: '',
+      registered_at: '',
+    })
+  })
+})
+
+describe('parsePendingRegistrations', () => {
+  it('throws on non-array input', () => {
+    expect(() => parsePendingRegistrations(null)).toThrow('unexpected response shape')
+    expect(() => parsePendingRegistrations({ pending: [] })).toThrow('unexpected response shape')
+  })
+
+  it('parses a list of entries', () => {
+    const list = parsePendingRegistrations([makeEntry()])
+    expect(list).toHaveLength(1)
+    expect(list[0]?.pending_id).toBe('pend-abc123')
+  })
+
+  it('drops entries without a pending_id', () => {
+    const list = parsePendingRegistrations([{}, makeEntry()])
+    expect(list).toHaveLength(1)
+  })
+})
+
+// ── List rendering ────────────────────────────────────────────────────────────
+
+describe('PendingQueueTab — list rendering', () => {
+  it('shows loading rows while the fetch is in-flight', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderTab()
+    expect(screen.getByTestId('pending-loading')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when no registrations are pending', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-empty')).toBeInTheDocument())
+  })
+
+  it('renders a table row per pending entry', async () => {
+    fetchMock.mockResolvedValue(
+      makePendingResponse([
+        makeEntry(),
+        makeEntry({ pending_id: 'pend-def456', steward_id: 'stwd-uvw321', source_ip: '10.0.0.2' }),
+      ]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+    expect(screen.getAllByTestId('pending-row')).toHaveLength(2)
+  })
+
+  it('renders pending_id, steward_id, source_ip, and registered_at as text nodes', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+    expect(screen.getByText('pend-abc123')).toBeInTheDocument()
+    expect(screen.getByText('stwd-xyz789')).toBeInTheDocument()
+    expect(screen.getByText('10.0.0.1')).toBeInTheDocument()
+    expect(screen.getByText('2026-07-25T10:00:00Z')).toBeInTheDocument()
+  })
+
+  it('shows a Deny button for each row', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+    expect(screen.getByTestId('deny-btn-pend-abc123')).toBeInTheDocument()
+  })
+
+  it('renders no approve control of any kind', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /approve/i })).toBeNull()
+  })
+
+  it('shows an error notice on a non-200 list response', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([], 500))
+    renderTab()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('500')
+  })
+
+  it('shows an error notice on a network-level failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    renderTab()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+
+  it('retries the fetch when the Retry button is clicked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([], 500))
+      .mockResolvedValueOnce(makePendingResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    await waitFor(() => expect(screen.getByTestId('pending-empty')).toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── Deny flow ─────────────────────────────────────────────────────────────────
+
+describe('PendingQueueTab — deny', () => {
+  it('deny removes the row from the list on success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('deny-btn-pend-abc123'))
+
+    await waitFor(() => expect(screen.getByTestId('pending-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('pending-row')).toBeNull()
+    const denyCall = fetchMock.mock.calls[1]!
+    expect(String(denyCall[0])).toContain('/deny')
+    expect((denyCall[1] as RequestInit | undefined)?.method).toBe('POST')
+  })
+
+  it('surfaces a row-level error on a failed deny without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('deny-btn-pend-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('deny-error-pend-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('deny-error-pend-abc123')).toHaveTextContent('403')
+    // Row is still present — the component did not crash
+    expect(screen.getByTestId('pending-table')).toBeInTheDocument()
+    expect(screen.getAllByTestId('pending-row')).toHaveLength(1)
+  })
+
+  it('surfaces a row-level error on a network failure during deny without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockRejectedValueOnce(new Error('connection refused'))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('deny-btn-pend-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('deny-error-pend-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('deny-error-pend-abc123')).toHaveTextContent('connection refused')
+    expect(screen.getAllByTestId('pending-row')).toHaveLength(1)
+  })
+
+  it('clears a previous deny error when deny is retried', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('deny-btn-pend-abc123'))
+    await waitFor(() =>
+      expect(screen.getByTestId('deny-error-pend-abc123')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('deny-btn-pend-abc123'))
+    await waitFor(() => expect(screen.getByTestId('pending-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('deny-error-pend-abc123')).toBeNull()
+  })
+
+  it('keeps other rows intact when one deny succeeds', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makePendingResponse([
+          makeEntry(),
+          makeEntry({ pending_id: 'pend-def456', steward_id: 'stwd-uvw321' }),
+        ]),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderTab()
+    await waitFor(() => expect(screen.getAllByTestId('pending-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByTestId('deny-btn-pend-abc123'))
+
+    await waitFor(() => expect(screen.getAllByTestId('pending-row')).toHaveLength(1))
+    expect(screen.getByText('pend-def456')).toBeInTheDocument()
+    expect(screen.queryByText('pend-abc123')).toBeNull()
+  })
+})

--- a/web/src/registration/PendingQueueTab.tsx
+++ b/web/src/registration/PendingQueueTab.tsx
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Pending registration queue (Story #2934).
+ * Fetches GET /api/v1/registration/pending — bare-array response (no
+ * {data:...} envelope, json.NewEncoder raw array). Shape-validated by
+ * parsePendingRegistrations before any value reaches the DOM.
+ *
+ * Deny calls POST /api/v1/registration/{id}/deny and removes the row on
+ * success; surfaces a row-level error without crashing on failure.
+ *
+ * Security A9.1: all steward-supplied and operator-influenced values render
+ * as JSX text nodes only, never via dangerouslySetInnerHTML.
+ */
+import { Fragment, useCallback, useEffect, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+import ErrorCard from '../shell/ErrorCard.tsx'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface PendingEntry {
+  pending_id: string
+  steward_id: string
+  source_ip: string
+  registered_at: string
+}
+
+interface FetchOutcome {
+  key: string
+  entries?: PendingEntry[]
+  error?: string
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+export function parsePendingEntry(value: unknown): PendingEntry | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const pending_id = str(r.pending_id)
+  if (!pending_id) return null
+  return {
+    pending_id,
+    steward_id: str(r.steward_id),
+    source_ip: str(r.source_ip),
+    registered_at: str(r.registered_at),
+  }
+}
+
+export function parsePendingRegistrations(data: unknown): PendingEntry[] {
+  if (!Array.isArray(data)) throw new Error('unexpected response shape')
+  const list: PendingEntry[] = []
+  for (const item of data) {
+    const entry = parsePendingEntry(item)
+    if (entry !== null) list.push(entry)
+  }
+  return list
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function LoadingRows() {
+  return (
+    <div data-testid="pending-loading" aria-label="Loading pending registrations">
+      {Array.from({ length: 3 }, (_, i) => (
+        <div className="skrow" key={i}>
+          <span className="skel" style={{ width: '20%' }} />
+          <span className="skel" style={{ width: '25%' }} />
+          <span className="skel" style={{ width: '15%' }} />
+          <span className="skel" style={{ width: '20%' }} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="notice empty" data-testid="pending-empty">
+      <div className="ic">◍</div>
+      <h3>No pending registrations</h3>
+      <p>Stewards awaiting approval will appear here.</p>
+    </div>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function PendingQueueTab() {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+  const [denyErrors, setDenyErrors] = useState<Map<string, string>>(new Map())
+
+  const key = `pending:${attempt}`
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/registration/pending')
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`GET /api/v1/registration/pending — ${response.status}`)
+        }
+        const body: unknown = await response.json()
+        const entries = parsePendingRegistrations(body)
+        if (cancelled) return
+        setOutcome({ key, entries })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/registration/pending — request failed',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, attempt])
+
+  async function handleDeny(pendingId: string) {
+    setDenyErrors((prev) => {
+      const next = new Map(prev)
+      next.delete(pendingId)
+      return next
+    })
+    try {
+      const response = await apiFetch(
+        `/api/v1/registration/${encodeURIComponent(pendingId)}/deny`,
+        { method: 'POST' },
+      )
+      if (!response.ok) {
+        setDenyErrors((prev) => new Map(prev).set(pendingId, `Deny failed — ${response.status}`))
+        return
+      }
+      setOutcome((prev) => {
+        if (!prev?.entries) return prev
+        return { ...prev, entries: prev.entries.filter((e) => e.pending_id !== pendingId) }
+      })
+    } catch (cause: unknown) {
+      setDenyErrors((prev) =>
+        new Map(prev).set(
+          pendingId,
+          cause instanceof Error && cause.message ? cause.message : 'Deny request failed',
+        ),
+      )
+    }
+  }
+
+  const current = outcome?.key === key ? outcome : null
+  const loading = current === null
+  const error = current?.error ?? null
+  const entries = current?.entries ?? null
+
+  return (
+    <section className="panel">
+      {loading ? (
+        <LoadingRows />
+      ) : error !== null ? (
+        <ErrorCard
+          heading="Couldn't load pending registrations"
+          detail={error}
+          onRetry={retry}
+        />
+      ) : entries === null || entries.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <>
+          <div className="ptool">
+            <span className="cnt" data-testid="pending-count">
+              {entries.length} pending
+            </span>
+          </div>
+          <table className="tbl" data-testid="pending-table">
+            <thead>
+              <tr>
+                <th>Pending ID</th>
+                <th>Steward ID</th>
+                <th>Source IP</th>
+                <th>Registered</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <Fragment key={entry.pending_id}>
+                  <tr data-testid="pending-row">
+                    <td>
+                      <span className="mono2">{entry.pending_id}</span>
+                    </td>
+                    <td>
+                      <span className="mono2">{entry.steward_id}</span>
+                    </td>
+                    <td>
+                      <span className="mono2">{entry.source_ip}</span>
+                    </td>
+                    <td>
+                      <span className="mono2">{entry.registered_at}</span>
+                    </td>
+                    <td>
+                      <button
+                        type="button"
+                        className="wf-btn-sm-danger"
+                        data-testid={`deny-btn-${entry.pending_id}`}
+                        onClick={() => void handleDeny(entry.pending_id)}
+                      >
+                        Deny
+                      </button>
+                    </td>
+                  </tr>
+                  {denyErrors.has(entry.pending_id) && (
+                    <tr>
+                      <td colSpan={5}>
+                        <span
+                          className="wf-form-error"
+                          data-testid={`deny-error-${entry.pending_id}`}
+                          role="alert"
+                        >
+                          {denyErrors.get(entry.pending_id)}
+                        </span>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </section>
+  )
+}

--- a/web/src/registration/RegistrationConsolePage.test.tsx
+++ b/web/src/registration/RegistrationConsolePage.test.tsx
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * RegistrationConsolePage suite (Stories #2934, #2935): tab strip composition,
+ * default tab, roving tabindex, ArrowLeft/ArrowRight keyboard navigation with
+ * wraparound, focus side-effects, and the real-vs-soon panel switch.
+ *
+ * Fetch is stubbed at the global level so PendingQueueTab and TokensTab render
+ * against real apiFetch, not stand-ins. Default mock never settles, keeping
+ * tabs in their loading state during structural assertions.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, createEvent, fireEvent, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import RegistrationConsolePage, { TABS } from './RegistrationConsolePage.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  // Default: fetches never settle — tab-strip assertions are not racing async updates.
+  fetchMock.mockReturnValue(new Promise(() => {}))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <RegistrationConsolePage />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+function tab(name: RegExp) {
+  return screen.getByRole('tab', { name })
+}
+
+// ── Tab strip composition ─────────────────────────────────────────────────────
+
+describe('RegistrationConsolePage — tab strip', () => {
+  it('renders a tablist with Pending, Tokens, and IP Trust', () => {
+    renderPage()
+
+    expect(screen.getByRole('tablist', { name: /registration sections/i })).toBeInTheDocument()
+    expect(tab(/^Pending/i)).toBeInTheDocument()
+    expect(tab(/^Tokens/i)).toBeInTheDocument()
+    expect(tab(/^IP Trust/i)).toBeInTheDocument()
+    expect(screen.getAllByRole('tab')).toHaveLength(TABS.length)
+  })
+
+  it('opens on Pending by default', () => {
+    renderPage()
+
+    expect(tab(/^Pending/i)).toHaveAttribute('aria-selected', 'true')
+    expect(tab(/^Tokens/i)).toHaveAttribute('aria-selected', 'false')
+    expect(tab(/^IP Trust/i)).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('gives the active tab a roving tabindex of 0 and the rest -1', () => {
+    renderPage()
+
+    expect(tab(/^Pending/i)).toHaveAttribute('tabindex', '0')
+    expect(tab(/^Tokens/i)).toHaveAttribute('tabindex', '-1')
+    expect(tab(/^IP Trust/i)).toHaveAttribute('tabindex', '-1')
+
+    fireEvent.click(tab(/^Tokens/i))
+
+    expect(tab(/^Pending/i)).toHaveAttribute('tabindex', '-1')
+    expect(tab(/^Tokens/i)).toHaveAttribute('tabindex', '0')
+  })
+
+  it('badges only the not-yet-available tabs with "soon"', () => {
+    renderPage()
+
+    for (const spec of TABS.filter((t) => t.soon)) {
+      const tabEl = screen.getByRole('tab', { name: (n) => n.startsWith(spec.label) })
+      expect(within(tabEl).getByText(/^soon$/i)).toBeInTheDocument()
+    }
+    expect(within(tab(/^Pending/i)).queryByText(/^soon$/i)).toBeNull()
+    expect(within(tab(/^Tokens/i)).queryByText(/^soon$/i)).toBeNull()
+  })
+
+  it('associates the panel with the active tab via aria-labelledby', () => {
+    renderPage()
+
+    const panel = screen.getByRole('tabpanel')
+    expect(panel).toHaveAttribute('aria-labelledby', 'reg-tab-pending')
+    expect(tab(/^Pending/i)).toHaveAttribute('id', 'reg-tab-pending')
+
+    fireEvent.click(tab(/^IP Trust/i))
+
+    const nextPanel = screen.getByRole('tabpanel')
+    expect(nextPanel).toHaveAttribute('aria-labelledby', 'reg-tab-ip-trust')
+    expect(nextPanel).toHaveAttribute('id', 'reg-panel-ip-trust')
+  })
+})
+
+// ── Panel switching ───────────────────────────────────────────────────────────
+
+describe('RegistrationConsolePage — panel rendering', () => {
+  it('mounts the real PendingQueueTab on the Pending tab, not a soon placeholder', () => {
+    renderPage()
+
+    expect(screen.getByTestId('pending-loading')).toBeInTheDocument()
+    expect(screen.queryByText(/Pending is not yet available/i)).toBeNull()
+  })
+
+  it('mounts the real TokensTab on the Tokens tab, not a soon placeholder', () => {
+    renderPage()
+
+    fireEvent.click(tab(/^Tokens/i))
+
+    expect(tab(/^Tokens/i)).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('tokens-loading')).toBeInTheDocument()
+    expect(screen.queryByText(/Tokens is not yet available/i)).toBeNull()
+    expect(screen.queryByTestId('pending-loading')).toBeNull()
+  })
+
+  it('renders the soon placeholder for IP Trust', () => {
+    renderPage()
+
+    fireEvent.click(tab(/^IP Trust/i))
+
+    expect(screen.getByText(/IP Trust is not yet available/i)).toBeInTheDocument()
+  })
+
+  it('restores the Pending panel after visiting the Tokens tab', () => {
+    renderPage()
+
+    fireEvent.click(tab(/^Tokens/i))
+    fireEvent.click(tab(/^Pending/i))
+
+    expect(tab(/^Pending/i)).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('pending-loading')).toBeInTheDocument()
+    expect(screen.queryByTestId('tokens-loading')).toBeNull()
+  })
+
+  it('exposes no approve control on the console shell', () => {
+    renderPage()
+
+    expect(screen.queryByRole('button', { name: /approve/i })).toBeNull()
+  })
+})
+
+// ── Keyboard navigation ───────────────────────────────────────────────────────
+
+describe('RegistrationConsolePage — keyboard navigation', () => {
+  it('ArrowRight advances through the tabs in order', () => {
+    renderPage()
+    const tablist = screen.getByRole('tablist')
+
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(tab(/^Tokens/i)).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(tab(/^IP Trust/i)).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('ArrowRight wraps from the last tab back to Pending', () => {
+    renderPage()
+    const tablist = screen.getByRole('tablist')
+
+    fireEvent.click(tab(/^IP Trust/i))
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+
+    expect(tab(/^Pending/i)).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('pending-loading')).toBeInTheDocument()
+  })
+
+  it('ArrowLeft wraps from Pending to IP Trust', () => {
+    renderPage()
+    const tablist = screen.getByRole('tablist')
+
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+
+    expect(tab(/^IP Trust/i)).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText(/IP Trust is not yet available/i)).toBeInTheDocument()
+  })
+
+  it('ArrowLeft steps backwards one tab at a time', () => {
+    renderPage()
+    const tablist = screen.getByRole('tablist')
+
+    fireEvent.click(tab(/^IP Trust/i))
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+
+    expect(tab(/^Tokens/i)).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('moves DOM focus to the newly activated tab', () => {
+    renderPage()
+    const tablist = screen.getByRole('tablist')
+
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(tab(/^Tokens/i))
+
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+    expect(document.activeElement).toBe(tab(/^Pending/i))
+  })
+
+  it('focuses the clicked tab', () => {
+    renderPage()
+
+    fireEvent.click(tab(/^IP Trust/i))
+
+    expect(document.activeElement).toBe(tab(/^IP Trust/i))
+  })
+
+  it('prevents default scrolling behaviour on the arrow keys it handles', () => {
+    renderPage()
+    const tablist = screen.getByRole('tablist')
+
+    const right = createEvent.keyDown(tablist, { key: 'ArrowRight' })
+    fireEvent(tablist, right)
+    expect(right.defaultPrevented).toBe(true)
+
+    const left = createEvent.keyDown(tablist, { key: 'ArrowLeft' })
+    fireEvent(tablist, left)
+    expect(left.defaultPrevented).toBe(true)
+  })
+
+  it('ignores keys it does not handle', () => {
+    renderPage()
+    const tablist = screen.getByRole('tablist')
+
+    const down = createEvent.keyDown(tablist, { key: 'ArrowDown' })
+    fireEvent(tablist, down)
+
+    expect(down.defaultPrevented).toBe(false)
+    expect(tab(/^Pending/i)).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.keyDown(tablist, { key: 'Enter' })
+    expect(tab(/^Pending/i)).toHaveAttribute('aria-selected', 'true')
+  })
+})
+
+// ── Tab specification ─────────────────────────────────────────────────────────
+
+describe('TABS', () => {
+  it('declares Pending and Tokens with real panels; IP Trust as soon', () => {
+    expect(TABS.map((t) => t.key)).toEqual(['pending', 'tokens', 'ip-trust'])
+    expect(TABS[0]?.soon).toBe(false)
+    expect(TABS[0]?.Panel).toBeDefined()
+    expect(TABS[1]?.soon).toBe(false)
+    expect(TABS[1]?.Panel).toBeDefined()
+    expect(TABS[2]?.soon).toBe(true)
+    expect(TABS[2]?.Panel).toBeUndefined()
+  })
+})

--- a/web/src/registration/RegistrationConsolePage.tsx
+++ b/web/src/registration/RegistrationConsolePage.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Registration console tab shell (Story #2934, #2935).
+ * Renders the /registration route with a tab strip:
+ *   Pending  — list + deny (Story #2934)
+ *   Tokens   — read-only token lifecycle view (Story #2935)
+ *   IP Trust — Story #2936 (soon placeholder)
+ *
+ * Tab pattern mirrors StewardAssetPage.tsx exactly: role="tablist", roving
+ * tabindex, ArrowLeft/Right keyboard navigation, implicit aria-labelledby
+ * association so inactive panels can be lazily rendered.
+ *
+ * No approve, approve-all, approve-by-CIDR, mint, rotate, revoke, or delete
+ * control is present — those are Section 2's follow-on epic.
+ */
+import { type ComponentType, useRef, useState } from 'react'
+import PendingQueueTab from './PendingQueueTab.tsx'
+import TokensTab from './TokensTab.tsx'
+
+type TabKey = 'pending' | 'tokens' | 'ip-trust'
+
+interface TabSpec {
+  key: TabKey
+  label: string
+  soon: boolean
+  Panel?: ComponentType
+}
+
+function SoonPanel({ label }: { label: string }) {
+  return (
+    <div className="notice">
+      <span className="tag">soon</span>
+      <p>{label} is not yet available.</p>
+    </div>
+  )
+}
+
+function PanelContent({ spec }: { spec: TabSpec }) {
+  const Panel = spec.Panel
+  return Panel ? <Panel /> : <SoonPanel label={spec.label} />
+}
+
+export const TABS: readonly TabSpec[] = [
+  { key: 'pending', label: 'Pending', soon: false, Panel: PendingQueueTab },
+  { key: 'tokens', label: 'Tokens', soon: false, Panel: TokensTab },
+  { key: 'ip-trust', label: 'IP Trust', soon: true },
+]
+
+export default function RegistrationConsolePage() {
+  const [activeTab, setActiveTab] = useState<TabKey>('pending')
+  const tabRefs = useRef<Map<TabKey, HTMLButtonElement>>(new Map())
+
+  const activeSpec = (TABS.find((t) => t.key === activeTab) ?? TABS[0])!
+
+  function activateTab(key: TabKey) {
+    setActiveTab(key)
+    tabRefs.current.get(key)?.focus()
+  }
+
+  function onKeyDown(event: React.KeyboardEvent) {
+    const keys = TABS.map((t) => t.key)
+    const current = keys.indexOf(activeTab)
+    if (event.key === 'ArrowRight') {
+      activateTab(keys[(current + 1) % keys.length]!)
+      event.preventDefault()
+    } else if (event.key === 'ArrowLeft') {
+      activateTab(keys[(current - 1 + keys.length) % keys.length]!)
+      event.preventDefault()
+    }
+  }
+
+  return (
+    <div className="asset-page">
+      <div className="htitle">
+        <h1>Registration</h1>
+      </div>
+
+      <div role="tablist" aria-label="Registration sections" onKeyDown={onKeyDown}>
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            role="tab"
+            id={`reg-tab-${tab.key}`}
+            type="button"
+            tabIndex={activeTab === tab.key ? 0 : -1}
+            aria-selected={activeTab === tab.key}
+            ref={(el) => {
+              if (el) tabRefs.current.set(tab.key, el)
+              else tabRefs.current.delete(tab.key)
+            }}
+            className={[
+              'asset-tab',
+              activeTab === tab.key ? 'active' : '',
+              tab.soon ? 'soon' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            onClick={() => activateTab(tab.key)}
+          >
+            {tab.label}
+            {tab.soon && <span className="tag asset-tab-soon">soon</span>}
+          </button>
+        ))}
+      </div>
+
+      <div
+        id={`reg-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`reg-tab-${activeTab}`}
+      >
+        <PanelContent spec={activeSpec} />
+      </div>
+    </div>
+  )
+}

--- a/web/src/registration/TokensTab.test.tsx
+++ b/web/src/registration/TokensTab.test.tsx
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * TokensTab test suite (Story #2935): list rendering, data states, parse
+ * helpers, and the required token-prefix security assertion.
+ *
+ * Required AC: rendered token rows must never contain a full-length token
+ * string in the DOM — only the prefix. Tests assert on textContent only,
+ * never on innerHTML (security A9.1).
+ *
+ * The GET /api/v1/registration/tokens response is {tokens:[...], total:N}
+ * — no {data:...} envelope — per handlers_registration_tokens.go:160.
+ *
+ * expires_at / revoked_at are optional (Go omitempty on pointer types)
+ * — absent fields render as an em-dash placeholder, matching columns.ts.
+ *
+ * No mint, rotate, revoke, or delete affordance exists in this component.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import TokensTab, { parseToken, parseTokenList } from './TokensTab.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+// ── Factories ─────────────────────────────────────────────────────────────────
+
+function makeToken(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    token_prefix: 'reg_a1b2c3',
+    tenant_id: 'root/msp-a/prod',
+    group: 'prod bulk enroll',
+    created_at: '2026-07-10T00:00:00Z',
+    expires_at: '2026-08-10T00:00:00Z',
+    revoked: false,
+    ...overrides,
+  }
+}
+
+function makeTokensResponse(tokens: object[], status = 200) {
+  return new Response(JSON.stringify({ tokens, total: tokens.length }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderTab() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <TokensTab />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+describe('parseToken', () => {
+  it('returns null for non-objects', () => {
+    expect(parseToken(null)).toBeNull()
+    expect(parseToken('string')).toBeNull()
+    expect(parseToken(42)).toBeNull()
+  })
+
+  it('returns null when token_prefix is missing or empty', () => {
+    expect(parseToken({})).toBeNull()
+    expect(parseToken({ token_prefix: '' })).toBeNull()
+  })
+
+  it('parses a full entry', () => {
+    const token = parseToken(makeToken())
+    expect(token).toEqual({
+      token_prefix: 'reg_a1b2c3',
+      tenant_id: 'root/msp-a/prod',
+      group: 'prod bulk enroll',
+      created_at: '2026-07-10T00:00:00Z',
+      expires_at: '2026-08-10T00:00:00Z',
+      revoked: false,
+      revoked_at: null,
+    })
+  })
+
+  it('coerces non-string tenant_id and group to empty string', () => {
+    const token = parseToken({ token_prefix: 'reg_xyz', tenant_id: 99, group: null })
+    expect(token?.tenant_id).toBe('')
+    expect(token?.group).toBe('')
+  })
+
+  it('sets expires_at to null when absent', () => {
+    const token = parseToken({ token_prefix: 'reg_xyz', tenant_id: 'root' })
+    expect(token?.expires_at).toBeNull()
+  })
+
+  it('sets revoked_at to null when absent', () => {
+    const token = parseToken({ token_prefix: 'reg_xyz', tenant_id: 'root' })
+    expect(token?.revoked_at).toBeNull()
+  })
+
+  it('parses revoked as boolean false when absent', () => {
+    const token = parseToken({ token_prefix: 'reg_xyz', tenant_id: 'root' })
+    expect(token?.revoked).toBe(false)
+  })
+
+  it('parses revoked:true', () => {
+    const token = parseToken({ token_prefix: 'reg_xyz', tenant_id: 'root', revoked: true })
+    expect(token?.revoked).toBe(true)
+  })
+
+  it('does not expose a token field even if wire data contains one', () => {
+    const WIRE_FULL = 'reg_a1b2c3d4e5f6g7h8i9j0k1l2m3n4'
+    const parsed = parseToken({ token_prefix: 'reg_a1b2c3', token: WIRE_FULL, tenant_id: 'root' })
+    expect(parsed).not.toHaveProperty('token')
+  })
+})
+
+describe('parseTokenList', () => {
+  it('throws on non-object input', () => {
+    expect(() => parseTokenList(null)).toThrow('unexpected response shape')
+    expect(() => parseTokenList([])).toThrow('unexpected response shape')
+    expect(() => parseTokenList('string')).toThrow('unexpected response shape')
+  })
+
+  it('throws when tokens field is not an array', () => {
+    expect(() => parseTokenList({ tokens: null, total: 0 })).toThrow('unexpected response shape')
+    expect(() => parseTokenList({ total: 0 })).toThrow('unexpected response shape')
+  })
+
+  it('parses a list of tokens', () => {
+    const list = parseTokenList({ tokens: [makeToken()], total: 1 })
+    expect(list).toHaveLength(1)
+    expect(list[0]?.token_prefix).toBe('reg_a1b2c3')
+  })
+
+  it('drops tokens without a token_prefix', () => {
+    const list = parseTokenList({ tokens: [{}, makeToken()], total: 2 })
+    expect(list).toHaveLength(1)
+  })
+})
+
+// ── List rendering ────────────────────────────────────────────────────────────
+
+describe('TokensTab — list rendering', () => {
+  it('shows a loading skeleton while the fetch is in-flight', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderTab()
+    expect(screen.getByTestId('tokens-loading')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when no tokens exist', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-empty')).toBeInTheDocument())
+  })
+
+  it('renders one row per token', async () => {
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([
+        makeToken(),
+        makeToken({ token_prefix: 'reg_9f8e7d', group: 'client-1 onboarding' }),
+      ]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    expect(screen.getAllByTestId('token-row')).toHaveLength(2)
+  })
+
+  it('renders an error card on a non-200 response', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([], 500))
+    renderTab()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('500')
+  })
+
+  it('renders an error card on a network failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    renderTab()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+
+  it('retries the fetch when Retry is clicked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([], 500))
+      .mockResolvedValueOnce(makeTokensResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    screen.getByRole('button', { name: /retry/i }).click()
+    await waitFor(() => expect(screen.getByTestId('tokens-empty')).toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── Field rendering ───────────────────────────────────────────────────────────
+
+describe('TokensTab — field rendering', () => {
+  it('renders token_prefix, tenant_id, group, created_at as text content', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([makeToken()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    const row = screen.getAllByTestId('token-row')[0]!
+    expect(within(row).getByTestId('token-prefix')).toHaveTextContent('reg_a1b2c3')
+    expect(within(row).getByTestId('token-tenant')).toHaveTextContent('root/msp-a/prod')
+    expect(within(row).getByTestId('token-group')).toHaveTextContent('prod bulk enroll')
+    expect(within(row).getByTestId('token-created')).toHaveTextContent('2026-07-10T00:00:00Z')
+  })
+
+  it('renders expires_at when present', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([makeToken()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    const row = screen.getAllByTestId('token-row')[0]!
+    expect(within(row).getByTestId('token-expires')).toHaveTextContent('2026-08-10T00:00:00Z')
+  })
+
+  it('renders em-dash when expires_at is absent', async () => {
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([makeToken({ expires_at: undefined })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    const row = screen.getAllByTestId('token-row')[0]!
+    expect(within(row).getByTestId('token-expires')).toHaveTextContent('—')
+  })
+
+  it('renders em-dash for empty tenant_id', async () => {
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([makeToken({ tenant_id: '' })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    const row = screen.getAllByTestId('token-row')[0]!
+    expect(within(row).getByTestId('token-tenant')).toHaveTextContent('—')
+  })
+
+  it('renders em-dash for empty group', async () => {
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([makeToken({ group: '' })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    const row = screen.getAllByTestId('token-row')[0]!
+    expect(within(row).getByTestId('token-group')).toHaveTextContent('—')
+  })
+})
+
+// ── Status badges ─────────────────────────────────────────────────────────────
+
+describe('TokensTab — status badges', () => {
+  it('shows Active for a non-revoked token with a future expiry', async () => {
+    const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([makeToken({ revoked: false, expires_at: futureDate })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    expect(screen.getByTestId('token-status')).toHaveTextContent('Active')
+  })
+
+  it('shows Active for a non-revoked token with no expiry', async () => {
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([makeToken({ revoked: false, expires_at: undefined })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    expect(screen.getByTestId('token-status')).toHaveTextContent('Active')
+  })
+
+  it('shows Expired for a non-revoked token with a past expiry', async () => {
+    const pastDate = '2026-01-01T00:00:00Z'
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([makeToken({ revoked: false, expires_at: pastDate })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    expect(screen.getByTestId('token-status')).toHaveTextContent('Expired')
+  })
+
+  it('shows Revoked for a revoked token regardless of expiry', async () => {
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([makeToken({ revoked: true, expires_at: undefined })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    expect(screen.getByTestId('token-status')).toHaveTextContent('Revoked')
+  })
+})
+
+// ── Security: prefix-only guarantee (required AC) ─────────────────────────────
+
+describe('TokensTab — token prefix security (required AC)', () => {
+  it('renders only the token_prefix, never a full-length token string', async () => {
+    const PREFIX = 'reg_x9y8z7'
+    // Simulates wire data that includes the full `token` field (as create/rotate
+    // would return). The list endpoint contract omits it, but this test verifies
+    // the component does not render it even if the wire unexpectedly includes it.
+    const WIRE_FULL = 'reg_x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4j3i2h1g0f9e8d7c6b5a4'
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([
+        makeToken({ token_prefix: PREFIX, token: WIRE_FULL }),
+      ]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+
+    const rows = screen.getAllByTestId('token-row')
+    expect(rows).toHaveLength(1)
+
+    // The prefix appears in the token-prefix cell
+    expect(within(rows[0]!).getByTestId('token-prefix')).toHaveTextContent(PREFIX)
+
+    // The full wire value must not appear anywhere in the DOM
+    expect(document.body.textContent).not.toContain(WIRE_FULL)
+  })
+
+  it('renders multiple tokens each showing only their prefix, never the full string', async () => {
+    const FULL_A = 'reg_aaaaaa1111111111111111111111111111111111111111111111111111'
+    const FULL_B = 'reg_bbbbbb2222222222222222222222222222222222222222222222222222'
+    fetchMock.mockResolvedValue(
+      makeTokensResponse([
+        makeToken({ token_prefix: 'reg_aaaaaa', token: FULL_A }),
+        makeToken({ token_prefix: 'reg_bbbbbb', token: FULL_B }),
+      ]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getAllByTestId('token-row')).toHaveLength(2))
+
+    expect(document.body.textContent).not.toContain(FULL_A)
+    expect(document.body.textContent).not.toContain(FULL_B)
+    expect(screen.getAllByTestId('token-prefix')[0]).toHaveTextContent('reg_aaaaaa')
+    expect(screen.getAllByTestId('token-prefix')[1]).toHaveTextContent('reg_bbbbbb')
+  })
+})
+
+// ── No write affordances ──────────────────────────────────────────────────────
+
+describe('TokensTab — no write affordances', () => {
+  it('renders no mint, rotate, revoke, or delete button', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([makeToken()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /mint/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /rotate/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /revoke/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /delete/i })).toBeNull()
+  })
+
+  it('renders no write controls even in the loading state', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderTab()
+    expect(screen.queryByRole('button', { name: /mint/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /rotate/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /revoke/i })).toBeNull()
+  })
+
+  it('renders no write controls in the empty state', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-empty')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /mint/i })).toBeNull()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/web/src/registration/TokensTab.tsx
+++ b/web/src/registration/TokensTab.tsx
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Registration token list tab (Story #2935) — read-only view.
+ * Fetches GET /api/v1/registration/tokens — {tokens:[...], total:N} shape
+ * per handlers_registration_tokens.go (no {data:...} envelope).
+ * Shape-validated by parseTokenList before any value reaches the DOM.
+ *
+ * Renders: token_prefix, tenant_id, group, created_at, expires_at, revoked.
+ * expires_at / revoked_at are optional (Go omitempty on pointer types) —
+ * renders '—' when absent, matching the columns.ts em-dash convention.
+ *
+ * No mint, rotate, revoke, or delete affordance of any kind — those are
+ * Section 2's follow-on epic.
+ *
+ * Security A9.1: all wire values render as JSX text nodes only, never markup.
+ * The component reads only token_prefix from wire data, never the full secret
+ * (token field) — the list endpoint contract omits it and parseToken enforces
+ * this by not reading the token field at all.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+import ErrorCard from '../shell/ErrorCard.tsx'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface RegistrationToken {
+  token_prefix: string
+  tenant_id: string
+  group: string
+  created_at: string
+  expires_at: string | null
+  revoked: boolean
+  revoked_at: string | null
+}
+
+interface FetchOutcome {
+  key: string
+  tokens?: RegistrationToken[]
+  error?: string
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+function optStr(v: unknown): string | null {
+  return typeof v === 'string' ? v : null
+}
+
+function bool(v: unknown): boolean {
+  return typeof v === 'boolean' && v
+}
+
+export function parseToken(value: unknown): RegistrationToken | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const token_prefix = str(r.token_prefix)
+  if (!token_prefix) return null
+  return {
+    token_prefix,
+    tenant_id: str(r.tenant_id),
+    group: str(r.group),
+    created_at: str(r.created_at),
+    expires_at: optStr(r.expires_at),
+    revoked: bool(r.revoked),
+    revoked_at: optStr(r.revoked_at),
+  }
+}
+
+export function parseTokenList(data: unknown): RegistrationToken[] {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('unexpected response shape')
+  }
+  const r = data as Record<string, unknown>
+  if (!Array.isArray(r.tokens)) throw new Error('unexpected response shape')
+  const list: RegistrationToken[] = []
+  for (const item of r.tokens) {
+    const parsed = parseToken(item)
+    if (parsed !== null) list.push(parsed)
+  }
+  return list
+}
+
+// ── Status helpers ────────────────────────────────────────────────────────────
+
+type TokenStatus = 'active' | 'expired' | 'revoked'
+
+function tokenStatus(token: RegistrationToken): TokenStatus {
+  if (token.revoked) return 'revoked'
+  if (token.expires_at !== null && new Date(token.expires_at) < new Date()) return 'expired'
+  return 'active'
+}
+
+function statusClass(s: TokenStatus): string {
+  if (s === 'active') return 'pill ok'
+  if (s === 'expired') return 'pill neutral'
+  return 'pill crit'
+}
+
+function statusLabel(s: TokenStatus): string {
+  if (s === 'active') return 'Active'
+  if (s === 'expired') return 'Expired'
+  return 'Revoked'
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function LoadingRows() {
+  return (
+    <div data-testid="tokens-loading" aria-label="Loading registration tokens">
+      {Array.from({ length: 3 }, (_, i) => (
+        <div className="skrow" key={i}>
+          <span className="skel" style={{ width: '18%' }} />
+          <span className="skel" style={{ width: '22%' }} />
+          <span className="skel" style={{ width: '18%' }} />
+          <span className="skel" style={{ width: '15%' }} />
+          <span className="skel" style={{ width: '15%' }} />
+          <span className="skel" style={{ width: '10%' }} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="notice empty" data-testid="tokens-empty">
+      <div className="ic">◍</div>
+      <h3>No registration tokens</h3>
+      <p>Tokens minted for this tenant will appear here.</p>
+    </div>
+  )
+}
+
+function StatusBadge({ token }: { token: RegistrationToken }) {
+  const status = tokenStatus(token)
+  return (
+    <span className={statusClass(status)} data-testid="token-status">
+      <span className="dot" />
+      {statusLabel(status)}
+    </span>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function TokensTab() {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+
+  const key = `tokens:${attempt}`
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/registration/tokens')
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`GET /api/v1/registration/tokens — ${response.status}`)
+        }
+        const body: unknown = await response.json()
+        const tokens = parseTokenList(body)
+        if (cancelled) return
+        setOutcome({ key, tokens })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/registration/tokens — request failed',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, attempt])
+
+  const current = outcome?.key === key ? outcome : null
+
+  if (current === null) return <LoadingRows />
+
+  if (current.error !== undefined) {
+    return (
+      <ErrorCard
+        heading="Couldn't load tokens"
+        detail={current.error}
+        onRetry={retry}
+      />
+    )
+  }
+
+  const tokens = current.tokens ?? []
+  if (tokens.length === 0) return <EmptyState />
+
+  return (
+    <section className="panel">
+      <table className="tbl" data-testid="tokens-table">
+        <thead>
+          <tr>
+            <th>Token</th>
+            <th>Tenant</th>
+            <th>Group</th>
+            <th>Created</th>
+            <th>Expires</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tokens.map((token) => (
+            <tr key={token.token_prefix} data-testid="token-row">
+              <td className="mono2" data-testid="token-prefix">
+                {token.token_prefix}
+              </td>
+              <td data-testid="token-tenant">{token.tenant_id || '—'}</td>
+              <td data-testid="token-group">{token.group || '—'}</td>
+              <td className="mono2" data-testid="token-created">
+                {token.created_at || '—'}
+              </td>
+              <td className="mono2" data-testid="token-expires">
+                {token.expires_at ?? '—'}
+              </td>
+              <td data-testid="token-status-cell">
+                <StatusBadge token={token} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mono2" style={{ fontSize: 'var(--text-sm)', marginTop: '8px' }}>
+        Only the token prefix is ever shown — the full secret is displayed once at mint and never
+        again.
+      </p>
+    </section>
+  )
+}

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -56,7 +56,7 @@ function renderShell() {
 }
 
 describe('AppShell', () => {
-  it('renders sidebar navigation with Fleet, Modules, Config, Workflows, Scripts, Audit, and Accounts as links', () => {
+  it('renders sidebar navigation with Fleet, Modules, Config, Workflows, Scripts, Registration, Audit, and Accounts as links', () => {
     renderShell()
     expect(screen.getByRole('navigation')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /fleet/i })).toBeInTheDocument()
@@ -64,11 +64,12 @@ describe('AppShell', () => {
     expect(screen.getByRole('link', { name: /config/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /workflows/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /scripts/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /registration/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /audit/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
   })
 
-  it('all nav items are real links; no soon-tagged placeholders remain (Issue #2732)', () => {
+  it('all nav items are real links; no soon-tagged placeholders remain (Issue #2732, #2934, #2935)', () => {
     renderShell()
     expect(screen.queryAllByText(/soon/i)).toHaveLength(0)
     expect(screen.getByRole('link', { name: /fleet/i })).toBeInTheDocument()
@@ -76,6 +77,7 @@ describe('AppShell', () => {
     expect(screen.getByRole('link', { name: /config/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /workflows/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /scripts/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /registration/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /audit/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
   })

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -32,6 +32,7 @@ const NAV_ITEMS = [
   { label: 'Config', to: '/config', soon: false },
   { label: 'Workflows', to: '/workflows', soon: false },
   { label: 'Scripts', to: '/scripts', soon: false },
+  { label: 'Registration', to: '/registration', soon: false },
   { label: 'Audit', to: '/audit', soon: false },
   { label: 'Accounts', to: '/accounts', soon: false },
 ] as const


### PR DESCRIPTION
## Summary

- Adds a read-only **Tokens tab** to the Registration console listing every token for the caller's tenant scope — `token_prefix`, `tenant_id`, `group`, `created_at`, `expires_at`, status badge
- Includes the **RegistrationConsolePage tab-strip shell** from #2934 (PR #3049 not yet merged into develop) so both land together
- Adds **PendingQueueTab** (queue view + deny flow) from the same dependency

## Security properties

- `parseToken()` deliberately ignores the `token` wire field — the full secret cannot reach the DOM even if the API unexpectedly includes it
- All wire values are shape-validated before render (untrusted wire data pattern, mirrors `parseDNAInfo` idiom)
- All values render as JSX text nodes only — never as markup (security A9.1)
- No mint, rotate, revoke, or delete affordance anywhere in this UI

## Test plan

- [x] 920 frontend tests pass across 47 test files (`npx vitest run`)
- [x] ESLint 0 warnings (`npx eslint src/registration/ --max-warnings=0`)
- [x] TypeScript typecheck passes
- [x] Gitleaks staged scan: no leaks found
- [x] Go `make test` passes (all packages cached/green)
- [x] Security scan: gosec, Trivy, Nancy, staticcheck all passed
- [x] Required AC: `TokensTab — token prefix security` test asserts `document.body.textContent` never contains the full wire token string

## Dependency note

This PR supersedes Story #2934 (PR #3049). If #3049 merges into develop first, this PR should be rebased to drop the duplicated files.

Fixes #2935

🤖 Generated with [Claude Code](https://claude.com/claude-code)