### PR TITLE
commands: add /pipeline as a dedicated entry point for the autonomous cron cycle

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -319,7 +319,7 @@ separate call needed.
   - `merge-queue` — queue state as JSON
   - `block <ISSUE> <reason>` — set project status Blocked, post escalation comment
   - `release-story <ITEM_ID>` — release a §7 self-dispatch story lease after the PR is up
-  - `cycle-start [cron|cycle]` / `cycle-end` — bracket a cycle's per-step manifest (Issue #3053); see §4.0/§4.1 Step 11 below. Every other subcommand above auto-records a step into it — with the work/no-op/error outcome it actually produced, classified from its own status markers — while a cycle is open. Nested `Agent`/`Skill` spawns (Tech Lead, BA, pin-refresh-runner, pipeline-sweep-runner, reviewers) are read out of this session's transcript by `cycle-end` and land in the manifest's `agents[]` with their roles and measured cost. **Nothing else to call, and nothing to narrate:** never report step outcomes, spawned agents or token counts into the manifest by hand — self-reported numbers were measured 31.5x low, which is why the record is taken from transcripts instead.
+  - `cycle-start [cron|cycle|pipeline]` / `cycle-end` — bracket a cycle's per-step manifest (Issue #3053); see §4.0/§4.1 Step 11 below. Every other subcommand above auto-records a step into it — with the work/no-op/error outcome it actually produced, classified from its own status markers — while a cycle is open. Nested `Agent`/`Skill` spawns (Tech Lead, BA, pin-refresh-runner, pipeline-sweep-runner, reviewers) are read out of this session's transcript by `cycle-end` and land in the manifest's `agents[]` with their roles and measured cost. **Nothing else to call, and nothing to narrate:** never report step outcomes, spawned agents or token counts into the manifest by hand — self-reported numbers were measured 31.5x low, which is why the record is taken from transcripts instead.
   - `cycle-report [N]` — average cost per cycle step (with its work/no-op split) and per nested agent role, across the last N completed cycles
 - `./scripts/pipeline-helper.sh lease-{acquire,release,status,list,gc}` — distributed-lease primitive (multi-host coordination, §4.-1). `lease-acquire <key> [ttl]` prints `ACQUIRED`/`RECLAIMED` (rc0), `HELD` (rc1), or `ACQUIRE_ERROR` (rc2). Used directly only for the inline-op leases below; container-op leases are managed by the dispatch helpers.
 - `./.claude/scripts/po-cycle-preflight.py` — the underlying preflight (called by `po-act.sh preflight`). Accepts `--stdout` for raw JSON or `--path` for the cache path.
@@ -330,7 +330,9 @@ separate call needed.
 Open this cycle's step manifest first (Issue #3053) — every `po-act.sh`
 subcommand from here through Step 11's `cycle-end` auto-records itself into
 it, so cost becomes attributable per step instead of only to the cycle as a
-whole. Pass `cron` for `/po cron`, `cycle` for `/po cycle`:
+whole. Pass `cron` for `/po cron`, `cycle` for `/po cycle`, `pipeline` for
+`/pipeline` (the dedicated cron-cycle entry point, same cycle as `/po cron`
+with its own segment for cost reporting):
 
 ```bash
 ./.claude/scripts/po-act.sh cycle-start cron

--- a/.claude/commands/pipeline.md
+++ b/.claude/commands/pipeline.md
@@ -1,0 +1,27 @@
+---
+name: pipeline
+description: Autonomous pipeline cycle — dedicated entry point for the recurring, clean-context PO cycle (equivalent to `/po cron`, given its own command for clean cost/usage attribution)
+---
+
+# Pipeline Command
+
+Runs one full autonomous Pipeline Cycle (`.claude/agents/po.md` §4) as a clean-context subagent — dispatch, review, fix, forward edge, no founder dialogue required. This is the dedicated entry point for the recurring cron/loop invocation (e.g. `/loop 20m /pipeline`); it does exactly what `/po cron` (Path B in `.claude/commands/po.md`) does, given its own top-level command so usage/cost reporting can attribute it to `/pipeline` instead of folding it into general `/po` traffic.
+
+`/po cron` still works unchanged for any existing automation that invokes it that way — this command doesn't replace it, it gives the same cycle a dedicated front door.
+
+## Execution
+
+Spawn a **`po` subagent** to run the full Pipeline Cycle (§4, **skip Step 7 — Planning Team**), same as `/po cron` Path B. Fresh context every invocation — the cycle is stateless, re-derived from GitHub each run. The subagent is on the same host, so it has full Docker access for dispatch/review/fix containers.
+
+```
+Agent tool:
+  subagent_type: po
+  prompt: "Run a full pipeline cycle per §4 of your agent definition (.claude/agents/po.md) — pipeline mode (pass `pipeline` to `cycle-start`, not `cron`), SKIP Step 7 (Planning Team). Execute every step that has work. Two subagent-context adaptations: (1) you have NO `Skill` tool — invoke the pin-refresh (§4.1 Step 1.6) and pipeline-sweep (§7.5) skills by spawning a `general-purpose` Agent that reads and runs the skill's SKILL.md inline; (2) spawn every nested `Agent` (the pin-refresh runner, the pipeline-sweep runner, and the Tech Lead in §2) SYNCHRONOUSLY with `run_in_background: false` — a foreground spawn blocks and returns its result on the same turn, so consume it inline and move on. Do NOT set `run_in_background: true` and do NOT end your turn expecting the harness to re-invoke you on the child's completion: a backgrounded `po` subagent parent is NOT re-invoked, so the cycle stalls. Hold any inline-op lease across a spawn and release it once the result returns on that same turn. Use the distributed leases (§4.-1) as normal. Report the standard cycle summary."
+  mode: auto
+```
+
+Then relay the subagent's cycle summary to the founder. If the subagent reports a blocker only the main session can resolve (e.g. an epic that needs the Planning Team), surface it as a `/po cycle` / `/po decompose <#>` recommendation.
+
+## Why a separate command
+
+Cost/usage reporting (`token_report.py`) attributes a session to a segment keyed off the first slash command it ran. Routing the autonomous loop through `/po cron` made it indistinguishable from any other `/po` usage in that reporting — a `/loop 20m /po cron` session and a founder's interactive `/po status` session both landed in the same `/po` bucket. `/pipeline` gives the recurring cycle its own segment so cost/usage for "the autonomous loop" can be read directly, without reconstructing it from cycle manifests after the fact.

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -54,6 +54,8 @@ Agent tool:
 
 Then relay the subagent's cycle summary to the founder. If the subagent reports a blocker only the main session can resolve (e.g. an epic that needs the Planning Team), surface it as a `/po cycle` / `/po decompose <#>` recommendation.
 
+**For the recurring cron/loop invocation (e.g. `/loop 20m /po cron`), prefer `.claude/commands/pipeline.md` instead.** It runs the identical cycle but as its own top-level command, so usage/cost reporting attributes it to a dedicated `/pipeline` segment instead of folding it into general `/po` traffic. `/po cron` still works unchanged for existing automation.
+
 ### Path C — lightweight conversation (spawn the PO subagent)
 
 For `status` (default), `intent <topic>`, `next`, `unblock #NNN`, or any natural-language pipeline query, spawn the PO agent so it stays in role for the rest of the session:


### PR DESCRIPTION
## Summary
- New `.claude/commands/pipeline.md` — runs the identical Pipeline Cycle as `/po cron` (Path B), given its own top-level command name.
- `.claude/agents/po.md` §4.0 now accepts `pipeline` as a third `cycle-start` mode value alongside the existing `cron`/`cycle`, and its Pre-Flight instruction spells out passing it for `/pipeline` invocations.
- `.claude/commands/po.md` gets a one-line pointer from Path B to `/pipeline` for the recurring loop use case.

## Why
Usage/cost reporting (`token_report.py`) attributes a session's `segment` off the first slash command it ran. Because the recurring autonomous loop went through `/po cron`, it was indistinguishable in that reporting from any interactive `/po` usage — both landed in one `/po` bucket, and separating them required manually reconstructing cycle boundaries from `po-act.sh`'s cycle manifests after the fact (done during a cost-optimization pass this week). `/pipeline` gives the loop its own segment going forward.

## Scope
Deliberately command-surface-only, confirmed with the founder before starting given a standing cron process is live on this host right now:
- `po-act.sh`'s cycle-manifest format, lease keys (`pr-<N>`), and existing tests are untouched.
- `cycle-start`'s `mode` argument was already a free-form label defaulting to `cron` (not used to build lease keys) — adding `pipeline` as a third accepted value is purely additive, affecting only what gets written into *new* manifests.
- `/po cron` keeps working exactly as before for any existing automation invoking it that way; this is a new front door, not a replacement.

## Test plan
- [ ] `/pipeline` (no args) spawns a `po` subagent that runs a full cycle identically to `/po cron` today
- [ ] A cycle run via `/pipeline` writes `"mode": "pipeline"` into its cycle manifest under `~/.cache/cfgms-po/cycles/`
- [ ] `/po cron` still behaves unchanged
- [ ] Existing `lease.test.sh` / `cycle_manifest.test.sh` still pass unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j6h4qSsAWzYNDmKoXFYL9