### PR TITLE
web: IP-trust add/revoke behind step-up (Issue #2971)

### DIFF
--- a/web/src/registration/IPTrustTab.test.tsx
+++ b/web/src/registration/IPTrustTab.test.tsx
@@ -2,12 +2,21 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * IPTrustTab test suite (Story #2936): data states (loading, empty, error,
- * populated), badge rendering, revoked entry display, retry flow, and
- * security checks (text-node-only rendering, no add/revoke controls).
+ * IPTrustTab test suite (Story #2936, #2971): data states (loading, empty, error,
+ * populated), badge rendering, revoked entry display, retry flow, add/revoke
+ * affordance and step-up wiring, and security checks (text-node-only rendering).
  *
  * The component fetches GET /api/v1/registration/ip-trust which uses the
  * {data: [...]} envelope shape.
+ *
+ * Add calls POST /api/v1/registration/ip-trust and revoke calls
+ * DELETE /api/v1/registration/ip-trust/{tenant_id}/{cidr}.  Both require
+ * AssuranceStrong; the step-up challenge is handled transparently by apiFetch
+ * → AuthProvider → StepUpModal (#2967). Tests verify:
+ *  - The form and revoke button render.
+ *  - A direct 204 (already-elevated session) succeeds and refreshes the list.
+ *  - A 401 + CFGMS-StepUp causes the StepUpModal to appear (step-up gate).
+ *  - A non-OK response surfaces an inline error.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -30,6 +39,7 @@ afterEach(() => {
 function makeEntry(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     cidr: '10.2.4.0/24',
+    tenant_id: 'test-tenant',
     pre_seeded: false,
     trusted_since: '2026-01-04T00:00:00Z',
     last_activity: '2026-07-30T00:00:00Z',
@@ -43,6 +53,20 @@ function makeListResponse(entries: object[], status = 200) {
     JSON.stringify({ data: entries }),
     { status, headers: { 'Content-Type': 'application/json' } },
   )
+}
+
+function make204() {
+  return new Response(null, { status: 204 })
+}
+
+function makeStepUpChallenge() {
+  return new Response(JSON.stringify({}), {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': 'CFGMS-StepUp realm="cfgms", required="strong"',
+      'Content-Type': 'application/json',
+    },
+  })
 }
 
 function renderTab() {
@@ -180,29 +204,198 @@ describe('IPTrustTab — security (A9.1)', () => {
   })
 })
 
-describe('IPTrustTab — no add/revoke affordance', () => {
-  it('renders no add button in any state', async () => {
-    fetchMock.mockResolvedValue(makeListResponse([makeEntry()]))
+// ── Add affordance ────────────────────────────────────────────────────────────
+
+describe('IPTrustTab — add form', () => {
+  it('renders the add form with a CIDR input and Add button', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
     renderTab()
-    await waitFor(() => expect(screen.getByTestId('iptrust-table')).toBeInTheDocument())
-    expect(screen.queryByRole('button', { name: /add/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId('iptrust-add-form')).toBeInTheDocument()
+    expect(screen.getByTestId('iptrust-cidr-input')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeInTheDocument()
   })
 
-  it('renders no revoke button even for active entries', async () => {
-    fetchMock.mockResolvedValue(makeListResponse([makeEntry({ revoked: false })]))
-    renderTab()
-    await waitFor(() => expect(screen.getByTestId('iptrust-table')).toBeInTheDocument())
-    expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument()
-  })
-
-  it('renders no add or revoke button in the empty state', async () => {
+  it('shows the add form even in the empty-list state', async () => {
     fetchMock.mockResolvedValue(makeListResponse([]))
     renderTab()
     await waitFor(() => expect(screen.getByTestId('iptrust-empty')).toBeInTheDocument())
-    expect(screen.queryByRole('button', { name: /add/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId('iptrust-add-form')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeInTheDocument()
+  })
+
+  it('shows an inline error when Add is submitted with an empty CIDR', async () => {
+    fetchMock.mockResolvedValue(makeListResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('iptrust-empty')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    expect(screen.getByTestId('iptrust-add-error')).toBeInTheDocument()
+    expect(screen.getByTestId('iptrust-add-error')).toHaveTextContent(/cidr is required/i)
+    // No fetch call for the mutation.
+    expect(fetchMock).toHaveBeenCalledTimes(1) // only the initial list fetch
+  })
+
+  it('[REQUIRED] Add calls POST and refreshes list on 204', async () => {
+    // First call: initial list (empty). Second: POST add. Third: refreshed list.
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([]))
+      .mockResolvedValueOnce(make204())
+      .mockResolvedValueOnce(makeListResponse([makeEntry({ cidr: '10.0.0.0/8' })]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('iptrust-empty')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('iptrust-cidr-input'), { target: { value: '10.0.0.0/8' } })
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() => expect(screen.getByTestId('iptrust-table')).toBeInTheDocument())
+
+    const postCall = fetchMock.mock.calls.find((c) => {
+      const init = c[1] as RequestInit | undefined
+      return init?.method === 'POST'
+    })
+    expect(postCall).toBeDefined()
+    expect(postCall?.[0]).toBe('/api/v1/registration/ip-trust')
+    const body = JSON.parse((postCall?.[1] as RequestInit)?.body as string) as Record<string, unknown>
+    expect(body.cidr).toBe('10.0.0.0/8')
+    expect(screen.getByText('10.0.0.0/8')).toBeInTheDocument()
+  })
+
+  it('includes pre_seeded: true in the POST body when checkbox is checked', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([]))
+      .mockResolvedValueOnce(make204())
+      .mockResolvedValueOnce(makeListResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('iptrust-empty')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('iptrust-cidr-input'), { target: { value: '10.0.0.0/8' } })
+    fireEvent.click(screen.getByTestId('iptrust-preseeded-checkbox'))
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    const postCall = fetchMock.mock.calls.find((c) => {
+      const init = c[1] as RequestInit | undefined
+      return init?.method === 'POST'
+    })
+    const body = JSON.parse((postCall?.[1] as RequestInit)?.body as string) as Record<string, unknown>
+    expect(body.pre_seeded).toBe(true)
+  })
+
+  it('shows an inline error on a non-OK add response', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([]))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('iptrust-empty')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('iptrust-cidr-input'), { target: { value: '10.0.0.0/8' } })
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() => expect(screen.getByTestId('iptrust-add-error')).toBeInTheDocument())
+    expect(screen.getByTestId('iptrust-add-error')).toHaveTextContent(/add failed.*500/i)
+  })
+
+  it('[REQUIRED] Add triggers step-up modal on 401 + CFGMS-StepUp', async () => {
+    // List succeeds; add returns a step-up challenge.
+    fetchMock
+      .mockResolvedValueOnce(makeListResponse([]))
+      .mockResolvedValueOnce(makeStepUpChallenge())
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('iptrust-empty')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('iptrust-cidr-input'), { target: { value: '10.0.0.0/8' } })
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    // AuthProvider should show the step-up modal.
+    await waitFor(() => expect(screen.getByTestId('step-up-overlay')).toBeInTheDocument())
   })
 })
+
+// ── Revoke affordance ─────────────────────────────────────────────────────────
+
+describe('IPTrustTab — revoke', () => {
+  it('[REQUIRED] renders a Revoke button for each active (non-revoked) entry', async () => {
+    fetchMock.mockResolvedValue(
+      makeListResponse([makeEntry({ cidr: '10.0.0.0/8', revoked: false })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('iptrust-table')).toBeInTheDocument())
+    expect(screen.getByTestId('revoke-btn-10.0.0.0/8')).toBeInTheDocument()
+  })
+
+  it('renders no Revoke button for already-revoked entries', async () => {
+    fetchMock.mockResolvedValue(
+      makeListResponse([makeEntry({ cidr: '10.0.0.0/8', revoked: true })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('iptrust-table')).toBeInTheDocument())
+    expect(screen.queryByTestId('revoke-btn-10.0.0.0/8')).not.toBeInTheDocument()
+  })
+
+  it('[REQUIRED] Revoke calls DELETE and refreshes list on 204', async () => {
+    // Initial list: one active entry. DELETE: 204. Refreshed list: entry revoked.
+    fetchMock
+      .mockResolvedValueOnce(
+        makeListResponse([makeEntry({ cidr: '10.0.0.0/8', tenant_id: 'test-tenant' })]),
+      )
+      .mockResolvedValueOnce(make204())
+      .mockResolvedValueOnce(
+        makeListResponse([makeEntry({ cidr: '10.0.0.0/8', tenant_id: 'test-tenant', revoked: true })]),
+      )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('revoke-btn-10.0.0.0/8')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('revoke-btn-10.0.0.0/8'))
+
+    await waitFor(() => expect(screen.getByTestId('badge-revoked')).toBeInTheDocument())
+
+    const deleteCall = fetchMock.mock.calls.find((c) => {
+      const init = c[1] as RequestInit | undefined
+      return init?.method === 'DELETE'
+    })
+    expect(deleteCall).toBeDefined()
+    // CIDR '10.0.0.0/8' must be encoded so the slash survives as a URL segment.
+    expect(deleteCall?.[0]).toBe(
+      '/api/v1/registration/ip-trust/test-tenant/10.0.0.0%2F8',
+    )
+  })
+
+  it('shows a per-row error on a non-OK revoke response', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeListResponse([makeEntry({ cidr: '10.0.0.0/8' })]),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('revoke-btn-10.0.0.0/8')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('revoke-btn-10.0.0.0/8'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('revoke-error-10.0.0.0/8')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('revoke-error-10.0.0.0/8')).toHaveTextContent(
+      /revoke failed.*403/i,
+    )
+  })
+
+  it('[REQUIRED] Revoke triggers step-up modal on 401 + CFGMS-StepUp', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeListResponse([makeEntry({ cidr: '10.0.0.0/8' })]),
+      )
+      .mockResolvedValueOnce(makeStepUpChallenge())
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('revoke-btn-10.0.0.0/8')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('revoke-btn-10.0.0.0/8'))
+
+    await waitFor(() => expect(screen.getByTestId('step-up-overlay')).toBeInTheDocument())
+  })
+})
+
+// ── parseIPTrustList unit tests ───────────────────────────────────────────────
 
 describe('parseIPTrustList', () => {
   it('throws on non-array input', () => {
@@ -229,10 +422,16 @@ describe('parseIPTrustList', () => {
     expect(result[0]?.revoked).toBe(false)
   })
 
+  it('coerces missing tenant_id to empty string', () => {
+    const result = parseIPTrustList([{ cidr: '10.0.0.0/8' }])
+    expect(result[0]?.tenantId).toBe('')
+  })
+
   it('maps wire fields to camelCase interface fields', () => {
     const result = parseIPTrustList([
       {
         cidr: '192.168.1.0/24',
+        tenant_id: 'acme',
         pre_seeded: true,
         trusted_since: '2026-01-01T00:00:00Z',
         last_activity: '2026-07-01T00:00:00Z',
@@ -242,6 +441,7 @@ describe('parseIPTrustList', () => {
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({
       cidr: '192.168.1.0/24',
+      tenantId: 'acme',
       preSeeded: true,
       trustedSince: '2026-01-01T00:00:00Z',
       lastActivity: '2026-07-01T00:00:00Z',

--- a/web/src/registration/IPTrustTab.tsx
+++ b/web/src/registration/IPTrustTab.tsx
@@ -2,24 +2,28 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * IP-Trust tab (Story #2936) — read-only list of trusted CIDR ranges for the
- * caller's tenant scope, mounted as a panel on the RegistrationConsolePage tab
- * strip (Story #2934).
+ * IP-Trust tab (Story #2936, #2971) — trusted CIDR ranges for the caller's tenant
+ * scope, mounted as a panel on the RegistrationConsolePage tab strip (Story #2934).
  *
  * Fetches GET /api/v1/registration/ip-trust, which uses the newer {data: [...]}
  * array-envelope shape (distinct from the bare-array the Pending tab uses).
  *
  * Renders: cidr, pre_seeded, trusted_since, last_activity, revoked.
- * No add/revoke affordance exists — those are Section 2's follow-on epic.
+ * Add: POST /api/v1/registration/ip-trust — requires AssuranceStrong (CFGMS-StepUp S1).
+ * Revoke: DELETE /api/v1/registration/ip-trust/{tenant_id}/{cidr} — same gate.
+ * Step-up is handled transparently by apiFetch → AuthProvider → StepUpModal (#2967).
+ * Per-action audit is emitted by the backend (registration:manage-ip-trust).
  *
  * Security: all API-supplied values render as JSX text nodes only (A9.1).
  */
-import { useCallback, useEffect, useState } from 'react'
+import { Fragment, useCallback, useEffect, useState } from 'react'
 import { apiFetch } from '../api/client.ts'
+import { useAuth } from '../auth/AuthContext.tsx'
 import ErrorCard from '../shell/ErrorCard.tsx'
 
 export interface IPTrustEntry {
   cidr: string
+  tenantId: string
   preSeeded: boolean
   trustedSince: string
   lastActivity: string
@@ -39,6 +43,7 @@ export function parseIPTrustList(data: unknown): IPTrustEntry[] {
     if (cidr === '') continue
     entries.push({
       cidr,
+      tenantId: typeof r.tenant_id === 'string' ? r.tenant_id : '',
       preSeeded: r.pre_seeded === true,
       trustedSince: typeof r.trusted_since === 'string' ? r.trusted_since : '',
       lastActivity: typeof r.last_activity === 'string' ? r.last_activity : '',
@@ -98,39 +103,88 @@ function SourceBadge({ preSeeded }: { preSeeded: boolean }) {
   )
 }
 
-function EntryRow({ entry }: { entry: IPTrustEntry }) {
+function EntryRow({
+  entry,
+  onRevoke,
+  revoking,
+  revokeError,
+}: {
+  entry: IPTrustEntry
+  onRevoke: (entry: IPTrustEntry) => void
+  revoking: boolean
+  revokeError: string | null
+}) {
   return (
-    <tr data-testid="iptrust-row">
-      <td>
-        <span className="mono2">{entry.cidr}</span>
-      </td>
-      <td>
-        <SourceBadge preSeeded={entry.preSeeded} />
-      </td>
-      <td>
-        <span className="mono2">{entry.trustedSince}</span>
-      </td>
-      <td>
-        <span className="mono2">{entry.lastActivity}</span>
-      </td>
-      <td>
-        {entry.revoked && (
-          <span className="badge b-crit" data-testid="badge-revoked">
-            <span className="dot" aria-hidden="true" />
-            Revoked
-          </span>
-        )}
-      </td>
-    </tr>
+    <Fragment>
+      <tr data-testid="iptrust-row">
+        <td>
+          <span className="mono2">{entry.cidr}</span>
+        </td>
+        <td>
+          <SourceBadge preSeeded={entry.preSeeded} />
+        </td>
+        <td>
+          <span className="mono2">{entry.trustedSince}</span>
+        </td>
+        <td>
+          <span className="mono2">{entry.lastActivity}</span>
+        </td>
+        <td>
+          {entry.revoked && (
+            <span className="badge b-crit" data-testid="badge-revoked">
+              <span className="dot" aria-hidden="true" />
+              Revoked
+            </span>
+          )}
+        </td>
+        <td>
+          {!entry.revoked && (
+            <button
+              type="button"
+              className="wf-btn-sm-danger"
+              data-testid={`revoke-btn-${entry.cidr}`}
+              disabled={revoking}
+              onClick={() => onRevoke(entry)}
+            >
+              {revoking ? 'Revoking…' : 'Revoke'}
+            </button>
+          )}
+        </td>
+      </tr>
+      {revokeError !== null && (
+        <tr>
+          <td colSpan={6}>
+            <span
+              className="wf-form-error"
+              data-testid={`revoke-error-${entry.cidr}`}
+              role="alert"
+            >
+              {revokeError}
+            </span>
+          </td>
+        </tr>
+      )}
+    </Fragment>
   )
 }
 
 const ENDPOINT = '/api/v1/registration/ip-trust'
 
 export default function IPTrustTab() {
+  const { principal } = useAuth()
   const [attempt, setAttempt] = useState(0)
   const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
   const key = `iptrust:${attempt}`
+
+  // Add form state
+  const [cidrInput, setCidrInput] = useState('')
+  const [preSeeded, setPreSeeded] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
+  const [addPending, setAddPending] = useState(false)
+
+  // Per-row revoke state
+  const [revokeErrors, setRevokeErrors] = useState<Map<string, string>>(new Map())
+  const [revokingSet, setRevokingSet] = useState<Set<string>>(new Set())
 
   const retry = useCallback(() => setAttempt((n) => n + 1), [])
 
@@ -162,6 +216,74 @@ export default function IPTrustTab() {
     }
   }, [key, attempt])
 
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    const cidr = cidrInput.trim()
+    if (cidr === '') {
+      setAddError('CIDR is required')
+      return
+    }
+    setAddError(null)
+    setAddPending(true)
+    try {
+      const response = await apiFetch(ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tenant_id: principal?.tenantId ?? '',
+          cidr,
+          pre_seeded: preSeeded,
+        }),
+      })
+      if (!response.ok) {
+        setAddError(`Add failed — ${response.status}`)
+        return
+      }
+      setCidrInput('')
+      setPreSeeded(false)
+      setAttempt((n) => n + 1)
+    } catch (cause: unknown) {
+      setAddError(
+        cause instanceof Error && cause.message ? cause.message : 'Add request failed',
+      )
+    } finally {
+      setAddPending(false)
+    }
+  }
+
+  async function handleRevoke(entry: IPTrustEntry) {
+    const { cidr, tenantId } = entry
+    setRevokeErrors((prev) => {
+      const m = new Map(prev)
+      m.delete(cidr)
+      return m
+    })
+    setRevokingSet((prev) => new Set([...prev, cidr]))
+    try {
+      const url =
+        `${ENDPOINT}/${encodeURIComponent(tenantId)}/${encodeURIComponent(cidr)}`
+      const response = await apiFetch(url, { method: 'DELETE' })
+      if (!response.ok) {
+        setRevokeErrors((prev) => new Map(prev).set(cidr, `Revoke failed — ${response.status}`))
+        return
+      }
+      setAttempt((n) => n + 1)
+    } catch (cause: unknown) {
+      setRevokeErrors((prev) =>
+        new Map(prev).set(
+          cidr,
+          cause instanceof Error && cause.message ? cause.message : 'Revoke request failed',
+        ),
+      )
+    } finally {
+      setRevokingSet((prev) => {
+        const s = new Set(prev)
+        s.delete(cidr)
+        return s
+      })
+    }
+  }
+
   const current = outcome?.key === key ? outcome : null
   const loading = current === null
   const error = current?.error ?? null
@@ -169,6 +291,50 @@ export default function IPTrustTab() {
 
   return (
     <section className="panel">
+      <form
+        className="iptrust-add-form"
+        data-testid="iptrust-add-form"
+        onSubmit={(e) => void handleAdd(e)}
+      >
+        <input
+          type="text"
+          className="wf-input"
+          data-testid="iptrust-cidr-input"
+          placeholder="10.0.0.0/8"
+          aria-label="CIDR range"
+          value={cidrInput}
+          onChange={(e) => setCidrInput(e.target.value)}
+          disabled={addPending}
+        />
+        <label className="iptrust-preseeded-label">
+          <input
+            type="checkbox"
+            data-testid="iptrust-preseeded-checkbox"
+            checked={preSeeded}
+            onChange={(e) => setPreSeeded(e.target.checked)}
+            disabled={addPending}
+          />
+          {' '}Pre-seeded
+        </label>
+        <button
+          type="submit"
+          className="btn"
+          data-testid="iptrust-add-btn"
+          disabled={addPending}
+        >
+          {addPending ? 'Adding…' : 'Add'}
+        </button>
+        {addError !== null && (
+          <span
+            className="wf-form-error"
+            data-testid="iptrust-add-error"
+            role="alert"
+          >
+            {addError}
+          </span>
+        )}
+      </form>
+
       {loading ? (
         <LoadingRows />
       ) : error !== null ? (
@@ -184,11 +350,18 @@ export default function IPTrustTab() {
               <th>Trusted since</th>
               <th>Last activity</th>
               <th>Status</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             {entries.map((entry) => (
-              <EntryRow key={entry.cidr} entry={entry} />
+              <EntryRow
+                key={entry.cidr}
+                entry={entry}
+                onRevoke={(e) => void handleRevoke(e)}
+                revoking={revokingSet.has(entry.cidr)}
+                revokeError={revokeErrors.get(entry.cidr) ?? null}
+              />
             ))}
           </tbody>
         </table>

--- a/web/src/registration/RegistrationConsolePage.test.tsx
+++ b/web/src/registration/RegistrationConsolePage.test.tsx
@@ -125,12 +125,14 @@ describe('RegistrationConsolePage — panel rendering', () => {
     expect(screen.queryByTestId('pending-loading')).toBeNull()
   })
 
-  it('renders the soon placeholder for IP Trust', () => {
+  it('mounts the real IPTrustTab on the IP Trust tab, not a soon placeholder', async () => {
     renderPage()
 
     fireEvent.click(tab(/^IP Trust/i))
 
-    expect(screen.getByText(/IP Trust is not yet available/i)).toBeInTheDocument()
+    expect(tab(/^IP Trust/i)).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('iptrust-loading')).toBeInTheDocument()
+    expect(screen.queryByText(/IP Trust is not yet available/i)).toBeNull()
   })
 
   it('restores the Pending panel after visiting the Tokens tab', () => {
@@ -176,14 +178,14 @@ describe('RegistrationConsolePage — keyboard navigation', () => {
     expect(screen.getByTestId('pending-loading')).toBeInTheDocument()
   })
 
-  it('ArrowLeft wraps from Pending to IP Trust', () => {
+  it('ArrowLeft wraps from Pending to IP Trust', async () => {
     renderPage()
     const tablist = screen.getByRole('tablist')
 
     fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
 
     expect(tab(/^IP Trust/i)).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByText(/IP Trust is not yet available/i)).toBeInTheDocument()
+    expect(screen.getByTestId('iptrust-loading')).toBeInTheDocument()
   })
 
   it('ArrowLeft steps backwards one tab at a time', () => {
@@ -246,13 +248,13 @@ describe('RegistrationConsolePage — keyboard navigation', () => {
 // ── Tab specification ─────────────────────────────────────────────────────────
 
 describe('TABS', () => {
-  it('declares Pending and Tokens with real panels; IP Trust as soon', () => {
+  it('declares Pending, Tokens, and IP Trust with real panels', () => {
     expect(TABS.map((t) => t.key)).toEqual(['pending', 'tokens', 'ip-trust'])
     expect(TABS[0]?.soon).toBe(false)
     expect(TABS[0]?.Panel).toBeDefined()
     expect(TABS[1]?.soon).toBe(false)
     expect(TABS[1]?.Panel).toBeDefined()
-    expect(TABS[2]?.soon).toBe(true)
-    expect(TABS[2]?.Panel).toBeUndefined()
+    expect(TABS[2]?.soon).toBe(false)
+    expect(TABS[2]?.Panel).toBeDefined()
   })
 })

--- a/web/src/registration/RegistrationConsolePage.tsx
+++ b/web/src/registration/RegistrationConsolePage.tsx
@@ -2,20 +2,18 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Registration console tab shell (Story #2934, #2935).
+ * Registration console tab shell (Story #2934, #2935, #2971).
  * Renders the /registration route with a tab strip:
  *   Pending  — list + deny (Story #2934)
  *   Tokens   — read-only token lifecycle view (Story #2935)
- *   IP Trust — Story #2936 (soon placeholder)
+ *   IP Trust — add/revoke behind step-up (Story #2936 layout, #2971 actions)
  *
  * Tab pattern mirrors StewardAssetPage.tsx exactly: role="tablist", roving
  * tabindex, ArrowLeft/Right keyboard navigation, implicit aria-labelledby
  * association so inactive panels can be lazily rendered.
- *
- * No approve, approve-all, approve-by-CIDR, mint, rotate, revoke, or delete
- * control is present — those are Section 2's follow-on epic.
  */
 import { type ComponentType, useRef, useState } from 'react'
+import IPTrustTab from './IPTrustTab.tsx'
 import PendingQueueTab from './PendingQueueTab.tsx'
 import TokensTab from './TokensTab.tsx'
 
@@ -45,7 +43,7 @@ function PanelContent({ spec }: { spec: TabSpec }) {
 export const TABS: readonly TabSpec[] = [
   { key: 'pending', label: 'Pending', soon: false, Panel: PendingQueueTab },
   { key: 'tokens', label: 'Tokens', soon: false, Panel: TokensTab },
-  { key: 'ip-trust', label: 'IP Trust', soon: true },
+  { key: 'ip-trust', label: 'IP Trust', soon: false, Panel: IPTrustTab },
 ]
 
 export default function RegistrationConsolePage() {


### PR DESCRIPTION
## Summary

- Wires add/revoke on the IP-Trust tab behind the S1 step-up gate (AssuranceStrong / CFGMS-StepUp) established in #2967
- Add form: CIDR input + pre_seeded checkbox → POST /api/v1/registration/ip-trust
- Per-row Revoke button: DELETE /api/v1/registration/ip-trust/{tenant_id}/{cidr} (CIDR is encodeURIComponent-encoded so the slash survives)
- Both mutations go through `apiFetch`, which transparently triggers StepUpModal on 401+CFGMS-StepUp, then retries — no step-up plumbing needed in the tab itself
- IP-Trust tab promoted from `soon:true` placeholder to a real panel in RegistrationConsolePage

## Acceptance criteria

- [x] add/revoke behind step-up; per-action audit (audit emitted server-side by existing `emitIPTrustAudit` on every mutation)

## Specialist review results

| Lens | Verdict | Notes |
|------|---------|-------|
| QA code review | **PASS** | No blocking issues; two warnings (stale comment, missing pre_seeded test) addressed before commit |
| Security | **PASS** | No XSS sinks, CSRF covered by apiFetch, step-up enforced server-side, scans clean |
| Test runner | **PASS** | 1013 frontend tests, 215+ Go tests, 5-platform builds all green |

## Test plan

- [ ] IP-Trust tab renders add form in all states (loading, empty, populated)
- [ ] Clicking Add on a Basic-assurance session triggers the step-up modal
- [ ] After step-up success, the add request retries automatically and the list refreshes
- [ ] Revoke button appears only for non-revoked entries
- [ ] Clicking Revoke triggers step-up modal; on success entry shows as Revoked
- [ ] Non-OK responses show inline errors per form / per row

Fixes #2971

🤖 Generated with [Claude Code](https://claude.com/claude-code)