### PR TITLE
modules: observe_when manifest field schema + parser (Issue #3101)

### DIFF
--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -140,6 +140,16 @@ observe_when:
     contains: hyperv
 ```
 
+Each list entry is an `ObservePredicate` struct (`features/modules/metadata.go`). Fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fact` | string | **Required.** Baseline DNA fact key to match (e.g. `"windows_feature"`, `"os"`) |
+| `equals` | string | Exact match on the fact value. Mutually exclusive with `contains`. |
+| `contains` | string | Substring match on the fact value. Mutually exclusive with `equals`. |
+
+Exactly one of `equals` or `contains` must be set per predicate; neither or both is a parse error caught at module load time.
+
 **Semantics (full contract in [ADR-024](../decisions/024-module-observation-vs-convergence.md)):**
 
 - **Observation ≠ convergence.** A module reports everything it can observe across its whole `<module>.*` domain (best-effort, silently continuing on absence); it *converges* only the resource instances declared in config. `observe_when` governs observation; declarations govern convergence.

--- a/features/modules/metadata.go
+++ b/features/modules/metadata.go
@@ -12,6 +12,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ObservePredicate is a single dumb fact-match predicate inside observe_when.
+// Exactly one of Equals or Contains must be set; both or neither is a parse error.
+// Multiple predicates in observe_when are OR'd: any one matching activates the module
+// for read-only DNA observation (ADR-024 Decision §2).
+type ObservePredicate struct {
+	// Fact is the baseline DNA fact key to match against (e.g. "windows_feature", "os").
+	Fact string `yaml:"fact" json:"fact"`
+	// Equals requires an exact string match of the fact value. Mutually exclusive with Contains.
+	Equals string `yaml:"equals,omitempty" json:"equals,omitempty"`
+	// Contains requires the fact value to contain this substring. Mutually exclusive with Equals.
+	Contains string `yaml:"contains,omitempty" json:"contains,omitempty"`
+}
+
 // OwnershipDeclaration records a single object-identity namespace that a module
 // authoritatively owns, per ADR-016 clause 5. When a module declares ownership
 // of a kind, it owns every object of that kind it manages — the entire DNA
@@ -73,6 +86,14 @@ type ModuleMetadata struct {
 	// this module declares no ownership — backward-compatible with all existing
 	// module.yaml files that predate this field.
 	Owns []OwnershipDeclaration `yaml:"owns,omitempty" json:"owns,omitempty"`
+
+	// ObserveWhen is a list of dumb fact-match predicates that activate this module
+	// for read-only DNA observation (ADR-024 Decision §2). Each predicate specifies
+	// a baseline DNA fact key and an equals/contains match value; predicates are OR'd
+	// so any one matching activates observation. Optional; nil means this module is
+	// never auto-pulled for DNA — backward-compatible with all existing module.yaml
+	// files that predate this field.
+	ObserveWhen []ObservePredicate `yaml:"observe_when,omitempty" json:"observe_when,omitempty"`
 }
 
 // BehavioralEnvelope documents the runtime behavior of a module for security auditing
@@ -172,6 +193,11 @@ func ParseModuleMetadata(reader io.Reader) (*ModuleMetadata, error) {
 		}
 	}
 
+	// Validate observe_when predicates
+	if err := validateObserveWhen(metadata.ObserveWhen); err != nil {
+		return nil, err
+	}
+
 	return &metadata, nil
 }
 
@@ -269,6 +295,28 @@ func (m *ModuleMetadata) Validate() error {
 		}
 	}
 
+	// Validate observe_when predicates
+	if err := validateObserveWhen(m.ObserveWhen); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateObserveWhen rejects malformed ObservePredicate entries: missing fact,
+// both equals+contains set, or neither set.
+func validateObserveWhen(predicates []ObservePredicate) error {
+	for i, p := range predicates {
+		if p.Fact == "" {
+			return fmt.Errorf("observe_when[%d]: fact is required", i)
+		}
+		if p.Equals != "" && p.Contains != "" {
+			return fmt.Errorf("observe_when[%d] (fact=%q): equals and contains are mutually exclusive; set exactly one", i, p.Fact)
+		}
+		if p.Equals == "" && p.Contains == "" {
+			return fmt.Errorf("observe_when[%d] (fact=%q): one of equals or contains is required", i, p.Fact)
+		}
+	}
 	return nil
 }
 
@@ -443,6 +491,12 @@ func (m *ModuleMetadata) Clone() *ModuleMetadata {
 				copy(clone.Owns[i].RequiredFields, o.RequiredFields)
 			}
 		}
+	}
+
+	// Deep copy observe_when predicates (each entry has only string fields — copy is safe)
+	if m.ObserveWhen != nil {
+		clone.ObserveWhen = make([]ObservePredicate, len(m.ObserveWhen))
+		copy(clone.ObserveWhen, m.ObserveWhen)
 	}
 
 	return clone

--- a/features/modules/metadata_test.go
+++ b/features/modules/metadata_test.go
@@ -1076,6 +1076,214 @@ owns:
 	}
 }
 
+// TestParseModuleMetadata_ObserveWhen verifies observe_when parse success, parse
+// rejection for each malformed predicate shape, and backward-compatibility for
+// module.yaml files that carry no observe_when key.
+func TestParseModuleMetadata_ObserveWhen(t *testing.T) {
+	baseYAML := func(extra string) string {
+		return `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+` + extra
+	}
+
+	t.Run("no observe_when — backward compatible, nil slice", func(t *testing.T) {
+		reader := strings.NewReader(baseYAML(""))
+		metadata, err := ParseModuleMetadata(reader)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+		if metadata.ObserveWhen != nil {
+			t.Errorf("ObserveWhen = %v, want nil for module.yaml with no observe_when key", metadata.ObserveWhen)
+		}
+	})
+
+	t.Run("valid single predicate with contains", func(t *testing.T) {
+		yaml := baseYAML(`observe_when:
+  - fact: windows_feature
+    contains: hyperv
+`)
+		reader := strings.NewReader(yaml)
+		metadata, err := ParseModuleMetadata(reader)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+		if len(metadata.ObserveWhen) != 1 {
+			t.Fatalf("ObserveWhen length = %d, want 1", len(metadata.ObserveWhen))
+		}
+		p := metadata.ObserveWhen[0]
+		if p.Fact != "windows_feature" {
+			t.Errorf("ObserveWhen[0].Fact = %q, want %q", p.Fact, "windows_feature")
+		}
+		if p.Contains != "hyperv" {
+			t.Errorf("ObserveWhen[0].Contains = %q, want %q", p.Contains, "hyperv")
+		}
+		if p.Equals != "" {
+			t.Errorf("ObserveWhen[0].Equals = %q, want empty", p.Equals)
+		}
+	})
+
+	t.Run("valid single predicate with equals", func(t *testing.T) {
+		yaml := baseYAML(`observe_when:
+  - fact: os
+    equals: windows
+`)
+		reader := strings.NewReader(yaml)
+		metadata, err := ParseModuleMetadata(reader)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+		if len(metadata.ObserveWhen) != 1 {
+			t.Fatalf("ObserveWhen length = %d, want 1", len(metadata.ObserveWhen))
+		}
+		p := metadata.ObserveWhen[0]
+		if p.Fact != "os" {
+			t.Errorf("ObserveWhen[0].Fact = %q, want %q", p.Fact, "os")
+		}
+		if p.Equals != "windows" {
+			t.Errorf("ObserveWhen[0].Equals = %q, want %q", p.Equals, "windows")
+		}
+		if p.Contains != "" {
+			t.Errorf("ObserveWhen[0].Contains = %q, want empty", p.Contains)
+		}
+	})
+
+	t.Run("valid multiple predicates OR'd", func(t *testing.T) {
+		yaml := baseYAML(`observe_when:
+  - fact: os
+    equals: windows
+  - fact: windows_feature
+    contains: hyperv
+`)
+		reader := strings.NewReader(yaml)
+		metadata, err := ParseModuleMetadata(reader)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+		if len(metadata.ObserveWhen) != 2 {
+			t.Fatalf("ObserveWhen length = %d, want 2", len(metadata.ObserveWhen))
+		}
+	})
+
+	t.Run("error: empty fact", func(t *testing.T) {
+		yaml := baseYAML(`observe_when:
+  - fact: ""
+    equals: windows
+`)
+		reader := strings.NewReader(yaml)
+		_, err := ParseModuleMetadata(reader)
+		if err == nil {
+			t.Error("expected error for predicate with empty fact, got nil")
+		}
+	})
+
+	t.Run("error: both equals and contains set", func(t *testing.T) {
+		yaml := baseYAML(`observe_when:
+  - fact: os
+    equals: windows
+    contains: win
+`)
+		reader := strings.NewReader(yaml)
+		_, err := ParseModuleMetadata(reader)
+		if err == nil {
+			t.Error("expected error for predicate with both equals and contains set, got nil")
+		}
+	})
+
+	t.Run("error: neither equals nor contains set", func(t *testing.T) {
+		yaml := baseYAML(`observe_when:
+  - fact: os
+`)
+		reader := strings.NewReader(yaml)
+		_, err := ParseModuleMetadata(reader)
+		if err == nil {
+			t.Error("expected error for predicate with neither equals nor contains set, got nil")
+		}
+	})
+
+	t.Run("error: second predicate malformed — empty fact", func(t *testing.T) {
+		yaml := baseYAML(`observe_when:
+  - fact: os
+    equals: windows
+  - fact: ""
+    contains: hyperv
+`)
+		reader := strings.NewReader(yaml)
+		_, err := ParseModuleMetadata(reader)
+		if err == nil {
+			t.Error("expected error for second predicate with empty fact, got nil")
+		}
+	})
+}
+
+// TestParseModuleMetadata_ObserveWhenRoundTrip verifies that observe_when survives
+// a YAML round-trip through ToYAML + Unmarshal.
+func TestParseModuleMetadata_ObserveWhenRoundTrip(t *testing.T) {
+	input := `name: test-module
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+observe_when:
+  - fact: windows_feature
+    contains: hyperv
+`
+	reader := strings.NewReader(input)
+	metadata, err := ParseModuleMetadata(reader)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	yamlBytes, err := metadata.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error: %v", err)
+	}
+
+	var reparsed ModuleMetadata
+	if err := yaml.Unmarshal(yamlBytes, &reparsed); err != nil {
+		t.Fatalf("failed to unmarshal round-tripped YAML: %v", err)
+	}
+
+	if len(reparsed.ObserveWhen) != 1 {
+		t.Fatalf("ObserveWhen after round-trip length = %d, want 1", len(reparsed.ObserveWhen))
+	}
+	if reparsed.ObserveWhen[0].Fact != "windows_feature" {
+		t.Errorf("ObserveWhen[0].Fact after round-trip = %q, want %q", reparsed.ObserveWhen[0].Fact, "windows_feature")
+	}
+	if reparsed.ObserveWhen[0].Contains != "hyperv" {
+		t.Errorf("ObserveWhen[0].Contains after round-trip = %q, want %q", reparsed.ObserveWhen[0].Contains, "hyperv")
+	}
+}
+
+// TestModuleMetadata_Clone_ObserveWhen verifies that Clone deep-copies ObserveWhen
+// so mutations to the clone do not affect the original.
+func TestModuleMetadata_Clone_ObserveWhen(t *testing.T) {
+	original := &ModuleMetadata{
+		Name:      "test",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
+		Kind:      "steward",
+		ObserveWhen: []ObservePredicate{
+			{Fact: "os", Equals: "windows"},
+			{Fact: "windows_feature", Contains: "hyperv"},
+		},
+	}
+
+	clone := original.Clone()
+
+	if len(clone.ObserveWhen) != len(original.ObserveWhen) {
+		t.Fatalf("Clone ObserveWhen length = %d, want %d", len(clone.ObserveWhen), len(original.ObserveWhen))
+	}
+
+	clone.ObserveWhen[0].Fact = "mutated"
+	if original.ObserveWhen[0].Fact == "mutated" {
+		t.Error("mutating clone ObserveWhen[0].Fact affected original")
+	}
+}
+
 // Benchmark tests
 func BenchmarkLoadModuleMetadata(b *testing.B) {
 	// Create temporary metadata file


### PR DESCRIPTION
## Summary

- Adds `ObservePredicate` struct (`Fact`, `Equals`, `Contains`) and `ObserveWhen []ObservePredicate` field to `ModuleMetadata`, implementing the module-level activation predicate schema from ADR-024 Decision §2
- Validation in `ParseModuleMetadata` and `Validate()` rejects malformed predicates (empty `fact`, both/neither of `equals`/`contains` set)
- `Clone()` deep-copies `ObserveWhen`; field is `omitempty` and nil-safe for all existing manifests
- `docs/architecture/modules/README.md` updated with `ObservePredicate` field table referencing the real struct location

## Test plan

- [x] `TestParseModuleMetadata_ObserveWhen` — 8 sub-cases covering backward compat, valid contains, valid equals, valid multi-predicate, and all 3 malformed shapes
- [x] `TestParseModuleMetadata_ObserveWhenRoundTrip` — YAML round-trip survives
- [x] `TestModuleMetadata_Clone_ObserveWhen` — deep copy isolation verified
- [x] All pre-existing module tests continue to pass

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

Zero findings; zero fix rounds.

Fixes #3101

🤖 Generated with [Claude Code](https://claude.com/claude-code)