### PR TITLE
web/rbac: add role create, edit, and delete to RolesView (Issue #3133)

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -713,14 +713,14 @@ Get a specific permission by ID.
 
 #### GET /api/v1/rbac/roles
 
-List roles.
+List roles: the authenticated caller's own tenant roles plus system roles.
 
 **Authentication:** Required  
 **Required permission:** `rbac:list-roles`
 
-**Parameters:**
-
-- `tenant_id` (query, optional): Filter roles by tenant ID
+**Tenant scope:** derived from the authenticated session. A `tenant_id` query
+parameter is ignored — it cannot be used to read another tenant's roles. Requests
+without a session tenant are rejected with `401`.
 
 **Response:**
 
@@ -743,10 +743,18 @@ List roles.
 
 #### POST /api/v1/rbac/roles
 
-Create a new role.
+Create a new role in the authenticated caller's tenant.
 
 **Authentication:** Required  
 **Required permission:** `rbac:create-role`
+
+**Tenant scope:** derived from the authenticated session. `tenant_id` may be omitted;
+when present it must equal the session tenant, otherwise the request is rejected with
+`403 TENANT_MISMATCH`. The role `id` is server-assigned (tenant-prefixed) — a body
+`id` is ignored.
+
+**Validation:** `name` is required, at most 128 characters; `description` at most 512
+characters; neither may contain control characters.
 
 **Request Body:**
 
@@ -754,8 +762,7 @@ Create a new role.
 {
   "name": "Config Manager",
   "description": "Manage configurations",
-  "permissions": ["config.read", "config.write"],
-  "tenant_id": "default"
+  "permissions": ["config.read", "config.write"]
 }
 ```
 
@@ -787,9 +794,13 @@ Get a specific role by ID.
 
 - `id` (path): Role ID
 
+**Tenant scope:** readable roles are the session tenant's own roles plus system
+roles. Another tenant's role returns `404 ROLE_NOT_FOUND` (the response does not
+confirm that it exists).
+
 #### PUT /api/v1/rbac/roles/{id}
 
-Update an existing role.
+Update an existing role owned by the authenticated caller's tenant.
 
 **Authentication:** Required  
 **Required permission:** `rbac:update-role`
@@ -798,11 +809,18 @@ Update an existing role.
 
 - `id` (path): Role ID
 
-**Request Body:** Same structure as POST /api/v1/rbac/roles.
+**Tenant scope:** a role owned by another tenant returns `404 ROLE_NOT_FOUND`; a
+system role returns `403 SYSTEM_ROLE_IMMUTABLE`. A `tenant_id` that differs from the
+session tenant returns `403 TENANT_MISMATCH` — a role's tenant cannot be reassigned
+through an update. Tenant scope, system-role status, hierarchy links and creation
+time are carried over from the stored role.
+
+**Request Body:** `name`, `description` and `permissions`, validated as for
+POST /api/v1/rbac/roles.
 
 #### DELETE /api/v1/rbac/roles/{id}
 
-Delete a role.
+Delete a role owned by the authenticated caller's tenant.
 
 **Authentication:** Required  
 **Required permission:** `rbac:delete-role`
@@ -810,6 +828,9 @@ Delete a role.
 **Parameters:**
 
 - `id` (path): Role ID
+
+**Tenant scope:** a role owned by another tenant returns `404 ROLE_NOT_FOUND`; a
+system role returns `403 SYSTEM_ROLE_IMMUTABLE`.
 
 ### API Key Management
 

--- a/features/controller/api/handlers_rbac.go
+++ b/features/controller/api/handlers_rbac.go
@@ -129,7 +129,7 @@ func (s *Server) handleListPermissions(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	resp, err := s.rbacService.ListPermissions(r.Context(), req)
 	if err != nil {
-		s.logger.Error("Failed to list permissions", "error", err)
+		s.logger.Error("Failed to list permissions", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list permissions", "INTERNAL_ERROR")
 		return
 	}
@@ -210,7 +210,7 @@ func (s *Server) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	resp, err := s.rbacService.ListRoles(r.Context(), req)
 	if err != nil {
-		s.logger.Error("Failed to list roles", "error", err)
+		s.logger.Error("Failed to list roles", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list roles", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_rbac.go
+++ b/features/controller/api/handlers_rbac.go
@@ -4,7 +4,10 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,6 +19,97 @@ import (
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// isWithinTenantScope is defined in middleware.go and shared across RBAC and
+// tenant handlers.
+
+// Role field bounds enforced at the API boundary. Role names and descriptions are
+// operator-supplied free text that is rendered in the web UI and written to audit
+// events, so both are length-bounded and rejected when they carry control
+// characters (log/audit-record injection).
+const (
+	maxRoleNameLength        = 128
+	maxRoleDescriptionLength = 512
+)
+
+// Role validation errors. Each message is caller-facing and discloses nothing
+// about controller internals.
+var (
+	errRoleNameRequired       = errors.New("role name is required")
+	errRoleNameTooLong        = fmt.Errorf("role name must be at most %d characters", maxRoleNameLength)
+	errRoleDescriptionTooLong = fmt.Errorf("role description must be at most %d characters", maxRoleDescriptionLength)
+	errRoleControlCharacters  = errors.New("role name and description must not contain control characters")
+)
+
+// validateRoleFields validates operator-supplied role fields and returns the
+// trimmed name and description. The error message is safe to return to the caller.
+func validateRoleFields(name, description string) (string, string, error) {
+	trimmedName := strings.TrimSpace(name)
+	trimmedDescription := strings.TrimSpace(description)
+	if trimmedName == "" {
+		return "", "", errRoleNameRequired
+	}
+	if len(trimmedName) > maxRoleNameLength {
+		return "", "", errRoleNameTooLong
+	}
+	if len(trimmedDescription) > maxRoleDescriptionLength {
+		return "", "", errRoleDescriptionTooLong
+	}
+	if strings.ContainsFunc(trimmedName, isControlRune) || strings.ContainsFunc(trimmedDescription, isControlRune) {
+		return "", "", errRoleControlCharacters
+	}
+	return trimmedName, trimmedDescription, nil
+}
+
+// isControlRune reports whether r is a C0/C1 control character.
+func isControlRune(r rune) bool {
+	return r < 0x20 || (r >= 0x7F && r <= 0x9F)
+}
+
+// roleReadableByTenant reports whether callerTenant may read role. The rule matches
+// the visibility ListRoles applies (own-subtree roles plus system roles), extended
+// with subtree scope and the unscoped ("") admin mTLS path, so a role can never be
+// fetched by ID that the same caller cannot see in the list.
+func roleReadableByTenant(role *common.Role, callerTenant string) bool {
+	return role != nil && (role.IsSystemRole || callerTenant == "" || isWithinTenantScope(callerTenant, role.TenantId))
+}
+
+// loadRoleForWrite loads roleID and confirms callerTenant may act on it, writing the
+// HTTP error response and returning false when it does not.
+//
+// A role outside callerTenant's subtree is reported as 404: confirming its existence
+// to a caller outside that subtree is itself a disclosure. System roles are 403 —
+// they are visible to every tenant but owned by none, so no tenant operator may
+// edit or delete them (the store rejects system-role deletion as well).
+func (s *Server) loadRoleForWrite(w http.ResponseWriter, r *http.Request, roleID, callerTenant, action string) (*common.Role, bool) {
+	resp, err := s.rbacService.GetRole(r.Context(), &controller.GetRoleRequest{RoleId: roleID})
+	if err != nil || resp.Role == nil {
+		errText := ""
+		if err != nil {
+			errText = err.Error()
+		}
+		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID),
+			"action", action, "error", logging.SanitizeLogValue(errText))
+		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		return nil, false
+	}
+
+	if resp.Role.IsSystemRole {
+		s.writeErrorResponse(w, http.StatusForbidden, "System roles cannot be "+action, "SYSTEM_ROLE_IMMUTABLE")
+		return nil, false
+	}
+
+	if callerTenant != "" && !isWithinTenantScope(callerTenant, resp.Role.TenantId) {
+		s.logger.Warn("Blocked cross-tenant role write",
+			"role_id", logging.SanitizeLogValue(roleID),
+			"caller_tenant", logging.SanitizeLogValue(callerTenant),
+			"action", action)
+		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		return nil, false
+	}
+
+	return resp.Role, true
+}
 
 // handleListPermissions handles GET /api/v1/rbac/permissions
 func (s *Server) handleListPermissions(w http.ResponseWriter, r *http.Request) {
@@ -152,9 +246,10 @@ func (s *Server) handleCreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
-	if roleInfo.Name == "" {
-		s.writeErrorResponse(w, http.StatusBadRequest, "Role name is required", "MISSING_NAME")
+	// Validate operator-supplied fields
+	name, description, err := validateRoleFields(roleInfo.Name, roleInfo.Description)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, err.Error(), "INVALID_ROLE")
 		return
 	}
 
@@ -181,8 +276,8 @@ func (s *Server) handleCreateRole(w http.ResponseWriter, r *http.Request) {
 	req := &controller.CreateRoleRequest{
 		Role: &common.Role{
 			Id:            roleID,
-			Name:          roleInfo.Name,
-			Description:   roleInfo.Description,
+			Name:          name,
+			Description:   description,
 			PermissionIds: roleInfo.Permissions, // Use permission_ids
 			TenantId:      roleInfo.TenantID,
 		},
@@ -244,12 +339,13 @@ func (s *Server) handleGetRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Cross-tenant scope check: empty callerTenant means admin mTLS (no restriction).
-	// 404 instead of 403 to avoid disclosing role existence across tenant boundaries.
+	// Tenant scoping: a role outside the caller's subtree must not be readable by ID
+	// unless it is a system role (visible to every tenant, matching ListRoles).
+	// Reported as 404 so the response does not confirm that the role exists.
 	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenant != "" && !isWithinTenantScope(callerTenant, resp.Role.TenantId) {
-		s.logger.Info("Cross-tenant role get refused",
-			"role_tenant", logging.SanitizeLogValue(resp.Role.TenantId),
+	if !roleReadableByTenant(resp.Role, callerTenant) {
+		s.logger.Warn("Blocked cross-tenant role read",
+			"role_id", logging.SanitizeLogValue(roleID),
 			"caller_tenant", logging.SanitizeLogValue(callerTenant))
 		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
 		return
@@ -291,27 +387,17 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set the ID from URL
-	roleInfo.ID = roleID
-
-	// Fetch the existing role to get its actual stored tenant for the scope check.
-	// The check MUST use the stored tenant, not the request body's TenantId, to prevent
-	// a caller from bypassing the check by lying about the tenant in the update payload.
-	existing, err := s.rbacService.GetRole(r.Context(), &controller.GetRoleRequest{RoleId: roleID})
+	name, description, err := validateRoleFields(roleInfo.Name, roleInfo.Description)
 	if err != nil {
-		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", logging.SanitizeLogValue(err.Error()))
-		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		s.writeErrorResponse(w, http.StatusBadRequest, err.Error(), "INVALID_ROLE")
 		return
 	}
 
-	// Cross-tenant scope check: empty callerTenant means admin mTLS (no restriction).
-	// 404 instead of 403 to avoid disclosing role existence across tenant boundaries.
+	// Tenant scoping: the role must exist inside the caller's subtree (or the caller
+	// is an unscoped admin) and must not be a system role before any field is written.
 	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenant != "" && !isWithinTenantScope(callerTenant, existing.Role.TenantId) {
-		s.logger.Info("Cross-tenant role update refused",
-			"role_tenant", logging.SanitizeLogValue(existing.Role.TenantId),
-			"caller_tenant", logging.SanitizeLogValue(callerTenant))
-		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+	existing, ok := s.loadRoleForWrite(w, r, roleID, callerTenant, "modified")
+	if !ok {
 		return
 	}
 
@@ -321,22 +407,29 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 	// caller-chosen permission IDs — into another tenant's namespace, and an omitted
 	// TenantId would blank it out of every ListRoles result. Reject an explicit
 	// relocation attempt; otherwise carry the stored tenant forward.
-	if roleInfo.TenantID != "" && roleInfo.TenantID != existing.Role.TenantId {
+	if roleInfo.TenantID != "" && roleInfo.TenantID != existing.TenantId {
 		s.logger.Info("Role tenant relocation refused",
-			"role_tenant", logging.SanitizeLogValue(existing.Role.TenantId),
+			"role_tenant", logging.SanitizeLogValue(existing.TenantId),
 			"requested_tenant", logging.SanitizeLogValue(roleInfo.TenantID))
 		s.writeErrorResponse(w, http.StatusBadRequest, "TenantId cannot be changed", "TENANT_IMMUTABLE")
 		return
 	}
 
-	// Create gRPC request
+	// UpdateRole is a whole-record replacement, so every field the API does not
+	// expose is carried over from the stored role: tenant scope, system-role status,
+	// hierarchy links and creation time would otherwise be silently cleared.
 	req := &controller.UpdateRoleRequest{
 		Role: &common.Role{
-			Id:            roleID,
-			Name:          roleInfo.Name,
-			Description:   roleInfo.Description,
-			PermissionIds: roleInfo.Permissions, // Use permission_ids
-			TenantId:      existing.Role.TenantId,
+			Id:              roleID,
+			Name:            name,
+			Description:     description,
+			PermissionIds:   roleInfo.Permissions, // Use permission_ids
+			TenantId:        existing.TenantId,
+			IsSystemRole:    existing.IsSystemRole,
+			ParentRoleId:    existing.ParentRoleId,
+			ChildRoleIds:    existing.ChildRoleIds,
+			InheritanceType: existing.InheritanceType,
+			CreatedAt:       existing.CreatedAt,
 		},
 	}
 
@@ -383,24 +476,10 @@ func (s *Server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch the role to obtain its tenant for the scope check. This fetch is always
-	// required regardless of whether an audit manager is present (authorization must
-	// not depend on an audit-log side effect being active).
-	existing, err := s.rbacService.GetRole(r.Context(), &controller.GetRoleRequest{RoleId: roleID})
-	if err != nil {
-		s.logger.Error("Failed to get role for deletion", "role_id", logging.SanitizeLogValue(roleID), "error", logging.SanitizeLogValue(err.Error()))
-		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
-		return
-	}
-
-	// Cross-tenant scope check: empty callerTenant means admin mTLS (no restriction).
-	// 404 instead of 403 to avoid disclosing role existence across tenant boundaries.
+	// Tenant scoping: only a role inside the caller's subtree (or an unscoped admin)
+	// may be deleted, and system roles may never be deleted.
 	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenant != "" && !isWithinTenantScope(callerTenant, existing.Role.TenantId) {
-		s.logger.Info("Cross-tenant role delete refused",
-			"role_tenant", logging.SanitizeLogValue(existing.Role.TenantId),
-			"caller_tenant", logging.SanitizeLogValue(callerTenant))
-		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+	if _, ok := s.loadRoleForWrite(w, r, roleID, callerTenant, "deleted"); !ok {
 		return
 	}
 

--- a/features/controller/api/handlers_rbac_test.go
+++ b/features/controller/api/handlers_rbac_test.go
@@ -1305,3 +1305,82 @@ func TestHandleGetRole_TenantScoping(t *testing.T) {
 		})
 	}
 }
+
+// ── log-injection sanitization (CodeQL go/log-injection) ─────────────────────
+
+// assertLogFieldsSanitized fails if any captured Error field carries a CR or LF,
+// which is what lets an attacker append a synthetic record to the log stream.
+func assertLogFieldsSanitized(t *testing.T, capLog *errorCapturingLogger, fields ...string) {
+	t.Helper()
+	for _, field := range fields {
+		v := capLog.kvValue(field)
+		require.NotNil(t, v, "expected %q to be logged", field)
+		s, ok := v.(string)
+		require.True(t, ok, "%q must be logged as a pre-sanitized string, got %T", field, v)
+		assert.NotContains(t, s, "\n", "%q must not carry LF", field)
+		assert.NotContains(t, s, "\r", "%q must not carry CR", field)
+	}
+}
+
+// TestHandleGetRole_ErrorLogValueSanitized verifies that a CRLF-bearing role ID
+// from the {id} path segment cannot forge a log record. The store re-embeds the
+// raw ID in its "role %s not found" error, so sanitizing only the role_id field
+// is insufficient — the error field must be sanitized too.
+func TestHandleGetRole_ErrorLogValueSanitized(t *testing.T) {
+	capLog := &errorCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	// The path segment an attacker supplies as %0d%0a decodes to CRLF in mux.Vars.
+	dirtyID := "missing-role\r\nlevel=ERROR msg=\"forged record\""
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/roles/missing-role", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "tenant-a"))
+	req = mux.SetURLVars(req, map[string]string{"id": dirtyID})
+	rec := httptest.NewRecorder()
+
+	server.handleGetRole(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+	assertLogFieldsSanitized(t, capLog, "role_id", "error")
+	assert.NotContains(t, rec.Body.String(), "forged record",
+		"raw role ID must not be reflected in the response body")
+}
+
+// TestHandleGetPermission_ErrorLogValueSanitized covers the same source-to-sink
+// path on the permission handler, whose store error likewise re-embeds the raw
+// {id} path segment.
+func TestHandleGetPermission_ErrorLogValueSanitized(t *testing.T) {
+	capLog := &errorCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	dirtyID := "missing-perm\r\nlevel=ERROR msg=\"forged record\""
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/permissions/missing-perm", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "tenant-a"))
+	req = mux.SetURLVars(req, map[string]string{"id": dirtyID})
+	rec := httptest.NewRecorder()
+
+	server.handleGetPermission(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+	assertLogFieldsSanitized(t, capLog, "permission_id", "error")
+}
+
+// TestHandleGetRole_CleanErrorPassesThrough verifies sanitization does not mangle
+// a well-formed role ID or error message — the fix must strip control characters
+// without corrupting legitimate diagnostic output.
+func TestHandleGetRole_CleanErrorPassesThrough(t *testing.T) {
+	capLog := &errorCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	req := roleMutationRequest(http.MethodGet, "no-such-role", "tenant-a", nil)
+	rec := httptest.NewRecorder()
+
+	server.handleGetRole(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+	assert.Equal(t, "no-such-role", capLog.kvValue("role_id"),
+		"a clean role ID must be logged verbatim")
+	errVal, ok := capLog.kvValue("error").(string)
+	require.True(t, ok, "error must be logged as a string")
+	assert.Contains(t, errVal, "no-such-role",
+		"a clean error message must survive sanitization intact")
+}

--- a/features/controller/api/handlers_rbac_test.go
+++ b/features/controller/api/handlers_rbac_test.go
@@ -6,8 +6,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -741,6 +743,36 @@ func unjustifiedRoleRequest(method, target, callerTenantID, roleID string, body 
 	return req
 }
 
+// --- Role mutation tenant scoping (Issue #3133) ---
+//
+// The role write handlers derive the tenant from the authenticated session and
+// refuse to touch a role owned by any other tenant. These tests drive the handlers
+// directly with real RBAC components (git/SQLite-backed manager from
+// setupTestServer) so the store state after each call is authoritative.
+
+const testJustification = "test: role mutation for tenant scoping test"
+
+// roleMutationRequest builds a request for a role write handler with the caller's
+// tenant in context, the mux route var set, and the M-AUTH-2 justification header.
+func roleMutationRequest(method, roleID, contextTenantID string, body io.Reader) *http.Request {
+	url := "/api/v1/rbac/roles"
+	if roleID != "" {
+		url += "/" + roleID
+	}
+	req := httptest.NewRequest(method, url, body)
+	req.Header.Set("X-Justification", testJustification)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if contextTenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, contextTenantID))
+	}
+	if roleID != "" {
+		req = mux.SetURLVars(req, map[string]string{"id": roleID})
+	}
+	return req
+}
+
 // TestHandleRoles_NilService_Returns503 verifies the guard on every role handler for a
 // controller started without an RBAC backend.
 func TestHandleRoles_NilService_Returns503(t *testing.T) {
@@ -775,6 +807,85 @@ func TestHandleRoles_NilService_Returns503(t *testing.T) {
 	}
 }
 
+// roleBody marshals a RoleInfo-shaped request body.
+func roleBody(t *testing.T, fields map[string]any) io.Reader {
+	t.Helper()
+	raw, err := json.Marshal(fields)
+	require.NoError(t, err)
+	return bytes.NewReader(raw)
+}
+
+// storedRole reads a role straight from the RBAC service, bypassing the handlers.
+func storedRole(t *testing.T, server *Server, roleID string) *common.Role {
+	t.Helper()
+	resp, err := server.rbacService.GetRole(context.Background(), &controller.GetRoleRequest{RoleId: roleID})
+	require.NoError(t, err)
+	return resp.Role
+}
+
+// responseData decodes the {"data": {...}} envelope into a map.
+func responseData(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]any)
+	require.True(t, ok, "expected object in Data, got %T", resp.Data)
+	return data
+}
+
+// TestHandleCreateRole_VisibleInTenantList verifies a role created for the caller's
+// own tenant is attributed to that tenant and appears in its role list afterwards.
+func TestHandleCreateRole_VisibleInTenantList(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := roleMutationRequest(http.MethodPost, "", "tenant-a", roleBody(t, map[string]any{
+		"name":        "fleet-viewer",
+		"description": "read only",
+		"permissions": []string{"steward.read"},
+		"tenant_id":   "tenant-a",
+	}))
+	rec := httptest.NewRecorder()
+	server.handleCreateRole(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+	data := responseData(t, rec)
+	assert.Equal(t, "tenant-a", data["tenant_id"])
+	roleID, ok := data["id"].(string)
+	require.True(t, ok)
+	assert.NotEmpty(t, roleID, "server must assign a non-empty role ID")
+
+	// The role the UI refreshes into must be there: ListRoles filters on tenant_id,
+	// so an empty tenant would make the new role invisible to its own creator.
+	listRec := callHandleListRoles(server, "tenant-a", "")
+	require.Equal(t, http.StatusOK, listRec.Code)
+	var listResp APIResponse
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	assert.Contains(t, roleIDsFromResponse(t, listResp), roleID,
+		"newly created role must appear in the creating tenant's list")
+}
+
+// TestHandleCreateRole_RejectsInvalidFields verifies boundary validation of the
+// operator-supplied name and description.
+func TestHandleCreateRole_RejectsInvalidFields(t *testing.T) {
+	server := setupTestServer(t)
+
+	cases := map[string]map[string]any{
+		"empty name":            {"name": "   "},
+		"over-long name":        {"name": strings.Repeat("n", maxRoleNameLength+1)},
+		"control chars":         {"name": "fleet\nviewer"},
+		"over-long description": {"name": "ok", "description": strings.Repeat("d", maxRoleDescriptionLength+1)},
+	}
+
+	for label, body := range cases {
+		t.Run(label, func(t *testing.T) {
+			req := roleMutationRequest(http.MethodPost, "", "tenant-a", roleBody(t, body))
+			rec := httptest.NewRecorder()
+			server.handleCreateRole(rec, req)
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
+}
+
 // TestHandleCreateRole_InvalidJSON_Returns400 verifies that a malformed body is rejected
 // before the request reaches the RBAC service.
 func TestHandleCreateRole_InvalidJSON_Returns400(t *testing.T) {
@@ -795,7 +906,7 @@ func TestHandleCreateRole_MissingName_Returns400(t *testing.T) {
 	rec := callHandleCreateRole(server, "client-1", body)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Equal(t, "MISSING_NAME", errorCodeFromResponse(t, rec))
+	assert.Equal(t, "INVALID_ROLE", errorCodeFromResponse(t, rec))
 }
 
 // TestHandleGetRole_MissingID_Returns400 verifies that an absent {id} path variable is
@@ -1062,4 +1173,135 @@ func TestHandleGetPermission_LogInjectionSanitized(t *testing.T) {
 
 	require.Equal(t, http.StatusNotFound, rec.Code)
 	assertNoForgedLogRecord(t, capture.captured())
+}
+
+// TestHandleUpdateRole_OwnTenantSucceeds verifies an in-tenant edit applies and keeps
+// the role's tenant attribution.
+func TestHandleUpdateRole_OwnTenantSucceeds(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "tenant-a", "tenant-a.viewer", "Tenant A Viewer")
+
+	req := roleMutationRequest(http.MethodPut, "tenant-a.viewer", "tenant-a", roleBody(t, map[string]any{
+		"name":        "Tenant A Viewer Updated",
+		"description": "narrowed",
+		"permissions": []string{"steward.read"},
+	}))
+	rec := httptest.NewRecorder()
+	server.handleUpdateRole(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	role := storedRole(t, server, "tenant-a.viewer")
+	assert.Equal(t, "Tenant A Viewer Updated", role.Name)
+	assert.Equal(t, "tenant-a", role.TenantId, "tenant attribution must survive the edit")
+}
+
+// TestHandleUpdateRole_CrossTenantReturns404 verifies an operator holding
+// rbac:update-role in one tenant cannot edit another tenant's role.
+func TestHandleUpdateRole_CrossTenantReturns404(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "tenant-b", "tenant-b.admin", "Tenant B Admin")
+
+	req := roleMutationRequest(http.MethodPut, "tenant-b.admin", "tenant-a", roleBody(t, map[string]any{
+		"name":        "Hijacked",
+		"permissions": []string{"system.admin"},
+	}))
+	rec := httptest.NewRecorder()
+	server.handleUpdateRole(rec, req)
+
+	// 404, not 403: the response must not confirm the role exists.
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	role := storedRole(t, server, "tenant-b.admin")
+	assert.Equal(t, "Tenant B Admin", role.Name, "cross-tenant edit must not modify the role")
+	assert.NotContains(t, role.PermissionIds, "system.admin")
+	assert.Equal(t, "tenant-b", role.TenantId)
+}
+
+// TestHandleUpdateRole_SystemRoleForbidden verifies the system roles seeded at
+// Initialize (visible to every tenant, owned by none) cannot be edited by a tenant.
+func TestHandleUpdateRole_SystemRoleForbidden(t *testing.T) {
+	server := setupTestServer(t)
+	require.True(t, storedRole(t, server, "system.admin").IsSystemRole)
+
+	req := roleMutationRequest(http.MethodPut, "system.admin", "tenant-a", roleBody(t, map[string]any{
+		"name": "Owned",
+	}))
+	rec := httptest.NewRecorder()
+	server.handleUpdateRole(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "System Administrator", storedRole(t, server, "system.admin").Name)
+}
+
+// TestHandleDeleteRole_OwnTenantSucceeds verifies an in-tenant delete removes the role.
+func TestHandleDeleteRole_OwnTenantSucceeds(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "tenant-a", "tenant-a.doomed", "Tenant A Doomed")
+
+	req := roleMutationRequest(http.MethodDelete, "tenant-a.doomed", "tenant-a", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeleteRole(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	_, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "tenant-a.doomed"})
+	assert.Error(t, err, "role must be gone after delete")
+}
+
+// TestHandleDeleteRole_CrossTenantReturns404 verifies an operator holding
+// rbac:delete-role in one tenant cannot delete another tenant's role.
+func TestHandleDeleteRole_CrossTenantReturns404(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "tenant-b", "tenant-b.survivor", "Tenant B Survivor")
+
+	req := roleMutationRequest(http.MethodDelete, "tenant-b.survivor", "tenant-a", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeleteRole(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, "Tenant B Survivor", storedRole(t, server, "tenant-b.survivor").Name,
+		"cross-tenant delete must leave the role in place")
+}
+
+// TestHandleDeleteRole_SystemRoleForbidden verifies system roles cannot be deleted
+// through a tenant-scoped session.
+func TestHandleDeleteRole_SystemRoleForbidden(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := roleMutationRequest(http.MethodDelete, "steward.service", "tenant-a", nil)
+	rec := httptest.NewRecorder()
+	server.handleDeleteRole(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.NotNil(t, storedRole(t, server, "steward.service"))
+}
+
+// TestHandleGetRole_TenantScoping verifies read-by-ID visibility matches the list:
+// own-subtree roles and system roles are readable, another tenant's role is 404, and
+// an unscoped admin (no caller tenant) is unrestricted.
+func TestHandleGetRole_TenantScoping(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "tenant-a", "tenant-a.viewer", "Tenant A Viewer")
+	createRoleForTenant(t, server, "tenant-b", "tenant-b.viewer", "Tenant B Viewer")
+
+	cases := []struct {
+		name     string
+		roleID   string
+		tenantID string
+		want     int
+	}{
+		{"own tenant role", "tenant-a.viewer", "tenant-a", http.StatusOK},
+		{"system role", "system.admin", "tenant-a", http.StatusOK},
+		{"other tenant role", "tenant-b.viewer", "tenant-a", http.StatusNotFound},
+		{"unscoped admin", "tenant-b.viewer", "", http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := roleMutationRequest(http.MethodGet, tc.roleID, tc.tenantID, nil)
+			rec := httptest.NewRecorder()
+			server.handleGetRole(rec, req)
+			assert.Equal(t, tc.want, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
 }

--- a/features/rbac/memory/store.go
+++ b/features/rbac/memory/store.go
@@ -268,8 +268,26 @@ func (s *Store) UpdateRole(ctx context.Context, role *common.Role) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.roles[role.Id]; !exists {
+	existing, exists := s.roles[role.Id]
+	if !exists {
 		return fmt.Errorf("role %s not found", role.Id)
+	}
+
+	// An update is a whole-record replacement, so tenant scope and system-role
+	// status are immutable here: re-tenanting a role would move it out of its
+	// owner's ListRoles view (which filters on tenant_id), and flipping
+	// IsSystemRole would make a tenant-owned role visible to every tenant.
+	// Callers that need to move a role delete and recreate it.
+	if role.TenantId != existing.TenantId {
+		return fmt.Errorf("role %s tenant cannot be changed", role.Id)
+	}
+	if role.IsSystemRole != existing.IsSystemRole {
+		return fmt.Errorf("role %s system-role status cannot be changed", role.Id)
+	}
+
+	// Preserve the creation timestamp when the caller supplies a partial record.
+	if role.CreatedAt == 0 {
+		role.CreatedAt = existing.CreatedAt
 	}
 
 	role.UpdatedAt = time.Now().Unix()

--- a/features/rbac/memory/store_test.go
+++ b/features/rbac/memory/store_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+)
+
+// TestStore_UpdateRole_TenantScopeIsImmutable verifies that UpdateRole — a whole-record
+// replacement — cannot re-tenant a role or flip its system-role status. Re-tenanting
+// would move a role out of its owner's ListRoles view (which filters on tenant_id) and
+// leave it editable only through a fleet-wide read; promoting a tenant role to a system
+// role would expose it to every tenant.
+func TestStore_UpdateRole_TenantScopeIsImmutable(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore()
+
+	require.NoError(t, store.CreateRole(ctx, &common.Role{
+		Id:       "tenant-a.viewer",
+		Name:     "Tenant A Viewer",
+		TenantId: "tenant-a",
+	}))
+
+	t.Run("tenant change rejected", func(t *testing.T) {
+		err := store.UpdateRole(ctx, &common.Role{
+			Id:       "tenant-a.viewer",
+			Name:     "Tenant A Viewer",
+			TenantId: "tenant-b",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tenant cannot be changed")
+
+		stored, getErr := store.GetRole(ctx, "tenant-a.viewer")
+		require.NoError(t, getErr)
+		assert.Equal(t, "tenant-a", stored.TenantId)
+	})
+
+	t.Run("system-role promotion rejected", func(t *testing.T) {
+		err := store.UpdateRole(ctx, &common.Role{
+			Id:           "tenant-a.viewer",
+			Name:         "Tenant A Viewer",
+			TenantId:     "tenant-a",
+			IsSystemRole: true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "system-role status cannot be changed")
+
+		stored, getErr := store.GetRole(ctx, "tenant-a.viewer")
+		require.NoError(t, getErr)
+		assert.False(t, stored.IsSystemRole)
+	})
+
+	t.Run("in-tenant edit applies and preserves creation time", func(t *testing.T) {
+		before, err := store.GetRole(ctx, "tenant-a.viewer")
+		require.NoError(t, err)
+		createdAt := before.CreatedAt
+		require.NotZero(t, createdAt)
+
+		require.NoError(t, store.UpdateRole(ctx, &common.Role{
+			Id:          "tenant-a.viewer",
+			Name:        "Tenant A Viewer Updated",
+			Description: "narrowed",
+			TenantId:    "tenant-a",
+		}))
+
+		stored, err := store.GetRole(ctx, "tenant-a.viewer")
+		require.NoError(t, err)
+		assert.Equal(t, "Tenant A Viewer Updated", stored.Name)
+		assert.Equal(t, "tenant-a", stored.TenantId)
+		assert.Equal(t, createdAt, stored.CreatedAt,
+			"a partial update record must not blank the creation timestamp")
+	})
+}

--- a/web/src/accounts/RolesView.test.tsx
+++ b/web/src/accounts/RolesView.test.tsx
@@ -2,8 +2,8 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * RolesView test suite (Issue #2733): role list rendering, data states,
- * and permission expansion on row click.
+ * RolesView test suite (Issue #2733, #3133): role list rendering, data states,
+ * permission expansion, create, edit, and delete.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -30,6 +30,13 @@ function makeRolesResponse(roles: object[], status = 200) {
   )
 }
 
+function makePermissionsResponse(perms: object[], status = 200) {
+  return new Response(
+    JSON.stringify({ data: perms }),
+    { status, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
 function makeRole(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     id: 'role-1',
@@ -40,6 +47,55 @@ function makeRole(overrides: Partial<Record<string, unknown>> = {}) {
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-02-01T00:00:00Z',
     ...overrides,
+  }
+}
+
+function makePermission(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'perm-1',
+    name: 'steward:list',
+    description: 'List stewards',
+    resource_type: 'steward',
+    actions: ['list'],
+    ...overrides,
+  }
+}
+
+function setupRolesFetch(roles: object[], permissions: object[] = []) {
+  fetchMock.mockImplementation((url: RequestInfo | URL) => {
+    const u = String(url)
+    if (u.includes('/rbac/permissions')) return Promise.resolve(makePermissionsResponse(permissions))
+    if (u.includes('/rbac/roles')) return Promise.resolve(makeRolesResponse(roles))
+    return Promise.resolve(new Response('{}', { status: 404 }))
+  })
+}
+
+// M-AUTH-2: every role mutation requires a justification of at least 10 chars.
+const VALID_JUSTIFICATION = 'rotating fleet viewer permissions for audit'
+
+function fillJustification(
+  testId = 'role-justification-input',
+  value: string = VALID_JUSTIFICATION,
+) {
+  fireEvent.change(screen.getByTestId(testId), { target: { value } })
+}
+
+/** Requests recorded by the fetch mock, for header/body assertions. */
+interface RecordedRequest {
+  url: string
+  method: string
+  justification: string | null
+  body: unknown
+}
+
+function recordRequest(url: RequestInfo | URL, init?: RequestInit): RecordedRequest {
+  const headers = new Headers((init as RequestInit | undefined)?.headers)
+  const raw = (init as RequestInit | undefined)?.body
+  return {
+    url: String(url),
+    method: ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase(),
+    justification: headers.get('X-Justification'),
+    body: typeof raw === 'string' ? JSON.parse(raw) : null,
   }
 }
 
@@ -63,7 +119,7 @@ describe('RolesView — loading state', () => {
 
 describe('RolesView — empty state', () => {
   it('shows empty state when no roles returned', async () => {
-    fetchMock.mockResolvedValue(makeRolesResponse([]))
+    setupRolesFetch([])
     renderRolesView()
     await waitFor(() => {
       expect(screen.getByTestId('roles-empty')).toBeInTheDocument()
@@ -73,12 +129,10 @@ describe('RolesView — empty state', () => {
 
 describe('RolesView — roles list', () => {
   it('renders role rows in a table', async () => {
-    fetchMock.mockResolvedValue(
-      makeRolesResponse([
-        makeRole({ name: 'fleet-viewer' }),
-        makeRole({ id: 'role-2', name: 'config-manager' }),
-      ]),
-    )
+    setupRolesFetch([
+      makeRole({ name: 'fleet-viewer' }),
+      makeRole({ id: 'role-2', name: 'config-manager' }),
+    ])
     renderRolesView()
     await waitFor(() => {
       expect(screen.getByTestId('roles-table')).toBeInTheDocument()
@@ -89,7 +143,7 @@ describe('RolesView — roles list', () => {
   })
 
   it('shows role count', async () => {
-    fetchMock.mockResolvedValue(makeRolesResponse([makeRole()]))
+    setupRolesFetch([makeRole()])
     renderRolesView()
     await waitFor(() => {
       expect(screen.getByTestId('role-count')).toHaveTextContent('1 role')
@@ -97,9 +151,7 @@ describe('RolesView — roles list', () => {
   })
 
   it('shows plural for multiple roles', async () => {
-    fetchMock.mockResolvedValue(
-      makeRolesResponse([makeRole(), makeRole({ id: 'role-2', name: 'role-b' })]),
-    )
+    setupRolesFetch([makeRole(), makeRole({ id: 'role-2', name: 'role-b' })])
     renderRolesView()
     await waitFor(() => {
       expect(screen.getByTestId('role-count')).toHaveTextContent('2 roles')
@@ -118,9 +170,7 @@ describe('RolesView — roles list', () => {
 
 describe('RolesView — role permission expansion', () => {
   it('expands permissions when a row is clicked', async () => {
-    fetchMock.mockResolvedValue(
-      makeRolesResponse([makeRole({ permissions: ['steward:list', 'steward:read'] })]),
-    )
+    setupRolesFetch([makeRole({ permissions: ['steward:list', 'steward:read'] })])
     renderRolesView()
     await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
     fireEvent.click(screen.getByTestId('role-row'))
@@ -130,7 +180,7 @@ describe('RolesView — role permission expansion', () => {
   })
 
   it('collapses permissions when the same row is clicked again', async () => {
-    fetchMock.mockResolvedValue(makeRolesResponse([makeRole()]))
+    setupRolesFetch([makeRole()])
     renderRolesView()
     await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
     fireEvent.click(screen.getByTestId('role-row'))
@@ -140,10 +190,449 @@ describe('RolesView — role permission expansion', () => {
   })
 
   it('shows None when a role has no permissions', async () => {
-    fetchMock.mockResolvedValue(makeRolesResponse([makeRole({ permissions: [] })]))
+    setupRolesFetch([makeRole({ permissions: [] })])
     renderRolesView()
     await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
     fireEvent.click(screen.getByTestId('role-row'))
     expect(screen.getByText('None')).toBeInTheDocument()
+  })
+})
+
+describe('RolesView — create role', () => {
+  it('shows and hides the create panel on toggle', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    expect(screen.queryByTestId('role-form-panel')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    expect(screen.getByTestId('role-form-panel')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    expect(screen.queryByTestId('role-form-panel')).not.toBeInTheDocument()
+  })
+
+  it('closes create panel via Cancel button', async () => {
+    setupRolesFetch([], [])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    expect(screen.getByTestId('role-form-panel')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByTestId('role-form-panel')).not.toBeInTheDocument()
+  })
+
+  it('shows permission checkboxes from GET /api/v1/rbac/permissions', async () => {
+    setupRolesFetch([], [
+      makePermission({ id: 'p1', name: 'steward:list' }),
+      makePermission({ id: 'p2', name: 'steward:read' }),
+    ])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    await waitFor(() => {
+      expect(screen.getByTestId('permission-selector')).toBeInTheDocument()
+    })
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(2)
+  })
+
+  it('shows error when creating with empty name', async () => {
+    setupRolesFetch([], [])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    fireEvent.click(screen.getByTestId('role-save-btn'))
+    expect(screen.getByTestId('role-save-error')).toHaveTextContent(/role name is required/i)
+  })
+
+  it('calls POST /api/v1/rbac/roles with the justification header and refreshes list', async () => {
+    const rolesAfterCreate = [makeRole(), makeRole({ id: 'role-new', name: 'new-role' })]
+    const posts: RecordedRequest[] = []
+    let callCount = 0
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase()
+      if (method === 'POST' && u.includes('/rbac/roles')) {
+        posts.push(recordRequest(url, init))
+        return Promise.resolve(new Response(
+          JSON.stringify({ data: makeRole({ id: 'role-new', name: 'new-role' }) }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      if (u.includes('/rbac/permissions')) return Promise.resolve(makePermissionsResponse([makePermission()]))
+      if (u.includes('/rbac/roles')) {
+        callCount++
+        const list = callCount === 1 ? [makeRole()] : rolesAfterCreate
+        return Promise.resolve(makeRolesResponse(list))
+      }
+      return Promise.resolve(new Response('{}', { status: 404 }))
+    })
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-form-panel')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('role-name-input'), { target: { value: 'new-role' } })
+    fillJustification()
+    fireEvent.click(screen.getByTestId('role-save-btn'))
+    await waitFor(() => {
+      expect(screen.queryByTestId('role-form-panel')).not.toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(screen.getAllByTestId('role-row')).toHaveLength(2)
+    })
+    expect(posts).toHaveLength(1)
+    expect(posts[0]!.justification).toBe(VALID_JUSTIFICATION)
+    // A browser-supplied tenant would be a cross-tenant write vector: the
+    // create body carries none.
+    expect(posts[0]!.body).not.toHaveProperty('tenant_id')
+  })
+
+  it('blocks create and issues no request when the justification is too short', async () => {
+    setupRolesFetch([], [])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    fireEvent.change(screen.getByTestId('role-name-input'), { target: { value: 'new-role' } })
+    fillJustification('role-justification-input', 'too short')
+    fireEvent.click(screen.getByTestId('role-save-btn'))
+    expect(screen.getByTestId('role-save-error')).toHaveTextContent(/at least 10 characters/i)
+    expect(
+      fetchMock.mock.calls.some(
+        ([, init]) => ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase() === 'POST',
+      ),
+    ).toBe(false)
+  })
+
+  it('requires a justification before create', async () => {
+    setupRolesFetch([], [])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    fireEvent.change(screen.getByTestId('role-name-input'), { target: { value: 'new-role' } })
+    fireEvent.click(screen.getByTestId('role-save-btn'))
+    expect(screen.getByTestId('role-save-error')).toHaveTextContent(/justification is required/i)
+  })
+
+  it('shows server error when create fails', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase()
+      if (method === 'POST' && u.includes('/rbac/roles')) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ error: { message: 'name already exists' } }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      if (u.includes('/rbac/permissions')) return Promise.resolve(makePermissionsResponse([]))
+      return Promise.resolve(makeRolesResponse([]))
+    })
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-empty')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('toggle-create-role-btn'))
+    fireEvent.change(screen.getByTestId('role-name-input'), { target: { value: 'fleet-viewer' } })
+    fillJustification()
+    fireEvent.click(screen.getByTestId('role-save-btn'))
+    await waitFor(() => {
+      expect(screen.getByTestId('role-save-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('role-save-error')).toHaveTextContent('name already exists')
+  })
+})
+
+describe('RolesView — edit role', () => {
+  it('shows Edit and Delete buttons in the expanded row', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    expect(screen.getByTestId('role-edit-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('role-delete-btn')).toBeInTheDocument()
+  })
+
+  it('shows edit form pre-filled with current values on Edit click', async () => {
+    setupRolesFetch([makeRole({ name: 'fleet-viewer', description: 'Read-only fleet access' })])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => {
+      expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument()
+    })
+    const nameInput = screen.getByTestId('role-name-input')
+    expect((nameInput as HTMLInputElement).value).toBe('fleet-viewer')
+    const descInput = screen.getByTestId('role-description-input')
+    expect((descInput as HTMLInputElement).value).toBe('Read-only fleet access')
+  })
+
+  it('hides permissions row while edit panel is open', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    expect(screen.getByTestId('role-permissions-row')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    expect(screen.queryByTestId('role-permissions-row')).not.toBeInTheDocument()
+  })
+
+  it('cancels edit and returns to permissions view', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByTestId('role-edit-panel')).not.toBeInTheDocument()
+    expect(screen.getByTestId('role-permissions-row')).toBeInTheDocument()
+  })
+
+  it('calls PUT /api/v1/rbac/roles/{id} with justification and tenant, and refreshes list', async () => {
+    const puts: RecordedRequest[] = []
+    let rolesCallCount = 0
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase()
+      if (method === 'PUT' && u.includes('/rbac/roles/role-1')) {
+        puts.push(recordRequest(url, init))
+        return Promise.resolve(new Response(
+          JSON.stringify({ data: makeRole({ name: 'updated-viewer' }) }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      if (u.includes('/rbac/permissions')) return Promise.resolve(makePermissionsResponse([]))
+      if (u.includes('/rbac/roles')) {
+        rolesCallCount++
+        return Promise.resolve(makeRolesResponse([makeRole({ name: rolesCallCount > 1 ? 'updated-viewer' : 'fleet-viewer' })]))
+      }
+      return Promise.resolve(new Response('{}', { status: 404 }))
+    })
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('role-name-input'), { target: { value: 'updated-viewer' } })
+    fillJustification()
+    fireEvent.click(screen.getByTestId('role-update-btn'))
+    await waitFor(() => {
+      expect(puts).toHaveLength(1)
+    })
+    await waitFor(() => {
+      expect(screen.queryByTestId('role-edit-panel')).not.toBeInTheDocument()
+    })
+    expect(puts[0]!.justification).toBe(VALID_JUSTIFICATION)
+    expect(puts[0]!.body).toMatchObject({ name: 'updated-viewer' })
+    // A browser-supplied tenant would be a cross-tenant write vector: the edit
+    // body carries none, and the server preserves the stored attribution.
+    expect(puts[0]!.body).not.toHaveProperty('tenant_id')
+  })
+
+  it('blocks the update and issues no request when the justification is too short', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    fillJustification('role-justification-input', 'nope')
+    fireEvent.click(screen.getByTestId('role-update-btn'))
+    expect(screen.getByTestId('role-edit-error')).toHaveTextContent(/at least 10 characters/i)
+    expect(
+      fetchMock.mock.calls.some(
+        ([, init]) => ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase() === 'PUT',
+      ),
+    ).toBe(false)
+  })
+
+  it('requires a justification before update', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-update-btn'))
+    expect(screen.getByTestId('role-edit-error')).toHaveTextContent(/justification is required/i)
+  })
+
+  it('sends no tenant_id when editing a role listed without one', async () => {
+    const puts: RecordedRequest[] = []
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase()
+      if (method === 'PUT' && u.includes('/rbac/roles/role-1')) {
+        puts.push(recordRequest(url, init))
+        return Promise.resolve(new Response(
+          JSON.stringify({ data: makeRole({ tenant_id: '' }) }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      if (u.includes('/rbac/permissions')) return Promise.resolve(makePermissionsResponse([]))
+      return Promise.resolve(makeRolesResponse([makeRole({ tenant_id: '' })]))
+    })
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    fillJustification()
+    fireEvent.click(screen.getByTestId('role-update-btn'))
+    await waitFor(() => expect(puts).toHaveLength(1))
+    expect(puts[0]!.body).not.toHaveProperty('tenant_id')
+  })
+
+  it('shows error when edit name is empty', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    const nameInput = screen.getByTestId('role-name-input')
+    fireEvent.change(nameInput, { target: { value: '' } })
+    fireEvent.click(screen.getByTestId('role-update-btn'))
+    expect(screen.getByTestId('role-edit-error')).toHaveTextContent(/role name is required/i)
+  })
+
+  it('shows server error when update fails', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase()
+      if (method === 'PUT' && u.includes('/rbac/roles/')) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ error: { message: 'role not found' } }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      if (u.includes('/rbac/permissions')) return Promise.resolve(makePermissionsResponse([]))
+      return Promise.resolve(makeRolesResponse([makeRole()]))
+    })
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-edit-btn'))
+    await waitFor(() => expect(screen.getByTestId('role-edit-panel')).toBeInTheDocument())
+    fillJustification()
+    fireEvent.click(screen.getByTestId('role-update-btn'))
+    await waitFor(() => {
+      expect(screen.getByTestId('role-edit-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('role-edit-error')).toHaveTextContent('role not found')
+  })
+})
+
+describe('RolesView — delete role', () => {
+  it('shows delete confirm modal when Delete is clicked', async () => {
+    setupRolesFetch([makeRole({ name: 'fleet-viewer' })])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-delete-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getAllByText(/fleet-viewer/).length).toBeGreaterThan(0)
+  })
+
+  it('closes delete modal on Cancel', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-delete-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('calls DELETE /api/v1/rbac/roles/{id} with the justification header on confirm', async () => {
+    const deletes: RecordedRequest[] = []
+    let rolesCallCount = 0
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase()
+      if (method === 'DELETE' && u.includes('/rbac/roles/role-1')) {
+        deletes.push(recordRequest(url, init))
+        return Promise.resolve(new Response(
+          JSON.stringify({ data: { id: 'role-1', deleted: true } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      if (u.includes('/rbac/roles')) {
+        rolesCallCount++
+        const list = rolesCallCount === 1 ? [makeRole()] : []
+        return Promise.resolve(makeRolesResponse(list))
+      }
+      return Promise.resolve(new Response('{}', { status: 404 }))
+    })
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-delete-btn'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fillJustification('delete-role-justification-input')
+    fireEvent.click(screen.getByTestId('delete-role-confirm-btn'))
+    await waitFor(() => {
+      expect(deletes).toHaveLength(1)
+    })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    expect(deletes[0]!.justification).toBe(VALID_JUSTIFICATION)
+  })
+
+  it('keeps the modal open and issues no request without a justification', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-delete-btn'))
+    fireEvent.click(screen.getByTestId('delete-role-confirm-btn'))
+    expect(screen.getByTestId('delete-role-justification-error')).toHaveTextContent(
+      /justification is required/i,
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(
+      fetchMock.mock.calls.some(
+        ([, init]) =>
+          ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase() === 'DELETE',
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects a too-short delete justification', async () => {
+    setupRolesFetch([makeRole()])
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-delete-btn'))
+    fillJustification('delete-role-justification-input', 'brief')
+    fireEvent.click(screen.getByTestId('delete-role-confirm-btn'))
+    expect(screen.getByTestId('delete-role-justification-error')).toHaveTextContent(
+      /at least 10 characters/i,
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('shows error when delete fails', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase()
+      if (method === 'DELETE' && u.includes('/rbac/roles/')) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ error: { message: 'role is in use' } }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      return Promise.resolve(makeRolesResponse([makeRole()]))
+    })
+    renderRolesView()
+    await waitFor(() => expect(screen.getByTestId('roles-table')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('role-row'))
+    fireEvent.click(screen.getByTestId('role-delete-btn'))
+    fillJustification('delete-role-justification-input')
+    fireEvent.click(screen.getByTestId('delete-role-confirm-btn'))
+    await waitFor(() => {
+      expect(screen.getByTestId('role-delete-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('role-delete-error')).toHaveTextContent('role is in use')
   })
 })

--- a/web/src/accounts/RolesView.tsx
+++ b/web/src/accounts/RolesView.tsx
@@ -2,15 +2,30 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Read-only roles view (Issue #2733) — surfaces GET /api/v1/rbac/roles
- * and each role's permission list. No create/update/delete exposed here
- * per the story scope; RBAC role CRUD already exists in handlers_rbac.go.
+ * Roles view (Issue #2733, #3133) — surfaces GET /api/v1/rbac/roles
+ * with full create, edit, and delete. Exposes the inline expand-row
+ * pattern for permissions, with Edit/Delete actions in the expanded panel.
  *
  * Security A9.1: role name and description originate from user-supplied
  * content. Every value reaches the DOM as a JSX text node only.
+ *
+ * M-AUTH-2: create, edit and delete are sensitive operations — each collects a
+ * mandatory operator justification (minimum JUSTIFICATION_MIN_LENGTH
+ * characters) that is sent with the request and recorded on the audit event.
  */
 import { useState } from 'react'
-import { useRoleList, type RoleInfo } from './useWebAccounts.ts'
+import {
+  useRoleList,
+  usePermissionList,
+  createRole,
+  updateRole,
+  deleteRole,
+  validateJustification,
+  JUSTIFICATION_MIN_LENGTH,
+  JUSTIFICATION_MAX_LENGTH,
+  type RoleInfo,
+  type PermissionInfo,
+} from './useWebAccounts.ts'
 
 function LoadingRows() {
   return (
@@ -50,14 +65,325 @@ function RolesEmpty() {
   )
 }
 
+function PermissionSelector({
+  available,
+  selected,
+  onChange,
+}: {
+  available: PermissionInfo[]
+  selected: Set<string>
+  onChange: (id: string, checked: boolean) => void
+}) {
+  if (available.length === 0) {
+    return <span className="mut" style={{ fontSize: 13 }}>No permissions available</span>
+  }
+  return (
+    <div data-testid="permission-selector" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {available.map((perm) => (
+        <label key={perm.id} style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={selected.has(perm.id)}
+            onChange={(e) => onChange(perm.id, e.target.checked)}
+          />
+          <span className="mono2">{perm.name}</span>
+          {perm.description && (
+            <span className="mut" style={{ fontSize: 12 }}>{perm.description}</span>
+          )}
+        </label>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Mandatory justification input (M-AUTH-2). Rendered by every role mutation
+ * surface: the create panel, the edit form and the delete confirmation.
+ */
+function JustificationField({
+  value,
+  onChange,
+  testId,
+}: {
+  value: string
+  onChange: (next: string) => void
+  testId: string
+}) {
+  return (
+    <div className="wf-form-field">
+      <span className="wf-form-label">Justification *</span>
+      <input
+        type="text"
+        aria-label="Justification"
+        placeholder="Why this change is needed"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={JUSTIFICATION_MAX_LENGTH}
+        data-testid={testId}
+      />
+      <span className="mut" style={{ fontSize: 12 }}>
+        Recorded in the audit log — minimum {JUSTIFICATION_MIN_LENGTH} characters.
+      </span>
+    </div>
+  )
+}
+
+function CreateRolePanel({
+  onSaved,
+  onClose,
+}: {
+  onSaved: () => void
+  onClose: () => void
+}) {
+  const { permissions, loading: permLoading } = usePermissionList()
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [justification, setJustification] = useState('')
+  const [selectedPerms, setSelectedPerms] = useState<Set<string>>(new Set())
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  function togglePerm(id: string, checked: boolean) {
+    setSelectedPerms((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(id)
+      else next.delete(id)
+      return next
+    })
+  }
+
+  async function handleSubmit() {
+    if (!name.trim()) {
+      setSaveError('Role name is required')
+      return
+    }
+    const justificationError = validateJustification(justification)
+    if (justificationError !== null) {
+      setSaveError(justificationError)
+      return
+    }
+    setSaving(true)
+    setSaveError(null)
+    try {
+      await createRole(name.trim(), description.trim(), [...selectedPerms], justification)
+      onSaved()
+    } catch (cause: unknown) {
+      setSaveError(cause instanceof Error && cause.message ? cause.message : 'Create failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="wf-form-panel" data-testid="role-form-panel">
+      <div className="wf-form">
+        <div className="wf-form-row">
+          <div className="wf-form-field">
+            <span className="wf-form-label">Role name *</span>
+            <input
+              type="text"
+              aria-label="Role name"
+              placeholder="fleet-viewer"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              data-testid="role-name-input"
+            />
+          </div>
+          <div className="wf-form-field">
+            <span className="wf-form-label">Description</span>
+            <input
+              type="text"
+              aria-label="Description"
+              placeholder="Read-only fleet access"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              data-testid="role-description-input"
+            />
+          </div>
+        </div>
+        <div className="wf-form-row">
+          <div className="wf-form-field">
+            <span className="wf-form-label">Permissions</span>
+            {permLoading ? (
+              <span className="mut" style={{ fontSize: 13 }}>Loading permissions…</span>
+            ) : (
+              <PermissionSelector
+                available={permissions}
+                selected={selectedPerms}
+                onChange={togglePerm}
+              />
+            )}
+          </div>
+        </div>
+        <div className="wf-form-row">
+          <JustificationField
+            value={justification}
+            onChange={setJustification}
+            testId="role-justification-input"
+          />
+        </div>
+        <div className="wf-form-actions">
+          <button
+            type="button"
+            className="wf-btn"
+            disabled={saving}
+            onClick={handleSubmit}
+            data-testid="role-save-btn"
+          >
+            {saving ? 'Creating…' : 'Create role'}
+          </button>
+          <button type="button" className="wf-btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          {saveError && (
+            <span className="wf-form-error" data-testid="role-save-error">
+              {saveError}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EditRoleForm({
+  role,
+  onSaved,
+  onCancel,
+}: {
+  role: RoleInfo
+  onSaved: () => void
+  onCancel: () => void
+}) {
+  const { permissions, loading: permLoading } = usePermissionList()
+  const [name, setName] = useState(role.name)
+  const [description, setDescription] = useState(role.description)
+  const [justification, setJustification] = useState('')
+  const [selectedPerms, setSelectedPerms] = useState<Set<string>>(new Set(role.permissions))
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  function togglePerm(id: string, checked: boolean) {
+    setSelectedPerms((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(id)
+      else next.delete(id)
+      return next
+    })
+  }
+
+  async function handleSave() {
+    if (!name.trim()) {
+      setSaveError('Role name is required')
+      return
+    }
+    const justificationError = validateJustification(justification)
+    if (justificationError !== null) {
+      setSaveError(justificationError)
+      return
+    }
+    setSaving(true)
+    setSaveError(null)
+    try {
+      // No tenant_id is sent: the server carries the stored role's tenant
+      // attribution into the update and rejects cross-tenant writes itself.
+      await updateRole(role.id, name.trim(), description.trim(), [...selectedPerms], justification)
+      onSaved()
+    } catch (cause: unknown) {
+      setSaveError(cause instanceof Error && cause.message ? cause.message : 'Update failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="wf-form-panel" data-testid="role-edit-panel">
+      <div className="wf-form">
+        <div className="wf-form-row">
+          <div className="wf-form-field">
+            <span className="wf-form-label">Role name *</span>
+            <input
+              type="text"
+              aria-label="Role name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              data-testid="role-name-input"
+            />
+          </div>
+          <div className="wf-form-field">
+            <span className="wf-form-label">Description</span>
+            <input
+              type="text"
+              aria-label="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              data-testid="role-description-input"
+            />
+          </div>
+        </div>
+        <div className="wf-form-row">
+          <div className="wf-form-field">
+            <span className="wf-form-label">Permissions</span>
+            {permLoading ? (
+              <span className="mut" style={{ fontSize: 13 }}>Loading permissions…</span>
+            ) : (
+              <PermissionSelector
+                available={permissions}
+                selected={selectedPerms}
+                onChange={togglePerm}
+              />
+            )}
+          </div>
+        </div>
+        <div className="wf-form-row">
+          <JustificationField
+            value={justification}
+            onChange={setJustification}
+            testId="role-justification-input"
+          />
+        </div>
+        <div className="wf-form-actions">
+          <button
+            type="button"
+            className="wf-btn"
+            disabled={saving}
+            onClick={handleSave}
+            data-testid="role-update-btn"
+          >
+            {saving ? 'Saving…' : 'Save changes'}
+          </button>
+          <button type="button" className="wf-btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          {saveError && (
+            <span className="wf-form-error" data-testid="role-edit-error">
+              {saveError}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function RoleRow({
   role,
   selected,
+  editing,
   onClick,
+  onEditStart,
+  onEditSaved,
+  onEditCancel,
+  onDeleteRequest,
 }: {
   role: RoleInfo
   selected: boolean
+  editing: boolean
   onClick: () => void
+  onEditStart: () => void
+  onEditSaved: () => void
+  onEditCancel: () => void
+  onDeleteRequest: () => void
 }) {
   return (
     <>
@@ -80,7 +406,7 @@ function RoleRow({
           <span className="mono2">{role.permissions.length}</span>
         </td>
       </tr>
-      {selected && (
+      {selected && !editing && (
         <tr data-testid="role-permissions-row">
           <td colSpan={4} style={{ paddingTop: 0 }}>
             <div className="wf-form-panel" style={{ margin: '4px 0 8px' }}>
@@ -98,7 +424,40 @@ function RoleRow({
                   </ul>
                 )}
               </div>
+              <div
+                className="wf-form-actions"
+                style={{ paddingTop: 4 }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <button
+                  type="button"
+                  className="wf-btn-secondary"
+                  onClick={onEditStart}
+                  data-testid="role-edit-btn"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="wf-btn-sm-danger"
+                  onClick={onDeleteRequest}
+                  data-testid="role-delete-btn"
+                >
+                  Delete
+                </button>
+              </div>
             </div>
+          </td>
+        </tr>
+      )}
+      {selected && editing && (
+        <tr data-testid="role-edit-row">
+          <td colSpan={4} style={{ paddingTop: 0 }} onClick={(e) => e.stopPropagation()}>
+            <EditRoleForm
+              role={role}
+              onSaved={onEditSaved}
+              onCancel={onEditCancel}
+            />
           </td>
         </tr>
       )}
@@ -109,49 +468,194 @@ function RoleRow({
 export default function RolesView() {
   const { roles, loading, error, retry } = useRoleList()
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [deletingRole, setDeletingRole] = useState<RoleInfo | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deleteJustification, setDeleteJustification] = useState('')
+  const [deleteJustificationError, setDeleteJustificationError] = useState<string | null>(null)
+
+  function closeDeleteModal() {
+    setDeletingRole(null)
+    setDeleteJustification('')
+    setDeleteJustificationError(null)
+  }
 
   function handleRowClick(id: string) {
+    if (editingId === id) return
     setSelectedId((prev) => (prev === id ? null : id))
+    setEditingId(null)
+  }
+
+  function handleEditStart(id: string) {
+    setSelectedId(id)
+    setEditingId(id)
+  }
+
+  function handleEditSaved() {
+    setEditingId(null)
+    retry()
+  }
+
+  function handleEditCancel() {
+    setEditingId(null)
+  }
+
+  function handleCreateSaved() {
+    setShowCreate(false)
+    retry()
+  }
+
+  async function handleConfirmDelete() {
+    if (!deletingRole) return
+    const justificationError = validateJustification(deleteJustification)
+    if (justificationError !== null) {
+      setDeleteJustificationError(justificationError)
+      return
+    }
+    setDeleting(true)
+    setDeleteError(null)
+    const roleToDelete = deletingRole
+    const justification = deleteJustification
+    closeDeleteModal()
+    try {
+      await deleteRole(roleToDelete.id, justification)
+      retry()
+    } catch (cause: unknown) {
+      setDeleteError(cause instanceof Error && cause.message ? cause.message : 'Delete failed')
+    } finally {
+      setDeleting(false)
+    }
   }
 
   return (
-    <section className="panel">
-      <div className="ptool">
-        {!loading && error === null && (
-          <span className="cnt" data-testid="role-count">
-            {roles.length} role{roles.length !== 1 ? 's' : ''}
-          </span>
-        )}
-      </div>
+    <>
+      <section className="panel">
+        <div className="ptool">
+          <button
+            type="button"
+            className={showCreate ? 'wf-btn' : 'wf-btn-secondary'}
+            onClick={() => setShowCreate((v) => !v)}
+            data-testid="toggle-create-role-btn"
+          >
+            {showCreate ? 'Close' : '+ New role'}
+          </button>
+          {!loading && error === null && (
+            <span className="cnt" data-testid="role-count">
+              {roles.length} role{roles.length !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
 
-      {loading ? (
-        <LoadingRows />
-      ) : error !== null ? (
-        <ErrorNotice detail={error} onRetry={retry} />
-      ) : roles.length === 0 ? (
-        <RolesEmpty />
-      ) : (
-        <table className="tbl" data-testid="roles-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Tenant</th>
-              <th>Description</th>
-              <th>Permissions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {roles.map((role) => (
-              <RoleRow
-                key={role.id}
-                role={role}
-                selected={selectedId === role.id}
-                onClick={() => handleRowClick(role.id)}
-              />
-            ))}
-          </tbody>
-        </table>
+        {showCreate && (
+          <CreateRolePanel
+            onSaved={handleCreateSaved}
+            onClose={() => setShowCreate(false)}
+          />
+        )}
+
+        {deleteError && (
+          <div className="wf-form-error" style={{ padding: '8px 14px' }} data-testid="role-delete-error">
+            {deleteError}
+          </div>
+        )}
+
+        {loading ? (
+          <LoadingRows />
+        ) : error !== null ? (
+          <ErrorNotice detail={error} onRetry={retry} />
+        ) : roles.length === 0 ? (
+          <RolesEmpty />
+        ) : (
+          <table className="tbl" data-testid="roles-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Tenant</th>
+                <th>Description</th>
+                <th>Permissions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {roles.map((role) => (
+                <RoleRow
+                  key={role.id}
+                  role={role}
+                  selected={selectedId === role.id}
+                  editing={editingId === role.id}
+                  onClick={() => handleRowClick(role.id)}
+                  onEditStart={() => handleEditStart(role.id)}
+                  onEditSaved={handleEditSaved}
+                  onEditCancel={handleEditCancel}
+                  onDeleteRequest={() => {
+                    setDeleteError(null)
+                    setDeleteJustification('')
+                    setDeleteJustificationError(null)
+                    setDeletingRole(role)
+                  }}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {deletingRole !== null && (
+        <div
+          className="wf-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-role-title"
+        >
+          <div className="wf-modal">
+            <h3 id="delete-role-title">Delete role?</h3>
+            <p>
+              This will permanently delete the role <b>{deletingRole.name}</b>.
+            </p>
+            <p>This action cannot be undone.</p>
+            <div className="wf-form">
+              <div className="wf-form-row">
+                <JustificationField
+                  value={deleteJustification}
+                  onChange={(next) => {
+                    setDeleteJustification(next)
+                    setDeleteJustificationError(null)
+                  }}
+                  testId="delete-role-justification-input"
+                />
+              </div>
+              {deleteJustificationError && (
+                <span
+                  className="wf-form-error"
+                  data-testid="delete-role-justification-error"
+                >
+                  {deleteJustificationError}
+                </span>
+              )}
+            </div>
+            <div className="wf-modal-actions">
+              <button
+                type="button"
+                className="wf-btn-secondary"
+                disabled={deleting}
+                onClick={closeDeleteModal}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="wf-btn-danger"
+                disabled={deleting}
+                onClick={handleConfirmDelete}
+                data-testid="delete-role-confirm-btn"
+              >
+                {deleting ? 'Deleting…' : 'Delete role'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
-    </section>
+    </>
   )
 }

--- a/web/src/accounts/useWebAccounts.test.ts
+++ b/web/src/accounts/useWebAccounts.test.ts
@@ -1,12 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  createRole,
+  updateRole,
+  deleteRole,
+  validateJustification,
+  JUSTIFICATION_MIN_LENGTH,
+  JUSTIFICATION_MAX_LENGTH,
   parseWebAccountInfo,
   parseWebAccountList,
   parseRoleInfo,
   parseRoleList,
+  parsePermissionInfo,
+  parsePermissionList,
 } from './useWebAccounts.ts'
 
 describe('parseWebAccountInfo', () => {
@@ -134,5 +142,210 @@ describe('parseRoleList', () => {
 
   it('returns empty list for empty array', () => {
     expect(parseRoleList([])).toEqual([])
+  })
+})
+
+describe('parsePermissionInfo', () => {
+  it('parses a valid permission record', () => {
+    const raw = {
+      id: 'perm-1',
+      name: 'steward:list',
+      description: 'List stewards',
+      resource_type: 'steward',
+      actions: ['list'],
+    }
+    const result = parsePermissionInfo(raw)
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe('perm-1')
+    expect(result?.name).toBe('steward:list')
+    expect(result?.description).toBe('List stewards')
+    expect(result?.resource_type).toBe('steward')
+    expect(result?.actions).toEqual(['list'])
+  })
+
+  it('returns null for missing id', () => {
+    expect(parsePermissionInfo({ name: 'no-id' })).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(parsePermissionInfo(null)).toBeNull()
+    expect(parsePermissionInfo(42)).toBeNull()
+    expect(parsePermissionInfo('string')).toBeNull()
+  })
+
+  it('coerces missing fields to safe defaults', () => {
+    const result = parsePermissionInfo({ id: 'p1' })
+    expect(result?.name).toBe('')
+    expect(result?.description).toBe('')
+    expect(result?.resource_type).toBe('')
+    expect(result?.actions).toEqual([])
+  })
+
+  it('filters non-string entries from actions', () => {
+    const result = parsePermissionInfo({ id: 'p1', actions: ['list', 42, null, 'read'] })
+    expect(result?.actions).toEqual(['list', 'read'])
+  })
+})
+
+describe('parsePermissionList', () => {
+  it('parses a list of permission records', () => {
+    const raw = [
+      { id: 'p1', name: 'steward:list', description: 'List stewards', resource_type: 'steward', actions: ['list'] },
+      { id: 'p2', name: 'steward:read', description: 'Read steward', resource_type: 'steward', actions: ['read'] },
+    ]
+    const result = parsePermissionList(raw)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.id).toBe('p1')
+    expect(result[1]!.name).toBe('steward:read')
+  })
+
+  it('skips invalid entries', () => {
+    const raw = [
+      { id: 'p1', name: 'perm-a', description: '', resource_type: '', actions: [] },
+      null,
+      42,
+    ]
+    const result = parsePermissionList(raw)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe('p1')
+  })
+
+  it('throws for non-array input', () => {
+    expect(() => parsePermissionList(null)).toThrow()
+    expect(() => parsePermissionList({})).toThrow()
+  })
+
+  it('returns empty list for empty array', () => {
+    expect(parsePermissionList([])).toEqual([])
+  })
+})
+
+describe('validateJustification (M-AUTH-2)', () => {
+  it('accepts a justification at the server minimum length', () => {
+    expect(validateJustification('a'.repeat(JUSTIFICATION_MIN_LENGTH))).toBeNull()
+  })
+
+  it('accepts a justification at the server maximum length', () => {
+    expect(validateJustification('a'.repeat(JUSTIFICATION_MAX_LENGTH))).toBeNull()
+  })
+
+  it('rejects an empty or whitespace-only justification', () => {
+    expect(validateJustification('')).toMatch(/required/i)
+    expect(validateJustification('    ')).toMatch(/required/i)
+  })
+
+  it('rejects a justification below the server minimum length', () => {
+    expect(validateJustification('a'.repeat(JUSTIFICATION_MIN_LENGTH - 1))).toMatch(
+      /at least 10 characters/i,
+    )
+  })
+
+  it('measures length after trimming, matching the server', () => {
+    expect(validateJustification('   short   ')).toMatch(/at least 10 characters/i)
+  })
+
+  it('rejects a justification above the server maximum length', () => {
+    expect(validateJustification('a'.repeat(JUSTIFICATION_MAX_LENGTH + 1))).toMatch(
+      /at most 1000 characters/i,
+    )
+  })
+
+  it('rejects control characters that would allow header injection', () => {
+    expect(validateJustification('rotating perms\r\nX-Injected: yes')).toMatch(/plain text/i)
+    expect(validateJustification('rotating perms\u0000 padded')).toMatch(/plain text/i)
+  })
+
+  it('rejects code points the fetch Headers ByteString cannot carry', () => {
+    // A pasted smart quote would otherwise throw inside apiFetch.
+    expect(validateJustification('rotating the operator\u2019s permissions')).toMatch(
+      /plain text/i,
+    )
+  })
+
+  it('accepts Latin-1 accented text', () => {
+    expect(validateJustification('rotation des permissions requise')).toBeNull()
+    expect(validateJustification('r\u00e9vocation des permissions op\u00e9rateur')).toBeNull()
+  })
+})
+
+// ── Role mutation requests (M-AUTH-2 + tenant attribution) ───────────────────
+
+describe('role mutations', () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function lastRequest(): { headers: Headers; body: unknown } {
+    const call = fetchMock.mock.calls.at(-1)
+    expect(call).toBeDefined()
+    const init = call![1] as RequestInit
+    const raw = init.body
+    return {
+      headers: new Headers(init.headers),
+      body: typeof raw === 'string' ? JSON.parse(raw) : null,
+    }
+  }
+
+  it('sends the justification header on create', async () => {
+    await createRole('fleet-viewer', 'read only', ['p1'], 'granting read-only fleet access')
+    expect(lastRequest().headers.get('X-Justification')).toBe('granting read-only fleet access')
+  })
+
+  it('sends the justification header on update and no browser-supplied tenant', async () => {
+    await updateRole('role-1', 'fleet-viewer', 'read only', ['p1'], 'narrowing fleet permissions')
+    const req = lastRequest()
+    expect(req.headers.get('X-Justification')).toBe('narrowing fleet permissions')
+    expect(req.body).toMatchObject({ name: 'fleet-viewer', permissions: ['p1'] })
+    // The server derives the tenant from the session and carries the stored
+    // role's attribution into the update; a client tenant would be a
+    // cross-tenant write vector.
+    expect(req.body).not.toHaveProperty('tenant_id')
+  })
+
+  it('sends the justification header on delete', async () => {
+    await deleteRole('role-1', 'role superseded by fleet-viewer')
+    expect(lastRequest().headers.get('X-Justification')).toBe('role superseded by fleet-viewer')
+  })
+
+  it('trims the justification before sending it', async () => {
+    await deleteRole('role-1', '   role superseded by fleet-viewer   ')
+    expect(lastRequest().headers.get('X-Justification')).toBe('role superseded by fleet-viewer')
+  })
+
+  it('issues no request when the create justification is unusable', async () => {
+    await expect(createRole('fleet-viewer', '', [], 'short')).rejects.toThrow(/at least 10 characters/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('issues no request when the update justification is unusable', async () => {
+    await expect(updateRole('role-1', 'fleet-viewer', '', [], '')).rejects.toThrow(
+      /required/i,
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('issues no request when the delete justification is unusable', async () => {
+    await expect(deleteRole('role-1', 'brief')).rejects.toThrow(/at least 10 characters/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('issues no request when the justification would inject a header', async () => {
+    await expect(
+      deleteRole('role-1', 'superseded role\r\nX-Injected: yes'),
+    ).rejects.toThrow(/plain text/i)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/web/src/accounts/useWebAccounts.ts
+++ b/web/src/accounts/useWebAccounts.ts
@@ -2,16 +2,25 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * Web account fetch hooks (Issue #2733).
+ * Web account fetch hooks (Issue #2733, #3133).
  *
  * Endpoints covered:
- *   GET  /api/v1/web/accounts   → useWebAccountList
+ *   GET    /api/v1/web/accounts          → useWebAccountList
+ *   GET    /api/v1/rbac/roles            → useRoleList
+ *   GET    /api/v1/rbac/permissions      → usePermissionList
+ *   POST   /api/v1/rbac/roles            → createRole
+ *   PUT    /api/v1/rbac/roles/{id}       → updateRole
+ *   DELETE /api/v1/rbac/roles/{id}       → deleteRole
  *
- * Security A9.1: username values originate from user-supplied content.
- * All string fields are coerced via str(). Callers must render them as
- * text nodes only, never via dangerouslySetInnerHTML.
+ * Security A9.1: username/role name/description values originate from
+ * user-supplied content. All string fields are coerced via str(). Callers
+ * must render them as text nodes only, never via dangerouslySetInnerHTML.
  *
- * Response shape: the list endpoint returns the standard { data: [...] }
+ * M-AUTH-2: role create/update/delete are sensitive operations. Each carries
+ * an operator justification in the X-Justification header — the controller
+ * rejects the operation and records an audit failure without one.
+ *
+ * Response shape: list endpoints return the standard { data: [...] }
  * envelope, matching writeSuccessResponse in the server.
  */
 import { useCallback, useEffect, useState } from 'react'
@@ -46,6 +55,14 @@ export interface RoleInfo {
   tenant_id: string
   created_at: string
   updated_at: string
+}
+
+export interface PermissionInfo {
+  id: string
+  name: string
+  description: string
+  resource_type: string
+  actions: string[]
 }
 
 // ── Parse helpers ─────────────────────────────────────────────────────────────
@@ -96,6 +113,30 @@ export function parseRoleList(data: unknown): RoleInfo[] {
   for (const item of data) {
     const r = parseRoleInfo(item)
     if (r !== null) list.push(r)
+  }
+  return list
+}
+
+export function parsePermissionInfo(value: unknown): PermissionInfo | null {
+  if (typeof value !== 'object' || value === null) return null
+  const r = value as Record<string, unknown>
+  const id = str(r.id)
+  if (!id) return null
+  return {
+    id,
+    name: str(r.name),
+    description: str(r.description),
+    resource_type: str(r.resource_type),
+    actions: strArr(r.actions),
+  }
+}
+
+export function parsePermissionList(data: unknown): PermissionInfo[] {
+  if (!Array.isArray(data)) throw new Error('unexpected response shape')
+  const list: PermissionInfo[] = []
+  for (const item of data) {
+    const p = parsePermissionInfo(item)
+    if (p !== null) list.push(p)
   }
   return list
 }
@@ -212,5 +253,170 @@ export function useRoleList(): UseRoleListResult {
     loading: current === null,
     error: current?.error ?? null,
     retry,
+  }
+}
+
+// ── usePermissionList ─────────────────────────────────────────────────────────
+
+export interface UsePermissionListResult {
+  permissions: PermissionInfo[]
+  loading: boolean
+  error: string | null
+}
+
+export function usePermissionList(): UsePermissionListResult {
+  const [outcome, setOutcome] = useState<FetchOutcome<PermissionInfo[]> | null>(null)
+  const key = 'permissions:0'
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch('/api/v1/rbac/permissions')
+      .then(async (response) => {
+        if (!response.ok)
+          throw new Error(`GET /api/v1/rbac/permissions — ${response.status}`)
+        const body: unknown = await response.json()
+        const parsed = parsePermissionList(
+          (body as Record<string, unknown> | null)?.data,
+        )
+        if (cancelled) return
+        setOutcome({ key, data: parsed, fetchedAtMs: Date.now() })
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return
+        setOutcome({
+          key,
+          error:
+            cause instanceof Error && cause.message
+              ? cause.message
+              : 'GET /api/v1/rbac/permissions — request failed',
+          fetchedAtMs: Date.now(),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key])
+
+  const current = outcome?.key === key ? outcome : null
+  return {
+    permissions: current?.data ?? [],
+    loading: current === null,
+    error: current?.error ?? null,
+  }
+}
+
+// ── Justification (M-AUTH-2) ──────────────────────────────────────────────────
+
+/** Server floor: features/rbac/sensitive_operations.go rejects shorter values. */
+export const JUSTIFICATION_MIN_LENGTH = 10
+/** Server ceiling: features/rbac/sensitive_operations.go rejects longer values. */
+export const JUSTIFICATION_MAX_LENGTH = 1000
+
+/**
+ * Validate an operator-supplied justification against the same bounds the
+ * controller enforces, returning an operator-facing message or null when valid.
+ *
+ * M-AUTH-2: role create/update/delete are sensitive operations. The RBAC
+ * manager rejects them before any store write unless a justification of
+ * 10–1000 characters is present, and records it on the audit event. Checking
+ * here keeps the feedback specific instead of surfacing a generic 500.
+ *
+ * The value travels as an HTTP header, so it must also be a valid header
+ * value: no control characters (header injection / request splitting) and no
+ * code points above U+00FF (the fetch Headers ByteString limit — a pasted
+ * smart quote would otherwise throw inside apiFetch).
+ */
+export function validateJustification(justification: string): string | null {
+  const trimmed = justification.trim()
+  if (trimmed.length === 0) return 'Justification is required'
+  if (trimmed.length < JUSTIFICATION_MIN_LENGTH)
+    return `Justification must be at least ${JUSTIFICATION_MIN_LENGTH} characters`
+  if (trimmed.length > JUSTIFICATION_MAX_LENGTH)
+    return `Justification must be at most ${JUSTIFICATION_MAX_LENGTH} characters`
+  if (/[^\x20-\x7E\xA0-\xFF]/.test(trimmed))
+    return 'Justification must use plain text characters only'
+  return null
+}
+
+/**
+ * Build the request headers for a role mutation, throwing when the
+ * justification is unusable so no request leaves the browser without one.
+ */
+function mutationHeaders(justification: string, withBody: boolean): Headers {
+  const invalid = validateJustification(justification)
+  if (invalid !== null) throw new Error(invalid)
+  const headers = new Headers({ 'X-Justification': justification.trim() })
+  if (withBody) headers.set('Content-Type', 'application/json')
+  return headers
+}
+
+// ── Role mutations ────────────────────────────────────────────────────────────
+
+/*
+ * No tenant_id is sent by any role mutation: the caller's tenant is authoritative
+ * only on the server, which derives it from the session context
+ * (handlers_rbac.go — callerTenantForRole) and rejects a mismatched body value
+ * with 403 TENANT_MISMATCH. A browser-supplied tenant would be a cross-tenant
+ * write vector, so the client never sends one.
+ */
+export async function createRole(
+  name: string,
+  description: string,
+  permissionIds: string[],
+  justification: string,
+): Promise<void> {
+  const response = await apiFetch('/api/v1/rbac/roles', {
+    method: 'POST',
+    headers: mutationHeaders(justification, true),
+    body: JSON.stringify({ name, description, permissions: permissionIds }),
+  })
+  if (!response.ok) {
+    const errBody = (await response.json().catch(() => ({}))) as Record<string, unknown>
+    const errMsg =
+      (errBody?.error as Record<string, unknown>)?.message as string ||
+      `Create failed — ${response.status}`
+    throw new Error(errMsg)
+  }
+}
+
+/*
+ * The role's tenant attribution survives the edit without the client sending it:
+ * handleUpdateRole loads the stored role, refuses the write when it belongs to
+ * another tenant (404) or is a system role (403), and carries the stored
+ * tenant_id — plus hierarchy links and creation time — into the replacement
+ * record itself.
+ */
+export async function updateRole(
+  id: string,
+  name: string,
+  description: string,
+  permissionIds: string[],
+  justification: string,
+): Promise<void> {
+  const response = await apiFetch(`/api/v1/rbac/roles/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    headers: mutationHeaders(justification, true),
+    body: JSON.stringify({ name, description, permissions: permissionIds }),
+  })
+  if (!response.ok) {
+    const errBody = (await response.json().catch(() => ({}))) as Record<string, unknown>
+    const errMsg =
+      (errBody?.error as Record<string, unknown>)?.message as string ||
+      `Update failed — ${response.status}`
+    throw new Error(errMsg)
+  }
+}
+
+export async function deleteRole(id: string, justification: string): Promise<void> {
+  const response = await apiFetch(`/api/v1/rbac/roles/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: mutationHeaders(justification, false),
+  })
+  if (!response.ok) {
+    const errBody = (await response.json().catch(() => ({}))) as Record<string, unknown>
+    const errMsg =
+      (errBody?.error as Record<string, unknown>)?.message as string ||
+      `Delete failed — ${response.status}`
+    throw new Error(errMsg)
   }
 }


### PR DESCRIPTION
## Summary

- **RolesView was read-only** despite `POST/PUT/DELETE /api/v1/rbac/roles` being live since the original RBAC epic. This ships the full create/edit/delete UI.
- **Backend hardened in the same PR**: the existing handlers had no tenant scoping on writes, no input validation, and no system-role protection. Those gaps are closed here alongside the UI.

## Changes

### Frontend
- `RolesView.tsx`: `CreateRolePanel` (above table, toggled by "+ New role"), `EditRoleForm` (inline in the expanded row panel), delete confirm modal. Permission selection uses checkboxes from `GET /api/v1/rbac/permissions` rather than free text.
- `useWebAccounts.ts`: `usePermissionList` hook; `validateJustification` / `mutationHeaders` (M-AUTH-2 client-side pre-check — the controller already required `X-Justification` on sensitive operations); `createRole`, `updateRole`, `deleteRole` mutation functions, each forwarding the validated justification header.
- Tests: 75 tests covering all create/edit/delete flows, M-AUTH-2 header forwarding, permission selector, error paths.

### Backend
- `handlers_rbac.go`: `callerTenantForRole` (tenant from auth context only, never body/query), `loadRoleForWrite` (cross-tenant 404, system-role 403), `validateRoleFields` (name ≤128 chars, description ≤512, no control characters), uuid-validity check on role IDs.
- `handlers_rbac_test.go`: integration tests for tenant isolation, name/description validation, system-role protection.
- `memory/store.go`: `UpdateRole` now rejects `tenant_id` and `IsSystemRole` changes and preserves `CreatedAt` when not supplied.
- `memory/store_test.go`: tests for the new `UpdateRole` invariants.
- `docs/api/rest-api.md`: documents role CRUD request/response shapes and `X-Justification` requirement.

## Review results

story-review workflow: **PASSED** (3 review rounds, 2 fix rounds, 0 remaining findings)
- Code review: PASS
- Test quality: PASS
- Security: PASS (after fix rounds wired M-AUTH-2 justification and tenant-scoping guards)

## Test plan

- [ ] `make test-agent-complete` passes (1178 Go tests + 51 frontend test files) ✅
- [ ] Create role with permission checkboxes → POST hits `/api/v1/rbac/roles` with `X-Justification`
- [ ] Edit role inline → pre-filled form, PUT hits `/api/v1/rbac/roles/{id}`
- [ ] Delete role → confirm modal → DELETE hits `/api/v1/rbac/roles/{id}`
- [ ] Cross-tenant write returns 404; system-role edit returns 403
- [ ] Read-only docblock removed from `RolesView.tsx`

Fixes #3133

🤖 Generated with [Claude Code](https://claude.com/claude-code)