### PR TITLE
web: workflow browse overlay drawer shell (Issue #3039)

### DIFF
--- a/web/src/workflow/Workflow.css
+++ b/web/src/workflow/Workflow.css
@@ -547,3 +547,108 @@ table.tbl {
   flex-direction: column;
   gap: 10px;
 }
+
+/* ── Workspace (list + overlay drawer, no reflow) ──────────────── */
+.workspace {
+  position: relative;
+  margin: 0 24px 20px;
+}
+.workspace .panel {
+  margin: 0;
+}
+
+/* ── Asset overlay drawer ──────────────────────────────────────── */
+.drawer {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: min(430px, calc(100% - 16px));
+  z-index: 6;
+  animation: wfx-slidein 0.24s cubic-bezier(0.4, 0.9, 0.3, 1);
+}
+@keyframes wfx-slidein {
+  from {
+    transform: translateX(14px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .drawer {
+    animation: none;
+  }
+}
+
+.dhead {
+  padding: 13px 15px;
+  border-bottom: 1px solid var(--border);
+}
+.dhead .top {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.dhead h2 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dhead .acts {
+  margin-left: auto;
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.dhead .meta {
+  margin-top: 5px;
+  font-size: 11px;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+}
+
+.dtabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border);
+}
+.dtabs button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 11px 12px;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+}
+.dtabs button.on {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.dbody {
+  overflow: auto;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}

--- a/web/src/workflow/WorkflowDrawer.test.tsx
+++ b/web/src/workflow/WorkflowDrawer.test.tsx
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * WorkflowDrawer test suite (Story #3039): drawer renders correctly, tabs
+ * switch visible pane, close button fires onClose, and user content is
+ * rendered as safe text nodes (Security A9.1).
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach } from 'vitest'
+import WorkflowDrawer from './WorkflowDrawer.tsx'
+import type { VersionedWorkflow } from './useWorkflows.ts'
+
+afterEach(cleanup)
+
+function makeWorkflow(overrides: Partial<VersionedWorkflow> = {}): VersionedWorkflow {
+  return {
+    name: 'onboard-user',
+    description: 'Create a user on the DC',
+    version: '1.5.0',
+    steps: [{ name: 'step-1', type: 'script', config: {} }],
+    semantic_version: { major: 1, minor: 5, patch: 0, pre_release: '', build_meta: '' },
+    ...overrides,
+  }
+}
+
+function renderDrawer(workflow = makeWorkflow(), onClose = vi.fn()) {
+  return render(<WorkflowDrawer workflow={workflow} onClose={onClose} />)
+}
+
+describe('WorkflowDrawer — header', () => {
+  it('renders the drawer with the workflow name in the header', () => {
+    renderDrawer()
+    expect(screen.getByTestId('workflow-drawer')).toBeInTheDocument()
+    expect(screen.getByTestId('drawer-name')).toHaveTextContent('onboard-user')
+  })
+
+  it('shows the version in the meta line', () => {
+    renderDrawer()
+    expect(screen.getByTestId('drawer-meta')).toHaveTextContent('v1.5.0')
+  })
+
+  it('renders "Open builder" affordance as a stub button', () => {
+    renderDrawer()
+    expect(screen.getByTestId('drawer-open-builder')).toBeInTheDocument()
+  })
+
+  it('close button calls onClose', () => {
+    const onClose = vi.fn()
+    renderDrawer(makeWorkflow(), onClose)
+    fireEvent.click(screen.getByTestId('drawer-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('WorkflowDrawer — tab bar', () => {
+  it('renders Run, Schedule, and What-it-does tabs', () => {
+    renderDrawer()
+    expect(screen.getByTestId('drawer-tab-run')).toBeInTheDocument()
+    expect(screen.getByTestId('drawer-tab-schedule')).toBeInTheDocument()
+    expect(screen.getByTestId('drawer-tab-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('drawer-tab-preview')).toHaveTextContent(/what it does/i)
+  })
+
+  it('Run tab is active by default', () => {
+    renderDrawer()
+    expect(screen.getByTestId('drawer-tab-run')).toHaveClass('on')
+    expect(screen.getByTestId('drawer-tab-schedule')).not.toHaveClass('on')
+    expect(screen.getByTestId('drawer-tab-preview')).not.toHaveClass('on')
+    expect(screen.getByTestId('drawer-pane-run')).toBeInTheDocument()
+  })
+
+  it('clicking Schedule tab activates it and shows the schedule pane', () => {
+    renderDrawer()
+    fireEvent.click(screen.getByTestId('drawer-tab-schedule'))
+    expect(screen.getByTestId('drawer-tab-schedule')).toHaveClass('on')
+    expect(screen.getByTestId('drawer-tab-run')).not.toHaveClass('on')
+    expect(screen.getByTestId('drawer-pane-schedule')).toBeInTheDocument()
+    expect(screen.queryByTestId('drawer-pane-run')).toBeNull()
+  })
+
+  it('clicking Preview tab activates it and shows the preview pane', () => {
+    renderDrawer()
+    fireEvent.click(screen.getByTestId('drawer-tab-preview'))
+    expect(screen.getByTestId('drawer-tab-preview')).toHaveClass('on')
+    expect(screen.getByTestId('drawer-pane-preview')).toBeInTheDocument()
+    expect(screen.queryByTestId('drawer-pane-run')).toBeNull()
+    expect(screen.queryByTestId('drawer-pane-schedule')).toBeNull()
+  })
+
+  it('switching back to Run tab from another tab shows the run pane', () => {
+    renderDrawer()
+    fireEvent.click(screen.getByTestId('drawer-tab-schedule'))
+    fireEvent.click(screen.getByTestId('drawer-tab-run'))
+    expect(screen.getByTestId('drawer-tab-run')).toHaveClass('on')
+    expect(screen.getByTestId('drawer-pane-run')).toBeInTheDocument()
+    expect(screen.queryByTestId('drawer-pane-schedule')).toBeNull()
+  })
+})
+
+describe('WorkflowDrawer — security (A9.1)', () => {
+  it('renders workflow name as a text node, not HTML', () => {
+    const xss = '<img src=x onerror="window.__xss_drawer=1">'
+    renderDrawer(makeWorkflow({ name: xss }))
+    expect(screen.getByTestId('drawer-name')).toHaveTextContent(xss)
+    expect((window as unknown as Record<string, unknown>).__xss_drawer).toBeUndefined()
+  })
+})

--- a/web/src/workflow/WorkflowDrawer.test.tsx
+++ b/web/src/workflow/WorkflowDrawer.test.tsx
@@ -11,6 +11,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach } from 'vitest'
 import WorkflowDrawer from './WorkflowDrawer.tsx'
 import type { VersionedWorkflow } from './useWorkflows.ts'
+import { TenantScopeProvider } from '../shell/TenantScopeContext.tsx'
 
 afterEach(cleanup)
 
@@ -25,8 +26,16 @@ function makeWorkflow(overrides: Partial<VersionedWorkflow> = {}): VersionedWork
   }
 }
 
-function renderDrawer(workflow = makeWorkflow(), onClose = vi.fn()) {
-  return render(<WorkflowDrawer workflow={workflow} onClose={onClose} />)
+function renderDrawer(
+  workflow = makeWorkflow(),
+  onClose = vi.fn(),
+  rootPath = 'root/msp-a/client-1',
+) {
+  return render(
+    <TenantScopeProvider rootPath={rootPath}>
+      <WorkflowDrawer workflow={workflow} onClose={onClose} />
+    </TenantScopeProvider>,
+  )
 }
 
 describe('WorkflowDrawer — header', () => {
@@ -39,6 +48,18 @@ describe('WorkflowDrawer — header', () => {
   it('shows the version in the meta line', () => {
     renderDrawer()
     expect(screen.getByTestId('drawer-meta')).toHaveTextContent('v1.5.0')
+  })
+
+  it('shows the current tenant scope path in the meta line', () => {
+    renderDrawer(makeWorkflow(), vi.fn(), 'root/msp-a/client-1')
+    expect(screen.getByTestId('drawer-tenant-path')).toHaveTextContent(
+      'root/msp-a/client-1',
+    )
+  })
+
+  it('falls back to "root" for an empty (unnarrowed) tenant scope', () => {
+    renderDrawer(makeWorkflow(), vi.fn(), '')
+    expect(screen.getByTestId('drawer-tenant-path')).toHaveTextContent('root')
   })
 
   it('renders "Open builder" affordance as a stub button', () => {

--- a/web/src/workflow/WorkflowDrawer.test.tsx
+++ b/web/src/workflow/WorkflowDrawer.test.tsx
@@ -3,17 +3,46 @@
 
 /*
  * WorkflowDrawer test suite (Story #3039): drawer renders correctly, tabs
- * switch visible pane, close button fires onClose, and user content is
- * rendered as safe text nodes (Security A9.1).
+ * switch visible pane, close button fires onClose, the last-run status pill
+ * reflects the most recent execution, and user content is rendered as safe
+ * text nodes (Security A9.1).
  */
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach } from 'vitest'
 import WorkflowDrawer from './WorkflowDrawer.tsx'
 import type { VersionedWorkflow } from './useWorkflows.ts'
 import { TenantScopeProvider } from '../shell/TenantScopeContext.tsx'
 
-afterEach(cleanup)
+const fetchMock = vi.fn<typeof fetch>()
+
+function makeExecutionsResponse(executions: object[], status = 200) {
+  return new Response(
+    JSON.stringify({ executions, count: executions.length }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeExecution(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'exec-1',
+    workflow_name: 'onboard-user',
+    status: 'completed',
+    start_time: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(makeExecutionsResponse([]))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
 
 function makeWorkflow(overrides: Partial<VersionedWorkflow> = {}): VersionedWorkflow {
   return {
@@ -117,6 +146,49 @@ describe('WorkflowDrawer — tab bar', () => {
     expect(screen.getByTestId('drawer-tab-run')).toHaveClass('on')
     expect(screen.getByTestId('drawer-pane-run')).toBeInTheDocument()
     expect(screen.queryByTestId('drawer-pane-schedule')).toBeNull()
+  })
+})
+
+describe('WorkflowDrawer — last-run status pill', () => {
+  it('shows a neutral "Never run" pill when the workflow has no executions', async () => {
+    fetchMock.mockResolvedValue(makeExecutionsResponse([]))
+    renderDrawer()
+    const pill = await screen.findByTestId('drawer-last-run-pill')
+    expect(pill).toHaveClass('pill', 'neutral')
+    expect(pill).toHaveTextContent('Never run')
+  })
+
+  it('shows the most recent execution status, chosen by start_time not array order', async () => {
+    fetchMock.mockResolvedValue(
+      makeExecutionsResponse([
+        makeExecution({
+          id: 'exec-newer',
+          status: 'completed',
+          start_time: '2026-01-03T00:00:00Z',
+        }),
+        makeExecution({
+          id: 'exec-older',
+          status: 'failed',
+          start_time: '2026-01-01T00:00:00Z',
+        }),
+      ]),
+    )
+    renderDrawer()
+    const pill = await screen.findByTestId('drawer-last-run-pill')
+    expect(pill).toHaveClass('pill', 'ok')
+    expect(pill).toHaveTextContent('completed')
+  })
+
+  it('maps a failed last run to the crit tone', async () => {
+    fetchMock.mockResolvedValue(
+      makeExecutionsResponse([
+        makeExecution({ status: 'failed', start_time: '2026-01-01T00:00:00Z' }),
+      ]),
+    )
+    renderDrawer()
+    const pill = await screen.findByTestId('drawer-last-run-pill')
+    expect(pill).toHaveClass('pill', 'crit')
+    expect(pill).toHaveTextContent('failed')
   })
 })
 

--- a/web/src/workflow/WorkflowDrawer.test.tsx
+++ b/web/src/workflow/WorkflowDrawer.test.tsx
@@ -19,7 +19,7 @@ function makeWorkflow(overrides: Partial<VersionedWorkflow> = {}): VersionedWork
     name: 'onboard-user',
     description: 'Create a user on the DC',
     version: '1.5.0',
-    steps: [{ name: 'step-1', type: 'script', config: {} }],
+    steps: [{ id: 'step-1', name: 'step-1', type: 'script', config: {} }],
     semantic_version: { major: 1, minor: 5, patch: 0, pre_release: '', build_meta: '' },
     ...overrides,
   }

--- a/web/src/workflow/WorkflowDrawer.tsx
+++ b/web/src/workflow/WorkflowDrawer.tsx
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * Overlay drawer shell for the /workflows browse view (Story #3039).
+ * Positioned absolute inside .workspace so the list table rows never
+ * reflow when the drawer opens or closes.
+ *
+ * Tab slots: Run (F3), Schedule (#2986), Preview (F4) are placeholder panes;
+ * sibling stories mount their content here.
+ *
+ * Security A9.1: workflow.name and workflow.description originate from
+ * user-supplied content and are rendered as JSX text nodes only —
+ * never dangerouslySetInnerHTML.
+ */
+import { useState } from 'react'
+import type { VersionedWorkflow } from './useWorkflows.ts'
+
+type DrawerTab = 'run' | 'schedule' | 'preview'
+
+interface WorkflowDrawerProps {
+  workflow: VersionedWorkflow
+  onClose: () => void
+}
+
+export default function WorkflowDrawer({ workflow, onClose }: WorkflowDrawerProps) {
+  const [activeTab, setActiveTab] = useState<DrawerTab>('run')
+
+  return (
+    <aside
+      className="drawer"
+      data-testid="workflow-drawer"
+      aria-label={`${workflow.name} details`}
+    >
+      <div className="dhead">
+        <div className="top">
+          <h2 data-testid="drawer-name">{workflow.name}</h2>
+          <div className="acts">
+            <button
+              type="button"
+              className="wf-btn-sm"
+              data-testid="drawer-open-builder"
+            >
+              ⤢ Open builder
+            </button>
+            <button
+              type="button"
+              className="icobtn"
+              aria-label="Close"
+              onClick={onClose}
+              data-testid="drawer-close"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+        {workflow.version && (
+          <div className="meta" data-testid="drawer-meta">
+            v{workflow.version}
+          </div>
+        )}
+      </div>
+
+      <div className="dtabs" role="tablist" aria-label="Workflow details tabs">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'run'}
+          className={activeTab === 'run' ? 'on' : ''}
+          onClick={() => setActiveTab('run')}
+          data-testid="drawer-tab-run"
+        >
+          Run
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'schedule'}
+          className={activeTab === 'schedule' ? 'on' : ''}
+          onClick={() => setActiveTab('schedule')}
+          data-testid="drawer-tab-schedule"
+        >
+          Schedule
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'preview'}
+          className={activeTab === 'preview' ? 'on' : ''}
+          onClick={() => setActiveTab('preview')}
+          data-testid="drawer-tab-preview"
+        >
+          What it does
+        </button>
+      </div>
+
+      <div className="dbody" role="tabpanel">
+        {activeTab === 'run' && (
+          <div data-testid="drawer-pane-run">
+            <p className="mut">Run and execution history — coming in a later story.</p>
+          </div>
+        )}
+        {activeTab === 'schedule' && (
+          <div data-testid="drawer-pane-schedule">
+            <p className="mut">Triggers and schedule — coming in a later story.</p>
+          </div>
+        )}
+        {activeTab === 'preview' && (
+          <div data-testid="drawer-pane-preview">
+            <p className="mut">Workflow preview — coming in a later story.</p>
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/web/src/workflow/WorkflowDrawer.tsx
+++ b/web/src/workflow/WorkflowDrawer.tsx
@@ -9,19 +9,18 @@
  * Tab slots: Run (F3), Schedule (#2986), Preview (F4) are placeholder panes;
  * sibling stories mount their content here.
  *
- * Deferred: tracked as a private backlog draft under epic #2859 (item
- * PVTI_lADOCrV4cc4BX5ezzg0p32k — materializes to a numbered issue at
- * dispatch). The header's last-run status pill needs per-workflow execution
- * data, which the Run tab (F3) also owns; wiring a second, independent fetch
- * here ahead of F3 risks duplicating/conflicting with that story's data flow,
- * so it's tracked as follow-up instead of implemented in this shell story.
+ * Last-run status pill: derived from useWorkflowExecutions(workflow.name) —
+ * the same fetch the Run tab (F3) will also mount — picking whichever
+ * execution has the latest start_time (the endpoint documents no ordering).
+ * A workflow with no executions yet renders a neutral "Never run" pill.
  *
- * Security A9.1: workflow.name and workflow.description originate from
- * user-supplied content and are rendered as JSX text nodes only —
- * never dangerouslySetInnerHTML.
+ * Security A9.1: workflow.name, workflow.description, and execution status
+ * originate from user-supplied / controller content and are rendered as
+ * JSX text nodes only — never dangerouslySetInnerHTML.
  */
 import { useState } from 'react'
-import type { VersionedWorkflow } from './useWorkflows.ts'
+import type { VersionedWorkflow, WorkflowExecution } from './useWorkflows.ts'
+import { useWorkflowExecutions } from './useWorkflows.ts'
 import { useTenantScope } from '../shell/TenantScopeContext.tsx'
 
 type DrawerTab = 'run' | 'schedule' | 'preview'
@@ -31,6 +30,31 @@ interface WorkflowDrawerProps {
   onClose: () => void
 }
 
+function lastRunTone(status: string): string {
+  switch (status) {
+    case 'completed':
+      return 'ok'
+    case 'failed':
+    case 'cancelled':
+      return 'crit'
+    case 'running':
+    case 'pending':
+    case 'paused':
+      return 'warn'
+    default:
+      return 'neutral'
+  }
+}
+
+function mostRecentExecution(
+  executions: WorkflowExecution[],
+): WorkflowExecution | null {
+  return executions.reduce<WorkflowExecution | null>((latest, ex) => {
+    if (!latest) return ex
+    return Date.parse(ex.start_time) > Date.parse(latest.start_time) ? ex : latest
+  }, null)
+}
+
 export default function WorkflowDrawer({ workflow, onClose }: WorkflowDrawerProps) {
   const [activeTab, setActiveTab] = useState<DrawerTab>('run')
   const { scope } = useTenantScope()
@@ -38,6 +62,8 @@ export default function WorkflowDrawer({ workflow, onClose }: WorkflowDrawerProp
   // request's scoped tenant (workflowStoreForRequest), so the current scope
   // is the correct tenant path for any workflow in this list.
   const tenantPath = scope || 'root'
+  const { executions } = useWorkflowExecutions(workflow.name)
+  const lastRun = mostRecentExecution(executions)
 
   return (
     <aside
@@ -70,6 +96,14 @@ export default function WorkflowDrawer({ workflow, onClose }: WorkflowDrawerProp
         <div className="meta" data-testid="drawer-meta">
           {workflow.version && <>v{workflow.version} · </>}
           <span data-testid="drawer-tenant-path">{tenantPath}</span>
+          {' · '}
+          <span
+            className={`pill ${lastRun ? lastRunTone(lastRun.status) : 'neutral'}`}
+            data-testid="drawer-last-run-pill"
+          >
+            <span className="dot" />
+            {lastRun ? lastRun.status : 'Never run'}
+          </span>
         </div>
       </div>
 

--- a/web/src/workflow/WorkflowDrawer.tsx
+++ b/web/src/workflow/WorkflowDrawer.tsx
@@ -9,12 +9,20 @@
  * Tab slots: Run (F3), Schedule (#2986), Preview (F4) are placeholder panes;
  * sibling stories mount their content here.
  *
+ * Deferred: tracked as a private backlog draft under epic #2859 (item
+ * PVTI_lADOCrV4cc4BX5ezzg0p32k — materializes to a numbered issue at
+ * dispatch). The header's last-run status pill needs per-workflow execution
+ * data, which the Run tab (F3) also owns; wiring a second, independent fetch
+ * here ahead of F3 risks duplicating/conflicting with that story's data flow,
+ * so it's tracked as follow-up instead of implemented in this shell story.
+ *
  * Security A9.1: workflow.name and workflow.description originate from
  * user-supplied content and are rendered as JSX text nodes only —
  * never dangerouslySetInnerHTML.
  */
 import { useState } from 'react'
 import type { VersionedWorkflow } from './useWorkflows.ts'
+import { useTenantScope } from '../shell/TenantScopeContext.tsx'
 
 type DrawerTab = 'run' | 'schedule' | 'preview'
 
@@ -25,6 +33,11 @@ interface WorkflowDrawerProps {
 
 export default function WorkflowDrawer({ workflow, onClose }: WorkflowDrawerProps) {
   const [activeTab, setActiveTab] = useState<DrawerTab>('run')
+  const { scope } = useTenantScope()
+  // Every workflow in a single GET /api/v1/workflows response belongs to the
+  // request's scoped tenant (workflowStoreForRequest), so the current scope
+  // is the correct tenant path for any workflow in this list.
+  const tenantPath = scope || 'root'
 
   return (
     <aside
@@ -54,11 +67,10 @@ export default function WorkflowDrawer({ workflow, onClose }: WorkflowDrawerProp
             </button>
           </div>
         </div>
-        {workflow.version && (
-          <div className="meta" data-testid="drawer-meta">
-            v{workflow.version}
-          </div>
-        )}
+        <div className="meta" data-testid="drawer-meta">
+          {workflow.version && <>v{workflow.version} · </>}
+          <span data-testid="drawer-tenant-path">{tenantPath}</span>
+        </div>
       </div>
 
       <div className="dtabs" role="tablist" aria-label="Workflow details tabs">

--- a/web/src/workflow/WorkflowListView.test.tsx
+++ b/web/src/workflow/WorkflowListView.test.tsx
@@ -13,6 +13,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { AuthProvider } from '../auth/AuthContext.tsx'
+import { TenantScopeProvider } from '../shell/TenantScopeContext.tsx'
 import WorkflowListView from './WorkflowListView.tsx'
 
 const fetchMock = vi.fn<typeof fetch>()
@@ -49,7 +50,9 @@ function renderWorkflowListView() {
   return render(
     <MemoryRouter>
       <AuthProvider>
-        <WorkflowListView />
+        <TenantScopeProvider rootPath="root">
+          <WorkflowListView />
+        </TenantScopeProvider>
       </AuthProvider>
     </MemoryRouter>,
   )
@@ -130,6 +133,7 @@ describe('WorkflowListView — overlay drawer', () => {
     fireEvent.click(screen.getByTestId('workflow-row'))
     expect(screen.getByTestId('workflow-drawer')).toBeInTheDocument()
     expect(screen.getByTestId('drawer-name')).toHaveTextContent('wf-1')
+    expect(screen.getByTestId('drawer-tenant-path')).toHaveTextContent('root')
   })
 
   it('clicking ✕ closes the drawer', async () => {

--- a/web/src/workflow/WorkflowListView.test.tsx
+++ b/web/src/workflow/WorkflowListView.test.tsx
@@ -2,9 +2,12 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * WorkflowListView test suite (Stories #2731, #2984): list rendering, data
- * states, create panel toggle, trigger panel toggle, delete confirm, and the
- * structured step/variable authoring path (Story #2984).
+ * WorkflowListView test suite (Story #3039): overlay drawer shell behavior —
+ * row-select opens the drawer, ✕ closes it, tab switching works, and the
+ * list column layout is unchanged between open/closed states.
+ *
+ * Also covers data states (loading, empty, error, table), the delete confirm
+ * dialog, and security (A9.1).
  */
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -42,20 +45,6 @@ function makeWorkflow(overrides: Partial<Record<string, unknown>> = {}) {
   }
 }
 
-function makeTriggersResponse(triggers: object[], status = 200) {
-  return new Response(
-    JSON.stringify({ triggers, count: triggers.length }),
-    { status, headers: { 'Content-Type': 'application/json' } },
-  )
-}
-
-function makeExecutionsResponse(executions: object[], status = 200) {
-  return new Response(
-    JSON.stringify({ executions, count: executions.length }),
-    { status, headers: { 'Content-Type': 'application/json' } },
-  )
-}
-
 function renderWorkflowListView() {
   return render(
     <MemoryRouter>
@@ -66,6 +55,8 @@ function renderWorkflowListView() {
   )
 }
 
+// ── Page structure ────────────────────────────────────────────────────────────
+
 describe('WorkflowListView — heading and page structure', () => {
   it('shows the Workflows heading', () => {
     fetchMock.mockReturnValue(new Promise(() => {}))
@@ -74,14 +65,9 @@ describe('WorkflowListView — heading and page structure', () => {
       screen.getByRole('heading', { name: /workflows/i, level: 1 }),
     ).toBeInTheDocument()
   })
-
-  it('shows the New workflow and Triggers buttons', () => {
-    fetchMock.mockResolvedValue(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    expect(screen.getByTestId('toggle-create-btn')).toBeInTheDocument()
-    expect(screen.getByTestId('toggle-triggers-btn')).toBeInTheDocument()
-  })
 })
+
+// ── Data states ───────────────────────────────────────────────────────────────
 
 describe('WorkflowListView — data states', () => {
   it('shows loading state before the response', () => {
@@ -132,180 +118,117 @@ describe('WorkflowListView — data states', () => {
   })
 })
 
-describe('WorkflowListView — create panel', () => {
-  it('shows create panel when New workflow is clicked', async () => {
-    fetchMock.mockResolvedValue(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-    expect(screen.getByTestId('workflow-form-panel')).toBeInTheDocument()
-    expect(screen.getByTestId('workflow-name-input')).toBeInTheDocument()
-  })
+// ── Overlay drawer (Story #3039) ──────────────────────────────────────────────
 
-  it('hides create panel when toggled off', async () => {
-    fetchMock.mockResolvedValue(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-    expect(screen.getByTestId('workflow-form-panel')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-    expect(screen.queryByTestId('workflow-form-panel')).toBeNull()
-  })
-
-  it('submits create form via POST and refreshes list', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-
-    // Fill in form
-    fireEvent.change(screen.getByTestId('workflow-name-input'), {
-      target: { value: 'new-workflow' },
-    })
-
-    // Mock create response + list refresh
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({ name: 'new-workflow', steps: [{ name: 's1', type: 'script' }], semantic_version: {}, version: '1.0.0', description: '' }),
-        { status: 201, headers: { 'Content-Type': 'application/json' } },
-      ),
-    )
-    fetchMock.mockResolvedValueOnce(
-      makeWorkflowListResponse([makeWorkflow({ name: 'new-workflow' })]),
-    )
-
-    fireEvent.click(screen.getByTestId('workflow-save-btn'))
-
-    await waitFor(() =>
-      expect(screen.queryByTestId('workflow-form-panel')).toBeNull(),
-    )
-  })
-
-  it('shows validation error when a step has an empty name', async () => {
-    fetchMock.mockResolvedValue(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-    fireEvent.change(screen.getByTestId('workflow-name-input'), {
-      target: { value: 'bad-wf' },
-    })
-    // Clear the step name to trigger validation
-    fireEvent.change(screen.getByTestId('step-name-input'), {
-      target: { value: '' },
-    })
-    fireEvent.click(screen.getByTestId('workflow-save-btn'))
-    expect(screen.getByTestId('workflow-save-error')).toBeInTheDocument()
-  })
-
-  it('shows server error and keeps panel open when create POST fails', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-    fireEvent.change(screen.getByTestId('workflow-name-input'), {
-      target: { value: 'dup-workflow' },
-    })
-
-    // Server rejects the create with a 409 and an error body.
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: 'workflow already exists' }), {
-        status: 409,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-
-    fireEvent.click(screen.getByTestId('workflow-save-btn'))
-
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-save-error')).toBeInTheDocument(),
-    )
-    expect(screen.getByTestId('workflow-save-error')).toHaveTextContent(
-      /workflow already exists/i,
-    )
-    // Panel stays open so the user can correct and retry.
-    expect(screen.getByTestId('workflow-form-panel')).toBeInTheDocument()
-  })
-
-  it('shows server error when edit PUT fails', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow()]))
+describe('WorkflowListView — overlay drawer', () => {
+  it('clicking a row opens the overlay drawer', async () => {
+    fetchMock.mockResolvedValue(makeWorkflowListResponse([makeWorkflow()]))
     renderWorkflowListView()
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
-
-    fireEvent.click(screen.getByTestId('workflow-edit-btn'))
-    expect(screen.getByTestId('workflow-form-panel')).toBeInTheDocument()
-
-    // Server rejects the update with a 500 (no parseable error body → status message).
-    fetchMock.mockResolvedValueOnce(
-      new Response('internal error', { status: 500 }),
-    )
-
-    fireEvent.click(screen.getByTestId('workflow-save-btn'))
-
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-save-error')).toBeInTheDocument(),
-    )
-    expect(screen.getByTestId('workflow-save-error')).toHaveTextContent(/500/)
-    expect(screen.getByTestId('workflow-form-panel')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('workflow-row'))
+    expect(screen.getByTestId('workflow-drawer')).toBeInTheDocument()
+    expect(screen.getByTestId('drawer-name')).toHaveTextContent('wf-1')
   })
-})
 
-describe('WorkflowListView — row actions', () => {
-  it('opens execution view when a row is clicked', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow()]))
-    // Mock the execution view's fetch
-    fetchMock.mockResolvedValue(makeExecutionsResponse([]))
-
+  it('clicking ✕ closes the drawer', async () => {
+    fetchMock.mockResolvedValue(makeWorkflowListResponse([makeWorkflow()]))
     renderWorkflowListView()
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
-
     fireEvent.click(screen.getByTestId('workflow-row'))
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-exec-panel')).toBeInTheDocument(),
-    )
+    expect(screen.getByTestId('workflow-drawer')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('drawer-close'))
+    expect(screen.queryByTestId('workflow-drawer')).toBeNull()
   })
 
-  it('closes execution view when same row is clicked again', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow()]))
-    fetchMock.mockResolvedValue(makeExecutionsResponse([]))
-
+  it('clicking the same row a second time closes the drawer', async () => {
+    fetchMock.mockResolvedValue(makeWorkflowListResponse([makeWorkflow()]))
     renderWorkflowListView()
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
-
     fireEvent.click(screen.getByTestId('workflow-row'))
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-exec-panel')).toBeInTheDocument(),
-    )
-
+    expect(screen.getByTestId('workflow-drawer')).toBeInTheDocument()
     fireEvent.click(screen.getByTestId('workflow-row'))
-    expect(screen.queryByTestId('workflow-exec-panel')).toBeNull()
+    expect(screen.queryByTestId('workflow-drawer')).toBeNull()
   })
 
-  it('shows delete confirm dialog when delete button is clicked', async () => {
+  it('clicking a different row switches the drawer to that workflow', async () => {
+    fetchMock.mockResolvedValue(
+      makeWorkflowListResponse([makeWorkflow(), makeWorkflow({ name: 'wf-2', version: '2.0.0' })]),
+    )
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
+    )
+    const rows = screen.getAllByTestId('workflow-row')
+    fireEvent.click(rows[0]!)
+    expect(screen.getByTestId('drawer-name')).toHaveTextContent('wf-1')
+    fireEvent.click(rows[1]!)
+    expect(screen.getByTestId('drawer-name')).toHaveTextContent('wf-2')
+    expect(screen.getByTestId('workflow-drawer')).toBeInTheDocument()
+  })
+
+  it('table column headers are identical whether the drawer is open or closed', async () => {
     fetchMock.mockResolvedValue(makeWorkflowListResponse([makeWorkflow()]))
     renderWorkflowListView()
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
 
+    const headersBefore = screen
+      .getAllByRole('columnheader')
+      .map((h) => h.textContent)
+
+    fireEvent.click(screen.getByTestId('workflow-row'))
+    expect(screen.getByTestId('workflow-drawer')).toBeInTheDocument()
+
+    const headersAfter = screen
+      .getAllByRole('columnheader')
+      .map((h) => h.textContent)
+
+    expect(headersAfter).toEqual(headersBefore)
+  })
+
+  it('tab switching: clicking Schedule tab shows schedule pane and hides run pane', async () => {
+    fetchMock.mockResolvedValue(makeWorkflowListResponse([makeWorkflow()]))
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('workflow-row'))
+    expect(screen.getByTestId('drawer-pane-run')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('drawer-tab-schedule'))
+    expect(screen.queryByTestId('drawer-pane-run')).toBeNull()
+    expect(screen.getByTestId('drawer-pane-schedule')).toBeInTheDocument()
+  })
+
+  it('tab switching: clicking Preview tab shows preview pane', async () => {
+    fetchMock.mockResolvedValue(makeWorkflowListResponse([makeWorkflow()]))
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('workflow-row'))
+    fireEvent.click(screen.getByTestId('drawer-tab-preview'))
+    expect(screen.getByTestId('drawer-pane-preview')).toBeInTheDocument()
+    expect(screen.queryByTestId('drawer-pane-run')).toBeNull()
+  })
+})
+
+// ── Delete confirm dialog ─────────────────────────────────────────────────────
+
+describe('WorkflowListView — delete confirm dialog', () => {
+  it('shows delete confirm dialog when delete button is clicked', async () => {
+    fetchMock.mockResolvedValue(makeWorkflowListResponse([makeWorkflow()]))
+    renderWorkflowListView()
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
+    )
     fireEvent.click(screen.getByTestId('workflow-delete-btn'))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByTestId('delete-confirm-btn')).toBeInTheDocument()
@@ -317,10 +240,8 @@ describe('WorkflowListView — row actions', () => {
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
-
     fireEvent.click(screen.getByTestId('workflow-delete-btn'))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
-
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(screen.queryByRole('dialog')).toBeNull()
   })
@@ -331,10 +252,8 @@ describe('WorkflowListView — row actions', () => {
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
-
     fireEvent.click(screen.getByTestId('workflow-delete-btn'))
 
-    // Queue DELETE + list-refresh responses before confirming (confirm fires fetch immediately)
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ deleted: 'wf-1', versions: 1 }), {
         status: 200,
@@ -348,8 +267,6 @@ describe('WorkflowListView — row actions', () => {
     await waitFor(() =>
       expect(screen.queryByRole('dialog')).toBeNull(),
     )
-    // The DELETE succeeded, so no error notice surfaces and the refreshed
-    // list renders the empty state.
     expect(screen.queryByTestId('delete-error')).toBeNull()
     await waitFor(() =>
       expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
@@ -362,10 +279,8 @@ describe('WorkflowListView — row actions', () => {
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
-
     fireEvent.click(screen.getByTestId('workflow-delete-btn'))
 
-    // Server rejects the delete with a 403 and an error body.
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ error: 'workflow is referenced by a trigger' }), {
         status: 403,
@@ -375,52 +290,17 @@ describe('WorkflowListView — row actions', () => {
 
     fireEvent.click(screen.getByTestId('delete-confirm-btn'))
 
-    // Dialog closes optimistically, then the error notice surfaces.
     await waitFor(() =>
       expect(screen.getByTestId('delete-error')).toBeInTheDocument(),
     )
     expect(screen.getByTestId('delete-error')).toHaveTextContent(
       /referenced by a trigger/i,
     )
-    // The workflow row remains since the delete did not take effect.
     expect(screen.getByTestId('workflow-table')).toBeInTheDocument()
   })
 })
 
-describe('WorkflowListView — trigger panel', () => {
-  it('shows trigger panel when Triggers is clicked', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
-    fetchMock.mockResolvedValue(makeTriggersResponse([]))
-
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-
-    fireEvent.click(screen.getByTestId('toggle-triggers-btn'))
-    await waitFor(() =>
-      expect(screen.getByTestId('trigger-panel')).toBeInTheDocument(),
-    )
-  })
-
-  it('hides trigger panel when toggled off', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
-    fetchMock.mockResolvedValue(makeTriggersResponse([]))
-
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-
-    fireEvent.click(screen.getByTestId('toggle-triggers-btn'))
-    await waitFor(() =>
-      expect(screen.getByTestId('trigger-panel')).toBeInTheDocument(),
-    )
-
-    fireEvent.click(screen.getByTestId('toggle-triggers-btn'))
-    expect(screen.queryByTestId('trigger-panel')).toBeNull()
-  })
-})
+// ── Error-card classification ─────────────────────────────────────────────────
 
 describe('WorkflowListView — error-card classification', () => {
   it('shows server-error copy (not connectivity) for a 5xx response', async () => {
@@ -439,6 +319,8 @@ describe('WorkflowListView — error-card classification', () => {
   })
 })
 
+// ── Security (A9.1) ───────────────────────────────────────────────────────────
+
 describe('WorkflowListView — security (A9.1)', () => {
   it('renders workflow name and description as plain text, not HTML', async () => {
     const xss = '<img src=x onerror="window.__xss=1">'
@@ -452,287 +334,18 @@ describe('WorkflowListView — security (A9.1)', () => {
     expect(screen.getAllByText(xss).length).toBeGreaterThan(0)
     expect((window as unknown as Record<string, unknown>).__xss).toBeUndefined()
   })
-})
 
-// ── Story #2984: structured step builder ─────────────────────────────────────
-
-async function openCreatePanel() {
-  fetchMock.mockResolvedValue(makeWorkflowListResponse([]))
-  renderWorkflowListView()
-  await waitFor(() =>
-    expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-  )
-  fireEvent.click(screen.getByTestId('toggle-create-btn'))
-  expect(screen.getByTestId('workflow-form-panel')).toBeInTheDocument()
-}
-
-describe('WorkflowListView — structured step builder (Story #2984)', () => {
-  it('shows one step row with name input and type select by default', async () => {
-    await openCreatePanel()
-    expect(screen.getAllByTestId('step-row')).toHaveLength(1)
-    expect(screen.getByTestId('step-name-input')).toBeInTheDocument()
-    expect(screen.getByTestId('step-type-select')).toBeInTheDocument()
-  })
-
-  it('default step type is script and shows script body input', async () => {
-    await openCreatePanel()
-    const typeSelect = screen.getByTestId('step-type-select') as HTMLSelectElement
-    expect(typeSelect.value).toBe('script')
-    expect(screen.getByTestId('step-script-input')).toBeInTheDocument()
-  })
-
-  it('does not show remove button when only one step exists', async () => {
-    await openCreatePanel()
-    expect(screen.queryByTestId('step-remove-btn')).toBeNull()
-  })
-
-  it('Add step button adds a second step row', async () => {
-    await openCreatePanel()
-    fireEvent.click(screen.getByTestId('add-step-btn'))
-    expect(screen.getAllByTestId('step-row')).toHaveLength(2)
-    expect(screen.getAllByTestId('step-name-input')).toHaveLength(2)
-  })
-
-  it('shows remove button on each row when multiple steps exist', async () => {
-    await openCreatePanel()
-    fireEvent.click(screen.getByTestId('add-step-btn'))
-    expect(screen.getAllByTestId('step-remove-btn')).toHaveLength(2)
-  })
-
-  it('Remove step button removes that row', async () => {
-    await openCreatePanel()
-    fireEvent.click(screen.getByTestId('add-step-btn'))
-    expect(screen.getAllByTestId('step-row')).toHaveLength(2)
-
-    const removeBtns = screen.getAllByTestId('step-remove-btn')
-    fireEvent.click(removeBtns[0]!)
-    expect(screen.getAllByTestId('step-row')).toHaveLength(1)
-  })
-
-  it('editing an existing workflow loads its step rows into the builder', async () => {
-    fetchMock.mockResolvedValueOnce(
-      makeWorkflowListResponse([
-        makeWorkflow({
-          name: 'wf-1',
-          steps: [
-            { name: 'step-a', type: 'script', config: { script: 'echo a' } },
-            { name: 'step-b', type: 'script', config: {} },
-          ],
-        }),
-      ]),
+  it('renders workflow name in drawer as plain text, not HTML', async () => {
+    const xss = '<img src=x onerror="window.__xss_list=1">'
+    fetchMock.mockResolvedValue(
+      makeWorkflowListResponse([makeWorkflow({ name: xss })]),
     )
     renderWorkflowListView()
     await waitFor(() =>
       expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
     )
-    fireEvent.click(screen.getByTestId('workflow-edit-btn'))
-
-    const nameInputs = screen.getAllByTestId('step-name-input') as HTMLInputElement[]
-    expect(nameInputs).toHaveLength(2)
-    expect(nameInputs[0]!.value).toBe('step-a')
-    expect(nameInputs[1]!.value).toBe('step-b')
-  })
-
-  it('script step script-body field is pre-populated from existing config.script', async () => {
-    fetchMock.mockResolvedValueOnce(
-      makeWorkflowListResponse([
-        makeWorkflow({
-          steps: [{ name: 'run', type: 'script', config: { script: 'echo hello' } }],
-        }),
-      ]),
-    )
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
-    )
-    fireEvent.click(screen.getByTestId('workflow-edit-btn'))
-
-    const scriptInput = screen.getByTestId('step-script-input') as HTMLTextAreaElement
-    expect(scriptInput.value).toBe('echo hello')
-  })
-
-  it('submit sends correct body shape with structured steps — no hand-written JSON', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-
-    fireEvent.change(screen.getByTestId('workflow-name-input'), {
-      target: { value: 'my-wf' },
-    })
-    fireEvent.change(screen.getByTestId('step-name-input'), {
-      target: { value: 'run-task' },
-    })
-    fireEvent.change(screen.getByTestId('step-script-input'), {
-      target: { value: 'echo done' },
-    })
-
-    let capturedBody: Record<string, unknown> | null = null
-    fetchMock.mockImplementationOnce((_url: RequestInfo | URL, opts?: RequestInit): Promise<Response> => {
-      capturedBody = JSON.parse((opts?.body as string) ?? '{}') as Record<string, unknown>
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({ name: 'my-wf', steps: [], semantic_version: {}, version: '1.0.0', description: '' }),
-          { status: 201, headers: { 'Content-Type': 'application/json' } },
-        ),
-      )
-    })
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow({ name: 'my-wf' })]))
-
-    fireEvent.click(screen.getByTestId('workflow-save-btn'))
-
-    await waitFor(() =>
-      expect(screen.queryByTestId('workflow-form-panel')).toBeNull(),
-    )
-    expect(capturedBody).not.toBeNull()
-    expect(capturedBody).toMatchObject({
-      name: 'my-wf',
-      steps: [{ name: 'run-task', type: 'script', config: { script: 'echo done' } }],
-    })
-    expect(capturedBody).not.toHaveProperty('steps[0].stepsJson')
-  })
-})
-
-// ── Story #2984: variables key/value row editor ───────────────────────────────
-
-describe('WorkflowListView — variables editor (Story #2984)', () => {
-  it('shows no variable rows by default in create form', async () => {
-    await openCreatePanel()
-    expect(screen.queryByTestId('var-row')).toBeNull()
-  })
-
-  it('Add variable button adds a key/value row', async () => {
-    await openCreatePanel()
-    fireEvent.click(screen.getByTestId('add-var-btn'))
-    expect(screen.getAllByTestId('var-row')).toHaveLength(1)
-    expect(screen.getByTestId('var-key-input')).toBeInTheDocument()
-    expect(screen.getByTestId('var-value-input')).toBeInTheDocument()
-  })
-
-  it('Remove variable button removes that row', async () => {
-    await openCreatePanel()
-    fireEvent.click(screen.getByTestId('add-var-btn'))
-    expect(screen.getAllByTestId('var-row')).toHaveLength(1)
-    fireEvent.click(screen.getByTestId('var-remove-btn'))
-    expect(screen.queryByTestId('var-row')).toBeNull()
-  })
-
-  it('multiple variable rows can be added and individually removed', async () => {
-    await openCreatePanel()
-    fireEvent.click(screen.getByTestId('add-var-btn'))
-    fireEvent.click(screen.getByTestId('add-var-btn'))
-    expect(screen.getAllByTestId('var-row')).toHaveLength(2)
-
-    const removeBtns = screen.getAllByTestId('var-remove-btn')
-    fireEvent.click(removeBtns[0]!)
-    expect(screen.getAllByTestId('var-row')).toHaveLength(1)
-  })
-
-  it('submit with variables sends the correct variables object shape', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-
-    fireEvent.change(screen.getByTestId('workflow-name-input'), {
-      target: { value: 'var-wf' },
-    })
-    fireEvent.change(screen.getByTestId('step-name-input'), {
-      target: { value: 'step-1' },
-    })
-
-    fireEvent.click(screen.getByTestId('add-var-btn'))
-    fireEvent.click(screen.getByTestId('add-var-btn'))
-
-    const keyInputs = screen.getAllByTestId('var-key-input') as HTMLInputElement[]
-    const valInputs = screen.getAllByTestId('var-value-input') as HTMLInputElement[]
-    fireEvent.change(keyInputs[0]!, { target: { value: 'ENV' } })
-    fireEvent.change(valInputs[0]!, { target: { value: 'production' } })
-    fireEvent.change(keyInputs[1]!, { target: { value: 'TIMEOUT' } })
-    fireEvent.change(valInputs[1]!, { target: { value: '30' } })
-
-    let capturedBody: Record<string, unknown> | null = null
-    fetchMock.mockImplementationOnce((_url: RequestInfo | URL, opts?: RequestInit): Promise<Response> => {
-      capturedBody = JSON.parse((opts?.body as string) ?? '{}') as Record<string, unknown>
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({ name: 'var-wf', steps: [], semantic_version: {}, version: '1.0.0', description: '' }),
-          { status: 201, headers: { 'Content-Type': 'application/json' } },
-        ),
-      )
-    })
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow({ name: 'var-wf' })]))
-
-    fireEvent.click(screen.getByTestId('workflow-save-btn'))
-
-    await waitFor(() =>
-      expect(screen.queryByTestId('workflow-form-panel')).toBeNull(),
-    )
-    expect(capturedBody).toMatchObject({
-      variables: { ENV: 'production', TIMEOUT: '30' },
-    })
-  })
-
-  it('editing a workflow with variables pre-populates the variable rows', async () => {
-    fetchMock.mockResolvedValueOnce(
-      makeWorkflowListResponse([
-        makeWorkflow({ variables: { FOO: 'bar', BAZ: '42' } }),
-      ]),
-    )
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-table')).toBeInTheDocument(),
-    )
-    fireEvent.click(screen.getByTestId('workflow-edit-btn'))
-
-    const keyInputs = screen.getAllByTestId('var-key-input') as HTMLInputElement[]
-    const valInputs = screen.getAllByTestId('var-value-input') as HTMLInputElement[]
-    expect(keyInputs).toHaveLength(2)
-    // Keys may be in any order depending on Object.entries order
-    const pairs = keyInputs.map((k, i) => `${k.value}=${valInputs.at(i)?.value ?? ''}`)
-    expect(pairs).toContain('FOO=bar')
-    expect(pairs).toContain('BAZ=42')
-  })
-
-  it('variables rows omitted from submit body when all keys are empty', async () => {
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([]))
-    renderWorkflowListView()
-    await waitFor(() =>
-      expect(screen.getByTestId('workflow-empty')).toBeInTheDocument(),
-    )
-    fireEvent.click(screen.getByTestId('toggle-create-btn'))
-
-    fireEvent.change(screen.getByTestId('workflow-name-input'), {
-      target: { value: 'no-vars-wf' },
-    })
-    fireEvent.change(screen.getByTestId('step-name-input'), {
-      target: { value: 'step-1' },
-    })
-
-    // Add a var row but leave key empty
-    fireEvent.click(screen.getByTestId('add-var-btn'))
-
-    let capturedBody: Record<string, unknown> | null = null
-    fetchMock.mockImplementationOnce((_url: RequestInfo | URL, opts?: RequestInit): Promise<Response> => {
-      capturedBody = JSON.parse((opts?.body as string) ?? '{}') as Record<string, unknown>
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({ name: 'no-vars-wf', steps: [], semantic_version: {}, version: '1.0.0', description: '' }),
-          { status: 201, headers: { 'Content-Type': 'application/json' } },
-        ),
-      )
-    })
-    fetchMock.mockResolvedValueOnce(makeWorkflowListResponse([makeWorkflow({ name: 'no-vars-wf' })]))
-
-    fireEvent.click(screen.getByTestId('workflow-save-btn'))
-
-    await waitFor(() =>
-      expect(screen.queryByTestId('workflow-form-panel')).toBeNull(),
-    )
-    expect(capturedBody).not.toHaveProperty('variables')
+    fireEvent.click(screen.getByTestId('workflow-row'))
+    expect(screen.getByTestId('drawer-name')).toHaveTextContent(xss)
+    expect((window as unknown as Record<string, unknown>).__xss_list).toBeUndefined()
   })
 })

--- a/web/src/workflow/WorkflowListView.tsx
+++ b/web/src/workflow/WorkflowListView.tsx
@@ -2,111 +2,27 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Workflow list view (Stories #2731, #2984) — the /workflows route entry point.
- * Fetches GET /api/v1/workflows, renders a table, and exposes workflow
- * create/edit/delete, execution tracking, and trigger management.
+ * Workflow list view (Stories #2731, #2984, #3039) — the /workflows route
+ * entry point. Fetches GET /api/v1/workflows and renders a table. Selecting
+ * a row opens the overlay drawer (WorkflowDrawer) without reflowing the list.
  *
- * Security A9.1: workflow name, description, step names, step values, and
- * variable keys/values originate from user-supplied content. Every value
- * reaches the DOM as a JSX text node or controlled input value —
- * never dangerouslySetInnerHTML.
+ * Story #3039: stacked inline panels (create/edit form, trigger panel,
+ * execution view) removed in favour of the overlay drawer shell. Tab content
+ * (Run/Schedule/Preview) is mounted by sibling stories F3, #2986, and F4.
+ *
+ * Security A9.1: workflow name and description originate from user-supplied
+ * content. Every value reaches the DOM as a JSX text node or controlled input
+ * value — never dangerouslySetInnerHTML.
  */
 import { useState } from 'react'
 import { apiFetch } from '../api/client.ts'
 import {
   useWorkflowList,
   type VersionedWorkflow,
-  type WorkflowStep,
 } from './useWorkflows.ts'
-import WorkflowExecutionView from './WorkflowExecutionView.tsx'
-import TriggerPanel from './TriggerPanel.tsx'
+import WorkflowDrawer from './WorkflowDrawer.tsx'
 import ErrorCard from '../shell/ErrorCard.tsx'
 import './Workflow.css'
-
-// ── Row ID counter (used only as React key, never surfaced to DOM) ────────────
-
-let _rowId = 0
-function mkid(): string {
-  _rowId += 1
-  return String(_rowId)
-}
-
-// ── Step builder types ────────────────────────────────────────────────────────
-
-const STEP_TYPES = ['script', 'shell', 'http', 'notification', 'approval'] as const
-
-interface StepRow {
-  id: string
-  name: string
-  type: string
-  scriptBody: string   // config.script for type === 'script'
-  configJson: string   // raw config JSON (for non-script types or advanced mode)
-  rawOpen: boolean     // whether the Raw config details panel is expanded
-}
-
-// ── Variable editor types ─────────────────────────────────────────────────────
-
-interface VarRow {
-  id: string
-  key: string
-  value: string
-}
-
-// ── Form state ────────────────────────────────────────────────────────────────
-
-interface FormState {
-  name: string
-  description: string
-  version: string
-  steps: StepRow[]
-  variables: VarRow[]
-}
-
-function defaultStep(): StepRow {
-  return { id: mkid(), name: 'step-1', type: 'script', scriptBody: '', configJson: '{}', rawOpen: false }
-}
-
-function stepToRow(step: WorkflowStep): StepRow {
-  const cfg = step.config ?? {}
-  const scriptBody = step.type === 'script' && typeof cfg.script === 'string' ? cfg.script : ''
-  // Show raw config when there are keys beyond 'script' (for script type) or any keys (for other types)
-  const hasExtra = step.type === 'script'
-    ? Object.keys(cfg).some((k) => k !== 'script')
-    : Object.keys(cfg).length > 0
-  return {
-    id: mkid(),
-    name: step.name,
-    type: step.type,
-    scriptBody,
-    configJson: hasExtra ? JSON.stringify(cfg, null, 2) : '{}',
-    rawOpen: hasExtra,
-  }
-}
-
-function defaultForm(wf: VersionedWorkflow | null): FormState {
-  if (wf === null) {
-    return {
-      name: '',
-      description: '',
-      version: '1.0.0',
-      steps: [defaultStep()],
-      variables: [],
-    }
-  }
-  return {
-    name: wf.name,
-    description: wf.description,
-    version: wf.version || '1.0.0',
-    steps: wf.steps.length > 0 ? wf.steps.map(stepToRow) : [defaultStep()],
-    variables: wf.variables
-      ? Object.entries(wf.variables).map(([k, v]) => ({
-          id: mkid(),
-          key: k,
-          value: typeof v === 'string' ? v : JSON.stringify(v),
-        }))
-      : [],
-  }
-}
 
 // ── Loading skeleton ──────────────────────────────────────────────────────────
 
@@ -130,7 +46,7 @@ function WorkflowEmpty() {
     <div className="notice empty" data-testid="workflow-empty">
       <div className="ic">◍</div>
       <h3>No workflows found</h3>
-      <p>No workflows have been created yet. Use New workflow to get started.</p>
+      <p>No workflows have been created yet.</p>
     </div>
   )
 }
@@ -141,13 +57,11 @@ function WorkflowRow({
   workflow,
   selected,
   onClick,
-  onEdit,
   onDelete,
 }: {
   workflow: VersionedWorkflow
   selected: boolean
   onClick: () => void
-  onEdit: () => void
   onDelete: () => void
 }) {
   return (
@@ -174,18 +88,9 @@ function WorkflowRow({
       >
         <button
           type="button"
-          className="wf-btn-sm"
-          onClick={onEdit}
-          data-testid="workflow-edit-btn"
-        >
-          Edit
-        </button>
-        <button
-          type="button"
           className="wf-btn-sm-danger"
           onClick={onDelete}
           data-testid="workflow-delete-btn"
-          style={{ marginLeft: 4 }}
         >
           Delete
         </button>
@@ -195,471 +100,19 @@ function WorkflowRow({
   )
 }
 
-// ── Step builder row ──────────────────────────────────────────────────────────
-
-function StepBuilderRow({
-  step,
-  index,
-  canRemove,
-  onChange,
-  onRemove,
-}: {
-  step: StepRow
-  index: number
-  canRemove: boolean
-  onChange: (updated: StepRow) => void
-  onRemove: () => void
-}) {
-  const isScriptType = step.type === 'script'
-  const isKnownType = (STEP_TYPES as readonly string[]).includes(step.type)
-
-  return (
-    <div className="wf-step-row" data-testid="step-row">
-      <div className="wf-form-row">
-        <div className="wf-form-field">
-          <span className="wf-form-label">Step {index + 1} name *</span>
-          <input
-            type="text"
-            aria-label={`Step ${index + 1} name`}
-            placeholder={`step-${index + 1}`}
-            value={step.name}
-            onChange={(e) => onChange({ ...step, name: e.target.value })}
-            data-testid="step-name-input"
-          />
-        </div>
-        <div className="wf-form-field">
-          <span className="wf-form-label">Type</span>
-          <select
-            aria-label={`Step ${index + 1} type`}
-            value={step.type}
-            onChange={(e) =>
-              onChange({ ...step, type: e.target.value, scriptBody: '', configJson: '{}', rawOpen: false })
-            }
-            data-testid="step-type-select"
-          >
-            {STEP_TYPES.map((t) => (
-              <option key={t} value={t}>{t}</option>
-            ))}
-            {!isKnownType && (
-              <option value={step.type}>{step.type}</option>
-            )}
-          </select>
-        </div>
-        {isScriptType && (
-          <div className="wf-form-field">
-            <span className="wf-form-label">Script</span>
-            <textarea
-              aria-label={`Step ${index + 1} script`}
-              placeholder="echo hello"
-              value={step.scriptBody}
-              onChange={(e) => onChange({ ...step, scriptBody: e.target.value })}
-              data-testid="step-script-input"
-            />
-          </div>
-        )}
-        {!isScriptType && (
-          <div className="wf-form-field">
-            <span className="wf-form-label">Config (JSON)</span>
-            <textarea
-              aria-label={`Step ${index + 1} config JSON`}
-              placeholder="{}"
-              value={step.configJson}
-              onChange={(e) => onChange({ ...step, configJson: e.target.value })}
-              data-testid="step-config-json"
-            />
-          </div>
-        )}
-        {canRemove && (
-          <button
-            type="button"
-            className="wf-btn-sm-danger wf-step-remove"
-            onClick={onRemove}
-            aria-label={`Remove step ${index + 1}`}
-            data-testid="step-remove-btn"
-          >
-            Remove
-          </button>
-        )}
-      </div>
-      {isScriptType && (
-        <details
-          open={step.rawOpen}
-          onToggle={(e) =>
-            onChange({ ...step, rawOpen: (e.currentTarget as HTMLDetailsElement).open })
-          }
-          className="wf-raw-config"
-        >
-          <summary className="wf-raw-config-toggle">Raw config JSON</summary>
-          <div className="wf-form-row" style={{ marginTop: 6 }}>
-            <div className="wf-form-field">
-              <textarea
-                aria-label={`Step ${index + 1} raw config JSON`}
-                placeholder="{}"
-                value={step.configJson}
-                onChange={(e) => onChange({ ...step, configJson: e.target.value })}
-                data-testid="step-config-json"
-              />
-            </div>
-          </div>
-        </details>
-      )}
-    </div>
-  )
-}
-
-// ── Variable key/value row ────────────────────────────────────────────────────
-
-function VarBuilderRow({
-  varRow,
-  onChange,
-  onRemove,
-}: {
-  varRow: VarRow
-  onChange: (updated: VarRow) => void
-  onRemove: () => void
-}) {
-  return (
-    <div className="wf-var-row wf-form-row" data-testid="var-row">
-      <div className="wf-form-field">
-        <span className="wf-form-label">Key</span>
-        <input
-          type="text"
-          aria-label="Variable key"
-          placeholder="var-name"
-          value={varRow.key}
-          onChange={(e) => onChange({ ...varRow, key: e.target.value })}
-          data-testid="var-key-input"
-        />
-      </div>
-      <div className="wf-form-field">
-        <span className="wf-form-label">Value</span>
-        <input
-          type="text"
-          aria-label="Variable value"
-          placeholder="value"
-          value={varRow.value}
-          onChange={(e) => onChange({ ...varRow, value: e.target.value })}
-          data-testid="var-value-input"
-        />
-      </div>
-      <button
-        type="button"
-        className="wf-btn-sm-danger wf-var-remove"
-        onClick={onRemove}
-        aria-label="Remove variable"
-        data-testid="var-remove-btn"
-      >
-        Remove
-      </button>
-    </div>
-  )
-}
-
-// ── Workflow form panel ───────────────────────────────────────────────────────
-
-function WorkflowFormPanel({
-  mode,
-  initial,
-  onSaved,
-  onClose,
-}: {
-  mode: 'create' | 'edit'
-  initial: VersionedWorkflow | null
-  onSaved: () => void
-  onClose: () => void
-}) {
-  const [form, setForm] = useState<FormState>(() => defaultForm(initial))
-  const [saving, setSaving] = useState(false)
-  const [saveError, setSaveError] = useState<string | null>(null)
-
-  // Step operations
-  function addStep() {
-    const num = form.steps.length + 1
-    setForm((prev) => ({
-      ...prev,
-      steps: [
-        ...prev.steps,
-        { id: mkid(), name: `step-${num}`, type: 'script', scriptBody: '', configJson: '{}', rawOpen: false },
-      ],
-    }))
-  }
-
-  function removeStep(idx: number) {
-    setForm((prev) => ({ ...prev, steps: prev.steps.filter((_, i) => i !== idx) }))
-  }
-
-  function updateStep(idx: number, updated: StepRow) {
-    setForm((prev) => ({
-      ...prev,
-      steps: prev.steps.map((s, i) => (i === idx ? updated : s)),
-    }))
-  }
-
-  // Variable operations
-  function addVar() {
-    setForm((prev) => ({
-      ...prev,
-      variables: [...prev.variables, { id: mkid(), key: '', value: '' }],
-    }))
-  }
-
-  function removeVar(idx: number) {
-    setForm((prev) => ({ ...prev, variables: prev.variables.filter((_, i) => i !== idx) }))
-  }
-
-  function updateVar(idx: number, updated: VarRow) {
-    setForm((prev) => ({
-      ...prev,
-      variables: prev.variables.map((v, i) => (i === idx ? updated : v)),
-    }))
-  }
-
-  async function handleSubmit() {
-    if (mode === 'create' && !form.name.trim()) {
-      setSaveError('Workflow name is required')
-      return
-    }
-    if (form.steps.length === 0) {
-      setSaveError('At least one step is required')
-      return
-    }
-    for (const s of form.steps) {
-      if (!s.name.trim()) {
-        setSaveError('All steps must have a name')
-        return
-      }
-    }
-    for (const s of form.steps) {
-      if (s.rawOpen || s.type !== 'script') {
-        try {
-          JSON.parse(s.configJson || '{}')
-        } catch {
-          setSaveError(`Step "${s.name}": config must be valid JSON`)
-          return
-        }
-      }
-    }
-
-    // Build steps array from structured state
-    const steps = form.steps.map((s) => {
-      let config: Record<string, unknown> = {}
-      if (s.rawOpen || s.type !== 'script') {
-        config = JSON.parse(s.configJson || '{}') as Record<string, unknown>
-      } else if (s.scriptBody.trim()) {
-        config = { script: s.scriptBody }
-      }
-      return { name: s.name.trim(), type: s.type, config }
-    })
-
-    // Build variables object, omitting rows with empty keys
-    const varEntries = form.variables.filter((v) => v.key.trim())
-    const variables: Record<string, unknown> | undefined =
-      varEntries.length > 0
-        ? Object.fromEntries(varEntries.map((v) => [v.key.trim(), v.value]))
-        : undefined
-
-    setSaving(true)
-    setSaveError(null)
-
-    const bodyObj = {
-      name: form.name.trim(),
-      description: form.description.trim(),
-      version: form.version.trim() || '1.0.0',
-      steps,
-      ...(variables !== undefined && { variables }),
-    }
-
-    try {
-      const url =
-        mode === 'create'
-          ? '/api/v1/workflows'
-          : `/api/v1/workflows/${encodeURIComponent(form.name.trim())}`
-      const response = await apiFetch(url, {
-        method: mode === 'create' ? 'POST' : 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(bodyObj),
-      })
-      if (!response.ok) {
-        const errBody = (await response.json().catch(() => ({}))) as Record<
-          string,
-          unknown
-        >
-        throw new Error(
-          (errBody?.error as string) || `Save failed — ${response.status}`,
-        )
-      }
-      onSaved()
-    } catch (cause: unknown) {
-      setSaveError(
-        cause instanceof Error && cause.message ? cause.message : 'Save failed',
-      )
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const isEdit = mode === 'edit'
-
-  return (
-    <div className="wf-form-panel" data-testid="workflow-form-panel">
-      <div className="wf-form">
-        {/* Workflow metadata row */}
-        <div className="wf-form-row">
-          <div className="wf-form-field">
-            <span className="wf-form-label">Name {isEdit ? '' : '*'}</span>
-            <input
-              type="text"
-              aria-label="Workflow name"
-              placeholder="my-workflow"
-              value={form.name}
-              disabled={isEdit}
-              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-              data-testid="workflow-name-input"
-            />
-          </div>
-          <div className="wf-form-field">
-            <span className="wf-form-label">Description</span>
-            <input
-              type="text"
-              aria-label="Description"
-              placeholder="Optional description"
-              value={form.description}
-              onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
-              className="wide"
-            />
-          </div>
-          <div className="wf-form-field">
-            <span className="wf-form-label">Version</span>
-            <input
-              type="text"
-              aria-label="Version"
-              placeholder="1.0.0"
-              value={form.version}
-              onChange={(e) => setForm((prev) => ({ ...prev, version: e.target.value }))}
-            />
-          </div>
-        </div>
-
-        {/* Step builder */}
-        <div className="wf-builder-section">
-          <div className="wf-builder-header">
-            <span className="wf-form-label">Steps *</span>
-            <button
-              type="button"
-              className="wf-btn-sm"
-              onClick={addStep}
-              data-testid="add-step-btn"
-            >
-              + Add step
-            </button>
-          </div>
-          {form.steps.map((step, idx) => (
-            <StepBuilderRow
-              key={step.id}
-              step={step}
-              index={idx}
-              canRemove={form.steps.length > 1}
-              onChange={(updated) => updateStep(idx, updated)}
-              onRemove={() => removeStep(idx)}
-            />
-          ))}
-        </div>
-
-        {/* Variables editor */}
-        <div className="wf-builder-section">
-          <div className="wf-builder-header">
-            <span className="wf-form-label">Variables</span>
-            <button
-              type="button"
-              className="wf-btn-sm"
-              onClick={addVar}
-              data-testid="add-var-btn"
-            >
-              + Add variable
-            </button>
-          </div>
-          {form.variables.length === 0 && (
-            <p className="wf-var-empty">No variables defined.</p>
-          )}
-          {form.variables.map((v, idx) => (
-            <VarBuilderRow
-              key={v.id}
-              varRow={v}
-              onChange={(updated) => updateVar(idx, updated)}
-              onRemove={() => removeVar(idx)}
-            />
-          ))}
-        </div>
-
-        <div className="wf-form-actions">
-          <button
-            type="button"
-            className="wf-btn"
-            disabled={saving}
-            onClick={handleSubmit}
-            data-testid="workflow-save-btn"
-          >
-            {saving ? 'Saving…' : isEdit ? 'Save changes' : 'Create workflow'}
-          </button>
-          <button
-            type="button"
-            className="wf-btn-secondary"
-            onClick={onClose}
-          >
-            Cancel
-          </button>
-          {saveError && (
-            <span className="wf-form-error" data-testid="workflow-save-error">
-              {saveError}
-            </span>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
-
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 export default function WorkflowListView() {
   const { workflows, loading, error, retry } = useWorkflowList()
   const [selectedName, setSelectedName] = useState<string | null>(null)
-  const [formMode, setFormMode] = useState<'create' | 'edit' | null>(null)
-  const [editingWorkflow, setEditingWorkflow] = useState<VersionedWorkflow | null>(null)
   const [deletingWorkflow, setDeletingWorkflow] = useState<VersionedWorkflow | null>(null)
-  const [showTriggers, setShowTriggers] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [deleting, setDeleting] = useState(false)
 
+  const selectedWorkflow = workflows.find((w) => w.name === selectedName) ?? null
+
   function handleRowClick(name: string) {
     setSelectedName((prev) => (prev === name ? null : name))
-    setFormMode(null)
-    setEditingWorkflow(null)
-  }
-
-  function handleOpenCreate() {
-    setFormMode('create')
-    setEditingWorkflow(null)
-    setSelectedName(null)
-    setShowTriggers(false)
-  }
-
-  function handleOpenEdit(wf: VersionedWorkflow) {
-    setFormMode('edit')
-    setEditingWorkflow(wf)
-    setSelectedName(null)
-    setShowTriggers(false)
-  }
-
-  function handleFormSaved() {
-    setFormMode(null)
-    setEditingWorkflow(null)
-    retry()
-  }
-
-  function handleFormClose() {
-    setFormMode(null)
-    setEditingWorkflow(null)
   }
 
   async function handleConfirmDelete() {
@@ -697,108 +150,68 @@ export default function WorkflowListView() {
     <>
       <div className="htitle">
         <h1>Workflows</h1>
-        <p>Manage automated workflows, view execution history, and configure triggers.</p>
+        <p>Author, schedule, and run automations. Select a workflow to run it or open the builder.</p>
       </div>
 
-      <section className="panel">
-        <div className="ptool">
-          <button
-            type="button"
-            className={formMode === 'create' ? 'wf-btn' : 'wf-btn-secondary'}
-            onClick={formMode === 'create' ? handleFormClose : handleOpenCreate}
-            data-testid="toggle-create-btn"
-          >
-            {formMode === 'create' ? 'Close' : '+ New workflow'}
-          </button>
-          <button
-            type="button"
-            className={showTriggers ? 'wf-btn' : 'wf-btn-secondary'}
-            onClick={() => {
-              setShowTriggers((v) => !v)
-              setFormMode(null)
-            }}
-            data-testid="toggle-triggers-btn"
-          >
-            {showTriggers ? 'Close triggers' : 'Triggers'}
-          </button>
-          {!loading && error === null && (
-            <span className="cnt" data-testid="workflow-count">
-              {workflows.length} workflow{workflows.length !== 1 ? 's' : ''}
-            </span>
-          )}
-        </div>
-
-        {formMode === 'create' && (
-          <WorkflowFormPanel
-            mode="create"
-            initial={null}
-            onSaved={handleFormSaved}
-            onClose={handleFormClose}
-          />
-        )}
-
-        {formMode === 'edit' && editingWorkflow && (
-          <WorkflowFormPanel
-            mode="edit"
-            initial={editingWorkflow}
-            onSaved={handleFormSaved}
-            onClose={handleFormClose}
-          />
-        )}
-
-        {showTriggers && (
-          <TriggerPanel onClose={() => setShowTriggers(false)} />
-        )}
-
-        {deleteError && (
-          <div className="wf-form-error" style={{ padding: '8px 14px' }} data-testid="delete-error">
-            {deleteError}
+      <div className="workspace">
+        <section className="panel">
+          <div className="ptool">
+            {!loading && error === null && (
+              <span className="cnt" data-testid="workflow-count">
+                {workflows.length} workflow{workflows.length !== 1 ? 's' : ''}
+              </span>
+            )}
           </div>
-        )}
 
-        {loading ? (
-          <LoadingRows />
-        ) : error !== null ? (
-          <ErrorCard heading="Couldn&apos;t load workflows" detail={error} onRetry={retry} />
-        ) : workflows.length === 0 ? (
-          <WorkflowEmpty />
-        ) : (
-          <table className="tbl" data-testid="workflow-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Version</th>
-                <th>Steps</th>
-                <th>Description</th>
-                <th>Actions</th>
-                <th className="c-spacer" aria-hidden="true" />
-              </tr>
-            </thead>
-            <tbody>
-              {workflows.map((wf) => (
-                <WorkflowRow
-                  key={wf.name}
-                  workflow={wf}
-                  selected={selectedName === wf.name}
-                  onClick={() => handleRowClick(wf.name)}
-                  onEdit={() => handleOpenEdit(wf)}
-                  onDelete={() => {
-                    setDeleteError(null)
-                    setDeletingWorkflow(wf)
-                  }}
-                />
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
+          {deleteError && (
+            <div className="wf-form-error" style={{ padding: '8px 14px' }} data-testid="delete-error">
+              {deleteError}
+            </div>
+          )}
 
-      {selectedName !== null && (
-        <WorkflowExecutionView
-          workflowName={selectedName}
-          onClose={() => setSelectedName(null)}
-        />
-      )}
+          {loading ? (
+            <LoadingRows />
+          ) : error !== null ? (
+            <ErrorCard heading="Couldn&apos;t load workflows" detail={error} onRetry={retry} />
+          ) : workflows.length === 0 ? (
+            <WorkflowEmpty />
+          ) : (
+            <table className="tbl" data-testid="workflow-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Version</th>
+                  <th>Steps</th>
+                  <th>Description</th>
+                  <th>Actions</th>
+                  <th className="c-spacer" aria-hidden="true" />
+                </tr>
+              </thead>
+              <tbody>
+                {workflows.map((wf) => (
+                  <WorkflowRow
+                    key={wf.name}
+                    workflow={wf}
+                    selected={selectedName === wf.name}
+                    onClick={() => handleRowClick(wf.name)}
+                    onDelete={() => {
+                      setDeleteError(null)
+                      setDeletingWorkflow(wf)
+                    }}
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        {selectedName !== null && selectedWorkflow !== null && (
+          <WorkflowDrawer
+            workflow={selectedWorkflow}
+            onClose={() => setSelectedName(null)}
+          />
+        )}
+      </div>
 
       {deletingWorkflow !== null && (
         <div


### PR DESCRIPTION
## Summary

- Replaces stacked inline panels (create/edit form, TriggerPanel, WorkflowExecutionView) with an **absolute-positioned overlay drawer** that never reflrows the list table rows
- New `WorkflowDrawer` component: `.dhead` header (mono name, version, Open-builder stub, ✕ close) + `.dtabs` (Run / Schedule / What it does) + `.dbody` scroll region with placeholder tab slots
- `WorkflowListView` wrapped in `.workspace {position:relative}` so the drawer overlays without displacing the list
- CSS uses design tokens only; slide-in animation with `prefers-reduced-motion` guard; correct in light + dark themes

## Test plan

- [x] `WorkflowDrawer.test.tsx` (new, 10 tests): header renders, tab switching, close fires `onClose`, XSS text-node check (A9.1)
- [x] `WorkflowListView.test.tsx` (21 tests): row-select opens drawer, ✕ closes, same-row toggle, multi-workflow switch, tab switching, **required AC no-reflow assertion** (column headers identical with drawer open vs closed), delete dialog, error-card, A9.1
- [x] Full suite: 994/994 tests pass; `tsc` + `vite build` clean; `make test-agent-complete` ✅

## Specialist review results

Story-review workflow (3 lenses — code, tests, security): **PASS** — round 1, zero findings, zero fix rounds.

Fixes #3039

🤖 Generated with [Claude Code](https://claude.com/claude-code)