### PR TITLE
docs: record Snyk/SonarCloud keep-drop decision in security-workflow-guide (Issue #3083)

### DIFF
--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -218,6 +218,57 @@ Populate this file after the first manual run reveals the alert baseline. Only s
 4. Confirmed false positives specific to CI surface → add an IGNORE entry in `.zap/rules.tsv` with a comment explaining why.
 5. Suppress nothing blindly — every entry in `rules.tsv` must have a justification comment.
 
+### 9. Snyk & SonarCloud — Tool Evaluation
+
+This section records the explicit keep/drop decision for Snyk and SonarCloud, evaluated against
+the security tooling stack already running in CI (§§1–8 above). The evaluation answers the
+acceptance criterion originally scoped in Issue #2930 and landed via Issue #3083.
+
+#### Snyk — Decision: DROP
+
+- **Purpose**: Developer-first SCA (Software Composition Analysis) platform combining CVE scanning
+  of dependencies (`snyk test`), container image scanning (`snyk container test`), and SAST
+  (`snyk code test`).
+- **Unique coverage over the existing stack**: Minimal.
+  - CVE / dependency scanning: Trivy (§1) already scans the filesystem for CRITICAL/HIGH CVEs and
+    is a blocking PR gate; Nancy (§2) specifically targets Go module vulnerabilities using OSV
+    data. Snyk's SCA surface is a subset of what Trivy + Nancy already cover.
+  - Container image scanning: Trivy (`--scanners vuln`) covers Docker images; the
+    `security-deployment-gate` already runs Trivy with `--exit-code 1` in `production-gates.yml`.
+  - SAST (`snyk code`): pattern-based; CodeQL (§5) provides deeper whole-program data-flow /
+    taint-tracking analysis for the same vulnerability classes (path-injection, log-injection,
+    clear-text logging). gosec (§3) covers Go-specific security anti-patterns. Snyk Code would be
+    a weaker, overlapping signal with no gap to fill.
+- **Operational cost**: new `SNYK_TOKEN` organization secret required; new CI job to maintain;
+  SaaS dependency; paid tier required for private repositories beyond the OSS free quota.
+- **Decision: DROP.** The existing Trivy + Nancy + gosec + CodeQL stack covers Snyk's entire scope
+  with a blocking gate (Trivy) and deeper semantic analysis (CodeQL). Adding Snyk would increase
+  operational surface and introduce a SaaS dependency without adding unique detection capability.
+
+#### SonarCloud — Decision: DROP
+
+- **Purpose**: Cloud-based code quality and security analysis platform offering quality rules,
+  security hotspot detection, and taint-flow analysis across Go and TypeScript in a unified
+  dashboard.
+- **Unique coverage over the existing stack**: Marginal.
+  - Go quality and security rules: staticcheck (§4) covers 47 categories of code quality and
+    correctness; gosec (§3) covers Go security anti-patterns. SonarCloud's Go ruleset is largely a
+    subset of what these two tools already report.
+  - TypeScript security analysis: CodeQL (§5) was extended to TypeScript during Issue #2930
+    (`language: ['go', 'typescript']`), providing deep data-flow analysis for the SPA. The lint
+    gate also runs `eslint-plugin-security` for pattern-based TypeScript security checks.
+  - Multi-language unified dashboard: provides a single-pane view, but all gate results are already
+    visible in the GitHub Security tab via SARIF (Trivy, gosec, CodeQL all upload SARIF). The
+    incremental value of a separate SonarCloud dashboard is low in the solo-dev model.
+- **Operational cost**: new `SONAR_TOKEN` organization secret required; new CI job to maintain;
+  paid tier required for private repositories (the free SonarCloud tier is OSS/public-repo only;
+  CFGMS is AGPL-3.0 but the repository is private); multi-language scan setup adds maintenance
+  complexity.
+- **Decision: DROP.** The existing staticcheck + gosec + CodeQL (Go + TypeScript) + eslint-plugin-security
+  stack covers SonarCloud's scope. The unified-dashboard benefit is not material given SARIF already
+  surfaces all findings in the GitHub Security tab. Operational cost (new secret, new CI job, paid
+  subscription for private repo) is not justified by the marginal incremental coverage.
+
 ## Local Development Workflow
 
 ### Prerequisites

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -377,8 +377,8 @@ engineering gaps are narrower than this section originally assumed.
 
 - [ ] OpenSSF Scorecard optimization (target score: 9.0+)
 - [ ] Go native fuzzing integration for critical packages
-- [ ] Evaluate and integrate Snyk (if beneficial beyond existing coverage)
-- [ ] Evaluate and integrate SonarCloud (if beneficial beyond staticcheck)
+- [x] Evaluate and integrate Snyk (if beneficial beyond existing coverage) — **DROP**: see [security-workflow-guide.md §9](../development/security-workflow-guide.md#9-snyk--sonarcloud--tool-evaluation)
+- [x] Evaluate and integrate SonarCloud (if beneficial beyond staticcheck) — **DROP**: see [security-workflow-guide.md §9](../development/security-workflow-guide.md#9-snyk--sonarcloud--tool-evaluation)
 - [ ] Security testing automation improvements
 
 **Web Frontend Security** — mostly delivered:


### PR DESCRIPTION
## Summary

- Adds `### 9. Snyk & SonarCloud — Tool Evaluation` to `docs/development/security-workflow-guide.md` under `## Security Tools Overview`, recording explicit **DROP** decisions for both tools against the existing CI security stack (Trivy, Nancy, gosec, staticcheck, CodeQL).
- Marks `docs/product/roadmap.md` lines 380-381 `[x]` (both DROP) and links to §9, closing the open-TODO state those lines have held since #2930.

This is the documentation-only remediation pass that satisfies the sixth (final) acceptance criterion from #2930 that was not satisfied on `develop`.

## Decisions recorded

**Snyk — DROP**: SCA/CVE overlap with Trivy (blocking gate) + Nancy (Go-module OSV); container scanning duplicate of Trivy; `snyk code` SAST is a weaker pattern-based signal compared to CodeQL taint-flow for the same vulnerability classes. Operational cost not justified (new `SNYK_TOKEN` secret, CI job, paid SaaS subscription for private repos).

**SonarCloud — DROP**: Go quality/security rules are a subset of staticcheck + gosec; TypeScript already covered by CodeQL (extended in #2930) and `eslint-plugin-security`; unified-dashboard benefit marginal since all tools emit SARIF to the GitHub Security tab. Operational cost not justified (new `SONAR_TOKEN` secret, CI job, paid subscription for private repos).

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

No fix rounds required. `remainingFindings: []`.

## Fixes

Fixes #3083

🤖 Generated with [Claude Code](https://claude.com/claude-code)