### PR TITLE
web: enforce tenant-subtree scope on GET /api/v1/web/accounts (Issue #3137)

### DIFF
--- a/features/controller/api/handlers_web_accounts.go
+++ b/features/controller/api/handlers_web_accounts.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -424,11 +425,19 @@ func (s *Server) handleCreateWebAccount(w http.ResponseWriter, r *http.Request) 
 // no Tier-3 wrapper — reads are categorically outside the Tier-3 surface; see
 // Implementation Notes in Issue #2733). The response uses WebAccountInfo: no
 // secret material is ever included.
+//
+// Issue #3137: results are scoped to the caller's tenant subtree. An unscoped
+// mTLS admin (callerTenant == "") sees all accounts. Any other caller sees only
+// accounts whose storage TenantID equals callerTenant or is a descendant of it
+// (i.e. starts with callerTenant + "/"), which covers the full subtree of child
+// tenants without requiring an exact-match-only TenantID filter.
 func (s *Server) handleListWebAccounts(w http.ResponseWriter, r *http.Request) {
 	if s.secretStore == nil {
 		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Secret store not available", "SERVICE_UNAVAILABLE")
 		return
 	}
+
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
 
 	metas, err := s.secretStore.ListSecrets(r.Context(), &secretsif.SecretFilter{
 		Metadata: map[string]string{
@@ -443,6 +452,14 @@ func (s *Server) handleListWebAccounts(w http.ResponseWriter, r *http.Request) {
 
 	accounts := make([]WebAccountInfo, 0, len(metas))
 	for _, meta := range metas {
+		// Issue #3137: enforce tenant-subtree scope. Skip accounts outside the
+		// caller's subtree. Unscoped admins (callerTenant == "") see everything.
+		if callerTenant != "" {
+			if meta.TenantID != callerTenant && !strings.HasPrefix(meta.TenantID, callerTenant+"/") {
+				continue
+			}
+		}
+
 		createdAt := meta.CreatedAt
 		if ts, ok := meta.Metadata["created_at"]; ok {
 			if t, parseErr := time.Parse(time.RFC3339, ts); parseErr == nil {

--- a/features/controller/api/handlers_web_accounts_test.go
+++ b/features/controller/api/handlers_web_accounts_test.go
@@ -509,6 +509,100 @@ func TestWebAccounts_RootScope_AppearsInList(t *testing.T) {
 	assert.Equal(t, "", found.TenantID, "tenant_id must be empty in list response for root-scoped account")
 }
 
+// ---- Issue #3137: tenant-subtree scope enforcement on GET /api/v1/web/accounts ----
+
+// TestWebAccounts_TenantScope_SiblingExclusion is the [REQUIRED TEST] from Issue #3137:
+// a caller scoped to client-1 must never see an account belonging to sibling tenant client-2.
+func TestWebAccounts_TenantScope_SiblingExclusion(t *testing.T) {
+	server := setupTestServer(t)
+	admin := testAdminPrincipal()
+
+	rec := postWebAccount(t, server, admin, WebAccountRequest{
+		Username: "client2-user",
+		TenantID: "root/msp-a/client-2",
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = postWebAccount(t, server, admin, WebAccountRequest{
+		Username: "client1-user",
+		TenantID: "root/msp-a/client-1",
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	client1Principal := &Principal{
+		ID:        "client1-admin",
+		TenantID:  "root/msp-a/client-1",
+		Assurance: session.AssuranceBasic,
+	}
+	_, accounts := listWebAccounts(t, server, client1Principal)
+
+	usernames := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		usernames = append(usernames, a.Username)
+	}
+	assert.Contains(t, usernames, "client1-user", "caller must see own tenant's accounts")
+	assert.NotContains(t, usernames, "client2-user", "caller must NOT see sibling tenant's accounts")
+}
+
+// TestWebAccounts_TenantScope_SubtreeInclusion is the [REQUIRED TEST] from Issue #3137:
+// a caller scoped to root/msp-a DOES see an account belonging to root/msp-a/client-1
+// (subtree inclusion, not exact-match-only).
+func TestWebAccounts_TenantScope_SubtreeInclusion(t *testing.T) {
+	server := setupTestServer(t)
+	admin := testAdminPrincipal()
+
+	rec := postWebAccount(t, server, admin, WebAccountRequest{
+		Username: "parent-user",
+		TenantID: "root/msp-a",
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = postWebAccount(t, server, admin, WebAccountRequest{
+		Username: "child-user",
+		TenantID: "root/msp-a/client-1",
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	mspaAdmin := &Principal{
+		ID:        "msp-a-admin",
+		TenantID:  "root/msp-a",
+		Assurance: session.AssuranceBasic,
+	}
+	_, accounts := listWebAccounts(t, server, mspaAdmin)
+
+	usernames := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		usernames = append(usernames, a.Username)
+	}
+	assert.Contains(t, usernames, "parent-user", "parent-tenant admin must see own accounts")
+	assert.Contains(t, usernames, "child-user", "parent-tenant admin must see child tenant accounts (subtree)")
+}
+
+// TestWebAccounts_TenantScope_UnscopedAdminSeesAll verifies that an unscoped mTLS admin
+// (callerTenant == "") still sees all accounts including those in multiple tenants.
+func TestWebAccounts_TenantScope_UnscopedAdminSeesAll(t *testing.T) {
+	server := setupTestServer(t)
+	admin := testAdminPrincipal()
+
+	for _, req := range []WebAccountRequest{
+		{Username: "scope-all-a", TenantID: "root/msp-a/client-1"},
+		{Username: "scope-all-b", TenantID: "root/msp-a/client-2"},
+		{Username: "scope-all-root", RootScope: true},
+	} {
+		rec := postWebAccount(t, server, admin, req)
+		require.Equal(t, http.StatusCreated, rec.Code)
+	}
+
+	_, accounts := listWebAccounts(t, server, admin)
+	usernames := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		usernames = append(usernames, a.Username)
+	}
+	assert.Contains(t, usernames, "scope-all-a")
+	assert.Contains(t, usernames, "scope-all-b")
+	assert.Contains(t, usernames, "scope-all-root")
+}
+
 // TestWebAccounts_RootScope_DeleteWorks verifies that deleting a root-scoped
 // account succeeds and the account is removed from the store.
 func TestWebAccounts_RootScope_DeleteWorks(t *testing.T) {


### PR DESCRIPTION
## Summary

- `handleListWebAccounts` previously returned all web accounts to any caller holding `web-account:list`, with no tenant filtering — any scoped API-key or session caller could enumerate accounts across all tenants.
- Fix reads `callerTenant` from `ctxkeys.TenantID` and post-filters results: accounts are kept only when `meta.TenantID == callerTenant` or starts with `callerTenant + "/"` (subtree prefix), covering descendant tenants in full.
- Unscoped mTLS admins (`callerTenant == ""`) are unchanged — they still see all accounts across all tenants.

Fixes #3137

## Specialist review results

- **Code review**: PASS (0 findings)
- **Test quality**: PASS (0 findings)
- **Security**: PASS (0 findings)

All three lenses cleared in one round; zero fix iterations required.

## Test plan

- [x] `TestWebAccounts_TenantScope_SiblingExclusion` — client-1 caller cannot see sibling client-2 accounts
- [x] `TestWebAccounts_TenantScope_SubtreeInclusion` — root/msp-a caller sees root/msp-a/client-1 accounts
- [x] `TestWebAccounts_TenantScope_UnscopedAdminSeesAll` — unscoped admin sees all tenants including root-scoped accounts
- [x] All pre-existing `TestWebAccounts_*` tests continue to pass
- [x] `make check-architecture` — no central-provider violations
- [x] `make lint-log-injection` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)