### PR TITLE
workflow: fix promote-hv-role template validation bugs (charset, semver) (Issue #3106)

### DIFF
--- a/cmd/cfg/cmd/templates/promote-hv-role.yaml
+++ b/cmd/cfg/cmd/templates/promote-hv-role.yaml
@@ -4,41 +4,28 @@
 workflow:
   name: promote-hv-role
   description: >
-    Hyper-V VM promotion from standalone to Failover Cluster role.
+    Hyper-V VM promotion from standalone to Failover Cluster role: writes
+    ha_role into device-scope config [set_ha_role], soaks to register the
+    cluster VM role, then moves the VM resource to cluster-policies scope
+    [move_resource_to_cluster].
 
-    Writes the ha_role block into the target VM's device-scope config
-    (set_ha_role step), soaks for a fixed delay to allow the steward's
-    convergence loop to register the cluster VM role, then moves the VM
-    resource definition from device scope to cluster-policies scope
-    (move_resource_to_cluster step).
+    Soak delay is a fixed wait; SetConfiguration triggers immediate fanout
+    push so the steward does not poll before acting. Increase delay at
+    execute time for slow cluster registration; default 30s is intentionally
+    conservative.
 
-    The soak delay is a fixed wait, not an active convergence check.
-    ConfigurationServiceV2.SetConfiguration triggers an immediate fanout push
-    to the steward, so the delay window is tight; the steward does not need to
-    poll before acting. For slow cluster registration, increase the delay at
-    execute time by passing an updated workflow definition — this default (30s)
-    is intentionally conservative.
+    Halts [on_failure: stop] if set_ha_role fails; no cluster-scope write
+    occurs when device-scope config is incomplete.
 
-    The workflow halts (on_failure: stop) if set_ha_role fails, ensuring no
-    cluster-scope write is attempted when the device-scope config is incomplete.
+    Operator setup: 1. Supply vm_name, steward_id, cluster_name, tenant_id
+    via cfg workflow promote-hv-role or the REST API execute endpoint
+    [variables map]; do not edit placeholders. 2. Target steward must be
+    registered and manage the VM. 3. Soak delay [step 2, 30s] is fixed;
+    Epic 2520 tracks convergence-poll gaps.
 
-    Operator setup:
-      1. Supply vm_name, steward_id, cluster_name, and tenant_id at execute
-         time via "cfg workflow promote-hv-role" (S5) or directly via
-         POST .../execute {"variables": {...}}.  Do NOT edit the variable
-         placeholders in this file — they are intentionally empty strings;
-         real values are always injected at execute time, not templated here.
-      2. Ensure the target steward (steward_id) is registered, reachable, and
-         already manages the VM (vm_name) before executing this workflow.
-      3. The soak delay (step 2, default 30s) is a fixed wait, not an active
-         convergence check. Epic #2520 tracks convergence-poll gaps; this
-         workflow intentionally avoids unreliable DNA polling in v1.
-
-    Durability note (v1): this workflow runs on the in-memory engine. A
-    controller restart during execution loses progress; re-run the workflow.
-    Config writes that completed before the restart are durable (git-backed).
-
-  version: "1.0"
+    Durability: runs on the in-memory engine. Restart loses progress; re-run.
+    Config writes before restart are durable [git-backed].
+  version: "1.0.0"
   timeout: 10m
   on_failure: stop
 

--- a/cmd/cfg/cmd/workflow_test.go
+++ b/cmd/cfg/cmd/workflow_test.go
@@ -12,8 +12,11 @@ import (
 	"strings"
 	"testing"
 
+	wfpkg "github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/pkg/security"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestWorkflowRunCmd_MissingFile(t *testing.T) {
@@ -1016,4 +1019,32 @@ func TestWorkflowPromoteHVRoleCmd_RequiresExactlyTwoArgs(t *testing.T) {
 
 	err = workflowPromoteHVRoleCmd.Args(workflowPromoteHVRoleCmd, []string{"vmname", "selector"})
 	require.NoError(t, err)
+}
+
+// ---- promote-hv-role template validation -------------------------------------
+
+// TestPromoteHVRoleTemplate_PassesProductionValidation verifies the embedded
+// promote-hv-role template satisfies the exact constraints enforced by
+// validateGenericRequest (validation_middleware.go): charset:safe_text and
+// max_length:1024 on description, and ParseSemanticVersion on version.
+// Uses the production validator — not a hand-rolled approximation — per AC.
+func TestPromoteHVRoleTemplate_PassesProductionValidation(t *testing.T) {
+	var wrapper workflowFileWrapper
+	require.NoError(t, yaml.Unmarshal(promoteHVRoleTemplateData, &wrapper),
+		"embedded template must parse as valid YAML")
+
+	desc := wrapper.Workflow.Description
+
+	validator := security.NewValidator()
+	result := &security.ValidationResult{Valid: true}
+	validator.ValidateString(result, "body.description", desc, "charset:safe_text", "max_length:1024")
+
+	assert.True(t, result.Valid,
+		"description must pass charset:safe_text + max_length:1024 (validateGenericRequest): %v", result.Errors)
+	assert.LessOrEqual(t, len(desc), 1024,
+		"description must be at most 1024 characters (validateGenericRequest body.description)")
+
+	_, err := wfpkg.ParseSemanticVersion(wrapper.Workflow.Version)
+	assert.NoError(t, err,
+		"version %q must parse as semantic version N.N.N (ParseSemanticVersion)", wrapper.Workflow.Version)
 }

--- a/features/controller/api/handlers_workflows_promote_hv_role_test.go
+++ b/features/controller/api/handlers_workflows_promote_hv_role_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// TestPromoteHVRoleTemplate_CreateAndExecute_AgainstRealController is the
+// integration-style regression test for Issue #3106: it drives the
+// promote-hv-role.yaml template through the real controller HTTP stack --
+// the same api.Server construction (New()) production uses, the real
+// validationMiddleware / validateGenericRequest, the real RBAC permission
+// gate, the real handleCreateWorkflow -> workflow.ParseSemanticVersion, and
+// a real git-backed WorkflowStore -- rather than a hand-rolled httptest mock
+// (makePromoteServer in cmd/cfg/cmd/workflow_test.go, which never calls
+// validateGenericRequest) or an in-process call directly into
+// security.NewValidator() (TestPromoteHVRoleTemplate_PassesProductionValidation).
+//
+// Before the #3106 fix, POSTing this template's description hit HTTP 400
+// from validateGenericRequest's charset:safe_text check; this test proves
+// the fixed template clears that check when submitted exactly as
+// `cfg workflow promote-hv-role` submits it: create, then execute.
+func TestPromoteHVRoleTemplate_CreateAndExecute_AgainstRealController(t *testing.T) {
+	server := setupTestServer(t)
+
+	storageManager := pkgtesting.SetupTestStorage(t)
+	configStore := storageManager.GetConfigStore()
+	logger := logging.NewNoopLogger()
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil, nil, nil, nil, nil)
+	handler := NewWorkflowHandler(engine, configStore, nil, logger)
+	server.SetWorkflowHandler(handler)
+
+	parser := workflow.NewParser()
+	wf, err := parser.ParseFile("../../workflow/templates/promote-hv-role.yaml")
+	require.NoError(t, err, "authoritative promote-hv-role.yaml must parse")
+
+	createReq := CreateWorkflowRequest{
+		Name:        wf.Name,
+		Description: wf.Description,
+		Version:     wf.Version,
+		Steps:       wf.Steps,
+		Variables:   wf.Variables,
+		Timeout:     wf.Timeout,
+	}
+	body, err := json.Marshal(createReq)
+	require.NoError(t, err)
+
+	apiKey := NewTestKey(t, server, []string{"workflow:write", "workflow:execute"})
+
+	createHTTPReq := httptest.NewRequest(http.MethodPost, "/api/v1/workflows", bytes.NewReader(body))
+	createHTTPReq.Header.Set("X-API-Key", apiKey)
+	createHTTPReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.router.ServeHTTP(createRec, createHTTPReq)
+
+	require.Equal(t, http.StatusCreated, createRec.Code,
+		"creating promote-hv-role against the real controller must succeed "+
+			"(pre-fix: 400 from validateGenericRequest on description charset): %s", createRec.Body.String())
+
+	variables := map[string]interface{}{
+		"vm_name":      "test-vm",
+		"steward_id":   "test-steward",
+		"cluster_name": "test-cluster",
+		"tenant_id":    "test-tenant",
+	}
+	execBody, err := json.Marshal(map[string]interface{}{"variables": variables})
+	require.NoError(t, err)
+
+	execHTTPReq := httptest.NewRequest(http.MethodPost, "/api/v1/workflows/"+wf.Name+"/execute", bytes.NewReader(execBody))
+	execHTTPReq.Header.Set("X-API-Key", apiKey)
+	execHTTPReq.Header.Set("Content-Type", "application/json")
+	execRec := httptest.NewRecorder()
+	server.router.ServeHTTP(execRec, execHTTPReq)
+
+	assert.Equal(t, http.StatusAccepted, execRec.Code,
+		"executing promote-hv-role against the real controller must succeed: %s", execRec.Body.String())
+}

--- a/features/workflow/templates/promote-hv-role.yaml
+++ b/features/workflow/templates/promote-hv-role.yaml
@@ -3,41 +3,28 @@
 workflow:
   name: promote-hv-role
   description: >
-    Hyper-V VM promotion from standalone to Failover Cluster role.
+    Hyper-V VM promotion from standalone to Failover Cluster role: writes
+    ha_role into device-scope config [set_ha_role], soaks to register the
+    cluster VM role, then moves the VM resource to cluster-policies scope
+    [move_resource_to_cluster].
 
-    Writes the ha_role block into the target VM's device-scope config
-    (set_ha_role step), soaks for a fixed delay to allow the steward's
-    convergence loop to register the cluster VM role, then moves the VM
-    resource definition from device scope to cluster-policies scope
-    (move_resource_to_cluster step).
+    Soak delay is a fixed wait; SetConfiguration triggers immediate fanout
+    push so the steward does not poll before acting. Increase delay at
+    execute time for slow cluster registration; default 30s is intentionally
+    conservative.
 
-    The soak delay is a fixed wait, not an active convergence check.
-    ConfigurationServiceV2.SetConfiguration triggers an immediate fanout push
-    to the steward, so the delay window is tight; the steward does not need to
-    poll before acting. For slow cluster registration, increase the delay at
-    execute time by passing an updated workflow definition — this default (30s)
-    is intentionally conservative.
+    Halts [on_failure: stop] if set_ha_role fails; no cluster-scope write
+    occurs when device-scope config is incomplete.
 
-    The workflow halts (on_failure: stop) if set_ha_role fails, ensuring no
-    cluster-scope write is attempted when the device-scope config is incomplete.
+    Operator setup: 1. Supply vm_name, steward_id, cluster_name, tenant_id
+    via cfg workflow promote-hv-role or the REST API execute endpoint
+    [variables map]; do not edit placeholders. 2. Target steward must be
+    registered and manage the VM. 3. Soak delay [step 2, 30s] is fixed;
+    Epic 2520 tracks convergence-poll gaps.
 
-    Operator setup:
-      1. Supply vm_name, steward_id, cluster_name, and tenant_id at execute
-         time via "cfg workflow promote-hv-role" (S5) or directly via
-         POST .../execute {"variables": {...}}.  Do NOT edit the variable
-         placeholders in this file — they are intentionally empty strings;
-         real values are always injected at execute time, not templated here.
-      2. Ensure the target steward (steward_id) is registered, reachable, and
-         already manages the VM (vm_name) before executing this workflow.
-      3. The soak delay (step 2, default 30s) is a fixed wait, not an active
-         convergence check. Epic #2520 tracks convergence-poll gaps; this
-         workflow intentionally avoids unreliable DNA polling in v1.
-
-    Durability note (v1): this workflow runs on the in-memory engine. A
-    controller restart during execution loses progress; re-run the workflow.
-    Config writes that completed before the restart are durable (git-backed).
-
-  version: "1.0"
+    Durability: runs on the in-memory engine. Restart loses progress; re-run.
+    Config writes before restart are durable [git-backed].
+  version: "1.0.0"
   timeout: 10m
   on_failure: stop
 

--- a/features/workflow/templates/promote-hv-role_test.go
+++ b/features/workflow/templates/promote-hv-role_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/pkg/security"
 )
 
 func TestPromoteHVRoleTemplateParses(t *testing.T) {
@@ -36,4 +37,29 @@ func TestPromoteHVRoleTemplateParses(t *testing.T) {
 	// Delay step must carry a positive duration so the engine can execute it.
 	require.NotNil(t, wf.Steps[1].Delay, "delay step must have a delay config block")
 	assert.Greater(t, wf.Steps[1].Delay.Duration, time.Duration(0), "delay duration must be positive")
+}
+
+// TestPromoteHVRoleTemplate_AuthoritativeSource_PassesProductionValidation confirms
+// the authoritative template copy (features/workflow/templates/) also satisfies the
+// same validateGenericRequest constraints tested via the embedded CLI copy.  Both
+// copies are byte-identical after their header comments, but keeping the assertion
+// here prevents a future edit to this file from silently reintroducing a description
+// that the controller's validation middleware would reject.
+func TestPromoteHVRoleTemplate_AuthoritativeSource_PassesProductionValidation(t *testing.T) {
+	parser := workflow.NewParser()
+	wf, err := parser.ParseFile("promote-hv-role.yaml")
+	require.NoError(t, err, "promote-hv-role.yaml must parse")
+
+	validator := security.NewValidator()
+	result := &security.ValidationResult{Valid: true}
+	validator.ValidateString(result, "body.description", wf.Description, "charset:safe_text", "max_length:1024")
+
+	assert.True(t, result.Valid,
+		"description must pass charset:safe_text + max_length:1024 (validateGenericRequest): %v", result.Errors)
+	assert.LessOrEqual(t, len(wf.Description), 1024,
+		"description must be at most 1024 characters")
+
+	_, err = workflow.ParseSemanticVersion(wf.Version)
+	assert.NoError(t, err,
+		"version %q must parse as semantic version N.N.N (ParseSemanticVersion)", wf.Version)
 }


### PR DESCRIPTION
## Summary

- Rewrites the `promote-hv-role` workflow template `description:` in both copies to use only `charset:safe_text`-allowed characters and fit within 1024 characters (1023 after YAML folding). The original description contained double-quotes, curly braces, em-dashes, hash signs, and forward slashes — all rejected by the controller's `validateGenericRequest` — causing HTTP 400 on every `cfg workflow promote-hv-role` invocation.
- Changes `version: "1.0"` to `version: "1.0.0"` so `ParseSemanticVersion` accepts it (requires three numeric groups).
- Adds `TestPromoteHVRoleTemplate_PassesProductionValidation` (embedded CLI copy) and `TestPromoteHVRoleTemplate_AuthoritativeSource_PassesProductionValidation` (authoritative features/ copy) using the exact production `security.NewValidator()` and `workflow.ParseSemanticVersion` — not hand-rolled approximations.

Fixes #3106

## Which constraint is empirically load-bearing

The **charset:safe_text violation** is load-bearing. `ValidateString` enforces the charset regex on every non-empty value; the global 4096-byte length ceiling is never reached (the original description is ~1773 chars). The `max_length:1024` rule string passed to `ValidateString` is documented intent — it is not independently enforced by the validator's `ValidateString` implementation — so the description was written to satisfy both the regex and the 1024-char target regardless.

## Cluster derivation coverage (AC note)

`cfg workflow promote-hv-role` working for **any cluster member** (not only the CNO owner) is already verified by:

- **`cmd/cfg/cmd/workflow_test.go:705-817`** — nine `TestDeriveHVPromoteCluster_*` cases covering zero-cluster, single-cluster (auto-derive + override match/mismatch), multi-cluster (ambiguous + override match/mismatch), nil-DNA, and malformed-key edge cases.
- **`features/controller/clusterregistry/registry_test.go:192` (`TestBuildRegistry_NonCNOSteward_HasClusterMembership`)** — independently proves the non-CNO DNA shape resolves at the registry layer (landed with #2891/PR #2924).

No new test was written for this sub-part per story scope.

## Docs

`docs/testing/hyperv-role-promotion-runbook.md` contains no `cfg workflow promote-hv-role` CLI invocation example that would hit the description/version validation failures. No update required (N/A justified).

## Specialist review results

| Lens | Verdict |
|------|---------|
| QA Code Reviewer | **PASS** — no mock usage, no skips, real production validators used in tests, thorough error-path coverage |
| QA Test Runner | **PASS** — `make test-agent-complete` exits 0 |
| Security Engineer | **PASS** — no blocking findings; gosec, staticcheck, Trivy, Nancy clean; no new secrets, SQL, or logging surfaces |

## Test plan

- [x] `TestPromoteHVRoleTemplate_PassesProductionValidation` — charset:safe_text + max_length:1024 + ParseSemanticVersion on embedded CLI copy
- [x] `TestPromoteHVRoleTemplate_AuthoritativeSource_PassesProductionValidation` — same constraints on authoritative features/ copy
- [x] All nine `TestDeriveHVPromoteCluster_*` cases pass
- [x] All `TestRunWorkflowPromoteHVRole_*` integration tests pass against mock server
- [x] Both template copies byte-identical from `workflow:` key onwards (verified via `diff`)
- [x] `make test-agent-complete` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)