### PR TITLE
web: refresh-request queue view (list + reject) (Issue #2941)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -420,6 +420,40 @@ All API-supplied values render as JSX text nodes only (security A9.1); the
 `parseIPTrustList` function shape-validates the wire payload before any field
 reaches the DOM.
 
+## Refresh-request queue (Story #2941)
+
+[`src/refresh/RefreshQueuePage.tsx`](src/refresh/RefreshQueuePage.tsx) — the
+`/refresh` route, accessible from the app shell nav as "Refresh Requests". A
+distinct page from the Registration console: refresh requests are a separate
+resource (`/stewards/refresh/*`, device-credential rotation) from steward
+enrollment (`/registration/*`).
+
+**Endpoint:** `GET /api/v1/stewards/refresh/pending` — bare JSON array (no
+`{data:...}` envelope), tenant-scoped from `ctxkeys.TenantID` in the handler.
+
+**Reject endpoint:** `POST /api/v1/stewards/refresh/{pending_id}/reject` —
+removes the row from the list on success; surfaces a row-level error without
+crashing on failure.
+
+**Fields rendered:**
+
+| Field | Wire key | Notes |
+|-------|----------|-------|
+| Pending ID | `pending_id` | Monospace; list key |
+| Device ID | `device_id` | Monospace |
+| Tenant | `tenant_id` | Monospace path |
+| Source IP | `source_ip` | Monospace |
+| Provenance | `provenance_matched_fields` / `provenance_total_fields` | Badge: green when matched == total (full match), amber when matched < total (partial) |
+| Requested | `created_at` | ISO-8601 string |
+
+**Out of scope:** Approve is entirely out of scope for this story — no button,
+no disabled state, no deferred control of any kind. Approve belongs to Section
+2's follow-on epic.
+
+All API-supplied values render as JSX text nodes only (security A9.1); the
+`parsePendingRefreshList` / `parsePendingRefreshEntry` functions shape-validate
+the wire payload before any field reaches the DOM.
+
 ## Testing
 
 Vitest with jsdom and Testing Library. Suites:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,7 @@
  * App root: router + auth provider + route guard around the authenticated
  * app shell (Story #2496).
  *
- * Route table (Story #2723, #2727, #2730, #2731, Issue #2732, #2733):
+ * Route table (Story #2723, #2727, #2730, #2731, Issue #2732, #2733, #2941):
  *   /                → AppShell layout → FleetOverview
  *   /stewards/:id    → AppShell layout → StewardAssetPage
  *   /audit           → AppShell layout → AuditView
@@ -14,6 +14,7 @@
  *   /workflows       → AppShell layout → WorkflowListView
  *   /accounts        → AppShell layout → AccountsView
  *   /registration    → AppShell layout → RegistrationConsolePage
+ *   /refresh         → AppShell layout → RefreshQueuePage
  *
  * Session presence is inferred from API responses, never from reading
  * cookies (#2495). The fleet view's own data call (GET /api/v1/stewards,
@@ -33,6 +34,7 @@ import AccountsView from './accounts/AccountsView.tsx'
 import ModuleReviewQueue from './modules/ModuleReviewQueue.tsx'
 import ScriptsView from './scripts/ScriptsView.tsx'
 import RegistrationConsolePage from './registration/RegistrationConsolePage.tsx'
+import RefreshQueuePage from './refresh/RefreshQueuePage.tsx'
 
 function App() {
   return (
@@ -49,6 +51,7 @@ function App() {
             <Route path="accounts" element={<AccountsView />} />
             <Route path="scripts" element={<ScriptsView />} />
             <Route path="registration" element={<RegistrationConsolePage />} />
+            <Route path="refresh" element={<RefreshQueuePage />} />
           </Route>
         </Routes>
       </RequireAuth>

--- a/web/src/refresh/RefreshQueuePage.test.tsx
+++ b/web/src/refresh/RefreshQueuePage.test.tsx
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * RefreshQueuePage test suite (Story #2941): list rendering, data states, and
+ * reject-remove / reject-error flows.
+ *
+ * Required AC: reject removes the row on success; surfaces a row-level error
+ * state on a failed request without crashing.
+ *
+ * Security A9.1: device-supplied and operator-influenced values (pending_id,
+ * device_id, tenant_id, source_ip, created_at) must render as text content,
+ * not markup. Tests assert on textContent only — never on innerHTML.
+ *
+ * The GET /api/v1/stewards/refresh/pending response is a bare JSON array (no
+ * {data:...} envelope) — confirmed against handlers_registration_refresh.go:624.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { AuthProvider } from '../auth/AuthContext.tsx'
+import RefreshQueuePage, {
+  parsePendingRefreshEntry,
+  parsePendingRefreshList,
+} from './RefreshQueuePage.tsx'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+// ── Factories ─────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    pending_id: 'ref-abc123',
+    device_id: 'dev-xyz789',
+    tenant_id: 'root/msp-a/prod',
+    source_ip: '10.2.4.19',
+    provenance_matched_fields: 7,
+    provenance_total_fields: 7,
+    status: 'pending',
+    created_at: '2026-07-25T10:00:00Z',
+    expires_at: '2026-07-25T11:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeRefreshResponse(entries: object[], status = 200) {
+  return new Response(JSON.stringify(entries), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <RefreshQueuePage />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+describe('parsePendingRefreshEntry', () => {
+  it('returns null for non-objects', () => {
+    expect(parsePendingRefreshEntry(null)).toBeNull()
+    expect(parsePendingRefreshEntry('string')).toBeNull()
+    expect(parsePendingRefreshEntry(42)).toBeNull()
+  })
+
+  it('returns null when pending_id is missing or empty', () => {
+    expect(parsePendingRefreshEntry({})).toBeNull()
+    expect(parsePendingRefreshEntry({ pending_id: '' })).toBeNull()
+  })
+
+  it('parses a valid entry', () => {
+    const entry = parsePendingRefreshEntry(makeEntry())
+    expect(entry).toEqual({
+      pending_id: 'ref-abc123',
+      device_id: 'dev-xyz789',
+      tenant_id: 'root/msp-a/prod',
+      source_ip: '10.2.4.19',
+      provenance_matched_fields: 7,
+      provenance_total_fields: 7,
+      status: 'pending',
+      created_at: '2026-07-25T10:00:00Z',
+    })
+  })
+
+  it('coerces non-string fields to empty string and numeric fields to 0', () => {
+    const entry = parsePendingRefreshEntry({
+      pending_id: 'ref-1',
+      device_id: 99,
+      tenant_id: null,
+      source_ip: undefined,
+      provenance_matched_fields: 'not-a-number',
+      provenance_total_fields: null,
+      status: false,
+      created_at: undefined,
+    })
+    expect(entry).toEqual({
+      pending_id: 'ref-1',
+      device_id: '',
+      tenant_id: '',
+      source_ip: '',
+      provenance_matched_fields: 0,
+      provenance_total_fields: 0,
+      status: '',
+      created_at: '',
+    })
+  })
+})
+
+describe('parsePendingRefreshList', () => {
+  it('throws on non-array input', () => {
+    expect(() => parsePendingRefreshList(null)).toThrow('unexpected response shape')
+    expect(() => parsePendingRefreshList({ pending: [] })).toThrow('unexpected response shape')
+  })
+
+  it('parses a list of entries', () => {
+    const list = parsePendingRefreshList([makeEntry()])
+    expect(list).toHaveLength(1)
+    expect(list[0]?.pending_id).toBe('ref-abc123')
+  })
+
+  it('drops entries without a pending_id', () => {
+    const list = parsePendingRefreshList([{}, makeEntry()])
+    expect(list).toHaveLength(1)
+  })
+})
+
+// ── List rendering ────────────────────────────────────────────────────────────
+
+describe('RefreshQueuePage — list rendering', () => {
+  it('shows loading rows while the fetch is in-flight', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByTestId('refresh-loading')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when no refresh requests are pending', async () => {
+    fetchMock.mockResolvedValue(makeRefreshResponse([]))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-empty')).toBeInTheDocument())
+  })
+
+  it('renders a table row per pending entry', async () => {
+    fetchMock.mockResolvedValue(
+      makeRefreshResponse([
+        makeEntry(),
+        makeEntry({ pending_id: 'ref-def456', device_id: 'dev-uvw321', source_ip: '10.2.4.20' }),
+      ]),
+    )
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+    expect(screen.getAllByTestId('refresh-row')).toHaveLength(2)
+  })
+
+  it('renders pending_id, device_id, tenant_id, source_ip, and created_at as text nodes', async () => {
+    fetchMock.mockResolvedValue(makeRefreshResponse([makeEntry()]))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+    expect(screen.getByText('ref-abc123')).toBeInTheDocument()
+    expect(screen.getByText('dev-xyz789')).toBeInTheDocument()
+    expect(screen.getByText('root/msp-a/prod')).toBeInTheDocument()
+    expect(screen.getByText('10.2.4.19')).toBeInTheDocument()
+    expect(screen.getByText('2026-07-25T10:00:00Z')).toBeInTheDocument()
+  })
+
+  it('shows a full-match provenance badge (7 / 7) with ok styling', async () => {
+    fetchMock.mockResolvedValue(
+      makeRefreshResponse([makeEntry({ provenance_matched_fields: 7, provenance_total_fields: 7 })]),
+    )
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+    const badge = screen.getByTestId('provenance-badge-ref-abc123')
+    expect(badge).toHaveTextContent('7 / 7')
+    expect(badge).toHaveClass('b-ok')
+  })
+
+  it('shows a partial-match provenance badge (4 / 7) with warn styling', async () => {
+    fetchMock.mockResolvedValue(
+      makeRefreshResponse([makeEntry({ provenance_matched_fields: 4, provenance_total_fields: 7 })]),
+    )
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+    const badge = screen.getByTestId('provenance-badge-ref-abc123')
+    expect(badge).toHaveTextContent('4 / 7')
+    expect(badge).toHaveClass('b-warn')
+  })
+
+  it('shows a Reject button for each row', async () => {
+    fetchMock.mockResolvedValue(makeRefreshResponse([makeEntry()]))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+    expect(screen.getByTestId('reject-btn-ref-abc123')).toBeInTheDocument()
+  })
+
+  it('renders no approve control of any kind', async () => {
+    fetchMock.mockResolvedValue(makeRefreshResponse([makeEntry()]))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /approve/i })).toBeNull()
+  })
+
+  it('shows an error notice on a non-200 list response', async () => {
+    fetchMock.mockResolvedValue(makeRefreshResponse([], 500))
+    renderPage()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('500')
+  })
+
+  it('shows an error notice on a network-level failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    renderPage()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+
+  it('retries the fetch when the Retry button is clicked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([], 500))
+      .mockResolvedValueOnce(makeRefreshResponse([]))
+    renderPage()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    await waitFor(() => expect(screen.getByTestId('refresh-empty')).toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── Reject flow ───────────────────────────────────────────────────────────────
+
+describe('RefreshQueuePage — reject', () => {
+  it('reject removes the row from the list on success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('reject-btn-ref-abc123'))
+
+    await waitFor(() => expect(screen.getByTestId('refresh-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('refresh-row')).toBeNull()
+    const rejectCall = fetchMock.mock.calls[1]!
+    expect(String(rejectCall[0])).toContain('/reject')
+    expect((rejectCall[1] as RequestInit | undefined)?.method).toBe('POST')
+  })
+
+  it('surfaces a row-level error on a failed reject without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('reject-btn-ref-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('reject-error-ref-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('reject-error-ref-abc123')).toHaveTextContent('403')
+    // Row is still present — the component did not crash
+    expect(screen.getByTestId('refresh-table')).toBeInTheDocument()
+    expect(screen.getAllByTestId('refresh-row')).toHaveLength(1)
+  })
+
+  it('surfaces a row-level error on a network failure during reject without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockRejectedValueOnce(new Error('connection refused'))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('reject-btn-ref-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('reject-error-ref-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('reject-error-ref-abc123')).toHaveTextContent('connection refused')
+    expect(screen.getAllByTestId('refresh-row')).toHaveLength(1)
+  })
+
+  it('clears a previous reject error when reject is retried', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('reject-btn-ref-abc123'))
+    await waitFor(() =>
+      expect(screen.getByTestId('reject-error-ref-abc123')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('reject-btn-ref-abc123'))
+    await waitFor(() => expect(screen.getByTestId('refresh-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('reject-error-ref-abc123')).toBeNull()
+  })
+
+  it('keeps other rows intact when one reject succeeds', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeRefreshResponse([
+          makeEntry(),
+          makeEntry({ pending_id: 'ref-def456', device_id: 'dev-uvw321' }),
+        ]),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderPage()
+    await waitFor(() => expect(screen.getAllByTestId('refresh-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByTestId('reject-btn-ref-abc123'))
+
+    await waitFor(() => expect(screen.getAllByTestId('refresh-row')).toHaveLength(1))
+    expect(screen.getByText('ref-def456')).toBeInTheDocument()
+    expect(screen.queryByText('ref-abc123')).toBeNull()
+  })
+})

--- a/web/src/refresh/RefreshQueuePage.tsx
+++ b/web/src/refresh/RefreshQueuePage.tsx
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Refresh-request queue page (Story #2941).
+ * Fetches GET /api/v1/stewards/refresh/pending — bare-array response (no
+ * {data:...} envelope). Shape-validated by parsePendingRefreshList before
+ * any value reaches the DOM.
+ *
+ * Reject calls POST /api/v1/stewards/refresh/{pending_id}/reject and removes
+ * the row on success; surfaces a row-level error without crashing on failure.
+ *
+ * Approve is out of scope for this story (Section 2 follow-on epic) — no
+ * button, no disabled state, no deferred control of any kind.
+ *
+ * Security A9.1: all device-supplied and operator-influenced values render
+ * as JSX text nodes only, never via dangerouslySetInnerHTML.
+ */
+import { Fragment, useCallback, useEffect, useState } from 'react'
+import { apiFetch } from '../api/client.ts'
+import ErrorCard from '../shell/ErrorCard.tsx'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface PendingRefreshEntry {
+  pending_id: string
+  device_id: string
+  tenant_id: string
+  source_ip: string
+  provenance_matched_fields: number
+  provenance_total_fields: number
+  status: string
+  created_at: string
+}
+
+interface FetchOutcome {
+  key: string
+  entries?: PendingRefreshEntry[]
+  error?: string
+}
+
+// ── Parse helpers ─────────────────────────────────────────────────────────────
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+function num(v: unknown): number {
+  return typeof v === 'number' ? v : 0
+}
+
+export function parsePendingRefreshEntry(value: unknown): PendingRefreshEntry | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const pending_id = str(r.pending_id)
+  if (!pending_id) return null
+  return {
+    pending_id,
+    device_id: str(r.device_id),
+    tenant_id: str(r.tenant_id),
+    source_ip: str(r.source_ip),
+    provenance_matched_fields: num(r.provenance_matched_fields),
+    provenance_total_fields: num(r.provenance_total_fields),
+    status: str(r.status),
+    created_at: str(r.created_at),
+  }
+}
+
+export function parsePendingRefreshList(data: unknown): PendingRefreshEntry[] {
+  if (!Array.isArray(data)) throw new Error('unexpected response shape')
+  const list: PendingRefreshEntry[] = []
+  for (const item of data) {
+    const entry = parsePendingRefreshEntry(item)
+    if (entry !== null) list.push(entry)
+  }
+  return list
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function LoadingRows() {
+  return (
+    <div data-testid="refresh-loading" aria-label="Loading pending refresh requests">
+      {Array.from({ length: 3 }, (_, i) => (
+        <div className="skrow" key={i}>
+          <span className="skel" style={{ width: '20%' }} />
+          <span className="skel" style={{ width: '20%' }} />
+          <span className="skel" style={{ width: '15%' }} />
+          <span className="skel" style={{ width: '12%' }} />
+          <span className="skel" style={{ width: '18%' }} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="notice empty" data-testid="refresh-empty">
+      <div className="ic">◍</div>
+      <h3>No pending refresh requests</h3>
+      <p>Steward device-credential rotations awaiting review will appear here.</p>
+    </div>
+  )
+}
+
+function ProvenanceBadge({
+  matched,
+  total,
+  pendingId,
+}: {
+  matched: number
+  total: number
+  pendingId: string
+}) {
+  const isFullMatch = total > 0 && matched === total
+  return (
+    <span
+      className={`badge ${isFullMatch ? 'b-ok' : 'b-warn'}`}
+      data-testid={`provenance-badge-${pendingId}`}
+    >
+      <span className="dot" aria-hidden="true" />
+      {matched} / {total}
+    </span>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function RefreshQueuePage() {
+  const [attempt, setAttempt] = useState(0)
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+  const [rejectErrors, setRejectErrors] = useState<Map<string, string>>(new Map())
+
+  const key = `refresh:${attempt}`
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/stewards/refresh/pending')
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`GET /api/v1/stewards/refresh/pending — ${response.status}`)
+        }
+        const body: unknown = await response.json()
+        const entries = parsePendingRefreshList(body)
+        if (cancelled) return
+        setOutcome({ key, entries })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/stewards/refresh/pending — request failed',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, attempt])
+
+  async function handleReject(pendingId: string) {
+    setRejectErrors((prev) => {
+      const next = new Map(prev)
+      next.delete(pendingId)
+      return next
+    })
+    try {
+      const response = await apiFetch(
+        `/api/v1/stewards/refresh/${encodeURIComponent(pendingId)}/reject`,
+        { method: 'POST' },
+      )
+      if (!response.ok) {
+        setRejectErrors((prev) =>
+          new Map(prev).set(pendingId, `Reject failed — ${response.status}`),
+        )
+        return
+      }
+      setOutcome((prev) => {
+        if (!prev?.entries) return prev
+        return { ...prev, entries: prev.entries.filter((e) => e.pending_id !== pendingId) }
+      })
+    } catch (cause: unknown) {
+      setRejectErrors((prev) =>
+        new Map(prev).set(
+          pendingId,
+          cause instanceof Error && cause.message ? cause.message : 'Reject request failed',
+        ),
+      )
+    }
+  }
+
+  const current = outcome?.key === key ? outcome : null
+  const loading = current === null
+  const error = current?.error ?? null
+  const entries = current?.entries ?? null
+
+  return (
+    <div className="page">
+      <div className="page-head">
+        <h1>Refresh requests</h1>
+        <p>Pending steward device-credential rotations awaiting review.</p>
+      </div>
+      <section className="panel">
+        {loading ? (
+          <LoadingRows />
+        ) : error !== null ? (
+          <ErrorCard
+            heading="Couldn't load pending refresh requests"
+            detail={error}
+            onRetry={retry}
+          />
+        ) : entries === null || entries.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <>
+            <div className="ptool">
+              <span className="cnt" data-testid="refresh-count">
+                {entries.length} pending
+              </span>
+            </div>
+            <table className="tbl" data-testid="refresh-table">
+              <thead>
+                <tr>
+                  <th>Pending ID</th>
+                  <th>Device ID</th>
+                  <th>Tenant</th>
+                  <th>Source IP</th>
+                  <th>Provenance</th>
+                  <th>Requested</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((entry) => (
+                  <Fragment key={entry.pending_id}>
+                    <tr data-testid="refresh-row">
+                      <td>
+                        <span className="mono2">{entry.pending_id}</span>
+                      </td>
+                      <td>
+                        <span className="mono2">{entry.device_id}</span>
+                      </td>
+                      <td>
+                        <span className="mono2">{entry.tenant_id}</span>
+                      </td>
+                      <td>
+                        <span className="mono2">{entry.source_ip}</span>
+                      </td>
+                      <td>
+                        <ProvenanceBadge
+                          matched={entry.provenance_matched_fields}
+                          total={entry.provenance_total_fields}
+                          pendingId={entry.pending_id}
+                        />
+                      </td>
+                      <td>
+                        <span className="mono2">{entry.created_at}</span>
+                      </td>
+                      <td>
+                        <button
+                          type="button"
+                          className="wf-btn-sm-danger"
+                          data-testid={`reject-btn-${entry.pending_id}`}
+                          onClick={() => void handleReject(entry.pending_id)}
+                        >
+                          Reject
+                        </button>
+                      </td>
+                    </tr>
+                    {rejectErrors.has(entry.pending_id) && (
+                      <tr>
+                        <td colSpan={7}>
+                          <span
+                            className="wf-form-error"
+                            data-testid={`reject-error-${entry.pending_id}`}
+                            role="alert"
+                          >
+                            {rejectErrors.get(entry.pending_id)}
+                          </span>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -33,6 +33,7 @@ const NAV_ITEMS = [
   { label: 'Workflows', to: '/workflows', soon: false },
   { label: 'Scripts', to: '/scripts', soon: false },
   { label: 'Registration', to: '/registration', soon: false },
+  { label: 'Refresh Requests', to: '/refresh', soon: false },
   { label: 'Audit', to: '/audit', soon: false },
   { label: 'Accounts', to: '/accounts', soon: false },
 ] as const


### PR DESCRIPTION
## Summary

- Adds `RefreshQueuePage` at `/refresh` — a distinct page (not a Registration tab) listing pending steward device-credential refresh requests with **Reject** fully functional
- Provenance column shows matched/total fields with a green (full match) or amber (partial) badge, following the founder-approved mockup (`docs/design/mockups/refresh-queue.html`)
- No approve control of any kind — Approve is deferred to Section 2's follow-on epic

## Files changed

| File | Change |
|------|--------|
| `web/src/refresh/RefreshQueuePage.tsx` | New component — list + reject flow |
| `web/src/refresh/RefreshQueuePage.test.tsx` | 23 tests (parse helpers, all states, reject flow) |
| `web/src/shell/AppShell.tsx` | "Refresh Requests" nav entry at `/refresh` |
| `web/src/App.tsx` | `/refresh` route wired to `RefreshQueuePage` |
| `web/README.md` | New `## Refresh-request queue (Story #2941)` section |

## Acceptance criteria

- [x] "Refresh Requests" nav entry lists every pending refresh request in the caller's tenant scope
- [x] Reject is fully functional, removes the entry from the list on success
- [x] No approve control of any kind exists in this story's components
- [x] [REQUIRED TEST] component test: reject removes the row and surfaces an error state on a failed request without crashing
- [x] Tests added/updated for all behavior changes (23 tests, 991 total pass)

## Adversarial review results

story-review workflow: **PASSED** — 1 round, 0 fix rounds, 0 remaining findings
- Code review: PASS
- Test quality: PASS
- Security: PASS

Fixes #2941