### PR TITLE
api/rbac: enforce tenant-subtree scope on role GET/PUT/DELETE/POST (Issue #3140)

### DIFF
--- a/features/controller/api/handlers_rbac.go
+++ b/features/controller/api/handlers_rbac.go
@@ -5,8 +5,10 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/api/proto/common"
@@ -15,6 +17,12 @@ import (
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// isWithinTenantScope reports whether resourceTenant is within callerTenant's subtree.
+// Returns true when callerTenant is empty (admin mTLS path carries no tenant restriction).
+func isWithinTenantScope(callerTenant, resourceTenant string) bool {
+	return resourceTenant == callerTenant || strings.HasPrefix(resourceTenant, callerTenant+"/")
+}
 
 // handleListPermissions handles GET /api/v1/rbac/permissions
 func (s *Server) handleListPermissions(w http.ResponseWriter, r *http.Request) {
@@ -157,9 +165,29 @@ func (s *Server) handleCreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate that the request body's TenantId is within the caller's subtree.
+	// 400 (not 404): there is no existing resource whose existence to conceal.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" && !isWithinTenantScope(callerTenant, roleInfo.TenantID) {
+		s.logger.Info("Cross-tenant role create refused",
+			"requested_tenant", logging.SanitizeLogValue(roleInfo.TenantID),
+			"caller_tenant", logging.SanitizeLogValue(callerTenant))
+		s.writeErrorResponse(w, http.StatusBadRequest, "TenantId is outside caller's scope", "TENANT_SCOPE_VIOLATION")
+		return
+	}
+
+	// Role IDs are a global primary key with no tenant binding, so a client-chosen ID
+	// leaks and reserves state across tenant boundaries: a duplicate-ID rejection tells
+	// the caller that ID exists in *some* tenant (an existence oracle that defeats the
+	// 404-instead-of-403 concealment on the read/update/delete paths), and a caller can
+	// squat IDs inside another tenant's naming space to permanently deny them. The REST
+	// contract assigns IDs server-side, so any client-supplied "id" is ignored.
+	roleID := uuid.New().String()
+
 	// Create gRPC request
 	req := &controller.CreateRoleRequest{
 		Role: &common.Role{
+			Id:            roleID,
 			Name:          roleInfo.Name,
 			Description:   roleInfo.Description,
 			PermissionIds: roleInfo.Permissions, // Use permission_ids
@@ -218,7 +246,18 @@ func (s *Server) handleGetRole(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	resp, err := s.rbacService.GetRole(r.Context(), req)
 	if err != nil {
-		s.logger.Error("Failed to get role", "role_id", roleID, "error", err)
+		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		return
+	}
+
+	// Cross-tenant scope check: empty callerTenant means admin mTLS (no restriction).
+	// 404 instead of 403 to avoid disclosing role existence across tenant boundaries.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" && !isWithinTenantScope(callerTenant, resp.Role.TenantId) {
+		s.logger.Info("Cross-tenant role get refused",
+			"role_tenant", logging.SanitizeLogValue(resp.Role.TenantId),
+			"caller_tenant", logging.SanitizeLogValue(callerTenant))
 		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
 		return
 	}
@@ -262,6 +301,41 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 	// Set the ID from URL
 	roleInfo.ID = roleID
 
+	// Fetch the existing role to get its actual stored tenant for the scope check.
+	// The check MUST use the stored tenant, not the request body's TenantId, to prevent
+	// a caller from bypassing the check by lying about the tenant in the update payload.
+	existing, err := s.rbacService.GetRole(r.Context(), &controller.GetRoleRequest{RoleId: roleID})
+	if err != nil {
+		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		return
+	}
+
+	// Cross-tenant scope check: empty callerTenant means admin mTLS (no restriction).
+	// 404 instead of 403 to avoid disclosing role existence across tenant boundaries.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" && !isWithinTenantScope(callerTenant, existing.Role.TenantId) {
+		s.logger.Info("Cross-tenant role update refused",
+			"role_tenant", logging.SanitizeLogValue(existing.Role.TenantId),
+			"caller_tenant", logging.SanitizeLogValue(callerTenant))
+		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		return
+	}
+
+	// A role's tenant is immutable through update. Every layer below this handler
+	// (manager, memory store, SQLite upsert) overwrites the stored tenant with the
+	// request value, so honouring the body's TenantId would relocate the role — with
+	// caller-chosen permission IDs — into another tenant's namespace, and an omitted
+	// TenantId would blank it out of every ListRoles result. Reject an explicit
+	// relocation attempt; otherwise carry the stored tenant forward.
+	if roleInfo.TenantID != "" && roleInfo.TenantID != existing.Role.TenantId {
+		s.logger.Info("Role tenant relocation refused",
+			"role_tenant", logging.SanitizeLogValue(existing.Role.TenantId),
+			"requested_tenant", logging.SanitizeLogValue(roleInfo.TenantID))
+		s.writeErrorResponse(w, http.StatusBadRequest, "TenantId cannot be changed", "TENANT_IMMUTABLE")
+		return
+	}
+
 	// Create gRPC request
 	req := &controller.UpdateRoleRequest{
 		Role: &common.Role{
@@ -269,7 +343,7 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 			Name:          roleInfo.Name,
 			Description:   roleInfo.Description,
 			PermissionIds: roleInfo.Permissions, // Use permission_ids
-			TenantId:      roleInfo.TenantID,
+			TenantId:      existing.Role.TenantId,
 		},
 	}
 
@@ -282,7 +356,7 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	resp, err := s.rbacService.UpdateRole(ctx, req)
 	if err != nil {
-		s.logger.Error("Failed to update role", "role_id", roleID, "error", err)
+		s.logger.Error("Failed to update role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to update role", "INTERNAL_ERROR")
 		return
 	}
@@ -316,6 +390,27 @@ func (s *Server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fetch the role to obtain its tenant for the scope check. This fetch is always
+	// required regardless of whether an audit manager is present (authorization must
+	// not depend on an audit-log side effect being active).
+	existing, err := s.rbacService.GetRole(r.Context(), &controller.GetRoleRequest{RoleId: roleID})
+	if err != nil {
+		s.logger.Error("Failed to get role for deletion", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		return
+	}
+
+	// Cross-tenant scope check: empty callerTenant means admin mTLS (no restriction).
+	// 404 instead of 403 to avoid disclosing role existence across tenant boundaries.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" && !isWithinTenantScope(callerTenant, existing.Role.TenantId) {
+		s.logger.Info("Cross-tenant role delete refused",
+			"role_tenant", logging.SanitizeLogValue(existing.Role.TenantId),
+			"caller_tenant", logging.SanitizeLogValue(callerTenant))
+		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
+		return
+	}
+
 	// Create gRPC request
 	req := &controller.DeleteRoleRequest{
 		RoleId: roleID,
@@ -327,16 +422,14 @@ func (s *Server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 		ctx = rbac.WithSensitiveOperationJustification(ctx, justification)
 	}
 
-	// Call gRPC service
-	resp, err := s.rbacService.DeleteRole(ctx, req)
-	if err != nil {
-		s.logger.Error("Failed to delete role", "role_id", roleID, "error", err)
+	// Call gRPC service. RBACService.DeleteRole signals failure exclusively through
+	// its error return; DeleteRoleResponse.Success is set to true on every non-error
+	// path (features/controller/service/rbac_service.go). A `!resp.Success` branch
+	// here would therefore be unreachable, so the error return is the only outcome
+	// this handler distinguishes.
+	if _, err := s.rbacService.DeleteRole(ctx, req); err != nil {
+		s.logger.Error("Failed to delete role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to delete role", "INTERNAL_ERROR")
-		return
-	}
-
-	if !resp.Success {
-		s.writeErrorResponse(w, http.StatusBadRequest, "Failed to delete role", "DELETE_FAILED")
 		return
 	}
 

--- a/features/controller/api/handlers_rbac.go
+++ b/features/controller/api/handlers_rbac.go
@@ -85,7 +85,7 @@ func (s *Server) handleGetPermission(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	resp, err := s.rbacService.GetPermission(r.Context(), req)
 	if err != nil {
-		s.logger.Error("Failed to get permission", "permission_id", permissionID, "error", err)
+		s.logger.Error("Failed to get permission", "permission_id", logging.SanitizeLogValue(permissionID), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusNotFound, "Permission not found", "PERMISSION_NOT_FOUND")
 		return
 	}
@@ -246,7 +246,7 @@ func (s *Server) handleGetRole(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	resp, err := s.rbacService.GetRole(r.Context(), req)
 	if err != nil {
-		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
 		return
 	}
@@ -306,7 +306,7 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 	// a caller from bypassing the check by lying about the tenant in the update payload.
 	existing, err := s.rbacService.GetRole(r.Context(), &controller.GetRoleRequest{RoleId: roleID})
 	if err != nil {
-		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
 		return
 	}
@@ -356,7 +356,7 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	resp, err := s.rbacService.UpdateRole(ctx, req)
 	if err != nil {
-		s.logger.Error("Failed to update role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.logger.Error("Failed to update role", "role_id", logging.SanitizeLogValue(roleID), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to update role", "INTERNAL_ERROR")
 		return
 	}
@@ -395,7 +395,7 @@ func (s *Server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 	// not depend on an audit-log side effect being active).
 	existing, err := s.rbacService.GetRole(r.Context(), &controller.GetRoleRequest{RoleId: roleID})
 	if err != nil {
-		s.logger.Error("Failed to get role for deletion", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.logger.Error("Failed to get role for deletion", "role_id", logging.SanitizeLogValue(roleID), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
 		return
 	}
@@ -428,7 +428,7 @@ func (s *Server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 	// here would therefore be unreachable, so the error return is the only outcome
 	// this handler distinguishes.
 	if _, err := s.rbacService.DeleteRole(ctx, req); err != nil {
-		s.logger.Error("Failed to delete role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+		s.logger.Error("Failed to delete role", "role_id", logging.SanitizeLogValue(roleID), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to delete role", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_rbac_test.go
+++ b/features/controller/api/handlers_rbac_test.go
@@ -927,3 +927,139 @@ func TestHandleDeleteRole_JustificationHeaderAccepted(t *testing.T) {
 		&controller.GetRoleRequest{RoleId: "client-1.role-hdr"})
 	assert.Error(t, err, "role must be gone after a justified delete")
 }
+
+// --- Log injection (CWE-117) regression coverage ---
+//
+// The {id} path segment is URL-decoded by the router, so "%0D%0A" arrives at the
+// handler as a real CRLF. That raw ID is echoed verbatim by the RBAC store's
+// "role %s not found" error (features/rbac/memory/store.go), which the handlers
+// then log as the "error" value — so both the "role_id" and the "error" values
+// carry attacker-controlled bytes and both must be sanitized.
+
+// forgedLogRecord is the tail of a log-forgery payload: the text an attacker wants
+// to land at the start of its own log line after an injected CRLF.
+const forgedLogRecord = `level=error msg="forged audit record"`
+
+// injectionRoleID returns a role ID within tenantID that carries a CRLF followed by
+// a complete forged log record — the decoded form of ".../roles/ghost%0D%0Alevel=...".
+func injectionRoleID(tenantID string) string {
+	return tenantID + ".ghost\r\n" + forgedLogRecord
+}
+
+// assertNoForgedLogRecord verifies that the tainted role ID reached the log in
+// neutralised form: present (so the assertion cannot pass vacuously) but with its
+// CR/LF replaced, leaving the forged record trapped inside a single log line.
+func assertNoForgedLogRecord(t *testing.T, captured string) {
+	t.Helper()
+	assert.NotContains(t, captured, "\r",
+		"carriage return from the role ID must not reach the log")
+	assert.NotContains(t, captured, "\n"+forgedLogRecord,
+		"payload must not be able to start a new log line")
+	assert.Contains(t, captured, "__"+forgedLogRecord,
+		"tainted value must reach the log with its CR/LF replaced (proves the log site was exercised)")
+}
+
+// TestRoleHandlers_LogInjectionSanitized verifies that every role handler log site on a
+// failure path neutralises control characters in both the role ID and the error text,
+// for the not-found paths (error raised by the store) and the service-rejection paths
+// (error raised by the real rbac.Manager for a missing M-AUTH-2 justification).
+func TestRoleHandlers_LogInjectionSanitized(t *testing.T) {
+	updateBody, err := json.Marshal(RoleInfo{Name: "Renamed", TenantID: "client-1"})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		existing   bool // create the role first, so the handler reaches its service call
+		wantStatus int
+		call       func(*Server, string) *httptest.ResponseRecorder
+	}{
+		{
+			name:       "get_not_found",
+			wantStatus: http.StatusNotFound,
+			call: func(s *Server, roleID string) *httptest.ResponseRecorder {
+				rec := httptest.NewRecorder()
+				s.handleGetRole(rec, unjustifiedRoleRequest(http.MethodGet,
+					"/api/v1/rbac/roles/ghost", "client-1", roleID, nil))
+				return rec
+			},
+		},
+		{
+			name:       "update_not_found",
+			wantStatus: http.StatusNotFound,
+			call: func(s *Server, roleID string) *httptest.ResponseRecorder {
+				rec := httptest.NewRecorder()
+				s.handleUpdateRole(rec, unjustifiedRoleRequest(http.MethodPut,
+					"/api/v1/rbac/roles/ghost", "client-1", roleID, updateBody))
+				return rec
+			},
+		},
+		{
+			name:       "delete_not_found",
+			wantStatus: http.StatusNotFound,
+			call: func(s *Server, roleID string) *httptest.ResponseRecorder {
+				rec := httptest.NewRecorder()
+				s.handleDeleteRole(rec, unjustifiedRoleRequest(http.MethodDelete,
+					"/api/v1/rbac/roles/ghost", "client-1", roleID, nil))
+				return rec
+			},
+		},
+		{
+			name:       "update_service_failure",
+			existing:   true,
+			wantStatus: http.StatusInternalServerError,
+			call: func(s *Server, roleID string) *httptest.ResponseRecorder {
+				rec := httptest.NewRecorder()
+				s.handleUpdateRole(rec, unjustifiedRoleRequest(http.MethodPut,
+					"/api/v1/rbac/roles/ghost", "client-1", roleID, updateBody))
+				return rec
+			},
+		},
+		{
+			name:       "delete_service_failure",
+			existing:   true,
+			wantStatus: http.StatusInternalServerError,
+			call: func(s *Server, roleID string) *httptest.ResponseRecorder {
+				rec := httptest.NewRecorder()
+				s.handleDeleteRole(rec, unjustifiedRoleRequest(http.MethodDelete,
+					"/api/v1/rbac/roles/ghost", "client-1", roleID, nil))
+				return rec
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The logger must be installed at construction: Server.New starts the
+			// API-key cleanup goroutine, which reads s.logger concurrently.
+			capture := &captureAllLogger{}
+			server := setupTestServerWithLogger(t, capture)
+
+			roleID := injectionRoleID("client-1")
+			if tc.existing {
+				createRoleForTenant(t, server, "client-1", roleID, "Injected Role")
+			}
+
+			rec := tc.call(server, roleID)
+
+			require.Equal(t, tc.wantStatus, rec.Code)
+			assertNoForgedLogRecord(t, capture.captured())
+		})
+	}
+}
+
+// TestHandleGetPermission_LogInjectionSanitized covers the same CWE-117 shape on the
+// permission read path: the {id} path segment is echoed by the store's
+// "permission %s not found" error and logged alongside the raw ID.
+func TestHandleGetPermission_LogInjectionSanitized(t *testing.T) {
+	capture := &captureAllLogger{}
+	server := setupTestServerWithLogger(t, capture)
+
+	permissionID := "ghost\r\n" + forgedLogRecord
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/permissions/ghost", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": permissionID})
+	rec := httptest.NewRecorder()
+	server.handleGetPermission(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	assertNoForgedLogRecord(t, capture.captured())
+}

--- a/features/controller/api/handlers_rbac_test.go
+++ b/features/controller/api/handlers_rbac_test.go
@@ -3,12 +3,14 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -158,4 +160,770 @@ func TestServer_RBACSubjectRoutesDeregistered(t *testing.T) {
 				tt.method, tt.path)
 		})
 	}
+}
+
+// callHandleGetRole calls handleGetRole directly, bypassing the router/middleware,
+// injecting the caller tenant and role ID via context and mux vars respectively.
+func callHandleGetRole(server *Server, callerTenantID, roleID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/roles/"+roleID, nil)
+	if callerTenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, callerTenantID))
+	}
+	req = mux.SetURLVars(req, map[string]string{"id": roleID})
+	rec := httptest.NewRecorder()
+	server.handleGetRole(rec, req)
+	return rec
+}
+
+// callHandleUpdateRole calls handleUpdateRole directly, bypassing the router/middleware.
+func callHandleUpdateRole(server *Server, callerTenantID, roleID string, body []byte) *httptest.ResponseRecorder {
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test: update role")
+	if callerTenantID != "" {
+		ctx = context.WithValue(ctx, ctxkeys.TenantID, callerTenantID)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/rbac/roles/"+roleID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"id": roleID})
+	rec := httptest.NewRecorder()
+	server.handleUpdateRole(rec, req)
+	return rec
+}
+
+// callHandleDeleteRole calls handleDeleteRole directly, bypassing the router/middleware.
+func callHandleDeleteRole(server *Server, callerTenantID, roleID string) *httptest.ResponseRecorder {
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test: delete role")
+	if callerTenantID != "" {
+		ctx = context.WithValue(ctx, ctxkeys.TenantID, callerTenantID)
+	}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/rbac/roles/"+roleID, nil)
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"id": roleID})
+	rec := httptest.NewRecorder()
+	server.handleDeleteRole(rec, req)
+	return rec
+}
+
+// callHandleCreateRole calls handleCreateRole directly, bypassing the router/middleware.
+func callHandleCreateRole(server *Server, callerTenantID string, body []byte) *httptest.ResponseRecorder {
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test: create role")
+	if callerTenantID != "" {
+		ctx = context.WithValue(ctx, ctxkeys.TenantID, callerTenantID)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rbac/roles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	server.handleCreateRole(rec, req)
+	return rec
+}
+
+// TestHandleGetRole_CrossTenantBlocked verifies that a caller scoped to client-1 gets 404
+// when attempting to GET a role belonging to client-2 (Issue #3140).
+func TestHandleGetRole_CrossTenantBlocked(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-2", "client-2.role-a", "Client Two Role")
+
+	rec := callHandleGetRole(server, "client-1", "client-2.role-a")
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"cross-tenant GET must return 404 to avoid disclosing role existence")
+}
+
+// TestHandleGetRole_SameTenantAllowed verifies that a caller scoped to client-1 can
+// GET a role in their own tenant.
+func TestHandleGetRole_SameTenantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-a", "Client One Role")
+
+	rec := callHandleGetRole(server, "client-1", "client-1.role-a")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandleGetRole_SubtenantAllowed verifies that a caller scoped to client-1 can
+// GET a role belonging to a child tenant (client-1/sub) within their subtree.
+func TestHandleGetRole_SubtenantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1/sub", "client-1.sub.role", "Sub Role")
+
+	rec := callHandleGetRole(server, "client-1", "client-1.sub.role")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandleGetRole_NoCallerTenant_Unrestricted verifies that a request with no
+// caller tenant (admin mTLS path — empty TenantID) is not restricted by scope.
+func TestHandleGetRole_NoCallerTenant_Unrestricted(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "some-tenant", "some-tenant.role", "Some Role")
+
+	rec := callHandleGetRole(server, "", "some-tenant.role")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandleUpdateRole_CrossTenantBlocked verifies that a caller scoped to client-1
+// gets 404 when attempting to UPDATE a role belonging to client-2, and the role is
+// left unmodified (Issue #3140).
+func TestHandleUpdateRole_CrossTenantBlocked(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-2", "client-2.role-b", "Original Name")
+
+	body, err := json.Marshal(RoleInfo{Name: "Modified Name", TenantID: "client-2"})
+	require.NoError(t, err)
+	rec := callHandleUpdateRole(server, "client-1", "client-2.role-b", body)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"cross-tenant UPDATE must return 404 to avoid disclosing role existence")
+
+	// The role must be left unmodified.
+	getResp, err := server.rbacService.GetRole(context.Background(), &controller.GetRoleRequest{
+		RoleId: "client-2.role-b",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Original Name", getResp.Role.Name, "role must not be modified on cross-tenant 404")
+}
+
+// TestHandleUpdateRole_CrossTenantBodyLie verifies that supplying the caller's own tenant
+// in the update body does not bypass the scope check — the check uses the role's stored
+// tenant, not the client-supplied TenantId (Issue #3140).
+func TestHandleUpdateRole_CrossTenantBodyLie(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-2", "client-2.role-c", "Original Name")
+
+	// Claim the role belongs to client-1 to try to bypass scope check.
+	body, err := json.Marshal(RoleInfo{Name: "Bypassed", TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := callHandleUpdateRole(server, "client-1", "client-2.role-c", body)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"scope check must use the stored tenant, not the body's TenantId")
+
+	getResp, err := server.rbacService.GetRole(context.Background(), &controller.GetRoleRequest{
+		RoleId: "client-2.role-c",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Original Name", getResp.Role.Name, "role must not be modified on body-lie 404")
+}
+
+// TestHandleUpdateRole_SameTenantAllowed verifies that a caller can update a role in
+// their own tenant.
+func TestHandleUpdateRole_SameTenantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-update", "Before Update")
+
+	body, err := json.Marshal(RoleInfo{Name: "After Update", TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := callHandleUpdateRole(server, "client-1", "client-1.role-update", body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandleDeleteRole_CrossTenantBlocked verifies that a caller scoped to client-1
+// gets 404 when attempting to DELETE a role belonging to client-2, and the role is
+// left intact (Issue #3140).
+func TestHandleDeleteRole_CrossTenantBlocked(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-2", "client-2.role-del", "Delete Target")
+
+	rec := callHandleDeleteRole(server, "client-1", "client-2.role-del")
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"cross-tenant DELETE must return 404 to avoid disclosing role existence")
+
+	// The role must still exist.
+	getResp, err := server.rbacService.GetRole(context.Background(), &controller.GetRoleRequest{
+		RoleId: "client-2.role-del",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, getResp.Role, "role must remain intact after cross-tenant delete attempt")
+}
+
+// TestHandleDeleteRole_SameTenantAllowed verifies that a caller can delete a role in
+// their own tenant.
+func TestHandleDeleteRole_SameTenantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-del", "To Delete")
+
+	rec := callHandleDeleteRole(server, "client-1", "client-1.role-del")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandleCreateRole_CrossTenantBlocked verifies that a caller scoped to client-1
+// gets 400 when the request body specifies tenant_id "client-2", and no role is
+// created (Issue #3140). 400 (not 404) because there is no existing resource to avoid
+// disclosing.
+func TestHandleCreateRole_CrossTenantBlocked(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{ID: "injected.role", Name: "Injected Role", TenantID: "client-2"})
+	require.NoError(t, err)
+	rec := callHandleCreateRole(server, "client-1", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"cross-tenant POST must return 400")
+
+	// The specific role ID must not have been created (scope check fires before CreateRole).
+	_, err = server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "injected.role"})
+	assert.Error(t, err, "role must not exist after cross-tenant create was rejected")
+}
+
+// TestHandleCreateRole_SameTenantAllowed verifies that a caller can create a role in
+// their own tenant.
+func TestHandleCreateRole_SameTenantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{ID: "client-1.new-role", Name: "My Role", TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := callHandleCreateRole(server, "client-1", body)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+// TestHandleCreateRole_SubtenantAllowed verifies that a caller can create a role in
+// a child tenant within their subtree.
+func TestHandleCreateRole_SubtenantAllowed(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{ID: "client-1.sub.role", Name: "Sub Role", TenantID: "client-1/sub"})
+	require.NoError(t, err)
+	rec := callHandleCreateRole(server, "client-1", body)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+// TestHandleCreateRole_NoCallerTenant_Unrestricted verifies that a request with no
+// caller tenant (admin mTLS path) is not restricted by scope.
+func TestHandleCreateRole_NoCallerTenant_Unrestricted(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{ID: "any-tenant.admin-role", Name: "Admin Role", TenantID: "any-tenant"})
+	require.NoError(t, err)
+	rec := callHandleCreateRole(server, "", body)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+// roleFromResponse decodes the RoleInfo carried in the "data" field of an API response.
+func roleFromResponse(t *testing.T, rec *httptest.ResponseRecorder) RoleInfo {
+	t.Helper()
+	var resp struct {
+		Data RoleInfo `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp.Data
+}
+
+// errorCodeFromResponse decodes the machine-readable error code from an API error response.
+func errorCodeFromResponse(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Error, "error response must carry an error object")
+	return resp.Error.Code
+}
+
+// TestHandleCreateRole_IgnoresClientSuppliedID verifies that the role ID is assigned
+// server-side. Role IDs are a global primary key with no tenant binding, so honouring a
+// client-supplied ID would let a caller reserve IDs in another tenant's naming space
+// (Issue #3140).
+func TestHandleCreateRole_IgnoresClientSuppliedID(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{ID: "client-2.squatted", Name: "My Role", TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := callHandleCreateRole(server, "client-1", body)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	created := roleFromResponse(t, rec)
+	assert.NotEqual(t, "client-2.squatted", created.ID,
+		"client-supplied id must be ignored; the server assigns the role ID")
+	assert.NotEmpty(t, created.ID, "server must assign a non-empty role ID")
+	assert.Equal(t, "client-1", created.TenantID)
+
+	// The client-supplied ID must not have been consumed in the global ID namespace.
+	_, err = server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-2.squatted"})
+	assert.Error(t, err, "client-supplied id must not be stored")
+
+	// The server-assigned ID resolves to the created role.
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: created.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "client-1", stored.Role.TenantId)
+	assert.Equal(t, "My Role", stored.Role.Name)
+}
+
+// TestHandleCreateRole_NoCrossTenantExistenceOracle verifies that reusing an ID that
+// already exists in another tenant neither fails nor perturbs the existing role. A
+// duplicate-ID rejection would be an existence oracle that defeats the 404-instead-of-403
+// concealment on the read/update/delete paths (Issue #3140).
+func TestHandleCreateRole_NoCrossTenantExistenceOracle(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-2", "client-2.reserved", "Client Two Role")
+
+	body, err := json.Marshal(RoleInfo{ID: "client-2.reserved", Name: "Probe Role", TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := callHandleCreateRole(server, "client-1", body)
+
+	assert.Equal(t, http.StatusCreated, rec.Code,
+		"colliding with another tenant's role ID must not produce a distinguishable failure")
+
+	created := roleFromResponse(t, rec)
+	assert.NotEqual(t, "client-2.reserved", created.ID)
+
+	// client-2's role must be untouched.
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-2.reserved"})
+	require.NoError(t, err)
+	assert.Equal(t, "Client Two Role", stored.Role.Name, "existing role must not be overwritten")
+	assert.Equal(t, "client-2", stored.Role.TenantId, "existing role must keep its tenant")
+}
+
+// TestHandleUpdateRole_DestinationTenantRejected verifies that a caller who legitimately
+// owns a role cannot relocate it into another tenant by supplying a different tenant_id
+// in the update body (Issue #3140). The source-tenant check alone does not cover this.
+func TestHandleUpdateRole_DestinationTenantRejected(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-move", "Original Name")
+
+	body, err := json.Marshal(RoleInfo{
+		Name:        "Relocated",
+		TenantID:    "client-2",
+		Permissions: []string{"rbac.manage"},
+	})
+	require.NoError(t, err)
+	rec := callHandleUpdateRole(server, "client-1", "client-1.role-move", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"relocating a role into another tenant must be rejected")
+	assert.Equal(t, "TENANT_IMMUTABLE", errorCodeFromResponse(t, rec))
+
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-1.role-move"})
+	require.NoError(t, err)
+	assert.Equal(t, "client-1", stored.Role.TenantId, "role must remain in its original tenant")
+	assert.Equal(t, "Original Name", stored.Role.Name, "role must not be modified on rejection")
+}
+
+// TestHandleUpdateRole_AdminCannotRelocateTenant verifies that the destination-tenant
+// check also applies on the admin mTLS path (no caller tenant), where the source scope
+// check is intentionally skipped (Issue #3140).
+func TestHandleUpdateRole_AdminCannotRelocateTenant(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-admin-move", "Original Name")
+
+	body, err := json.Marshal(RoleInfo{Name: "Relocated", TenantID: "client-2"})
+	require.NoError(t, err)
+	rec := callHandleUpdateRole(server, "", "client-1.role-admin-move", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "TENANT_IMMUTABLE", errorCodeFromResponse(t, rec))
+
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-1.role-admin-move"})
+	require.NoError(t, err)
+	assert.Equal(t, "client-1", stored.Role.TenantId)
+}
+
+// TestHandleUpdateRole_OmittedTenantPreservesStoredTenant verifies that an update body
+// without a tenant_id does not blank the role's tenant, which would orphan it from every
+// ListRoles result (Issue #3140).
+func TestHandleUpdateRole_OmittedTenantPreservesStoredTenant(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-partial", "Before Update")
+
+	body, err := json.Marshal(map[string]interface{}{"name": "After Update"})
+	require.NoError(t, err)
+	rec := callHandleUpdateRole(server, "client-1", "client-1.role-partial", body)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "client-1", roleFromResponse(t, rec).TenantID,
+		"response must report the preserved tenant")
+
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-1.role-partial"})
+	require.NoError(t, err)
+	assert.Equal(t, "client-1", stored.Role.TenantId, "omitted tenant_id must not blank the stored tenant")
+	assert.Equal(t, "After Update", stored.Role.Name)
+
+	// The role must still be listed for its tenant.
+	listRec := callHandleListRoles(server, "client-1", "")
+	require.Equal(t, http.StatusOK, listRec.Code)
+	var listResp APIResponse
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	assert.Contains(t, roleIDsFromResponse(t, listResp), "client-1.role-partial")
+}
+
+// callHandleListPermissions calls handleListPermissions directly, bypassing the
+// router/middleware, with an optional resource_type query filter.
+func callHandleListPermissions(server *Server, resourceType string) *httptest.ResponseRecorder {
+	url := "/api/v1/rbac/permissions"
+	if resourceType != "" {
+		url += "?resource_type=" + resourceType
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	server.handleListPermissions(rec, req)
+	return rec
+}
+
+// callHandleGetPermission calls handleGetPermission directly, bypassing the
+// router/middleware. When setVar is false the {id} mux var is absent, which is how the
+// handler observes a missing path variable.
+func callHandleGetPermission(server *Server, permissionID string, setVar bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/permissions/"+permissionID, nil)
+	if setVar {
+		req = mux.SetURLVars(req, map[string]string{"id": permissionID})
+	}
+	rec := httptest.NewRecorder()
+	server.handleGetPermission(rec, req)
+	return rec
+}
+
+// permissionsFromResponse decodes the permission list carried in an API response.
+func permissionsFromResponse(t *testing.T, rec *httptest.ResponseRecorder) []PermissionInfo {
+	t.Helper()
+	var resp struct {
+		Data []PermissionInfo `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp.Data
+}
+
+// permissionFromResponse decodes a single permission carried in an API response.
+func permissionFromResponse(t *testing.T, rec *httptest.ResponseRecorder) PermissionInfo {
+	t.Helper()
+	var resp struct {
+		Data PermissionInfo `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp.Data
+}
+
+// TestHandleListPermissions_NilService_Returns503 verifies the guard for a controller
+// started without an RBAC service.
+func TestHandleListPermissions_NilService_Returns503(t *testing.T) {
+	server := setupTestServer(t)
+	server.rbacService = nil
+
+	rec := callHandleListPermissions(server, "")
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "SERVICE_UNAVAILABLE", errorCodeFromResponse(t, rec))
+}
+
+// TestHandleListPermissions_ReturnsAllPermissions verifies the unfiltered list returns
+// the default permission catalogue loaded at RBAC initialization.
+func TestHandleListPermissions_ReturnsAllPermissions(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := callHandleListPermissions(server, "")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	perms := permissionsFromResponse(t, rec)
+	require.NotEmpty(t, perms, "default permissions must be returned")
+
+	byID := make(map[string]PermissionInfo, len(perms))
+	for _, p := range perms {
+		byID[p.ID] = p
+	}
+	require.Contains(t, byID, "steward.read")
+	require.Contains(t, byID, "config.read", "unfiltered list must span resource types")
+	assert.Equal(t, "steward", byID["steward.read"].ResourceType)
+	assert.Equal(t, []string{"read"}, byID["steward.read"].Actions)
+}
+
+// TestHandleListPermissions_ResourceTypeFilter verifies the resource_type query parameter
+// is applied to the listing.
+func TestHandleListPermissions_ResourceTypeFilter(t *testing.T) {
+	server := setupTestServer(t)
+
+	all := permissionsFromResponse(t, callHandleListPermissions(server, ""))
+
+	rec := callHandleListPermissions(server, "steward")
+	require.Equal(t, http.StatusOK, rec.Code)
+	filtered := permissionsFromResponse(t, rec)
+
+	require.NotEmpty(t, filtered)
+	assert.Less(t, len(filtered), len(all), "filter must narrow the result set")
+
+	ids := make([]string, 0, len(filtered))
+	for _, p := range filtered {
+		assert.Equal(t, "steward", p.ResourceType,
+			"permission %q must not appear under resource_type=steward", p.ID)
+		ids = append(ids, p.ID)
+	}
+	assert.Contains(t, ids, "steward.read")
+	assert.NotContains(t, ids, "config.read")
+}
+
+// TestHandleGetPermission_NilService_Returns503 verifies the guard for a controller
+// started without an RBAC service.
+func TestHandleGetPermission_NilService_Returns503(t *testing.T) {
+	server := setupTestServer(t)
+	server.rbacService = nil
+
+	rec := callHandleGetPermission(server, "steward.read", true)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "SERVICE_UNAVAILABLE", errorCodeFromResponse(t, rec))
+}
+
+// TestHandleGetPermission_MissingID_Returns400 verifies that an absent path variable is
+// reported as a client error rather than being forwarded to the service.
+func TestHandleGetPermission_MissingID_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := callHandleGetPermission(server, "", false)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "MISSING_PERMISSION_ID", errorCodeFromResponse(t, rec))
+}
+
+// TestHandleGetPermission_UnknownID_Returns404 verifies the not-found path.
+func TestHandleGetPermission_UnknownID_Returns404(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := callHandleGetPermission(server, "does.not.exist", true)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, "PERMISSION_NOT_FOUND", errorCodeFromResponse(t, rec))
+	assert.NotContains(t, rec.Body.String(), "not found: permission",
+		"internal error detail must not be disclosed to the client")
+}
+
+// TestHandleGetPermission_Success verifies a known default permission is returned with
+// all fields mapped onto the API representation.
+func TestHandleGetPermission_Success(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := callHandleGetPermission(server, "steward.read", true)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	perm := permissionFromResponse(t, rec)
+	assert.Equal(t, "steward.read", perm.ID)
+	assert.Equal(t, "Read Steward", perm.Name)
+	assert.Equal(t, "steward", perm.ResourceType)
+	assert.Equal(t, []string{"read"}, perm.Actions)
+	assert.NotEmpty(t, perm.Description)
+}
+
+// Role-handler guard and failure-path coverage.
+//
+// The 500 cases below are driven by omitting the X-Justification header. That header
+// is the only channel through which a REST client supplies a justification for a
+// sensitive RBAC operation (M-AUTH-2), and the real rbac.Manager rejects unjustified
+// create/update/delete role operations. The failure therefore originates in the real
+// RBAC component stack — no wrapper, substitute, or synthetic error is involved.
+
+// unjustifiedRoleRequest builds a role request that carries no X-Justification header
+// and no justification in its context: the exact state of a REST client that omits the
+// header. roleID, when non-empty, is installed as the {id} mux var.
+func unjustifiedRoleRequest(method, target, callerTenantID, roleID string, body []byte) *http.Request {
+	var req *http.Request
+	if body == nil {
+		req = httptest.NewRequest(method, target, nil)
+	} else {
+		req = httptest.NewRequest(method, target, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if callerTenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, callerTenantID))
+	}
+	if roleID != "" {
+		req = mux.SetURLVars(req, map[string]string{"id": roleID})
+	}
+	return req
+}
+
+// TestHandleRoles_NilService_Returns503 verifies the guard on every role handler for a
+// controller started without an RBAC backend.
+func TestHandleRoles_NilService_Returns503(t *testing.T) {
+	body, err := json.Marshal(RoleInfo{Name: "Any Role", TenantID: "client-1"})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		call func(*Server) *httptest.ResponseRecorder
+	}{
+		{"list", func(s *Server) *httptest.ResponseRecorder { return callHandleListRoles(s, "client-1", "") }},
+		{"create", func(s *Server) *httptest.ResponseRecorder { return callHandleCreateRole(s, "client-1", body) }},
+		{"get", func(s *Server) *httptest.ResponseRecorder { return callHandleGetRole(s, "client-1", "client-1.role") }},
+		{"update", func(s *Server) *httptest.ResponseRecorder {
+			return callHandleUpdateRole(s, "client-1", "client-1.role", body)
+		}},
+		{"delete", func(s *Server) *httptest.ResponseRecorder {
+			return callHandleDeleteRole(s, "client-1", "client-1.role")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := setupTestServer(t)
+			server.rbacService = nil
+
+			rec := tc.call(server)
+
+			assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+			assert.Equal(t, "SERVICE_UNAVAILABLE", errorCodeFromResponse(t, rec))
+		})
+	}
+}
+
+// TestHandleCreateRole_InvalidJSON_Returns400 verifies that a malformed body is rejected
+// before the request reaches the RBAC service.
+func TestHandleCreateRole_InvalidJSON_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := callHandleCreateRole(server, "client-1", []byte(`{"name": "Broken"`))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "INVALID_JSON", errorCodeFromResponse(t, rec))
+}
+
+// TestHandleCreateRole_MissingName_Returns400 verifies the required-field check on name.
+func TestHandleCreateRole_MissingName_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := callHandleCreateRole(server, "client-1", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "MISSING_NAME", errorCodeFromResponse(t, rec))
+}
+
+// TestHandleGetRole_MissingID_Returns400 verifies that an absent {id} path variable is
+// reported as a client error rather than being forwarded to the service.
+func TestHandleGetRole_MissingID_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.handleGetRole(rec, unjustifiedRoleRequest(http.MethodGet, "/api/v1/rbac/roles/", "client-1", "", nil))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "MISSING_ROLE_ID", errorCodeFromResponse(t, rec))
+}
+
+// TestHandleUpdateRole_MissingID_Returns400 verifies the same guard on the update path.
+func TestHandleUpdateRole_MissingID_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{Name: "Any Role"})
+	require.NoError(t, err)
+	rec := httptest.NewRecorder()
+	server.handleUpdateRole(rec, unjustifiedRoleRequest(http.MethodPut, "/api/v1/rbac/roles/", "client-1", "", body))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "MISSING_ROLE_ID", errorCodeFromResponse(t, rec))
+}
+
+// TestHandleUpdateRole_InvalidJSON_Returns400 verifies that a malformed update body is
+// rejected before the existing role is fetched or modified.
+func TestHandleUpdateRole_InvalidJSON_Returns400(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-badjson", "Original Name")
+
+	rec := callHandleUpdateRole(server, "client-1", "client-1.role-badjson", []byte(`{"name": `))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "INVALID_JSON", errorCodeFromResponse(t, rec))
+
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-1.role-badjson"})
+	require.NoError(t, err)
+	assert.Equal(t, "Original Name", stored.Role.Name, "role must not be modified on a malformed body")
+}
+
+// TestHandleCreateRole_ServiceFailure_Returns500 verifies that a create rejected by the
+// RBAC manager is reported as 500 without leaking the underlying error text, and that no
+// role is left behind.
+func TestHandleCreateRole_ServiceFailure_Returns500(t *testing.T) {
+	server := setupTestServer(t)
+
+	body, err := json.Marshal(RoleInfo{Name: "Unjustified Role", TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := httptest.NewRecorder()
+	server.handleCreateRole(rec, unjustifiedRoleRequest(http.MethodPost, "/api/v1/rbac/roles", "client-1", "", body))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, "INTERNAL_ERROR", errorCodeFromResponse(t, rec))
+	assert.NotContains(t, rec.Body.String(), "justification",
+		"internal error detail must not be disclosed to the client")
+
+	listed, err := server.rbacService.ListRoles(context.Background(),
+		&controller.ListRolesRequest{TenantId: "client-1"})
+	require.NoError(t, err)
+	for _, role := range listed.Roles {
+		assert.NotEqual(t, "Unjustified Role", role.Name, "rejected create must not persist a role")
+	}
+}
+
+// TestHandleUpdateRole_ServiceFailure_Returns500 verifies that an update rejected by the
+// RBAC manager is reported as 500 and leaves the stored role untouched.
+func TestHandleUpdateRole_ServiceFailure_Returns500(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-unjustified", "Original Name")
+
+	body, err := json.Marshal(RoleInfo{Name: "Renamed", TenantID: "client-1"})
+	require.NoError(t, err)
+	rec := httptest.NewRecorder()
+	server.handleUpdateRole(rec, unjustifiedRoleRequest(http.MethodPut,
+		"/api/v1/rbac/roles/client-1.role-unjustified", "client-1", "client-1.role-unjustified", body))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, "INTERNAL_ERROR", errorCodeFromResponse(t, rec))
+	assert.NotContains(t, rec.Body.String(), "justification",
+		"internal error detail must not be disclosed to the client")
+
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-1.role-unjustified"})
+	require.NoError(t, err)
+	assert.Equal(t, "Original Name", stored.Role.Name, "role must not be modified when the update is rejected")
+}
+
+// TestHandleDeleteRole_ServiceFailure_Returns500 verifies that a delete rejected by the
+// RBAC manager is reported as 500 and leaves the role in place.
+func TestHandleDeleteRole_ServiceFailure_Returns500(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-nodelete", "Keep Me")
+
+	rec := httptest.NewRecorder()
+	server.handleDeleteRole(rec, unjustifiedRoleRequest(http.MethodDelete,
+		"/api/v1/rbac/roles/client-1.role-nodelete", "client-1", "client-1.role-nodelete", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, "INTERNAL_ERROR", errorCodeFromResponse(t, rec))
+	assert.NotContains(t, rec.Body.String(), "justification",
+		"internal error detail must not be disclosed to the client")
+
+	stored, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-1.role-nodelete"})
+	require.NoError(t, err)
+	assert.Equal(t, "Keep Me", stored.Role.Name, "role must survive a rejected delete")
+}
+
+// TestHandleDeleteRole_JustificationHeaderAccepted verifies the X-Justification header
+// path that the handler uses to satisfy the M-AUTH-2 requirement, complementing the
+// rejection case above.
+func TestHandleDeleteRole_JustificationHeaderAccepted(t *testing.T) {
+	server := setupTestServer(t)
+	createRoleForTenant(t, server, "client-1", "client-1.role-hdr", "Delete Me")
+
+	req := unjustifiedRoleRequest(http.MethodDelete,
+		"/api/v1/rbac/roles/client-1.role-hdr", "client-1", "client-1.role-hdr", nil)
+	req.Header.Set("X-Justification", "test: delete role via header justification")
+	rec := httptest.NewRecorder()
+	server.handleDeleteRole(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	_, err := server.rbacService.GetRole(context.Background(),
+		&controller.GetRoleRequest{RoleId: "client-1.role-hdr"})
+	assert.Error(t, err, "role must be gone after a justified delete")
 }


### PR DESCRIPTION
## Summary

- `GET/PUT/DELETE /api/v1/rbac/roles/{id}` now fetch the role first to get its stored tenant, then call `isWithinTenantScope(callerTenant, role.TenantId)` before proceeding — 404 on cross-tenant access (matching the established steward/registration/cluster pattern)
- `POST /api/v1/rbac/roles` validates the request body's `TenantId` against the caller's subtree before calling `CreateRole` — 400 if out of scope; server-side UUID generation replaces client-supplied IDs to prevent cross-tenant existence oracles and namespace squatting
- `handleUpdateRole` scope check uses the role's **stored** tenant (fetched fresh), not the body's `TenantId`, to close the body-lie bypass
- Admin mTLS callers (empty `callerTenant`) remain unrestricted on all paths
- Adds shared `isWithinTenantScope` helper using path-separator-aware prefix matching, consistent with all existing inline `sameTenant`/`ancestorTenant` checks in the package

## Specialist Review Results

- **Code Review**: PASS (3 rounds, 2 fix iterations — uuid import added, server-side ID generation for create)
- **Test Quality**: PASS
- **Security**: PASS

## Test Plan

- [x] `TestHandleGetRole_CrossTenantBlocked` — client-1 caller gets 404 for client-2 role
- [x] `TestHandleGetRole_SameTenantAllowed` / `_SubtenantAllowed` / `_NoCallerTenant_Unrestricted`
- [x] `TestHandleUpdateRole_CrossTenantBlocked` — 404 with role unmodified
- [x] `TestHandleUpdateRole_CrossTenantBodyLie` — body claiming caller's own tenant still 404
- [x] `TestHandleUpdateRole_SameTenantAllowed`
- [x] `TestHandleDeleteRole_CrossTenantBlocked` — 404 with role intact
- [x] `TestHandleDeleteRole_SameTenantAllowed`
- [x] `TestHandleCreateRole_CrossTenantBlocked` — 400, no role created
- [x] `TestHandleCreateRole_SameTenantAllowed` / `_SubtenantAllowed` / `_NoCallerTenant_Unrestricted`
- [x] All pre-existing RBAC handler tests continue to pass
- [x] Full `features/controller/api` package test suite passes

Fixes #3140

🤖 Generated with [Claude Code](https://claude.com/claude-code)