### PR TITLE
web/registration: token mint/rotate/revoke/delete behind step-up (Issue #2970)

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -977,30 +977,34 @@ Registration tokens authorise steward self-registration. The token encodes the t
 
 **Note:** The path is `/api/v1/registration/tokens` — NOT `/admin/registration-tokens`.
 
+**Show-once secret:** The full token secret is only ever returned in the response body of create and rotate — never on list, get, or revoke. Once that response is dismissed the secret cannot be re-fetched; only a 6-char `token_prefix` remains visible. The secret is never written to the audit trail or server logs — audit events for create/delete/revoke/rotate record `token_prefix` and the stable `token_id` (UUID) only.
+
+**Path parameter, two forms:** `{token}` in the paths below accepts either the full token secret (exact match — used by mTLS admin callers that hold the raw token) or the token's stable `token_id` UUID (used by the web UI, which never receives the raw secret outside the mint/rotate response). Lookup tries an exact match first, then falls back to UUID lookup.
+
 #### GET /api/v1/registration/tokens
 
-List registration tokens.
+List registration tokens. Each entry includes `token_id` (stable UUID, safe to expose) and `token_prefix`, never the secret.
 
 **Authentication:** Required  
 **Required permission:** `registration:list-tokens`
 
 #### POST /api/v1/registration/tokens
 
-Create a new registration token.
+Create a new registration token. The response includes the full secret (`token`) and the stable `token_id` — this is the only time the secret is returned.
 
 **Authentication:** Required  
 **Required permission:** `registration:create-token`
 
 #### GET /api/v1/registration/tokens/{token}
 
-Get a specific registration token's metadata.
+Get a specific registration token's metadata (redacted — no secret).
 
 **Authentication:** Required  
 **Required permission:** `registration:read-token`
 
 **Parameters:**
 
-- `token` (path): Registration token value
+- `token` (path): Registration token value or `token_id`
 
 #### DELETE /api/v1/registration/tokens/{token}
 
@@ -1011,18 +1015,30 @@ Delete a registration token.
 
 **Parameters:**
 
-- `token` (path): Registration token value
+- `token` (path): Registration token value or `token_id`
 
 #### POST /api/v1/registration/tokens/{token}/revoke
 
-Revoke a registration token without deleting it. A revoked token remains in the store but is rejected on use.
+Revoke a registration token without deleting it. A revoked token remains in the store but is rejected on use. Response is redacted (no secret).
 
 **Authentication:** Required  
 **Required permission:** `registration:revoke-token`
 
 **Parameters:**
 
-- `token` (path): Registration token value
+- `token` (path): Registration token value or `token_id`
+
+#### POST /api/v1/registration/tokens/{tenant_id}/rotate
+
+Atomically revoke the active token(s) for a tenant (optionally scoped to `group`) and mint a replacement. The response includes the full secret of the new token — this is a mint window like create.
+
+**Authentication:** Required  
+**Required permission:** `registration:rotate-token`
+
+**Parameters:**
+
+- `tenant_id` (path): Tenant to rotate tokens for
+- `group` (body, optional): Restrict rotation to tokens in this group
 
 ### Monitoring
 

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -18,7 +18,9 @@ import (
 // TokenResponse represents a registration token in API responses.
 // Token (full secret) is only populated by create and rotate responses.
 // All other endpoints (list, get, revoke) set TokenPrefix only.
+// TokenID is a stable UUID, always set, safe to expose — it is NOT the secret.
 type TokenResponse struct {
+	TokenID       string  `json:"token_id,omitempty"`     // stable UUID — always set (Issue #2970)
 	Token         string  `json:"token,omitempty"`        // full secret — create/rotate only
 	TokenPrefix   string  `json:"token_prefix,omitempty"` // first 6 chars — always set
 	TenantID      string  `json:"tenant_id"`
@@ -247,7 +249,11 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 
 	// Look up the token first for tenant scope enforcement and audit.
+	// Try exact match first (mTLS admin with full token), then UUID lookup (web UI).
 	token, err := s.registrationTokenStore.GetToken(r.Context(), tokenStr)
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		token, err = s.registrationTokenStore.GetTokenByID(r.Context(), tokenStr)
+	}
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			http.Error(w, "Token not found", http.StatusNotFound)
@@ -268,8 +274,9 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	// Delete token from store
-	if err := s.registrationTokenStore.DeleteToken(r.Context(), tokenStr); err != nil {
+	// Delete token from store. Always use token.Token (the full secret string) as the
+	// store key, not tokenStr which may be a UUID from a web UI caller.
+	if err := s.registrationTokenStore.DeleteToken(r.Context(), token.Token); err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			http.Error(w, "Token not found", http.StatusNotFound)
 			return
@@ -280,7 +287,8 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 
 	// SanitizeLogValue wraps strings.ReplaceAll so CodeQL's ReplaceSanitizer clears the taint.
-	tokenPrefix := logging.SanitizeLogValue(tokenStr[:min(len(tokenStr), 6)])
+	// Use token.Token for the prefix — tokenStr may be a UUID from a web UI caller.
+	tokenPrefix := logging.SanitizeLogValue(token.Token[:min(len(token.Token), 6)])
 	s.logger.Info("Deleted registration token", "token_prefix", tokenPrefix)
 	s.emitTokenManagementAudit(r, "registration_token.deleted", tokenPrefix, token.TenantID)
 
@@ -309,8 +317,12 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Get token from store
+	// Get token from store.
+	// Try exact match first (mTLS admin with full token), then UUID lookup (web UI).
 	token, err := s.registrationTokenStore.GetToken(r.Context(), tokenStr)
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		token, err = s.registrationTokenStore.GetTokenByID(r.Context(), tokenStr)
+	}
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			http.Error(w, "Token not found", http.StatusNotFound)
@@ -342,7 +354,8 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 
 	// SanitizeLogValue wraps strings.ReplaceAll so CodeQL's ReplaceSanitizer clears the taint.
-	tokenPrefix := logging.SanitizeLogValue(tokenStr[:min(len(tokenStr), 6)])
+	// Use token.Token for the prefix — tokenStr may be a UUID from a web UI caller.
+	tokenPrefix := logging.SanitizeLogValue(token.Token[:min(len(token.Token), 6)])
 	s.logger.Info("Revoked registration token", "token_prefix", tokenPrefix)
 	s.emitTokenManagementAudit(r, "registration_token.revoked", tokenPrefix, token.TenantID)
 
@@ -421,6 +434,7 @@ func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Re
 // Use ONLY for create and rotate responses where the secret must be returned once.
 func tokenToResponse(token *registration.Token) TokenResponse {
 	resp := TokenResponse{
+		TokenID:       token.ID,
 		Token:         token.Token,
 		TokenPrefix:   token.Token[:min(len(token.Token), 6)],
 		TenantID:      token.TenantID,

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -117,7 +117,7 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 		"token_prefix", token.Token[:min(len(token.Token), 6)],
 		"tenant_id", logging.SanitizeLogValue(token.TenantID))
 	s.emitTokenManagementAudit(r, "registration_token.created",
-		token.Token[:min(len(token.Token), 6)], token.TenantID)
+		token.Token[:min(len(token.Token), 6)], token.ID, token.TenantID)
 
 	// Return full token response — create is the one-time mint window where the secret is disclosed.
 	resp := tokenToResponse(token)
@@ -290,7 +290,7 @@ func (s *Server) handleDeleteRegistrationToken(w http.ResponseWriter, r *http.Re
 	// Use token.Token for the prefix — tokenStr may be a UUID from a web UI caller.
 	tokenPrefix := logging.SanitizeLogValue(token.Token[:min(len(token.Token), 6)])
 	s.logger.Info("Deleted registration token", "token_prefix", tokenPrefix)
-	s.emitTokenManagementAudit(r, "registration_token.deleted", tokenPrefix, token.TenantID)
+	s.emitTokenManagementAudit(r, "registration_token.deleted", tokenPrefix, token.ID, token.TenantID)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -357,7 +357,7 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 	// Use token.Token for the prefix — tokenStr may be a UUID from a web UI caller.
 	tokenPrefix := logging.SanitizeLogValue(token.Token[:min(len(token.Token), 6)])
 	s.logger.Info("Revoked registration token", "token_prefix", tokenPrefix)
-	s.emitTokenManagementAudit(r, "registration_token.revoked", tokenPrefix, token.TenantID)
+	s.emitTokenManagementAudit(r, "registration_token.revoked", tokenPrefix, token.ID, token.TenantID)
 
 	// Return redacted response — revoke callers do not receive the raw secret.
 	resp := tokenToResponseRedacted(token)
@@ -419,7 +419,7 @@ func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Re
 	s.logger.Info("Rotated registration token",
 		"token_prefix", tokenPrefix,
 		"tenant_id", logging.SanitizeLogValue(tenantID))
-	s.emitTokenManagementAudit(r, "registration_token.rotated", tokenPrefix, tenantID)
+	s.emitTokenManagementAudit(r, "registration_token.rotated", tokenPrefix, newToken.ID, tenantID)
 
 	// Return full token response — rotate is a mint window where the new secret is disclosed once.
 	resp := tokenToResponse(newToken)
@@ -468,7 +468,9 @@ func tokenToResponseRedacted(token *registration.Token) TokenResponse {
 
 // emitTokenManagementAudit records an audit event for a token management action
 // (create, rotate, revoke, delete). It is a no-op when auditManager is nil.
-func (s *Server) emitTokenManagementAudit(r *http.Request, action, tokenPrefix, tenantID string) {
+// tokenID is the stable UUID (registration.Token.ID) — never the secret — recorded
+// as the resource name so the audit trail can be correlated to a token by ID.
+func (s *Server) emitTokenManagementAudit(r *http.Request, action, tokenPrefix, tokenID, tenantID string) {
 	if s.auditManager == nil {
 		return
 	}
@@ -486,7 +488,7 @@ func (s *Server) emitTokenManagementAudit(r *http.Request, action, tokenPrefix, 
 		Type(business.AuditEventSystemAccess).
 		Action(action).
 		User(principalID, business.AuditUserTypeHuman).
-		Resource("registration_token", tokenPrefix, "").
+		Resource("registration_token", tokenPrefix, tokenID).
 		Result(business.AuditResultSuccess).
 		Severity(business.AuditSeverityHigh)
 	if err := s.auditManager.RecordEvent(r.Context(), b); err != nil {

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -959,6 +959,8 @@ func TestCreateRegistrationToken_EmitsAuditEvent(t *testing.T) {
 	assert.Equal(t, "audit-tenant", entry.TenantID)
 	assert.Equal(t, "registration_token", entry.ResourceType)
 	assert.Equal(t, resp.Token[:6], entry.ResourceID, "audit resource must record the token prefix")
+	assert.Equal(t, resp.TokenID, entry.ResourceName, "audit resource name must record the stable token id")
+	assert.NotContains(t, entry.ResourceName, resp.Token, "audit resource name must never contain the secret")
 	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
 	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
 }
@@ -987,6 +989,8 @@ func TestDeleteRegistrationToken_EmitsAuditEvent(t *testing.T) {
 	assert.Equal(t, "audit-tenant", entry.TenantID)
 	assert.Equal(t, "registration_token", entry.ResourceType)
 	assert.Equal(t, token.Token[:6], entry.ResourceID, "audit resource must record the token prefix")
+	assert.Equal(t, token.ID, entry.ResourceName, "audit resource name must record the stable token id")
+	assert.NotContains(t, entry.ResourceName, token.Token, "audit resource name must never contain the secret")
 	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
 	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
 }
@@ -1015,6 +1019,8 @@ func TestRevokeRegistrationToken_EmitsAuditEvent(t *testing.T) {
 	assert.Equal(t, "audit-tenant", entry.TenantID)
 	assert.Equal(t, "registration_token", entry.ResourceType)
 	assert.Equal(t, token.Token[:6], entry.ResourceID, "audit resource must record the token prefix")
+	assert.Equal(t, token.ID, entry.ResourceName, "audit resource name must record the stable token id")
+	assert.NotContains(t, entry.ResourceName, token.Token, "audit resource name must never contain the secret")
 	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
 	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
 }
@@ -1050,6 +1056,8 @@ func TestRotateRegistrationToken_EmitsAuditEvent(t *testing.T) {
 	assert.Equal(t, "audit-tenant", entry.TenantID)
 	assert.Equal(t, "registration_token", entry.ResourceType)
 	assert.Equal(t, resp.Token[:6], entry.ResourceID, "audit resource must record the new token prefix")
+	assert.Equal(t, resp.TokenID, entry.ResourceName, "audit resource name must record the stable token id")
+	assert.NotContains(t, entry.ResourceName, resp.Token, "audit resource name must never contain the secret")
 	assert.Equal(t, string(business.AuditEventSystemAccess), string(entry.EventType))
 	assert.Equal(t, string(business.AuditResultSuccess), string(entry.Result))
 }

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
@@ -115,6 +117,17 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 	})
 
 	return server, tokenStore
+}
+
+// makeScopedTokenRequest builds a request for a tenant-scoped (web session) caller
+// addressing a registration token by path variable. Delete and revoke require
+// AssuranceStrong, which an API key can never hold, so scope-enforcement tests
+// invoke the handler directly with the tenant in context and the mux var set.
+func makeScopedTokenRequest(t *testing.T, method, path, tenantID, tokenVar string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	return mux.SetURLVars(req, map[string]string{"token": tokenVar})
 }
 
 func TestCreateRegistrationToken(t *testing.T) {
@@ -442,6 +455,33 @@ func TestDeleteRegistrationToken(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	// Issue #2970: the web UI never holds the secret, so it addresses a token by its
+	// stable UUID. The handler falls back to a GetTokenByID lookup for that caller.
+	t.Run("delete by token_id", func(t *testing.T) {
+		token, err := registration.CreateToken(&registration.TokenCreateRequest{
+			TenantID:      "test-tenant",
+			ControllerURL: "grpc://controller.example.com:7443",
+		})
+		require.NoError(t, err)
+		require.NoError(t, tokenStore.SaveToken(ctx, token))
+		require.NotEmpty(t, token.ID)
+		require.NotEqual(t, token.Token, token.ID)
+
+		req := makeAdminRequest(t, "DELETE", "/api/v1/registration/tokens/"+token.ID, nil)
+		rec := httptest.NewRecorder()
+
+		server.router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+
+		// The row keyed by the secret must be gone — the handler must delete by
+		// token.Token, not by the UUID it was addressed with.
+		_, err = tokenStore.GetToken(ctx, token.Token)
+		assert.Error(t, err)
+		_, err = tokenStore.GetTokenByID(ctx, token.ID)
+		assert.Error(t, err)
+	})
+
 	t.Run("delete non-existent token returns 404", func(t *testing.T) {
 		req := makeAdminRequest(t, "DELETE", "/api/v1/registration/tokens/nonexistent-token", nil)
 		rec := httptest.NewRecorder()
@@ -449,6 +489,42 @@ func TestDeleteRegistrationToken(t *testing.T) {
 		server.router.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("delete unknown token_id returns 404 not 500", func(t *testing.T) {
+		req := makeAdminRequest(t, "DELETE",
+			"/api/v1/registration/tokens/aaaaaaaa-0000-4000-8000-0000000000ff", nil)
+		rec := httptest.NewRecorder()
+
+		server.router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code,
+			"an unknown UUID must be a clean 404, never a store error surfaced as 500")
+	})
+
+	t.Run("scoped caller cannot delete another tenant's token by token_id", func(t *testing.T) {
+		token, err := registration.CreateToken(&registration.TokenCreateRequest{
+			TenantID:      "other-tenant",
+			ControllerURL: "grpc://controller.example.com:7443",
+		})
+		require.NoError(t, err)
+		require.NoError(t, tokenStore.SaveToken(ctx, token))
+
+		// Scoped (web session) caller: tenant scope comes from the request context.
+		// The handler is invoked directly because AssuranceStrong routes cannot be
+		// reached with an API key.
+		req := makeScopedTokenRequest(t, "DELETE",
+			"/api/v1/registration/tokens/"+token.ID, "scoped-tenant", token.ID)
+		rec := httptest.NewRecorder()
+
+		server.handleDeleteRegistrationToken(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code,
+			"tenant-scope enforcement must apply to the token_id path too")
+
+		// The token must still exist.
+		_, err = tokenStore.GetTokenByID(ctx, token.ID)
+		require.NoError(t, err)
 	})
 
 	t.Run("unauthorized without API key", func(t *testing.T) {
@@ -494,6 +570,80 @@ func TestRevokeRegistrationToken(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, updated.Revoked)
 		assert.False(t, updated.IsValid())
+	})
+
+	// Issue #2970: the web UI revokes by stable UUID because it never holds the secret.
+	t.Run("revoke by token_id", func(t *testing.T) {
+		token, err := registration.CreateToken(&registration.TokenCreateRequest{
+			TenantID:      "test-tenant",
+			ControllerURL: "grpc://controller.example.com:7443",
+		})
+		require.NoError(t, err)
+		require.NoError(t, tokenStore.SaveToken(ctx, token))
+		require.NotEmpty(t, token.ID)
+		require.NotEqual(t, token.Token, token.ID)
+
+		req := makeAdminRequest(t, "POST", "/api/v1/registration/tokens/"+token.ID+"/revoke", nil)
+		rec := httptest.NewRecorder()
+
+		server.router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp TokenResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.True(t, resp.Revoked)
+		assert.NotNil(t, resp.RevokedAt)
+		assert.Equal(t, token.ID, resp.TokenID, "the response must echo the stable token_id")
+		assert.Empty(t, resp.Token, "revoke must never return the raw secret")
+		assert.Equal(t, token.Token[:6], resp.TokenPrefix)
+
+		// The stored row (keyed by the secret) must be the one that got revoked.
+		updated, err := tokenStore.GetToken(ctx, token.Token)
+		require.NoError(t, err)
+		assert.True(t, updated.Revoked)
+		assert.False(t, updated.IsValid())
+
+		// It must remain addressable by id after revocation (delete-after-revoke).
+		byID, err := tokenStore.GetTokenByID(ctx, token.ID)
+		require.NoError(t, err)
+		assert.True(t, byID.Revoked)
+	})
+
+	t.Run("revoke unknown token_id returns 404 not 500", func(t *testing.T) {
+		req := makeAdminRequest(t, "POST",
+			"/api/v1/registration/tokens/aaaaaaaa-0000-4000-8000-0000000000ff/revoke", nil)
+		rec := httptest.NewRecorder()
+
+		server.router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code,
+			"an unknown UUID must be a clean 404, never a store error surfaced as 500")
+	})
+
+	t.Run("scoped caller cannot revoke another tenant's token by token_id", func(t *testing.T) {
+		token, err := registration.CreateToken(&registration.TokenCreateRequest{
+			TenantID:      "other-tenant",
+			ControllerURL: "grpc://controller.example.com:7443",
+		})
+		require.NoError(t, err)
+		require.NoError(t, tokenStore.SaveToken(ctx, token))
+
+		// Scoped (web session) caller: tenant scope comes from the request context.
+		// The handler is invoked directly because AssuranceStrong routes cannot be
+		// reached with an API key.
+		req := makeScopedTokenRequest(t, "POST",
+			"/api/v1/registration/tokens/"+token.ID+"/revoke", "scoped-tenant", token.ID)
+		rec := httptest.NewRecorder()
+
+		server.handleRevokeRegistrationToken(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code,
+			"tenant-scope enforcement must apply to the token_id path too")
+
+		still, err := tokenStore.GetTokenByID(ctx, token.ID)
+		require.NoError(t, err)
+		assert.False(t, still.Revoked, "the token must not be revoked by an out-of-scope caller")
 	})
 
 	t.Run("revoke non-existent token returns 404", func(t *testing.T) {

--- a/pkg/controlplane/providers/grpc/provider_register_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_register_identity_test.go
@@ -99,6 +99,17 @@ func (s *inMemoryTokenStore) RotateToken(_ context.Context, tenantID, group stri
 	return newTok, nil
 }
 
+func (s *inMemoryTokenStore) GetTokenByID(_ context.Context, id string) (*business.RegistrationTokenData, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, t := range s.tokens {
+		if t.ID == id {
+			return t, nil
+		}
+	}
+	return nil, fmt.Errorf("registration token not found")
+}
+
 func (s *inMemoryTokenStore) Initialize(_ context.Context) error { return nil }
 func (s *inMemoryTokenStore) Close() error                       { return nil }
 

--- a/pkg/registration/adapter.go
+++ b/pkg/registration/adapter.go
@@ -35,6 +35,15 @@ func (a *StorageAdapter) GetToken(ctx context.Context, tokenStr string) (*Token,
 	return dataToToken(data), nil
 }
 
+// GetTokenByID retrieves a token by its stable UUID.
+func (a *StorageAdapter) GetTokenByID(ctx context.Context, id string) (*Token, error) {
+	data, err := a.store.GetTokenByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return dataToToken(data), nil
+}
+
 // ListTokens lists all tokens for a tenant
 func (a *StorageAdapter) ListTokens(ctx context.Context, tenantID string) ([]*Token, error) {
 	filter := &business.RegistrationTokenFilter{
@@ -75,6 +84,7 @@ func (a *StorageAdapter) RotateToken(ctx context.Context, tenantID, group string
 // tokenToData converts a Token to RegistrationTokenData
 func tokenToData(token *Token) *business.RegistrationTokenData {
 	return &business.RegistrationTokenData{
+		ID:            token.ID,
 		Token:         token.Token,
 		TenantID:      token.TenantID,
 		ControllerURL: token.ControllerURL,
@@ -89,6 +99,7 @@ func tokenToData(token *Token) *business.RegistrationTokenData {
 // dataToToken converts a RegistrationTokenData to Token
 func dataToToken(data *business.RegistrationTokenData) *Token {
 	return &Token{
+		ID:            data.ID,
 		Token:         data.Token,
 		TenantID:      data.TenantID,
 		ControllerURL: data.ControllerURL,

--- a/pkg/registration/adapter.go
+++ b/pkg/registration/adapter.go
@@ -20,10 +20,17 @@ func NewStorageAdapter(store business.RegistrationTokenStore) *StorageAdapter {
 	return &StorageAdapter{store: store}
 }
 
-// SaveToken saves a registration token by converting to storage format
+// SaveToken saves a registration token by converting to storage format.
+// A store that assigns a stable ID to a token saved without one (Issue #2970) has
+// that ID written back onto the caller's token, matching memoryStore, so the caller
+// can address the token by ID immediately after saving.
 func (a *StorageAdapter) SaveToken(ctx context.Context, token *Token) error {
 	data := tokenToData(token)
-	return a.store.SaveToken(ctx, data)
+	if err := a.store.SaveToken(ctx, data); err != nil {
+		return err
+	}
+	token.ID = data.ID
+	return nil
 }
 
 // GetToken retrieves a token and converts from storage format

--- a/pkg/registration/adapter_test.go
+++ b/pkg/registration/adapter_test.go
@@ -129,6 +129,112 @@ func TestStorageAdapter_WithSQLiteStore(t *testing.T) {
 	})
 }
 
+func TestStorageAdapter_GetTokenByID(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := interfaces.CreateRegistrationTokenStoreFromConfig(
+		"sqlite",
+		map[string]interface{}{"path": tempDir + "/tokens.db"},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx))
+
+	adapter := NewStorageAdapter(store)
+
+	created, err := CreateToken(&TokenCreateRequest{
+		TenantID:      "tenant-byid",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "byid-group",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.ID)
+	require.NoError(t, adapter.SaveToken(ctx, created))
+
+	t.Run("round-trips the token by its stable ID", func(t *testing.T) {
+		got, err := adapter.GetTokenByID(ctx, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, got.ID)
+		assert.Equal(t, created.Token, got.Token)
+		assert.Equal(t, "tenant-byid", got.TenantID)
+		assert.Equal(t, "byid-group", got.Group)
+		assert.Equal(t, "grpc://controller:7443", got.ControllerURL)
+		assert.False(t, got.Revoked)
+	})
+
+	t.Run("GetToken also returns the stable ID", func(t *testing.T) {
+		got, err := adapter.GetToken(ctx, created.Token)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, got.ID, "the ID must survive the storage round-trip")
+	})
+
+	t.Run("ListTokens returns the stable ID", func(t *testing.T) {
+		tokens, err := adapter.ListTokens(ctx, "tenant-byid")
+		require.NoError(t, err)
+		require.Len(t, tokens, 1)
+		assert.Equal(t, created.ID, tokens[0].ID)
+	})
+
+	t.Run("unknown ID returns a not-found error", func(t *testing.T) {
+		_, err := adapter.GetTokenByID(ctx, "aaaaaaaa-0000-4000-8000-00000000dead")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("the secret string does not resolve as an ID", func(t *testing.T) {
+		_, err := adapter.GetTokenByID(ctx, created.Token)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("rotated token is addressable by its new ID", func(t *testing.T) {
+		rotated, err := adapter.RotateToken(ctx, "tenant-byid", "byid-group")
+		require.NoError(t, err)
+		require.NotEmpty(t, rotated.ID)
+		assert.NotEqual(t, created.ID, rotated.ID)
+
+		got, err := adapter.GetTokenByID(ctx, rotated.ID)
+		require.NoError(t, err)
+		assert.Equal(t, rotated.Token, got.Token)
+		assert.False(t, got.Revoked)
+	})
+}
+
+func TestStorageAdapter_SaveToken_AssignsIDWhenMissing(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := interfaces.CreateRegistrationTokenStoreFromConfig(
+		"sqlite",
+		map[string]interface{}{"path": tempDir + "/tokens.db"},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx))
+
+	adapter := NewStorageAdapter(store)
+
+	token := &Token{
+		Token:         "adapter-token-without-id",
+		TenantID:      "tenant-noid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, adapter.SaveToken(ctx, token))
+	require.NotEmpty(t, token.ID, "SaveToken must write the assigned ID back onto the caller's token")
+
+	got, err := adapter.GetToken(ctx, token.Token)
+	require.NoError(t, err)
+	assert.Equal(t, token.ID, got.ID, "the persisted ID must match the one written back")
+
+	byID, err := adapter.GetTokenByID(ctx, got.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token.Token, byID.Token)
+}
+
 func TestStorageAdapter_InterfaceCompliance(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/pkg/registration/generator.go
+++ b/pkg/registration/generator.go
@@ -31,6 +31,20 @@ func GenerateToken() (string, error) {
 	return token, nil
 }
 
+// GenerateTokenID generates a stable UUID v4 for use as a non-secret token identifier
+// (Issue #2970 — web UI can reference a token by ID without holding the secret).
+// No external dependency: produced directly from crypto/rand.
+func GenerateTokenID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate token ID bytes: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
 // ParseExpiration parses expiration duration string (e.g., "24h", "7d", "30d")
 func ParseExpiration(expiresIn string) (*time.Time, error) {
 	if expiresIn == "" {
@@ -70,10 +84,14 @@ func CreateToken(req *TokenCreateRequest) (*Token, error) {
 		return nil, fmt.Errorf("controller_url is required")
 	}
 
-	// Generate token string
+	// Generate token string and stable ID
 	tokenStr, err := GenerateToken()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
+	tokenID, err := GenerateTokenID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token ID: %w", err)
 	}
 
 	// Parse expiration
@@ -84,6 +102,7 @@ func CreateToken(req *TokenCreateRequest) (*Token, error) {
 
 	// Create token
 	token := &Token{
+		ID:            tokenID,
 		Token:         tokenStr,
 		TenantID:      req.TenantID,
 		ControllerURL: req.ControllerURL,

--- a/pkg/registration/generator_test.go
+++ b/pkg/registration/generator_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package registration
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// uuidV4Pattern matches the canonical lowercase UUID v4 form with the version
+// nibble fixed at 4 and the variant nibble in [89ab].
+var uuidV4Pattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestGenerateTokenID_Format(t *testing.T) {
+	id, err := GenerateTokenID()
+	require.NoError(t, err)
+	assert.Len(t, id, 36, "token ID must be a canonical 36-character UUID")
+	assert.Regexp(t, uuidV4Pattern, id, "token ID must be a lowercase UUID v4")
+}
+
+func TestGenerateTokenID_Unique(t *testing.T) {
+	const iterations = 1000
+	seen := make(map[string]struct{}, iterations)
+	for i := 0; i < iterations; i++ {
+		id, err := GenerateTokenID()
+		require.NoError(t, err)
+		require.Regexp(t, uuidV4Pattern, id)
+		_, dup := seen[id]
+		require.False(t, dup, "GenerateTokenID must not repeat an ID (iteration %d)", i)
+		seen[id] = struct{}{}
+	}
+	assert.Len(t, seen, iterations)
+}
+
+func TestGenerateTokenID_DiffersFromSecret(t *testing.T) {
+	id, err := GenerateTokenID()
+	require.NoError(t, err)
+	secret, err := GenerateToken()
+	require.NoError(t, err)
+	assert.NotEqual(t, secret, id, "the non-secret ID must never equal the secret")
+	assert.NotContains(t, secret, id)
+}
+
+func TestCreateToken_AssignsStableID(t *testing.T) {
+	first, err := CreateToken(&TokenCreateRequest{
+		TenantID:      "tenant-gen",
+		ControllerURL: "grpc://controller:7443",
+	})
+	require.NoError(t, err)
+	assert.Regexp(t, uuidV4Pattern, first.ID, "CreateToken must assign a UUID v4 ID")
+	assert.NotEqual(t, first.Token, first.ID, "ID must not be derived from the secret")
+
+	second, err := CreateToken(&TokenCreateRequest{
+		TenantID:      "tenant-gen",
+		ControllerURL: "grpc://controller:7443",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, first.ID, second.ID, "each created token must get a distinct ID")
+}

--- a/pkg/registration/store.go
+++ b/pkg/registration/store.go
@@ -17,6 +17,9 @@ type Store interface {
 	// GetToken retrieves a token by its token string
 	GetToken(ctx context.Context, tokenStr string) (*Token, error)
 
+	// GetTokenByID retrieves a token by its stable UUID (Issue #2970).
+	GetTokenByID(ctx context.Context, id string) (*Token, error)
+
 	// ListTokens lists all tokens for a tenant
 	ListTokens(ctx context.Context, tenantID string) ([]*Token, error)
 
@@ -35,13 +38,15 @@ type Store interface {
 // memoryStore is an in-memory implementation of Store (for use within this package only).
 type memoryStore struct {
 	mu     sync.RWMutex
-	tokens map[string]*Token
+	tokens map[string]*Token // keyed by token string
+	byID   map[string]string // id → token string
 }
 
 // newMemoryStore creates a new in-memory token store.
 func newMemoryStore() *memoryStore {
 	return &memoryStore{
 		tokens: make(map[string]*Token),
+		byID:   make(map[string]string),
 	}
 }
 
@@ -51,6 +56,9 @@ func (s *memoryStore) SaveToken(ctx context.Context, token *Token) error {
 	defer s.mu.Unlock()
 
 	s.tokens[token.Token] = token
+	if token.ID != "" {
+		s.byID[token.ID] = token.Token
+	}
 	return nil
 }
 
@@ -64,6 +72,22 @@ func (s *memoryStore) GetToken(ctx context.Context, tokenStr string) (*Token, er
 		return nil, fmt.Errorf("token not found")
 	}
 
+	return token, nil
+}
+
+// GetTokenByID retrieves a token by its stable UUID.
+func (s *memoryStore) GetTokenByID(ctx context.Context, id string) (*Token, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tokenStr, exists := s.byID[id]
+	if !exists {
+		return nil, fmt.Errorf("token not found")
+	}
+	token, exists := s.tokens[tokenStr]
+	if !exists {
+		return nil, fmt.Errorf("token not found")
+	}
 	return token, nil
 }
 
@@ -127,10 +151,14 @@ func (s *memoryStore) RotateToken(ctx context.Context, tenantID, group string) (
 		return nil, fmt.Errorf("no active tokens found for tenant %q group %q", tenantID, group)
 	}
 
-	// Generate new token string.
+	// Generate new token string and stable ID.
 	tokenStr, err := GenerateToken()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
+	tokenID, err := GenerateTokenID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token ID: %w", err)
 	}
 
 	now := time.Now()
@@ -144,6 +172,7 @@ func (s *memoryStore) RotateToken(ctx context.Context, tenantID, group string) (
 	}
 
 	newToken := &Token{
+		ID:            tokenID,
 		Token:         tokenStr,
 		TenantID:      tenantID,
 		ControllerURL: controllerURL,
@@ -151,6 +180,7 @@ func (s *memoryStore) RotateToken(ctx context.Context, tenantID, group string) (
 		CreatedAt:     now,
 	}
 	s.tokens[tokenStr] = newToken
+	s.byID[tokenID] = tokenStr
 
 	return newToken, nil
 }

--- a/pkg/registration/store.go
+++ b/pkg/registration/store.go
@@ -50,15 +50,28 @@ func newMemoryStore() *memoryStore {
 	}
 }
 
-// SaveToken saves a registration token.
+// SaveToken saves a registration token. Tokens saved without a stable ID receive a
+// generated one so that every stored token is addressable by ID (Issue #2970),
+// matching the durable store implementations.
 func (s *memoryStore) SaveToken(ctx context.Context, token *Token) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.tokens[token.Token] = token
-	if token.ID != "" {
-		s.byID[token.ID] = token.Token
+	if token.ID == "" {
+		// Preserve the ID already assigned to this token string, if any.
+		if existing, ok := s.tokens[token.Token]; ok && existing.ID != "" {
+			token.ID = existing.ID
+		} else {
+			id, err := GenerateTokenID()
+			if err != nil {
+				return fmt.Errorf("failed to generate token ID: %w", err)
+			}
+			token.ID = id
+		}
 	}
+
+	s.tokens[token.Token] = token
+	s.byID[token.ID] = token.Token
 	return nil
 }
 
@@ -119,11 +132,14 @@ func (s *memoryStore) UpdateToken(ctx context.Context, token *Token) error {
 	return nil
 }
 
-// DeleteToken deletes a token.
+// DeleteToken deletes a token and its ID index entry.
 func (s *memoryStore) DeleteToken(ctx context.Context, tokenStr string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if token, ok := s.tokens[tokenStr]; ok && token.ID != "" {
+		delete(s.byID, token.ID)
+	}
 	delete(s.tokens, tokenStr)
 	return nil
 }

--- a/pkg/registration/store_test.go
+++ b/pkg/registration/store_test.go
@@ -40,6 +40,121 @@ func TestMemoryStore_RotateToken_Basic(t *testing.T) {
 	assert.True(t, got.Revoked, "initial token must be revoked after rotation")
 }
 
+func TestMemoryStore_GetTokenByID(t *testing.T) {
+	store := newMemoryStore()
+	ctx := context.Background()
+
+	tok, err := CreateToken(&TokenCreateRequest{
+		TenantID:      "tenant-byid",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "byid-group",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, tok.ID)
+	require.NoError(t, store.SaveToken(ctx, tok))
+
+	got, err := store.GetTokenByID(ctx, tok.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tok.Token, got.Token, "lookup by ID must return the same token")
+	assert.Equal(t, tok.ID, got.ID)
+	assert.Equal(t, "tenant-byid", got.TenantID)
+	assert.Equal(t, "byid-group", got.Group)
+}
+
+func TestMemoryStore_GetTokenByID_NotFound(t *testing.T) {
+	store := newMemoryStore()
+	ctx := context.Background()
+
+	_, err := store.GetTokenByID(ctx, "aaaaaaaa-0000-4000-8000-000000000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// The secret string must not resolve through the ID index.
+	tok, err := CreateToken(&TokenCreateRequest{
+		TenantID:      "tenant-byid",
+		ControllerURL: "grpc://controller:7443",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.SaveToken(ctx, tok))
+
+	_, err = store.GetTokenByID(ctx, tok.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestMemoryStore_SaveToken_AssignsIDWhenMissing(t *testing.T) {
+	store := newMemoryStore()
+	ctx := context.Background()
+
+	tok := &Token{
+		Token:         "no-id-token",
+		TenantID:      "tenant-noid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, store.SaveToken(ctx, tok))
+	require.NotEmpty(t, tok.ID, "SaveToken must assign an ID when the caller supplies none")
+	assignedID := tok.ID
+
+	got, err := store.GetTokenByID(ctx, assignedID)
+	require.NoError(t, err)
+	assert.Equal(t, "no-id-token", got.Token)
+
+	// Re-saving the same token string must keep the ID stable.
+	resaved := &Token{
+		Token:         "no-id-token",
+		TenantID:      "tenant-noid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     tok.CreatedAt,
+	}
+	require.NoError(t, store.SaveToken(ctx, resaved))
+	assert.Equal(t, assignedID, resaved.ID, "token ID must be stable across saves")
+}
+
+func TestMemoryStore_DeleteToken_ClearsIDIndex(t *testing.T) {
+	store := newMemoryStore()
+	ctx := context.Background()
+
+	tok, err := CreateToken(&TokenCreateRequest{
+		TenantID:      "tenant-del",
+		ControllerURL: "grpc://controller:7443",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.SaveToken(ctx, tok))
+	require.NoError(t, store.DeleteToken(ctx, tok.Token))
+
+	_, err = store.GetTokenByID(ctx, tok.ID)
+	require.Error(t, err, "a deleted token must not remain addressable by ID")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestMemoryStore_RotateToken_AssignsIDToNewToken(t *testing.T) {
+	store := newMemoryStore()
+	ctx := context.Background()
+
+	initial, err := CreateToken(&TokenCreateRequest{
+		TenantID:      "tenant-rot-id",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "rot-group",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.SaveToken(ctx, initial))
+
+	rotated, err := store.RotateToken(ctx, "tenant-rot-id", "rot-group")
+	require.NoError(t, err)
+	require.NotEmpty(t, rotated.ID)
+	assert.NotEqual(t, initial.ID, rotated.ID, "rotation must mint a new ID")
+
+	byID, err := store.GetTokenByID(ctx, rotated.ID)
+	require.NoError(t, err)
+	assert.Equal(t, rotated.Token, byID.Token)
+
+	// The rotated-away token remains addressable by its own ID (and is revoked).
+	old, err := store.GetTokenByID(ctx, initial.ID)
+	require.NoError(t, err)
+	assert.True(t, old.Revoked)
+}
+
 func TestMemoryStore_RotateToken_NoActiveTokens(t *testing.T) {
 	store := newMemoryStore()
 	ctx := context.Background()

--- a/pkg/registration/types.go
+++ b/pkg/registration/types.go
@@ -12,6 +12,9 @@ import "time"
 // Tokens are perennial: they survive multiple registrations and are never consumed on use.
 // Rotation atomically revokes the old token and issues a new one.
 type Token struct {
+	// ID is a stable UUID for this token (Issue #2970 — web UI identifier).
+	ID string `json:"id"`
+
 	// Token is the unique token string (e.g., "abcdefghijklmnopqrstuvwxyz")
 	Token string `json:"token"`
 

--- a/pkg/storage/interfaces/business/registration_store.go
+++ b/pkg/storage/interfaces/business/registration_store.go
@@ -14,6 +14,9 @@ type RegistrationTokenStore interface {
 	// Token management
 	SaveToken(ctx context.Context, token *RegistrationTokenData) error
 	GetToken(ctx context.Context, tokenStr string) (*RegistrationTokenData, error)
+	// GetTokenByID retrieves a token by its stable UUID (Issue #2970).
+	// Returns "registration token not found" when absent.
+	GetTokenByID(ctx context.Context, id string) (*RegistrationTokenData, error)
 	UpdateToken(ctx context.Context, token *RegistrationTokenData) error
 	DeleteToken(ctx context.Context, tokenStr string) error
 	ListTokens(ctx context.Context, filter *RegistrationTokenFilter) ([]*RegistrationTokenData, error)
@@ -30,6 +33,10 @@ type RegistrationTokenStore interface {
 
 // RegistrationTokenData represents a registration token in the storage layer
 type RegistrationTokenData struct {
+	// ID is a stable UUID for this token (Issue #2970 — web UI identifier).
+	// Never the secret: the Token field is the credential.
+	ID string `json:"id" yaml:"id"`
+
 	// Token is the unique token string (e.g., "abcdefghijklmnopqrstuvwxyz")
 	Token string `json:"token" yaml:"token"`
 

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -5,6 +5,7 @@ package interfaces
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -691,6 +692,9 @@ func (s *mockRegistrationTokenStore) SaveToken(_ context.Context, _ *business.Re
 }
 func (s *mockRegistrationTokenStore) GetToken(_ context.Context, tokenStr string) (*business.RegistrationTokenData, error) {
 	return &business.RegistrationTokenData{Token: tokenStr, TenantID: "test-tenant"}, nil
+}
+func (s *mockRegistrationTokenStore) GetTokenByID(_ context.Context, _ string) (*business.RegistrationTokenData, error) {
+	return nil, fmt.Errorf("registration token not found")
 }
 func (s *mockRegistrationTokenStore) UpdateToken(_ context.Context, _ *business.RegistrationTokenData) error {
 	return nil

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -395,6 +395,9 @@ func (m *MockRegistrationTokenStore) SaveToken(_ context.Context, _ *business.Re
 func (m *MockRegistrationTokenStore) GetToken(_ context.Context, _ string) (*business.RegistrationTokenData, error) {
 	return nil, fmt.Errorf("token not found")
 }
+func (m *MockRegistrationTokenStore) GetTokenByID(_ context.Context, _ string) (*business.RegistrationTokenData, error) {
+	return nil, fmt.Errorf("registration token not found")
+}
 func (m *MockRegistrationTokenStore) UpdateToken(_ context.Context, _ *business.RegistrationTokenData) error {
 	return nil
 }

--- a/pkg/storage/providers/database/migrations/007_registration_token_id.sql
+++ b/pkg/storage/providers/database/migrations/007_registration_token_id.sql
@@ -1,0 +1,30 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Migration 007: Add the stable, non-secret `id` column to cfgms_registration_tokens
+-- (Issue #2970).
+--
+-- Why the column exists:
+--   The web UI never holds a registration token secret — list and get responses are
+--   redacted to a 6-character prefix. To revoke or delete a token it addresses the
+--   token by a stable UUID (`token_id` in API responses, `id` here), which the
+--   handlers resolve through GetTokenByID.
+--
+-- Why existing rows must be back-filled:
+--   A row with a NULL id reports token_id: "" to the web UI, which then has no value
+--   to address the token with — the token can never be revoked or deleted from the
+--   UI. That would fail on exactly the tokens most likely to need revoking: the
+--   pre-existing ones. Every row therefore receives a UUID.
+--
+-- The controller applies this migration automatically at startup via
+-- DatabaseSchemas.BackfillRegistrationTokenIDs (schemas.go), which generates the
+-- UUIDs in Go and therefore carries no minimum Postgres version. This file is for
+-- operators who provision schema out-of-band; gen_random_uuid() requires Postgres 13+
+-- (or the pgcrypto extension on older servers).
+
+ALTER TABLE cfgms_registration_tokens ADD COLUMN IF NOT EXISTS id VARCHAR(36);
+
+UPDATE cfgms_registration_tokens
+SET id = gen_random_uuid()::text
+WHERE id IS NULL OR id = '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_id
+    ON cfgms_registration_tokens(id);

--- a/pkg/storage/providers/database/registration_store.go
+++ b/pkg/storage/providers/database/registration_store.go
@@ -101,21 +101,40 @@ func (s *DatabaseRegistrationTokenStore) SaveToken(ctx context.Context, token *b
 		return fmt.Errorf("token string cannot be empty")
 	}
 
+	// Every persisted token carries a stable, non-secret UUID (Issue #2970) so the
+	// web UI can address it without holding the secret.
+	if token.ID == "" {
+		id, err := generateTokenID()
+		if err != nil {
+			return fmt.Errorf("failed to generate token id: %w", err)
+		}
+		token.ID = id
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	_, err := s.db.ExecContext(ctx, `
+	// The id is assigned once and never reassigned: on conflict the stored id wins and
+	// EXCLUDED.id only fills in a row that has none. NULLIF treats an empty stored id as
+	// absent — the same "missing" predicate the back-fill uses (id IS NULL OR id = '') —
+	// so a row that reaches this path unaddressable is healed rather than kept that way.
+	// RETURNING keeps the caller's in-memory ID identical to the persisted one.
+	var storedID string
+	err := s.db.QueryRowContext(ctx, `
 		INSERT INTO cfgms_registration_tokens
-			(token, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			(token, id, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (token) DO UPDATE SET
+			id = COALESCE(NULLIF(cfgms_registration_tokens.id, ''), EXCLUDED.id),
 			tenant_id = EXCLUDED.tenant_id,
 			controller_url = EXCLUDED.controller_url,
 			group_name = EXCLUDED.group_name,
 			expires_at = EXCLUDED.expires_at,
 			revoked = EXCLUDED.revoked,
-			revoked_at = EXCLUDED.revoked_at`,
+			revoked_at = EXCLUDED.revoked_at
+		RETURNING id`,
 		token.Token,
+		token.ID,
 		token.TenantID,
 		token.ControllerURL,
 		token.Group,
@@ -123,10 +142,11 @@ func (s *DatabaseRegistrationTokenStore) SaveToken(ctx context.Context, token *b
 		nullTimeOrNil(token.ExpiresAt),
 		token.Revoked,
 		nullTimeOrNil(token.RevokedAt),
-	)
+	).Scan(&storedID)
 	if err != nil {
 		return fmt.Errorf("failed to save token: %w", err)
 	}
+	token.ID = storedID
 	return nil
 }
 
@@ -141,13 +161,14 @@ func (s *DatabaseRegistrationTokenStore) GetToken(ctx context.Context, tokenStr 
 
 	var token business.RegistrationTokenData
 	var expiresAt, revokedAt sql.NullTime
-	var group sql.NullString
+	var group, id sql.NullString
 
 	err := s.db.QueryRowContext(ctx, `
-		SELECT token, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at
+		SELECT token, id, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at
 		FROM cfgms_registration_tokens
 		WHERE token = $1`, tokenStr).Scan(
 		&token.Token,
+		&id,
 		&token.TenantID,
 		&token.ControllerURL,
 		&group,
@@ -163,6 +184,7 @@ func (s *DatabaseRegistrationTokenStore) GetToken(ctx context.Context, tokenStr 
 		return nil, fmt.Errorf("failed to get token: %w", err)
 	}
 
+	token.ID = id.String
 	token.Group = group.String
 	if expiresAt.Valid {
 		token.ExpiresAt = &expiresAt.Time
@@ -288,7 +310,7 @@ func (s *DatabaseRegistrationTokenStore) ListTokens(ctx context.Context, filter 
 	defer s.mutex.RUnlock()
 
 	query := `
-		SELECT token, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at
+		SELECT token, id, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at
 		FROM cfgms_registration_tokens
 		WHERE 1=1`
 	args := []interface{}{}
@@ -325,10 +347,11 @@ func (s *DatabaseRegistrationTokenStore) ListTokens(ctx context.Context, filter 
 	for rows.Next() {
 		var token business.RegistrationTokenData
 		var expiresAt, revokedAt sql.NullTime
-		var group sql.NullString
+		var group, id sql.NullString
 
 		if err := rows.Scan(
 			&token.Token,
+			&id,
 			&token.TenantID,
 			&token.ControllerURL,
 			&group,
@@ -340,6 +363,7 @@ func (s *DatabaseRegistrationTokenStore) ListTokens(ctx context.Context, filter 
 			return nil, fmt.Errorf("failed to scan token row: %w", err)
 		}
 
+		token.ID = id.String
 		token.Group = group.String
 		if expiresAt.Valid {
 			token.ExpiresAt = &expiresAt.Time
@@ -397,12 +421,17 @@ func (s *DatabaseRegistrationTokenStore) RotateToken(ctx context.Context, tenant
 
 	now := time.Now().UTC()
 
+	newID, err := generateTokenID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token id: %w", err)
+	}
+
 	// Insert the new token.
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO cfgms_registration_tokens
-			(token, tenant_id, controller_url, group_name, created_at, revoked)
-		VALUES ($1, $2, $3, $4, $5, false)`,
-		newTokenStr, tenantID, controllerURL, group, now,
+			(token, id, tenant_id, controller_url, group_name, created_at, revoked)
+		VALUES ($1, $2, $3, $4, $5, $6, false)`,
+		newTokenStr, newID, tenantID, controllerURL, group, now,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert new token: %w", err)
@@ -425,6 +454,7 @@ func (s *DatabaseRegistrationTokenStore) RotateToken(ctx context.Context, tenant
 	committed = true
 
 	return &business.RegistrationTokenData{
+		ID:            newID,
 		Token:         newTokenStr,
 		TenantID:      tenantID,
 		ControllerURL: controllerURL,
@@ -448,4 +478,17 @@ func generateTokenString() (string, error) {
 		return "", fmt.Errorf("failed to read random bytes: %w", err)
 	}
 	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b)), nil
+}
+
+// generateTokenID produces a UUID v4 string used as a stable, non-secret token identifier
+// (Issue #2970). It is the value the web UI addresses a token by.
+func generateTokenID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to read random bytes for token ID: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
 }

--- a/pkg/storage/providers/database/registration_store.go
+++ b/pkg/storage/providers/database/registration_store.go
@@ -174,6 +174,51 @@ func (s *DatabaseRegistrationTokenStore) GetToken(ctx context.Context, tokenStr 
 	return &token, nil
 }
 
+// GetTokenByID implements RegistrationTokenStore.GetTokenByID (Issue #2970).
+func (s *DatabaseRegistrationTokenStore) GetTokenByID(ctx context.Context, id string) (*business.RegistrationTokenData, error) {
+	if id == "" {
+		return nil, fmt.Errorf("token id cannot be empty")
+	}
+
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var token business.RegistrationTokenData
+	var expiresAt, revokedAt sql.NullTime
+	var group sql.NullString
+
+	err := s.db.QueryRowContext(ctx, `
+		SELECT token, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at
+		FROM cfgms_registration_tokens
+		WHERE id = $1`, id).Scan(
+		&token.Token,
+		&token.TenantID,
+		&token.ControllerURL,
+		&group,
+		&token.CreatedAt,
+		&expiresAt,
+		&token.Revoked,
+		&revokedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("registration token not found")
+		}
+		return nil, fmt.Errorf("failed to get token by id: %w", err)
+	}
+
+	token.ID = id
+	token.Group = group.String
+	if expiresAt.Valid {
+		token.ExpiresAt = &expiresAt.Time
+	}
+	if revokedAt.Valid {
+		token.RevokedAt = &revokedAt.Time
+	}
+
+	return &token, nil
+}
+
 // UpdateToken implements RegistrationTokenStore.UpdateToken
 func (s *DatabaseRegistrationTokenStore) UpdateToken(ctx context.Context, token *business.RegistrationTokenData) error {
 	if token == nil {

--- a/pkg/storage/providers/database/registration_store_test.go
+++ b/pkg/storage/providers/database/registration_store_test.go
@@ -135,3 +135,234 @@ func TestDatabaseRegistrationStore_RotateToken_Race(t *testing.T) {
 	}
 	assert.Equal(t, 1, validCount, "exactly one valid token must exist after all rotations")
 }
+
+func TestDatabaseRegistrationStore_SaveAndGetByID(t *testing.T) {
+	store := newTestRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &business.RegistrationTokenData{
+		ID:            "aaaaaaaa-0000-4000-8000-000000000001",
+		Token:         "db-byid-token",
+		TenantID:      "tenant-byid",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "prod",
+		CreatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+
+	// The id must round-trip through the id-addressed lookup used by the web UI.
+	byID, err := store.GetTokenByID(ctx, token.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token.Token, byID.Token)
+	assert.Equal(t, token.ID, byID.ID)
+	assert.Equal(t, "tenant-byid", byID.TenantID)
+	assert.Equal(t, "prod", byID.Group)
+
+	// ...and through the token-addressed lookup and the list endpoint.
+	byToken, err := store.GetToken(ctx, token.Token)
+	require.NoError(t, err)
+	assert.Equal(t, token.ID, byToken.ID)
+
+	listed, err := store.ListTokens(ctx, &business.RegistrationTokenFilter{TenantID: "tenant-byid"})
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, token.ID, listed[0].ID)
+}
+
+func TestDatabaseRegistrationStore_GetTokenByID_NotFound(t *testing.T) {
+	store := newTestRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &business.RegistrationTokenData{
+		ID:            "aaaaaaaa-0000-4000-8000-000000000002",
+		Token:         "db-byid-nf",
+		TenantID:      "tenant-byid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+
+	// An unknown id must be reported as not-found (404 at the API), never as a
+	// driver error that the handler would turn into a 500.
+	_, err := store.GetTokenByID(ctx, "aaaaaaaa-0000-4000-8000-0000000000ff")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// The secret string must not resolve through the id column.
+	_, err = store.GetTokenByID(ctx, token.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	_, err = store.GetTokenByID(ctx, "")
+	require.Error(t, err)
+}
+
+func TestDatabaseRegistrationStore_SaveToken_AssignsIDWhenMissing(t *testing.T) {
+	store := newTestRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &business.RegistrationTokenData{
+		Token:         "db-no-id",
+		TenantID:      "tenant-noid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+	require.NotEmpty(t, token.ID, "SaveToken must assign an id when the caller supplies none")
+	assignedID := token.ID
+
+	byID, err := store.GetTokenByID(ctx, assignedID)
+	require.NoError(t, err)
+	assert.Equal(t, "db-no-id", byID.Token)
+
+	// Upserting the same token must not reassign the id.
+	resaved := &business.RegistrationTokenData{
+		Token:         "db-no-id",
+		TenantID:      "tenant-noid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     token.CreatedAt,
+	}
+	require.NoError(t, store.SaveToken(ctx, resaved))
+	assert.Equal(t, assignedID, resaved.ID, "token id must be stable across saves")
+}
+
+// TestDatabaseRegistrationStore_SaveToken_HealsEmptyStoredID covers a row whose stored id
+// is the empty string rather than NULL (an out-of-band write, or a row the back-fill has
+// not run against yet). Such a row is unaddressable by GetTokenByID, so the next save must
+// heal it instead of preserving the empty value forever.
+func TestDatabaseRegistrationStore_SaveToken_HealsEmptyStoredID(t *testing.T) {
+	store := newTestRegistrationStore(t)
+	ctx := context.Background()
+
+	seed := &business.RegistrationTokenData{
+		Token:         "db-empty-id",
+		TenantID:      "tenant-noid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, store.SaveToken(ctx, seed))
+
+	// Force the stored id to the empty string, bypassing the store's own assignment.
+	_, err := store.db.ExecContext(ctx,
+		`UPDATE cfgms_registration_tokens SET id = '' WHERE token = $1`, "db-empty-id")
+	require.NoError(t, err)
+
+	stale, err := store.GetToken(ctx, "db-empty-id")
+	require.NoError(t, err)
+	require.Empty(t, stale.ID, "precondition: the row is unaddressable by id")
+
+	resaved := &business.RegistrationTokenData{
+		Token:         "db-empty-id",
+		TenantID:      "tenant-noid",
+		ControllerURL: "grpc://controller:7443",
+		CreatedAt:     seed.CreatedAt,
+	}
+	require.NoError(t, store.SaveToken(ctx, resaved))
+	require.NotEmpty(t, resaved.ID, "an empty stored id must be healed, not preserved")
+
+	byID, err := store.GetTokenByID(ctx, resaved.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "db-empty-id", byID.Token)
+}
+
+func TestDatabaseRegistrationStore_RotateToken_AssignsID(t *testing.T) {
+	store := newTestRegistrationStore(t)
+	ctx := context.Background()
+
+	seed := &business.RegistrationTokenData{
+		Token:         "db-rotate-id-seed",
+		TenantID:      "tenant-rotate-id",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "prod",
+		CreatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, store.SaveToken(ctx, seed))
+
+	rotated, err := store.RotateToken(ctx, "tenant-rotate-id", "prod")
+	require.NoError(t, err)
+	require.NotEmpty(t, rotated.ID, "rotation must mint an id for the new token")
+	assert.NotEqual(t, seed.ID, rotated.ID)
+
+	got, err := store.GetTokenByID(ctx, rotated.ID)
+	require.NoError(t, err)
+	assert.Equal(t, rotated.Token, got.Token)
+	assert.True(t, got.IsValid())
+
+	old, err := store.GetTokenByID(ctx, seed.ID)
+	require.NoError(t, err)
+	assert.True(t, old.Revoked)
+}
+
+// TestDatabaseRegistrationStore_BackfillLegacyRows verifies that a table created before
+// Issue #2970 gains the id column and that every pre-existing row is assigned a UUID —
+// without it, legacy tokens report an empty token_id and can never be revoked or deleted
+// from the web UI.
+func TestDatabaseRegistrationStore_BackfillLegacyRows(t *testing.T) {
+	db := setupTestDatabase(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	// Legacy schema: no id column.
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE cfgms_registration_tokens (
+			token VARCHAR(255) PRIMARY KEY,
+			tenant_id VARCHAR(255) NOT NULL,
+			controller_url VARCHAR(1000) NOT NULL,
+			group_name VARCHAR(255) DEFAULT '',
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+			expires_at TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+			revoked BOOLEAN NOT NULL DEFAULT FALSE,
+			revoked_at TIMESTAMP WITH TIME ZONE DEFAULT NULL
+		)`)
+	require.NoError(t, err)
+
+	for _, tok := range []string{"legacy-a", "legacy-b"} {
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO cfgms_registration_tokens (token, tenant_id, controller_url, created_at)
+			VALUES ($1, 'tenant-legacy', 'grpc://controller:7443', NOW())`, tok)
+		require.NoError(t, err)
+	}
+
+	schemas := NewDatabaseSchemas()
+	require.NoError(t, schemas.CreateRegistrationTokensTable(ctx, db))
+
+	store := &DatabaseRegistrationTokenStore{db: db, config: nil, schemas: schemas}
+	ids := make(map[string]string, 2)
+	for _, tok := range []string{"legacy-a", "legacy-b"} {
+		got, err := store.GetToken(ctx, tok)
+		require.NoError(t, err)
+		require.NotEmpty(t, got.ID, "legacy row %q must be assigned a UUID", tok)
+		assert.Regexp(t,
+			`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+			got.ID, "backfilled id must be a UUID v4")
+
+		byID, err := store.GetTokenByID(ctx, got.ID)
+		require.NoError(t, err, "backfilled token must be addressable by id")
+		assert.Equal(t, tok, byID.Token)
+
+		ids[tok] = got.ID
+	}
+	assert.NotEqual(t, ids["legacy-a"], ids["legacy-b"], "each legacy row gets a distinct id")
+
+	// Re-running schema init must be idempotent — ids stay stable.
+	require.NoError(t, schemas.CreateRegistrationTokensTable(ctx, db))
+	for tok, id := range ids {
+		got, err := store.GetToken(ctx, tok)
+		require.NoError(t, err)
+		assert.Equal(t, id, got.ID, "re-running the migration must not reassign %q", tok)
+	}
+}
+
+func TestDatabaseGenerateTokenID(t *testing.T) {
+	const iterations = 100
+	pattern := `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`
+	seen := make(map[string]struct{}, iterations)
+	for i := 0; i < iterations; i++ {
+		id, err := generateTokenID()
+		require.NoError(t, err)
+		assert.Regexp(t, pattern, id)
+		_, dup := seen[id]
+		require.False(t, dup, "generateTokenID must not repeat an id")
+		seen[id] = struct{}{}
+	}
+}

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -586,11 +586,14 @@ func (s DatabaseSchemas) CreateRBACRoleAssignmentsTable(ctx context.Context, db 
 
 // CreateRegistrationTokensTable creates the registration_tokens table for token persistence.
 // Migration note: single_use, used_at, and used_by columns were removed in Issue #1690
-// (perennial token model with immediate-invalidation rotation).
+// (perennial token model with immediate-invalidation rotation). The id column (stable,
+// non-secret UUID used by the web UI to address a token) was added in Issue #2970 —
+// BackfillRegistrationTokenIDs handles pre-existing deployments.
 func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *sql.DB) error {
 	createTableQuery := `
 		CREATE TABLE IF NOT EXISTS cfgms_registration_tokens (
 			token VARCHAR(255) PRIMARY KEY,
+			id VARCHAR(36),
 			tenant_id VARCHAR(255) NOT NULL,
 			controller_url VARCHAR(1000) NOT NULL,
 			group_name VARCHAR(255) DEFAULT '',
@@ -605,6 +608,12 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 		return fmt.Errorf("failed to create cfgms_registration_tokens table: %w", err)
 	}
 
+	// Migration for deployments created before Issue #2970: add the column and
+	// assign a UUID to every pre-existing row so the web UI can address them.
+	if err := s.BackfillRegistrationTokenIDs(ctx, db); err != nil {
+		return err
+	}
+
 	// Create indexes for performance and tenant isolation
 	indexes := []string{
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_tenant_id ON cfgms_registration_tokens(tenant_id);",
@@ -612,6 +621,8 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_created_at ON cfgms_registration_tokens(created_at);",
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_expires_at ON cfgms_registration_tokens(expires_at);",
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_revoked ON cfgms_registration_tokens(revoked);",
+		// Unique lookup index for GetTokenByID (Issue #2970).
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_id ON cfgms_registration_tokens(id);",
 		// Composite index for filtering non-revoked tokens by tenant
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_tenant_active ON cfgms_registration_tokens(tenant_id) WHERE revoked = FALSE;",
 	}
@@ -619,6 +630,54 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 	for _, indexQuery := range indexes {
 		if _, err := db.ExecContext(ctx, indexQuery); err != nil {
 			return fmt.Errorf("failed to create cfgms_registration_tokens index: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// BackfillRegistrationTokenIDs adds the id column to a pre-existing
+// cfgms_registration_tokens table and assigns a UUID to every row that lacks one
+// (Issue #2970). Without the back-fill, legacy rows would report an empty token_id
+// and could never be revoked or deleted from the web UI — exactly the tokens most
+// likely to need revoking. Idempotent: ADD COLUMN IF NOT EXISTS is a no-op on an
+// up-to-date table and the UPDATE matches no rows once every row has an id.
+func (s DatabaseSchemas) BackfillRegistrationTokenIDs(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx,
+		`ALTER TABLE cfgms_registration_tokens ADD COLUMN IF NOT EXISTS id VARCHAR(36)`); err != nil {
+		return fmt.Errorf("failed to add id column to cfgms_registration_tokens: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT token FROM cfgms_registration_tokens WHERE id IS NULL OR id = ''`)
+	if err != nil {
+		return fmt.Errorf("failed to select registration tokens missing an id: %w", err)
+	}
+	var tokensMissingID []string
+	for rows.Next() {
+		var tokenStr string
+		if err := rows.Scan(&tokenStr); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("failed to scan registration token missing an id: %w", err)
+		}
+		tokensMissingID = append(tokensMissingID, tokenStr)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("error iterating registration tokens missing an id: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to close registration token back-fill rows: %w", err)
+	}
+
+	for _, tokenStr := range tokensMissingID {
+		id, err := generateTokenID()
+		if err != nil {
+			return fmt.Errorf("failed to generate registration token id for back-fill: %w", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`UPDATE cfgms_registration_tokens SET id = $1 WHERE token = $2`, id, tokenStr); err != nil {
+			return fmt.Errorf("failed to back-fill registration token id: %w", err)
 		}
 	}
 

--- a/pkg/storage/providers/sqlite/registration_store.go
+++ b/pkg/storage/providers/sqlite/registration_store.go
@@ -47,10 +47,11 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO registration_tokens
-			(token, tenant_id, controller_url, group_name, created_at,
+			(token, id, tenant_id, controller_url, group_name, created_at,
 			 expires_at, revoked, revoked_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(token) DO UPDATE SET
+			id = COALESCE(excluded.id, registration_tokens.id),
 			tenant_id = excluded.tenant_id,
 			controller_url = excluded.controller_url,
 			group_name = excluded.group_name,
@@ -58,6 +59,7 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 			revoked = excluded.revoked,
 			revoked_at = excluded.revoked_at`,
 		token.Token,
+		nullableStr(token.ID),
 		token.TenantID,
 		token.ControllerURL,
 		token.Group,
@@ -75,9 +77,18 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 // GetToken retrieves a registration token by its token string.
 func (s *SQLiteRegistrationTokenStore) GetToken(ctx context.Context, tokenStr string) (*business.RegistrationTokenData, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT token, tenant_id, controller_url, group_name, created_at,
+		SELECT token, id, tenant_id, controller_url, group_name, created_at,
 		       expires_at, revoked, revoked_at
 		FROM registration_tokens WHERE token = ?`, tokenStr)
+	return scanToken(row)
+}
+
+// GetTokenByID retrieves a registration token by its stable UUID (Issue #2970).
+func (s *SQLiteRegistrationTokenStore) GetTokenByID(ctx context.Context, id string) (*business.RegistrationTokenData, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT token, id, tenant_id, controller_url, group_name, created_at,
+		       expires_at, revoked, revoked_at
+		FROM registration_tokens WHERE id = ?`, id)
 	return scanToken(row)
 }
 
@@ -125,7 +136,7 @@ func (s *SQLiteRegistrationTokenStore) DeleteToken(ctx context.Context, tokenStr
 
 // ListTokens returns registration tokens matching an optional filter.
 func (s *SQLiteRegistrationTokenStore) ListTokens(ctx context.Context, filter *business.RegistrationTokenFilter) ([]*business.RegistrationTokenData, error) {
-	query := `SELECT token, tenant_id, controller_url, group_name, created_at,
+	query := `SELECT token, id, tenant_id, controller_url, group_name, created_at,
 	                 expires_at, revoked, revoked_at
 	          FROM registration_tokens WHERE 1=1`
 	var args []interface{}
@@ -205,12 +216,17 @@ func (s *SQLiteRegistrationTokenStore) RotateToken(ctx context.Context, tenantID
 	now := nowUTC()
 	nowStr := formatTime(now)
 
+	newID, err := generateTokenID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token ID: %w", err)
+	}
+
 	// Insert the new token.
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO registration_tokens
-			(token, tenant_id, controller_url, group_name, created_at, revoked)
-		VALUES (?, ?, ?, ?, ?, 0)`,
-		newTokenStr, tenantID, controllerURL, group, nowStr,
+			(token, id, tenant_id, controller_url, group_name, created_at, revoked)
+		VALUES (?, ?, ?, ?, ?, ?, 0)`,
+		newTokenStr, newID, tenantID, controllerURL, group, nowStr,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert new token: %w", err)
@@ -233,6 +249,7 @@ func (s *SQLiteRegistrationTokenStore) RotateToken(ctx context.Context, tenantID
 	committed = true
 
 	return &business.RegistrationTokenData{
+		ID:            newID,
 		Token:         newTokenStr,
 		TenantID:      tenantID,
 		ControllerURL: controllerURL,
@@ -246,11 +263,12 @@ func (s *SQLiteRegistrationTokenStore) RotateToken(ctx context.Context, tenantID
 func scanToken(row *sql.Row) (*business.RegistrationTokenData, error) {
 	t := &business.RegistrationTokenData{}
 	var createdStr string
+	var id sql.NullString
 	var expiresAt, revokedAt sql.NullString
 	var revoked int
 
 	err := row.Scan(
-		&t.Token, &t.TenantID, &t.ControllerURL, &t.Group,
+		&t.Token, &id, &t.TenantID, &t.ControllerURL, &t.Group,
 		&createdStr, &expiresAt, &revoked, &revokedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -259,21 +277,24 @@ func scanToken(row *sql.Row) (*business.RegistrationTokenData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan registration token: %w", err)
 	}
+	t.ID = id.String
 	return populateToken(t, createdStr, revoked, expiresAt, revokedAt)
 }
 
 func scanTokenRow(rows *sql.Rows) (*business.RegistrationTokenData, error) {
 	t := &business.RegistrationTokenData{}
 	var createdStr string
+	var id sql.NullString
 	var expiresAt, revokedAt sql.NullString
 	var revoked int
 
 	if err := rows.Scan(
-		&t.Token, &t.TenantID, &t.ControllerURL, &t.Group,
+		&t.Token, &id, &t.TenantID, &t.ControllerURL, &t.Group,
 		&createdStr, &expiresAt, &revoked, &revokedAt,
 	); err != nil {
 		return nil, fmt.Errorf("failed to scan registration token row: %w", err)
 	}
+	t.ID = id.String
 	return populateToken(t, createdStr, revoked, expiresAt, revokedAt)
 }
 
@@ -290,6 +311,14 @@ func populateToken(
 	return t, nil
 }
 
+// nullableStr returns nil for an empty string (allowing SQL NULL storage).
+func nullableStr(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
 // generateTokenString produces a random base32-encoded token string (16 bytes / 128-bit entropy).
 func generateTokenString() (string, error) {
 	b := make([]byte, 16)
@@ -297,6 +326,18 @@ func generateTokenString() (string, error) {
 		return "", fmt.Errorf("failed to read random bytes: %w", err)
 	}
 	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b)), nil
+}
+
+// generateTokenID produces a UUID v4 string for use as a stable non-secret token identifier.
+func generateTokenID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to read random bytes for token ID: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
 }
 
 // ensure SQLiteRegistrationTokenStore satisfies the interface at compile time

--- a/pkg/storage/providers/sqlite/registration_store.go
+++ b/pkg/storage/providers/sqlite/registration_store.go
@@ -44,20 +44,36 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 	if token.CreatedAt.IsZero() {
 		token.CreatedAt = nowUTC()
 	}
+	// Every persisted token carries a stable, non-secret UUID (Issue #2970) so the
+	// web UI can address it without holding the secret.
+	if token.ID == "" {
+		id, err := generateTokenID()
+		if err != nil {
+			return fmt.Errorf("failed to generate token id: %w", err)
+		}
+		token.ID = id
+	}
 
-	_, err := s.db.ExecContext(ctx, `
+	// The id is assigned once and never reassigned: on conflict the stored id wins and
+	// excluded.id only fills in a row that has none. NULLIF treats an empty stored id as
+	// absent — the same "missing" predicate the back-fill uses (id IS NULL OR id = '') —
+	// so a row that reaches this path unaddressable is healed rather than kept that way.
+	// RETURNING keeps the caller's in-memory ID identical to the persisted one.
+	var storedID sql.NullString
+	err := s.db.QueryRowContext(ctx, `
 		INSERT INTO registration_tokens
 			(token, id, tenant_id, controller_url, group_name, created_at,
 			 expires_at, revoked, revoked_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(token) DO UPDATE SET
-			id = COALESCE(excluded.id, registration_tokens.id),
+			id = COALESCE(NULLIF(registration_tokens.id, ''), excluded.id),
 			tenant_id = excluded.tenant_id,
 			controller_url = excluded.controller_url,
 			group_name = excluded.group_name,
 			expires_at = excluded.expires_at,
 			revoked = excluded.revoked,
-			revoked_at = excluded.revoked_at`,
+			revoked_at = excluded.revoked_at
+		RETURNING id`,
 		token.Token,
 		nullableStr(token.ID),
 		token.TenantID,
@@ -67,10 +83,11 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 		nullTime(token.ExpiresAt),
 		boolToInt(token.Revoked),
 		nullTime(token.RevokedAt),
-	)
+	).Scan(&storedID)
 	if err != nil {
 		return fmt.Errorf("failed to save registration token: %w", err)
 	}
+	token.ID = storedID.String
 	return nil
 }
 
@@ -85,6 +102,9 @@ func (s *SQLiteRegistrationTokenStore) GetToken(ctx context.Context, tokenStr st
 
 // GetTokenByID retrieves a registration token by its stable UUID (Issue #2970).
 func (s *SQLiteRegistrationTokenStore) GetTokenByID(ctx context.Context, id string) (*business.RegistrationTokenData, error) {
+	if id == "" {
+		return nil, fmt.Errorf("registration token not found")
+	}
 	row := s.db.QueryRowContext(ctx, `
 		SELECT token, id, tenant_id, controller_url, group_name, created_at,
 		       expires_at, revoked, revoked_at

--- a/pkg/storage/providers/sqlite/registration_store_test.go
+++ b/pkg/storage/providers/sqlite/registration_store_test.go
@@ -49,6 +49,167 @@ func TestRegistrationStore_SaveAndGet(t *testing.T) {
 	assert.Nil(t, got.ExpiresAt)
 }
 
+func TestRegistrationStore_GetTokenByID(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &business.RegistrationTokenData{
+		Token:         "tok-byid",
+		ID:            "aaaaaaaa-0000-4000-8000-000000000001",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://controller.example.com",
+		Group:         "servers",
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+
+	got, err := store.GetTokenByID(ctx, token.ID)
+	require.NoError(t, err)
+	assert.Equal(t, token.Token, got.Token)
+	assert.Equal(t, token.ID, got.ID)
+	assert.Equal(t, token.TenantID, got.TenantID)
+	assert.Equal(t, token.Group, got.Group)
+
+	// GetToken must return the same id — the web UI reads it from list/get responses.
+	byToken, err := store.GetToken(ctx, token.Token)
+	require.NoError(t, err)
+	assert.Equal(t, token.ID, byToken.ID)
+}
+
+func TestRegistrationStore_GetTokenByID_NotFound(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &business.RegistrationTokenData{
+		Token:         "tok-byid-nf",
+		ID:            "aaaaaaaa-0000-4000-8000-000000000002",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://controller.example.com",
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+
+	for name, id := range map[string]string{
+		"unknown id":   "aaaaaaaa-0000-4000-8000-0000000000ff",
+		"empty id":     "",
+		"secret value": token.Token,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := store.GetTokenByID(ctx, id)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not found")
+		})
+	}
+}
+
+func TestRegistrationStore_SaveToken_AssignsIDWhenMissing(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &business.RegistrationTokenData{
+		Token:         "tok-no-id",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://controller.example.com",
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+	require.NotEmpty(t, token.ID, "SaveToken must assign an id when the caller supplies none")
+	assignedID := token.ID
+
+	byID, err := store.GetTokenByID(ctx, assignedID)
+	require.NoError(t, err)
+	assert.Equal(t, "tok-no-id", byID.Token)
+
+	// Re-saving the same token (upsert) must not reassign the id.
+	resaved := &business.RegistrationTokenData{
+		Token:         "tok-no-id",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://controller.example.com",
+	}
+	require.NoError(t, store.SaveToken(ctx, resaved))
+	assert.Equal(t, assignedID, resaved.ID, "token id must be stable across saves")
+
+	got, err := store.GetToken(ctx, "tok-no-id")
+	require.NoError(t, err)
+	assert.Equal(t, assignedID, got.ID)
+}
+
+func TestRegistrationStore_UpdateToken_PreservesID(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &business.RegistrationTokenData{
+		Token:         "tok-upd-id",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://controller.example.com",
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+	id := token.ID
+	require.NotEmpty(t, id)
+
+	token.Revoke()
+	require.NoError(t, store.UpdateToken(ctx, token))
+
+	// A revoked token must still be addressable by id (delete-after-revoke from the UI).
+	got, err := store.GetTokenByID(ctx, id)
+	require.NoError(t, err)
+	assert.True(t, got.Revoked)
+	assert.Equal(t, id, got.ID)
+}
+
+func TestRegistrationStore_ListTokens_ReturnsIDs(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	for _, tok := range []*business.RegistrationTokenData{
+		{Token: "id-l-1", TenantID: "t-ids", ControllerURL: "https://c.example.com"},
+		{Token: "id-l-2", TenantID: "t-ids", ControllerURL: "https://c.example.com"},
+	} {
+		require.NoError(t, store.SaveToken(ctx, tok))
+	}
+
+	listed, err := store.ListTokens(ctx, &business.RegistrationTokenFilter{TenantID: "t-ids"})
+	require.NoError(t, err)
+	require.Len(t, listed, 2)
+
+	seen := make(map[string]struct{}, len(listed))
+	for _, tok := range listed {
+		require.NotEmpty(t, tok.ID, "every listed token must carry its id")
+		_, dup := seen[tok.ID]
+		require.False(t, dup, "listed token ids must be distinct")
+		seen[tok.ID] = struct{}{}
+
+		byID, err := store.GetTokenByID(ctx, tok.ID)
+		require.NoError(t, err)
+		assert.Equal(t, tok.Token, byID.Token)
+	}
+}
+
+func TestRegistrationStore_RotateToken_AssignsID(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	seed := &business.RegistrationTokenData{
+		Token:         "rotate-id-seed",
+		TenantID:      "tenant-rotate-id",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "prod",
+	}
+	require.NoError(t, store.SaveToken(ctx, seed))
+
+	rotated, err := store.RotateToken(ctx, "tenant-rotate-id", "prod")
+	require.NoError(t, err)
+	require.NotEmpty(t, rotated.ID)
+	assert.NotEqual(t, seed.ID, rotated.ID, "rotation must mint a new id")
+
+	got, err := store.GetTokenByID(ctx, rotated.ID)
+	require.NoError(t, err)
+	assert.Equal(t, rotated.Token, got.Token)
+	assert.True(t, got.IsValid())
+
+	// The rotated-away token stays addressable by its own id.
+	old, err := store.GetTokenByID(ctx, seed.ID)
+	require.NoError(t, err)
+	assert.True(t, old.Revoked)
+}
+
 func TestRegistrationStore_GetNotFound(t *testing.T) {
 	store := newRegistrationStore(t)
 	ctx := context.Background()

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -161,9 +161,11 @@ func backfillSessionTokenRecords(ctx context.Context, db *sql.DB) error {
 }
 
 // backfillRegistrationTokenID adds the `id` UUID column to a pre-existing
-// registration_tokens table (Issue #2970 — stable non-secret identifier for web UI).
-// Fresh databases (table absent) are skipped. The column is nullable so existing
-// rows remain valid; new rows always receive a generated UUID.
+// registration_tokens table and assigns a UUID to every row that lacks one
+// (Issue #2970 — stable non-secret identifier for web UI). Fresh databases
+// (table absent) are skipped. Without the row back-fill, legacy tokens would
+// report an empty token_id forever and could never be revoked or deleted from
+// the web UI — exactly the tokens most likely to need revoking.
 func backfillRegistrationTokenID(ctx context.Context, db *sql.DB) error {
 	exists, err := tableExists(ctx, db, "registration_tokens")
 	if err != nil {
@@ -176,11 +178,48 @@ func backfillRegistrationTokenID(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return fmt.Errorf("sqlite: registration_tokens id-column probe failed: %w", err)
 	}
-	if present {
-		return nil
+	if !present {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE registration_tokens ADD COLUMN id TEXT`); err != nil {
+			return fmt.Errorf("sqlite: registration_tokens back-fill (id) failed: %w", err)
+		}
 	}
-	if _, err := db.ExecContext(ctx, `ALTER TABLE registration_tokens ADD COLUMN id TEXT`); err != nil {
-		return fmt.Errorf("sqlite: registration_tokens back-fill (id) failed: %w", err)
+	return assignMissingRegistrationTokenIDs(ctx, db)
+}
+
+// assignMissingRegistrationTokenIDs gives every registration_tokens row without an id
+// a freshly generated UUID. Idempotent: matches no rows once every row has an id.
+func assignMissingRegistrationTokenIDs(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx,
+		`SELECT token FROM registration_tokens WHERE id IS NULL OR id = ''`)
+	if err != nil {
+		return fmt.Errorf("sqlite: registration_tokens id back-fill query failed: %w", err)
+	}
+	var tokensMissingID []string
+	for rows.Next() {
+		var tokenStr string
+		if err := rows.Scan(&tokenStr); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("sqlite: registration_tokens id back-fill scan failed: %w", err)
+		}
+		tokensMissingID = append(tokensMissingID, tokenStr)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("sqlite: registration_tokens id back-fill iteration failed: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("sqlite: registration_tokens id back-fill close failed: %w", err)
+	}
+
+	for _, tokenStr := range tokensMissingID {
+		id, err := generateTokenID()
+		if err != nil {
+			return fmt.Errorf("sqlite: registration_tokens id generation failed: %w", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`UPDATE registration_tokens SET id = ? WHERE token = ?`, id, tokenStr); err != nil {
+			return fmt.Errorf("sqlite: registration_tokens id back-fill update failed: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -160,6 +160,31 @@ func backfillSessionTokenRecords(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+// backfillRegistrationTokenID adds the `id` UUID column to a pre-existing
+// registration_tokens table (Issue #2970 — stable non-secret identifier for web UI).
+// Fresh databases (table absent) are skipped. The column is nullable so existing
+// rows remain valid; new rows always receive a generated UUID.
+func backfillRegistrationTokenID(ctx context.Context, db *sql.DB) error {
+	exists, err := tableExists(ctx, db, "registration_tokens")
+	if err != nil {
+		return fmt.Errorf("sqlite: registration_tokens back-fill probe failed: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	present, err := columnExists(ctx, db, "registration_tokens", "id")
+	if err != nil {
+		return fmt.Errorf("sqlite: registration_tokens id-column probe failed: %w", err)
+	}
+	if present {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE registration_tokens ADD COLUMN id TEXT`); err != nil {
+		return fmt.Errorf("sqlite: registration_tokens back-fill (id) failed: %w", err)
+	}
+	return nil
+}
+
 // initializeSchema creates all tables and tracks schema version.
 // It is safe to call multiple times (all statements use IF NOT EXISTS).
 // All DDL statements are executed inside a single transaction to reduce WAL
@@ -173,6 +198,9 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		return err
 	}
 	if err := backfillSessionTokenRecords(ctx, db); err != nil {
+		return err
+	}
+	if err := backfillRegistrationTokenID(ctx, db); err != nil {
 		return err
 	}
 
@@ -337,6 +365,7 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		// Pre-existing deployments must DROP these columns before upgrading.
 		`CREATE TABLE IF NOT EXISTS registration_tokens (
 			token          TEXT PRIMARY KEY,
+			id             TEXT,
 			tenant_id      TEXT NOT NULL,
 			controller_url TEXT NOT NULL,
 			group_name     TEXT NOT NULL DEFAULT '',
@@ -347,6 +376,7 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_registration_tokens_tenant_id  ON registration_tokens(tenant_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_registration_tokens_group_name ON registration_tokens(group_name)`,
+		`CREATE INDEX IF NOT EXISTS idx_registration_tokens_id         ON registration_tokens(id)`,
 
 		// Stewards — durable fleet registry (ADR-003 §2, Issue #663)
 		// Records are never deleted; deregistered stewards are retained for audit.

--- a/pkg/storage/providers/sqlite/schema_backfill_test.go
+++ b/pkg/storage/providers/sqlite/schema_backfill_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -411,4 +413,180 @@ func TestBackfillSessionTokenRecords_AlterFailure(t *testing.T) {
 	err = backfillSessionTokenRecords(context.Background(), roDB)
 	require.Error(t, err, "ALTER TABLE on read-only DB must return an error")
 	assert.Contains(t, err.Error(), "back-fill", "error must identify the back-fill stage")
+}
+
+// legacyRegistrationTokensSchema is the registration_tokens DDL from before the id
+// column was added in Issue #2970.
+const legacyRegistrationTokensSchema = `CREATE TABLE IF NOT EXISTS registration_tokens (
+	token          TEXT PRIMARY KEY,
+	tenant_id      TEXT NOT NULL,
+	controller_url TEXT NOT NULL,
+	group_name     TEXT NOT NULL DEFAULT '',
+	created_at     TEXT NOT NULL,
+	expires_at     TEXT,
+	revoked        INTEGER NOT NULL DEFAULT 0,
+	revoked_at     TEXT
+)`
+
+// TestBackfillRegistrationTokenID_LegacyRowsGetUUIDs verifies that a pre-existing
+// registration_tokens table gains the id column AND that every legacy row is assigned
+// a UUID (Issue #2970). Without the row back-fill the oldest tokens — the ones most
+// likely to need revoking — would report an empty token_id forever and could never be
+// revoked or deleted from the web UI.
+func TestBackfillRegistrationTokenID_LegacyRowsGetUUIDs(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "legacy-regtokens.db")
+	ctx := context.Background()
+
+	setup, err := openDB(dbPath)
+	require.NoError(t, err)
+	_, err = setup.ExecContext(ctx, legacyRegistrationTokensSchema)
+	require.NoError(t, err)
+	require.False(t, hasColumn(t, setup, "registration_tokens", "id"), "legacy table has no id column")
+	for _, tok := range []string{"legacy-a", "legacy-b"} {
+		_, err = setup.ExecContext(ctx,
+			`INSERT INTO registration_tokens (token, tenant_id, controller_url, created_at)
+			 VALUES (?, 'tenant-legacy', 'grpc://controller:7443', '2026-01-01T00:00:00Z')`, tok)
+		require.NoError(t, err)
+	}
+	require.NoError(t, setup.Close())
+
+	// Re-open with migration.
+	db, err := openAndInit(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.True(t, hasColumn(t, db, "registration_tokens", "id"), "migration must add the id column")
+
+	store := &SQLiteRegistrationTokenStore{db: db}
+	ids := make(map[string]string, 2)
+	for _, tok := range []string{"legacy-a", "legacy-b"} {
+		got, err := store.GetToken(ctx, tok)
+		require.NoError(t, err)
+		require.NotEmpty(t, got.ID, "legacy row %q must be assigned a UUID", tok)
+		assert.Regexp(t,
+			`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+			got.ID, "backfilled id must be a UUID v4")
+
+		byID, err := store.GetTokenByID(ctx, got.ID)
+		require.NoError(t, err, "backfilled token must be addressable by id")
+		assert.Equal(t, tok, byID.Token)
+
+		ids[tok] = got.ID
+	}
+	assert.NotEqual(t, ids["legacy-a"], ids["legacy-b"], "each legacy row gets a distinct id")
+
+	// Re-running the migration must be idempotent — ids stay stable.
+	require.NoError(t, backfillRegistrationTokenID(ctx, db))
+	for tok, id := range ids {
+		got, err := store.GetToken(ctx, tok)
+		require.NoError(t, err)
+		assert.Equal(t, id, got.ID, "re-running the back-fill must not reassign %q", tok)
+	}
+}
+
+// TestBackfillRegistrationTokenID_NullIDRowsGetUUIDs covers a table that already has the
+// id column but holds rows written before ids were persisted (NULL id).
+func TestBackfillRegistrationTokenID_NullIDRowsGetUUIDs(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+	require.NoError(t, initializeSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO registration_tokens (token, id, tenant_id, controller_url, created_at)
+		 VALUES ('null-id-token', NULL, 'tenant-legacy', 'grpc://controller:7443', '2026-01-01T00:00:00Z')`)
+	require.NoError(t, err)
+
+	require.NoError(t, backfillRegistrationTokenID(ctx, db))
+
+	store := &SQLiteRegistrationTokenStore{db: db}
+	got, err := store.GetToken(ctx, "null-id-token")
+	require.NoError(t, err)
+	require.NotEmpty(t, got.ID, "NULL-id row must be assigned a UUID")
+
+	byID, err := store.GetTokenByID(ctx, got.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "null-id-token", byID.Token)
+}
+
+// TestSaveToken_HealsEmptyStoredID covers a row whose stored id is the empty string rather
+// than NULL — the second half of the back-fill's "missing id" predicate. Such a row is
+// unaddressable by GetTokenByID, so a save that upserts onto it must heal the id instead
+// of preserving the empty value forever.
+func TestSaveToken_HealsEmptyStoredID(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+	require.NoError(t, initializeSchema(ctx, db))
+
+	store := &SQLiteRegistrationTokenStore{db: db}
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO registration_tokens (token, id, tenant_id, controller_url, created_at)
+		 VALUES ('empty-id-token', '', 'tenant-legacy', 'grpc://controller:7443', '2026-01-01T00:00:00Z')`)
+	require.NoError(t, err)
+
+	stale, err := store.GetToken(ctx, "empty-id-token")
+	require.NoError(t, err)
+	require.Empty(t, stale.ID, "precondition: the row is unaddressable by id")
+
+	resaved := &business.RegistrationTokenData{
+		Token:         "empty-id-token",
+		TenantID:      "tenant-legacy",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, store.SaveToken(ctx, resaved))
+	require.NotEmpty(t, resaved.ID, "an empty stored id must be healed, not preserved")
+
+	byID, err := store.GetTokenByID(ctx, resaved.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "empty-id-token", byID.Token)
+}
+
+// TestBackfillRegistrationTokenID_FreshDB verifies a fresh database carries the id column
+// from the CREATE TABLE statement, so the back-fill is a no-op.
+func TestBackfillRegistrationTokenID_FreshDB(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, initializeSchema(ctx, db), "fresh DB initialization")
+	assert.True(t, hasColumn(t, db, "registration_tokens", "id"), "id column present on fresh DB")
+	require.NoError(t, backfillRegistrationTokenID(ctx, db), "back-fill is a no-op on a fresh DB")
+}
+
+// TestBackfillRegistrationTokenID_ProbeFailure verifies that a tableExists failure
+// propagates rather than being silently ignored.
+func TestBackfillRegistrationTokenID_ProbeFailure(t *testing.T) {
+	db, err := openDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	err = backfillRegistrationTokenID(context.Background(), db)
+	require.Error(t, err, "closed DB must return an error")
+	assert.Contains(t, err.Error(), "back-fill probe failed", "error must identify the probe stage")
+}
+
+// TestBackfillRegistrationTokenID_UpdateFailure verifies that a failure to write the
+// generated ids propagates instead of leaving rows silently unaddressable.
+func TestBackfillRegistrationTokenID_UpdateFailure(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "readonly-regtokens.db")
+	ctx := context.Background()
+
+	setup, err := openDB(dbPath)
+	require.NoError(t, err)
+	_, err = setup.ExecContext(ctx, legacyRegistrationTokensSchema)
+	require.NoError(t, err)
+	_, err = setup.ExecContext(ctx, `ALTER TABLE registration_tokens ADD COLUMN id TEXT`)
+	require.NoError(t, err)
+	_, err = setup.ExecContext(ctx,
+		`INSERT INTO registration_tokens (token, tenant_id, controller_url, created_at)
+		 VALUES ('ro-token', 'tenant-legacy', 'grpc://controller:7443', '2026-01-01T00:00:00Z')`)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close())
+
+	roDB, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = roDB.Close() })
+	require.NoError(t, roDB.Ping())
+
+	err = backfillRegistrationTokenID(ctx, roDB)
+	require.Error(t, err, "UPDATE on read-only DB must return an error")
+	assert.Contains(t, err.Error(), "back-fill update failed", "error must identify the update stage")
 }

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>CFGMS</title>
-    <script type="module" crossorigin src="/assets/index-B5_FIcyH.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DTG8X7eM.css">
+    <script type="module" crossorigin src="/assets/index-DLA4F6vx.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Csqy_JQl.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/registration/TokensTab.test.tsx
+++ b/web/src/registration/TokensTab.test.tsx
@@ -507,6 +507,49 @@ describe('TokensTab — delete', () => {
   })
 })
 
+// ── Tokens without a stable id ────────────────────────────────────────────────
+
+describe('TokensTab — token without token_id', () => {
+  it('disables revoke and delete and never builds a degenerate URL', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeTokensResponse([makeToken({ token_id: '', token_prefix: 'reg_leg' })]),
+    )
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+
+    // Row state is keyed by token_prefix when there is no id.
+    expect(screen.getByTestId('revoke-btn-reg_leg')).toBeDisabled()
+    expect(screen.getByTestId('delete-btn-reg_leg')).toBeDisabled()
+    // Rotate addresses the tenant, not the token id — it stays available.
+    expect(screen.getByTestId('rotate-btn-reg_leg')).toBeEnabled()
+
+    fireEvent.click(screen.getByTestId('revoke-btn-reg_leg'))
+    fireEvent.click(screen.getByTestId('delete-btn-reg_leg'))
+
+    // Only the initial list GET was issued — no `/tokens//revoke` and no `/tokens/`.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/registration/tokens')
+  })
+
+  it('keeps per-row state separate for two tokens without an id', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeTokensResponse([
+          makeToken({ token_id: '', token_prefix: 'reg_one' }),
+          makeToken({ token_id: '', token_prefix: 'reg_two' }),
+        ]),
+      )
+      .mockResolvedValueOnce(new Response('err', { status: 409 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('rotate-btn-reg_one'))
+
+    await waitFor(() => expect(screen.getByTestId('action-error-reg_one')).toBeInTheDocument())
+    expect(screen.queryByTestId('action-error-reg_two')).toBeNull()
+  })
+})
+
 // ── SecretOnceModal ───────────────────────────────────────────────────────────
 
 describe('SecretOnceModal', () => {

--- a/web/src/registration/TokensTab.test.tsx
+++ b/web/src/registration/TokensTab.test.tsx
@@ -2,26 +2,28 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * TokensTab test suite (Story #2935): list rendering, data states, parse
- * helpers, and the required token-prefix security assertion.
+ * TokensTab test suite (Story #2935, #2970): list rendering, data states,
+ * parse helpers, mint/rotate/revoke/delete actions, SecretOnceModal, and
+ * token-prefix security assertions.
  *
- * Required AC: rendered token rows must never contain a full-length token
- * string in the DOM — only the prefix. Tests assert on textContent only,
- * never on innerHTML (security A9.1).
+ * Required AC (Story #2970):
+ *   - mint/rotate/revoke/delete wired behind apiFetch (step-up handled by AuthProvider)
+ *   - minted/rotated secret shown exactly once in SecretOnceModal; dismissed by clearing state
+ *   - secret never stored in a durable location; absent from DOM after dismiss
+ *   - secret never rendered in the token table — only token_prefix appears
  *
  * The GET /api/v1/registration/tokens response is {tokens:[...], total:N}
- * — no {data:...} envelope — per handlers_registration_tokens.go:160.
+ * — no {data:...} envelope — per handlers_registration_tokens.go.
  *
  * expires_at / revoked_at are optional (Go omitempty on pointer types)
  * — absent fields render as an em-dash placeholder, matching columns.ts.
- *
- * No mint, rotate, revoke, or delete affordance exists in this component.
  */
+import { useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { AuthProvider } from '../auth/AuthContext.tsx'
-import TokensTab, { parseToken, parseTokenList } from './TokensTab.tsx'
+import TokensTab, { SecretOnceModal, parseToken, parseTokenList } from './TokensTab.tsx'
 
 const fetchMock = vi.fn<typeof fetch>()
 
@@ -39,6 +41,7 @@ afterEach(() => {
 
 function makeToken(overrides: Partial<Record<string, unknown>> = {}) {
   return {
+    token_id: 'aaaaaaaa-0000-4000-8000-000000000001',
     token_prefix: 'reg_a1b2c3',
     tenant_id: 'root/msp-a/prod',
     group: 'prod bulk enroll',
@@ -51,6 +54,13 @@ function makeToken(overrides: Partial<Record<string, unknown>> = {}) {
 
 function makeTokensResponse(tokens: object[], status = 200) {
   return new Response(JSON.stringify({ tokens, total: tokens.length }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
     status,
     headers: { 'Content-Type': 'application/json' },
   })
@@ -83,6 +93,7 @@ describe('parseToken', () => {
   it('parses a full entry', () => {
     const token = parseToken(makeToken())
     expect(token).toEqual({
+      token_id: 'aaaaaaaa-0000-4000-8000-000000000001',
       token_prefix: 'reg_a1b2c3',
       tenant_id: 'root/msp-a/prod',
       group: 'prod bulk enroll',
@@ -119,6 +130,15 @@ describe('parseToken', () => {
     expect(token?.revoked).toBe(true)
   })
 
+  it('parses token_id when present', () => {
+    const token = parseToken({
+      token_prefix: 'reg_xyz',
+      tenant_id: 'root',
+      token_id: 'aaaaaaaa-0000-4000-8000-000000000099',
+    })
+    expect(token?.token_id).toBe('aaaaaaaa-0000-4000-8000-000000000099')
+  })
+
   it('does not expose a token field even if wire data contains one', () => {
     const WIRE_FULL = 'reg_a1b2c3d4e5f6g7h8i9j0k1l2m3n4'
     const parsed = parseToken({ token_prefix: 'reg_a1b2c3', token: WIRE_FULL, tenant_id: 'root' })
@@ -142,6 +162,7 @@ describe('parseTokenList', () => {
     const list = parseTokenList({ tokens: [makeToken()], total: 1 })
     expect(list).toHaveLength(1)
     expect(list[0]?.token_prefix).toBe('reg_a1b2c3')
+    expect(list[0]?.token_id).toBe('aaaaaaaa-0000-4000-8000-000000000001')
   })
 
   it('drops tokens without a token_prefix', () => {
@@ -169,7 +190,11 @@ describe('TokensTab — list rendering', () => {
     fetchMock.mockResolvedValue(
       makeTokensResponse([
         makeToken(),
-        makeToken({ token_prefix: 'reg_9f8e7d', group: 'client-1 onboarding' }),
+        makeToken({
+          token_id: 'aaaaaaaa-0000-4000-8000-000000000002',
+          token_prefix: 'reg_9f8e7d',
+          group: 'client-1 onboarding',
+        }),
       ]),
     )
     renderTab()
@@ -298,14 +323,276 @@ describe('TokensTab — status badges', () => {
   })
 })
 
+// ── Mint ──────────────────────────────────────────────────────────────────────
+
+describe('TokensTab — mint', () => {
+  it('renders a mint form in the empty state', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-empty')).toBeInTheDocument())
+    expect(screen.getByTestId('mint-form')).toBeInTheDocument()
+    expect(screen.getByTestId('mint-btn')).toBeInTheDocument()
+  })
+
+  it('renders a mint form when tokens exist', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([makeToken()]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    expect(screen.getByTestId('mint-form')).toBeInTheDocument()
+  })
+
+  it('posts to the tokens endpoint and shows SecretOnceModal with the minted secret', async () => {
+    const SECRET = 'reg_mintedtoken1234567890abcde'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([]))                // initial GET
+      .mockResolvedValueOnce(jsonResponse({ token: SECRET, token_id: 'uuid-1', token_prefix: 'reg_min' }, 201))  // POST
+      .mockResolvedValueOnce(makeTokensResponse([makeToken()]))     // reload GET
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('mint-form')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('mint-controller-url'), { target: { value: 'https://ctrl.example.com' } })
+    fireEvent.click(screen.getByTestId('mint-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('secret-once-modal')).toBeInTheDocument())
+    expect(screen.getByTestId('secret-value')).toHaveTextContent(SECRET)
+    // POST was called
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/registration/tokens',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('shows SecretOnceModal with action label "Minted"', async () => {
+    const SECRET = 'reg_mintedtoken1234567890abcde'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ token: SECRET }, 201))
+      .mockResolvedValueOnce(makeTokensResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('mint-form')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('mint-controller-url'), { target: { value: 'https://ctrl.example.com' } })
+    fireEvent.click(screen.getByTestId('mint-btn'))
+    await waitFor(() => expect(screen.getByTestId('secret-once-modal')).toBeInTheDocument())
+    expect(screen.getByRole('dialog')).toHaveTextContent(/minted/i)
+  })
+
+  it('shows mint error on non-201 response', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([]))
+      .mockResolvedValueOnce(new Response('bad', { status: 400 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('mint-form')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('mint-controller-url'), { target: { value: 'https://ctrl.example.com' } })
+    fireEvent.click(screen.getByTestId('mint-btn'))
+    await waitFor(() => expect(screen.getByTestId('mint-error')).toBeInTheDocument())
+    expect(screen.getByTestId('mint-error')).toHaveTextContent('400')
+  })
+
+  it('validates that controller URL is required', async () => {
+    fetchMock.mockResolvedValue(makeTokensResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('mint-form')).toBeInTheDocument())
+    // fireEvent.submit bypasses HTML5 required validation so React's own check runs.
+    fireEvent.submit(screen.getByTestId('mint-form'))
+    await waitFor(() => expect(screen.getByTestId('mint-error')).toBeInTheDocument())
+    expect(screen.getByTestId('mint-error')).toHaveTextContent(/required/i)
+  })
+})
+
+// ── Rotate ────────────────────────────────────────────────────────────────────
+
+describe('TokensTab — rotate', () => {
+  it('sends POST to the rotate endpoint and shows SecretOnceModal with rotated secret', async () => {
+    const TOKEN_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+    const SECRET = 'reg_rotatedtoken1234567890abcde'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([makeToken({ token_id: TOKEN_ID })]))
+      .mockResolvedValueOnce(jsonResponse({ token: SECRET, token_id: 'uuid-new', token_prefix: 'reg_rot' }, 201))
+      .mockResolvedValueOnce(makeTokensResponse([makeToken({ token_id: 'uuid-new', token_prefix: 'reg_rot' })]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId(`rotate-btn-${TOKEN_ID}`))
+
+    await waitFor(() => expect(screen.getByTestId('secret-once-modal')).toBeInTheDocument())
+    expect(screen.getByTestId('secret-value')).toHaveTextContent(SECRET)
+    expect(screen.getByRole('dialog')).toHaveTextContent(/rotated/i)
+  })
+
+  it('shows action error on rotate failure', async () => {
+    const TOKEN_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([makeToken({ token_id: TOKEN_ID })]))
+      .mockResolvedValueOnce(new Response('err', { status: 409 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId(`rotate-btn-${TOKEN_ID}`))
+    await waitFor(() => expect(screen.getByTestId(`action-error-${TOKEN_ID}`)).toBeInTheDocument())
+    expect(screen.getByTestId(`action-error-${TOKEN_ID}`)).toHaveTextContent('409')
+  })
+})
+
+// ── Revoke ────────────────────────────────────────────────────────────────────
+
+describe('TokensTab — revoke', () => {
+  it('sends POST /{token_id}/revoke and reloads', async () => {
+    const TOKEN_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+    const revokedToken = makeToken({ token_id: TOKEN_ID, revoked: true })
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([makeToken({ token_id: TOKEN_ID })]))
+      .mockResolvedValueOnce(jsonResponse({ token_id: TOKEN_ID, revoked: true }, 200))
+      .mockResolvedValueOnce(makeTokensResponse([revokedToken]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId(`revoke-btn-${TOKEN_ID}`))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/v1/registration/tokens/${TOKEN_ID}/revoke`,
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    )
+    // After reload the row shows Revoked
+    await waitFor(() => expect(screen.getByTestId('token-status')).toHaveTextContent('Revoked'))
+  })
+
+  it('shows action error on revoke failure', async () => {
+    const TOKEN_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([makeToken({ token_id: TOKEN_ID })]))
+      .mockResolvedValueOnce(new Response('err', { status: 500 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId(`revoke-btn-${TOKEN_ID}`))
+    await waitFor(() => expect(screen.getByTestId(`action-error-${TOKEN_ID}`)).toBeInTheDocument())
+    expect(screen.getByTestId(`action-error-${TOKEN_ID}`)).toHaveTextContent('500')
+  })
+})
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+describe('TokensTab — delete', () => {
+  it('sends DELETE /{token_id} and removes the row', async () => {
+    const TOKEN_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([makeToken({ token_id: TOKEN_ID })]))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(makeTokensResponse([]))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId(`delete-btn-${TOKEN_ID}`))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/v1/registration/tokens/${TOKEN_ID}`,
+        expect.objectContaining({ method: 'DELETE' }),
+      ),
+    )
+    // After reload, empty state
+    await waitFor(() => expect(screen.getByTestId('tokens-empty')).toBeInTheDocument())
+  })
+
+  it('shows action error on delete failure', async () => {
+    const TOKEN_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([makeToken({ token_id: TOKEN_ID })]))
+      .mockResolvedValueOnce(new Response('err', { status: 500 }))
+    renderTab()
+    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId(`delete-btn-${TOKEN_ID}`))
+    await waitFor(() => expect(screen.getByTestId(`action-error-${TOKEN_ID}`)).toBeInTheDocument())
+    expect(screen.getByTestId(`action-error-${TOKEN_ID}`)).toHaveTextContent('500')
+  })
+})
+
+// ── SecretOnceModal ───────────────────────────────────────────────────────────
+
+describe('SecretOnceModal', () => {
+  it('renders the secret value and a copy button', () => {
+    const onDismiss = vi.fn()
+    render(
+      <SecretOnceModal
+        secret="reg_secretvalue12345678901234"
+        action="minted"
+        onDismiss={onDismiss}
+      />,
+    )
+    expect(screen.getByTestId('secret-value')).toHaveTextContent('reg_secretvalue12345678901234')
+    expect(screen.getByTestId('copy-secret-btn')).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when the dismiss button is clicked', async () => {
+    const onDismiss = vi.fn()
+    render(
+      <SecretOnceModal
+        secret="reg_secretvalue12345678901234"
+        action="minted"
+        onDismiss={onDismiss}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('dismiss-secret-btn'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows "Minted" heading for minted action', () => {
+    render(
+      <SecretOnceModal
+        secret="reg_secretvalue12345678901234"
+        action="minted"
+        onDismiss={() => {}}
+      />,
+    )
+    expect(screen.getByRole('heading')).toHaveTextContent(/minted/i)
+  })
+
+  it('shows "Rotated" heading for rotated action', () => {
+    render(
+      <SecretOnceModal
+        secret="reg_secretvalue12345678901234"
+        action="rotated"
+        onDismiss={() => {}}
+      />,
+    )
+    expect(screen.getByRole('heading')).toHaveTextContent(/rotated/i)
+  })
+
+  it('includes a one-time warning message', () => {
+    render(
+      <SecretOnceModal
+        secret="reg_secretvalue12345678901234"
+        action="minted"
+        onDismiss={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('secret-once-warning')).toBeInTheDocument()
+    expect(screen.getByTestId('secret-once-warning')).toHaveTextContent(/not be shown again/i)
+  })
+
+  it('is dismissed — secret absent from DOM after onDismiss is called', async () => {
+    const SECRET = 'reg_secretvalue12345678901234'
+    function Wrapper() {
+      const [show, setShow] = useState(true)
+      return show ? (
+        <SecretOnceModal secret={SECRET} action="minted" onDismiss={() => setShow(false)} />
+      ) : (
+        <div data-testid="dismissed" />
+      )
+    }
+    render(<Wrapper />)
+    expect(screen.getByTestId('secret-value')).toHaveTextContent(SECRET)
+    fireEvent.click(screen.getByTestId('dismiss-secret-btn'))
+    await waitFor(() => expect(screen.getByTestId('dismissed')).toBeInTheDocument())
+    expect(document.body.textContent).not.toContain(SECRET)
+  })
+})
+
 // ── Security: prefix-only guarantee (required AC) ─────────────────────────────
 
 describe('TokensTab — token prefix security (required AC)', () => {
   it('renders only the token_prefix, never a full-length token string', async () => {
     const PREFIX = 'reg_x9y8z7'
-    // Simulates wire data that includes the full `token` field (as create/rotate
-    // would return). The list endpoint contract omits it, but this test verifies
-    // the component does not render it even if the wire unexpectedly includes it.
     const WIRE_FULL = 'reg_x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4j3i2h1g0f9e8d7c6b5a4'
     fetchMock.mockResolvedValue(
       makeTokensResponse([
@@ -317,11 +604,7 @@ describe('TokensTab — token prefix security (required AC)', () => {
 
     const rows = screen.getAllByTestId('token-row')
     expect(rows).toHaveLength(1)
-
-    // The prefix appears in the token-prefix cell
     expect(within(rows[0]!).getByTestId('token-prefix')).toHaveTextContent(PREFIX)
-
-    // The full wire value must not appear anywhere in the DOM
     expect(document.body.textContent).not.toContain(WIRE_FULL)
   })
 
@@ -330,8 +613,8 @@ describe('TokensTab — token prefix security (required AC)', () => {
     const FULL_B = 'reg_bbbbbb2222222222222222222222222222222222222222222222222222'
     fetchMock.mockResolvedValue(
       makeTokensResponse([
-        makeToken({ token_prefix: 'reg_aaaaaa', token: FULL_A }),
-        makeToken({ token_prefix: 'reg_bbbbbb', token: FULL_B }),
+        makeToken({ token_prefix: 'reg_aaaaaa', token: FULL_A, token_id: 'uuid-a' }),
+        makeToken({ token_prefix: 'reg_bbbbbb', token: FULL_B, token_id: 'uuid-b' }),
       ]),
     )
     renderTab()
@@ -342,35 +625,21 @@ describe('TokensTab — token prefix security (required AC)', () => {
     expect(screen.getAllByTestId('token-prefix')[0]).toHaveTextContent('reg_aaaaaa')
     expect(screen.getAllByTestId('token-prefix')[1]).toHaveTextContent('reg_bbbbbb')
   })
-})
 
-// ── No write affordances ──────────────────────────────────────────────────────
-
-describe('TokensTab — no write affordances', () => {
-  it('renders no mint, rotate, revoke, or delete button', async () => {
-    fetchMock.mockResolvedValue(makeTokensResponse([makeToken()]))
+  it('secret shown in SecretOnceModal is absent from DOM after dismiss', async () => {
+    const SECRET = 'reg_mintonce1234567890abcde'
+    fetchMock
+      .mockResolvedValueOnce(makeTokensResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ token: SECRET }, 201))
+      .mockResolvedValueOnce(makeTokensResponse([]))
     renderTab()
-    await waitFor(() => expect(screen.getByTestId('tokens-table')).toBeInTheDocument())
-
-    expect(screen.queryByRole('button', { name: /mint/i })).toBeNull()
-    expect(screen.queryByRole('button', { name: /rotate/i })).toBeNull()
-    expect(screen.queryByRole('button', { name: /revoke/i })).toBeNull()
-    expect(screen.queryByRole('button', { name: /delete/i })).toBeNull()
-  })
-
-  it('renders no write controls even in the loading state', () => {
-    fetchMock.mockReturnValue(new Promise(() => {}))
-    renderTab()
-    expect(screen.queryByRole('button', { name: /mint/i })).toBeNull()
-    expect(screen.queryByRole('button', { name: /rotate/i })).toBeNull()
-    expect(screen.queryByRole('button', { name: /revoke/i })).toBeNull()
-  })
-
-  it('renders no write controls in the empty state', async () => {
-    fetchMock.mockResolvedValue(makeTokensResponse([]))
-    renderTab()
-    await waitFor(() => expect(screen.getByTestId('tokens-empty')).toBeInTheDocument())
-    expect(screen.queryByRole('button', { name: /mint/i })).toBeNull()
-    expect(screen.queryByRole('button')).toBeNull()
+    await waitFor(() => expect(screen.getByTestId('mint-form')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('mint-controller-url'), { target: { value: 'https://ctrl.example.com' } })
+    fireEvent.click(screen.getByTestId('mint-btn'))
+    await waitFor(() => expect(screen.getByTestId('secret-once-modal')).toBeInTheDocument())
+    expect(document.body.textContent).toContain(SECRET)
+    fireEvent.click(screen.getByTestId('dismiss-secret-btn'))
+    await waitFor(() => expect(screen.queryByTestId('secret-once-modal')).toBeNull())
+    expect(document.body.textContent).not.toContain(SECRET)
   })
 })

--- a/web/src/registration/TokensTab.tsx
+++ b/web/src/registration/TokensTab.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Registration token list tab (Story #2935) — read-only view.
+ * Registration token list tab (Story #2935, #2970) — read + write operations.
  * Fetches GET /api/v1/registration/tokens — {tokens:[...], total:N} shape
  * per handlers_registration_tokens.go (no {data:...} envelope).
  * Shape-validated by parseTokenList before any value reaches the DOM.
@@ -11,21 +11,32 @@
  * expires_at / revoked_at are optional (Go omitempty on pointer types) —
  * renders '—' when absent, matching the columns.ts em-dash convention.
  *
- * No mint, rotate, revoke, or delete affordance of any kind — those are
- * Section 2's follow-on epic.
+ * Write operations (Story #2970): all four actions are behind AssuranceStrong
+ * (CFGMS-StepUp) — handled transparently by apiFetch → AuthProvider → StepUpModal.
+ *   Mint:   POST /api/v1/registration/tokens
+ *   Rotate: POST /api/v1/registration/tokens/{tenant_id}/rotate
+ *   Revoke: POST /api/v1/registration/tokens/{token_id}/revoke
+ *   Delete: DELETE /api/v1/registration/tokens/{token_id}
+ *
+ * Secret-once guarantee (AC Story #2970): mint and rotate return the full token
+ * in the response. SecretOnceModal renders it once and discards it — the value
+ * is never stored in a ref, localStorage, or any other durable location.
+ * The modal is dismissed by clearing state; the secret is gone after that point.
  *
  * Security A9.1: all wire values render as JSX text nodes only, never markup.
- * The component reads only token_prefix from wire data, never the full secret
- * (token field) — the list endpoint contract omits it and parseToken enforces
- * this by not reading the token field at all.
+ * parseToken never reads the token field from wire data — only token_prefix and
+ * token_id are stored in RegistrationToken; the mint/rotate response token is
+ * held transiently in pendingSecret and passed directly to SecretOnceModal.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { apiFetch } from '../api/client.ts'
+import { useAuth } from '../auth/AuthContext.tsx'
 import ErrorCard from '../shell/ErrorCard.tsx'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface RegistrationToken {
+  token_id: string   // stable UUID — safe to expose, used to address revoke/delete
   token_prefix: string
   tenant_id: string
   group: string
@@ -61,6 +72,7 @@ export function parseToken(value: unknown): RegistrationToken | null {
   const token_prefix = str(r.token_prefix)
   if (!token_prefix) return null
   return {
+    token_id: str(r.token_id),
     token_prefix,
     tenant_id: str(r.tenant_id),
     group: str(r.group),
@@ -107,6 +119,193 @@ function statusLabel(s: TokenStatus): string {
   return 'Revoked'
 }
 
+// ── SecretOnceModal ───────────────────────────────────────────────────────────
+
+/*
+ * Renders the minted or rotated secret exactly once. On dismiss, the secret is
+ * cleared from state and is unrecoverable from the client. No ref, no
+ * localStorage, no clipboard persistence beyond the copy affordance.
+ * Security AC Story #2970: secret shown once, unrecoverable after dismiss.
+ */
+interface SecretOnceModalProps {
+  secret: string         // full token — passed transiently, never stored
+  action: 'minted' | 'rotated'
+  onDismiss: () => void  // caller clears pendingSecret on dismiss
+}
+
+export function SecretOnceModal({ secret, action, onDismiss }: SecretOnceModalProps) {
+  const [copied, setCopied] = useState(false)
+  const copyRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function handleCopy() {
+    navigator.clipboard.writeText(secret).then(() => {
+      setCopied(true)
+      if (copyRef.current !== null) clearTimeout(copyRef.current)
+      copyRef.current = setTimeout(() => setCopied(false), 2000)
+    }).catch(() => {})
+  }
+
+  // Clean up timeout on unmount.
+  useEffect(() => {
+    return () => {
+      if (copyRef.current !== null) clearTimeout(copyRef.current)
+    }
+  }, [])
+
+  const verb = action === 'minted' ? 'Minted' : 'Rotated'
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="secret-modal-title"
+      data-testid="secret-once-modal"
+    >
+      <div className="modal-panel">
+        <h2 id="secret-modal-title">{verb} — copy your token now</h2>
+        <p className="notice-warn" data-testid="secret-once-warning">
+          This token will not be shown again. Copy it before dismissing.
+        </p>
+        <div className="secret-row" data-testid="secret-value-row">
+          <code className="mono2 secret-value" data-testid="secret-value">
+            {secret}
+          </code>
+          <button
+            type="button"
+            className="wf-btn-sm"
+            onClick={handleCopy}
+            data-testid="copy-secret-btn"
+            aria-label="Copy token to clipboard"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+        <button
+          type="button"
+          className="wf-btn-primary"
+          onClick={onDismiss}
+          data-testid="dismiss-secret-btn"
+          aria-label="Dismiss — token will not be shown again"
+        >
+          I have copied the token — dismiss
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Mint form ─────────────────────────────────────────────────────────────────
+
+interface MintFormProps {
+  tenantId: string
+  onMinted: (secret: string) => void
+  onReload: () => void
+}
+
+function MintForm({ tenantId, onMinted, onReload }: MintFormProps) {
+  const [group, setGroup] = useState('')
+  const [controllerUrl, setControllerUrl] = useState('')
+  const [expiresIn, setExpiresIn] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (controllerUrl.trim() === '') {
+      setError('Controller URL is required')
+      return
+    }
+    setError(null)
+    setPending(true)
+    try {
+      const body: Record<string, unknown> = {
+        tenant_id: tenantId,
+        controller_url: controllerUrl.trim(),
+      }
+      if (group.trim() !== '') body.group = group.trim()
+      if (expiresIn.trim() !== '') body.expires_in = expiresIn.trim()
+
+      const response = await apiFetch('/api/v1/registration/tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        setError(`Mint failed — ${response.status}`)
+        return
+      }
+      const data = (await response.json()) as Record<string, unknown>
+      const secret = typeof data.token === 'string' ? data.token : ''
+      setGroup('')
+      setControllerUrl('')
+      setExpiresIn('')
+      onReload()
+      if (secret !== '') onMinted(secret)
+    } catch (cause: unknown) {
+      setError(cause instanceof Error && cause.message ? cause.message : 'Mint request failed')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <form className="wf-form" onSubmit={handleSubmit} data-testid="mint-form">
+      <h3>Mint new token</h3>
+      <div className="wf-field">
+        <label htmlFor="mint-controller-url">Controller URL</label>
+        <input
+          id="mint-controller-url"
+          type="text"
+          className="wf-input"
+          value={controllerUrl}
+          onChange={(e) => setControllerUrl(e.target.value)}
+          placeholder="https://controller.example.com"
+          data-testid="mint-controller-url"
+          required
+        />
+      </div>
+      <div className="wf-field">
+        <label htmlFor="mint-group">Group (optional)</label>
+        <input
+          id="mint-group"
+          type="text"
+          className="wf-input"
+          value={group}
+          onChange={(e) => setGroup(e.target.value)}
+          placeholder="prod-enroll"
+          data-testid="mint-group"
+        />
+      </div>
+      <div className="wf-field">
+        <label htmlFor="mint-expires-in">Expires in (optional, e.g. 30d)</label>
+        <input
+          id="mint-expires-in"
+          type="text"
+          className="wf-input"
+          value={expiresIn}
+          onChange={(e) => setExpiresIn(e.target.value)}
+          placeholder="30d"
+          data-testid="mint-expires-in"
+        />
+      </div>
+      {error !== null && (
+        <span className="wf-form-error" role="alert" data-testid="mint-error">
+          {error}
+        </span>
+      )}
+      <button
+        type="submit"
+        className="wf-btn-primary"
+        disabled={pending}
+        data-testid="mint-btn"
+      >
+        {pending ? 'Minting…' : 'Mint token'}
+      </button>
+    </form>
+  )
+}
+
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function LoadingRows() {
@@ -126,12 +325,15 @@ function LoadingRows() {
   )
 }
 
-function EmptyState() {
+function EmptyState({ tenantId, onMinted, onReload }: { tenantId: string; onMinted: (s: string) => void; onReload: () => void }) {
   return (
-    <div className="notice empty" data-testid="tokens-empty">
-      <div className="ic">◍</div>
-      <h3>No registration tokens</h3>
-      <p>Tokens minted for this tenant will appear here.</p>
+    <div>
+      <div className="notice empty" data-testid="tokens-empty">
+        <div className="ic">◍</div>
+        <h3>No registration tokens</h3>
+        <p>Tokens minted for this tenant will appear here.</p>
+      </div>
+      <MintForm tenantId={tenantId} onMinted={onMinted} onReload={onReload} />
     </div>
   )
 }
@@ -146,21 +348,112 @@ function StatusBadge({ token }: { token: RegistrationToken }) {
   )
 }
 
+// ── TokenRow ──────────────────────────────────────────────────────────────────
+
+interface TokenRowProps {
+  token: RegistrationToken
+  onAction: (action: 'rotate' | 'revoke' | 'delete', token: RegistrationToken) => void
+  actionPending: boolean
+  actionError: string | null
+}
+
+function TokenRow({ token, onAction, actionPending, actionError }: TokenRowProps) {
+  return (
+    <>
+      <tr data-testid="token-row">
+        <td className="mono2" data-testid="token-prefix">
+          {token.token_prefix}
+        </td>
+        <td data-testid="token-tenant">{token.tenant_id || '—'}</td>
+        <td data-testid="token-group">{token.group || '—'}</td>
+        <td className="mono2" data-testid="token-created">
+          {token.created_at || '—'}
+        </td>
+        <td className="mono2" data-testid="token-expires">
+          {token.expires_at ?? '—'}
+        </td>
+        <td data-testid="token-status-cell">
+          <StatusBadge token={token} />
+        </td>
+        <td data-testid="token-actions">
+          {!token.revoked && (
+            <button
+              type="button"
+              className="wf-btn-sm"
+              disabled={actionPending}
+              onClick={() => onAction('rotate', token)}
+              data-testid={`rotate-btn-${token.token_id}`}
+            >
+              {actionPending ? '…' : 'Rotate'}
+            </button>
+          )}
+          {!token.revoked && (
+            <button
+              type="button"
+              className="wf-btn-sm-danger"
+              disabled={actionPending}
+              onClick={() => onAction('revoke', token)}
+              data-testid={`revoke-btn-${token.token_id}`}
+            >
+              {actionPending ? '…' : 'Revoke'}
+            </button>
+          )}
+          <button
+            type="button"
+            className="wf-btn-sm-danger"
+            disabled={actionPending}
+            onClick={() => onAction('delete', token)}
+            data-testid={`delete-btn-${token.token_id}`}
+          >
+            {actionPending ? '…' : 'Delete'}
+          </button>
+        </td>
+      </tr>
+      {actionError !== null && (
+        <tr>
+          <td colSpan={7}>
+            <span
+              className="wf-form-error"
+              role="alert"
+              data-testid={`action-error-${token.token_id}`}
+            >
+              {actionError}
+            </span>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
+const TOKENS_ENDPOINT = '/api/v1/registration/tokens'
+
 export default function TokensTab() {
+  const { principal } = useAuth()
+  const tenantId = principal?.tenantId ?? ''
+
   const [attempt, setAttempt] = useState(0)
   const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+
+  // pendingSecret holds the minted/rotated secret transiently for SecretOnceModal.
+  // It is never written to any durable store; cleared on modal dismiss.
+  const [pendingSecret, setPendingSecret] = useState<{ secret: string; action: 'minted' | 'rotated' } | null>(null)
+
+  // Per-token action state keyed by token_id.
+  const [actionPending, setActionPending] = useState<Set<string>>(new Set())
+  const [actionErrors, setActionErrors] = useState<Map<string, string>>(new Map())
 
   const key = `tokens:${attempt}`
   const retry = useCallback(() => setAttempt((n) => n + 1), [])
 
   useEffect(() => {
     let cancelled = false
-    apiFetch('/api/v1/registration/tokens')
+    apiFetch(TOKENS_ENDPOINT)
       .then(async (response) => {
         if (!response.ok) {
-          throw new Error(`GET /api/v1/registration/tokens — ${response.status}`)
+          throw new Error(`GET ${TOKENS_ENDPOINT} — ${response.status}`)
         }
         const body: unknown = await response.json()
         const tokens = parseTokenList(body)
@@ -174,13 +467,76 @@ export default function TokensTab() {
           error:
             cause instanceof Error && cause.message
               ? cause.message
-              : 'GET /api/v1/registration/tokens — request failed',
+              : `GET ${TOKENS_ENDPOINT} — request failed`,
         })
       })
     return () => {
       cancelled = true
     }
   }, [key, attempt])
+
+  function handleMinted(secret: string) {
+    setPendingSecret({ secret, action: 'minted' })
+  }
+
+  function handleRotated(secret: string) {
+    setPendingSecret({ secret, action: 'rotated' })
+  }
+
+  function dismissSecret() {
+    setPendingSecret(null)
+  }
+
+  async function handleTokenAction(action: 'rotate' | 'revoke' | 'delete', token: RegistrationToken) {
+    const id = token.token_id
+    setActionErrors((prev) => { const m = new Map(prev); m.delete(id); return m })
+    setActionPending((prev) => new Set([...prev, id]))
+
+    try {
+      let response: Response
+      if (action === 'rotate') {
+        response = await apiFetch(`${TOKENS_ENDPOINT}/${encodeURIComponent(token.tenant_id)}/rotate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ group: token.group }),
+        })
+      } else if (action === 'revoke') {
+        response = await apiFetch(`${TOKENS_ENDPOINT}/${encodeURIComponent(id)}/revoke`, {
+          method: 'POST',
+        })
+      } else {
+        response = await apiFetch(`${TOKENS_ENDPOINT}/${encodeURIComponent(id)}`, {
+          method: 'DELETE',
+        })
+      }
+
+      if (!response.ok) {
+        setActionErrors((prev) => new Map(prev).set(id, `${action} failed — ${response.status}`))
+        return
+      }
+
+      if (action === 'rotate') {
+        const data = (await response.json()) as Record<string, unknown>
+        const secret = typeof data.token === 'string' ? data.token : ''
+        if (secret !== '') handleRotated(secret)
+      }
+
+      setAttempt((n) => n + 1)
+    } catch (cause: unknown) {
+      setActionErrors((prev) =>
+        new Map(prev).set(
+          id,
+          cause instanceof Error && cause.message ? cause.message : `${action} request failed`,
+        ),
+      )
+    } finally {
+      setActionPending((prev) => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  }
 
   const current = outcome?.key === key ? outcome : null
 
@@ -197,46 +553,51 @@ export default function TokensTab() {
   }
 
   const tokens = current.tokens ?? []
-  if (tokens.length === 0) return <EmptyState />
 
   return (
-    <section className="panel">
-      <table className="tbl" data-testid="tokens-table">
-        <thead>
-          <tr>
-            <th>Token</th>
-            <th>Tenant</th>
-            <th>Group</th>
-            <th>Created</th>
-            <th>Expires</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {tokens.map((token) => (
-            <tr key={token.token_prefix} data-testid="token-row">
-              <td className="mono2" data-testid="token-prefix">
-                {token.token_prefix}
-              </td>
-              <td data-testid="token-tenant">{token.tenant_id || '—'}</td>
-              <td data-testid="token-group">{token.group || '—'}</td>
-              <td className="mono2" data-testid="token-created">
-                {token.created_at || '—'}
-              </td>
-              <td className="mono2" data-testid="token-expires">
-                {token.expires_at ?? '—'}
-              </td>
-              <td data-testid="token-status-cell">
-                <StatusBadge token={token} />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <p className="mono2" style={{ fontSize: 'var(--text-sm)', marginTop: '8px' }}>
-        Only the token prefix is ever shown — the full secret is displayed once at mint and never
-        again.
-      </p>
-    </section>
+    <>
+      {pendingSecret !== null && (
+        <SecretOnceModal
+          secret={pendingSecret.secret}
+          action={pendingSecret.action}
+          onDismiss={dismissSecret}
+        />
+      )}
+      {tokens.length === 0 ? (
+        <EmptyState tenantId={tenantId} onMinted={handleMinted} onReload={retry} />
+      ) : (
+        <section className="panel">
+          <table className="tbl" data-testid="tokens-table">
+            <thead>
+              <tr>
+                <th>Token</th>
+                <th>Tenant</th>
+                <th>Group</th>
+                <th>Created</th>
+                <th>Expires</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((token) => (
+                <TokenRow
+                  key={token.token_id || token.token_prefix}
+                  token={token}
+                  onAction={handleTokenAction}
+                  actionPending={actionPending.has(token.token_id)}
+                  actionError={actionErrors.get(token.token_id) ?? null}
+                />
+              ))}
+            </tbody>
+          </table>
+          <p className="mono2" style={{ fontSize: 'var(--text-sm)', marginTop: '8px' }}>
+            Only the token prefix is ever shown — the full secret is displayed once at mint and never
+            again.
+          </p>
+          <MintForm tenantId={tenantId} onMinted={handleMinted} onReload={retry} />
+        </section>
+      )}
+    </>
   )
 }

--- a/web/src/registration/TokensTab.tsx
+++ b/web/src/registration/TokensTab.tsx
@@ -241,7 +241,7 @@ function MintForm({ tenantId, onMinted, onReload }: MintFormProps) {
       setControllerUrl('')
       setExpiresIn('')
       onReload()
-      if (secret !== '') onMinted(secret)
+      if (secret.length > 0) onMinted(secret)
     } catch (cause: unknown) {
       setError(cause instanceof Error && cause.message ? cause.message : 'Mint request failed')
     } finally {
@@ -350,6 +350,13 @@ function StatusBadge({ token }: { token: RegistrationToken }) {
 
 // ── TokenRow ──────────────────────────────────────────────────────────────────
 
+// rowKeyFor identifies a row in per-token UI state (pending/error maps, test ids).
+// token_id is the identity everywhere it exists; token_prefix is the fallback for
+// legacy rows that have no id yet, so their state never collides on the empty string.
+function rowKeyFor(token: RegistrationToken): string {
+  return token.token_id || token.token_prefix
+}
+
 interface TokenRowProps {
   token: RegistrationToken
   onAction: (action: 'rotate' | 'revoke' | 'delete', token: RegistrationToken) => void
@@ -358,6 +365,13 @@ interface TokenRowProps {
 }
 
 function TokenRow({ token, onAction, actionPending, actionError }: TokenRowProps) {
+  // Revoke and delete address the token by its stable UUID. A token without one
+  // (a row that predates the id column and has not been migrated) cannot be
+  // addressed at all — the action is disabled rather than issuing a request to a
+  // degenerate URL that would 404 with no explanation.
+  const rowKey = rowKeyFor(token)
+  const addressable = token.token_id.length > 0
+  const unaddressableTitle = 'Token has no identifier — restart the controller to migrate legacy tokens'
   return (
     <>
       <tr data-testid="token-row">
@@ -382,7 +396,7 @@ function TokenRow({ token, onAction, actionPending, actionError }: TokenRowProps
               className="wf-btn-sm"
               disabled={actionPending}
               onClick={() => onAction('rotate', token)}
-              data-testid={`rotate-btn-${token.token_id}`}
+              data-testid={`rotate-btn-${rowKey}`}
             >
               {actionPending ? '…' : 'Rotate'}
             </button>
@@ -391,9 +405,10 @@ function TokenRow({ token, onAction, actionPending, actionError }: TokenRowProps
             <button
               type="button"
               className="wf-btn-sm-danger"
-              disabled={actionPending}
+              disabled={actionPending || !addressable}
+              title={addressable ? undefined : unaddressableTitle}
               onClick={() => onAction('revoke', token)}
-              data-testid={`revoke-btn-${token.token_id}`}
+              data-testid={`revoke-btn-${rowKey}`}
             >
               {actionPending ? '…' : 'Revoke'}
             </button>
@@ -401,9 +416,10 @@ function TokenRow({ token, onAction, actionPending, actionError }: TokenRowProps
           <button
             type="button"
             className="wf-btn-sm-danger"
-            disabled={actionPending}
+            disabled={actionPending || !addressable}
+            title={addressable ? undefined : unaddressableTitle}
             onClick={() => onAction('delete', token)}
-            data-testid={`delete-btn-${token.token_id}`}
+            data-testid={`delete-btn-${rowKey}`}
           >
             {actionPending ? '…' : 'Delete'}
           </button>
@@ -415,7 +431,7 @@ function TokenRow({ token, onAction, actionPending, actionError }: TokenRowProps
             <span
               className="wf-form-error"
               role="alert"
-              data-testid={`action-error-${token.token_id}`}
+              data-testid={`action-error-${rowKey}`}
             >
               {actionError}
             </span>
@@ -489,8 +505,19 @@ export default function TokensTab() {
 
   async function handleTokenAction(action: 'rotate' | 'revoke' | 'delete', token: RegistrationToken) {
     const id = token.token_id
-    setActionErrors((prev) => { const m = new Map(prev); m.delete(id); return m })
-    setActionPending((prev) => new Set([...prev, id]))
+    const rowKey = rowKeyFor(token)
+    setActionErrors((prev) => { const m = new Map(prev); m.delete(rowKey); return m })
+
+    // Revoke and delete address the token by UUID; without one there is no URL to
+    // call. Report it instead of requesting `/tokens//revoke` or `/tokens/`.
+    if (action !== 'rotate' && id.length === 0) {
+      setActionErrors((prev) =>
+        new Map(prev).set(rowKey, `${action} unavailable — token has no identifier`),
+      )
+      return
+    }
+
+    setActionPending((prev) => new Set([...prev, rowKey]))
 
     try {
       let response: Response
@@ -511,28 +538,28 @@ export default function TokensTab() {
       }
 
       if (!response.ok) {
-        setActionErrors((prev) => new Map(prev).set(id, `${action} failed — ${response.status}`))
+        setActionErrors((prev) => new Map(prev).set(rowKey, `${action} failed — ${response.status}`))
         return
       }
 
       if (action === 'rotate') {
         const data = (await response.json()) as Record<string, unknown>
         const secret = typeof data.token === 'string' ? data.token : ''
-        if (secret !== '') handleRotated(secret)
+        if (secret.length > 0) handleRotated(secret)
       }
 
       setAttempt((n) => n + 1)
     } catch (cause: unknown) {
       setActionErrors((prev) =>
         new Map(prev).set(
-          id,
+          rowKey,
           cause instanceof Error && cause.message ? cause.message : `${action} request failed`,
         ),
       )
     } finally {
       setActionPending((prev) => {
         const next = new Set(prev)
-        next.delete(id)
+        next.delete(rowKey)
         return next
       })
     }
@@ -582,11 +609,11 @@ export default function TokensTab() {
             <tbody>
               {tokens.map((token) => (
                 <TokenRow
-                  key={token.token_id || token.token_prefix}
+                  key={rowKeyFor(token)}
                   token={token}
                   onAction={handleTokenAction}
-                  actionPending={actionPending.has(token.token_id)}
-                  actionError={actionErrors.get(token.token_id) ?? null}
+                  actionPending={actionPending.has(rowKeyFor(token))}
+                  actionError={actionErrors.get(rowKeyFor(token)) ?? null}
                 />
               ))}
             </tbody>


### PR DESCRIPTION
## Summary

- **Backend**: Add stable UUID `token_id` to every registration token. `GetTokenByID` added to all store implementations (SQLite, PostgreSQL, memory, adapter). `DELETE /{token}` and `POST /{token}/revoke` handlers now try exact-match first (mTLS admin compat) then UUID lookup (web UI), and always use `token.Token` for the store operation and log prefix once resolved. SQLite schema migrates via `columnExists + ALTER TABLE`. Audit records token prefix + token ID only — secret never written.
- **Frontend**: `TokensTab` gains `SecretOnceModal` (secret shown once with copy-to-clipboard, cleared from state on dismiss — never persisted), `MintForm`, and per-row Rotate/Revoke/Delete buttons. All four actions go through `apiFetch`, so `AssuranceStrong` step-up is handled transparently by the existing `StepUpModal`/`AuthContext` infrastructure.
- **Tests**: `make test` and all 1102 frontend tests pass. TokensTab test suite updated from 23 to 50 tests; "no write affordances" suite removed and replaced with action coverage + `SecretOnceModal` dismiss-clears-secret assertion.

## Security invariants

- Secret (`token` field) never stored in `RegistrationToken` interface type — `parseToken` discards it
- `SecretOnceModal` receives secret as a prop and clears parent state on dismiss; no ref/localStorage/sessionStorage
- Audit records `token_prefix` (6 chars) + action only — secret never in audit or server logs
- `logging.SanitizeLogValue()` applied to all tainted HTTP values in handlers
- `token_id` is a UUID v4 — stable, non-secret, safe to expose in list responses

## Test plan

- [x] `make test` — all Go tests pass
- [x] `vitest run` — 1102 frontend tests pass (50 in TokensTab, 0 regressions elsewhere)
- [x] `go build ./...` — clean compile on all packages

Fixes #2970

🤖 Generated with [Claude Code](https://claude.com/claude-code)