### PR TITLE
modules/resolution: observe-resolution — match observe_when against baseline DNA (Issue #3103)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -1208,3 +1208,31 @@ cfg module approve <publisher>/<name>@<version>
 `cfg module approve` calls `POST /api/v1/modules/<publisher>/<name>/<version>/approve`, which invokes `ApprovalWorkflow.Approve()` server-side. Only bundles in `pending` state can be approved; an error is returned for bundles that are already approved or rejected.
 
 Admin mTLS authentication (via admin bundle file) is required for both commands, following the same auth pattern as `cfg registration approve`.
+
+## Observe-Resolution: DNA-driven Module Activation
+
+`ResolveObserveModules` (`features/controller/modules/resolution/observe.go`) computes the set of modules a steward should observe based on its baseline DNA attributes and the registered module manifests.
+
+### How it works
+
+Each module manifest may carry an `observe_when` list of predicates. `ResolveObserveModules` takes a DNA attribute map and a slice of manifests, and returns the names of modules that match:
+
+- A manifest with no `observe_when` (nil or empty) is **never** included. Absence means "never auto-pull for DNA" (ADR-024 §2).
+- Predicates within a single manifest use **OR semantics**: any one matching predicate activates that module.
+- `equals` requires an exact string match of the DNA attribute value.
+- `contains` requires `strings.Contains` on the DNA attribute value.
+
+### Relation to `ResolveCfgRequiredModules`
+
+These are two distinct resolution functions serving different triggers:
+
+| Function | File | Trigger | Input | Purpose |
+|---|---|---|---|---|
+| `ResolveCfgRequiredModules` | `resolution.go` | Cfg deployment | `required_modules:` list from cfg | Verify/fetch/approve modules before a cfg can deploy |
+| `ResolveObserveModules` | `observe.go` | Baseline DNA available | DNA attribute map + manifests | Determine which modules to auto-pull for read-only DNA observation |
+
+Do not conflate the two. `required_modules:` is a deployment-time cfg contract; `observe_when` is a baseline-fact-driven auto-pull signal. They use separate code paths intentionally.
+
+### Purity guarantee
+
+`ResolveObserveModules` is a pure function — no I/O, no RPC, no side effects. Wiring the result into a steward-facing RPC (the observation pull path) is the responsibility of the sibling steward observation loop story.

--- a/features/controller/modules/resolution/observe.go
+++ b/features/controller/modules/resolution/observe.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+package resolution
+
+import (
+	"strings"
+
+	modules "github.com/cfgis/cfgms/features/modules"
+)
+
+// ResolveObserveModules returns the names of modules whose observe_when predicates
+// match the given baseline DNA attribute map.
+//
+// Matching rules (ADR-024 §5):
+//   - A manifest with nil or empty ObserveWhen never appears in the result.
+//     Absence of ObserveWhen means "never auto-pull for DNA" (ADR-024 §2).
+//   - Predicates within a single manifest are OR'd: any one match activates
+//     that module. equals requires exact string equality; contains requires
+//     strings.Contains on the fact value.
+//
+// This is a pure function — no I/O, no RPC. The wiring to an actual call site
+// (steward observation loop RPC) is handled by a separate sibling story.
+func ResolveObserveModules(dna map[string]string, manifests []*modules.ModuleMetadata) []string {
+	if len(manifests) == 0 {
+		return nil
+	}
+
+	var result []string
+	for _, m := range manifests {
+		if len(m.ObserveWhen) == 0 {
+			continue
+		}
+		if matchesAnyPredicate(dna, m.ObserveWhen) {
+			result = append(result, m.Name)
+		}
+	}
+	return result
+}
+
+// matchesAnyPredicate returns true if at least one predicate in the list matches
+// the given DNA map (OR semantics across predicates).
+func matchesAnyPredicate(dna map[string]string, predicates []modules.ObservePredicate) bool {
+	for _, p := range predicates {
+		value, ok := dna[p.Fact]
+		if !ok {
+			continue
+		}
+		if p.Equals != "" && value == p.Equals {
+			return true
+		}
+		if p.Contains != "" && strings.Contains(value, p.Contains) {
+			return true
+		}
+	}
+	return false
+}

--- a/features/controller/modules/resolution/observe_test.go
+++ b/features/controller/modules/resolution/observe_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package resolution_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/modules/resolution"
+	modules "github.com/cfgis/cfgms/features/modules"
+)
+
+// makeObserveManifest builds a minimal ModuleMetadata with the given observe_when predicates.
+func makeObserveManifest(name string, predicates []modules.ObservePredicate) *modules.ModuleMetadata {
+	return &modules.ModuleMetadata{
+		Name:        name,
+		Version:     "1.0.0",
+		Description: "test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
+		Kind:        "steward",
+		ObserveWhen: predicates,
+	}
+}
+
+func TestResolveObserveModules_EmptyObserveWhenNeverMatches(t *testing.T) {
+	// A manifest with no ObserveWhen must never appear in the result, even if
+	// the DNA contains data (ADR-024 §2: absence means never auto-pull).
+	dna := map[string]string{
+		"hyperv_enabled": "true",
+		"os":             "windows",
+	}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("no-observe", nil),
+		makeObserveManifest("empty-observe", []modules.ObservePredicate{}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	assert.Empty(t, got, "manifests with nil or empty ObserveWhen must not match")
+}
+
+func TestResolveObserveModules_EqualsMatch(t *testing.T) {
+	dna := map[string]string{"hyperv_enabled": "true"}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("hyperv-observer", []modules.ObservePredicate{
+			{Fact: "hyperv_enabled", Equals: "true"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	require.Len(t, got, 1)
+	assert.Equal(t, "hyperv-observer", got[0])
+}
+
+func TestResolveObserveModules_EqualsNoMatch(t *testing.T) {
+	// hyperv_enabled absent → no match.
+	dna := map[string]string{"os": "windows"}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("hyperv-observer", []modules.ObservePredicate{
+			{Fact: "hyperv_enabled", Equals: "true"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	assert.Empty(t, got)
+}
+
+func TestResolveObserveModules_EqualsFalseNoMatch(t *testing.T) {
+	// hyperv_enabled present but "false" → predicate requires "true", so no match.
+	dna := map[string]string{"hyperv_enabled": "false"}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("hyperv-observer", []modules.ObservePredicate{
+			{Fact: "hyperv_enabled", Equals: "true"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	assert.Empty(t, got)
+}
+
+func TestResolveObserveModules_ContainsMatch(t *testing.T) {
+	dna := map[string]string{"os_description": "Ubuntu 24.04 LTS"}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("ubuntu-observer", []modules.ObservePredicate{
+			{Fact: "os_description", Contains: "Ubuntu"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	require.Len(t, got, 1)
+	assert.Equal(t, "ubuntu-observer", got[0])
+}
+
+func TestResolveObserveModules_ContainsNoMatch(t *testing.T) {
+	dna := map[string]string{"os_description": "Windows Server 2022"}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("ubuntu-observer", []modules.ObservePredicate{
+			{Fact: "os_description", Contains: "Ubuntu"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	assert.Empty(t, got)
+}
+
+func TestResolveObserveModules_ORSemantics_AnyPredicateMatches(t *testing.T) {
+	// Module has two predicates; only the second is satisfied.
+	// OR semantics: any one match activates the module.
+	dna := map[string]string{"hyperv_role_installed": "true"}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("hyperv-observer", []modules.ObservePredicate{
+			{Fact: "hyperv_enabled", Equals: "true"},        // not satisfied
+			{Fact: "hyperv_role_installed", Equals: "true"}, // satisfied
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	require.Len(t, got, 1, "OR semantics: single satisfied predicate must activate the module")
+	assert.Equal(t, "hyperv-observer", got[0])
+}
+
+func TestResolveObserveModules_MultipleManifests_IndependentResolution(t *testing.T) {
+	// Two manifests: one matches, one doesn't.
+	dna := map[string]string{"hyperv_enabled": "true"}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("hyperv-observer", []modules.ObservePredicate{
+			{Fact: "hyperv_enabled", Equals: "true"},
+		}),
+		makeObserveManifest("vmware-observer", []modules.ObservePredicate{
+			{Fact: "virtualization_type", Equals: "vmware"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	require.Len(t, got, 1)
+	assert.Equal(t, "hyperv-observer", got[0])
+}
+
+func TestResolveObserveModules_AllManifestsMatch(t *testing.T) {
+	dna := map[string]string{
+		"hyperv_enabled":        "true",
+		"virtualization_type":   "hyperv",
+		"hyperv_role_installed": "true",
+	}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("hyperv-observer", []modules.ObservePredicate{
+			{Fact: "hyperv_enabled", Equals: "true"},
+		}),
+		makeObserveManifest("virt-observer", []modules.ObservePredicate{
+			{Fact: "virtualization_type", Contains: "hyper"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	sort.Strings(got)
+	assert.Equal(t, []string{"hyperv-observer", "virt-observer"}, got)
+}
+
+func TestResolveObserveModules_EmptyDNA(t *testing.T) {
+	// With an empty DNA map, no predicate can match.
+	dna := map[string]string{}
+	manifests := []*modules.ModuleMetadata{
+		makeObserveManifest("hyperv-observer", []modules.ObservePredicate{
+			{Fact: "hyperv_enabled", Equals: "true"},
+		}),
+	}
+
+	got := resolution.ResolveObserveModules(dna, manifests)
+	assert.Empty(t, got)
+}
+
+func TestResolveObserveModules_EmptyManifests(t *testing.T) {
+	dna := map[string]string{"hyperv_enabled": "true"}
+	got := resolution.ResolveObserveModules(dna, nil)
+	assert.Empty(t, got)
+}
+
+// TestResolveObserveModules_HypervEnabledDNAFact is the end-to-end fixture that
+// confirms key-convention alignment between the already-shipped hyperv_enabled
+// DNA fact (features/steward/dna/hardware_windows.go collectHyperVInfo) and the
+// new matcher. The fact key "hyperv_enabled" with value "true" or "false" is the
+// real contract; this test locks it down so a rename on either side fails loudly.
+func TestResolveObserveModules_HypervEnabledDNAFact(t *testing.T) {
+	// The actual DNA key emitted by collectHyperVInfo is "hyperv_enabled" with
+	// the value produced by strconv.FormatBool — "true" or "false".
+	dnaTrueHost := map[string]string{
+		"hyperv_enabled":        "true",
+		"hyperv_role_installed": "true",
+		"virtualization_type":   "none",
+		"virtualization_role":   "host",
+	}
+	dnaFalseGuest := map[string]string{
+		"hyperv_enabled":        "false",
+		"hyperv_role_installed": "false",
+		"virtualization_type":   "hyperv",
+		"virtualization_role":   "guest",
+	}
+	dnaMissingElevation := map[string]string{
+		// hyperv_enabled omitted (elevation unavailable — collector omits the key per #1950)
+		"hyperv_role_installed": "true",
+		"virtualization_type":   "none",
+		"virtualization_role":   "host",
+	}
+
+	hypervModule := makeObserveManifest("hyperv", []modules.ObservePredicate{
+		{Fact: "hyperv_enabled", Equals: "true"},
+	})
+
+	t.Run("matches_when_hyperv_enabled_true", func(t *testing.T) {
+		got := resolution.ResolveObserveModules(dnaTrueHost, []*modules.ModuleMetadata{hypervModule})
+		require.Len(t, got, 1)
+		assert.Equal(t, "hyperv", got[0])
+	})
+
+	t.Run("no_match_when_hyperv_enabled_false", func(t *testing.T) {
+		got := resolution.ResolveObserveModules(dnaFalseGuest, []*modules.ModuleMetadata{hypervModule})
+		assert.Empty(t, got)
+	})
+
+	t.Run("no_match_when_hyperv_enabled_absent", func(t *testing.T) {
+		// Collector omits the key entirely on elevation failure — must not match.
+		got := resolution.ResolveObserveModules(dnaMissingElevation, []*modules.ModuleMetadata{hypervModule})
+		assert.Empty(t, got)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `ResolveObserveModules` — a pure function in the `resolution` package that computes the subset of module manifests whose `observe_when` predicates match a steward's baseline DNA attribute map (ADR-024 §5).
- Manifests with nil/empty `ObserveWhen` never appear in the result (ADR-024 §2: absence means never auto-pull).
- Predicates use OR semantics: any one matching predicate activates the module; `equals` requires exact string match, `contains` requires `strings.Contains`.
- Unit tests cover: `equals` match/no-match, `contains` match/no-match, empty-`ObserveWhen` never-matches, 2-predicate OR semantics, multiple independent manifests, empty DNA, and an end-to-end `hyperv_enabled` fixture that locks key-convention alignment with `hardware_windows.go:collectHyperVInfo`.
- `controller-operating-model.md` updated with a new "Observe-Resolution" section that distinguishes this from `ResolveCfgRequiredModules`.

Fixes #3103

## Specialist Review Results

| Lens | Result |
|------|--------|
| Code Review | PASS |
| Test Quality | PASS |
| Security | PASS |

## Test plan

- [ ] `go test ./features/controller/modules/resolution/...` passes
- [ ] All `TestResolveObserveModules_*` tests cover: `equals` match, `contains` match, no-match, empty-`ObserveWhen` never-matches, 2+-predicate OR semantics, `hyperv_enabled` end-to-end fixture (true/false/absent)
- [ ] `make test-complete` passes (CI gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)