### PR TITLE
tooling: float agent dispatch routing to sonnet/opus aliases (Issue #3030)

### DIFF
--- a/.claude/model-routing.yaml
+++ b/.claude/model-routing.yaml
@@ -20,10 +20,10 @@
 # Fixed two-level shape: do not add nesting beyond defaults:/segments: — the
 # resolver is a plain-stdlib parser, not a general YAML implementation.
 defaults:
-  model: claude-sonnet-4-6
+  model: sonnet
   effort: high
 segments:
-  dev-agent:          { model: claude-sonnet-4-6 }
-  fix-agent:          { model: claude-sonnet-4-6 }
-  pr-review:          { model: claude-sonnet-4-6 }
-  acceptance-review:  { model: claude-sonnet-4-6 }
+  dev-agent:          { model: sonnet }
+  fix-agent:          { model: sonnet }
+  pr-review:          { model: sonnet }
+  acceptance-review:  { model: sonnet }

--- a/.claude/scripts/tests/model_routing.test.sh
+++ b/.claude/scripts/tests/model_routing.test.sh
@@ -51,7 +51,7 @@ echo "----------------------"
 
 printf '\n== .claude/model-routing.yaml ==\n'
 routing_src="$(cat "$ROUTING_FILE")"
-check_contains "declares defaults model" "$routing_src" "model: claude-sonnet-4-6"
+check_contains "declares defaults model" "$routing_src" "model: sonnet"
 check_contains "declares defaults effort" "$routing_src" "effort: high"
 for seg in dev-agent fix-agent pr-review acceptance-review; do
   check_contains "declares segment ${seg}" "$routing_src" "${seg}:"


### PR DESCRIPTION
## Summary
- `model-routing.yaml` pinned every dispatch segment (dev-agent, fix-agent, pr-review, acceptance-review) to `claude-sonnet-4-6`, a version predating the current `-5` model family.
- Switched defaults + all four segments to the generic `sonnet` alias, which `claude --model` already resolves at invocation time (same mechanism used by `.claude/agents/*.md` frontmatter and the entrypoint healthcheck's `--model haiku`).
- No functional change to which tier each segment runs on — this only removes the version pin so routing doesn't go stale as new model versions ship.
- Updated `model_routing.test.sh`'s content assertion to match (it asserts the literal committed file content).
- `pricing.json` already has entries for `claude-sonnet-5`/`claude-opus-5` — no pricing change needed.

## Test plan
- [x] `bash .claude/scripts/tests/model_routing.test.sh` — 42/42 checks pass
- [x] Pre-push `make test` (smart mode) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)