### PR TITLE
web/refresh: wire approve behind step-up (Issue #2973)

### DIFF
--- a/web/src/refresh/RefreshQueuePage.test.tsx
+++ b/web/src/refresh/RefreshQueuePage.test.tsx
@@ -207,11 +207,11 @@ describe('RefreshQueuePage — list rendering', () => {
     expect(screen.getByTestId('reject-btn-ref-abc123')).toBeInTheDocument()
   })
 
-  it('renders no approve control of any kind', async () => {
+  it('shows an Approve button for each row', async () => {
     fetchMock.mockResolvedValue(makeRefreshResponse([makeEntry()]))
     renderPage()
     await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
-    expect(screen.queryByRole('button', { name: /approve/i })).toBeNull()
+    expect(screen.getByTestId('approve-btn-ref-abc123')).toBeInTheDocument()
   })
 
   it('shows an error notice on a non-200 list response', async () => {
@@ -324,6 +324,100 @@ describe('RefreshQueuePage — reject', () => {
     await waitFor(() => expect(screen.getAllByTestId('refresh-row')).toHaveLength(2))
 
     fireEvent.click(screen.getByTestId('reject-btn-ref-abc123'))
+
+    await waitFor(() => expect(screen.getAllByTestId('refresh-row')).toHaveLength(1))
+    expect(screen.getByText('ref-def456')).toBeInTheDocument()
+    expect(screen.queryByText('ref-abc123')).toBeNull()
+  })
+})
+
+// ── Approve flow (Story #2973) ────────────────────────────────────────────────
+// Approve calls POST /api/v1/stewards/refresh/{pending_id}/approve.
+// Strong step-up (S1 elevation) is handled transparently by apiFetch +
+// StepUpModal in AuthContext — no explicit assertion here; the step-up
+// ceremony fires only when the server returns 401 CFGMS-StepUp.
+
+describe('RefreshQueuePage — approve', () => {
+  it('approve removes the row from the list on success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-btn-ref-abc123'))
+
+    await waitFor(() => expect(screen.getByTestId('refresh-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('refresh-row')).toBeNull()
+    const approveCall = fetchMock.mock.calls[1]!
+    expect(String(approveCall[0])).toContain('/approve')
+    expect((approveCall[1] as RequestInit | undefined)?.method).toBe('POST')
+  })
+
+  it('surfaces a row-level error on a failed approve without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-btn-ref-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('approve-error-ref-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('approve-error-ref-abc123')).toHaveTextContent('403')
+    expect(screen.getByTestId('refresh-table')).toBeInTheDocument()
+    expect(screen.getAllByTestId('refresh-row')).toHaveLength(1)
+  })
+
+  it('surfaces a row-level error on a network failure during approve without crashing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockRejectedValueOnce(new Error('connection refused'))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-btn-ref-abc123'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('approve-error-ref-abc123')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('approve-error-ref-abc123')).toHaveTextContent('connection refused')
+    expect(screen.getAllByTestId('refresh-row')).toHaveLength(1)
+  })
+
+  it('clears a previous approve error when approve is retried', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeRefreshResponse([makeEntry()]))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('refresh-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('approve-btn-ref-abc123'))
+    await waitFor(() =>
+      expect(screen.getByTestId('approve-error-ref-abc123')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('approve-btn-ref-abc123'))
+    await waitFor(() => expect(screen.getByTestId('refresh-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('approve-error-ref-abc123')).toBeNull()
+  })
+
+  it('keeps other rows intact when one approve succeeds', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeRefreshResponse([
+          makeEntry(),
+          makeEntry({ pending_id: 'ref-def456', device_id: 'dev-uvw321' }),
+        ]),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    renderPage()
+    await waitFor(() => expect(screen.getAllByTestId('refresh-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByTestId('approve-btn-ref-abc123'))
 
     await waitFor(() => expect(screen.getAllByTestId('refresh-row')).toHaveLength(1))
     expect(screen.getByText('ref-def456')).toBeInTheDocument()

--- a/web/src/refresh/RefreshQueuePage.tsx
+++ b/web/src/refresh/RefreshQueuePage.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Refresh-request queue page (Story #2941).
+ * Refresh-request queue page (Story #2941, #2973).
  * Fetches GET /api/v1/stewards/refresh/pending — bare-array response (no
  * {data:...} envelope). Shape-validated by parsePendingRefreshList before
  * any value reaches the DOM.
@@ -10,8 +10,10 @@
  * Reject calls POST /api/v1/stewards/refresh/{pending_id}/reject and removes
  * the row on success; surfaces a row-level error without crashing on failure.
  *
- * Approve is out of scope for this story (Section 2 follow-on epic) — no
- * button, no disabled state, no deferred control of any kind.
+ * Approve calls POST /api/v1/stewards/refresh/{pending_id}/approve and removes
+ * the row on success; surfaces a row-level error without crashing on failure.
+ * Approve is Strong-gated (AssuranceStrong / S1 elevation); step-up is handled
+ * transparently by apiFetch + StepUpModal in AuthContext (Story #2967).
  *
  * Security A9.1: all device-supplied and operator-influenced values render
  * as JSX text nodes only, never via dangerouslySetInnerHTML.
@@ -131,6 +133,7 @@ export default function RefreshQueuePage() {
   const [attempt, setAttempt] = useState(0)
   const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
   const [rejectErrors, setRejectErrors] = useState<Map<string, string>>(new Map())
+  const [approveErrors, setApproveErrors] = useState<Map<string, string>>(new Map())
 
   const key = `refresh:${attempt}`
   const retry = useCallback(() => setAttempt((n) => n + 1), [])
@@ -188,6 +191,37 @@ export default function RefreshQueuePage() {
         new Map(prev).set(
           pendingId,
           cause instanceof Error && cause.message ? cause.message : 'Reject request failed',
+        ),
+      )
+    }
+  }
+
+  async function handleApprove(pendingId: string) {
+    setApproveErrors((prev) => {
+      const next = new Map(prev)
+      next.delete(pendingId)
+      return next
+    })
+    try {
+      const response = await apiFetch(
+        `/api/v1/stewards/refresh/${encodeURIComponent(pendingId)}/approve`,
+        { method: 'POST' },
+      )
+      if (!response.ok) {
+        setApproveErrors((prev) =>
+          new Map(prev).set(pendingId, `Approve failed — ${response.status}`),
+        )
+        return
+      }
+      setOutcome((prev) => {
+        if (!prev?.entries) return prev
+        return { ...prev, entries: prev.entries.filter((e) => e.pending_id !== pendingId) }
+      })
+    } catch (cause: unknown) {
+      setApproveErrors((prev) =>
+        new Map(prev).set(
+          pendingId,
+          cause instanceof Error && cause.message ? cause.message : 'Approve request failed',
         ),
       )
     }
@@ -263,6 +297,14 @@ export default function RefreshQueuePage() {
                       <td>
                         <button
                           type="button"
+                          className="wf-btn-sm"
+                          data-testid={`approve-btn-${entry.pending_id}`}
+                          onClick={() => void handleApprove(entry.pending_id)}
+                        >
+                          Approve
+                        </button>
+                        <button
+                          type="button"
                           className="wf-btn-sm-danger"
                           data-testid={`reject-btn-${entry.pending_id}`}
                           onClick={() => void handleReject(entry.pending_id)}
@@ -271,6 +313,19 @@ export default function RefreshQueuePage() {
                         </button>
                       </td>
                     </tr>
+                    {approveErrors.has(entry.pending_id) && (
+                      <tr>
+                        <td colSpan={7}>
+                          <span
+                            className="wf-form-error"
+                            data-testid={`approve-error-${entry.pending_id}`}
+                            role="alert"
+                          >
+                            {approveErrors.get(entry.pending_id)}
+                          </span>
+                        </td>
+                      </tr>
+                    )}
                     {rejectErrors.has(entry.pending_id) && (
                       <tr>
                         <td colSpan={7}>


### PR DESCRIPTION
## Summary

- Activates the Approve button in the refresh-request queue (`RefreshQueuePage`), wiring it to `POST /api/v1/stewards/refresh/{pending_id}/approve`
- Step-up (S1 elevation to `AssuranceStrong`) fires transparently via the global `apiFetch` interceptor + `StepUpModal` in `AuthContext` (#2967) — no ceremony code needed in the component
- Per-action audit (`refresh_admin_approved`) was already present in `handleApproveRefresh`; no backend changes required

## Changes

- `web/src/refresh/RefreshQueuePage.tsx`: added `approveErrors` state, `handleApprove` handler, Approve button per row, and approve error row display
- `web/src/refresh/RefreshQueuePage.test.tsx`: replaced "renders no approve control" guard with "shows an Approve button" assertion; added 5 approve flow tests (success, 4xx error, network error, retry clears error, sibling rows intact)

## Specialist Review Results

| Lens | Result |
|------|--------|
| Code review | ✅ PASS |
| Test quality | ✅ PASS |
| Security | ✅ PASS |

All 3 lenses passed in round 1 with zero findings. `make test-agent-complete` green (1080 frontend tests pass, all Go unit/integration tests pass).

Fixes #2973