### PR TITLE
tooling: fix UTF-8 encoding loss in project-queue.sh file reads

### DIFF
--- a/scripts/project-queue.sh
+++ b/scripts/project-queue.sh
@@ -47,7 +47,7 @@ _yaml_get() {
 import re, os, sys
 key = os.environ["YAML_KEY"]
 pattern = re.compile(r"^" + re.escape(key) + r":\s*(.*)")
-with open(os.environ["YAML_FILE"]) as _f:
+with open(os.environ["YAML_FILE"], encoding="utf-8") as _f:
     for _line in _f:
         _m = pattern.match(_line.rstrip())
         if _m:
@@ -123,7 +123,7 @@ body_file = os.environ['GQ_BODY_FILE']
 field_id = os.environ['GQ_FIELD_ID']
 option_id = os.environ['GQ_OPTION_ID']
 story_num = int(os.environ['GQ_STORY_NUM'])
-body = open(body_file).read()
+body = open(body_file, encoding='utf-8').read()
 
 data = graphql({
     'query': (
@@ -377,7 +377,7 @@ yaml_path = os.environ['GQ_PIPELINE_YAML']
 # Parse simple key: value YAML using stdlib only (no PyYAML required)
 import re as _re
 cfg = {}
-with open(yaml_path) as _f:
+with open(yaml_path, encoding='utf-8') as _f:
     for _line in _f:
         _m = _re.match(r'^([A-Za-z0-9_]+):\s*(.*)', _line.rstrip())
         if _m:


### PR DESCRIPTION
## Summary
- `python3`'s `open()` defaults to the platform's preferred encoding (`cp1252` on Windows) when no `encoding=` argument is given, silently corrupting any non-ASCII byte sequence read from a story/epic body file or `pipeline.yaml`.
- Verified at the codepoint level: a UTF-8 em-dash (`E2 80 94`) read without `encoding='utf-8'` decodes as three separate mangled `cp1252` characters instead of one `—`.
- This exact corruption was found live in six GitHub issue bodies created via `create-story` during this session, before the fix.
- Adds explicit `encoding='utf-8'` to all three `open()` calls in `scripts/project-queue.sh` (`_yaml_get`'s fallback YAML parser, `cmd_create_draft`'s body read, and `cmd_update_field`'s YAML parser).

## Test plan
- [x] `bash -n scripts/project-queue.sh` — syntax valid
- [x] Reproduced the bug and the fix at the codepoint level via a standalone Python snippet (default `open()` → 3 mangled codepoints; `encoding='utf-8'` → 1 correct codepoint)
- [x] Ran `project-queue.sh list-by-status` live against the real project board post-fix — works correctly
- [x] Created 3 real GitHub issues via `create-story` after the fix landed — verified zero mojibake in each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoA5aAg7UzTokM7dyDwyZ9