### PR TITLE
steward: tiered observation loop — Tier-2 whole-domain observe sweep (Issue #3104)

### DIFF
--- a/api/proto/transport/control.pb.go
+++ b/api/proto/transport/control.pb.go
@@ -42,6 +42,7 @@ const (
 	CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY CommandType = 10 // Issue #1943: controller pushes a new steward binary for self-upgrade
 	CommandType_COMMAND_TYPE_RELAY_RESPONSE      CommandType = 11 // Issue #1994: controller sends relay response back to steward relay goroutine
 	CommandType_COMMAND_TYPE_OPEN_TERMINAL       CommandType = 12 // Issue #2760: steward dials out Terminal RPC and bridges to a local PTY
+	CommandType_COMMAND_TYPE_OBSERVE_MODULES     CommandType = 13 // Issue #3104: controller pushes resolved observe-module set to steward
 )
 
 // Enum value maps for CommandType.
@@ -60,6 +61,7 @@ var (
 		10: "COMMAND_TYPE_PUSH_STEWARD_BINARY",
 		11: "COMMAND_TYPE_RELAY_RESPONSE",
 		12: "COMMAND_TYPE_OPEN_TERMINAL",
+		13: "COMMAND_TYPE_OBSERVE_MODULES",
 	}
 	CommandType_value = map[string]int32{
 		"COMMAND_TYPE_UNSPECIFIED":         0,
@@ -75,6 +77,7 @@ var (
 		"COMMAND_TYPE_PUSH_STEWARD_BINARY": 10,
 		"COMMAND_TYPE_RELAY_RESPONSE":      11,
 		"COMMAND_TYPE_OPEN_TERMINAL":       12,
+		"COMMAND_TYPE_OBSERVE_MODULES":     13,
 	}
 )
 
@@ -126,7 +129,8 @@ const (
 	EventType_EVENT_TYPE_UPGRADE_DOWNLOADED  EventType = 12 // steward.upgrade.downloaded
 	EventType_EVENT_TYPE_UPGRADE_SWAPPED     EventType = 13 // steward.upgrade.swapped
 	EventType_EVENT_TYPE_UPGRADE_COMMITTED   EventType = 14 // steward.upgrade.committed
-	EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK EventType = 15 // steward.upgrade.rolled_back
+	EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK    EventType = 15 // steward.upgrade.rolled_back
+	EventType_EVENT_TYPE_OBSERVE_SWEEP_REQUEST  EventType = 16 // Issue #3104: steward initiates Tier-2 observe sweep
 )
 
 // Enum value maps for EventType.
@@ -148,6 +152,7 @@ var (
 		13: "EVENT_TYPE_UPGRADE_SWAPPED",
 		14: "EVENT_TYPE_UPGRADE_COMMITTED",
 		15: "EVENT_TYPE_UPGRADE_ROLLED_BACK",
+		16: "EVENT_TYPE_OBSERVE_SWEEP_REQUEST",
 	}
 	EventType_value = map[string]int32{
 		"EVENT_TYPE_UNSPECIFIED":         0,
@@ -165,7 +170,8 @@ var (
 		"EVENT_TYPE_UPGRADE_DOWNLOADED":  12,
 		"EVENT_TYPE_UPGRADE_SWAPPED":     13,
 		"EVENT_TYPE_UPGRADE_COMMITTED":   14,
-		"EVENT_TYPE_UPGRADE_ROLLED_BACK": 15,
+		"EVENT_TYPE_UPGRADE_ROLLED_BACK":    15,
+		"EVENT_TYPE_OBSERVE_SWEEP_REQUEST":  16,
 	}
 )
 

--- a/api/proto/transport/control.proto
+++ b/api/proto/transport/control.proto
@@ -25,6 +25,10 @@ enum CommandType {
   // Issue #2760: steward dials out Terminal RPC and bridges to a local PTY.
   // Command.params keys: session_id (string), shell (string), cols (int32), rows (int32).
   COMMAND_TYPE_OPEN_TERMINAL = 12;
+  // Issue #3104 (ADR-024 Amendment 1): controller pushes the resolved observe-module
+  // set back to the steward after receiving EventObserveSweepRequest.
+  // Command.params keys: "modules" (JSON array of ObserveModuleSpec objects).
+  COMMAND_TYPE_OBSERVE_MODULES = 13;
 }
 
 // EventType enumerates the types of events a steward emits to a controller.
@@ -47,6 +51,10 @@ enum EventType {
   EVENT_TYPE_UPGRADE_SWAPPED = 13;    // steward.upgrade.swapped
   EVENT_TYPE_UPGRADE_COMMITTED = 14;  // steward.upgrade.committed
   EVENT_TYPE_UPGRADE_ROLLED_BACK = 15; // steward.upgrade.rolled_back
+  // Issue #3104 (ADR-024 Amendment 1): steward initiates a Tier-2 whole-domain
+  // observe sweep by publishing baseline DNA; the controller responds with
+  // COMMAND_TYPE_OBSERVE_MODULES carrying the resolved module set.
+  EVENT_TYPE_OBSERVE_SWEEP_REQUEST = 16;
 }
 
 // Severity is used by both Event and LogEntry to indicate importance level.

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -30,7 +30,9 @@ import (
 	"github.com/cfgis/cfgms/features/steward"
 	"github.com/cfgis/cfgms/features/steward/client"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
 	"github.com/cfgis/cfgms/features/steward/dna"
+	"github.com/cfgis/cfgms/features/steward/factory"
 	"github.com/cfgis/cfgms/features/steward/registration"
 	"github.com/cfgis/cfgms/pkg/cert"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
@@ -1281,12 +1283,16 @@ func connectWithApprovedRegistration(
 	var scriptSigning stewardconfig.ScriptSigningConfig
 	var upgradeAllowDowngrade bool
 	var dnaRefreshInterval time.Duration
+	// Tier-2 observe sweep cadence: the config default applies when no config file
+	// is present, so the sweep is active on a purely controller-managed steward.
+	observeSweepN := stewardconfig.DefaultObserveSweepN
 	if cfg, cfgErr := stewardconfig.LoadConfiguration(""); cfgErr == nil {
 		commandReplayWindow = cfg.Steward.SignedCommandReplayWindow
 		commandMaxParamsBytes = cfg.Steward.SignedCommandMaxParamsBytes
 		scriptSigning = cfg.Steward.ScriptSigning
 		upgradeAllowDowngrade = cfg.Steward.Upgrade.AllowDowngrade
 		dnaRefreshInterval = stewardconfig.GetDNARefreshInterval(cfg)
+		observeSweepN = stewardconfig.GetObserveSweepN(cfg)
 	}
 
 	// Build cert.Manager and SecretStore for on-demand TLS cert loading and
@@ -1314,6 +1320,8 @@ func connectWithApprovedRegistration(
 		UpgradePublisherTrustStore:  buildTestPublisherTrustStore(logger),
 		DNARefreshInterval:          dnaRefreshInterval,
 		DNACollector:                dnaAdapter,
+		ObserveSweepN:               observeSweepN,
+		ObserveModuleLoader:         newObserveModuleLoader(reg.StewardID, secretStore, logger),
 		Logger:                      logger,
 		IdentityPersistFunc: func(pems []string, at *time.Time) error {
 			cur, loadErr := loadIdentity(certStoreDir)
@@ -1434,11 +1442,13 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 	var commandMaxParamsBytes int
 	var upgradeAllowDowngradeReconnect bool
 	var dnaRefreshIntervalReconnect time.Duration
+	observeSweepNReconnect := stewardconfig.DefaultObserveSweepN
 	if cfg, cfgErr := stewardconfig.LoadConfiguration(""); cfgErr == nil {
 		commandReplayWindow = cfg.Steward.SignedCommandReplayWindow
 		commandMaxParamsBytes = cfg.Steward.SignedCommandMaxParamsBytes
 		upgradeAllowDowngradeReconnect = cfg.Steward.Upgrade.AllowDowngrade
 		dnaRefreshIntervalReconnect = stewardconfig.GetDNARefreshInterval(cfg)
+		observeSweepNReconnect = stewardconfig.GetObserveSweepN(cfg)
 	}
 
 	// Build the composite DNA collector early so we can wire the executor into it
@@ -1462,6 +1472,8 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 		UpgradePublisherTrustStore:  buildTestPublisherTrustStore(logger),
 		DNARefreshInterval:          dnaRefreshIntervalReconnect,
 		DNACollector:                dnaAdapterReconnect,
+		ObserveSweepN:               observeSweepNReconnect,
+		ObserveModuleLoader:         newObserveModuleLoader(id.StewardID, secretStore, logger),
 		Logger:                      logger,
 		IdentityPersistFunc: func(pems []string, at *time.Time) error {
 			cur, loadErr := loadIdentity(certStoreDir)
@@ -1546,6 +1558,31 @@ func buildTestPublisherTrustStore(logger logging.Logger) trust.TrustStore {
 		logger.Info("Test mode: overriding steward binary publisher trust store (Issue #1948)")
 	}
 	return ts
+}
+
+// newObserveModuleLoader builds the module loader used by the Tier-2 whole-domain
+// observe sweep (Issue #3104, ADR-024 Amendment 1 §3).
+//
+// It returns a factory.ModuleFactory — the same trust-verified, on-demand module
+// load path the convergence executor uses — with an empty discovery registry, so
+// a module resolved by the controller is pulled on first use and then served from
+// the factory's instance cache on every later sweep. The observe sweep only calls
+// Get, so the factory's error policy is the executor's default (a load failure is
+// logged and skipped rather than aborting the sweep).
+//
+// The secret store is injected so observe modules implementing SecretStoreInjectable
+// are usable without a separate wiring path.
+func newObserveModuleLoader(stewardID string, secretStore secretsif.SecretStore, logger logging.Logger) *factory.ModuleFactory {
+	errCfg := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure:  stewardconfig.ActionContinue,
+		ResourceFailure:    stewardconfig.ActionWarn,
+		ConfigurationError: stewardconfig.ActionFail,
+	}
+	f := factory.NewWithStewardID(discovery.ModuleRegistry{}, errCfg, stewardID, logger)
+	if secretStore != nil {
+		f.SetSecretStore(secretStore)
+	}
+	return f
 }
 
 // hasValidClientCert reports whether certs contains at least one non-expired client certificate.

--- a/cmd/steward/observe_wiring_test.go
+++ b/cmd/steward/observe_wiring_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+//
+// Wiring tests for the Tier-2 whole-domain observe sweep (Issue #3104,
+// ADR-024 Amendment 1 §3). These cover the production loader the steward binary
+// threads into client.TransportConfig.ObserveModuleLoader.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cfgis/cfgms/features/steward/client"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The production observe loader must satisfy the client's loader contract; if the
+// interface changes this fails at compile time rather than silently leaving the
+// sweep unwired.
+var _ client.ObserveModuleLoader = newObserveModuleLoader("steward-1", nil, logging.NewLogger("error"))
+
+func TestNewObserveModuleLoader_LoadsRealBuiltinModule(t *testing.T) {
+	loader := newObserveModuleLoader("steward-1", nil, logging.NewLogger("error"))
+	require.NotNil(t, loader)
+
+	mod, err := loader.LoadModule("file")
+	require.NoError(t, err, "the observe loader must resolve built-in modules through the factory load path")
+	require.NotNil(t, mod)
+}
+
+func TestNewObserveModuleLoader_CachesLoadedInstance(t *testing.T) {
+	loader := newObserveModuleLoader("steward-1", nil, logging.NewLogger("error"))
+
+	first, err := loader.LoadModule("file")
+	require.NoError(t, err)
+	second, err := loader.LoadModule("file")
+	require.NoError(t, err)
+
+	assert.Same(t, first, second,
+		"a module already active must be reused, not re-instantiated on every sweep")
+}
+
+func TestNewObserveModuleLoader_UnknownModuleReturnsError(t *testing.T) {
+	loader := newObserveModuleLoader("steward-1", nil, logging.NewLogger("error"))
+
+	_, err := loader.LoadModule("no-such-observe-module")
+	require.Error(t, err, "an unresolvable module name must surface an error so the sweep can skip it")
+}
+
+// TestObserveSweepCadence_DefaultIsActive pins the cadence the steward binary
+// applies when no local config file declares observe_sweep_n: the production
+// default must be a live cadence, not 0 (sweep disabled).
+func TestObserveSweepCadence_DefaultIsActive(t *testing.T) {
+	assert.Positive(t, stewardconfig.DefaultObserveSweepN,
+		"the shipped Tier-2 cadence default must enable the observe sweep")
+	assert.Equal(t, 10, stewardconfig.DefaultObserveSweepN,
+		"steward-operating-model.md documents a default of 10 convergence ticks")
+}

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -1235,4 +1235,14 @@ Do not conflate the two. `required_modules:` is a deployment-time cfg contract; 
 
 ### Purity guarantee
 
-`ResolveObserveModules` is a pure function — no I/O, no RPC, no side effects. Wiring the result into a steward-facing RPC (the observation pull path) is the responsibility of the sibling steward observation loop story.
+`ResolveObserveModules` is a pure function — no I/O, no RPC, no side effects. Wiring the result into a steward-facing command is done by the server's `handleObserveSweepRequest` handler (see below).
+
+### Tier-2 observe RPC (Issue #3104, ADR-024 Amendment 1)
+
+The observe-resolution path is triggered by the steward's Tier-2 convergence cycle:
+
+1. **Steward → Controller:** On every Nth convergence tick (N = the steward's `steward.observe_sweep_n` config key, default 10), the steward publishes `EventObserveSweepRequest` carrying its current baseline DNA attribute map in `Details["baseline_dna"]`.
+2. **Controller:** `handleObserveSweepRequest` in `features/controller/server/` receives the event, calls `ResolveObserveModules(baselineDNA, manifests)`, and — if any modules matched — sends `CommandObserveModules` back to the originating steward. The command's `params["modules"]` field carries a JSON array of `{name, kind}` specs.
+3. **Steward:** `handleObserveModules` receives the command, loads each module via the signed/trust-verified pull path, runs `Get()` read-only, and merges the resulting fragments into the existing DNA fragment set via `setCurrentDNAFragments`.
+
+If no modules match (empty resolution result), no command is sent — the steward's DNA update is skipped for that Tier-2 cycle. If the manifest provider is unavailable, the handler returns without sending a command (non-fatal).

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -115,6 +115,23 @@ This is the steward's core activity. It runs on startup, on schedule, and in res
 | **Event hook** | Module-defined monitor detects a relevant change (e.g., file modified, service stopped) |
 | **Controller command** | Controller sends `sync_config` — immediate convergence trigger, an optimization not a dependency |
 
+### Tiered Convergence (ADR-024 Amendment 1)
+
+Each convergence tick is classified as **Tier-1** or **Tier-2**. Both tiers enforce identical drift-detection and resource-enforcement semantics; they differ only in what happens after declared-resource work completes.
+
+**Tier-1 (every cycle):** Declared-resource enforcement — `Get → Compare → Set → Verify` for every resource in the active cfg. Fast and lightweight; runs every convergence tick.
+
+**Tier-2 (every Nth cycle):** All of Tier-1, plus a whole-domain observe sweep. `N` is the `steward.observe_sweep_n` knob in the steward config file. When the key is absent — including when the steward has no local config file at all — `N` defaults to 10, so the sweep runs on every 10th tick. Setting `N = 0` disables the sweep entirely. Setting `N = 1` runs the sweep on every tick. Negative values are rejected at config validation.
+
+**Tier-2 observe sweep sequence:**
+
+1. The steward reports its current baseline DNA to the controller as an `EventObserveSweepRequest`.
+2. The controller resolves which observe modules apply to this device (matching `observe_when` predicates against the reported DNA) and responds with `CommandObserveModules` carrying the resolved `{name, kind}` specs.
+3. For each spec, the steward loads the module via the existing signed/trust-verified pull path, invokes its `Get()` read-only, and collects the resulting fragments.
+4. Observe-module fragments are merged into the existing DNA fragment set via `Assembler.Assemble`, then committed through `setCurrentDNAFragments` — **the same emission path used by declared-resource convergence** (ADR-024 Amendment 1 §2; no new channel). Module authority always preempts observe-only host-fact fragments for the same kind (ADR-016).
+
+The observe sweep adds endpoint-side CPU proportional to the number and cost of matched observe modules, controllable by tuning `N`.
+
 ### Per-Resource Cycle
 
 For each resource in the cfg, the execution engine runs:

--- a/docs/deployment/steward.cfg
+++ b/docs/deployment/steward.cfg
@@ -39,6 +39,12 @@ steward:
   # Default: 30m. Accepts Go duration strings (e.g. "15m", "1h").
   # dna_refresh_interval: "30m"
 
+  # Tier-2 whole-domain observe sweep cadence, in convergence cycles: on every
+  # Nth tick the steward reports its baseline DNA and runs the observe modules
+  # the controller resolves for it (read-only Get).
+  # Default: 10. Set to 0 to disable the sweep; 1 runs it on every tick.
+  # observe_sweep_n: 10
+
   logging:
     level: "info"
     format: "text"

--- a/features/config/stewardtypes/json_roundtrip_test.go
+++ b/features/config/stewardtypes/json_roundtrip_test.go
@@ -33,6 +33,7 @@ func TestStewardConfig_JSONKeysAreSnakeCase(t *testing.T) {
 			Upgrade:                     UpgradeConfig{DesiredVersion: "v0.9.7"},
 			RegistrationPollTimeout:     time.Hour,
 			DNARefreshInterval:          "30m",
+			ObserveSweepN:               intPtr(10),
 		},
 		Resources: []ResourceConfig{{Name: "r1", Module: "file", Config: map[string]interface{}{"path": "/tmp/x"}}},
 	}
@@ -52,6 +53,7 @@ func TestStewardConfig_JSONKeysAreSnakeCase(t *testing.T) {
 		`"allow_public_ca"`, `"require_signed_adhoc"`, `"module_trust"`, `"additional_publishers"`,
 		`"signed_command_replay_window"`, `"signed_command_max_params_bytes"`, `"drift_mode"`,
 		`"upgrade"`, `"desired_version"`, `"registration_poll_timeout"`, `"dna_refresh_interval"`,
+		`"observe_sweep_n"`,
 	}
 	for _, k := range wantKeys {
 		if !strings.Contains(got, k) {
@@ -65,6 +67,7 @@ func TestStewardConfig_JSONKeysAreSnakeCase(t *testing.T) {
 		`"ModuleLoadFailure"`, `"ResourceFailure"`, `"ConfigurationError"`, `"ScriptSigning"`,
 		`"ModuleTrust"`, `"SecretsDir"`, `"DesiredVersion"`, `"RegistrationPollTimeout"`,
 		`"DNARefreshInterval"`, `"AllowPublicCA"`, `"TrustMode"`, `"PublicKeyRef"`,
+		`"ObserveSweepN"`,
 	}
 	for _, k := range leaked {
 		if strings.Contains(got, k) {

--- a/features/config/stewardtypes/stewardtypes_test.go
+++ b/features/config/stewardtypes/stewardtypes_test.go
@@ -257,6 +257,59 @@ func TestGetDNARefreshInterval_ZeroFallback(t *testing.T) {
 		"zero duration must fall back to 30m default")
 }
 
+// --- GetObserveSweepN (Issue #3104, ADR-024 Amendment 1 §3) ---
+
+// intPtr returns a pointer to n. StewardSettings.ObserveSweepN is a *int so an
+// explicitly configured 0 (sweep disabled) is distinguishable from an absent key.
+func intPtr(n int) *int { return &n }
+
+func TestGetObserveSweepN_UnsetUsesDefault(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{}}
+	assert.Equal(t, DefaultObserveSweepN, GetObserveSweepN(cfg),
+		"an absent observe_sweep_n must yield the shipped default cadence")
+}
+
+func TestGetObserveSweepN_ExplicitZeroDisables(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{ObserveSweepN: intPtr(0)}}
+	assert.Equal(t, 0, GetObserveSweepN(cfg),
+		"an explicit observe_sweep_n: 0 must disable the sweep, not fall back to the default")
+}
+
+func TestGetObserveSweepN_ExplicitValue(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{ObserveSweepN: intPtr(3)}}
+	assert.Equal(t, 3, GetObserveSweepN(cfg))
+}
+
+func TestGetObserveSweepN_NegativeTreatedAsDisabled(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{ObserveSweepN: intPtr(-1)}}
+	assert.Equal(t, 0, GetObserveSweepN(cfg),
+		"a negative cadence must never reach the client as a live cadence")
+}
+
+func TestValidateConfiguration_RejectsNegativeObserveSweepN(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:            "steward-1",
+			Mode:          ModeStandalone,
+			ObserveSweepN: intPtr(-1),
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "observe_sweep_n")
+}
+
+func TestValidateConfiguration_AcceptsZeroObserveSweepN(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:            "steward-1",
+			Mode:          ModeStandalone,
+			ObserveSweepN: intPtr(0),
+		},
+	}
+	require.NoError(t, ValidateConfiguration(cfg))
+}
+
 // --- GetConfiguredModules ---
 
 func TestGetConfiguredModules_DeduplicatesModules(t *testing.T) {

--- a/features/config/stewardtypes/types.go
+++ b/features/config/stewardtypes/types.go
@@ -65,6 +65,13 @@ type StewardSettings struct {
 	// Accepts Go duration strings (e.g. "30m", "1h"). Default: 30m.
 	DNARefreshInterval string `yaml:"dna_refresh_interval,omitempty" json:"dna_refresh_interval,omitempty"`
 
+	// ObserveSweepN is the Tier-2 whole-domain observe sweep cadence: the sweep
+	// runs on every Nth convergence tick (Issue #3104, ADR-024 Amendment 1 §3).
+	// Unset (nil) applies DefaultObserveSweepN. 0 disables the sweep entirely;
+	// 1 runs it on every tick. The field is a pointer so an explicitly configured
+	// 0 (disable) is distinguishable from an absent key (use the default).
+	ObserveSweepN *int `yaml:"observe_sweep_n,omitempty" json:"observe_sweep_n,omitempty"`
+
 	// TenantDefaultTimezone is the IANA timezone name applied when a reboot_window
 	// does not declare an explicit timezone. A future story reuses this same field
 	// for the workflow-trigger scheduler's timezone default (ADR-026 decision 4).

--- a/features/config/stewardtypes/validation.go
+++ b/features/config/stewardtypes/validation.go
@@ -106,6 +106,10 @@ func ValidateConfiguration(config StewardConfig) error {
 		}
 	}
 
+	if config.Steward.ObserveSweepN != nil && *config.Steward.ObserveSweepN < 0 {
+		return fmt.Errorf("observe_sweep_n must be 0 (disabled) or a positive cycle count, got %d", *config.Steward.ObserveSweepN)
+	}
+
 	if err := ValidateScriptSigningConfig(config.Steward.ScriptSigning); err != nil {
 		return fmt.Errorf("script_signing configuration invalid: %w", err)
 	}
@@ -221,6 +225,25 @@ func GetDNARefreshInterval(cfg StewardConfig) time.Duration {
 		return 30 * time.Minute
 	}
 	return d
+}
+
+// DefaultObserveSweepN is the Tier-2 whole-domain observe sweep cadence applied
+// when observe_sweep_n is not set: the sweep runs on every 10th convergence tick
+// (Issue #3104, ADR-024 Amendment 1 §3).
+const DefaultObserveSweepN = 10
+
+// GetObserveSweepN returns the Tier-2 observe sweep cadence in convergence cycles.
+// An unset observe_sweep_n yields DefaultObserveSweepN; an explicit 0 disables the
+// sweep. Negative values are rejected by ValidateConfiguration and treated as
+// disabled here so an unvalidated config can never produce a negative cadence.
+func GetObserveSweepN(cfg StewardConfig) int {
+	if cfg.Steward.ObserveSweepN == nil {
+		return DefaultObserveSweepN
+	}
+	if n := *cfg.Steward.ObserveSweepN; n > 0 {
+		return n
+	}
+	return 0
 }
 
 // GetConfiguredModules returns a deduplicated list of module names required by the configuration.

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -35,12 +35,14 @@ import (
 	"github.com/cfgis/cfgms/features/controller/heartbeat"
 	"github.com/cfgis/cfgms/features/controller/initialization"
 	modulecache "github.com/cfgis/cfgms/features/controller/modules/cache"
+	"github.com/cfgis/cfgms/features/controller/modules/resolution"
 	"github.com/cfgis/cfgms/features/controller/push"
 	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
 	controllerrun "github.com/cfgis/cfgms/features/controller/run"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/controller/tagstore"
 	controllerTransport "github.com/cfgis/cfgms/features/controller/transport"
+	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/features/modules/hyperv"
 	hypervcompletion "github.com/cfgis/cfgms/features/modules/hyperv/completion"
 	scriptmodule "github.com/cfgis/cfgms/features/modules/stdlib/script"
@@ -90,6 +92,46 @@ import (
 // buildVersionCheck is a compile-time constant to verify code version in Docker
 const buildVersionCheck = "story-362-config-signing-enabled"
 
+// ObserveManifestProvider is the interface through which the controller server
+// accesses module manifests for the Tier-2 observe-module resolution step
+// (Issue #3104, ADR-024 Amendment 1 §3). It wraps the module cache in production
+// and an in-memory stub in tests. Nil = feature disabled.
+type ObserveManifestProvider interface {
+	// ListObservableManifests returns all module manifests that declare at least
+	// one observe_when predicate and are eligible for Tier-2 dispatch.
+	ListObservableManifests() ([]*modules.ModuleMetadata, error)
+}
+
+// moduleCacheManifestProvider adapts *modulecache.ModuleCache as
+// ObserveManifestProvider. Only approved bundles are returned; manifests with no
+// observe_when predicates are silently filtered out.
+type moduleCacheManifestProvider struct {
+	cache *modulecache.ModuleCache
+}
+
+var _ ObserveManifestProvider = (*moduleCacheManifestProvider)(nil)
+
+func (p *moduleCacheManifestProvider) ListObservableManifests() ([]*modules.ModuleMetadata, error) {
+	entries, err := p.cache.List()
+	if err != nil {
+		return nil, fmt.Errorf("list module cache: %w", err)
+	}
+	var result []*modules.ModuleMetadata
+	for _, entry := range entries {
+		if entry.Status != modulecache.ApprovalStatusApproved {
+			continue
+		}
+		b, getErr := p.cache.Get(entry.Addr)
+		if getErr != nil {
+			continue
+		}
+		if b.Manifest != nil && len(b.Manifest.ObserveWhen) > 0 {
+			result = append(result, b.Manifest)
+		}
+	}
+	return result, nil
+}
+
 // Server represents the controller server component (gRPC-over-QUIC based)
 type Server struct {
 	mu                      sync.RWMutex
@@ -133,6 +175,7 @@ type Server struct {
 	ipTrustExpiryJob        *controllerRegistration.IPTrustExpiryJob // Issue #1697: 30-day dark-window expiry
 	pendingExpiryJob        *controllerRegistration.PendingExpiryJob // Issue #1697: 5-day pending-registration expiry
 	stewardEventManager     *logging.LoggingManager                  // Issue #2139: dedicated sink for ingested steward events
+	observeManifestProvider ObserveManifestProvider                  // Issue #3104: nil = Tier-2 disabled
 }
 
 // resolveDNADataRoot returns an ABSOLUTE directory under which the durable DNA
@@ -1254,6 +1297,14 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		logger.Info("Workflow engine wired to HTTP API server")
 	}
 
+	// Wire Tier-2 observe-module manifest provider from the module cache.
+	// When the cache failed to initialize, moduleCache is nil and Tier-2 is disabled.
+	// (Issue #3104, ADR-024 Amendment 1 §3)
+	if moduleCache != nil {
+		srv.observeManifestProvider = &moduleCacheManifestProvider{cache: moduleCache}
+		logger.Info("Tier-2 observe manifest provider wired to module cache")
+	}
+
 	// Issue #1695: Wire the registration approval hook based on registration.workflow.
 	// ip-trust is the new default and does not require the workflow engine.
 	{
@@ -2240,6 +2291,8 @@ func (s *Server) handleEventFromProvider(ctx context.Context, event *controlplan
 		return s.handleDNAEvent(ctx, event)
 	case controlplaneTypes.EventConfigApplied:
 		return s.handleConfigAppliedEvent(ctx, event)
+	case controlplaneTypes.EventObserveSweepRequest:
+		return s.handleObserveSweepRequest(ctx, event)
 	default:
 		// Log unhandled event types for debugging
 		s.logger.Debug("Received event from steward",
@@ -2335,6 +2388,96 @@ func (s *Server) handleConfigAppliedEvent(ctx context.Context, event *controlpla
 	}
 
 	// TODO: Store status report in database/audit log for MSP admin visibility
+
+	return nil
+}
+
+// handleObserveSweepRequest processes EventObserveSweepRequest from a steward.
+// It extracts the baseline DNA, resolves the observe-module set via the manifest
+// provider, and sends CommandObserveModules back to the originating steward.
+// (Issue #3104, ADR-024 Amendment 1 §3)
+func (s *Server) handleObserveSweepRequest(ctx context.Context, event *controlplaneTypes.Event) error {
+	s.mu.RLock()
+	provider := s.observeManifestProvider
+	publisher := s.commandPublisher
+	s.mu.RUnlock()
+
+	if provider == nil {
+		s.logger.Debug("Tier-2 observe sweep request received but provider not configured",
+			"steward_id", event.StewardID)
+		return nil
+	}
+	if publisher == nil {
+		s.logger.Warn("Tier-2 observe sweep request: command publisher not available",
+			"steward_id", event.StewardID)
+		return nil
+	}
+
+	// Extract baseline DNA from the event details.
+	var baselineDNA map[string]string
+	if details := event.Details; details != nil {
+		if raw, ok := details["baseline_dna"].(string); ok && raw != "" {
+			if err := json.Unmarshal([]byte(raw), &baselineDNA); err != nil {
+				s.logger.Warn("Tier-2 observe sweep: failed to parse baseline_dna",
+					"steward_id", event.StewardID, "error", err)
+				return nil
+			}
+		}
+	}
+
+	// Resolve the observe-module set from the baseline DNA.
+	manifests, err := provider.ListObservableManifests()
+	if err != nil {
+		s.logger.Warn("Tier-2 observe sweep: failed to list manifests",
+			"steward_id", event.StewardID, "error", err)
+		return nil
+	}
+
+	names := resolution.ResolveObserveModules(baselineDNA, manifests)
+	if len(names) == 0 {
+		s.logger.Debug("Tier-2 observe sweep: no modules resolved",
+			"steward_id", event.StewardID)
+		return nil
+	}
+
+	// Build ObserveModuleSpec list from resolved names and their ownership declarations.
+	nameSet := make(map[string]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	var specs []controlplaneTypes.ObserveModuleSpec
+	for _, m := range manifests {
+		if !nameSet[m.Name] {
+			continue
+		}
+		for _, own := range m.Owns {
+			specs = append(specs, controlplaneTypes.ObserveModuleSpec{
+				Name: m.Name,
+				Kind: own.Kind,
+			})
+		}
+	}
+	if len(specs) == 0 {
+		// All resolved modules have no ownership declarations — nothing to observe.
+		s.logger.Debug("Tier-2 observe sweep: resolved modules have no ownership declarations",
+			"steward_id", event.StewardID, "names", names)
+		return nil
+	}
+
+	specsJSON, err := json.Marshal(specs)
+	if err != nil {
+		return fmt.Errorf("tier-2 observe sweep: marshal specs: %w", err)
+	}
+
+	if _, err := publisher.PublishCommand(ctx, event.StewardID, controlplaneTypes.CommandObserveModules, map[string]interface{}{
+		"modules": string(specsJSON),
+	}); err != nil {
+		return fmt.Errorf("tier-2 observe sweep: publish command: %w", err)
+	}
+
+	s.logger.Info("Tier-2 observe sweep dispatched",
+		"steward_id", event.StewardID,
+		"module_count", len(specs))
 
 	return nil
 }

--- a/features/controller/server/server_observe_test.go
+++ b/features/controller/server/server_observe_test.go
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+//
+// Tests for the Tier-2 observe sweep handler on the controller side (Issue #3104).
+// handleObserveSweepRequest receives EventObserveSweepRequest from a steward,
+// resolves the observe-module set, and responds with CommandObserveModules.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/features/modules"
+	cpinterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ---------------------------------------------------------------------------
+// Real in-process test components (not mocks)
+// ---------------------------------------------------------------------------
+
+// inMemoryManifestProvider is a real, deterministic implementation of
+// ObserveManifestProvider backed by a fixed manifest slice. Not a mock.
+type inMemoryManifestProvider struct {
+	manifests []*modules.ModuleMetadata
+	listErr   error
+}
+
+var _ ObserveManifestProvider = (*inMemoryManifestProvider)(nil)
+
+func (p *inMemoryManifestProvider) ListObservableManifests() ([]*modules.ModuleMetadata, error) {
+	if p.listErr != nil {
+		return nil, p.listErr
+	}
+	return p.manifests, nil
+}
+
+// inObserveSweepControlPlane is a minimal in-process ControlPlaneProvider for
+// observe-sweep tests. It records SendCommand calls and ignores everything else.
+type inObserveSweepControlPlane struct {
+	mu   sync.Mutex
+	sent []*controlplaneTypes.SignedCommand
+}
+
+var _ cpinterfaces.ControlPlaneProvider = (*inObserveSweepControlPlane)(nil)
+
+func (p *inObserveSweepControlPlane) Name() string      { return "observe-test" }
+func (p *inObserveSweepControlPlane) IsConnected() bool { return true }
+func (p *inObserveSweepControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (p *inObserveSweepControlPlane) Start(_ context.Context) error     { return nil }
+func (p *inObserveSweepControlPlane) Stop(_ context.Context) error      { return nil }
+func (p *inObserveSweepControlPlane) Reconnect(_ context.Context) error { return nil }
+func (p *inObserveSweepControlPlane) SendCommand(_ context.Context, sc *controlplaneTypes.SignedCommand) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sent = append(p.sent, sc)
+	return nil
+}
+func (p *inObserveSweepControlPlane) FanOutCommand(_ context.Context, _ *controlplaneTypes.SignedCommand, ids []string) (*controlplaneTypes.FanOutResult, error) {
+	return &controlplaneTypes.FanOutResult{Succeeded: ids, Failed: map[string]error{}}, nil
+}
+func (p *inObserveSweepControlPlane) SubscribeCommands(_ context.Context, _ string, _ cpinterfaces.CommandHandler) error {
+	return nil
+}
+func (p *inObserveSweepControlPlane) PublishEvent(_ context.Context, _ *controlplaneTypes.Event) error {
+	return nil
+}
+func (p *inObserveSweepControlPlane) SubscribeEvents(_ context.Context, _ *controlplaneTypes.EventFilter, _ cpinterfaces.EventHandler) error {
+	return nil
+}
+func (p *inObserveSweepControlPlane) SendHeartbeat(_ context.Context, _ *controlplaneTypes.Heartbeat) error {
+	return nil
+}
+func (p *inObserveSweepControlPlane) SubscribeHeartbeats(_ context.Context, _ cpinterfaces.HeartbeatHandler) error {
+	return nil
+}
+func (p *inObserveSweepControlPlane) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
+	return &controlplaneTypes.ControlPlaneStats{}, nil
+}
+
+func (p *inObserveSweepControlPlane) sentCommandsOfType(t controlplaneTypes.CommandType) []*controlplaneTypes.SignedCommand {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var result []*controlplaneTypes.SignedCommand
+	for _, sc := range p.sent {
+		if sc.Command.Type == t {
+			result = append(result, sc)
+		}
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Test helper: minimal Server for observe-sweep handler tests
+// ---------------------------------------------------------------------------
+
+// newObserveServer builds a minimal *Server with the fields required by
+// handleObserveSweepRequest. All other fields are zero/nil.
+func newObserveServer(t *testing.T, cp *inObserveSweepControlPlane, provider ObserveManifestProvider) *Server {
+	t.Helper()
+	logger := logging.NewLogger("debug")
+
+	// Build a minimal commandPublisher backed by the test control plane.
+	// We wire commandPublisher using the same path as real code: commands.New.
+	// Since commands.New requires a non-nil control plane and logger we pass
+	// the test control plane directly.
+	pub := newObserveTestPublisher(t, cp)
+
+	return &Server{
+		logger:                  logger,
+		commandPublisher:        pub,
+		observeManifestProvider: provider,
+	}
+}
+
+// newObserveTestPublisher creates a real commands.Publisher backed by the
+// given control plane. The signer is nil (unsigned commands), which is fine
+// for unit tests that only inspect the command type and params.
+func newObserveTestPublisher(t *testing.T, cp *inObserveSweepControlPlane) *commands.Publisher {
+	t.Helper()
+	pub, err := commands.New(&commands.Config{
+		ControlPlane: cp,
+		Logger:       logging.NewLogger("debug"),
+	})
+	require.NoError(t, err)
+	return pub
+}
+
+// sweepEvent builds an EventObserveSweepRequest with the given baseline DNA.
+func sweepEvent(stewardID string, baselineDNA map[string]string) *controlplaneTypes.Event {
+	raw, _ := json.Marshal(baselineDNA)
+	return &controlplaneTypes.Event{
+		ID:        "evt-sweep-1",
+		Type:      controlplaneTypes.EventObserveSweepRequest,
+		StewardID: stewardID,
+		TenantID:  "tenant-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"baseline_dna": string(raw),
+		},
+	}
+}
+
+// makeManifest builds a minimal ModuleMetadata with the given name, kind
+// (ownership), and observe_when predicate. The publisher "test-publisher" and
+// version "1.0.0" satisfy the metadata parser requirements.
+func makeManifest(name, kind, factKey, factEquals string) *modules.ModuleMetadata {
+	return &modules.ModuleMetadata{
+		Name:      name,
+		Version:   "1.0.0",
+		Publisher: "test-publisher",
+		Executors: []string{"steward"},
+		Kind:      "steward",
+		Owns:      []modules.OwnershipDeclaration{{Kind: kind}},
+		ObserveWhen: []modules.ObservePredicate{
+			{Fact: factKey, Equals: factEquals},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleObserveSweepRequest tests
+// ---------------------------------------------------------------------------
+
+// TestHandleObserveSweepRequest_SendsCommandToSteward verifies that a sweep event
+// with matching baseline DNA causes the controller to send CommandObserveModules
+// to the originating steward.
+func TestHandleObserveSweepRequest_SendsCommandToSteward(t *testing.T) {
+	cp := &inObserveSweepControlPlane{}
+	manifest := makeManifest("hyperv", "hyperv", "windows_feature", "Hyper-V")
+	provider := &inMemoryManifestProvider{manifests: []*modules.ModuleMetadata{manifest}}
+	srv := newObserveServer(t, cp, provider)
+
+	baselineDNA := map[string]string{"windows_feature": "Hyper-V", "os": "windows"}
+	event := sweepEvent("steward-42", baselineDNA)
+
+	err := srv.handleObserveSweepRequest(context.Background(), event)
+	require.NoError(t, err)
+
+	cmds := cp.sentCommandsOfType(controlplaneTypes.CommandObserveModules)
+	require.Len(t, cmds, 1, "one CommandObserveModules must be sent to the steward")
+	assert.Equal(t, "steward-42", cmds[0].Command.StewardID)
+
+	// Verify the modules param contains the resolved module+kind spec.
+	rawModules, ok := cmds[0].Command.Params["modules"].(string)
+	require.True(t, ok, "modules param must be a JSON string")
+	var specs []controlplaneTypes.ObserveModuleSpec
+	require.NoError(t, json.Unmarshal([]byte(rawModules), &specs))
+	require.Len(t, specs, 1)
+	assert.Equal(t, "hyperv", specs[0].Name)
+	assert.Equal(t, "hyperv", specs[0].Kind)
+}
+
+// TestHandleObserveSweepRequest_NoMatchNoCommand verifies that when no module's
+// observe_when predicates match the baseline DNA, no command is sent.
+func TestHandleObserveSweepRequest_NoMatchNoCommand(t *testing.T) {
+	cp := &inObserveSweepControlPlane{}
+	manifest := makeManifest("hyperv", "hyperv", "windows_feature", "Hyper-V")
+	provider := &inMemoryManifestProvider{manifests: []*modules.ModuleMetadata{manifest}}
+	srv := newObserveServer(t, cp, provider)
+
+	// Linux baseline: "windows_feature" fact is absent → hyperv predicate won't match.
+	baselineDNA := map[string]string{"os": "linux", "arch": "amd64"}
+	event := sweepEvent("steward-99", baselineDNA)
+
+	err := srv.handleObserveSweepRequest(context.Background(), event)
+	require.NoError(t, err)
+
+	cmds := cp.sentCommandsOfType(controlplaneTypes.CommandObserveModules)
+	assert.Empty(t, cmds, "no command must be sent when no modules match the baseline DNA")
+}
+
+// TestHandleObserveSweepRequest_NilProvider is a no-op when no manifest
+// provider is configured (feature disabled).
+func TestHandleObserveSweepRequest_NilProvider(t *testing.T) {
+	cp := &inObserveSweepControlPlane{}
+	srv := newObserveServer(t, cp, nil)
+
+	event := sweepEvent("steward-1", map[string]string{"os": "windows"})
+	err := srv.handleObserveSweepRequest(context.Background(), event)
+	require.NoError(t, err)
+
+	cmds := cp.sentCommandsOfType(controlplaneTypes.CommandObserveModules)
+	assert.Empty(t, cmds, "nil provider must be a no-op")
+}
+
+// TestHandleObserveSweepRequest_ManifestListError verifies graceful handling when
+// the provider returns an error. The handler must return nil (non-fatal) and send
+// no command.
+func TestHandleObserveSweepRequest_ManifestListError(t *testing.T) {
+	cp := &inObserveSweepControlPlane{}
+	provider := &inMemoryManifestProvider{listErr: fmt.Errorf("storage unavailable")}
+	srv := newObserveServer(t, cp, provider)
+
+	event := sweepEvent("steward-1", map[string]string{"os": "windows"})
+	err := srv.handleObserveSweepRequest(context.Background(), event)
+	require.NoError(t, err, "manifest list error must be handled gracefully (non-fatal)")
+
+	cmds := cp.sentCommandsOfType(controlplaneTypes.CommandObserveModules)
+	assert.Empty(t, cmds)
+}
+
+// TestHandleObserveSweepRequest_MultipleModulesMatched verifies that when multiple
+// modules match the baseline DNA, specs for all of them are sent in one command.
+func TestHandleObserveSweepRequest_MultipleModulesMatched(t *testing.T) {
+	cp := &inObserveSweepControlPlane{}
+	manifests := []*modules.ModuleMetadata{
+		makeManifest("hyperv", "hyperv", "windows_feature", "Hyper-V"),
+		makeManifest("cluster", "cluster", "windows_feature", "Failover-Clustering"),
+	}
+	provider := &inMemoryManifestProvider{manifests: manifests}
+	srv := newObserveServer(t, cp, provider)
+
+	baselineDNA := map[string]string{
+		"windows_feature": "Hyper-V Failover-Clustering",
+	}
+	event := sweepEvent("steward-7", baselineDNA)
+	// Use "contains" predicate: the manifests above use "equals" so they won't both
+	// match "Hyper-V Failover-Clustering" with equals. Let's use a fact that both match.
+	// Rebuild manifests with Contains predicates for this test.
+	manifests[0].ObserveWhen = []modules.ObservePredicate{{Fact: "windows_feature", Contains: "Hyper-V"}}
+	manifests[1].ObserveWhen = []modules.ObservePredicate{{Fact: "windows_feature", Contains: "Failover-Clustering"}}
+
+	err := srv.handleObserveSweepRequest(context.Background(), event)
+	require.NoError(t, err)
+
+	cmds := cp.sentCommandsOfType(controlplaneTypes.CommandObserveModules)
+	require.Len(t, cmds, 1)
+
+	rawModules, ok := cmds[0].Command.Params["modules"].(string)
+	require.True(t, ok)
+	var specs []controlplaneTypes.ObserveModuleSpec
+	require.NoError(t, json.Unmarshal([]byte(rawModules), &specs))
+	require.Len(t, specs, 2, "both matched modules must appear in the command")
+
+	names := make(map[string]bool)
+	for _, s := range specs {
+		names[s.Name] = true
+	}
+	assert.True(t, names["hyperv"])
+	assert.True(t, names["cluster"])
+}
+
+// TestHandleEventFromProvider_RoutesObserveSweepRequest verifies that
+// handleEventFromProvider correctly routes EventObserveSweepRequest events to
+// handleObserveSweepRequest (AC1 controller routing).
+func TestHandleEventFromProvider_RoutesObserveSweepRequest(t *testing.T) {
+	cp := &inObserveSweepControlPlane{}
+	// No modules match → no command sent, but the event must be routed (no error).
+	provider := &inMemoryManifestProvider{manifests: nil}
+	srv := newObserveServer(t, cp, provider)
+
+	event := &controlplaneTypes.Event{
+		ID:        "evt-routing",
+		Type:      controlplaneTypes.EventObserveSweepRequest,
+		StewardID: "steward-1",
+		Timestamp: time.Now(),
+		Details:   map[string]interface{}{"baseline_dna": `{}`},
+	}
+	err := srv.handleEventFromProvider(context.Background(), event)
+	require.NoError(t, err, "EventObserveSweepRequest must be handled without error")
+}

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -34,6 +34,7 @@ import (
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
 	controller "github.com/cfgis/cfgms/api/proto/controller"
 	"github.com/cfgis/cfgms/features/config/signature"
+	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/features/steward/commands"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	dna "github.com/cfgis/cfgms/features/steward/dna"
@@ -57,6 +58,13 @@ import (
 // inject a stub returning deterministic attribute maps without real I/O.
 type DNACollector interface {
 	CollectAttributes(ctx context.Context) (map[string]string, error)
+}
+
+// ObserveModuleLoader loads steward modules by name for the Tier-2 whole-domain
+// observe sweep (Issue #3104, ADR-024 Amendment 1 §3). Production code wraps
+// factory.ModuleFactory; tests inject a deterministic in-memory implementation.
+type ObserveModuleLoader interface {
+	LoadModule(name string) (modules.Module, error)
 }
 
 // FragmentCollector is an optional extension of DNACollector. When the wired
@@ -256,6 +264,22 @@ type TransportClient struct {
 	// early-returns), so it adds no overhead and never blocks the loop. Tests use
 	// it to observe real ticks without wall-clock sleeps.
 	dnaRefreshTick chan struct{}
+
+	// Tier-2 whole-domain observe sweep (Issue #3104, ADR-024 Amendment 1 §3).
+	// observeSweepN is the cadence: run sweep every Nth convergence cycle.
+	// 0 = disabled. Protected by mu.
+	observeSweepN int
+	// observeSweepCounter counts convergence ticks toward the next sweep.
+	// Resets to 0 after each sweep. Protected by mu.
+	observeSweepCounter int
+	// observeModuleLoader loads modules by name for the Tier-2 sweep.
+	// Nil = disabled. Injectable for testing. Protected by mu.
+	observeModuleLoader ObserveModuleLoader
+	// observeSweepTick, when non-nil, receives one value after each call to
+	// checkAndTriggerObserveSweep (whether or not a sweep fired). Nil in
+	// production; non-nil in tests for deterministic cadence synchronisation.
+	// Uses the same pattern as dnaRefreshTick.
+	observeSweepTick chan struct{}
 
 	// certStoreDir is the on-disk cert/identity directory. The upgrade handler
 	// downloads binaries to a subdirectory here. (Issue #1943)
@@ -486,6 +510,18 @@ type TransportConfig struct {
 	// dna.Collector via main.go after registration.
 	DNACollector DNACollector
 
+	// ObserveSweepN sets the Tier-2 observe sweep cadence: every Nth convergence
+	// cycle the steward publishes an EventObserveSweepRequest so the controller can
+	// push back the resolved observe-module set (Issue #3104, ADR-024 Amendment 1 §3).
+	// 0 (the zero value) disables the sweep.
+	ObserveSweepN int
+
+	// ObserveModuleLoader loads steward modules by name for the Tier-2 sweep.
+	// When nil, the sweep runs but cannot execute module Get calls (no-op).
+	// Production code wires factory.ModuleFactory; tests inject a deterministic
+	// in-memory implementation.
+	ObserveModuleLoader ObserveModuleLoader
+
 	// Logger for client logging
 	Logger logging.Logger
 }
@@ -560,8 +596,10 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 		upgradePublisherTrustStore: cfg.UpgradePublisherTrustStore,
 		// Self-exit after a pushed-upgrade swap only when a launcher is supervising
 		// this process (it sets EnvStewardLauncherManaged=1 on its child). (Issue #2003)
-		launcherManaged: os.Getenv(version.EnvStewardLauncherManaged) == "1",
-		logger:          cfg.Logger,
+		launcherManaged:     os.Getenv(version.EnvStewardLauncherManaged) == "1",
+		observeSweepN:       cfg.ObserveSweepN,
+		observeModuleLoader: cfg.ObserveModuleLoader,
+		logger:              cfg.Logger,
 	}
 
 	return c, nil
@@ -1097,6 +1135,14 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 		return c.handlePushStewardBinary(ctx, cmd)
 	})
 
+	// Register observe_modules handler — controller pushes the resolved Tier-2
+	// observe-module set. The handler loads each module, runs Get read-only, and
+	// merges the resulting fragments into the existing DNA fragment emission path.
+	// (Issue #3104, ADR-024 Amendment 1 §3)
+	handler.RegisterHandler(cpTypes.CommandObserveModules, func(ctx context.Context, cmd *cpTypes.Command) error {
+		return c.handleObserveModules(ctx, cmd)
+	})
+
 	return handler, nil
 }
 
@@ -1602,6 +1648,10 @@ func (c *TransportClient) StartConvergenceLoop(ctx context.Context) {
 				if err := c.TriggerConvergence(ctx); err != nil {
 					c.logger.Warn("Scheduled convergence failed", "error", err)
 				}
+				// Tier-2 cadence: run whole-domain observe sweep every Nth cycle.
+				// The counter increments regardless of convergence success so the
+				// cadence is wall-clock-based, not config-dependent.
+				c.checkAndTriggerObserveSweep(ctx)
 			}
 		}
 	}()
@@ -2611,4 +2661,218 @@ func copyStringMap(m map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+// ---------------------------------------------------------------------------
+// Tier-2 whole-domain observe sweep (Issue #3104, ADR-024 Amendment 1 §3)
+// ---------------------------------------------------------------------------
+
+// checkAndTriggerObserveSweep is called by StartConvergenceLoop on each
+// convergence tick. It increments the Tier-2 counter; when the counter reaches
+// observeSweepN it fires a whole-domain observe sweep request and resets the
+// counter. N=0 disables the sweep.
+//
+// This method always signals observeSweepTick on completion so that tests can
+// synchronize with the cadence counter without using wall-clock sleeps — the
+// same pattern as notifyDNARefreshTick.
+func (c *TransportClient) checkAndTriggerObserveSweep(ctx context.Context) {
+	c.mu.Lock()
+	n := c.observeSweepN
+	if n <= 0 {
+		c.mu.Unlock()
+		c.notifyObserveSweepTick(ctx)
+		return
+	}
+	c.observeSweepCounter++
+	fire := c.observeSweepCounter >= n
+	if fire {
+		c.observeSweepCounter = 0
+	}
+	c.mu.Unlock()
+
+	if fire {
+		c.triggerObserveSweep(ctx)
+	}
+	c.notifyObserveSweepTick(ctx)
+}
+
+// notifyObserveSweepTick signals observeSweepTick after each
+// checkAndTriggerObserveSweep call. Nil in production; non-nil in tests.
+// The send is guarded by ctx.Done so an un-drained channel never blocks.
+func (c *TransportClient) notifyObserveSweepTick(ctx context.Context) {
+	c.mu.RLock()
+	tick := c.observeSweepTick
+	c.mu.RUnlock()
+	if tick == nil {
+		return
+	}
+	select {
+	case tick <- struct{}{}:
+	case <-ctx.Done():
+	}
+}
+
+// triggerObserveSweep publishes an EventObserveSweepRequest carrying the current
+// baseline DNA to the controller. The controller resolves the observe-module set
+// and responds with CommandObserveModules. (Issue #3104, ADR-024 Amendment 1 §3)
+func (c *TransportClient) triggerObserveSweep(ctx context.Context) {
+	c.mu.RLock()
+	sid := c.stewardID
+	tid := c.tenantID
+	c.mu.RUnlock()
+
+	if sid == "" {
+		c.logger.Debug("Tier-2 observe sweep skipped: steward not yet registered")
+		return
+	}
+
+	c.dnaMu.RLock()
+	attrs := copyStringMap(c.currentDNAAttrs)
+	c.dnaMu.RUnlock()
+
+	dnaJSON, err := json.Marshal(attrs)
+	if err != nil {
+		c.logger.Warn("Tier-2 observe sweep: failed to marshal baseline DNA", "error", err)
+		return
+	}
+
+	event := &cpTypes.Event{
+		ID:        fmt.Sprintf("evt_obs_%d", time.Now().UnixNano()),
+		Type:      cpTypes.EventObserveSweepRequest,
+		StewardID: sid,
+		TenantID:  tid,
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"baseline_dna": string(dnaJSON),
+		},
+	}
+
+	if err := c.publishEventWithQueue(ctx, event); err != nil {
+		c.logger.Warn("Tier-2 observe sweep: failed to publish sweep request", "error", err)
+	}
+}
+
+// handleObserveModules processes a COMMAND_TYPE_OBSERVE_MODULES command from the
+// controller. It loads each specified module, calls Get read-only, and merges
+// the resulting fragments into currentDNAFragments through the existing
+// setCurrentDNAFragments path (ADR-024 Amendment 1 §2 — no new parallel channel).
+func (c *TransportClient) handleObserveModules(ctx context.Context, cmd *cpTypes.Command) error {
+	c.mu.RLock()
+	loader := c.observeModuleLoader
+	c.mu.RUnlock()
+
+	if loader == nil {
+		c.logger.Warn("observe_modules: no module loader configured; skipping observe sweep")
+		return nil
+	}
+
+	specs, err := parseObserveModuleSpecs(cmd.Params["modules"])
+	if err != nil {
+		return fmt.Errorf("observe_modules: %w", err)
+	}
+	if len(specs) == 0 {
+		return nil
+	}
+
+	// Load each module and build the inputs for Assembler.Assemble.
+	activeModules := make(map[string]modules.Module, len(specs))
+	ownership := make(map[string][]modules.OwnershipDeclaration, len(specs))
+	for _, spec := range specs {
+		mod, loadErr := loader.LoadModule(spec.Name)
+		if loadErr != nil {
+			c.logger.Warn("observe sweep: module load failed; skipping",
+				"module", logging.SanitizeLogValue(spec.Name), "error", loadErr)
+			continue
+		}
+		activeModules[spec.Name] = mod
+		ownership[spec.Name] = []modules.OwnershipDeclaration{{Kind: spec.Kind}}
+	}
+
+	if len(activeModules) == 0 {
+		return nil
+	}
+
+	// Snapshot current host-fact fragments as input to the assembler so that
+	// module-owned kinds preempt the corresponding host-fact fragments
+	// (ADR-016 clause 5, Assembler phase 3).
+	c.dnaMu.RLock()
+	hostFactFragments := make([]*commonpb.Fragment, len(c.currentDNAFragments))
+	copy(hostFactFragments, c.currentDNAFragments)
+	c.dnaMu.RUnlock()
+
+	// Merge observe-module fragments with host-fact fragments. The Assembler
+	// handles authority resolution per ADR-016 and ADR-017.
+	assembler := dna.NewAssembler(c.logger)
+	merged, _, assembleErr := assembler.Assemble(ctx, activeModules, ownership, hostFactFragments)
+	if assembleErr != nil {
+		return fmt.Errorf("observe sweep: assemble fragments: %w", assembleErr)
+	}
+
+	// Write through the existing fragment emission path (ADR-024 Amendment 1 §2).
+	// setCurrentDNAFragments updates currentDNAAggregateRoot, which the heartbeat
+	// loop carries to the controller; the controller detects the change and issues
+	// CommandSyncDNA to pull the merged fragment set.
+	c.setCurrentDNAFragments(merged)
+
+	c.logger.Info("Tier-2 observe sweep completed",
+		"observe_modules", len(activeModules),
+		"total_fragments", len(merged))
+
+	return nil
+}
+
+// parseObserveModuleSpecs converts the "modules" param from a CommandObserveModules
+// command into a []cpTypes.ObserveModuleSpec. It handles the three shapes the param
+// can arrive in:
+//
+//   - string: JSON-encoded array (gRPC wire path)
+//   - []interface{}: already-parsed JSON array (in-process path)
+//   - []cpTypes.ObserveModuleSpec: native slice (test path)
+func parseObserveModuleSpecs(raw interface{}) ([]cpTypes.ObserveModuleSpec, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	var specs []cpTypes.ObserveModuleSpec
+
+	switch v := raw.(type) {
+	case string:
+		if v == "" {
+			return nil, nil
+		}
+		if err := json.Unmarshal([]byte(v), &specs); err != nil {
+			return nil, fmt.Errorf("modules param is not a JSON array: %w", err)
+		}
+	case []interface{}:
+		specs = make([]cpTypes.ObserveModuleSpec, 0, len(v))
+		for i, elem := range v {
+			m, ok := elem.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("modules[%d]: expected object, got %T", i, elem)
+			}
+			spec := cpTypes.ObserveModuleSpec{}
+			if name, ok := m["name"].(string); ok {
+				spec.Name = name
+			}
+			if kind, ok := m["kind"].(string); ok {
+				spec.Kind = kind
+			}
+			specs = append(specs, spec)
+		}
+	case []cpTypes.ObserveModuleSpec:
+		specs = v
+	default:
+		return nil, fmt.Errorf("modules param has unsupported type %T", raw)
+	}
+
+	for i, spec := range specs {
+		if spec.Name == "" {
+			return nil, fmt.Errorf("modules[%d]: name is required", i)
+		}
+		if spec.Kind == "" {
+			return nil, fmt.Errorf("modules[%d]: kind is required", i)
+		}
+	}
+
+	return specs, nil
 }

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -280,6 +281,16 @@ type TransportClient struct {
 	// production; non-nil in tests for deterministic cadence synchronisation.
 	// Uses the same pattern as dnaRefreshTick.
 	observeSweepTick chan struct{}
+	// observeSweepInFlight is the single-flight guard for handleObserveModules.
+	// Command handlers run one goroutine per command, and the cadence in
+	// checkAndTriggerObserveSweep keeps firing while a sweep is still running
+	// (a module Get slower than N convergence ticks yields two in-flight
+	// observe_modules commands with distinct IDs, which replay de-duplication
+	// does not catch). Overlapping sweeps would drive concurrent module loads
+	// and concurrent fragment merges, so a second sweep is dropped while one is
+	// in flight rather than queued — the dropped sweep's work is fully covered
+	// by the next cadence tick.
+	observeSweepInFlight atomic.Bool
 
 	// certStoreDir is the on-disk cert/identity directory. The upgrade handler
 	// downloads binaries to a subdirectory here. (Issue #1943)
@@ -2712,6 +2723,20 @@ func (c *TransportClient) notifyObserveSweepTick(ctx context.Context) {
 	}
 }
 
+// observeSweepEventSeq is a monotonically increasing counter appended to
+// Tier-2 observe sweep event IDs. time.Now().UnixNano() alone can collide
+// when checkAndTriggerObserveSweep fires in tight succession under coarse
+// clock resolution (observed on Windows CI runners); the offline queue
+// de-duplicates events by ID, so a collision silently drops the later event.
+// The counter guarantees uniqueness independent of clock resolution.
+var observeSweepEventSeq atomic.Int64
+
+// newObserveSweepEventID builds a collision-resistant ID for a Tier-2 observe
+// sweep event from a nanosecond timestamp and a monotonic sequence number.
+func newObserveSweepEventID(nowUnixNano, seq int64) string {
+	return fmt.Sprintf("evt_obs_%d_%d", nowUnixNano, seq)
+}
+
 // triggerObserveSweep publishes an EventObserveSweepRequest carrying the current
 // baseline DNA to the controller. The controller resolves the observe-module set
 // and responds with CommandObserveModules. (Issue #3104, ADR-024 Amendment 1 §3)
@@ -2737,7 +2762,7 @@ func (c *TransportClient) triggerObserveSweep(ctx context.Context) {
 	}
 
 	event := &cpTypes.Event{
-		ID:        fmt.Sprintf("evt_obs_%d", time.Now().UnixNano()),
+		ID:        newObserveSweepEventID(time.Now().UnixNano(), observeSweepEventSeq.Add(1)),
 		Type:      cpTypes.EventObserveSweepRequest,
 		StewardID: sid,
 		TenantID:  tid,
@@ -2756,7 +2781,18 @@ func (c *TransportClient) triggerObserveSweep(ctx context.Context) {
 // controller. It loads each specified module, calls Get read-only, and merges
 // the resulting fragments into currentDNAFragments through the existing
 // setCurrentDNAFragments path (ADR-024 Amendment 1 §2 — no new parallel channel).
+//
+// Sweeps are single-flight: while one sweep is running, any further
+// observe_modules command is dropped instead of running concurrently. The
+// controller re-requests on the next cadence tick, so no observation is lost.
 func (c *TransportClient) handleObserveModules(ctx context.Context, cmd *cpTypes.Command) error {
+	if !c.observeSweepInFlight.CompareAndSwap(false, true) {
+		c.logger.Warn("observe_modules: sweep already in flight; dropping overlapping command",
+			"command_id", logging.SanitizeLogValue(cmd.ID))
+		return nil
+	}
+	defer c.observeSweepInFlight.Store(false)
+
 	c.mu.RLock()
 	loader := c.observeModuleLoader
 	c.mu.RUnlock()

--- a/features/steward/client/client_transport_observe_test.go
+++ b/features/steward/client/client_transport_observe_test.go
@@ -1,0 +1,622 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+//
+// Tests for the Tier-2 whole-domain observe sweep (Issue #3104, ADR-024 Amendment 1).
+//
+// inMemoryModule, inMemoryConfigState, and inMemoryObserveModuleLoader are real,
+// deterministic in-process implementations of their respective interfaces — not
+// mocks. No framework, no expectation recording, no call verification. They
+// provide the same guarantee the production implementations do: defined inputs
+// produce defined outputs, consistently and without I/O.
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/modules"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+)
+
+// ---------------------------------------------------------------------------
+// Real in-process test components (not mocks)
+// ---------------------------------------------------------------------------
+
+// inMemoryConfigState is a real, deterministic implementation of modules.ConfigState
+// backed by a fixed AsMap value. Satisfies the ADR-016 clause 4 contract: identical
+// state always produces identical AsMap output.
+type inMemoryConfigState struct {
+	data map[string]interface{}
+}
+
+var _ modules.ConfigState = (*inMemoryConfigState)(nil)
+
+func (s *inMemoryConfigState) AsMap() map[string]interface{} {
+	out := make(map[string]interface{}, len(s.data))
+	for k, v := range s.data {
+		out[k] = v
+	}
+	return out
+}
+func (s *inMemoryConfigState) ToYAML() ([]byte, error)    { return nil, nil }
+func (s *inMemoryConfigState) FromYAML(_ []byte) error    { return nil }
+func (s *inMemoryConfigState) Validate() error            { return nil }
+func (s *inMemoryConfigState) GetManagedFields() []string { return nil }
+
+// inMemoryModule is a real, thread-safe implementation of modules.Module backed
+// by a fixed ConfigState. Get always returns the same state; Set is a no-op.
+type inMemoryModule struct {
+	mu     sync.RWMutex
+	state  map[string]interface{}
+	getErr error
+}
+
+var _ modules.Module = (*inMemoryModule)(nil)
+
+func (m *inMemoryModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return &inMemoryConfigState{data: m.state}, nil
+}
+
+func (m *inMemoryModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+// inMemoryObserveModuleLoader is a real, thread-safe implementation of
+// ObserveModuleLoader backed by a name→Module map. Returns a module-not-found
+// error for any name absent from the map. No frameworks, no expectation recording.
+type inMemoryObserveModuleLoader struct {
+	mu      sync.RWMutex
+	mods    map[string]modules.Module
+	loadErr map[string]error
+}
+
+var _ ObserveModuleLoader = (*inMemoryObserveModuleLoader)(nil)
+
+func newInMemoryLoader(mods map[string]modules.Module) *inMemoryObserveModuleLoader {
+	return &inMemoryObserveModuleLoader{
+		mods:    mods,
+		loadErr: make(map[string]error),
+	}
+}
+
+func (l *inMemoryObserveModuleLoader) LoadModule(name string) (modules.Module, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if err, ok := l.loadErr[name]; ok && err != nil {
+		return nil, err
+	}
+	mod, ok := l.mods[name]
+	if !ok {
+		return nil, fmt.Errorf("module not found: %s", name)
+	}
+	return mod, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a TransportClient wired for observe tests
+// ---------------------------------------------------------------------------
+
+// newObserveTestClient builds a minimal TransportClient with an in-memory
+// offline queue (for capturing published events), a test logger, and an
+// observeSweepTick channel for cadence-test synchronisation.
+func newObserveTestClient(t *testing.T) (*TransportClient, *OfflineQueue) {
+	t.Helper()
+	c, q := newClientWithOfflineQueue(t)
+	// Buffer large enough that batch cadence tests can call checkAndTriggerObserveSweep
+	// multiple times without blocking (sender never blocks, never drops for count ≤ 16).
+	c.observeSweepTick = make(chan struct{}, 16)
+	return c, q
+}
+
+// drainObserveSweepEvents drains all events from the offline queue and returns
+// those of type EventObserveSweepRequest.
+func drainObserveSweepEvents(q *OfflineQueue) []*cpTypes.Event {
+	var result []*cpTypes.Event
+	q.Drain(func(e *cpTypes.Event) error {
+		if e.Type == cpTypes.EventObserveSweepRequest {
+			result = append(result, e)
+		}
+		return nil
+	})
+	return result
+}
+
+// observeCmd builds a CommandObserveModules command carrying the given specs
+// as a JSON-encoded "modules" param (the wire format the controller sends).
+func observeCmd(t *testing.T, specs []cpTypes.ObserveModuleSpec) *cpTypes.Command {
+	t.Helper()
+	raw, err := json.Marshal(specs)
+	require.NoError(t, err)
+	return &cpTypes.Command{
+		ID:        "cmd-obs-1",
+		Type:      cpTypes.CommandObserveModules,
+		StewardID: "steward-1",
+		Params:    map[string]interface{}{"modules": string(raw)},
+	}
+}
+
+// makeHostFact returns a Fragment that looks like a host-fact fragment
+// (non-module-owned) with the given kind and a dummy CanonicalBytes.
+func makeHostFact(kind string) *commonpb.Fragment {
+	return &commonpb.Fragment{
+		FragmentId:     kind,
+		Authority:      "gatherer",
+		CanonicalBytes: []byte(`{"kind":"` + kind + `"}`),
+		FragmentHash:   kind + "-hash",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseObserveModuleSpecs unit tests
+// ---------------------------------------------------------------------------
+
+func TestParseObserveModuleSpecs_NilInput(t *testing.T) {
+	specs, err := parseObserveModuleSpecs(nil)
+	require.NoError(t, err)
+	assert.Empty(t, specs)
+}
+
+func TestParseObserveModuleSpecs_EmptyString(t *testing.T) {
+	specs, err := parseObserveModuleSpecs("")
+	require.NoError(t, err)
+	assert.Empty(t, specs)
+}
+
+func TestParseObserveModuleSpecs_JSONString(t *testing.T) {
+	raw := `[{"name":"hyperv","kind":"hyperv"}]`
+	specs, err := parseObserveModuleSpecs(raw)
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+	assert.Equal(t, "hyperv", specs[0].Name)
+	assert.Equal(t, "hyperv", specs[0].Kind)
+}
+
+func TestParseObserveModuleSpecs_SliceInterface(t *testing.T) {
+	raw := []interface{}{
+		map[string]interface{}{"name": "hyperv", "kind": "vm"},
+		map[string]interface{}{"name": "cluster", "kind": "cluster"},
+	}
+	specs, err := parseObserveModuleSpecs(raw)
+	require.NoError(t, err)
+	require.Len(t, specs, 2)
+	assert.Equal(t, "hyperv", specs[0].Name)
+	assert.Equal(t, "cluster", specs[1].Name)
+}
+
+func TestParseObserveModuleSpecs_NativeSlice(t *testing.T) {
+	raw := []cpTypes.ObserveModuleSpec{{Name: "hyperv", Kind: "vm"}}
+	specs, err := parseObserveModuleSpecs(raw)
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+	assert.Equal(t, "vm", specs[0].Kind)
+}
+
+func TestParseObserveModuleSpecs_MissingName(t *testing.T) {
+	raw := `[{"name":"","kind":"vm"}]`
+	_, err := parseObserveModuleSpecs(raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
+}
+
+func TestParseObserveModuleSpecs_MissingKind(t *testing.T) {
+	raw := `[{"name":"hyperv","kind":""}]`
+	_, err := parseObserveModuleSpecs(raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kind")
+}
+
+// ---------------------------------------------------------------------------
+// handleObserveModules — AC2 and AC3
+// ---------------------------------------------------------------------------
+
+// TestHandleObserveModules_MergesFragmentIntoCurrentDNA verifies AC2 (module Get
+// invoked) and AC3 (Get output merged into existing DNA fragment emission path).
+// After handleObserveModules, currentDNAFragments must contain a fragment whose
+// FragmentId matches the spec's Kind. This is the existing partial-sync emission
+// path — setCurrentDNAFragments is the only write to currentDNAFragments.
+func TestHandleObserveModules_MergesFragmentIntoCurrentDNA(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+
+	// Wire a loader that returns a module with known, stable Get output.
+	mod := &inMemoryModule{state: map[string]interface{}{"vm_count": 3, "cluster": "site-a"}}
+	c.observeModuleLoader = newInMemoryLoader(map[string]modules.Module{"hyperv": mod})
+
+	cmd := observeCmd(t, []cpTypes.ObserveModuleSpec{{Name: "hyperv", Kind: "hyperv"}})
+	err := c.handleObserveModules(context.Background(), cmd)
+	require.NoError(t, err)
+
+	c.dnaMu.RLock()
+	frags := c.currentDNAFragments
+	c.dnaMu.RUnlock()
+
+	require.NotEmpty(t, frags, "currentDNAFragments must be non-empty after observe sweep")
+	var found bool
+	for _, f := range frags {
+		if f.GetFragmentId() == "hyperv" {
+			found = true
+			assert.NotEmpty(t, f.GetCanonicalBytes(), "fragment must have canonical bytes")
+			assert.NotEmpty(t, f.GetFragmentHash(), "fragment must have a hash")
+			assert.Equal(t, "hyperv", f.GetAuthority(), "module authority must be the module name")
+		}
+	}
+	assert.True(t, found, "currentDNAFragments should contain a fragment with FragmentId=hyperv")
+}
+
+// TestHandleObserveModules_HostFactFragmentsPreserved verifies that pre-existing
+// host-fact fragments for kinds NOT claimed by the observe module are preserved
+// after handleObserveModules (Assembler phase 3: merge observe-only host facts).
+func TestHandleObserveModules_HostFactFragmentsPreserved(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+
+	// Seed an existing host-fact fragment for a different kind.
+	hostFact := makeHostFact("host:network")
+	c.dnaMu.Lock()
+	c.currentDNAFragments = []*commonpb.Fragment{hostFact}
+	c.dnaMu.Unlock()
+
+	mod := &inMemoryModule{state: map[string]interface{}{"vm_count": 1}}
+	c.observeModuleLoader = newInMemoryLoader(map[string]modules.Module{"hyperv": mod})
+
+	cmd := observeCmd(t, []cpTypes.ObserveModuleSpec{{Name: "hyperv", Kind: "hyperv"}})
+	err := c.handleObserveModules(context.Background(), cmd)
+	require.NoError(t, err)
+
+	c.dnaMu.RLock()
+	frags := c.currentDNAFragments
+	c.dnaMu.RUnlock()
+
+	// Both the observe-module fragment AND the host-fact fragment must be present.
+	kindSet := make(map[string]bool)
+	for _, f := range frags {
+		kindSet[f.GetFragmentId()] = true
+	}
+	assert.True(t, kindSet["hyperv"], "observe-module fragment must be present")
+	assert.True(t, kindSet["host:network"], "pre-existing host-fact fragment must be preserved")
+}
+
+// TestHandleObserveModules_ModuleAuthorityPreemptsHostFact verifies ADR-016 clause 5:
+// when the observe module claims a kind that was previously in a host-fact fragment,
+// the module fragment wins and the host-fact fragment is dropped.
+func TestHandleObserveModules_ModuleAuthorityPreemptsHostFact(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+
+	// Seed a host-fact fragment for the SAME kind the module will claim.
+	hostFact := makeHostFact("hyperv")
+	c.dnaMu.Lock()
+	c.currentDNAFragments = []*commonpb.Fragment{hostFact}
+	c.dnaMu.Unlock()
+
+	mod := &inMemoryModule{state: map[string]interface{}{"vm_count": 2}}
+	c.observeModuleLoader = newInMemoryLoader(map[string]modules.Module{"hyperv": mod})
+
+	cmd := observeCmd(t, []cpTypes.ObserveModuleSpec{{Name: "hyperv", Kind: "hyperv"}})
+	err := c.handleObserveModules(context.Background(), cmd)
+	require.NoError(t, err)
+
+	c.dnaMu.RLock()
+	frags := c.currentDNAFragments
+	c.dnaMu.RUnlock()
+
+	// There must be exactly one fragment for kind "hyperv" and its authority must
+	// be the module (not the gatherer from the host-fact fragment).
+	var hypervFrags []*commonpb.Fragment
+	for _, f := range frags {
+		if f.GetFragmentId() == "hyperv" {
+			hypervFrags = append(hypervFrags, f)
+		}
+	}
+	require.Len(t, hypervFrags, 1, "exactly one hyperv fragment must exist after authority preemption")
+	assert.Equal(t, "hyperv", hypervFrags[0].GetAuthority(),
+		"module authority must win over gatherer authority (ADR-016 clause 5)")
+}
+
+// TestHandleObserveModules_LoaderUnavailable verifies graceful handling when the
+// module loader is nil (disabled). The call must succeed without panicking.
+func TestHandleObserveModules_LoaderNil(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+	c.observeModuleLoader = nil // explicitly disabled
+
+	cmd := observeCmd(t, []cpTypes.ObserveModuleSpec{{Name: "hyperv", Kind: "hyperv"}})
+	err := c.handleObserveModules(context.Background(), cmd)
+	require.NoError(t, err, "nil loader must be a no-op, not an error")
+
+	c.dnaMu.RLock()
+	frags := c.currentDNAFragments
+	c.dnaMu.RUnlock()
+	assert.Empty(t, frags, "no fragments should be emitted when loader is nil")
+}
+
+// TestHandleObserveModules_ModuleLoadError verifies graceful handling when the
+// loader returns an error for a specific module. The module is skipped; others
+// in the spec list are still processed.
+func TestHandleObserveModules_ModuleLoadError(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+
+	goodMod := &inMemoryModule{state: map[string]interface{}{"disk_count": 4}}
+	loader := newInMemoryLoader(map[string]modules.Module{"storage": goodMod})
+	loader.loadErr["hyperv"] = fmt.Errorf("module binary not cached")
+	c.observeModuleLoader = loader
+
+	cmd := observeCmd(t, []cpTypes.ObserveModuleSpec{
+		{Name: "hyperv", Kind: "hyperv"},   // fails to load
+		{Name: "storage", Kind: "storage"}, // succeeds
+	})
+	err := c.handleObserveModules(context.Background(), cmd)
+	require.NoError(t, err, "per-module load failure must be skipped, not propagated")
+
+	c.dnaMu.RLock()
+	frags := c.currentDNAFragments
+	c.dnaMu.RUnlock()
+
+	kindSet := make(map[string]bool)
+	for _, f := range frags {
+		kindSet[f.GetFragmentId()] = true
+	}
+	assert.True(t, kindSet["storage"], "successfully loaded module must produce a fragment")
+	assert.False(t, kindSet["hyperv"], "failed module must not produce a fragment")
+}
+
+// TestHandleObserveModules_NoSpecs verifies that an empty spec list is a no-op.
+func TestHandleObserveModules_NoSpecs(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+	c.observeModuleLoader = newInMemoryLoader(nil)
+
+	cmd := observeCmd(t, nil)
+	err := c.handleObserveModules(context.Background(), cmd)
+	require.NoError(t, err)
+
+	c.dnaMu.RLock()
+	frags := c.currentDNAFragments
+	c.dnaMu.RUnlock()
+	assert.Empty(t, frags)
+}
+
+// ---------------------------------------------------------------------------
+// AC4 — Integration test: full Tier-2 cycle
+// ---------------------------------------------------------------------------
+
+// TestHandleObserveModules_FullCycle verifies AC4: one full Tier-2 cycle in terms
+// of the steward side — baseline DNA is in currentDNAAttrs (carried to the
+// controller via EventObserveSweepRequest), the controller resolves the module set
+// and sends CommandObserveModules back, handleObserveModules runs Get and merges
+// results, and currentDNAFragments contains the new module data through the same
+// emission path (setCurrentDNAFragments).
+//
+// The controller-side resolution is not exercised here; this test verifies the
+// steward-side fragment emission path end-to-end: baseline in → module loaded →
+// Get called → fragment in currentDNAFragments.
+func TestHandleObserveModules_FullCycle(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+
+	// Seed baseline DNA (as if the DNA refresh loop already ran once).
+	baselineDNA := map[string]string{
+		"os":              "windows",
+		"windows_feature": "Hyper-V",
+	}
+	c.dnaMu.Lock()
+	c.currentDNAAttrs = baselineDNA
+	c.dnaMu.Unlock()
+
+	// Wire a loader for the "hyperv" module the controller resolved.
+	mod := &inMemoryModule{state: map[string]interface{}{
+		"vm_count":   2,
+		"cluster":    "site-a",
+		"hypervisor": "hyper-v",
+	}}
+	c.observeModuleLoader = newInMemoryLoader(map[string]modules.Module{"hyperv": mod})
+
+	// Simulate the CommandObserveModules the controller would send.
+	cmd := observeCmd(t, []cpTypes.ObserveModuleSpec{{Name: "hyperv", Kind: "hyperv"}})
+
+	// Run handleObserveModules — this is the core of the Tier-2 sweep on the steward side.
+	err := c.handleObserveModules(context.Background(), cmd)
+	require.NoError(t, err)
+
+	// Verify: currentDNAFragments contains the hyperv fragment, using the existing
+	// setCurrentDNAFragments emission path (not a new channel — ADR-024 Amendment 1 §2).
+	c.dnaMu.RLock()
+	frags := c.currentDNAFragments
+	root := c.currentDNAAggregateRoot
+	c.dnaMu.RUnlock()
+
+	require.NotEmpty(t, frags, "fragment set must be non-empty after full Tier-2 cycle")
+	assert.NotEmpty(t, root, "aggregate root must be updated after fragment merge")
+
+	var found bool
+	for _, f := range frags {
+		if f.GetFragmentId() == "hyperv" {
+			found = true
+			assert.NotEmpty(t, f.GetCanonicalBytes())
+			assert.NotEmpty(t, f.GetFragmentHash())
+		}
+	}
+	assert.True(t, found, "fragment set must contain hyperv module data after full Tier-2 cycle")
+}
+
+// ---------------------------------------------------------------------------
+// AC1 — triggerObserveSweep publishes EventObserveSweepRequest
+// ---------------------------------------------------------------------------
+
+// TestTriggerObserveSweep_PublishesEventWithBaselineDNA verifies AC1: the
+// triggerObserveSweep method publishes an EventObserveSweepRequest event that
+// carries the current baseline DNA in the "baseline_dna" detail key.
+func TestTriggerObserveSweep_PublishesEventWithBaselineDNA(t *testing.T) {
+	c, q := newObserveTestClient(t)
+	c.stewardID = "steward-1"
+	c.tenantID = "tenant-1"
+
+	baselineAttrs := map[string]string{
+		"os":   "windows",
+		"arch": "amd64",
+	}
+	c.dnaMu.Lock()
+	c.currentDNAAttrs = baselineAttrs
+	c.dnaMu.Unlock()
+
+	c.triggerObserveSweep(context.Background())
+
+	events := drainObserveSweepEvents(q)
+	require.Len(t, events, 1, "exactly one EventObserveSweepRequest must be published")
+
+	evt := events[0]
+	assert.Equal(t, cpTypes.EventObserveSweepRequest, evt.Type)
+	assert.Equal(t, "steward-1", evt.StewardID)
+
+	rawDNA, ok := evt.Details["baseline_dna"].(string)
+	require.True(t, ok, "baseline_dna detail must be a JSON string")
+
+	var decoded map[string]string
+	require.NoError(t, json.Unmarshal([]byte(rawDNA), &decoded))
+	assert.Equal(t, baselineAttrs["os"], decoded["os"])
+	assert.Equal(t, baselineAttrs["arch"], decoded["arch"])
+}
+
+// TestTriggerObserveSweep_NoopWhenNotRegistered verifies that triggerObserveSweep
+// is a no-op when the steward is not yet registered (empty stewardID). No event
+// should be published and no error should occur.
+func TestTriggerObserveSweep_NoopWhenNotRegistered(t *testing.T) {
+	c, q := newObserveTestClient(t)
+	c.stewardID = "" // not registered
+
+	c.triggerObserveSweep(context.Background())
+
+	events := drainObserveSweepEvents(q)
+	assert.Empty(t, events, "no event must be published when steward is not registered")
+}
+
+// ---------------------------------------------------------------------------
+// AC5 — Cadence test: sweep fires only on Nth cycle
+// ---------------------------------------------------------------------------
+
+// TestObserveSweepCadence_FiresOnNthCycle verifies AC5: the whole-domain sweep
+// fires exactly once every N convergence ticks, not on every tick.
+//
+// checkAndTriggerObserveSweep is called directly to isolate the counter logic
+// from the wall-clock-based convergence ticker. The test drives N ticks,
+// verifies the sweep fires once, then drives N-1 more ticks and confirms no
+// second sweep fires prematurely.
+func TestObserveSweepCadence_FiresOnNthCycle(t *testing.T) {
+	const N = 3
+	c, q := newObserveTestClient(t)
+	c.stewardID = "steward-1"
+	c.tenantID = "tenant-1"
+	c.observeSweepN = N
+
+	// Set some baseline DNA so triggerObserveSweep has something to publish.
+	c.dnaMu.Lock()
+	c.currentDNAAttrs = map[string]string{"os": "linux"}
+	c.dnaMu.Unlock()
+
+	ctx := context.Background()
+
+	// Ticks 1 and 2: no sweep yet.
+	c.checkAndTriggerObserveSweep(ctx)
+	c.checkAndTriggerObserveSweep(ctx)
+	assert.Empty(t, drainObserveSweepEvents(q), "sweep must not fire before Nth cycle")
+
+	// Tick 3: sweep fires.
+	c.checkAndTriggerObserveSweep(ctx)
+	events := drainObserveSweepEvents(q)
+	require.Len(t, events, 1, "sweep must fire exactly once on the Nth cycle")
+	assert.Equal(t, cpTypes.EventObserveSweepRequest, events[0].Type)
+
+	// Ticks 4 and 5: no sweep yet (counter reset to 0 after tick 3).
+	c.checkAndTriggerObserveSweep(ctx)
+	c.checkAndTriggerObserveSweep(ctx)
+	assert.Empty(t, drainObserveSweepEvents(q), "sweep must not fire between Nth cycles")
+}
+
+// TestObserveSweepCadence_DisabledWhenZero verifies that setting ObserveSweepN=0
+// disables the Tier-2 sweep entirely. No events must be published regardless of
+// how many convergence ticks fire.
+func TestObserveSweepCadence_DisabledWhenZero(t *testing.T) {
+	c, q := newObserveTestClient(t)
+	c.stewardID = "steward-1"
+	c.observeSweepN = 0 // disabled
+
+	c.dnaMu.Lock()
+	c.currentDNAAttrs = map[string]string{"os": "linux"}
+	c.dnaMu.Unlock()
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		c.checkAndTriggerObserveSweep(ctx)
+	}
+	assert.Empty(t, drainObserveSweepEvents(q), "sweep must never fire when ObserveSweepN=0")
+}
+
+// TestObserveSweepCadence_N1FiresEveryTick verifies that N=1 causes the sweep
+// to fire on every convergence tick.
+func TestObserveSweepCadence_N1FiresEveryTick(t *testing.T) {
+	c, q := newObserveTestClient(t)
+	c.stewardID = "steward-1"
+	c.tenantID = "tenant-1"
+	c.observeSweepN = 1
+
+	c.dnaMu.Lock()
+	c.currentDNAAttrs = map[string]string{"os": "linux"}
+	c.dnaMu.Unlock()
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		c.checkAndTriggerObserveSweep(ctx)
+	}
+	events := drainObserveSweepEvents(q)
+	assert.Len(t, events, 3, "with N=1 every convergence tick must trigger a sweep")
+}
+
+// ---------------------------------------------------------------------------
+// observeSweepTick synchronisation (mirrors dnaRefreshTick pattern)
+// ---------------------------------------------------------------------------
+
+// TestCheckAndTriggerObserveSweep_SignalsTick verifies that checkAndTriggerObserveSweep
+// always sends on observeSweepTick after completion, regardless of whether the
+// sweep fired. This allows tests to observe each tick deterministically.
+func TestCheckAndTriggerObserveSweep_SignalsTick(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+	c.observeSweepN = 5 // won't fire within 3 calls
+	tick := make(chan struct{}, 3)
+	c.observeSweepTick = tick
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		c.checkAndTriggerObserveSweep(ctx)
+	}
+
+	assert.Equal(t, 3, len(tick),
+		"observeSweepTick must receive one value per checkAndTriggerObserveSweep call")
+}
+
+// ---------------------------------------------------------------------------
+// NewTransportClient wiring: ObserveSweepN and ObserveModuleLoader
+// ---------------------------------------------------------------------------
+
+// TestNewTransportClient_WiresObserveSweepFields verifies that TransportConfig fields
+// ObserveSweepN and ObserveModuleLoader are correctly threaded into the client struct
+// by NewTransportClient.
+func TestNewTransportClient_WiresObserveSweepFields(t *testing.T) {
+	loader := newInMemoryLoader(nil)
+	cfg := &TransportConfig{
+		ControllerURL:       "controller:4433",
+		Logger:              newTestLogger(t),
+		ObserveSweepN:       7,
+		ObserveModuleLoader: loader,
+	}
+	c, err := NewTransportClient(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, 7, c.observeSweepN, "observeSweepN must be set from TransportConfig")
+	assert.Equal(t, loader, c.observeModuleLoader, "observeModuleLoader must be set from TransportConfig")
+}

--- a/features/steward/client/client_transport_observe_test.go
+++ b/features/steward/client/client_transport_observe_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,11 @@ import (
 
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/modules"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
+	"github.com/cfgis/cfgms/features/steward/factory"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // ---------------------------------------------------------------------------
@@ -137,10 +142,19 @@ func drainObserveSweepEvents(q *OfflineQueue) []*cpTypes.Event {
 // as a JSON-encoded "modules" param (the wire format the controller sends).
 func observeCmd(t *testing.T, specs []cpTypes.ObserveModuleSpec) *cpTypes.Command {
 	t.Helper()
+	return observeCmdWithID(t, "cmd-obs-1", specs)
+}
+
+// observeCmdWithID is observeCmd with an explicit command ID. Overlapping
+// sweeps arrive as commands with distinct IDs (replay de-duplication keys on
+// the ID and therefore does not suppress them), so concurrency tests must be
+// able to set the ID.
+func observeCmdWithID(t *testing.T, id string, specs []cpTypes.ObserveModuleSpec) *cpTypes.Command {
+	t.Helper()
 	raw, err := json.Marshal(specs)
 	require.NoError(t, err)
 	return &cpTypes.Command{
-		ID:        "cmd-obs-1",
+		ID:        id,
 		Type:      cpTypes.CommandObserveModules,
 		StewardID: "steward-1",
 		Params:    map[string]interface{}{"modules": string(raw)},
@@ -577,6 +591,47 @@ func TestObserveSweepCadence_N1FiresEveryTick(t *testing.T) {
 	assert.Len(t, events, 3, "with N=1 every convergence tick must trigger a sweep")
 }
 
+// TestNewObserveSweepEventID_UniqueUnderIdenticalTimestamp reproduces the
+// Windows CI failure of TestObserveSweepCadence_N1FiresEveryTick: three
+// tight-loop calls to triggerObserveSweep landed within the same clock tick
+// (coarse timer resolution), so time.Now().UnixNano() alone produced three
+// identical event IDs. The offline queue de-duplicates by event ID (see
+// OfflineQueue.Add's seenIDs check), so only one of the three events survived
+// draining even though three sweeps fired. Fixing this requires uniqueness
+// that does not depend on clock resolution at all.
+func TestNewObserveSweepEventID_UniqueUnderIdenticalTimestamp(t *testing.T) {
+	const collidingTimestamp = int64(1234567890)
+
+	seen := make(map[string]struct{})
+	for seq := int64(1); seq <= 3; seq++ {
+		id := newObserveSweepEventID(collidingTimestamp, seq)
+		_, dup := seen[id]
+		assert.False(t, dup, "event ID must be unique even when the timestamp component collides: %s", id)
+		seen[id] = struct{}{}
+	}
+	assert.Len(t, seen, 3, "all three IDs must be distinct despite the identical timestamp")
+}
+
+// TestTriggerObserveSweep_RapidSuccessionProducesDistinctEvents drives
+// triggerObserveSweep in a tight loop (no wall-clock gaps between calls,
+// mirroring how checkAndTriggerObserveSweep is exercised in cadence tests)
+// and confirms every call survives offline-queue de-duplication as a
+// separate event.
+func TestTriggerObserveSweep_RapidSuccessionProducesDistinctEvents(t *testing.T) {
+	c, q := newObserveTestClient(t)
+	c.stewardID = "steward-1"
+	c.tenantID = "tenant-1"
+
+	ctx := context.Background()
+	const iterations = 25
+	for i := 0; i < iterations; i++ {
+		c.triggerObserveSweep(ctx)
+	}
+
+	events := drainObserveSweepEvents(q)
+	assert.Len(t, events, iterations, "each triggerObserveSweep call must publish a distinct, undeduplicated event")
+}
+
 // ---------------------------------------------------------------------------
 // observeSweepTick synchronisation (mirrors dnaRefreshTick pattern)
 // ---------------------------------------------------------------------------
@@ -597,6 +652,175 @@ func TestCheckAndTriggerObserveSweep_SignalsTick(t *testing.T) {
 
 	assert.Equal(t, 3, len(tick),
 		"observeSweepTick must receive one value per checkAndTriggerObserveSweep call")
+}
+
+// ---------------------------------------------------------------------------
+// Overlapping sweeps: single-flight guard and shared-loader concurrency
+// ---------------------------------------------------------------------------
+
+// sweepProbeModule is a real modules.Module that records how many Get calls are
+// in flight at once and can be held inside Get until released. It is the
+// instrument the overlapping-sweep tests read: maxInFlight > 1 means two sweeps
+// ran concurrently over the shared module loader.
+type sweepProbeModule struct {
+	calls       atomic.Int32
+	inFlight    atomic.Int32
+	maxInFlight atomic.Int32
+	entered     chan struct{} // signalled once per Get entry (buffered)
+	release     chan struct{} // Get blocks until closed; nil = never block
+}
+
+var _ modules.Module = (*sweepProbeModule)(nil)
+
+func (m *sweepProbeModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	m.calls.Add(1)
+	n := m.inFlight.Add(1)
+	defer m.inFlight.Add(-1)
+	for {
+		high := m.maxInFlight.Load()
+		if n <= high || m.maxInFlight.CompareAndSwap(high, n) {
+			break
+		}
+	}
+	if m.entered != nil {
+		m.entered <- struct{}{}
+	}
+	if m.release != nil {
+		<-m.release
+	}
+	return &inMemoryConfigState{data: map[string]interface{}{"vm_count": 1}}, nil
+}
+
+func (m *sweepProbeModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+// TestHandleObserveModules_OverlappingSweepIsDropped verifies the single-flight
+// guard. The controller can issue a second observe_modules command while the
+// first sweep is still inside a module Get (a Get slower than N convergence
+// ticks is enough, and the two commands carry distinct IDs so replay
+// de-duplication does not suppress the second). Without the guard both sweeps
+// run concurrently over the same module loader, which for the production
+// *factory.ModuleFactory is a concurrent map write — a fatal, unrecoverable
+// process abort. The overlapping command must be dropped instead.
+func TestHandleObserveModules_OverlappingSweepIsDropped(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+
+	mod := &sweepProbeModule{
+		entered: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	c.observeModuleLoader = newInMemoryLoader(map[string]modules.Module{"hyperv": mod})
+
+	specs := []cpTypes.ObserveModuleSpec{{Name: "hyperv", Kind: "hyperv"}}
+	ctx := context.Background()
+
+	// release unblocks every Get held in the module. Idempotent so the failure
+	// path can unblock leaked sweeps without risking a double close.
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(mod.release) }) }
+	t.Cleanup(release)
+
+	// Sweep A: enters the module Get and stays there until released.
+	first := make(chan error, 1)
+	go func() {
+		first <- c.handleObserveModules(ctx, observeCmdWithID(t, "cmd-obs-a", specs))
+	}()
+	<-mod.entered // sweep A is now inside Get — a sweep is definitively in flight
+
+	// Sweep B arrives while A is in flight: it must return without touching the
+	// loader. Racing its completion against a second Get entry keeps the
+	// assertion deterministic — no timeout, no sleep. mod.entered has spare
+	// buffer capacity, so an unguarded sweep B signals it and is detected here
+	// rather than deadlocking the test.
+	second := make(chan error, 1)
+	go func() {
+		second <- c.handleObserveModules(ctx, observeCmdWithID(t, "cmd-obs-b", specs))
+	}()
+	select {
+	case err := <-second:
+		require.NoError(t, err, "a dropped overlapping sweep is not a command failure")
+	case <-mod.entered:
+		release()
+		t.Fatal("overlapping sweep ran against the shared module loader while a sweep was in flight")
+	}
+	assert.Equal(t, int32(1), mod.calls.Load(),
+		"overlapping sweep must be dropped, not run against the shared module loader")
+
+	release()
+	require.NoError(t, <-first)
+	assert.Equal(t, int32(1), mod.maxInFlight.Load(),
+		"at most one observe sweep may be in flight at a time")
+
+	// The guard is released once the sweep finishes: the next command runs.
+	require.NoError(t, c.handleObserveModules(ctx, observeCmdWithID(t, "cmd-obs-c", specs)))
+	assert.Equal(t, int32(2), mod.calls.Load(),
+		"a sweep issued after the previous one completed must run")
+}
+
+// TestHandleObserveModules_ConcurrentCommandsWithRealFactory_NoDataRace runs
+// concurrent observe_modules commands against the production module loader —
+// the single long-lived *factory.ModuleFactory that cmd/steward wires into
+// TransportConfig.ObserveModuleLoader — while other goroutines load modules
+// from that same factory the way the convergence path does.
+//
+// Under -race this fails on any unsynchronized access to the factory's instance
+// cache or injection-status map, which in production surfaces as
+// "fatal error: concurrent map writes" and kills the steward process.
+func TestHandleObserveModules_ConcurrentCommandsWithRealFactory_NoDataRace(t *testing.T) {
+	c, _ := newObserveTestClient(t)
+
+	loader := factory.NewWithStewardID(
+		discovery.ModuleRegistry{},
+		stewardconfig.ErrorHandlingConfig{ModuleLoadFailure: stewardconfig.ActionContinue},
+		"steward-1",
+		logging.NewNoopLogger(),
+	)
+	c.observeModuleLoader = loader
+
+	specs := []cpTypes.ObserveModuleSpec{
+		{Name: "file", Kind: "file"},
+		{Name: "script", Kind: "script"},
+		{Name: "user", Kind: "user"},
+	}
+
+	ctx := context.Background()
+	const sweeps = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < sweeps; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			cmd := observeCmdWithID(t, fmt.Sprintf("cmd-obs-%d", i), specs)
+			if err := c.handleObserveModules(ctx, cmd); err != nil {
+				t.Errorf("handleObserveModules: %v", err)
+			}
+		}(i)
+	}
+
+	// Concurrent module loads off the same factory, mirroring the convergence
+	// executor running alongside the Tier-2 sweep.
+	for i := 0; i < sweeps; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for _, spec := range specs {
+				if _, err := loader.LoadModule(spec.Name); err != nil {
+					t.Errorf("LoadModule(%s): %v", spec.Name, err)
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.ElementsMatch(t, []string{"file", "script", "user"}, loader.GetLoadedModules(),
+		"each module must be cached exactly once after concurrent sweeps and loads")
 }
 
 // ---------------------------------------------------------------------------

--- a/features/steward/config/config_test.go
+++ b/features/steward/config/config_test.go
@@ -1257,3 +1257,91 @@ resources:
 	assert.Empty(t, cfg.Steward.DriftMode,
 		"DriftMode must be cleared after loading from local file (security invariant)")
 }
+
+// --- observe_sweep_n (Issue #3104, ADR-024 Amendment 1 §3) ---
+
+func TestLoadConfiguration_ObserveSweepN_ParsesExplicitValue(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	configData := `steward:
+  id: test-steward
+  observe_sweep_n: 3
+
+resources:
+  - name: test-resource
+    module: file
+    config:
+      path: /tmp/x
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	cfg, err := LoadConfiguration(configFile)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Steward.ObserveSweepN)
+	assert.Equal(t, 3, GetObserveSweepN(cfg))
+}
+
+func TestLoadConfiguration_ObserveSweepN_ZeroDisablesSweep(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	configData := `steward:
+  id: test-steward
+  observe_sweep_n: 0
+
+resources:
+  - name: test-resource
+    module: file
+    config:
+      path: /tmp/x
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	cfg, err := LoadConfiguration(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, 0, GetObserveSweepN(cfg),
+		"observe_sweep_n: 0 must disable the Tier-2 sweep, not fall back to the default")
+}
+
+func TestLoadConfiguration_ObserveSweepN_AbsentUsesDefault(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	configData := `steward:
+  id: test-steward
+
+resources:
+  - name: test-resource
+    module: file
+    config:
+      path: /tmp/x
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	cfg, err := LoadConfiguration(configFile)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Steward.ObserveSweepN)
+	assert.Equal(t, DefaultObserveSweepN, GetObserveSweepN(cfg))
+}
+
+func TestLoadConfiguration_ObserveSweepN_NegativeRejected(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	configData := `steward:
+  id: test-steward
+  observe_sweep_n: -1
+
+resources:
+  - name: test-resource
+    module: file
+    config:
+      path: /tmp/x
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	_, err := LoadConfiguration(configFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "observe_sweep_n")
+}

--- a/features/steward/config/validation.go
+++ b/features/steward/config/validation.go
@@ -28,6 +28,14 @@ func GetDNARefreshInterval(cfg StewardConfig) time.Duration {
 	return stewardtypes.GetDNARefreshInterval(cfg)
 }
 
+// DefaultObserveSweepN re-exports the shared Tier-2 observe sweep cadence default.
+const DefaultObserveSweepN = stewardtypes.DefaultObserveSweepN
+
+// GetObserveSweepN delegates to the shared stewardtypes implementation.
+func GetObserveSweepN(cfg StewardConfig) int {
+	return stewardtypes.GetObserveSweepN(cfg)
+}
+
 // GetConfiguredModules delegates to the shared stewardtypes implementation.
 func GetConfiguredModules(config StewardConfig) []string {
 	return stewardtypes.GetConfiguredModules(config)

--- a/features/steward/factory/factory.go
+++ b/features/steward/factory/factory.go
@@ -37,6 +37,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/cfgis/cfgms/features/modules"
@@ -64,33 +65,47 @@ import (
 // The factory provides on-demand loading of modules from the discovery registry,
 // caches loaded instances for reuse, handles errors according to the configured
 // error handling policy, and implements centralized logging injection.
+//
+// A ModuleFactory is safe for concurrent use. A single factory is shared by all
+// steward call paths (convergence, command handlers, the Tier-2 observe sweep),
+// and command handlers run one goroutine per command, so every access to the
+// mutable fields below must hold mu. Unsynchronized map access here would be a
+// concurrent map read/write — a fatal, unrecoverable process abort.
 type ModuleFactory struct {
+	// mu guards all mutable factory state: instances, injectionStatus,
+	// stewardID, loggerProvider, secretStore and gate. registry and config are
+	// immutable after construction and may be read without holding mu.
+	mu sync.RWMutex
+
 	// registry contains information about discovered modules
 	registry discovery.ModuleRegistry
 
-	// instances caches loaded module instances for reuse
+	// instances caches loaded module instances for reuse. Guarded by mu.
 	instances map[string]modules.Module
 
 	// config defines error handling behavior
 	config config.ErrorHandlingConfig
 
-	// stewardID identifies the steward this factory belongs to
+	// stewardID identifies the steward this factory belongs to. Guarded by mu.
 	stewardID string
 
-	// logger is the factory's own operational logger
+	// logger is the factory's own operational logger. Set at construction and
+	// never reassigned; logging.Logger implementations are safe for concurrent use.
 	logger logging.Logger
 
-	// loggerProvider creates loggers for module injection
+	// loggerProvider creates loggers for module injection. Guarded by mu.
 	loggerProvider modules.LoggerProvider
 
-	// secretStore is injected into modules that implement SecretStoreInjectable
+	// secretStore is injected into modules that implement SecretStoreInjectable.
+	// Guarded by mu.
 	secretStore secretsif.SecretStore
 
 	// gate is the maintenance gate injected into the patch module for reboot-window
 	// enforcement. When nil, the patch module uses the fail-closed default (nil manager → deny).
+	// Guarded by mu.
 	gate maintinterfaces.Gate
 
-	// injectionStatus tracks logger injection status for each module
+	// injectionStatus tracks logger injection status for each module. Guarded by mu.
 	injectionStatus map[string]modules.LoggerInjectionStatus
 }
 
@@ -145,7 +160,15 @@ func NewWithStewardID(registry discovery.ModuleRegistry, errorConfig config.Erro
 //
 // This allows built-in modules (file, directory, firewall, etc.) to work
 // even when no external modules are discovered on the filesystem.
+//
+// LoadModule is safe for concurrent use: the whole load is serialized under mu
+// so that a cache hit, module construction, dependency injection and the cache
+// write are atomic with respect to other callers. Serializing construction also
+// guarantees every caller receives the same cached instance for a given name.
 func (f *ModuleFactory) LoadModule(moduleName string) (modules.Module, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	// Check if module is already loaded
 	if instance, exists := f.instances[moduleName]; exists {
 		return instance, nil
@@ -202,6 +225,8 @@ var builtinModuleConstructors = map[string]func() modules.Module{
 // The hyperv module is handled specially so a durable provision store can be
 // wired via the factory logger (required for the fallback warn path).
 // The patch module is handled specially so the maintenance gate can be injected.
+//
+// Callers must hold f.mu (it reads f.gate and f.stewardID via newPatchModule).
 func (f *ModuleFactory) loadBuiltinModule(moduleName string) (modules.Module, error) {
 	if moduleName == "hyperv" {
 		return f.newHypervModule(), nil
@@ -220,6 +245,8 @@ func (f *ModuleFactory) loadBuiltinModule(moduleName string) (modules.Module, er
 // GateWindowAdapter when a maintenance gate is available. When no gate has been
 // set (f.gate == nil), the patch module starts without a window manager; any
 // patch config that declares a maintenance.window will then be denied fail-closed.
+//
+// Callers must hold f.mu (it reads f.gate and f.stewardID).
 func (f *ModuleFactory) newPatchModule() modules.Module {
 	m := patch.New()
 	if f.gate == nil {
@@ -239,6 +266,8 @@ func (f *ModuleFactory) newPatchModule() modules.Module {
 // reboot-window enforcement. Must be called before the first LoadModule("patch")
 // for the gate to take effect. Parallels SetSecretStore.
 func (f *ModuleFactory) SetMaintenanceGate(gate maintinterfaces.Gate) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.gate = gate
 }
 
@@ -246,6 +275,8 @@ func (f *ModuleFactory) SetMaintenanceGate(gate maintinterfaces.Gate) {
 // If the store cannot be created (e.g. the path is not writable on this boot),
 // it falls back to the module's built-in in-memory store — steward startup
 // never crashes over a non-critical store init failure.
+//
+// Callers must hold f.mu (invoked from the LoadModule critical section).
 func (f *ModuleFactory) newHypervModule() modules.Module {
 	store := f.newHypervProvisionStore()
 	if store == nil {
@@ -335,6 +366,9 @@ func (f *ModuleFactory) CreateModuleInstance(moduleName string) (modules.Module,
 
 // GetLoadedModules returns a list of currently loaded module names
 func (f *ModuleFactory) GetLoadedModules() []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	modules := make([]string, 0, len(f.instances))
 	for name := range f.instances {
 		modules = append(modules, name)
@@ -347,16 +381,22 @@ func (f *ModuleFactory) GetLoadedModules() []string {
 // Used in tests to inject real test implementations and in production to pre-wire
 // modules that need special construction (e.g. modules with injected dependencies).
 func (f *ModuleFactory) RegisterModule(name string, mod modules.Module) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.instances[name] = mod
 }
 
 // UnloadModule removes a module instance from the cache
 func (f *ModuleFactory) UnloadModule(moduleName string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	delete(f.instances, moduleName)
 }
 
 // UnloadAllModules removes all module instances from the cache
 func (f *ModuleFactory) UnloadAllModules() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.instances = make(map[string]modules.Module)
 }
 
@@ -368,6 +408,8 @@ func (f *ModuleFactory) GetModuleInfo(moduleName string) (discovery.ModuleInfo, 
 
 // SetStewardID updates the steward ID for this factory and reinitializes the logger provider
 func (f *ModuleFactory) SetStewardID(stewardID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.stewardID = stewardID
 	f.loggerProvider = &StewardLoggerProvider{
 		stewardID: stewardID,
@@ -376,10 +418,14 @@ func (f *ModuleFactory) SetStewardID(stewardID string) {
 
 // SetSecretStore sets the secret store for module injection.
 func (f *ModuleFactory) SetSecretStore(store secretsif.SecretStore) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.secretStore = store
 }
 
 // attemptSecretStoreInjection tries to inject a secret store into a module if it supports injection.
+//
+// Callers must hold f.mu (it reads f.secretStore).
 func (f *ModuleFactory) attemptSecretStoreInjection(instance modules.Module, moduleName string) {
 	injectable, ok := instance.(modules.SecretStoreInjectable)
 	if !ok || f.secretStore == nil {
@@ -392,7 +438,9 @@ func (f *ModuleFactory) attemptSecretStoreInjection(instance modules.Module, mod
 	}
 }
 
-// attemptLoggerInjection tries to inject a logger into a module if it supports injection
+// attemptLoggerInjection tries to inject a logger into a module if it supports injection.
+//
+// Callers must hold f.mu (it reads f.stewardID / f.loggerProvider and writes f.injectionStatus).
 func (f *ModuleFactory) attemptLoggerInjection(instance modules.Module, moduleName string) {
 	// Initialize injection status
 	status := modules.LoggerInjectionStatus{
@@ -446,6 +494,9 @@ func (f *ModuleFactory) attemptLoggerInjection(instance modules.Module, moduleNa
 
 // InjectLogger implements modules.CentralLoggingManager.InjectLogger
 func (f *ModuleFactory) InjectLogger(module modules.Module, moduleName string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	injectable, supportsInjection := module.(modules.LoggingInjectable)
 	if !supportsInjection {
 		return false, nil // Not an error, just doesn't support injection
@@ -491,6 +542,9 @@ func (f *ModuleFactory) GetModuleLogger(module modules.Module) (logging.Logger, 
 
 // ListModulesWithLoggers implements modules.CentralLoggingManager.ListModulesWithLoggers
 func (f *ModuleFactory) ListModulesWithLoggers() map[string]modules.LoggerInjectionStatus {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	// Return a copy to prevent external modification
 	result := make(map[string]modules.LoggerInjectionStatus)
 	for name, status := range f.injectionStatus {

--- a/features/steward/factory/factory_test.go
+++ b/features/steward/factory/factory_test.go
@@ -4,8 +4,10 @@ package factory
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -230,6 +232,155 @@ func TestAllBuiltinModulesLoad(t *testing.T) {
 		assert.NoError(t, err, "built-in module %q must load without error", name)
 		assert.NotNil(t, mod, "built-in module %q must not be nil", name)
 	}
+}
+
+// TestModuleFactory_ConcurrentLoadModule_NoDataRace exercises the single
+// long-lived factory the way the steward does: one shared *ModuleFactory reached
+// concurrently from many goroutines (convergence executor, command handlers —
+// which run one goroutine per command — and the Tier-2 observe sweep). Before
+// the factory carried a mutex, the unguarded reads/writes of f.instances and
+// f.injectionStatus made this a "fatal error: concurrent map writes", an
+// unrecoverable process abort that no recover() can catch.
+//
+// Run under -race (make test runs the suite with -race) this fails on any
+// unsynchronized access to the factory's mutable state.
+func TestModuleFactory_ConcurrentLoadModule_NoDataRace(t *testing.T) {
+	f := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail}, logging.NewNoopLogger())
+
+	// Names spanning the constructor map plus the specially-handled patch module.
+	names := []string{"file", "directory", "script", "user", "time", "package", "firewall", "cert_trust", "hostname", "patch"}
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, goroutines*len(names))
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			<-start
+			for i := range names {
+				// Rotate the starting offset so goroutines contend on different
+				// names at the same moment rather than marching in lockstep.
+				name := names[(i+g)%len(names)]
+				mod, err := f.LoadModule(name)
+				if err != nil {
+					errs <- err
+					continue
+				}
+				if mod == nil {
+					errs <- fmt.Errorf("module %q loaded as nil", name)
+				}
+				// Concurrent readers of the same guarded state.
+				_ = f.GetLoadedModules()
+				_ = f.ListModulesWithLoggers()
+			}
+		}(g)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent LoadModule: %v", err)
+	}
+
+	// Every requested module must be cached exactly once (the instance cache is
+	// consistent, not corrupted, after concurrent loads).
+	loaded := f.GetLoadedModules()
+	assert.ElementsMatch(t, names, loaded, "each concurrently loaded module must be cached exactly once")
+}
+
+// TestModuleFactory_ConcurrentLoadModule_ReturnsSharedInstance verifies that
+// serializing construction under the factory mutex yields a single shared
+// instance per module name: concurrent callers must not each get their own
+// module object, which would silently split module state across call paths.
+func TestModuleFactory_ConcurrentLoadModule_ReturnsSharedInstance(t *testing.T) {
+	f := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail}, logging.NewNoopLogger())
+
+	const goroutines = 24
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make(chan modules.Module, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			mod, err := f.LoadModule("file")
+			if err == nil {
+				results <- mod
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var first modules.Module
+	count := 0
+	for mod := range results {
+		count++
+		if first == nil {
+			first = mod
+			continue
+		}
+		assert.Same(t, first, mod, "all concurrent LoadModule callers must receive the same cached instance")
+	}
+	assert.Equal(t, goroutines, count, "every goroutine must load the module successfully")
+}
+
+// TestModuleFactory_ConcurrentMutatorsAndLoads_NoDataRace drives the setters
+// (SetStewardID / SetSecretStore / SetMaintenanceGate / RegisterModule /
+// UnloadModule) concurrently with LoadModule. These all touch the same guarded
+// fields the load path reads, so any missing lock shows up under -race.
+func TestModuleFactory_ConcurrentMutatorsAndLoads_NoDataRace(t *testing.T) {
+	f := NewWithStewardID(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail}, "steward-1", logging.NewNoopLogger())
+
+	const iterations = 50
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			if _, err := f.LoadModule("file"); err != nil {
+				t.Errorf("LoadModule(file): %v", err)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			f.SetStewardID(fmt.Sprintf("steward-%d", i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			f.SetMaintenanceGate(nil)
+			f.SetSecretStore(nil)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			f.RegisterModule("script", file.New())
+			f.UnloadModule("script")
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }
 
 // TestGithubRunner_IsInBuiltinModuleConstructors asserts that "github_runner" is

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -34,7 +34,8 @@ var commandTypeToProto = map[types.CommandType]transportpb.CommandType{
 	types.CommandRelayResponse:     transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE, // Issue #1994
 	types.CommandPushSigningCert:   transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT,
 	types.CommandPushStewardBinary: transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY,
-	types.CommandOpenTerminal:      transportpb.CommandType_COMMAND_TYPE_OPEN_TERMINAL, // Issue #2760
+	types.CommandOpenTerminal:      transportpb.CommandType_COMMAND_TYPE_OPEN_TERMINAL,   // Issue #2760
+	types.CommandObserveModules:    transportpb.CommandType_COMMAND_TYPE_OBSERVE_MODULES, // Issue #3104
 }
 
 // protoToCommandType maps proto enum to semantic CommandType.
@@ -46,7 +47,8 @@ var protoToCommandType = map[transportpb.CommandType]types.CommandType{
 	transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE:      types.CommandRelayResponse, // Issue #1994
 	transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT:   types.CommandPushSigningCert,
 	transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY: types.CommandPushStewardBinary,
-	transportpb.CommandType_COMMAND_TYPE_OPEN_TERMINAL:       types.CommandOpenTerminal, // Issue #2760
+	transportpb.CommandType_COMMAND_TYPE_OPEN_TERMINAL:       types.CommandOpenTerminal,   // Issue #2760
+	transportpb.CommandType_COMMAND_TYPE_OBSERVE_MODULES:     types.CommandObserveModules, // Issue #3104
 }
 
 func commandToProto(cmd *types.Command) *transportpb.Command {
@@ -180,6 +182,7 @@ var eventTypeToProto = map[types.EventType]transportpb.EventType{
 	types.EventStewardUpgradeSwapped:    transportpb.EventType_EVENT_TYPE_UPGRADE_SWAPPED,
 	types.EventStewardUpgradeCommitted:  transportpb.EventType_EVENT_TYPE_UPGRADE_COMMITTED,
 	types.EventStewardUpgradeRolledBack: transportpb.EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK,
+	types.EventObserveSweepRequest:      transportpb.EventType_EVENT_TYPE_OBSERVE_SWEEP_REQUEST, // Issue #3104
 }
 
 // protoToEventType maps proto enum to semantic EventType.
@@ -193,13 +196,14 @@ var protoToEventType = map[transportpb.EventType]types.EventType{
 	transportpb.EventType_EVENT_TYPE_COMMAND_COMPLETED: types.EventCommandCompleted,
 	transportpb.EventType_EVENT_TYPE_COMMAND_FAILED:    types.EventCommandFailed,
 	// Issue #1997: reverse mapping for the wire-crossing events added above.
-	transportpb.EventType_EVENT_TYPE_SCRIPT_COMPLETED:    types.EventScriptCompleted,
-	transportpb.EventType_EVENT_TYPE_DNA_CHANGED:         types.EventDNAChanged,
-	transportpb.EventType_EVENT_TYPE_RELAY_REQUEST:       types.EventRelayRequest,
-	transportpb.EventType_EVENT_TYPE_UPGRADE_DOWNLOADED:  types.EventStewardUpgradeDownloaded,
-	transportpb.EventType_EVENT_TYPE_UPGRADE_SWAPPED:     types.EventStewardUpgradeSwapped,
-	transportpb.EventType_EVENT_TYPE_UPGRADE_COMMITTED:   types.EventStewardUpgradeCommitted,
-	transportpb.EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK: types.EventStewardUpgradeRolledBack,
+	transportpb.EventType_EVENT_TYPE_SCRIPT_COMPLETED:      types.EventScriptCompleted,
+	transportpb.EventType_EVENT_TYPE_DNA_CHANGED:           types.EventDNAChanged,
+	transportpb.EventType_EVENT_TYPE_RELAY_REQUEST:         types.EventRelayRequest,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_DOWNLOADED:    types.EventStewardUpgradeDownloaded,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_SWAPPED:       types.EventStewardUpgradeSwapped,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_COMMITTED:     types.EventStewardUpgradeCommitted,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK:   types.EventStewardUpgradeRolledBack,
+	transportpb.EventType_EVENT_TYPE_OBSERVE_SWEEP_REQUEST: types.EventObserveSweepRequest, // Issue #3104
 }
 
 // severityToProto maps semantic severity string to proto enum.

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -100,7 +100,8 @@ var allCommandTypes = []types.CommandType{
 	types.CommandRelayResponse,
 	types.CommandPushSigningCert,
 	types.CommandPushStewardBinary,
-	types.CommandOpenTerminal, // Issue #2760
+	types.CommandOpenTerminal,   // Issue #2760
+	types.CommandObserveModules, // Issue #3104
 }
 
 func TestCommandTypeRoundTrip(t *testing.T) {
@@ -357,6 +358,7 @@ var wireCrossingEventTypes = []types.EventType{
 	types.EventStewardUpgradeSwapped,
 	types.EventStewardUpgradeCommitted,
 	types.EventStewardUpgradeRolledBack,
+	types.EventObserveSweepRequest, // Issue #3104
 }
 
 func TestEventTypeRoundTrip(t *testing.T) {

--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -53,7 +53,20 @@ const (
 	// and bridge the stream to a local PTY for an interactive admin session. (Issue #2760)
 	// Params: session_id (string), shell (string), cols (int32), rows (int32).
 	CommandOpenTerminal CommandType = "open_terminal"
+
+	// CommandObserveModules pushes the controller's resolved observe-module set to the steward
+	// in response to an EventObserveSweepRequest. (Issue #3104, ADR-024 Amendment 1 §3)
+	// Params: "modules" (JSON array of ObserveModuleSpec: {name, kind}).
+	CommandObserveModules CommandType = "observe_modules"
 )
+
+// ObserveModuleSpec identifies a module+kind pair resolved by the controller for
+// Tier-2 whole-domain observation (Issue #3104, ADR-024 Amendment 1 §3).
+// Carried in CommandObserveModules params as a JSON array under "modules".
+type ObserveModuleSpec struct {
+	Name string `json:"name"` // module name (e.g. "hyperv")
+	Kind string `json:"kind"` // ownership kind for fragment assembly (e.g. "hyperv")
+}
 
 // Command represents a command sent from controller to steward.
 //
@@ -140,6 +153,12 @@ const (
 	// auto-rolled-back to the previous version after the new binary failed its
 	// startup window. (Epic #1930, Issue #1943)
 	EventStewardUpgradeRolledBack EventType = "steward.upgrade.rolled_back"
+
+	// EventObserveSweepRequest initiates a Tier-2 whole-domain observe sweep. The steward
+	// sends this event carrying its baseline DNA; the controller resolves the observe-module
+	// set and responds with CommandObserveModules. (Issue #3104, ADR-024 Amendment 1 §3)
+	// Details keys: "baseline_dna" (map[string]string JSON).
+	EventObserveSweepRequest EventType = "observe_sweep_request"
 )
 
 // Event represents an event published from steward to controller.


### PR DESCRIPTION
## Summary

- Adds Tier-2 convergence tier to the steward (ADR-024 Amendment 1): every Nth convergence tick, the steward runs a whole-domain observe sweep using modules resolved by the controller against its baseline DNA
- Tier-2 uses the existing DNA fragment emission path (`setCurrentDNAFragments`) — no new channel (ADR-024 Amendment 1 §2)
- Controller side resolves observe-module set via `ResolveObserveModules` and delivers it as `CommandObserveModules`; steward loads modules via the signed/trust-verified pull path and runs `Get()` read-only
- `observe_sweep_n` knob in steward config controls cadence (default 10, 0 = disabled, 1 = every tick); validated and wired through cmd/steward/main.go

## Changes

| Area | What changed |
|------|-------------|
| `api/proto` | New enum values: `COMMAND_TYPE_OBSERVE_MODULES` (13), `EVENT_TYPE_OBSERVE_SWEEP_REQUEST` (16) |
| `pkg/controlplane/types` | `CommandObserveModules`, `EventObserveSweepRequest`, `ObserveModuleSpec` struct |
| `pkg/controlplane/providers/grpc` | Convert maps wired for both new types; exhaustive-map tests updated |
| `features/config/stewardtypes` | `ObserveSweepN int` field with default and validation |
| `features/steward/client` | `checkAndTriggerObserveSweep`, `triggerObserveSweep`, `handleObserveModules`, `ObserveModuleLoader` interface |
| `features/controller/server` | `ObserveManifestProvider` interface, `handleObserveSweepRequest`, event routing |
| `cmd/steward` | Wire `ObserveSweepN` from config into `TransportConfig` |
| `docs` | Tiered Convergence section in steward-operating-model; Tier-2 RPC in controller-operating-model |

## Test coverage

All acceptance criteria covered by dedicated tests in `client_transport_observe_test.go` and `server_observe_test.go`:
- AC1: `TestTriggerObserveSweep_PublishesEventWithBaselineDNA`
- AC2+AC3: `TestHandleObserveModules_MergesFragmentIntoCurrentDNA`, `TestHandleObserveModules_ModuleAuthorityPreemptsHostFact`
- AC4: `TestHandleObserveModules_FullCycle`, `TestHandleObserveSweepRequest_SendsCommandToSteward`
- AC5: `TestObserveSweepCadence_FiresOnNthCycle`, `TestObserveSweepCadence_DisabledWhenZero`

`make test-agent-complete` passes (364 packages). Story-review: passed (2 rounds, 1 fix round, 0 remaining findings).

Fixes #3104

🤖 Generated with [Claude Code](https://claude.com/claude-code)