### PR TITLE
web: move-tenant + decommission from row menu and bulk bar (Issue #2972)

### DIFF
--- a/docs/administration/steward-management.md
+++ b/docs/administration/steward-management.md
@@ -85,3 +85,42 @@ cfg steward move steward-abc --to-tenant dest-tenant
 # Move with an explicit controller URL
 cfg steward move steward-abc --to-tenant msp-a/client-1 --url https://controller.example.com
 ```
+
+**Web console**
+
+Move is available from the per-row action menu (kebab → Move to tenant) and the bulk selection bar.
+Both paths use the browser session and require AssuranceStrong (ADR-021 §S3). If the current
+session is below Strong, the web client triggers an elevation step-up ceremony before the request
+is issued — no explicit step-up button is needed.
+
+Bulk move fans out one `POST /api/v1/stewards/:id/move` call per selected steward. Each call is
+individually authorized and audited server-side; there is no batch endpoint that would bypass
+per-steward tenant scoping. Per-item success and failure are reported inline.
+
+---
+
+## Steward Decommission
+
+Permanently decommission (tombstone) a steward. The steward's durable record is tombstoned,
+its in-memory status is set to `deregistered`, and its active QUIC/gRPC session is dropped.
+
+**Authentication and authorization**
+
+Decommission requires AssuranceStrong (ADR-021). The caller must have `steward:decommission`
+permission on the steward's tenant.
+
+**Audit trail**
+
+Every decommission produces an audit record with severity `high`, containing the steward ID,
+admin identity, source IP, and request ID.
+
+**Web console**
+
+Decommission is available from the per-row action menu (kebab → Decommission) and the bulk
+selection bar (Decommission selected → Confirm decommission). Both paths require
+AssuranceStrong; the step-up elevation ceremony fires automatically if the current session
+is below Strong.
+
+Bulk decommission fans out one `DELETE /api/v1/stewards/:id` call per selected steward. Each
+call is individually authorized and audited server-side; no batch endpoint is used. Per-item
+success and failure are reported inline.

--- a/web/src/fleet/BulkActionBar.test.tsx
+++ b/web/src/fleet/BulkActionBar.test.tsx
@@ -38,8 +38,10 @@ function mockAllOk() {
 describe('bar mode', () => {
   it('shows selected count', () => {
     render(<BulkActionBar selectedIds={new Set(['s1', 's2', 's3'])} onClear={vi.fn()} />)
-    expect(screen.getByText('3')).toBeInTheDocument()
-    expect(screen.getByText(/selected/)).toBeInTheDocument()
+    const countEl = screen.getByText('3')
+    expect(countEl).toBeInTheDocument()
+    // parentElement is the .bulk-sel span whose textContent is "3 selected"
+    expect(countEl.parentElement?.textContent).toContain('selected')
   })
 
   it('renders "Edit tags" button', () => {
@@ -263,5 +265,241 @@ describe('results mode', () => {
     await waitFor(() =>
       expect(screen.getByTestId('bulk-result-summary').textContent).toContain('1 of 1 succeeded'),
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bulk move to tenant (Story #2972)
+// ---------------------------------------------------------------------------
+
+describe('bulk move to tenant', () => {
+  it('bar renders "Move to tenant" button', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Move to tenant' })).toBeInTheDocument()
+  })
+
+  it('"Move to tenant" opens the tenant ID input', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    expect(screen.getByRole('textbox', { name: 'Target tenant ID' })).toBeInTheDocument()
+  })
+
+  it('"Move selected" is disabled while the tenant input is empty', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    expect(screen.getByRole('button', { name: 'Move selected' })).toBeDisabled()
+  })
+
+  it('"Cancel" returns to bar mode from the move tenant panel', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    expect(screen.getByRole('textbox', { name: 'Target tenant ID' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Move to tenant' })).toBeInTheDocument()
+  })
+
+  it('Escape in the tenant input returns to bar mode', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Target tenant ID' }), { key: 'Escape' })
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Move to tenant' })).toBeInTheDocument()
+  })
+
+  it('[REQUIRED] mixed-outcome move: some succeed (200), some fail (403) — surfaces per-item results', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      if (String(url).includes('s3-fail')) {
+        return Promise.resolve(
+          new Response('{}', { status: 403, headers: { 'Content-Type': 'application/json' } }),
+        )
+      }
+      return Promise.resolve(
+        new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      )
+    })
+
+    render(
+      <BulkActionBar selectedIds={new Set(['s1', 's2', 's3-fail'])} onClear={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target tenant ID' }), {
+      target: { value: 'tenant-b' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move selected' }))
+
+    const summary = await screen.findByTestId('bulk-result-summary')
+    expect(summary.textContent).toContain('2 of 3 succeeded')
+    expect(summary.textContent).toContain('1 failed')
+    expect(summary.textContent).toContain('s3-fail')
+  })
+
+  it('"Move selected" issues one POST /stewards/:id/move per selected steward', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    render(
+      <BulkActionBar selectedIds={new Set(['stw-a', 'stw-b'])} onClear={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target tenant ID' }), {
+      target: { value: 'tenant-b' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move selected' }))
+
+    await screen.findByTestId('bulk-result-summary')
+
+    const postCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1]?.method ?? '').toUpperCase() === 'POST',
+    )
+    expect(postCalls).toHaveLength(2)
+    const urls = postCalls.map((c) => String(c[0]))
+    expect(urls).toContain('/api/v1/stewards/stw-a/move')
+    expect(urls).toContain('/api/v1/stewards/stw-b/move')
+
+    for (const call of postCalls) {
+      const body = JSON.parse(String(call[1]?.body)) as { new_tenant_id: string }
+      expect(body.new_tenant_id).toBe('tenant-b')
+    }
+  })
+
+  it('encodes special characters in steward IDs for move requests', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    render(<BulkActionBar selectedIds={new Set(['stw/sp ec'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target tenant ID' }), {
+      target: { value: 'tid' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move selected' }))
+
+    await screen.findByTestId('bulk-result-summary')
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('/api/v1/stewards/stw%2Fsp%20ec/move')
+  })
+
+  it('"Done" in move results returns to bar mode', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Move to tenant' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target tenant ID' }), {
+      target: { value: 'tid' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move selected' }))
+
+    await screen.findByTestId('bulk-result-summary')
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(screen.queryByTestId('bulk-result-summary')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Move to tenant' })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bulk decommission (Story #2972)
+// ---------------------------------------------------------------------------
+
+describe('bulk decommission', () => {
+  it('bar renders "Decommission selected" button', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Decommission selected' })).toBeInTheDocument()
+  })
+
+  it('"Decommission selected" opens the confirmation dialog', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1', 's2'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Decommission selected' }))
+    expect(screen.getByRole('button', { name: 'Confirm decommission' })).toBeInTheDocument()
+  })
+
+  it('"Cancel" returns to bar mode from the decommission confirmation', () => {
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Decommission selected' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByRole('button', { name: 'Confirm decommission' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Decommission selected' })).toBeInTheDocument()
+  })
+
+  it('[REQUIRED] mixed-outcome decommission: some succeed (200), some fail (403) — surfaces per-item results', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      if (String(url).includes('s3-fail')) {
+        return Promise.resolve(
+          new Response('{}', { status: 403, headers: { 'Content-Type': 'application/json' } }),
+        )
+      }
+      return Promise.resolve(
+        new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      )
+    })
+
+    render(
+      <BulkActionBar selectedIds={new Set(['s1', 's2', 's3-fail'])} onClear={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Decommission selected' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    const summary = await screen.findByTestId('bulk-result-summary')
+    expect(summary.textContent).toContain('2 of 3 succeeded')
+    expect(summary.textContent).toContain('1 failed')
+    expect(summary.textContent).toContain('s3-fail')
+  })
+
+  it('confirming decommission issues one DELETE /stewards/:id per selected steward', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    render(
+      <BulkActionBar selectedIds={new Set(['stw-a', 'stw-b'])} onClear={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Decommission selected' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    await screen.findByTestId('bulk-result-summary')
+
+    const deleteCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1]?.method ?? '').toUpperCase() === 'DELETE',
+    )
+    expect(deleteCalls).toHaveLength(2)
+    const urls = deleteCalls.map((c) => String(c[0]))
+    expect(urls).toContain('/api/v1/stewards/stw-a')
+    expect(urls).toContain('/api/v1/stewards/stw-b')
+  })
+
+  it('network error for a steward counts as a failure in decommission results', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      if (String(url).includes('stw-net-err')) {
+        return Promise.reject(new Error('network failure'))
+      }
+      return Promise.resolve(
+        new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      )
+    })
+
+    render(
+      <BulkActionBar selectedIds={new Set(['stw-ok', 'stw-net-err'])} onClear={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Decommission selected' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    const summary = await screen.findByTestId('bulk-result-summary')
+    expect(summary.textContent).toContain('1 of 2 succeeded')
+    expect(summary.textContent).toContain('stw-net-err')
+  })
+
+  it('"Done" in decommission results returns to bar mode', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    render(<BulkActionBar selectedIds={new Set(['s1'])} onClear={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Decommission selected' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    await screen.findByTestId('bulk-result-summary')
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(screen.queryByTestId('bulk-result-summary')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Decommission selected' })).toBeInTheDocument()
   })
 })

--- a/web/src/fleet/BulkActionBar.tsx
+++ b/web/src/fleet/BulkActionBar.tsx
@@ -2,15 +2,17 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Bulk action bar (Story #2939) — appears above the fleet panel when ≥1 row is
- * selected. "Edit tags" issues one authorized POST or DELETE per selected
- * steward, never a batch endpoint that would bypass per-steward tenant checks.
- * Per-item failure is surfaced per steward — never swallowed into a single
- * pass/fail result.
+ * Bulk action bar (Story #2939, #2972) — appears above the fleet panel when ≥1
+ * row is selected. All bulk operations issue one authorized/audited call per
+ * selected steward — never a batch endpoint that would bypass per-steward
+ * tenant checks. Per-item failure is surfaced per steward, never swallowed into
+ * a single aggregate pass/fail result.
  *
- * Design source: docs/design/mockups/fleet-bulk.html (founder-approved
- * 2026-07-24). No decommission affordance of any kind — Section 2's follow-on
- * epic owns that.
+ * Move-tenant and decommission (Story #2972) are gated behind AssuranceStrong
+ * step-up via apiFetch's automatic CFGMS-StepUp 401 handling. The bulk fan-out
+ * issues concurrent per-steward calls; apiFetch's concurrent-dedup mechanism
+ * ensures only one step-up ceremony fires even when multiple calls land 401
+ * simultaneously, then all callers retry with the elevated session.
  *
  * Security A9.1: steward IDs and tag values reach the DOM through JSX text
  * nodes only — no dangerouslySetInnerHTML.
@@ -27,7 +29,11 @@ export interface TagOpResult {
 type Mode =
   | { kind: 'bar' }
   | { kind: 'editTags' }
+  | { kind: 'moveTenant' }
+  | { kind: 'confirmDecommission' }
   | { kind: 'results'; op: 'add' | 'remove'; tag: string; results: TagOpResult[] }
+  | { kind: 'moveTenantResults'; results: TagOpResult[] }
+  | { kind: 'decommissionResults'; results: TagOpResult[] }
 
 export default function BulkActionBar({
   selectedIds,
@@ -39,6 +45,7 @@ export default function BulkActionBar({
   const count = selectedIds.size
   const [mode, setMode] = useState<Mode>({ kind: 'bar' })
   const [tag, setTag] = useState('')
+  const [targetTenantId, setTargetTenantId] = useState('')
   const [busy, setBusy] = useState(false)
 
   async function runOp(op: 'add' | 'remove') {
@@ -67,12 +74,61 @@ export default function BulkActionBar({
     setMode({ kind: 'results', op, tag: tagVal, results })
   }
 
+  async function runMoveTenant() {
+    const tid = targetTenantId.trim()
+    if (!tid) return
+    setBusy(true)
+    const results = await Promise.all(
+      [...selectedIds].map(async (id): Promise<TagOpResult> => {
+        try {
+          const resp = await apiFetch(
+            `/api/v1/stewards/${encodeURIComponent(id)}/move`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ new_tenant_id: tid }),
+            },
+          )
+          return { id, ok: resp.ok, status: resp.status }
+        } catch {
+          return { id, ok: false }
+        }
+      }),
+    )
+    setBusy(false)
+    setMode({ kind: 'moveTenantResults', results })
+  }
+
+  async function runDecommission() {
+    setBusy(true)
+    const results = await Promise.all(
+      [...selectedIds].map(async (id): Promise<TagOpResult> => {
+        try {
+          const resp = await apiFetch(
+            `/api/v1/stewards/${encodeURIComponent(id)}`,
+            { method: 'DELETE' },
+          )
+          return { id, ok: resp.ok, status: resp.status }
+        } catch {
+          return { id, ok: false }
+        }
+      }),
+    )
+    setBusy(false)
+    setMode({ kind: 'decommissionResults', results })
+  }
+
   function backToBar() {
     setMode({ kind: 'bar' })
     setTag('')
+    setTargetTenantId('')
   }
 
-  if (mode.kind === 'results') {
+  if (
+    mode.kind === 'results' ||
+    mode.kind === 'moveTenantResults' ||
+    mode.kind === 'decommissionResults'
+  ) {
     const succeeded = mode.results.filter((r) => r.ok)
     const failed = mode.results.filter((r) => !r.ok)
     return (
@@ -138,6 +194,66 @@ export default function BulkActionBar({
     )
   }
 
+  if (mode.kind === 'moveTenant') {
+    return (
+      <div className="bulkbar" data-testid="bulk-action-bar">
+        <span className="bulk-sel">
+          <span className="bulk-n">{count}</span> selected
+        </span>
+        <input
+          type="text"
+          className="bulk-tenant-in"
+          placeholder="tenant-id"
+          aria-label="Target tenant ID"
+          value={targetTenantId}
+          disabled={busy}
+          onChange={(e) => setTargetTenantId(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.stopPropagation()
+              backToBar()
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="bbtn bbtn-primary"
+          disabled={busy || !targetTenantId.trim()}
+          onClick={() => void runMoveTenant()}
+        >
+          Move selected
+        </button>
+        <button type="button" className="bbtn-clear" disabled={busy} onClick={backToBar}>
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  if (mode.kind === 'confirmDecommission') {
+    return (
+      <div className="bulkbar" data-testid="bulk-action-bar">
+        <span className="bulk-sel">
+          <span className="bulk-n">{count}</span> selected
+        </span>
+        <span className="bulk-warn">
+          Decommission {count} steward{count === 1 ? '' : 's'}? This cannot be undone.
+        </span>
+        <button
+          type="button"
+          className="bbtn bbtn-danger"
+          disabled={busy}
+          onClick={() => void runDecommission()}
+        >
+          Confirm decommission
+        </button>
+        <button type="button" className="bbtn-clear" disabled={busy} onClick={backToBar}>
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
   return (
     <div className="bulkbar" data-testid="bulk-action-bar">
       <span className="bulk-sel">
@@ -150,6 +266,20 @@ export default function BulkActionBar({
         onClick={() => setMode({ kind: 'editTags' })}
       >
         Edit tags
+      </button>
+      <button
+        type="button"
+        className="bbtn"
+        onClick={() => setMode({ kind: 'moveTenant' })}
+      >
+        Move to tenant
+      </button>
+      <button
+        type="button"
+        className="bbtn bbtn-danger"
+        onClick={() => setMode({ kind: 'confirmDecommission' })}
+      >
+        Decommission selected
       </button>
       <button type="button" className="bbtn-clear" onClick={onClear}>
         Clear

--- a/web/src/fleet/RowActionMenu.test.tsx
+++ b/web/src/fleet/RowActionMenu.test.tsx
@@ -337,3 +337,216 @@ describe('tag editor', () => {
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Move to tenant (Story #2972)
+// ---------------------------------------------------------------------------
+
+describe('move to tenant', () => {
+  it('menu shows "Move to tenant" item', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    expect(screen.getByRole('menuitem', { name: 'Move to tenant' })).toBeInTheDocument()
+  })
+
+  it('clicking "Move to tenant" shows the panel with a tenant ID input', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to tenant' }))
+    expect(screen.getByRole('textbox', { name: 'New tenant ID' })).toBeInTheDocument()
+  })
+
+  it('move calls POST /stewards/:id/move with the new tenant ID', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { steward_id: 'stw-1', tenant_id: 'tenant-b', status: 'moved' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to tenant' }))
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'New tenant ID' }), {
+      target: { value: 'tenant-b' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toBe('/api/v1/stewards/stw-1/move')
+    expect((init?.method ?? '').toUpperCase()).toBe('POST')
+    const body = JSON.parse(String(init?.body)) as { new_tenant_id: string }
+    expect(body.new_tenant_id).toBe('tenant-b')
+  })
+
+  it('move encodes special characters in the steward ID', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    render(<RowActionMenu stewardId="stw/sp ec" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to tenant' }))
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'New tenant ID' }), {
+      target: { value: 'tid' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('/api/v1/stewards/stw%2Fsp%20ec/move')
+  })
+
+  it('move success shows a status message', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { steward_id: 'stw-1', tenant_id: 'tenant-b', status: 'moved' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to tenant' }))
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'New tenant ID' }), {
+      target: { value: 'tenant-b' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move' }))
+
+    expect(await screen.findByRole('status')).toBeInTheDocument()
+  })
+
+  it('move error shows an alert with the status code', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to tenant' }))
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'New tenant ID' }), {
+      target: { value: 'nonexistent' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Move' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('404')
+  })
+
+  it('"Move" is disabled when the tenant input is empty', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to tenant' }))
+    expect(screen.getByRole('button', { name: 'Move' })).toBeDisabled()
+  })
+
+  it('back button returns to the menu from the move panel', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to tenant' }))
+
+    expect(screen.getByRole('textbox', { name: 'New tenant ID' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to menu' }))
+
+    expect(screen.getByRole('menuitem', { name: 'Move to tenant' })).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Decommission (Story #2972)
+// ---------------------------------------------------------------------------
+
+describe('decommission', () => {
+  it('menu shows "Decommission" item', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    expect(screen.getByRole('menuitem', { name: 'Decommission' })).toBeInTheDocument()
+  })
+
+  it('clicking "Decommission" shows the confirmation panel', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Decommission' }))
+    expect(screen.getByRole('button', { name: 'Confirm decommission' })).toBeInTheDocument()
+  })
+
+  it('confirming decommission calls DELETE /stewards/:id', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { id: 'stw-1', status: 'deregistered' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Decommission' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toBe('/api/v1/stewards/stw-1')
+    expect((init?.method ?? '').toUpperCase()).toBe('DELETE')
+  })
+
+  it('decommission encodes special characters in the steward ID', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    render(<RowActionMenu stewardId="stw/sp ec" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Decommission' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('/api/v1/stewards/stw%2Fsp%20ec')
+  })
+
+  it('decommission success shows a status message', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { id: 'stw-1', status: 'deregistered' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Decommission' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    expect(await screen.findByRole('status')).toBeInTheDocument()
+  })
+
+  it('decommission error shows an alert with the status code', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'unauthorized' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Decommission' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm decommission' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('403')
+  })
+
+  it('back button returns to the menu from the decommission panel', () => {
+    render(<RowActionMenu stewardId="stw-1" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Decommission' }))
+
+    expect(screen.getByRole('button', { name: 'Confirm decommission' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to menu' }))
+
+    expect(screen.getByRole('menuitem', { name: 'Decommission' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Confirm decommission' })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/fleet/RowActionMenu.tsx
+++ b/web/src/fleet/RowActionMenu.tsx
@@ -2,12 +2,15 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Per-row action menu (Story #2938) — mockup `.rowkebab` / `.pop .row` pattern
- * from `asset-live-activity.html` lines 204-205/500, applied to FleetTable.
+ * Per-row action menu (Story #2938, #2972) — mockup `.rowkebab` / `.pop .row`
+ * pattern from `asset-live-activity.html` lines 204-205/500, applied to
+ * FleetTable.
  *
  * The component is structured as an ordered MenuItemSpec list so later entries
- * can be appended without restructuring the JSX. Only tag edit is wired in
- * this story — move-tenant and decommission are out of scope (Section 2).
+ * can be appended without restructuring the JSX. Story #2972 adds move-tenant
+ * and decommission behind CFGMS-StepUp (elevation path, AssuranceStrong);
+ * step-up fires automatically via apiFetch on a 401 with WWW-Authenticate:
+ * CFGMS-StepUp — no special handling is needed in this component.
  *
  * Popover lifecycle (Escape + outside-click) is a verbatim reuse of the
  * pattern established by ColumnPicker.tsx and SavedViews.tsx.
@@ -180,9 +183,160 @@ function TagEditor({
   )
 }
 
+function MoveTenantPanel({
+  stewardId,
+  onBack,
+}: {
+  stewardId: string
+  onBack: () => void
+}) {
+  const [tenantId, setTenantId] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  async function move() {
+    const tid = tenantId.trim()
+    if (!tid) return
+    setBusy(true)
+    setError(null)
+    try {
+      const resp = await apiFetch(
+        `/api/v1/stewards/${encodeURIComponent(stewardId)}/move`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ new_tenant_id: tid }),
+        },
+      )
+      if (!resp.ok) {
+        setError(`Failed to move steward (${resp.status})`)
+        return
+      }
+      setDone(true)
+    } catch {
+      setError('Failed to move steward')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="row-move-panel">
+      <div className="rtag-hd">
+        <button type="button" className="rtag-back" aria-label="Back to menu" onClick={onBack}>
+          ←
+        </button>
+        <span className="rtag-title">Move to tenant</span>
+      </div>
+      {error !== null && (
+        <div className="rtag-err" role="alert">
+          {error}
+        </div>
+      )}
+      {done ? (
+        <div className="rmove-ok" role="status">
+          Moved successfully
+        </div>
+      ) : (
+        <div className="rtag-row">
+          <input
+            type="text"
+            className="rtag-in"
+            placeholder="tenant-id"
+            aria-label="New tenant ID"
+            value={tenantId}
+            disabled={busy}
+            onChange={(e) => setTenantId(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void move()
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="rtag-btn"
+            disabled={busy || !tenantId.trim()}
+            onClick={() => void move()}
+          >
+            Move
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DecommissionPanel({
+  stewardId,
+  onBack,
+}: {
+  stewardId: string
+  onBack: () => void
+}) {
+  const [error, setError] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  async function decommission() {
+    setBusy(true)
+    setError(null)
+    try {
+      const resp = await apiFetch(
+        `/api/v1/stewards/${encodeURIComponent(stewardId)}`,
+        { method: 'DELETE' },
+      )
+      if (!resp.ok) {
+        setError(`Failed to decommission (${resp.status})`)
+        return
+      }
+      setDone(true)
+    } catch {
+      setError('Failed to decommission')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="row-decommission-panel">
+      <div className="rtag-hd">
+        <button type="button" className="rtag-back" aria-label="Back to menu" onClick={onBack}>
+          ←
+        </button>
+        <span className="rtag-title">Decommission</span>
+      </div>
+      {error !== null && (
+        <div className="rtag-err" role="alert">
+          {error}
+        </div>
+      )}
+      {done ? (
+        <div className="rdecom-ok" role="status">
+          Decommissioned
+        </div>
+      ) : (
+        <div className="rdecom-confirm">
+          <p className="rdecom-warn">This cannot be undone.</p>
+          <button
+            type="button"
+            className="rtag-btn rtag-btn-danger"
+            disabled={busy}
+            onClick={() => void decommission()}
+          >
+            Confirm decommission
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function RowActionMenu({ stewardId }: { stewardId: string }) {
   const [open, setOpen] = useState(false)
-  const [mode, setMode] = useState<'menu' | 'tags'>('menu')
+  const [mode, setMode] = useState<'menu' | 'tags' | 'move' | 'decommission'>('menu')
   const wrapRef = useRef<HTMLDivElement>(null)
 
   /* Escape and outside-click lifecycle — verbatim reuse of ColumnPicker.tsx pattern. */
@@ -211,6 +365,8 @@ export default function RowActionMenu({ stewardId }: { stewardId: string }) {
   /* Ordered spec list — append later entries here without restructuring the JSX. */
   const MENU_ITEMS: MenuItemSpec[] = [
     { id: 'tags', label: 'Edit tags', onActivate: () => setMode('tags') },
+    { id: 'move', label: 'Move to tenant', onActivate: () => setMode('move') },
+    { id: 'decommission', label: 'Decommission', onActivate: () => setMode('decommission') },
   ]
 
   return (
@@ -261,6 +417,12 @@ export default function RowActionMenu({ stewardId }: { stewardId: string }) {
             ))}
           {mode === 'tags' && (
             <TagEditor stewardId={stewardId} onBack={() => setMode('menu')} />
+          )}
+          {mode === 'move' && (
+            <MoveTenantPanel stewardId={stewardId} onBack={() => setMode('menu')} />
+          )}
+          {mode === 'decommission' && (
+            <DecommissionPanel stewardId={stewardId} onBack={() => setMode('menu')} />
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

- **Move-tenant and decommission** wired into the fleet UI behind AssuranceStrong step-up (CFGMS-StepUp elevation path) from both the per-row kebab action menu and the bulk selection bar
- **Step-up is automatic** — both operations use `apiFetch` which fires the step-up ceremony on a `401 WWW-Authenticate: CFGMS-StepUp` response; no special handling needed in components
- **Bulk fan-out is per-steward** — one individually-authorized, individually-audited call per selected steward (`POST /stewards/:id/move` or `DELETE /stewards/:id`); no batch endpoint; per-item results surfaced inline

Fixes #2972

## Changes

**`web/src/fleet/RowActionMenu.tsx`**
- Added `MoveTenantPanel` sub-panel: tenant ID input → `POST /api/v1/stewards/:id/move`
- Added `DecommissionPanel` sub-panel: confirmation → `DELETE /api/v1/stewards/:id`
- Extended mode union: `'menu' | 'tags' | 'move' | 'decommission'`
- Appended "Move to tenant" and "Decommission" to the ordered `MENU_ITEMS` spec list

**`web/src/fleet/BulkActionBar.tsx`**
- Added `moveTenant` and `confirmDecommission` modes with tenant ID input / confirmation UI
- Added `runMoveTenant()` and `runDecommission()` fan-out functions (per-steward `Promise.all`)
- Extended results rendering to cover `moveTenantResults` and `decommissionResults` modes
- Added "Move to tenant" and "Decommission selected" buttons in bar mode

**`web/src/fleet/RowActionMenu.test.tsx`**
- 14 new tests: menu items, panel rendering, API URLs/bodies, URL encoding, success/error states, back navigation

**`web/src/fleet/BulkActionBar.test.tsx`**
- 16 new tests including two REQUIRED mixed-outcome tests (move + decommission)
- Updated `shows selected count` assertion to use `parentElement.textContent` (the prior `/selected/` regex was fragile — now a second element with "selected" exists in bar mode)

**`docs/administration/steward-management.md`**
- Added "Web console" subsection to `cfg steward move` documenting step-up gating and per-steward-fan-out bulk model
- Added new `## Steward Decommission` section documenting auth, audit, and web console behavior

## Adversarial Review Results

| Reviewer | Result |
|----------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

All 3 reviewers passed in round 1 — 0 fix rounds, 0 remaining findings.

`make test-agent-complete` exit code 0 (pre-commit + fast + production-critical + cross-platform + frontend all pass).

## Test plan

- [ ] Open fleet table → row kebab → "Move to tenant": enter a tenant ID → "Move" → verify step-up fires if session is below Strong, then `POST /stewards/:id/move` is issued and success state shown
- [ ] Row kebab → "Decommission" → "Confirm decommission" → verify step-up fires, then `DELETE /stewards/:id` is issued and success state shown
- [ ] Select multiple stewards → bulk bar → "Move to tenant" → enter tenant ID → "Move selected" → verify one POST per steward, per-item results shown
- [ ] Bulk bar → "Decommission selected" → "Confirm decommission" → verify one DELETE per steward, per-item results shown including any failures
- [ ] Verify back button returns to menu in all new sub-panels
- [ ] Verify Escape closes the whole popover from sub-panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)