### PR TITLE
web/registration: approve / approve-all / approve-by-CIDR with step-up + dry-run preview (Issue #2969)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -845,12 +845,17 @@ cfg registration ip-trust revoke 10.0.0.0/8 --tenant-id acme-corp
 | `cfg registration pending` | `GET /api/v1/registration/pending` | Lists all quarantined stewards with SOURCE_IP and RDNS |
 | `cfg registration approve <id>` | `POST /api/v1/registration/{id}/approve` | Promotes steward status to `registered` |
 | `cfg registration deny <id>` | `POST /api/v1/registration/{id}/deny` | Removes steward from pending queue |
-| `cfg registration approve-all` | `POST /api/v1/registration/approve-all` | Approves all pending registrations; prints count approved |
-| `cfg registration approve-by-cidr <cidr>` | `POST /api/v1/registration/approve-by-cidr` | Approves pending entries whose source IP falls in the CIDR |
+| `cfg registration approve-all` | `POST /api/v1/registration/approve-all` | Approves all pending registrations in the caller's tenant scope; prints count approved |
+| _(web registration console only)_ | `GET /api/v1/registration/approve-by-cidr/preview?cidr=<cidr>` | Read-only dry run: returns the count, pending IDs, and source IPs that `approve-by-cidr` would approve. Mutates nothing |
+| `cfg registration approve-by-cidr <cidr>` | `POST /api/v1/registration/approve-by-cidr` | Approves pending entries in the caller's tenant scope whose source IP falls in the CIDR. Requires a user-presence step-up (below) |
 | `cfg registration ip-trust add <cidr>` | `POST /api/v1/registration/ip-trust` | Adds a pre-seeded trusted CIDR for `--tenant-id` |
 | `cfg registration ip-trust revoke <cidr>` | `DELETE /api/v1/registration/ip-trust/{tenant_id}/{cidr}` | Revokes a trusted CIDR for `--tenant-id` |
 
-Required API key permissions: `registration:list-pending`, `registration:approve`, `registration:deny` for individual and bulk approval operations; `registration:manage-ip-trust` for ip-trust subcommands.
+Required API key permissions: `registration:list-pending` for `pending` and for the approve-by-CIDR preview; `registration:approve` for individual approval and `approve-all`; `registration:approve-by-cidr` for `approve-by-cidr`; `registration:deny` for denial; `registration:manage-ip-trust` for ip-trust subcommands.
+
+**Tenant scoping of bulk approval.** `approve-all` and `approve-by-cidr` — and the preview — resolve their target set through `ListPending(ctx, callerTenantID)`, so a caller whose principal carries a tenant (API key or non-root web account) can only approve pending entries belonging to that tenant. A caller with no tenant on its principal (mTLS admin bundle, root-scoped web account) retains fleet-wide reach. Entries outside the caller's scope are never listed, previewed, or mutated.
+
+**Presence step-up on `approve-by-cidr`.** `registration:approve-by-cidr` carries `RequireUserPresence: true` (ADR-021 Decision 4): `AssuranceStrong` alone is not enough, and the request must also carry a fresh, single-use `X-Presence-Token` obtained from `POST /api/v1/webauthn/presence/begin` → `/finish`. Without one the call returns `401` with `WWW-Authenticate: CFGMS-StepUp realm="cfgms", required="strong", presence="required"`. Rationale: one call admits every pending steward in an IP range, and RFC1918 ranges collide across tenants, so the match set is a trust-boundary decision. The preview endpoint is deliberately *not* presence-gated — an operator inspects the exact match set first, then spends one gesture on the mutation. The web console blocks the mutating call until the preview has been shown and confirmed.
 
 The `pending` output includes a `SOURCE_IP` column showing the steward's source IP at registration time, and an `RDNS` column populated by a best-effort reverse DNS lookup at display time (shows `-` on failure or timeout).
 

--- a/docs/architecture/decisions/021-identity-assurance-levels.md
+++ b/docs/architecture/decisions/021-identity-assurance-levels.md
@@ -263,6 +263,11 @@ human every single time:
 - `module:approve` / `module:reject` — an approved bundle is code that executes on
   every managed endpoint. This is the largest blast radius in the system (ADR-006).
 - `publisher-trust:add` — grants an entire publisher standing authority.
+- `registration:approve-by-cidr` — one call admits every pending steward whose source
+  IP falls in a range, and RFC1918 ranges collide across tenants, so the match set is
+  a trust-boundary decision rather than a convenience filter. The read-only preview
+  (`GET /registration/approve-by-cidr/preview`) is *not* presence-gated, so the
+  gesture is spent once, on a match set the operator has already inspected.
 
 Everything else in `permissionAssurance` is gated on level alone. **Growing this
 set is a founder decision, not a reviewer's judgement call** — every addition
@@ -682,7 +687,7 @@ amendment specifies that ceremony and its threat model.
 - **Orthogonal to presence tokens (Decision 4 / #2784).** Elevation raises the *session's
   assurance level*; it does **not** substitute for the per-action human-presence gesture that
   the `RequireUserPresence` catastrophic actions demand. An elevated Strong session still mints
-  a presence token for those two permissions. Elevation and presence are distinct layers.
+  a presence token for each of those permissions. Elevation and presence are distinct layers.
 - **Composes with Amendment 1.** A freshly self-enrolled passkey is immediately usable as the
   assertion credential here — that is how a no-MFA account completes password → self-enroll →
   assert → Strong in a single browser sitting, with no cert.

--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -313,7 +313,8 @@ Routes that require elevated assurance are declared in `permissionAssurance` (`f
 | `registration:delete-token` | `DELETE /api/v1/registration/tokens/{token}` |
 | `registration:revoke-token` | `POST /api/v1/registration/tokens/{token}/revoke` |
 | `registration:rotate-token` | `POST /api/v1/registration/tokens/{tenant_id}/rotate` |
-| `registration:approve` | `POST /api/v1/registration/{id}/approve`, `/approve-all`, `/approve-by-cidr` |
+| `registration:approve` | `POST /api/v1/registration/{id}/approve`, `/approve-all` |
+| `registration:approve-by-cidr` | `POST /api/v1/registration/approve-by-cidr` — **also requires user presence** (see below) |
 | `registration:manage-ip-trust` | `POST /api/v1/registration/ip-trust`, `DELETE /api/v1/registration/ip-trust/{tenant}/{cidr}` |
 | `tenant:create` | `POST /api/v1/tenants` |
 | `refresh:approve` | `POST /api/v1/stewards/refresh/{pending_id}/approve` |
@@ -328,6 +329,15 @@ Routes that require elevated assurance are declared in `permissionAssurance` (`f
 | `module:approve`, `module:reject`, `publisher-trust:add` | _(forward-declared; routes not yet wired)_ |
 
 The canonical source of truth is `permissionAssurance` in `features/controller/api/assurance.go`. The `TestF2_AssuranceGate_ParityWithPermissionRegistry` test asserts at test time that the wired route set and the registry match — any drift is a test failure.
+
+**Presence-gated subset** (`RequireUserPresence: true`, ADR-021 Decision 4): `AssuranceStrong` alone is not sufficient. `requirePermission` additionally requires an `X-Presence-Token` header — a fresh, single-use token minted by `POST /api/v1/webauthn/presence/finish` after a WebAuthn assertion with `userVerification: "required"`. Requests without one receive `401` with `WWW-Authenticate: CFGMS-StepUp realm="cfgms", required="strong", presence="required"`.
+
+| Permission | Endpoint | Why presence |
+|------------|----------|--------------|
+| `module:approve`, `module:reject`, `publisher-trust:add` | _(forward-declared; routes not yet wired)_ | An approved bundle or trusted publisher is code that executes on every managed endpoint |
+| `registration:approve-by-cidr` | `POST /api/v1/registration/approve-by-cidr` | A single call admits every pending steward in an IP range; RFC1918 ranges collide across tenants, so the match set is a trust-boundary decision, not a convenience filter |
+
+The read-only dry run for the CIDR match set — `GET /api/v1/registration/approve-by-cidr/preview` — is *not* in this set. It mutates nothing and is gated on `registration:list-pending` (Machine assurance), so an operator can inspect exactly which entries a call would approve before spending a presence gesture on the mutation.
 
 **Rationale:** Endpoints in this set can issue credentials, modify trust anchors, or alter the authorization model itself. Restricting them to `AssuranceStrong` provides a hardware-backed authentication guarantee that cannot be replicated by a compromised or stolen API key or web session. Operators who need these capabilities must authenticate with an admin credential bundle (mTLS client certificate).
 

--- a/features/controller/api/assurance.go
+++ b/features/controller/api/assurance.go
@@ -38,7 +38,7 @@ var permissionAssurance = map[string]Requirement{
 	"registration:delete-token":    {Min: session.AssuranceStrong}, // DELETE /registration/tokens/{token}
 	"registration:revoke-token":    {Min: session.AssuranceStrong}, // POST /registration/tokens/{token}/revoke
 	"registration:rotate-token":    {Min: session.AssuranceStrong}, // POST /registration/tokens/{tenant_id}/rotate
-	"registration:approve":         {Min: session.AssuranceStrong}, // POST /registration/{id}/approve + approve-all + approve-by-cidr
+	"registration:approve":         {Min: session.AssuranceStrong}, // POST /registration/{id}/approve + approve-all
 	"registration:manage-ip-trust": {Min: session.AssuranceStrong}, // POST + DELETE /registration/ip-trust
 	"tenant:create":                {Min: session.AssuranceStrong}, // POST /tenants
 	"refresh:approve":              {Min: session.AssuranceStrong}, // POST /stewards/refresh/{pending_id}/approve
@@ -77,15 +77,21 @@ var permissionAssurance = map[string]Requirement{
 	// (API keys) cannot call this endpoint — they hold no web session to elevate.
 	"webauthn:elevate": {Min: session.AssuranceBasic}, // POST /webauthn/elevate/begin|finish
 
-	// Catastrophic permissions (no live REST routes yet — issue #2728/#2732 adds the routes).
-	// RequireUserPresence: true is ENFORCED as of Issue #2784: requirePermission now validates
-	// the X-Presence-Token header (minted by POST /api/v1/webauthn/presence/finish) and rejects
-	// requests without a valid, fresh, single-use token with:
+	// Catastrophic permissions: RequireUserPresence: true is ENFORCED as of Issue #2784.
+	// requirePermission validates the X-Presence-Token header (minted by
+	// POST /api/v1/webauthn/presence/finish) and rejects requests without a valid,
+	// fresh, single-use token with:
 	//   401 WWW-Authenticate: CFGMS-StepUp realm="cfgms", required="strong", presence="required"
-	// Implementers of #2728 (module:approve/reject routes) and any future publisher-trust:add
-	// routes must document to their clients that a presence ceremony is required before each call.
 	// The presence mechanism: POST /webauthn/presence/begin → finish → attach X-Presence-Token.
+
+	// Module bundle approval (Issue #2728/#2732) — code that runs on every managed endpoint.
 	"module:approve":      {Min: session.AssuranceStrong, RequireUserPresence: true},
 	"module:reject":       {Min: session.AssuranceStrong, RequireUserPresence: true},
 	"publisher-trust:add": {Min: session.AssuranceStrong, RequireUserPresence: true},
+
+	// Bulk CIDR registration approval (Issue #2969): RFC1918 ranges collide across tenants,
+	// making this a trust-boundary decision that must not be a convenience gate.
+	// Approve-by-CIDR requires AssuranceStrong + a fresh user-presence proof.
+	// (Single-entry approve and approve-all use registration:approve — AssuranceStrong only.)
+	"registration:approve-by-cidr": {Min: session.AssuranceStrong, RequireUserPresence: true},
 }

--- a/features/controller/api/assurance_test.go
+++ b/features/controller/api/assurance_test.go
@@ -87,10 +87,15 @@ func TestPermissionAssurance_SessionListRevoke_Absent(t *testing.T) {
 	}
 }
 
-// TestPermissionAssurance_CatastrophicForwardDeclarations verifies that the three
-// forward-declared catastrophic permissions carry RequireUserPresence: true.
+// TestPermissionAssurance_CatastrophicForwardDeclarations verifies that all
+// catastrophic permissions carry RequireUserPresence: true (Issue #2784, #2969).
 func TestPermissionAssurance_CatastrophicForwardDeclarations(t *testing.T) {
-	catastrophic := []string{"module:approve", "module:reject", "publisher-trust:add"}
+	catastrophic := []string{
+		"module:approve",
+		"module:reject",
+		"publisher-trust:add",
+		"registration:approve-by-cidr", // Issue #2969: bulk CIDR approval
+	}
 	for _, perm := range catastrophic {
 		req, found := permissionAssurance[perm]
 		require.True(t, found, "catastrophic permission %q must be in permissionAssurance", perm)
@@ -99,10 +104,31 @@ func TestPermissionAssurance_CatastrophicForwardDeclarations(t *testing.T) {
 	}
 }
 
+// TestPermissionAssurance_ApproveByCIDRIsGrantable verifies that
+// registration:approve-by-cidr is in the knownPermissions allow-list (Issue #2969).
+// Splitting approve-by-cidr out of registration:approve is only usable if the new
+// permission can actually be granted: handleCreateWebAccount and handleCreateAPIKey
+// reject any permission ID absent from that list with 400 INVALID_PERMISSION, which
+// would make the web console's CIDR approval flow ungrantable.
+func TestPermissionAssurance_ApproveByCIDRIsGrantable(t *testing.T) {
+	assert.True(t, isKnownPermission("registration:approve-by-cidr"),
+		"registration:approve-by-cidr must be grantable to web accounts")
+	// The permission it was split out of remains grantable and unchanged.
+	assert.True(t, isKnownPermission("registration:approve"),
+		"registration:approve must remain grantable for single approve + approve-all")
+	// Sanity: the allow-list still rejects the wildcard.
+	assert.False(t, isKnownPermission("*"), "wildcard must never be a valid permission ID")
+}
+
 // TestPermissionAssurance_NonCatastrophicNoUserPresence verifies that non-catastrophic
 // permissions do not accidentally have RequireUserPresence set.
 func TestPermissionAssurance_NonCatastrophicNoUserPresence(t *testing.T) {
-	catastrophic := map[string]bool{"module:approve": true, "module:reject": true, "publisher-trust:add": true}
+	catastrophic := map[string]bool{
+		"module:approve":               true,
+		"module:reject":                true,
+		"publisher-trust:add":          true,
+		"registration:approve-by-cidr": true, // Issue #2969
+	}
 	for perm, req := range permissionAssurance {
 		if catastrophic[perm] {
 			continue

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -499,6 +499,70 @@ func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// approveByCIDRPreviewResponse is returned by GET /api/v1/registration/approve-by-cidr/preview.
+type approveByCIDRPreviewResponse struct {
+	Count      int      `json:"count"`
+	PendingIDs []string `json:"pending_ids"`
+	SourceIPs  []string `json:"source_ips"`
+}
+
+// handleApproveByCIDRPreview handles GET /api/v1/registration/approve-by-cidr/preview.
+// Returns a dry-run preview of pending entries whose source IP falls in the given CIDR,
+// without mutating any state. Requires the ?cidr= query parameter.
+// Scoped callers see only their own tenant subtree.
+// The caller must show this preview to the operator before the mutating POST is allowed.
+func (s *Server) handleApproveByCIDRPreview(w http.ResponseWriter, r *http.Request) {
+	if s.pendingStore == nil {
+		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	cidr := r.URL.Query().Get("cidr")
+	if cidr == "" {
+		http.Error(w, "cidr query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		http.Error(w, "invalid CIDR", http.StatusBadRequest)
+		return
+	}
+
+	callerTenant := s.callerTenantID(r)
+	entries, err := s.pendingStore.ListPending(r.Context(), callerTenant)
+	if err != nil {
+		s.logger.Error("Failed to list pending registrations for approve-by-cidr preview", "error", err)
+		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
+		return
+	}
+
+	pendingIDs := make([]string, 0)
+	sourceIPs := make([]string, 0)
+	for _, e := range entries {
+		if e.Status != business.PendingRegistrationStatusPending {
+			continue
+		}
+		ip := net.ParseIP(e.SourceIP)
+		if ip == nil || !ipNet.Contains(ip) {
+			continue
+		}
+		pendingIDs = append(pendingIDs, e.PendingID)
+		sourceIPs = append(sourceIPs, e.SourceIP)
+	}
+
+	s.logger.Info("CIDR bulk approve preview",
+		"cidr", logging.SanitizeLogValue(cidr), "matched", len(pendingIDs))
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(approveByCIDRPreviewResponse{
+		Count:      len(pendingIDs),
+		PendingIDs: pendingIDs,
+		SourceIPs:  sourceIPs,
+	}); err != nil {
+		s.logger.Error("Failed to encode approve-by-cidr preview response", "error", err)
+	}
+}
+
 // isValidDeviceID returns true if id is exactly 64 lowercase hex characters.
 // The DeviceID is the SHA-256 fingerprint of the steward's Ed25519 identity key (ADR-010 §1).
 func isValidDeviceID(id string) bool {

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -1013,6 +1013,8 @@ func TestApproveByCIDR_FiltersCorrectly(t *testing.T) {
 	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-by-cidr",
 		strings.NewReader(`{"cidr":"192.168.1.0/24"}`))
 	req.Header.Set("Content-Type", "application/json")
+	// registration:approve-by-cidr requires RequireUserPresence (Issue #2969).
+	req.Header.Set(presenceTokenHeader, mintPresenceToken(t, server, "test-admin"))
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 
@@ -1080,6 +1082,8 @@ func TestHandleApproveByCIDR_InvalidCIDR(t *testing.T) {
 	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-by-cidr",
 		strings.NewReader(`{"cidr":"not-a-cidr"}`))
 	req.Header.Set("Content-Type", "application/json")
+	// Presence token required even for error paths — gate is enforced before handler logic.
+	req.Header.Set(presenceTokenHeader, mintPresenceToken(t, server, "test-admin"))
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 
@@ -1095,6 +1099,112 @@ func TestHandleApproveByCIDR_NoPendingStore(t *testing.T) {
 	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-by-cidr",
 		strings.NewReader(`{"cidr":"10.0.0.0/8"}`))
 	req.Header.Set("Content-Type", "application/json")
+	// Presence token required — gate fires before handler's pendingStore nil check.
+	req.Header.Set(presenceTokenHeader, mintPresenceToken(t, server, "test-admin"))
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleApproveByCIDR_RequiresPresence verifies that calling approve-by-cidr without
+// a presence token returns 401 with presence="required" in WWW-Authenticate.
+func TestHandleApproveByCIDR_RequiresPresence(t *testing.T) {
+	server, ts, _ := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	// No presence token attached — should be rejected before reaching the handler.
+	req := makeAdminRequest(t, "POST", "/api/v1/registration/approve-by-cidr",
+		strings.NewReader(`{"cidr":"10.0.0.0/8"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Header().Get("WWW-Authenticate"), `presence="required"`,
+		"approve-by-cidr must require a user-presence proof (Issue #2969)")
+}
+
+// TestHandleApproveByCIDRPreview_HappyPath verifies that the preview endpoint returns
+// the count, IDs, and source IPs of matching pending entries without mutating state.
+func TestHandleApproveByCIDRPreview_HappyPath(t *testing.T) {
+	server, ts, pendingStore := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	addPendingEntry(t, pendingStore, "prev-in-1", "stwd-in-1", "tenant-a", "192.168.1.10")
+	addPendingEntry(t, pendingStore, "prev-in-2", "stwd-in-2", "tenant-a", "192.168.1.20")
+	addPendingEntry(t, pendingStore, "prev-out-1", "stwd-out-1", "tenant-a", "10.0.0.5")
+
+	req := makeAdminRequest(t, "GET", "/api/v1/registration/approve-by-cidr/preview?cidr=192.168.1.0/24", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var result approveByCIDRPreviewResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&result))
+	assert.Equal(t, 2, result.Count)
+	assert.ElementsMatch(t, []string{"prev-in-1", "prev-in-2"}, result.PendingIDs)
+	assert.ElementsMatch(t, []string{"192.168.1.10", "192.168.1.20"}, result.SourceIPs)
+
+	// Verify the store is unmodified — preview must not mutate state.
+	for _, id := range []string{"prev-in-1", "prev-in-2", "prev-out-1"} {
+		e, err := pendingStore.GetPendingByID(context.Background(), id)
+		require.NoError(t, err)
+		assert.Equal(t, business.PendingRegistrationStatusPending, e.Status,
+			"preview must not mutate entry %q", id)
+	}
+}
+
+// TestHandleApproveByCIDRPreview_EmptyResult verifies that the preview returns an empty
+// JSON array (not null) when no entries match.
+func TestHandleApproveByCIDRPreview_EmptyResult(t *testing.T) {
+	server, ts, _ := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	req := makeAdminRequest(t, "GET", "/api/v1/registration/approve-by-cidr/preview?cidr=10.0.0.0/8", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var result approveByCIDRPreviewResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&result))
+	assert.Equal(t, 0, result.Count)
+	assert.NotNil(t, result.PendingIDs, "pending_ids must be an empty array, not null")
+	assert.NotNil(t, result.SourceIPs, "source_ips must be an empty array, not null")
+}
+
+// TestHandleApproveByCIDRPreview_InvalidCIDR verifies that a malformed CIDR returns 400.
+func TestHandleApproveByCIDRPreview_InvalidCIDR(t *testing.T) {
+	server, ts, _ := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	req := makeAdminRequest(t, "GET", "/api/v1/registration/approve-by-cidr/preview?cidr=not-a-cidr", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleApproveByCIDRPreview_MissingCIDR verifies that a missing cidr parameter returns 400.
+func TestHandleApproveByCIDRPreview_MissingCIDR(t *testing.T) {
+	server, ts, _ := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	req := makeAdminRequest(t, "GET", "/api/v1/registration/approve-by-cidr/preview", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleApproveByCIDRPreview_NoPendingStore verifies 503 when pendingStore is nil.
+func TestHandleApproveByCIDRPreview_NoPendingStore(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	req := makeAdminRequest(t, "GET", "/api/v1/registration/approve-by-cidr/preview?cidr=10.0.0.0/8", nil)
 	rec := httptest.NewRecorder()
 	server.router.ServeHTTP(rec, req)
 

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -56,6 +56,11 @@ var knownPermissions = map[string]bool{
 	"registration:list-pending": true,
 	"registration:approve":      true,
 	"registration:deny":         true,
+	// Bulk CIDR approval (Issue #2969) — separate from registration:approve because it
+	// additionally carries RequireUserPresence in permissionAssurance. Web accounts must be
+	// able to hold it, so it belongs in this allow-list even though a Machine-assurance API
+	// key can never satisfy its assurance requirement.
+	"registration:approve-by-cidr": true,
 	// IP-trust management (Issue #1698, #2932)
 	"registration:list-ip-trust":   true,
 	"registration:manage-ip-trust": true,

--- a/features/controller/api/route_registry_test.go
+++ b/features/controller/api/route_registry_test.go
@@ -132,6 +132,7 @@ var goldenRouteTable = []string{
 	"GET /api/v1/rbac/roles",
 	"GET /api/v1/rbac/roles/{id}",
 	"GET /api/v1/ready",
+	"GET /api/v1/registration/approve-by-cidr/preview",
 	"GET /api/v1/registration/ip-trust",
 	"GET /api/v1/registration/pending",
 	"GET /api/v1/registration/status/{pending_id}",

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -508,9 +508,11 @@ func (s *Server) setupRouter() {
 	api.Handle("/registration/{id}/approve", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveRegistration))).Methods("POST")
 	api.Handle("/registration/{id}/deny", s.requirePermission("registration", "deny")(http.HandlerFunc(s.handleDenyRegistration))).Methods("POST")
 
-	// Bulk registration approval and IP-trust management (Issue #1698)
+	// Bulk registration approval and IP-trust management (Issue #1698, #2969)
 	api.Handle("/registration/approve-all", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveAllRegistrations))).Methods("POST")
-	api.Handle("/registration/approve-by-cidr", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveByCIDR))).Methods("POST")
+	// Preview (dry-run) must be registered before the mutation POST to avoid path ambiguity.
+	api.Handle("/registration/approve-by-cidr/preview", s.requirePermission("registration", "list-pending")(http.HandlerFunc(s.handleApproveByCIDRPreview))).Methods("GET")
+	api.Handle("/registration/approve-by-cidr", s.requirePermission("registration", "approve-by-cidr")(http.HandlerFunc(s.handleApproveByCIDR))).Methods("POST")
 	api.Handle("/registration/ip-trust", s.requirePermission("registration", "list-ip-trust")(http.HandlerFunc(s.handleListIPTrust))).Methods("GET")
 	api.Handle("/registration/ip-trust", s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleAddIPTrust))).Methods("POST")
 	// {cidr:.+} allows the CIDR slash to appear literally in the URL path after decoding.

--- a/features/controller/api/tier_enforcement_test.go
+++ b/features/controller/api/tier_enforcement_test.go
@@ -61,7 +61,7 @@ var strongAssuranceRouteTable = []strongAssuranceRouteEntry{
 	{"POST", "/api/v1/registration/tokens/test-tenant/rotate", "registration:rotate-token"},
 	{"POST", "/api/v1/registration/reg-123/approve", "registration:approve"},
 	{"POST", "/api/v1/registration/approve-all", "registration:approve"},
-	{"POST", "/api/v1/registration/approve-by-cidr", "registration:approve"},
+	{"POST", "/api/v1/registration/approve-by-cidr", "registration:approve-by-cidr"}, // Issue #2969: presence-gated bulk CIDR approval
 	{"POST", "/api/v1/registration/ip-trust", "registration:manage-ip-trust"},
 	{"DELETE", "/api/v1/registration/ip-trust/test-tenant/192.168.1.0/24", "registration:manage-ip-trust"},
 	{"POST", "/api/v1/tenants", "tenant:create"},

--- a/features/controller/api/validation_middleware.go
+++ b/features/controller/api/validation_middleware.go
@@ -157,6 +157,9 @@ func (s *Server) validateQueryParameters(validator *security.EnhancedValidator, 
 				// Hierarchical tenant IDs use '/' as a path separator (e.g., "fleet-root/fleet-child-b").
 				// Must match charset:tenant_path_id which allows letters, digits, hyphens, underscores, and '/'.
 				validator.ValidateString(result, fieldName, value, "charset:tenant_path_id", "max_length:256")
+			case "cidr":
+				// CIDR ranges (e.g. "192.168.1.0/24", "2001:db8::/32") — the slash is not in safe_text.
+				validator.ValidateString(result, fieldName, value, "charset:cidr", "max_length:64")
 			default:
 				// Generic query parameter validation
 				validator.ValidateString(result, fieldName, value, "charset:safe_text", "max_length:512", "no_control_chars")

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>CFGMS</title>
-    <script type="module" crossorigin src="/assets/index-pOoyNo6q.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D2CWu187.css">
+    <script type="module" crossorigin src="/assets/index-B5_FIcyH.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DTG8X7eM.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/registration/PendingQueueTab.test.tsx
+++ b/web/src/registration/PendingQueueTab.test.tsx
@@ -164,11 +164,19 @@ describe('PendingQueueTab — list rendering', () => {
     expect(screen.getByTestId('deny-btn-pend-abc123')).toBeInTheDocument()
   })
 
-  it('renders no approve control of any kind', async () => {
+  it('shows an Approve button for each row', async () => {
     fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
     renderTab()
     await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
-    expect(screen.queryByRole('button', { name: /approve/i })).toBeNull()
+    expect(screen.getByTestId('approve-btn-pend-abc123')).toBeInTheDocument()
+  })
+
+  it('shows Approve All and Approve by CIDR buttons in the toolbar', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+    expect(screen.getByTestId('approve-all-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('approve-by-cidr-btn')).toBeInTheDocument()
   })
 
   it('shows an error notice on a non-200 list response', async () => {
@@ -285,5 +293,249 @@ describe('PendingQueueTab — deny', () => {
     await waitFor(() => expect(screen.getAllByTestId('pending-row')).toHaveLength(1))
     expect(screen.getByText('pend-def456')).toBeInTheDocument()
     expect(screen.queryByText('pend-abc123')).toBeNull()
+  })
+})
+
+// ── Approve (per-row) ─────────────────────────────────────────────────────────
+
+describe('PendingQueueTab — approve', () => {
+  it('approve removes the row from the list on success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-btn-pend-abc123'))
+
+    await waitFor(() => expect(screen.getByTestId('pending-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('pending-row')).toBeNull()
+    const approveCall = fetchMock.mock.calls[1]!
+    expect(String(approveCall[0])).toContain('/approve')
+    expect((approveCall[1] as RequestInit | undefined)?.method).toBe('POST')
+  })
+
+  it('surfaces a row-level error on a failed approve without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-btn-pend-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('approve-error-pend-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('approve-error-pend-abc123')).toHaveTextContent('403')
+    expect(screen.getAllByTestId('pending-row')).toHaveLength(1)
+  })
+
+  it('surfaces a row-level error on a network failure during approve without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockRejectedValueOnce(new Error('network error'))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-btn-pend-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('approve-error-pend-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('approve-error-pend-abc123')).toHaveTextContent('network error')
+    expect(screen.getAllByTestId('pending-row')).toHaveLength(1)
+  })
+})
+
+// ── Approve All ───────────────────────────────────────────────────────────────
+
+describe('PendingQueueTab — approve all', () => {
+  it('approve-all calls the correct endpoint and refreshes the list on success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ approved: 1 }), { status: 200 }))
+      .mockResolvedValueOnce(makePendingResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-all-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('pending-empty')).toBeInTheDocument())
+    const approveAllCall = fetchMock.mock.calls[1]!
+    expect(String(approveAllCall[0])).toContain('/approve-all')
+    expect((approveAllCall[1] as RequestInit | undefined)?.method).toBe('POST')
+  })
+
+  it('surfaces a toolbar error on a failed approve-all without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-all-btn'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('approve-all-error')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('approve-all-error')).toHaveTextContent('500')
+    expect(screen.getAllByTestId('pending-row')).toHaveLength(1)
+  })
+})
+
+// ── Approve by CIDR ───────────────────────────────────────────────────────────
+
+describe('PendingQueueTab — approve by CIDR', () => {
+  function makeCIDRPreviewResponse(
+    count: number,
+    pending_ids: string[],
+    source_ips: string[],
+    status = 200,
+  ) {
+    return new Response(JSON.stringify({ count, pending_ids, source_ips }), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  it('opens the CIDR modal when Approve by CIDR is clicked', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+
+    expect(screen.getByTestId('cidr-modal')).toBeInTheDocument()
+  })
+
+  it('closes the modal when Cancel is clicked', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+    expect(screen.getByTestId('cidr-modal')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('cidr-cancel-btn'))
+    expect(screen.queryByTestId('cidr-modal')).toBeNull()
+  })
+
+  it('confirm button is disabled until preview is loaded', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+
+    expect(screen.getByTestId('cidr-confirm-btn')).toBeDisabled()
+  })
+
+  it('preview button is disabled when CIDR input is empty', async () => {
+    fetchMock.mockResolvedValue(makePendingResponse([makeEntry()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+
+    expect(screen.getByTestId('cidr-preview-btn')).toBeDisabled()
+  })
+
+  it('shows preview result and enables confirm after successful preview', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(makeCIDRPreviewResponse(2, ['pend-a', 'pend-b'], ['10.0.0.1', '10.0.0.2']))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+    fireEvent.change(screen.getByTestId('cidr-input'), { target: { value: '10.0.0.0/24' } })
+    fireEvent.click(screen.getByTestId('cidr-preview-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('cidr-preview-result')).toBeInTheDocument())
+    expect(screen.getByTestId('cidr-preview-result')).toHaveTextContent('2 pending registrations will be approved')
+    expect(screen.getByTestId('cidr-confirm-btn')).not.toBeDisabled()
+  })
+
+  it('clears preview and disables confirm when CIDR input changes after preview', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(makeCIDRPreviewResponse(1, ['pend-a'], ['10.0.0.1']))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+    fireEvent.change(screen.getByTestId('cidr-input'), { target: { value: '10.0.0.0/24' } })
+    fireEvent.click(screen.getByTestId('cidr-preview-btn'))
+    await waitFor(() => expect(screen.getByTestId('cidr-preview-result')).toBeInTheDocument())
+
+    // Change CIDR after preview — confirm must be re-disabled.
+    fireEvent.change(screen.getByTestId('cidr-input'), { target: { value: '192.168.0.0/16' } })
+
+    expect(screen.queryByTestId('cidr-preview-result')).toBeNull()
+    expect(screen.getByTestId('cidr-confirm-btn')).toBeDisabled()
+  })
+
+  it('surfaces a preview error without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+    fireEvent.change(screen.getByTestId('cidr-input'), { target: { value: 'bad' } })
+    fireEvent.click(screen.getByTestId('cidr-preview-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('cidr-preview-error')).toBeInTheDocument())
+    expect(screen.getByTestId('cidr-preview-error')).toHaveTextContent('400')
+    expect(screen.getByTestId('cidr-confirm-btn')).toBeDisabled()
+  })
+
+  it('calls the mutation endpoint with the correct CIDR and closes modal on success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(makeCIDRPreviewResponse(1, ['pend-abc123'], ['10.0.0.1']))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ approved: 1 }), { status: 200 }))
+      .mockResolvedValueOnce(makePendingResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+    fireEvent.change(screen.getByTestId('cidr-input'), { target: { value: '10.0.0.0/24' } })
+    fireEvent.click(screen.getByTestId('cidr-preview-btn'))
+    await waitFor(() => expect(screen.getByTestId('cidr-confirm-btn')).not.toBeDisabled())
+
+    fireEvent.click(screen.getByTestId('cidr-confirm-btn'))
+
+    await waitFor(() => expect(screen.queryByTestId('cidr-modal')).toBeNull())
+    await waitFor(() => expect(screen.getByTestId('pending-empty')).toBeInTheDocument())
+
+    const mutationCall = fetchMock.mock.calls[2]!
+    expect(String(mutationCall[0])).toContain('/approve-by-cidr')
+    expect((mutationCall[1] as RequestInit | undefined)?.method).toBe('POST')
+    const body = JSON.parse((mutationCall[1] as RequestInit).body as string) as { cidr: string }
+    expect(body.cidr).toBe('10.0.0.0/24')
+  })
+
+  it('surfaces a mutation error without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makePendingResponse([makeEntry()]))
+      .mockResolvedValueOnce(makeCIDRPreviewResponse(1, ['pend-abc123'], ['10.0.0.1']))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('pending-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-by-cidr-btn'))
+    fireEvent.change(screen.getByTestId('cidr-input'), { target: { value: '10.0.0.0/24' } })
+    fireEvent.click(screen.getByTestId('cidr-preview-btn'))
+    await waitFor(() => expect(screen.getByTestId('cidr-confirm-btn')).not.toBeDisabled())
+
+    fireEvent.click(screen.getByTestId('cidr-confirm-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('cidr-approve-error')).toBeInTheDocument())
+    expect(screen.getByTestId('cidr-approve-error')).toHaveTextContent('401')
+    // Modal stays open so the operator can retry.
+    expect(screen.getByTestId('cidr-modal')).toBeInTheDocument()
   })
 })

--- a/web/src/registration/PendingQueueTab.tsx
+++ b/web/src/registration/PendingQueueTab.tsx
@@ -2,13 +2,24 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Pending registration queue (Story #2934).
+ * Pending registration queue (Story #2934, #2969).
  * Fetches GET /api/v1/registration/pending — bare-array response (no
  * {data:...} envelope, json.NewEncoder raw array). Shape-validated by
  * parsePendingRegistrations before any value reaches the DOM.
  *
  * Deny calls POST /api/v1/registration/{id}/deny and removes the row on
  * success; surfaces a row-level error without crashing on failure.
+ *
+ * Approve calls POST /api/v1/registration/{id}/approve and removes the row
+ * on success; surfaces a row-level error without crashing on failure.
+ *
+ * Approve All calls POST /api/v1/registration/approve-all and refreshes the
+ * list on success.
+ *
+ * Approve by CIDR (Story #2969): operator must preview (GET
+ * /api/v1/registration/approve-by-cidr/preview?cidr=...) before the confirm
+ * button becomes active. The mutation POST requires user-presence step-up,
+ * handled transparently by apiFetch + StepUpModal in AuthContext.
  *
  * Security A9.1: all steward-supplied and operator-influenced values render
  * as JSX text nodes only, never via dangerouslySetInnerHTML.
@@ -30,6 +41,21 @@ interface FetchOutcome {
   key: string
   entries?: PendingEntry[]
   error?: string
+}
+
+interface CIDRPreview {
+  count: number
+  pending_ids: string[]
+  source_ips: string[]
+}
+
+interface CIDRModalState {
+  cidr: string
+  preview: CIDRPreview | null
+  previewLoading: boolean
+  previewError: string | null
+  approveLoading: boolean
+  approveError: string | null
 }
 
 // ── Parse helpers ─────────────────────────────────────────────────────────────
@@ -94,6 +120,10 @@ export default function PendingQueueTab() {
   const [attempt, setAttempt] = useState(0)
   const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
   const [denyErrors, setDenyErrors] = useState<Map<string, string>>(new Map())
+  const [approveErrors, setApproveErrors] = useState<Map<string, string>>(new Map())
+  const [approveAllLoading, setApproveAllLoading] = useState(false)
+  const [approveAllError, setApproveAllError] = useState<string | null>(null)
+  const [cidrModal, setCidrModal] = useState<CIDRModalState | null>(null)
 
   const key = `pending:${attempt}`
   const retry = useCallback(() => setAttempt((n) => n + 1), [])
@@ -154,6 +184,139 @@ export default function PendingQueueTab() {
     }
   }
 
+  async function handleApprove(pendingId: string) {
+    setApproveErrors((prev) => {
+      const next = new Map(prev)
+      next.delete(pendingId)
+      return next
+    })
+    try {
+      const response = await apiFetch(
+        `/api/v1/registration/${encodeURIComponent(pendingId)}/approve`,
+        { method: 'POST' },
+      )
+      if (!response.ok) {
+        setApproveErrors((prev) =>
+          new Map(prev).set(pendingId, `Approve failed — ${response.status}`),
+        )
+        return
+      }
+      setOutcome((prev) => {
+        if (!prev?.entries) return prev
+        return { ...prev, entries: prev.entries.filter((e) => e.pending_id !== pendingId) }
+      })
+    } catch (cause: unknown) {
+      setApproveErrors((prev) =>
+        new Map(prev).set(
+          pendingId,
+          cause instanceof Error && cause.message ? cause.message : 'Approve request failed',
+        ),
+      )
+    }
+  }
+
+  async function handleApproveAll() {
+    setApproveAllError(null)
+    setApproveAllLoading(true)
+    try {
+      const response = await apiFetch('/api/v1/registration/approve-all', { method: 'POST' })
+      if (!response.ok) {
+        setApproveAllError(`Approve all failed — ${response.status}`)
+        return
+      }
+      retry()
+    } catch (cause: unknown) {
+      setApproveAllError(
+        cause instanceof Error && cause.message ? cause.message : 'Approve all request failed',
+      )
+    } finally {
+      setApproveAllLoading(false)
+    }
+  }
+
+  function openCIDRModal() {
+    setCidrModal({
+      cidr: '',
+      preview: null,
+      previewLoading: false,
+      previewError: null,
+      approveLoading: false,
+      approveError: null,
+    })
+  }
+
+  async function handleCIDRPreview() {
+    if (!cidrModal) return
+    const cidr = cidrModal.cidr
+    setCidrModal((prev) =>
+      prev ? { ...prev, previewLoading: true, previewError: null, preview: null } : prev,
+    )
+    try {
+      const response = await apiFetch(
+        `/api/v1/registration/approve-by-cidr/preview?cidr=${encodeURIComponent(cidr)}`,
+      )
+      if (!response.ok) {
+        setCidrModal((prev) =>
+          prev
+            ? { ...prev, previewLoading: false, previewError: `Preview failed — ${response.status}` }
+            : prev,
+        )
+        return
+      }
+      const body = (await response.json()) as CIDRPreview
+      setCidrModal((prev) => (prev ? { ...prev, previewLoading: false, preview: body } : prev))
+    } catch (cause: unknown) {
+      setCidrModal((prev) =>
+        prev
+          ? {
+              ...prev,
+              previewLoading: false,
+              previewError:
+                cause instanceof Error && cause.message
+                  ? cause.message
+                  : 'Preview request failed',
+            }
+          : prev,
+      )
+    }
+  }
+
+  async function handleCIDRApprove() {
+    if (!cidrModal?.preview) return
+    const cidr = cidrModal.cidr
+    setCidrModal((prev) => (prev ? { ...prev, approveLoading: true, approveError: null } : prev))
+    try {
+      const response = await apiFetch('/api/v1/registration/approve-by-cidr', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cidr }),
+      })
+      if (!response.ok) {
+        setCidrModal((prev) =>
+          prev
+            ? { ...prev, approveLoading: false, approveError: `Approve failed — ${response.status}` }
+            : prev,
+        )
+        return
+      }
+      setCidrModal(null)
+      retry()
+    } catch (cause: unknown) {
+      setCidrModal((prev) =>
+        prev
+          ? {
+              ...prev,
+              approveLoading: false,
+              approveError:
+                cause instanceof Error && cause.message
+                  ? cause.message
+                  : 'Approve request failed',
+            }
+          : prev,
+      )
+    }
+  }
+
   const current = outcome?.key === key ? outcome : null
   const loading = current === null
   const error = current?.error ?? null
@@ -177,6 +340,28 @@ export default function PendingQueueTab() {
             <span className="cnt" data-testid="pending-count">
               {entries.length} pending
             </span>
+            <button
+              type="button"
+              className="wf-btn-sm"
+              data-testid="approve-all-btn"
+              disabled={approveAllLoading}
+              onClick={() => void handleApproveAll()}
+            >
+              Approve All
+            </button>
+            <button
+              type="button"
+              className="wf-btn-sm"
+              data-testid="approve-by-cidr-btn"
+              onClick={openCIDRModal}
+            >
+              Approve by CIDR
+            </button>
+            {approveAllError !== null && (
+              <span className="wf-form-error" role="alert" data-testid="approve-all-error">
+                {approveAllError}
+              </span>
+            )}
           </div>
           <table className="tbl" data-testid="pending-table">
             <thead>
@@ -207,6 +392,14 @@ export default function PendingQueueTab() {
                     <td>
                       <button
                         type="button"
+                        className="wf-btn-sm"
+                        data-testid={`approve-btn-${entry.pending_id}`}
+                        onClick={() => void handleApprove(entry.pending_id)}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
                         className="wf-btn-sm-danger"
                         data-testid={`deny-btn-${entry.pending_id}`}
                         onClick={() => void handleDeny(entry.pending_id)}
@@ -215,6 +408,19 @@ export default function PendingQueueTab() {
                       </button>
                     </td>
                   </tr>
+                  {approveErrors.has(entry.pending_id) && (
+                    <tr>
+                      <td colSpan={5}>
+                        <span
+                          className="wf-form-error"
+                          data-testid={`approve-error-${entry.pending_id}`}
+                          role="alert"
+                        >
+                          {approveErrors.get(entry.pending_id)}
+                        </span>
+                      </td>
+                    </tr>
+                  )}
                   {denyErrors.has(entry.pending_id) && (
                     <tr>
                       <td colSpan={5}>
@@ -233,6 +439,93 @@ export default function PendingQueueTab() {
             </tbody>
           </table>
         </>
+      )}
+
+      {cidrModal !== null && (
+        <div
+          className="modal-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Approve by CIDR"
+          data-testid="cidr-modal"
+        >
+          <div className="modal-box">
+            <h3>Approve registrations by CIDR</h3>
+            <p className="modal-desc">
+              Enter a CIDR range to preview which pending registrations match, then confirm to
+              approve them. A user-presence verification will be required before approval.
+            </p>
+            <label className="field-label">
+              CIDR range
+              <input
+                type="text"
+                className="wf-input"
+                data-testid="cidr-input"
+                placeholder="e.g. 192.168.1.0/24"
+                value={cidrModal.cidr}
+                onChange={(e) =>
+                  setCidrModal((prev) =>
+                    prev ? { ...prev, cidr: e.target.value, preview: null } : prev,
+                  )
+                }
+              />
+            </label>
+            <button
+              type="button"
+              className="wf-btn-sm"
+              data-testid="cidr-preview-btn"
+              disabled={!cidrModal.cidr || cidrModal.previewLoading}
+              onClick={() => void handleCIDRPreview()}
+            >
+              {cidrModal.previewLoading ? 'Loading…' : 'Preview'}
+            </button>
+            {cidrModal.previewError !== null && (
+              <span
+                className="wf-form-error"
+                role="alert"
+                data-testid="cidr-preview-error"
+              >
+                {cidrModal.previewError}
+              </span>
+            )}
+            {cidrModal.preview !== null && (
+              <div className="cidr-preview" data-testid="cidr-preview-result">
+                <p>
+                  {cidrModal.preview.count} pending registration
+                  {cidrModal.preview.count !== 1 ? 's' : ''} will be approved.
+                </p>
+              </div>
+            )}
+            <div className="modal-actions">
+              <button
+                type="button"
+                className="wf-btn-sm-danger"
+                data-testid="cidr-cancel-btn"
+                onClick={() => setCidrModal(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="wf-btn-sm"
+                data-testid="cidr-confirm-btn"
+                disabled={cidrModal.preview === null || cidrModal.approveLoading}
+                onClick={() => void handleCIDRApprove()}
+              >
+                {cidrModal.approveLoading ? 'Approving…' : 'Confirm & Approve'}
+              </button>
+            </div>
+            {cidrModal.approveError !== null && (
+              <span
+                className="wf-form-error"
+                role="alert"
+                data-testid="cidr-approve-error"
+              >
+                {cidrModal.approveError}
+              </span>
+            )}
+          </div>
+        </div>
       )}
     </section>
   )


### PR DESCRIPTION
## Summary

- New `registration:approve-by-cidr` permission with `RequireUserPresence: true`, split from `registration:approve` so single-entry approve and approve-all keep their existing behavior (no presence ceremony required)
- Read-only preview endpoint `GET /api/v1/registration/approve-by-cidr/preview?cidr=...` gated on `registration:list-pending` (Machine assurance) — returns count, pending IDs, and source IPs without mutating anything
- Mutation `POST /api/v1/registration/approve-by-cidr` requires AssuranceStrong + a fresh user-presence token; web console blocks the call until the preview has been shown and confirmed
- Both preview and mutation route through `callerTenantID` so tenant-scoped principals (API key or non-root web account) only see/approve entries in their subtree; mTLS admin and root-scoped accounts retain fleet-wide reach
- `validateQueryParameters` extended with a `case "cidr":` block using `charset:cidr` — the default `safe_text` charset excludes `/`, which would have rejected every preview request
- `registration:approve-by-cidr` added to the `knownPermissions` allow-list so it can be granted to web accounts and API keys via the console
- Frontend: Approve, Approve All, and Approve by CIDR buttons wired in `PendingQueueTab`; all routes go through the `apiFetch` step-up interceptor (401 + CFGMS-StepUp → StepUpModal)
- Docs updated: controller-operating-model table, ADR-021 catastrophic-actions list, security/architecture presence-gated subset table

## Test plan

- [ ] Go: `go test ./features/controller/api/...` — all handlers, middleware, tier enforcement, and route-parity tests pass
- [ ] Frontend: `cd web && npm test` — 983 tests pass including new CIDR modal suite (9 tests)
- [ ] `make check-architecture` — no central-provider violations
- [ ] `make lint-log-injection` — all HTTP params and CIDR values sanitized via `logging.SanitizeLogValue()`
- [ ] `make test-agent-complete` — full gate (unit + production-critical + cross-platform compilation + frontend)
- [ ] CI: unit-tests, integration-tests, Build Gate, security-deployment-gate

Fixes #2969

🤖 Generated with [Claude Code](https://claude.com/claude-code)