### PR TITLE
docs: add ADR-025 and ADR-027 for tenant access boundary + deletion safety

### DIFF
--- a/docs/architecture/decisions/025-tenant-access-boundary.md
+++ b/docs/architecture/decisions/025-tenant-access-boundary.md
@@ -1,0 +1,241 @@
+# ADR-025: SaaS-Operator ↔ MSP Tenant Access Boundary
+
+**Status:** Accepted
+
+**Date:** 2026-07-30
+
+**Deciders:** Founder, Architecture
+
+**Related:** Epic [#2858](https://github.com/cfg-is/cfgms/issues/2858) (web tenant & access
+administration — this ADR governs its access model). Story
+[#3125](https://github.com/cfg-is/cfgms/issues/3125) (tenant list/update/delete API — its
+proposed shared subtree-check helper is extended here). Story
+[#3131](https://github.com/cfg-is/cfgms/issues/3131) (tenant admin tree UI — blocked pending
+this ADR; the reason this ADR exists). ADR-027 (Tenant Suspension, Archive, and Cascading
+Deletion Lifecycle — the sibling decision covering *what happens inside* a tenant subtree;
+this ADR covers *who gets in from outside it*, a deliberately separate concern). ADR-021
+(Identity Assurance Levels — break-glass and step-up compose with `AssuranceStrong`, not with
+a parallel mechanism). CLAUDE.md Threat Model (rarely-touched, blast-radius-bounding config
+knobs — `module_trust.mode` is the existing precedent this ADR's config toggles follow) and
+Multi-Tenancy section (the recursive parent-child path model this ADR narrows).
+
+---
+
+## Context
+
+### The current model grants ancestors default access to every descendant
+
+CFGMS's tenant model is a recursive parent-child tree with path-based identification
+(`root/msp-a/client-1/servers`, CLAUDE.md). Server-side scope enforcement — where it
+exists — uses the same prefix-match shape in multiple handlers: `id == callerTenant ||
+strings.HasPrefix(id, callerTenant+"/")` (e.g. `handlers_stewards.go:142`,
+`handlers_push.go:113`, `handlers_fleet.go:70`, `handlers_ip_trust.go:105`, among others).
+The config-store layer's `checkCrossTenant` (`pkg/configrouting/providers/controller/
+router.go:243-264`) calls `tenantStore.IsTenantAncestor` and permits an ancestor to read a
+descendant's config. This is deliberate and correct **within** an organization: an MSP
+administrator scoped to `root/msp-a` is expected to see and manage `root/msp-a/client-1`.
+
+It is not correct **at the top of the tree** in a multi-tenant SaaS deployment. `root` is
+the SaaS operator's own scope. Under the existing rule, a principal scoped to `root`
+automatically has the same descendant access to `root/msp-a` (and everything below it) that
+`root/msp-a` has to its own children — there is no gate between "the company that operates
+the SaaS platform" and "a customer's entire business." One handler currently has no check at
+all: `handleGetTenant` (`features/controller/api/handlers_tenants.go:44-64`) performs no
+subtree check whatsoever — any caller holding `tenant:read` can fetch any tenant by ID,
+regardless of ancestry. Story #3125 already flags this as an unresolved defect and proposes
+introducing a shared subtree-check helper. This ADR decides what that helper — and the
+`root` boundary specifically — must enforce.
+
+### Why this matters more than an ordinary access bug
+
+An MSP's CFGMS tenant is not a sandbox — per the founder, "an MSP's tenant is likely to be
+what they run their business on." Default visibility from the SaaS operator's root scope
+into that tenant is a standing trust assumption CFGMS has never asked customers to make
+explicitly. It also cuts against CLAUDE.md's own threat model framing: rarely-touched
+settings should "bound the blast radius of admin or controller compromise." Today a
+compromised root-scoped credential at the SaaS operator has that blast radius by
+construction, with nothing to bound it.
+
+### What does not exist today that this ADR needs
+
+- **No cross-tenant consent or elevation mechanism.** `emergency.break-glass`
+  (`features/rbac/templates.go:332-354`, `features/rbac/defaults.go:229-234`) is a real,
+  tested, time-boxed (4h) RBAC permission template — but it grants `emergency.access` "on
+  system resources only." It is not a tenant-crossing mechanism and this ADR does not
+  overload it; a new, analogous permission is needed for crossing the root↔MSP boundary
+  specifically.
+- **No per-tenant "allow support access" grant.** Nothing today lets an MSP administrator
+  explicitly permit the SaaS operator into their tenant, time-boxed and revocable.
+
+### Scope decided in conversation with the founder (2026-07-30)
+
+1. **`root` stays a real tenant node.** It is not removed from the path model or renamed —
+   it remains useful for SaaS-operator-level operations (billing, cross-MSP ops). It is
+   *walled off* from MSP subtrees by default, not eliminated.
+2. **The boundary is exactly one seam: `root` ↔ its immediate MSP children.** It is
+   deliberately **not** recursive at every parent/child level. An MSP's own default
+   visibility into its clients' sub-tenants is unchanged — today's ancestor-inherits-
+   descendant behavior continues to apply below `root` exactly as it does now.
+3. **This is its own ADR, decided before #3131/#2858 continue** — not an interim rule bolted
+   onto the tenant-admin-tree story. #3131 stays blocked until this ADR is accepted and its
+   body is rescoped against it.
+4. **A narrow, transparent logging/metrics carve-out exists independent of the access
+   boundary** (Decision 4) — the boundary gates *administrative* access into a tenant's
+   config and resources; it does not blind the SaaS operator to platform-level security and
+   operability signals.
+
+---
+
+## Decision
+
+### 1. A single, named boundary — not a general recursive rule
+
+The existing ancestor-prefix-match rule (`id == callerTenant || HasPrefix(id,
+callerTenant+"/")`) is **suspended specifically when `callerTenant` is the root tenant path
+and the target is a descendant of it** (i.e. `target != root && strings.HasPrefix(target,
+rootPath+"/")`). Every other ancestor/descendant pair — `root/msp-a` looking at
+`root/msp-a/client-1`, `root/msp-a/client-1` looking at `root/msp-a/client-1/servers`, and so
+on — is **unchanged** and keeps today's behavior. This is one boundary check, not a rewrite
+of the general scope-matching helper, and it composes with (rather than replaces) the shared
+subtree-check helper #3125 already proposes introducing for `handleGetTenant` and friends.
+
+### 2. Crossing the boundary requires an explicit, auditable grant
+
+Two distinct mechanisms, both logged via `pkg/audit` and both visible to the MSP whose
+boundary was crossed (surfaced in their own tenant activity/audit view, not hidden from
+them):
+
+- **(a) Client-granted access.** An MSP administrator, from inside their own tenant scope,
+  explicitly enables a support-access grant (e.g. "Allow CFGMS support access for
+  troubleshooting"), time-boxed with an expiry, and revocable at any time. This is the
+  preferred path and requires no root-side justification, because the customer opted in.
+- **(b) Break-glass access.** A SaaS-operator principal invokes an emergency, time-boxed
+  elevation without a prior grant (security incident, legal request, billing dispute).
+  Modeled on the existing `emergency.break-glass` shape (time-boxed permission assignment,
+  `features/rbac/engine.go:72` already enforces `ExpiresAt`) but as a **new**,
+  tenant-crossing-specific permission — not a reuse of the system-resource-only template.
+  Requires a mandatory recorded justification string; whether it additionally requires a
+  second approver by default is a PO/founder tunable (see Remaining Tunables).
+
+Neither mechanism grants standing access: both expire, and expiry ends the elevation without
+requiring an explicit revoke.
+
+### 3. Enforcement lives in the shared subtree-check helper, not scattered per-handler
+
+The shared `isWithinTenantScope`-shaped helper #3125 already proposes (to fix
+`handleGetTenant`'s missing check, among others) is the single place this boundary is
+enforced. It must reject — with a step-up-shaped challenge per ADR-021's composition model,
+not a bare 403, so a legitimate break-glass invocation has a clear path forward — any
+`root`-scoped caller reaching into a descendant path without an active grant or break-glass
+session flag. A caller with an active grant/break-glass session is allowed through exactly as
+an ordinary ancestor would be, for the lifetime of that elevation.
+
+### 4. A narrow, transparent security/platform log and metrics carve-out
+
+The access boundary gates **administrative access to a tenant's own config, resources, and
+business data.** It is not a blindfold on the SaaS operator's ability to run the platform
+safely. A defined, narrow allowlist of signal categories remains visible to `root` **at all
+times, independent of any grant or break-glass session**:
+
+- Authentication failures, account lockouts, and suspicious-login patterns on MSP admin
+  accounts.
+- Break-glass and access-grant usage itself — the meta-log of when and why the boundary was
+  crossed. (This must be root-visible by construction, or root could not audit its own
+  break-glass usage.)
+- Abuse and resource-exhaustion signals — rate-limit trips, anomalous API volume, and similar
+  platform-health indicators.
+- Billing and subscription state changes, including non-payment flags (this is also what
+  drives the non-payment suspension trigger in ADR-027).
+- **System/platform logs and metrics generally** — operational telemetry, performance
+  metrics, and platform-level system logs needed to run and support the SaaS deployment.
+
+**Explicitly not carved out:** ordinary business/config audit trail — e.g. "MSP created
+client tenant X," "admin changed config value Y." That is normal business activity and stays
+behind the boundary; the carve-out is for platform operability and trust-and-safety signals,
+not a backdoor into tenant administration.
+
+**Design constraints:**
+
+- The carve-out is a **narrow, explicit allowlist of audit-event/metric categories**, not
+  "everything above some severity." Growing it is a founder decision, not a reviewer's
+  judgement call — the same posture ADR-021 takes with its `RequireUserPresence` set.
+- **Visibility is bidirectionally transparent.** An MSP can see that (and roughly when) root
+  viewed a carved-out signal about them, the same way they can see break-glass or grant
+  usage. There is no silent, root-only visibility.
+- Carve-out entries must avoid leaking sensitive business/config content — e.g. "auth failure
+  for user X at time Y," not "auth failure while accessing config value Z."
+- **Pull, not push, for v1.** A carved-out signal is queryable/visible at all times (during
+  an investigation, a billing review, or routine platform monitoring). Real-time alerting
+  into the existing `AlertCenter`/notification path is a later increment, not part of this
+  ADR's decision.
+
+---
+
+## Non-Goals
+
+- **Not designing the client-grant UI in this ADR.** The "allow support access" surface
+  inside an MSP's own tenant view is a follow-on story once this ADR is accepted.
+- **Not extending the access boundary recursively below `root`.** Explicitly decided
+  (Context, axis 2): an MSP's default visibility into its own clients' sub-tenants is
+  unchanged.
+- **Not building real-time alerting on the logging carve-out.** Pull/queryable only for v1
+  (Decision 4).
+- **Not covering tenant suspension, archival, or deletion.** That is ADR-027's concern
+  entirely; this ADR only governs who may look into or act on a tenant from outside its own
+  subtree.
+
+---
+
+## Consequences
+
+### Positive
+
+- Closes the default-access gap the founder identified: a compromised or merely careless
+  root-scoped credential at the SaaS operator no longer has standing access into every
+  customer's tenant tree.
+- Composes with existing machinery rather than inventing parallel systems: break-glass
+  mirrors the existing `emergency.break-glass` shape; the boundary check slots into #3125's
+  already-planned shared helper; elevation can be gated at `AssuranceStrong` per ADR-021
+  rather than defining a new auth concept.
+- The platform keeps the operability and trust-and-safety visibility it actually needs
+  (abuse detection, billing state, security signals) without that visibility doubling as
+  general tenant access — the two concerns don't get conflated into one permission.
+
+### Negative / costs
+
+- **New state required.** Client-grant records and break-glass session flags/audit entries
+  need a store, plus a defined, versioned allowlist for the logging/metrics carve-out.
+- **#3125's `handleGetTenant` (and sibling handlers') subtree check** must be implemented
+  against this boundary from the start, not the plain ancestor-prefix rule.
+- **#3131's tenant admin tree UI** must not render descendant tenants' detail at all for a
+  `root`-scoped session without an active grant/break-glass flag — a boundary/empty state,
+  not just hidden action buttons.
+- **Break-glass and client-grant both need an audit-visible surface on the MSP side** — real
+  UI work beyond what #2858 currently scopes, and should be called out explicitly when
+  #2858's body is updated.
+
+### Migration / Sequencing
+
+- **#3125 is not yet merged.** Its read/update/delete endpoints must be designed against this
+  ADR from the start. Its proposed shared subtree-check helper is the correct enforcement
+  point for Decision 3 above and should be extended, not duplicated.
+- **#3131 stays Blocked** pending this ADR's acceptance and a rescoped story body.
+- **#2858's epic body needs a note** that this ADR governs its access model, and that a
+  client-grant UI and break-glass audit surface are in its scope even though they weren't
+  called out in the epic's original stories.
+
+---
+
+## Remaining tunables (PO-set, founder may override)
+
+1. **Whether break-glass requires a second approver by default** — this ADR requires
+   break-glass to be time-boxed and justified/audited, but does not fix whether it
+   additionally needs dual approval.
+2. **Exact permission names** (e.g. `tenant:cross-boundary-access`, `tenant:break-glass`) —
+   left to the implementing story, following existing RBAC naming conventions in
+   `features/rbac/defaults.go`.
+3. **Whether client-granted access defaults to a fixed expiry** (e.g. 24h, renewable) or
+   stays open until the MSP explicitly revokes it.
+4. **The exact carve-out allowlist's final shape** — the category list in Decision 4 is
+   founder-confirmed at the level described; the precise audit-event-type enum is an
+   implementation detail for the story that builds it.

--- a/docs/architecture/decisions/027-tenant-suspension-archive-and-cascading-deletion.md
+++ b/docs/architecture/decisions/027-tenant-suspension-archive-and-cascading-deletion.md
@@ -1,0 +1,211 @@
+# ADR-027: Tenant Suspension, Archive, and Cascading Deletion Lifecycle
+
+**Status:** Accepted
+
+**Date:** 2026-07-31
+
+**Deciders:** Founder, Architecture
+
+**Related:** Epic [#2858](https://github.com/cfg-is/cfgms/issues/2858) (web tenant & access
+administration — this ADR governs its deletion/suspension model). Story
+[#3125](https://github.com/cfg-is/cfgms/issues/3125) (tenant list/update/delete API — its
+`DELETE` design is superseded by this ADR's pipeline, and its existing
+`ErrTenantHasChildren` check changes meaning, see Decision 2). Story
+[#3131](https://github.com/cfg-is/cfgms/issues/3131) (tenant admin tree UI — blocked pending
+this ADR; its original mockup's single delete-confirm-with-409 interaction is superseded).
+ADR-025 (SaaS-Operator ↔ MSP Tenant Access Boundary — the sibling decision covering *who gets
+in from outside a tenant subtree*; this ADR covers *what a tenant's own administrator can do
+to their subtree*, a deliberately separate concern). CLAUDE.md Threat Model (rarely-touched,
+blast-radius-bounding config knobs — `module_trust.mode` is the precedent this ADR's
+dual-control toggle follows).
+
+---
+
+## Context
+
+### Deletion is a real, unrecoverable SQL `DELETE` today, gated only by "no children"
+
+`Manager.DeleteTenant` (`features/tenant/manager.go:220-255`) already refuses to delete the
+`default` tenant and already refuses deletion while children exist (`ErrTenantHasChildren`).
+But once those two conditions are satisfied, it cascades RBAC cleanup and calls the store, and
+`DatabaseTenantStore.DeleteTenant` (`pkg/storage/providers/database/tenant_store.go:241-249`)
+issues an unrecoverable `DELETE FROM cfgms_tenants` — despite a stale comment at
+`manager.go:253` calling it a "soft delete." There is no hold period and no second approver.
+No HTTP route exposes this yet (#3125 is what would add `DELETE /api/v1/tenants/{id}`), which
+is exactly why this ADR needs to land before that route is designed rather than after.
+
+`Suspend` (`POST /tenants/{id}/suspend`, already implemented and already reversible) has no
+such children check — but it also has no cascade: suspending a parent today does not suspend
+its children, and nothing stops a "suspended" MSP's client sub-tenants from continuing to
+operate independently, which does not match how suspension needs to work for the reasons
+tenants actually get suspended.
+
+### Why this needs to be an explicit lifecycle, not a single delete action
+
+Per the founder: the realistic reasons an MSP tenant gets suspended or deleted are
+**non-payment** or **the client has left.** In both cases:
+
+- The operator (whether that's a SaaS-side billing action or an MSP administrator
+  offboarding a client) needs to suspend the *entire* affected business relationship in one
+  action — an MSP that stops paying has every one of its clients' sub-tenants suspended with
+  it, not just its own top-level record. A partial suspension that leaves child tenants
+  running defeats the purpose of suspending for non-payment.
+- The same logic applies recursively at every level: an MSP offboarding `client-1` needs
+  `client-1`'s entire sub-tree (`servers`, `workstations`, whatever exists under it)
+  suspended together, not blocked by a "has children" error that forces deleting or
+  reassigning them first.
+- Because a tenant subtree is "what a business runs on" (ADR-025's framing), the eventual,
+  irreversible deletion of that whole suspended subtree needs a deliberate hold period and,
+  by default, a second approver — not a single click.
+
+This ADR replaces the current "delete a single childless tenant" model with a **cascading
+suspend/archive/restore/delete lifecycle** that operates on a tenant and its entire subtree
+as one unit, at any level of the tree.
+
+---
+
+## Decision
+
+### 1. Suspend cascades to the entire subtree; no children check applies
+
+`POST /tenants/{id}/suspend` suspends the target tenant **and every descendant in its
+subtree**, atomically, regardless of depth. The existing `ErrTenantHasChildren` check is
+**removed from Suspend** — it never applied a real constraint suspension needs; a tenant with
+children should always be suspendable, and suspending it must take its children with it.
+
+This applies **at any level**: suspending `root/msp-a` suspends `client-1`, `client-2`, and
+everything beneath them; suspending `root/msp-a/client-1` suspends only `servers` and
+`workstations` beneath it, leaving `client-2` (a sibling, not a descendant) untouched.
+
+### 2. Cascade-suspended vs. directly-suspended is tracked separately
+
+Each tenant's suspension record carries **why** it is suspended:
+
+- `DirectlySuspended` — this specific tenant was the target of a suspend action.
+- `CascadeSuspended(from=<ancestor id>)` — this tenant is suspended purely as a side effect
+  of an ancestor's suspend action.
+
+A tenant can be both: independently suspended for its own reason (e.g. a client sub-tenant
+already suspended for its own non-payment) and *also* cascade-suspended when its parent is
+later suspended. **Restoring an ancestor only lifts the cascade effect it caused** — it never
+overrides a descendant's own independent suspension. Concretely: if `client-1` was already
+suspended on its own before `msp-a` (its parent) was suspended, restoring `msp-a` un-suspends
+`msp-a` and any children that were *only* suspended via that cascade, but `client-1` stays
+suspended until it is independently restored. This is founder-confirmed (2026-07-31) as the
+correct behavior — cascade actions must never silently discard an unrelated, pre-existing
+suspension.
+
+### 3. Deletion operates on a subtree, gated by "fully suspended," not "childless"
+
+The `ErrTenantHasChildren` check is **repurposed, not removed, for Delete**: a delete request
+is no longer rejected because children exist — it is rejected unless **the entire target
+subtree (the target tenant and every descendant) is already suspended.** A single childless
+tenant is simply the size-1 case of the same rule. This replaces #3131's original mockup
+interaction (a delete-confirm that 409s with "has children" and stops there) with a
+cascading pipeline:
+
+1. **Suspend** (Decision 1) — the only immediately-effective step, cascades to the whole
+   subtree, reversible at any time subject to Decision 2's independence rule.
+2. **Hold.** A delete request against a tenant whose **entire subtree is suspended** starts a
+   single hold-period timer for the whole cascade (`tenant_admin.delete_hold_period`, a
+   `Duration` mirroring the `Duration` type already used elsewhere in controller config, e.g.
+   `RingSpec.Soak` at `features/controller/config/config.go:48`). The timer is scoped to the
+   subtree root the delete was requested against — it is **not** per-node; a child suspended
+   moments before its parent does not reach eligibility on a different clock than the rest of
+   the cascade.
+   - If any part of the subtree is not (yet) suspended when delete is requested — e.g. a
+     child was independently restored after the cascade suspend — the delete request is
+     rejected with a clear "not fully suspended" error naming the offending descendant(s),
+     distinct from a generic failure.
+3. **Eligible.** Once the hold elapses and the entire subtree is still suspended, the deletion
+   becomes eligible to execute. It does not execute automatically.
+4. **Execute, dual-control default-on.** Executing the terminal, unrecoverable delete of the
+   whole subtree requires approval from a second distinct principal — not the one who
+   initiated the hold — enforced server-side (compare-and-swap on approver identity, not
+   client-asserted). Controlled by a new controller config toggle,
+   `tenant_admin.delete_requires_dual_control` (bool, default `true`), settable to `false`
+   for deployments where a second approver isn't practical (e.g. a single-admin on-prem
+   install) — the same shape as `module_trust.mode`: a rarely-touched knob that bounds blast
+   radius by default but is not forced on every deployment.
+5. **Hard delete, cascaded.** `Manager.DeleteTenant`'s existing SQL delete becomes the
+   terminal step, executed for every tenant in the held subtree together, not one node at a
+   time. The already-implemented RBAC cleanup cascade and `default`-tenant protection are
+   unchanged.
+
+### 4. Cancelling a pending deletion never discards state
+
+Cancelling a delete at the Hold or Eligible step returns the subtree to ordinary Suspended
+state (not Active) — an administrator who wants the tenant back must still explicitly
+restore it (Decision 2), the same as any other suspension. Cancelling never partially
+restores only some of the subtree.
+
+---
+
+## Non-Goals
+
+- **Not covering who is allowed to suspend/delete from outside a tenant's own subtree** —
+  that is ADR-025's access-boundary concern entirely. This ADR assumes the caller already has
+  ordinary administrative access to the subtree in question.
+- **Not fixing the hold-period length or break-glass-style justification requirements for
+  delete** — the config toggle and `Duration` field shape are decided here; the default
+  values are a PO/founder tunable (see below).
+- **Not building a UI in this ADR** — #3131's story body is rescoped separately to reflect
+  this pipeline once both this ADR and ADR-025 are accepted.
+- **Not changing `default`-tenant protection or the RBAC-cleanup cascade** — both are kept
+  exactly as `manager.go` implements them today.
+
+---
+
+## Consequences
+
+### Positive
+
+- Suspension finally does what "suspend an MSP for non-payment" needs: the whole business
+  relationship stops together, not just the top-level record.
+- Deletion of a real, populated business (an MSP's entire tenant tree, or a departed client's
+  sub-tree) is possible without first manually deleting or reassigning every leaf — a
+  realistic and previously-blocked operation — while remaining safe: nothing is deleted until
+  every affected tenant has been suspended, held, and (by default) approved by a second
+  principal.
+- The independent-vs-cascade suspension distinction (Decision 2) means restoring a parent can
+  never accidentally reactivate a child that has its own, unrelated reason to stay suspended.
+
+### Negative / costs
+
+- **New state required.** Per-tenant suspension provenance (`DirectlySuspended` vs.
+  `CascadeSuspended(from)`), a subtree-scoped pending-deletion record (requested-by,
+  requested-at, eligible-at, approved-by), and cascade-execution logic (suspend/restore/
+  delete walking the whole subtree, not a single row) are all new — this is real storage and
+  business-logic work, not a UI-only change.
+- **#3125's `DELETE /api/v1/tenants/{id}` design changes** — it cannot be a direct call into
+  `Manager.DeleteTenant`. It must initiate or advance the Suspend→Hold→Delete pipeline across
+  a subtree, and a distinct approval step/endpoint is needed for dual-control.
+- **`POST /tenants/{id}/suspend`'s contract changes** — it must become subtree-cascading and
+  return enough information (which descendants were newly cascade-suspended vs. already
+  independently suspended) for the UI to render accurately.
+- **#3131's tenant admin tree UI** needs cascade-aware suspend/restore affordances, a
+  hold-eligibility countdown, a distinct "approve pending deletion" action for the second
+  approver, and must render a tenant's suspension provenance (direct vs. cascaded) so an
+  admin understands why restoring a parent didn't restore a given child.
+
+### Migration / Sequencing
+
+- **#3125 is not yet merged.** Its delete implementation must be built against this pipeline
+  from the start.
+- **#3131 stays Blocked** pending both this ADR and ADR-025's acceptance, and a rescoped story
+  body reflecting cascade suspend/restore, hold-eligibility, and dual-control approval UX
+  (replacing the original mockup's single delete-confirm-with-409 interaction).
+- **#2858's epic body needs a note** that this ADR governs its deletion/suspension model.
+
+---
+
+## Remaining tunables (PO-set, founder may override)
+
+1. **Default hold-period length** (`tenant_admin.delete_hold_period`) — no default is fixed by
+   this ADR. 30 days is a reasonable starting point to propose at decomposition.
+2. **Whether initiating a delete (starting the hold) itself requires dual-control**, or only
+   the terminal execute step does — this ADR specifies dual-control on execute (Decision 3,
+   step 4); whether the initiating action also needs a second approver is open.
+3. **Exact permission names** (e.g. `tenant:suspend`, `tenant:delete`,
+   `tenant:approve-delete`) — left to the implementing story, following existing RBAC naming
+   conventions in `features/rbac/defaults.go`.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -68,6 +68,8 @@ What becomes easier or harder by making this decision?
 | [019](019-third-party-module-inclusion-and-trust.md) | Third-Party Module Inclusion and Delegated Publisher Trust | 2026-07-04 | Proposed |
 | [020](020-dna-required-field-declaration.md) | DNA Required-Field Declaration — per-configuration-type contract, module-manifest sourced | 2026-07-13 | Accepted |
 | [021](021-identity-assurance-levels.md) | Identity Assurance Levels and Step-Up Authentication | 2026-07-16 | Accepted |
+| [025](025-tenant-access-boundary.md) | SaaS-Operator ↔ MSP Tenant Access Boundary | 2026-07-30 | Accepted |
+| [027](027-tenant-suspension-archive-and-cascading-deletion.md) | Tenant Suspension, Archive, and Cascading Deletion Lifecycle | 2026-07-31 | Accepted |
 
 ### Superseded/Deprecated
 


### PR DESCRIPTION
## Summary
- Adds ADR-025 (SaaS-Operator ↔ MSP Tenant Access Boundary): `root` loses default ancestor-inherited access into any MSP's subtree; crossing requires a client-granted, time-boxed access grant or an audited break-glass elevation, both visible to the MSP. A narrow, transparent carve-out (auth/security signals, break-glass usage, abuse/billing signals, system logs & metrics) stays root-visible at all times, pull-only.
- Adds ADR-027 (Tenant Suspension, Archive, and Cascading Deletion Lifecycle): Suspend cascades to a tenant's entire subtree (no children-check), tracked as directly-suspended vs. cascade-suspended so restoring a parent never overrides an independently-suspended child. Delete becomes Suspend → Hold → Delete, gated on the whole subtree being suspended, dual-control default-on (config-toggleable) at the terminal execute step.
- Both Accepted (founder + architecture, 2026-07-30/31), added to the ADR index.
- Updates #2858 (epic), #3125, and #3131 bodies to reference these ADRs and correct now-stale assumptions (#3125's claim that `DeleteTenant` is "fully implemented" no longer holds for the cascade/hold/dual-control pipeline; #3131's original mockup and delete/409 acceptance criteria are superseded and it stays Blocked pending a new mockup).

## Test plan
- [x] Docs-only change — no code paths affected.
- [x] Cross-referenced against live code (`handlers_stewards.go`, `handlers_tenants.go`, `features/tenant/manager.go`, `features/rbac/templates.go`, `features/rbac/defaults.go`) before writing, not from memory.

Relates to #3131, #3125, #2858