### PR TITLE
api/tenants: enforce tenant-subtree scope on GET /api/v1/tenants/{id} (Issue #3147)

### DIFF
--- a/features/controller/api/handlers_rbac.go
+++ b/features/controller/api/handlers_rbac.go
@@ -5,7 +5,6 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,12 +16,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
-
-// isWithinTenantScope reports whether resourceTenant is within callerTenant's subtree.
-// Returns true when callerTenant is empty (admin mTLS path carries no tenant restriction).
-func isWithinTenantScope(callerTenant, resourceTenant string) bool {
-	return resourceTenant == callerTenant || strings.HasPrefix(resourceTenant, callerTenant+"/")
-}
 
 // handleListPermissions handles GET /api/v1/rbac/permissions
 func (s *Server) handleListPermissions(w http.ResponseWriter, r *http.Request) {

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -392,20 +392,15 @@ func (s *Server) handleGetSteward(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cross-tenant scope check: API-key principals carry a non-empty TenantID; admin mTLS
-	// principals have TenantID="" meaning no scope restriction.
-	// Use path-separator-aware prefix matching so "root/msp-a" cannot match "root/msp-alpha".
+	// principals have TenantID="" meaning no scope restriction (callerTenant == "" → always allowed).
 	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenant != "" {
-		sameTenant := stewardInfo.TenantID == callerTenant
-		ancestorTenant := strings.HasPrefix(stewardInfo.TenantID, callerTenant+"/")
-		if !sameTenant && !ancestorTenant {
-			// 404 instead of 403 to avoid disclosing steward existence across tenants.
-			s.logger.Info("Cross-tenant steward get refused",
-				"steward_tenant", logging.SanitizeLogValue(stewardInfo.TenantID),
-				"caller_tenant", logging.SanitizeLogValue(callerTenant))
-			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
-			return
-		}
+	if !isWithinTenantScope(callerTenant, stewardInfo.TenantID) {
+		// 404 instead of 403 to avoid disclosing steward existence across tenants.
+		s.logger.Info("Cross-tenant steward get refused",
+			"steward_tenant", logging.SanitizeLogValue(stewardInfo.TenantID),
+			"caller_tenant", logging.SanitizeLogValue(callerTenant))
+		s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+		return
 	}
 
 	activeSessions := 0

--- a/features/controller/api/handlers_tenants.go
+++ b/features/controller/api/handlers_tenants.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -57,6 +58,17 @@ func (s *Server) handleGetTenant(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.writeErrorResponse(w, http.StatusInternalServerError, "failed to get tenant", "GET_FAILED")
+		return
+	}
+
+	// Cross-tenant scope check: reject requests from callers outside the tenant's subtree.
+	// 404 instead of 403 to avoid disclosing the tenant's existence across tenant boundaries.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if !isWithinTenantScope(callerTenant, td.ID) {
+		s.logger.Info("Cross-tenant tenant get refused",
+			"resource_tenant", logging.SanitizeLogValue(td.ID),
+			"caller_tenant", logging.SanitizeLogValue(callerTenant))
+		s.writeErrorResponse(w, http.StatusNotFound, "tenant not found", "TENANT_NOT_FOUND")
 		return
 	}
 

--- a/features/controller/api/handlers_tenants_test.go
+++ b/features/controller/api/handlers_tenants_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -99,15 +100,13 @@ func TestHandleCreateTenant_MissingPermission(t *testing.T) {
 
 func TestHandleGetTenant_Exists(t *testing.T) {
 	server := setupTestServer(t)
-	apiKey := NewTestKey(t, server, []string{"tenant:read"})
 
-	// Create a tenant to retrieve
+	// Use an unscoped admin request so the caller can read any tenant.
 	ctx := context.Background()
 	td, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "readable-tenant"})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/tenants/%s", td.ID), nil)
-	req.Header.Set("X-API-Key", apiKey)
+	req := makeAdminRequest(t, http.MethodGet, fmt.Sprintf("/api/v1/tenants/%s", td.ID), nil)
 	w := httptest.NewRecorder()
 
 	server.router.ServeHTTP(w, req)
@@ -209,7 +208,6 @@ func TestHandleSuspendTenant_MissingPermission(t *testing.T) {
 // TestHandleGetTenant_ResponseShape verifies the full shape of the tenant JSON response.
 func TestHandleGetTenant_ResponseShape(t *testing.T) {
 	server := setupTestServer(t)
-	apiKey := NewTestKey(t, server, []string{"tenant:read"})
 
 	ctx := context.Background()
 	td, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{
@@ -218,8 +216,8 @@ func TestHandleGetTenant_ResponseShape(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/shape-tenant", nil)
-	req.Header.Set("X-API-Key", apiKey)
+	// Unscoped admin reads any tenant.
+	req := makeAdminRequest(t, http.MethodGet, "/api/v1/tenants/shape-tenant", nil)
 	w := httptest.NewRecorder()
 
 	server.router.ServeHTTP(w, req)
@@ -233,4 +231,113 @@ func TestHandleGetTenant_ResponseShape(t *testing.T) {
 	assert.Equal(t, td.ID, data["id"])
 	assert.Equal(t, string(business.TenantStatusActive), data["status"])
 	assert.NotEmpty(t, data["created_at"])
+}
+
+// TestHandleGetTenant_CrossTenant_Returns404 verifies that a caller scoped to one
+// tenant receives 404 (not 403) when requesting a tenant outside its subtree, so the
+// response is indistinguishable from a nonexistent ID (Issue #3147, AC: REQUIRED TEST).
+func TestHandleGetTenant_CrossTenant_Returns404(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Create two sibling tenants — the caller is scoped to client-1, not client-2.
+	ctx := context.Background()
+	_, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "client-2"})
+	require.NoError(t, err)
+
+	// Caller scoped to client-1.
+	callerKey := NewEphemeralTestKey(t, server, []string{"tenant:read"}, "client-1", 5*time.Minute)
+
+	// Request the existing client-2 record — must be 404 (existence must not be disclosed).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/client-2", nil)
+	req.Header.Set("X-API-Key", callerKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	// Compare with a genuinely nonexistent tenant to ensure the responses are identical.
+	reqNonexistent := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/does-not-exist", nil)
+	reqNonexistent.Header.Set("X-API-Key", callerKey)
+	recNonexistent := httptest.NewRecorder()
+	server.router.ServeHTTP(recNonexistent, reqNonexistent)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant get must return 404, not 403")
+	assert.Equal(t, recNonexistent.Code, rec.Code, "status must match nonexistent-ID response")
+
+	var errResp, errRespNonexistent ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	require.NoError(t, json.NewDecoder(recNonexistent.Body).Decode(&errRespNonexistent))
+	assert.Equal(t, "TENANT_NOT_FOUND", errResp.Error.Code)
+	assert.Equal(t, errRespNonexistent.Error.Code, errResp.Error.Code,
+		"error code must match nonexistent-ID response")
+	assert.Equal(t, errRespNonexistent.Error.Message, errResp.Error.Message,
+		"error message must match nonexistent-ID response")
+}
+
+// TestHandleGetTenant_SameTenant_Returns200 verifies that a caller scoped to a tenant
+// can read that tenant's own record (Issue #3147).
+func TestHandleGetTenant_SameTenant_Returns200(t *testing.T) {
+	server := setupTestServer(t)
+
+	ctx := context.Background()
+	_, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "msp-a"})
+	require.NoError(t, err)
+
+	callerKey := NewEphemeralTestKey(t, server, []string{"tenant:read"}, "msp-a", 5*time.Minute)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/msp-a", nil)
+	req.Header.Set("X-API-Key", callerKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "msp-a", data["id"])
+}
+
+// TestHandleGetTenant_UnscopedAdmin_CanReadAnyTenant verifies that a principal with an
+// empty caller tenant (unscoped mTLS admin) can read any tenant record (Issue #3147).
+func TestHandleGetTenant_UnscopedAdmin_CanReadAnyTenant(t *testing.T) {
+	server := setupTestServer(t)
+
+	ctx := context.Background()
+	_, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "any-tenant"})
+	require.NoError(t, err)
+
+	req := makeAdminRequest(t, http.MethodGet, "/api/v1/tenants/any-tenant", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "any-tenant", data["id"])
+}
+
+// TestHandleGetTenant_SiblingPrefix_Returns404 verifies that "client-1" cannot read
+// "client-10" — a bare HasPrefix check without the "/" separator would allow this
+// incorrectly (Issue #3147).
+func TestHandleGetTenant_SiblingPrefix_Returns404(t *testing.T) {
+	server := setupTestServer(t)
+
+	ctx := context.Background()
+	_, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "client-10"})
+	require.NoError(t, err)
+
+	// "client-1" scoped caller tries to read "client-10".
+	callerKey := NewEphemeralTestKey(t, server, []string{"tenant:read"}, "client-1", 5*time.Minute)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/client-10", nil)
+	req.Header.Set("X-API-Key", callerKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"sibling-prefix tenant must return 404 (client-1 must not match client-10)")
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "TENANT_NOT_FOUND", errResp.Error.Code)
 }

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -594,6 +594,17 @@ type AuthorizationDecision struct {
 	ConditionalVars map[string]interface{} `json:"conditional_vars,omitempty"`
 }
 
+// isWithinTenantScope reports whether resourceTenant falls within callerTenant's
+// subtree. callerTenant == "" means an unscoped mTLS admin — always true. Otherwise
+// resourceTenant must equal callerTenant or be a "/"-prefixed descendant, so
+// "root/msp-a" cannot match "root/msp-alpha".
+func isWithinTenantScope(callerTenant, resourceTenant string) bool {
+	if callerTenant == "" {
+		return true
+	}
+	return resourceTenant == callerTenant || strings.HasPrefix(resourceTenant, callerTenant+"/")
+}
+
 // requirePermission creates middleware that enforces specific permission requirements.
 // Human-authenticated principals (Assurance >= AssuranceBasic) short-circuit to ALLOW for any permission.
 func (s *Server) requirePermission(resourceType, action string) func(http.Handler) http.Handler {

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -1782,3 +1782,36 @@ func TestWebSessionCookie_AssurancePropagatedToPrincipal(t *testing.T) {
 			"IP-change downgrade must be reflected in web session Principal Assurance")
 	})
 }
+
+// TestIsWithinTenantScope verifies the helper introduced by Issue #3147.
+func TestIsWithinTenantScope(t *testing.T) {
+	tests := []struct {
+		callerTenant   string
+		resourceTenant string
+		want           bool
+		desc           string
+	}{
+		{"", "any-tenant", true, "unscoped admin (empty caller) always allowed"},
+		{"", "", true, "unscoped admin with empty resource tenant"},
+		{"msp-a", "msp-a", true, "same-tenant match"},
+		{"msp-a", "msp-a/client-1", true, "direct descendant allowed"},
+		{"msp-a", "msp-a/client-1/server", true, "deep descendant allowed"},
+		{"msp-a", "msp-b", false, "sibling tenant denied"},
+		{"msp-a", "msp-alpha", false, "sibling with shared prefix denied (no slash separator)"},
+		{"msp-a", "root/msp-a", false, "ancestor not in subtree denied"},
+		{"root/msp-a", "root/msp-a", true, "hierarchical path same-tenant"},
+		{"root/msp-a", "root/msp-a/client-1", true, "hierarchical path descendant"},
+		{"root/msp-a", "root/msp-alpha", false, "hierarchical sibling-prefix denied"},
+		{"root/msp-a", "root/msp-b", false, "hierarchical sibling denied"},
+		{"client-1", "client-2", false, "flat sibling denied (required AC)"},
+		{"client-1", "client-10", false, "flat sibling-prefix denied"},
+		{"client-1", "client-1", true, "flat same-tenant"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := isWithinTenantScope(tc.callerTenant, tc.resourceTenant)
+			assert.Equal(t, tc.want, got,
+				"isWithinTenantScope(%q, %q)", tc.callerTenant, tc.resourceTenant)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `isWithinTenantScope` to `middleware.go` as the canonical package-level helper: `callerTenant == ""` (unscoped mTLS admin) always returns true; otherwise uses path-separator-aware prefix matching so `"msp-a"` cannot match `"msp-alpha"`.
- `handleGetTenant` now rejects out-of-scope requests with 404 `TENANT_NOT_FOUND` (same as not-found) to avoid disclosing tenant existence across subtree boundaries.
- `handleGetSteward` retrofitted to call `isWithinTenantScope` in place of its inline `sameTenant`/`ancestorTenant` block (behavior-preserving refactor, no AC change).
- Fixes the missing empty-caller check in the prior `handlers_rbac.go` copy of `isWithinTenantScope` (RBAC handlers were guarding with `callerTenant != ""` before calling it, masking the bug; the new canonical version makes the guard internal).

Fixes #3147

## Acceptance criteria verified

- [x] `isWithinTenantScope` added to `middleware.go` with exact semantics (empty-caller always true, `/`-prefixed descendant matching)
- [x] `handleGetTenant` returns 404 (`TENANT_NOT_FOUND`) for out-of-scope requests using the helper
- [x] `handleGetSteward` retrofitted; no behavior change (same 404, same log fields)
- [x] `TestHandleGetTenant_CrossTenant_Returns404`: caller scoped to `client-1` gets 404 for `GET /tenants/client-2`, response identical to nonexistent ID
- [x] `TestHandleGetSteward_CrossTenant_Returns404` and all other steward cross-tenant tests pass unmodified
- [x] Unscoped mTLS admin (`callerTenant == ""`) can read any tenant
- [x] `TestIsWithinTenantScope` table test covers all edge cases

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

story-review workflow: `passed: true`, 1 round, 0 fix rounds, 0 remaining findings.

## Test plan

- [x] `go test ./features/controller/api/... -count=1` — all tests pass
- [x] `make lint-log-injection` — exits 0
- [x] `make check-architecture` — no violations
- [x] Story-review adversarial workflow: all three lenses clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)