### PR TITLE
web: workflow flowchart renderer — read-only block-tree → graph (Issue #3037)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
+        "@xyflow/react": "^12.11.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router": "^8.3.0"
@@ -507,6 +509,21 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -1239,6 +1256,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1274,7 +1340,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1284,7 +1350,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -1714,6 +1780,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -2181,6 +2289,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2254,8 +2368,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -5886,6 +6105,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
@@ -6292,6 +6520,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
+    "@xyflow/react": "^12.11.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router": "^8.3.0"

--- a/web/src/workflow/WorkflowGraph.css
+++ b/web/src/workflow/WorkflowGraph.css
@@ -1,0 +1,227 @@
+/* SPDX-License-Identifier: AGPL-3.0-only */
+/* Copyright 2026 Jordan Ritz */
+
+/*
+ * WorkflowGraph styles (Story #3037) — token-based, no hardcoded colors.
+ * All values are var(--…) consumed from @design-tokens.
+ * Mirrors the .node / .nico / .nhead / .nttl / .ntype / .nfoot / .port /
+ * .badge / svg.links path language in docs/design/mockups/workflow-studio.html.
+ */
+
+@import '@design-tokens';
+
+/* ── Root container ─────────────────────────────────────────────────────────── */
+
+.wfg-root {
+  width: 100%;
+  height: 100%;
+  min-height: 500px;
+  background: var(--bg-primary);
+}
+
+/* Dot-grid canvas background uses the --grid-dot token; ReactFlow <Background>
+   receives gap/size props, color is controlled below via the RF CSS override. */
+.wfg-root .react-flow__background {
+  background-color: var(--bg-primary);
+}
+.wfg-root .react-flow__background pattern circle {
+  fill: color-mix(in srgb, var(--text-primary) 14%, transparent);
+}
+
+/* ── Node card ──────────────────────────────────────────────────────────────── */
+
+.wfg-node {
+  width: 150px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  /* Neutral card drop shadow, verbatim from the mockup's .node rule — the same
+     theme-independent literal already used by Workflow.css / Config.css. Every
+     *palette* value below is a token; --shadow is the page-level drop for full
+     cards and is far too large for a 150px node. */
+  box-shadow: 0 6px 16px -12px rgba(60, 45, 30, 0.5);
+  overflow: visible;
+  position: relative;
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.45;
+  color: var(--text-primary);
+}
+
+/* ── Run states ─────────────────────────────────────────────────────────────── */
+
+.wfg-node.done {
+  border-color: var(--state-ok);
+}
+
+.wfg-node.running {
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 3px var(--accent-weak),
+    0 8px 20px -10px color-mix(in srgb, var(--accent) 60%, transparent);
+}
+
+.wfg-node.failed {
+  border-color: var(--state-crit);
+}
+
+.wfg-node.pending {
+  opacity: 0.6;
+  border-style: dashed;
+}
+
+/* ── Badge ──────────────────────────────────────────────────────────────────── */
+
+.wfg-badge {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 19px;
+  height: 19px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 10px;
+  font-weight: 800;
+  border: 2px solid var(--bg-surface);
+}
+
+/* Badge glyph sits on a saturated state fill; --accent-ink is the token for
+   text on a filled swatch and flips with the theme (white on light, ink on
+   dark), so the glyph stays legible in both. */
+.wfg-node.done .wfg-badge {
+  background: var(--state-ok);
+  color: var(--accent-ink);
+}
+
+.wfg-node.running .wfg-badge {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.wfg-node.failed .wfg-badge {
+  background: var(--state-crit);
+  color: var(--accent-ink);
+}
+
+/* ── Node header ────────────────────────────────────────────────────────────── */
+
+.wfg-nhead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 11px 8px;
+}
+
+/* ── Icon chip (matches .nico in the mockup) ────────────────────────────────── */
+
+.wfg-nico {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  border: 1px solid var(--border);
+  flex: none;
+}
+
+/* Type tints — mirrors .nico.{type} in workflow-studio.html */
+.wfg-nico.trig    { background: var(--accent-weak);  color: var(--accent);      border-color: var(--accent);      }
+.wfg-nico.module  { background: var(--tint-green);   color: var(--state-ok);    border-color: var(--state-ok);    }
+.wfg-nico.cond    { background: var(--tint-blue);    color: var(--accent);      border-color: var(--accent);      }
+.wfg-nico.wait    { background: var(--tint-orange);  color: var(--state-warn);  border-color: var(--state-warn);  }
+.wfg-nico.gate    { background: var(--tint-orange);  color: var(--state-warn);  border-color: var(--state-warn);  }
+.wfg-nico.notify  { background: var(--tint-blue);    color: var(--accent);                                        }
+
+/* ── Title and type label ───────────────────────────────────────────────────── */
+
+.wfg-nttl {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  word-break: break-all;
+}
+
+.wfg-ntype {
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  font-weight: 600;
+}
+
+/* ── Footer ─────────────────────────────────────────────────────────────────── */
+
+.wfg-nfoot {
+  padding: 0 11px 9px;
+  font-size: 10.5px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+
+/* ── Ports ──────────────────────────────────────────────────────────────────── */
+
+.wfg-port-wrap {
+  display: contents;
+}
+
+.wfg-plabel {
+  position: absolute;
+  right: 14px;
+  font-size: 8.5px;
+  font-weight: 700;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+/* ReactFlow handle dots */
+.wfg-root .react-flow__handle {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  border: 2px solid var(--border);
+}
+
+/* ── Edge styling ───────────────────────────────────────────────────────────── */
+
+.wfg-root .react-flow__edge-path {
+  stroke: var(--border);
+  stroke-width: 2;
+}
+
+.wfg-root .react-flow__edge.done .react-flow__edge-path {
+  stroke: var(--state-ok);
+}
+
+.wfg-root .react-flow__edge.active .react-flow__edge-path {
+  stroke: var(--accent);
+  stroke-dasharray: 6 5;
+  animation: wfg-dash 1s linear infinite;
+}
+
+.wfg-root .react-flow__edge.pend .react-flow__edge-path {
+  stroke: var(--border);
+  stroke-dasharray: 4 5;
+  opacity: 0.6;
+}
+
+@keyframes wfg-dash {
+  to {
+    stroke-dashoffset: -22;
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .wfg-root .react-flow__edge.active .react-flow__edge-path {
+    animation: none;
+  }
+}

--- a/web/src/workflow/WorkflowGraph.test.tsx
+++ b/web/src/workflow/WorkflowGraph.test.tsx
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * WorkflowGraph component tests (Story #3037).
+ *
+ * Tests run against the REAL @xyflow/react renderer and the REAL @dagrejs/dagre
+ * layout engine — no library is stubbed or mocked. The only environment shim is
+ * a ResizeObserver polyfill: jsdom does not implement the ResizeObserver DOM API
+ * that React Flow uses to measure its viewport, so without it the renderer
+ * throws on mount. That is a missing browser API, not a substituted component.
+ *
+ * Because jsdom reports every element as 0x0, React Flow never resolves handle
+ * bounds and therefore paints no edge SVG paths. Edge topology is consequently
+ * asserted on buildGraphElements() — the real, exported block-tree → graph
+ * mapping the renderer itself consumes — while node rendering, run-state
+ * classes, dagre-computed positions and the read-only surface are asserted on
+ * the real mounted DOM.
+ *
+ * Security A9.1: every node label/footer is verified to reach the DOM as a
+ * text node (RTL getByText), confirming no dangerouslySetInnerHTML path.
+ */
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import WorkflowGraph, { buildGraphElements, TRIGGER_NODE_ID } from './WorkflowGraph.tsx'
+import type { WorkflowStep, WorkflowExecution } from './useWorkflows.ts'
+
+// ── jsdom environment polyfill ────────────────────────────────────────────────
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    // Minimal spec-shaped ResizeObserver: jsdom never lays elements out, so no
+    // observation ever fires. React Flow only requires the constructor and the
+    // observe/unobserve/disconnect surface to exist.
+    globalThis.ResizeObserver = class implements ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+  }
+})
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function step(
+  overrides: Partial<WorkflowStep> & Pick<WorkflowStep, 'id' | 'name'>,
+): WorkflowStep {
+  return { type: 'module', config: {}, ...overrides }
+}
+
+function renderGraph(steps: WorkflowStep[], execution?: WorkflowExecution) {
+  return render(<WorkflowGraph steps={steps} execution={execution} />)
+}
+
+// React Flow's node wrapper carries the dagre-computed transform; the inner
+// element is the component's own card (data-testid={`node-${id}`}).
+function nodeWrapper(container: HTMLElement, id: string): HTMLElement {
+  const el = container.querySelector<HTMLElement>(`.react-flow__node[data-id="${CSS.escape(id)}"]`)
+  if (el === null) throw new Error(`no rendered React Flow node for id ${id}`)
+  return el
+}
+
+// ── Sequential topology ───────────────────────────────────────────────────────
+
+describe('WorkflowGraph — sequential topology', () => {
+  it('renders one node per step plus the synthetic trigger node', () => {
+    const steps = [step({ id: 's1', name: 'step-one' }), step({ id: 's2', name: 'step-two' })]
+    const { container } = renderGraph(steps)
+    expect(screen.getByTestId('node-__trigger__')).toBeInTheDocument()
+    expect(screen.getByTestId('node-s1')).toBeInTheDocument()
+    expect(screen.getByTestId('node-s2')).toBeInTheDocument()
+    expect(container.querySelectorAll('.react-flow__node')).toHaveLength(3)
+  })
+
+  it('chain edges connect steps in order: trigger → s1 → s2', () => {
+    const steps = [step({ id: 's1', name: 'a' }), step({ id: 's2', name: 'b' })]
+    const { edges } = buildGraphElements(steps)
+    expect(edges.some((e) => e.source === TRIGGER_NODE_ID && e.target === 's1')).toBe(true)
+    expect(edges.some((e) => e.source === 's1' && e.target === 's2')).toBe(true)
+    // A chain must not fan out: exactly one outgoing edge per node.
+    expect(edges).toHaveLength(2)
+  })
+
+  it('nodes are keyed by step.id, not by array position', () => {
+    const steps = [step({ id: 'unique-step-id', name: 'check' })]
+    const { container } = renderGraph(steps)
+    expect(screen.getByTestId('node-unique-step-id')).toBeInTheDocument()
+    // React Flow keys its wrapper by node id — position indexes never appear.
+    expect(nodeWrapper(container, 'unique-step-id')).toBeInTheDocument()
+  })
+
+  it('buildGraphElements produces one node per step plus trigger', () => {
+    const steps = [step({ id: 'x', name: 'x' }), step({ id: 'y', name: 'y' })]
+    const { nodes } = buildGraphElements(steps)
+    expect(nodes.map((n) => n.id)).toContain(TRIGGER_NODE_ID)
+    expect(nodes.map((n) => n.id)).toContain('x')
+    expect(nodes.map((n) => n.id)).toContain('y')
+    expect(nodes).toHaveLength(3)
+  })
+
+  it('dagre auto-layout assigns each node a distinct position (never hardcoded)', () => {
+    const steps = [step({ id: 's1', name: 'a' }), step({ id: 's2', name: 'b' })]
+    const { container } = renderGraph(steps)
+    const transforms = [TRIGGER_NODE_ID, 's1', 's2'].map(
+      (id) => nodeWrapper(container, id).style.transform,
+    )
+    expect(new Set(transforms).size).toBe(3)
+    // buildGraphElements emits placeholder 0,0 — the rendered transform proves
+    // the real dagre layout ran and moved the chain apart.
+    expect(transforms.every((t) => t !== '' && t !== 'translate(0px,0px)')).toBe(true)
+  })
+})
+
+// ── Parallel topology ─────────────────────────────────────────────────────────
+
+describe('WorkflowGraph — parallel topology', () => {
+  it('fan-out: parallel step produces edges to each child branch', () => {
+    const steps = [
+      step({
+        id: 'par',
+        name: 'parallel-block',
+        type: 'parallel',
+        steps: [
+          step({ id: 'child-a', name: 'branch-a' }),
+          step({ id: 'child-b', name: 'branch-b' }),
+        ],
+      }),
+    ]
+    const { edges } = buildGraphElements(steps)
+    expect(edges.some((e) => e.source === 'par' && e.target === 'child-a')).toBe(true)
+    expect(edges.some((e) => e.source === 'par' && e.target === 'child-b')).toBe(true)
+  })
+
+  it('fan-in: child exit nodes each connect to the next step in the parent list', () => {
+    const steps = [
+      step({
+        id: 'par',
+        name: 'parallel-block',
+        type: 'parallel',
+        steps: [
+          step({ id: 'child-a', name: 'branch-a' }),
+          step({ id: 'child-b', name: 'branch-b' }),
+        ],
+      }),
+      step({ id: 'join', name: 'after-parallel' }),
+    ]
+    const { edges } = buildGraphElements(steps)
+    expect(edges.some((e) => e.source === 'child-a' && e.target === 'join')).toBe(true)
+    expect(edges.some((e) => e.source === 'child-b' && e.target === 'join')).toBe(true)
+    // The join is not also wired directly from the parallel container.
+    expect(edges.some((e) => e.source === 'par' && e.target === 'join')).toBe(false)
+  })
+
+  it('renders all parallel branch nodes', () => {
+    const steps = [
+      step({
+        id: 'par',
+        name: 'parallel',
+        type: 'parallel',
+        steps: [step({ id: 'ba', name: 'ba' }), step({ id: 'bb', name: 'bb' })],
+      }),
+    ]
+    renderGraph(steps)
+    expect(screen.getByTestId('node-par')).toBeInTheDocument()
+    expect(screen.getByTestId('node-ba')).toBeInTheDocument()
+    expect(screen.getByTestId('node-bb')).toBeInTheDocument()
+  })
+})
+
+// ── Conditional topology ──────────────────────────────────────────────────────
+
+describe('WorkflowGraph — conditional topology', () => {
+  it('conditional node has isConditional=true in graph data', () => {
+    const steps = [step({ id: 'cond', name: 'check', type: 'condition' })]
+    const { nodes } = buildGraphElements(steps)
+    const condNode = nodes.find((n) => n.id === 'cond')
+    expect(condNode?.data.isConditional).toBe(true)
+  })
+
+  it('yes branch: edge from cond → yes-step uses sourceHandle="yes"', () => {
+    const steps = [
+      step({
+        id: 'cond',
+        name: 'check-license',
+        type: 'condition',
+        steps: [step({ id: 'yes-step', name: 'ok-path' })],
+      }),
+    ]
+    const { edges } = buildGraphElements(steps)
+    const yesEdge = edges.find((e) => e.source === 'cond' && e.target === 'yes-step')
+    expect(yesEdge).toBeDefined()
+    expect(yesEdge?.sourceHandle).toBe('yes')
+  })
+
+  it('no branch rejoins the step following the conditional', () => {
+    const steps = [
+      step({
+        id: 'cond',
+        name: 'check-license',
+        type: 'condition',
+        steps: [step({ id: 'yes-step', name: 'ok-path' })],
+      }),
+      step({ id: 'after', name: 'after-cond' }),
+    ]
+    const { edges } = buildGraphElements(steps)
+    const noEdge = edges.find(
+      (e) => e.source === 'cond' && e.target === 'after' && e.sourceHandle === 'no',
+    )
+    expect(noEdge).toBeDefined()
+    expect(edges.some((e) => e.source === 'yes-step' && e.target === 'after')).toBe(true)
+  })
+
+  it('renders both labeled branch ports on the conditional node', () => {
+    renderGraph([
+      step({
+        id: 'cond',
+        name: 'check',
+        type: 'condition',
+        steps: [step({ id: 'yes-step', name: 'ok-path' })],
+      }),
+    ])
+    expect(screen.getByText('yes')).toBeInTheDocument()
+    expect(screen.getByText('no')).toBeInTheDocument()
+  })
+
+  it('conditional type "conditional" is also recognized', () => {
+    const steps = [step({ id: 'c', name: 'c', type: 'conditional' })]
+    const { nodes } = buildGraphElements(steps)
+    const n = nodes.find((n) => n.id === 'c')
+    expect(n?.data.isConditional).toBe(true)
+  })
+})
+
+// ── Switch topology ───────────────────────────────────────────────────────────
+
+describe('WorkflowGraph — switch topology', () => {
+  it('switch renders one labeled edge per case with sequential case-N handles', () => {
+    const steps = [
+      step({
+        id: 'sw',
+        name: 'route',
+        type: 'switch',
+        switch: [
+          { label: 'option-a', steps: [step({ id: 'a', name: 'handle-a' })] },
+          { label: 'option-b', steps: [step({ id: 'b', name: 'handle-b' })] },
+          { label: 'option-c', steps: [step({ id: 'c', name: 'handle-c' })] },
+        ],
+      }),
+    ]
+    const { edges } = buildGraphElements(steps)
+    expect(
+      edges.some((e) => e.source === 'sw' && e.target === 'a' && e.sourceHandle === 'case-0'),
+    ).toBe(true)
+    expect(
+      edges.some((e) => e.source === 'sw' && e.target === 'b' && e.sourceHandle === 'case-1'),
+    ).toBe(true)
+    expect(
+      edges.some((e) => e.source === 'sw' && e.target === 'c' && e.sourceHandle === 'case-2'),
+    ).toBe(true)
+    // Exactly one edge leaves the switch per case (plus none extra).
+    expect(edges.filter((e) => e.source === 'sw')).toHaveLength(3)
+  })
+
+  it('switch case labels are recorded in node data and rendered as port labels', () => {
+    const steps = [
+      step({
+        id: 'sw',
+        name: 'route',
+        type: 'switch',
+        switch: [
+          { label: 'opt-a', steps: [] },
+          { label: 'opt-b', steps: [] },
+        ],
+      }),
+    ]
+    const { nodes } = buildGraphElements(steps)
+    const swNode = nodes.find((n) => n.id === 'sw')
+    expect(Array.isArray(swNode?.data.switchCaseLabels)).toBe(true)
+    expect(swNode?.data.switchCaseLabels as string[]).toHaveLength(2)
+
+    renderGraph(steps)
+    expect(screen.getByText('opt-a')).toBeInTheDocument()
+    expect(screen.getByText('opt-b')).toBeInTheDocument()
+  })
+})
+
+// ── Execution colorization ────────────────────────────────────────────────────
+
+describe('WorkflowGraph — execution colorization', () => {
+  it('node matching current_step renders with running class', () => {
+    const steps = [step({ id: 'step-x', name: 'running-step' })]
+    const execution: WorkflowExecution = {
+      id: 'exec-1',
+      workflow_name: 'wf',
+      status: 'running',
+      start_time: '2026-01-01T00:00:00Z',
+      current_step: 'step-x',
+    }
+    renderGraph(steps, execution)
+    const nodeEl = screen.getByTestId('node-step-x')
+    expect(nodeEl.className).toContain('running')
+  })
+
+  it('step with completed status in step_results renders with done class', () => {
+    const steps = [step({ id: 'step-y', name: 'done-step' })]
+    const execution: WorkflowExecution = {
+      id: 'exec-1',
+      workflow_name: 'wf',
+      status: 'running',
+      start_time: '2026-01-01T00:00:00Z',
+      step_results: { 'step-y': { status: 'completed' } },
+    }
+    renderGraph(steps, execution)
+    const nodeEl = screen.getByTestId('node-step-y')
+    expect(nodeEl.className).toContain('done')
+  })
+
+  it('step with failed status in step_results renders with failed class', () => {
+    const steps = [step({ id: 'step-f', name: 'failed-step' })]
+    const execution: WorkflowExecution = {
+      id: 'exec-1',
+      workflow_name: 'wf',
+      status: 'failed',
+      start_time: '2026-01-01T00:00:00Z',
+      step_results: { 'step-f': { status: 'failed' } },
+    }
+    renderGraph(steps, execution)
+    const nodeEl = screen.getByTestId('node-step-f')
+    expect(nodeEl.className).toContain('failed')
+  })
+
+  it('only the matching step.id is colorized; siblings stay pending', () => {
+    const steps = [
+      step({ id: 'done-one', name: 'first' }),
+      step({ id: 'later-one', name: 'second' }),
+    ]
+    const execution: WorkflowExecution = {
+      id: 'exec-1',
+      workflow_name: 'wf',
+      status: 'running',
+      start_time: '2026-01-01T00:00:00Z',
+      step_results: { 'done-one': { status: 'completed' } },
+    }
+    renderGraph(steps, execution)
+    expect(screen.getByTestId('node-done-one').className).toContain('done')
+    expect(screen.getByTestId('node-later-one').className).toContain('pending')
+  })
+
+  it('a prototype-named step id resolves to pending, never an inherited property', () => {
+    // step ids are user-authored; "__proto__"/"constructor" must not be able to
+    // reach Object.prototype through the step_results lookup.
+    const steps = [
+      step({ id: '__proto__', name: 'proto-step' }),
+      step({ id: 'constructor', name: 'ctor-step' }),
+    ]
+    const execution: WorkflowExecution = {
+      id: 'exec-1',
+      workflow_name: 'wf',
+      status: 'running',
+      start_time: '2026-01-01T00:00:00Z',
+      step_results: {},
+    }
+    renderGraph(steps, execution)
+    expect(screen.getByTestId('node-__proto__').className).toContain('pending')
+    expect(screen.getByTestId('node-constructor').className).toContain('pending')
+    // Nothing (status lookup or dagre layout) wrote through to Object.prototype:
+    // its own properties are all non-enumerable, so any pollution shows up here.
+    expect(Object.keys(Object.prototype)).toHaveLength(0)
+  })
+
+  it('all nodes render as pending when no execution prop is provided', () => {
+    const steps = [step({ id: 'step-z', name: 'pending-step' })]
+    renderGraph(steps)
+    const nodeEl = screen.getByTestId('node-step-z')
+    expect(nodeEl.className).toContain('pending')
+  })
+
+  it('WorkflowGraph performs no fetching or polling internally', () => {
+    const steps = [step({ id: 'step-a', name: 'a' })]
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    renderGraph(steps)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
+  })
+})
+
+// ── A9.1 security: text nodes only, no innerHTML ──────────────────────────────
+
+describe('WorkflowGraph — A9.1 security (no dangerouslySetInnerHTML)', () => {
+  it('step name with XSS payload is rendered as a text node, not executed HTML', () => {
+    const xssName = '<img src=x onerror="window.__xss_graph=1">'
+    const steps = [step({ id: 's1', name: xssName })]
+    const { container } = renderGraph(steps)
+    // getByText confirms the string reached the DOM as a text node
+    expect(screen.getByText(xssName)).toBeInTheDocument()
+    // …and no element was parsed out of it.
+    expect(container.querySelector('img')).toBeNull()
+    expect((window as unknown as Record<string, unknown>).__xss_graph).toBeUndefined()
+  })
+
+  it('config-derived footer with an XSS payload is rendered as a text node', () => {
+    const payload = '<script>window.__xss_foot=1</script>'
+    const steps = [step({ id: 's1', name: 'runner', config: { module: payload } })]
+    const { container } = renderGraph(steps)
+    expect(screen.getByText(payload)).toBeInTheDocument()
+    expect(container.querySelector('script')).toBeNull()
+    expect((window as unknown as Record<string, unknown>).__xss_foot).toBeUndefined()
+  })
+
+  it('step type is rendered as a text node (getByText finds it)', () => {
+    const steps = [step({ id: 's1', name: 'step', type: 'module' })]
+    renderGraph(steps)
+    expect(screen.getByText('module')).toBeInTheDocument()
+  })
+
+  it('step name is rendered as a text node (getByText finds it)', () => {
+    const steps = [step({ id: 's1', name: 'my-step-name' })]
+    renderGraph(steps)
+    expect(screen.getByText('my-step-name')).toBeInTheDocument()
+  })
+})
+
+// ── Read-only surface ─────────────────────────────────────────────────────────
+
+describe('WorkflowGraph — read-only surface', () => {
+  it('renders successfully with only steps prop (no mutation callbacks in props)', () => {
+    const steps = [step({ id: 's1', name: 'step' })]
+    expect(() => renderGraph(steps)).not.toThrow()
+  })
+
+  it('React Flow nodes are not draggable and not selectable', () => {
+    const { container } = renderGraph([step({ id: 's1', name: 'step' })])
+    const wrapper = nodeWrapper(container, 's1')
+    // React Flow adds `draggable` / `selectable` classes only when the
+    // corresponding interaction is enabled.
+    expect(wrapper.classList.contains('draggable')).toBe(false)
+    expect(wrapper.classList.contains('selectable')).toBe(false)
+  })
+
+  it('renders an empty workflow (zero steps) as just the trigger node', () => {
+    const { container } = renderGraph([])
+    expect(screen.getByTestId('node-__trigger__')).toBeInTheDocument()
+    expect(container.querySelectorAll('.react-flow__node')).toHaveLength(1)
+  })
+})

--- a/web/src/workflow/WorkflowGraph.tsx
+++ b/web/src/workflow/WorkflowGraph.tsx
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * WorkflowGraph — read-only flowchart renderer (Story #3037).
+ *
+ * Renders a WorkflowStep[] block tree as a dagre-auto-laid-out React Flow
+ * graph. Typed nodes (module/condition/wait/gate/notify + synthetic trigger),
+ * edges derived from step nesting, run-state colorization from an optional
+ * WorkflowExecution prop.
+ *
+ * No editing, no drag, no connect — strictly read-only. The caller owns
+ * execution fetching via useExecutionStatus; this component only colors nodes
+ * from an already-fetched execution value.
+ *
+ * Security A9.1: step names, types, and config-derived footer text originate
+ * from user-authored workflow content. All strings are rendered as JSX text
+ * nodes — never dangerouslySetInnerHTML.
+ */
+import { useMemo } from 'react'
+import {
+  ReactFlow,
+  Handle,
+  Position,
+  Background,
+  BackgroundVariant,
+  type NodeProps,
+  type Node as RFNode,
+  type Edge as RFEdge,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import Dagre from '@dagrejs/dagre'
+import type { WorkflowStep, WorkflowExecution } from './useWorkflows.ts'
+import './WorkflowGraph.css'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const NODE_W = 150
+const NODE_H = 82
+// Fixed id for the synthetic trigger node (no backing WorkflowStep)
+export const TRIGGER_NODE_ID = '__trigger__'
+
+// ── Node data ─────────────────────────────────────────────────────────────────
+
+interface WFNodeData extends Record<string, unknown> {
+  stepName: string
+  stepType: string
+  visualType: string
+  runState: 'done' | 'running' | 'failed' | 'pending'
+  footer: string
+  isConditional: boolean
+  switchCaseLabels: string[] | null
+}
+
+type WFNode = RFNode<WFNodeData, 'workflowNode'>
+
+// ── Visual-type mapping ───────────────────────────────────────────────────────
+
+function toVisualType(stepType: string): string {
+  switch (stepType) {
+    case 'trig':
+    case 'trigger':
+      return 'trig'
+    case 'module':
+    case 'script':
+    case 'api':
+    case 'http':
+      return 'module'
+    case 'condition':
+    case 'conditional':
+      return 'cond'
+    case 'wait':
+    case 'poll':
+      return 'wait'
+    case 'approval':
+    case 'gate':
+      return 'gate'
+    case 'notify':
+    case 'notification':
+      return 'notify'
+    default:
+      return 'module'
+  }
+}
+
+function iconLabel(vtype: string): string {
+  switch (vtype) {
+    case 'trig':
+      return 'HK'
+    case 'module':
+      return 'MD'
+    case 'cond':
+      return 'IF'
+    case 'wait':
+      return 'WT'
+    case 'gate':
+      return 'AP'
+    case 'notify':
+      return 'NT'
+    default:
+      return 'MD'
+  }
+}
+
+// ── Run-state resolution ──────────────────────────────────────────────────────
+
+type RunState = 'done' | 'running' | 'failed' | 'pending'
+
+/*
+ * Step ids come from user-authored workflow content, so they are never used as
+ * a computed key into a plain object: `step_results['__proto__'].status` would
+ * read an inherited property rather than a real result. The execution is
+ * flattened once into a Map keyed by own enumerable properties only
+ * (Object.entries), which has no prototype chain to walk.
+ */
+interface ExecutionIndex {
+  currentStep: string
+  statuses: Map<string, string>
+}
+
+function indexExecution(execution: WorkflowExecution | undefined): ExecutionIndex | undefined {
+  if (!execution) return undefined
+  const statuses = new Map<string, string>()
+  for (const [stepID, result] of Object.entries(execution.step_results ?? {})) {
+    if (typeof result !== 'object' || result === null) continue
+    const status = (result as Record<string, unknown>).status
+    if (typeof status === 'string') statuses.set(stepID, status)
+  }
+  return { currentStep: execution.current_step ?? '', statuses }
+}
+
+function resolveRunState(stepId: string, index: ExecutionIndex | undefined): RunState {
+  if (!index) return 'pending'
+  if (index.currentStep !== '' && index.currentStep === stepId) return 'running'
+  const status = index.statuses.get(stepId)
+  if (status === 'completed') return 'done'
+  if (status === 'failed') return 'failed'
+  if (status === 'running') return 'running'
+  return 'pending'
+}
+
+// ── Custom node component ─────────────────────────────────────────────────────
+
+function WorkflowNode({ id, data }: NodeProps<WFNode>) {
+  const { stepName, stepType, visualType, runState, footer, isConditional, switchCaseLabels } =
+    data
+
+  const badge =
+    runState === 'done' ? '✓' : runState === 'running' ? '▸' : runState === 'failed' ? '✕' : null
+
+  const nodeClass = `wfg-node ${runState}`
+
+  // Source ports carry their own label so the render pass never indexes back
+  // into switchCaseLabels by position.
+  const ports: { id: string; label: string | null }[] = isConditional
+    ? [
+        { id: 'yes', label: 'yes' },
+        { id: 'no', label: 'no' },
+      ]
+    : switchCaseLabels
+      ? switchCaseLabels.map((label, i) => ({ id: `case-${i}`, label }))
+      : [{ id: 'out', label: null }]
+
+  return (
+    <div className={nodeClass} data-testid={`node-${id}`}>
+      {badge !== null && <span className="wfg-badge">{badge}</span>}
+      <Handle type="target" position={Position.Left} id="in" />
+      <div className="wfg-nhead">
+        <span className={`wfg-nico ${visualType}`}>{iconLabel(visualType)}</span>
+        <div>
+          <div className="wfg-ntype">{stepType}</div>
+          <div className="wfg-nttl">{stepName}</div>
+        </div>
+      </div>
+      {footer && <div className="wfg-nfoot">{footer}</div>}
+      {ports.map((port) => (
+        <span key={port.id} className="wfg-port-wrap">
+          {port.label !== null && <span className="wfg-plabel">{port.label}</span>}
+          <Handle type="source" position={Position.Right} id={port.id} />
+        </span>
+      ))}
+    </div>
+  )
+}
+
+const nodeTypes = { workflowNode: WorkflowNode }
+
+// ── Graph building ────────────────────────────────────────────────────────────
+
+export interface GraphElements {
+  nodes: WFNode[]
+  edges: RFEdge[]
+}
+
+type ExitRef = { id: string; handle: string }
+
+function makeStepNode(step: WorkflowStep, execution: ExecutionIndex | undefined): WFNode {
+  const isConditional = step.type === 'condition' || step.type === 'conditional'
+  const isSwitchStep = step.type === 'switch'
+  const switchCaseLabels =
+    isSwitchStep && step.switch ? step.switch.map((c) => c.label) : null
+
+  const footer = extractFooter(step)
+  const visualType = toVisualType(step.type)
+  const runState = resolveRunState(step.id, execution)
+
+  return {
+    id: step.id,
+    type: 'workflowNode',
+    position: { x: 0, y: 0 },
+    data: {
+      stepName: step.name,
+      stepType: step.type,
+      visualType,
+      runState,
+      footer,
+      isConditional,
+      switchCaseLabels,
+    },
+  }
+}
+
+function extractFooter(step: WorkflowStep): string {
+  const cfg = step.config ?? {}
+  // Only extract safe scalar display values from config
+  if (typeof cfg.module === 'string') return cfg.module
+  if (typeof cfg.script === 'string') return cfg.script.substring(0, 40)
+  if (typeof cfg.channel === 'string') return cfg.channel
+  if (typeof cfg.until === 'string') return cfg.until
+  return ''
+}
+
+function makeEdge(
+  source: string,
+  target: string,
+  sourceHandle: string,
+  edgeRunState: RunState,
+): RFEdge {
+  const edgeClass =
+    edgeRunState === 'done' ? 'done' : edgeRunState === 'running' ? 'active' : 'pend'
+  return {
+    id: `${source}:${sourceHandle}->${target}`,
+    source,
+    target,
+    sourceHandle,
+    targetHandle: 'in',
+    className: edgeClass,
+    type: 'default',
+  }
+}
+
+// Recursively build nodes and edges for a list of steps, returning exit refs
+// so the caller can wire the next sibling's entry edges.
+function processStepList(
+  steps: WorkflowStep[],
+  predExits: ExitRef[],
+  elements: GraphElements,
+  execution: ExecutionIndex | undefined,
+): ExitRef[] {
+  let currentExits = predExits
+
+  for (const step of steps) {
+    elements.nodes.push(makeStepNode(step, execution))
+
+    // Wire predecessors → this step
+    const entryState = resolveRunState(currentExits[0]?.id ?? TRIGGER_NODE_ID, execution)
+    for (const pred of currentExits) {
+      elements.edges.push(makeEdge(pred.id, step.id, pred.handle, entryState))
+    }
+
+    const type = step.type
+
+    if ((type === 'condition' || type === 'conditional') && step.steps?.length) {
+      // yes branch runs the nested steps; no branch exits unresolved from cond node
+      const yesExits = processStepList(
+        step.steps,
+        [{ id: step.id, handle: 'yes' }],
+        elements,
+        execution,
+      )
+      currentExits = [...yesExits, { id: step.id, handle: 'no' }]
+    } else if (type === 'switch' && step.switch?.length) {
+      const allBranchExits: ExitRef[] = []
+      step.switch.forEach((switchCase, i) => {
+        if (switchCase.steps.length) {
+          const exits = processStepList(
+            switchCase.steps,
+            [{ id: step.id, handle: `case-${i}` }],
+            elements,
+            execution,
+          )
+          allBranchExits.push(...exits)
+        } else {
+          allBranchExits.push({ id: step.id, handle: `case-${i}` })
+        }
+      })
+      currentExits = allBranchExits
+    } else if (
+      (type === 'parallel' || type === 'fanout' || type === 'fan_out') &&
+      step.steps?.length
+    ) {
+      // Fan-out: step node is the fan-out point; each child branch exits independently
+      const allBranchExits: ExitRef[] = []
+      for (const child of step.steps) {
+        const exits = processStepList(
+          [child],
+          [{ id: step.id, handle: 'out' }],
+          elements,
+          execution,
+        )
+        allBranchExits.push(...exits)
+      }
+      currentExits = allBranchExits
+    } else if (type === 'sequential' && step.steps?.length) {
+      // Chain children sequentially under this container
+      currentExits = processStepList(
+        step.steps,
+        [{ id: step.id, handle: 'out' }],
+        elements,
+        execution,
+      )
+    } else if (
+      (type === 'for' || type === 'while' || type === 'foreach') &&
+      step.steps?.length
+    ) {
+      // Render loop body once (no loop-back visual in read-only view)
+      processStepList(
+        step.steps,
+        [{ id: step.id, handle: 'out' }],
+        elements,
+        execution,
+      )
+      currentExits = [{ id: step.id, handle: 'out' }]
+    } else {
+      currentExits = [{ id: step.id, handle: 'out' }]
+    }
+  }
+
+  return currentExits
+}
+
+export function buildGraphElements(
+  steps: WorkflowStep[],
+  execution?: WorkflowExecution,
+): GraphElements {
+  const elements: GraphElements = { nodes: [], edges: [] }
+  const index = indexExecution(execution)
+
+  // Synthetic trigger node — no backing WorkflowStep
+  const trigRunState: 'done' | 'pending' = execution ? 'done' : 'pending'
+  elements.nodes.push({
+    id: TRIGGER_NODE_ID,
+    type: 'workflowNode',
+    position: { x: 0, y: 0 },
+    data: {
+      stepName: 'start',
+      stepType: 'trigger',
+      visualType: 'trig',
+      runState: trigRunState,
+      footer: '',
+      isConditional: false,
+      switchCaseLabels: null,
+    },
+  })
+
+  processStepList(steps, [{ id: TRIGGER_NODE_ID, handle: 'out' }], elements, index)
+
+  return elements
+}
+
+// ── Dagre layout ──────────────────────────────────────────────────────────────
+
+/*
+ * graphlib keeps its node/edge tables in plain objects keyed by node id, so a
+ * step id authored as "__proto__" (or "constructor") would write through the
+ * prototype chain and corrupt Object.prototype for the whole page. Layout
+ * therefore runs on opaque generated keys, and positions are mapped back onto
+ * the real node ids afterwards — user-authored ids never reach graphlib.
+ */
+function applyDagreLayout(nodes: WFNode[], edges: RFEdge[]): WFNode[] {
+  const layoutKeys = new Map<string, string>()
+  nodes.forEach((n, i) => {
+    if (!layoutKeys.has(n.id)) layoutKeys.set(n.id, `n${i}`)
+  })
+
+  const g = new Dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'LR', nodesep: 50, ranksep: 60, marginx: 20, marginy: 20 })
+
+  for (const n of nodes) {
+    const key = layoutKeys.get(n.id)
+    if (key === undefined) continue
+    g.setNode(key, { width: NODE_W, height: NODE_H })
+  }
+  for (const e of edges) {
+    const source = layoutKeys.get(e.source)
+    const target = layoutKeys.get(e.target)
+    if (source === undefined || target === undefined) continue
+    g.setEdge(source, target)
+  }
+
+  Dagre.layout(g)
+
+  return nodes.map((n) => {
+    const key = layoutKeys.get(n.id)
+    const pos = key === undefined ? undefined : g.node(key)
+    if (pos === undefined) return n
+    return {
+      ...n,
+      position: { x: pos.x - NODE_W / 2, y: pos.y - NODE_H / 2 },
+    }
+  })
+}
+
+// ── WorkflowGraph component ───────────────────────────────────────────────────
+
+export interface WorkflowGraphProps {
+  steps: WorkflowStep[]
+  execution?: WorkflowExecution
+}
+
+export default function WorkflowGraph({ steps, execution }: WorkflowGraphProps) {
+  const { nodes: rawNodes, edges } = useMemo(
+    () => buildGraphElements(steps, execution),
+    [steps, execution],
+  )
+
+  const nodes = useMemo(() => applyDagreLayout(rawNodes, edges), [rawNodes, edges])
+
+  return (
+    <div className="wfg-root">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+      >
+        <Background variant={BackgroundVariant.Dots} gap={22} size={1.4} />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/web/src/workflow/useWorkflows.ts
+++ b/web/src/workflow/useWorkflows.ts
@@ -42,11 +42,23 @@ function bool(value: unknown): boolean {
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+export interface SwitchCase {
+  label: string
+  steps: WorkflowStep[]
+}
+
 export interface WorkflowStep {
   id: string
   name: string
   type: string
   config?: Record<string, unknown>
+  // Nested block tree fields — used by WorkflowGraph renderer (Story #3037)
+  steps?: WorkflowStep[]        // children of sequential/parallel/loop containers
+  condition?: string            // expression string for conditional steps
+  switch?: SwitchCase[]         // cases for switch steps
+  loop?: boolean                // true for for/while/foreach container steps
+  fan_out?: boolean
+  fan_in?: boolean
 }
 
 export interface SemanticVersion {
@@ -99,10 +111,21 @@ export interface TriggerItem {
 
 // ── Parse helpers ─────────────────────────────────────────────────────────────
 
-function parseStep(value: unknown): WorkflowStep | null {
+function parseSwitchCase(value: unknown): SwitchCase | null {
   if (typeof value !== 'object' || value === null) return null
   const r = value as Record<string, unknown>
   return {
+    label: str(r.label),
+    steps: Array.isArray(r.steps)
+      ? r.steps.flatMap((s) => { const p = parseStep(s); return p ? [p] : [] })
+      : [],
+  }
+}
+
+function parseStep(value: unknown): WorkflowStep | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const step: WorkflowStep = {
     id: str(r.id),
     name: str(r.name),
     type: str(r.type),
@@ -111,6 +134,17 @@ function parseStep(value: unknown): WorkflowStep | null {
         ? (r.config as Record<string, unknown>)
         : {},
   }
+  if (Array.isArray(r.steps)) {
+    step.steps = r.steps.flatMap((s) => { const p = parseStep(s); return p ? [p] : [] })
+  }
+  if (r.condition !== undefined) step.condition = str(r.condition)
+  if (Array.isArray(r.switch)) {
+    step.switch = r.switch.flatMap((c) => { const p = parseSwitchCase(c); return p ? [p] : [] })
+  }
+  if (r.loop !== undefined) step.loop = bool(r.loop)
+  if (r.fan_out !== undefined) step.fan_out = bool(r.fan_out)
+  if (r.fan_in !== undefined) step.fan_in = bool(r.fan_in)
+  return step
 }
 
 function parseSemanticVersion(value: unknown): SemanticVersion {


### PR DESCRIPTION
## Summary

- Adds `WorkflowGraph` — a standalone read-only React component that renders a `WorkflowStep[]` nested block tree as a Dagre-auto-laid-out React Flow graph with typed nodes (trig/module/cond/wait/gate/notify), edges derived from block nesting, and optional execution colorization.
- Expands `WorkflowStep` / `parseStep` in `useWorkflows.ts` with recursive `steps`, `condition`, `switch` (SwitchCase[]), loop markers, and fan_out/fan_in fields the renderer needs.
- Adds `@xyflow/react` (MIT, v12) and `@dagrejs/dagre` (MIT, v3) — bundled same-origin by Vite, no external/CDN fetch.

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS (3 rounds — security reviewer had 529 API errors on rounds 1-2; cleared cleanly on round 3) |

## Test plan

- [x] `WorkflowGraph.test.tsx` — 26 tests: sequential chain topology, parallel fan-out/fan-in, conditional yes/no handles, switch case-N handles, step.id-keyed nodes, dagre assigns distinct non-zero positions, execution colorization (running/done/failed/pending), no-fetch guarantee, A9.1 XSS-as-text-node, read-only surface
- [x] All 1104 web tests pass (`npm test`)
- [x] `vite build` succeeds — single 447 kB JS chunk, no CDN fetch
- [x] TypeScript clean (`tsc -b`)

## Key design decisions

- **`@xyflow/react` + `@dagrejs/dagre`** per Tech Lead decision; no re-litigation.
- **Prototype-safe execution indexing**: `step_results` is flattened into a `Map` via `Object.entries` (not plain-object property access) so a crafted step id like `__proto__` cannot walk the prototype chain.
- **Read-only**: no `onNodeClick`, no `onConnect`, no drag handlers — `nodesDraggable={false}`, `nodesConnectable={false}`, `elementsSelectable={false}`.
- **No fetching**: `WorkflowGraph` accepts an already-fetched `execution?` prop; callers own polling via the existing `useExecutionStatus` hook.
- **A9.1**: all `stepName`, `stepType`, and footer strings render as JSX text nodes; `dangerouslySetInnerHTML` is never used.

Fixes #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)