### PR TITLE
metrics: add unified SQLite usage store covering local + container sessions

### DIFF
--- a/.claude/metrics/tests/test_usage_db.py
+++ b/.claude/metrics/tests/test_usage_db.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Tests for the unified SQLite usage store (usage_db.py).
+
+Run: python3 -m unittest discover -s .claude/metrics/tests -t .
+
+Covers: schema creation, idempotent re-ingest (no duplicate rows on repeat
+runs), incremental skip of unchanged files, dev-agent container tagging and
+bucket mapping, cycle-manifest ingestion, and the group-by report query.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from token_report import Pricing  # noqa: E402
+from test_token_report import assistant_row, usage  # noqa: E402
+
+import usage_db as udb  # noqa: E402
+
+PRICING = Pricing.load()
+
+
+def local_session(root: Path, project: str, session_id: str, command: str | None = None, n_calls: int = 1) -> Path:
+    """Write a minimal local-session transcript under <root>/<project>/<session_id>.jsonl."""
+    project_dir = root / project
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    lines = []
+    if command:
+        lines.append(json.dumps({
+            "type": "user", "gitBranch": "develop", "cwd": "/x",
+            "message": {"content": f"<command-name>{command}</command-name>"},
+        }))
+    for i in range(n_calls):
+        lines.append(assistant_row(f"req_{session_id}_{i}", usage=usage(inp=100, out=50)))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def container(
+    sessions_base: Path, name: str, mode: str, issue=None, pr=None, branch="",
+    started_at="2026-07-28T10:00:00Z", write_transcript: bool = True,
+) -> Path:
+    container_dir = sessions_base / name
+    container_dir.mkdir(parents=True)
+    meta = {"container": name, "mode": mode, "issue": issue, "pr": pr, "branch": branch, "started_at": started_at}
+    (container_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    (container_dir / "agent-result.json").write_text(
+        json.dumps({"mode": mode, "usage": {"cost_usd": 99999.0}}), encoding="utf-8"
+    )
+    if write_transcript:
+        workspace = container_dir / "-workspace"
+        workspace.mkdir()
+        (workspace / "sess.jsonl").write_text(
+            assistant_row(f"req_{name}", usage=usage(inp=1000, out=1000)) + "\n", encoding="utf-8"
+        )
+    return container_dir
+
+
+class TestSchema(unittest.TestCase):
+    def test_open_db_creates_all_tables(self):
+        db_path = Path(tempfile.mkdtemp()) / "usage.db"
+        conn = udb.open_db(db_path)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        for expected in ("calls", "containers", "cycles", "cycle_steps", "cycle_containers", "ingested_files"):
+            self.assertIn(expected, tables)
+        conn.close()
+
+
+class TestIngestLocal(unittest.TestCase):
+    def test_local_session_populates_calls_with_segment(self):
+        root = Path(tempfile.mkdtemp())
+        local_session(root, "proj", "sess1", command="/po", n_calls=2)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        stats = udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        self.assertEqual(stats["local_calls"], 2)
+        rows = conn.execute("SELECT segment, source, container FROM calls").fetchall()
+        self.assertEqual(len(rows), 2)
+        for segment, source, container_name in rows:
+            self.assertEqual(segment, "/po")
+            self.assertEqual(source, "local")
+            self.assertIsNone(container_name)
+
+    def test_reingest_is_idempotent_no_duplicate_rows(self):
+        root = Path(tempfile.mkdtemp())
+        local_session(root, "proj", "sess1", command="/po", n_calls=3)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=True)
+        count = conn.execute("SELECT COUNT(*) FROM calls").fetchone()[0]
+        self.assertEqual(count, 3)
+
+    def test_unchanged_file_is_skipped_on_second_ingest(self):
+        root = Path(tempfile.mkdtemp())
+        local_session(root, "proj", "sess1", command="/po", n_calls=1)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        stats = udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        self.assertGreaterEqual(stats["files_skipped"], 1)
+        self.assertEqual(stats["local_calls"], 0)
+
+    def test_force_reparses_even_when_unchanged(self):
+        root = Path(tempfile.mkdtemp())
+        local_session(root, "proj", "sess1", command="/po", n_calls=1)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        stats = udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=True)
+        self.assertEqual(stats["local_calls"], 1)
+        self.assertEqual(stats["files_skipped"], 0)
+
+    def test_modified_file_is_reparsed_and_new_calls_added(self):
+        root = Path(tempfile.mkdtemp())
+        path = local_session(root, "proj", "sess1", command="/po", n_calls=1)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        # Append a second call -- mtime/size change, so it must be re-parsed.
+        with path.open("a", encoding="utf-8") as f:
+            f.write(assistant_row("req_sess1_extra", usage=usage(inp=10, out=10)) + "\n")
+        stats = udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        self.assertEqual(stats["local_calls"], 2)  # whole file re-parsed: original + new
+        count = conn.execute("SELECT COUNT(*) FROM calls").fetchone()[0]
+        self.assertEqual(count, 2)  # but no duplicate of the original request_id
+
+
+class TestIngestContainers(unittest.TestCase):
+    def test_container_calls_tagged_and_bucketed(self):
+        sessions = Path(tempfile.mkdtemp())
+        container(sessions, "cfg-agent-42", "issue", issue=42)
+        container(sessions, "cfg-agent-pr-fix-42", "fix-pr", issue=42, pr=100)
+        container(sessions, "cfg-agent-review-pr-42", "review", issue=42, pr=100)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        stats = udb.ingest_local_and_containers(conn, PRICING, [], sessions, force=False)
+        self.assertEqual(stats["containers"], 3)
+        self.assertEqual(stats["container_calls"], 3)
+
+        rows = {r[0]: r for r in conn.execute(
+            "SELECT name, bucket, issue, pr, has_transcript, cost_usd FROM containers"
+        ).fetchall()}
+        self.assertEqual(rows["cfg-agent-42"][1], "dev")
+        self.assertEqual(rows["cfg-agent-pr-fix-42"][1], "fix")
+        self.assertEqual(rows["cfg-agent-review-pr-42"][1], "review")
+        for name in rows:
+            self.assertEqual(rows[name][2], 42)
+            self.assertGreater(rows[name][5], 0)  # cost measured from transcript
+
+        call_containers = {r[0] for r in conn.execute("SELECT DISTINCT container FROM calls")}
+        self.assertEqual(call_containers, {"cfg-agent-42", "cfg-agent-pr-fix-42", "cfg-agent-review-pr-42"})
+
+    def test_reingest_does_not_multiply_cost_for_container_with_multiple_files(self):
+        # Regression: the rollup used to be accumulated inside the per-file
+        # loop, re-adding the container's ALREADY-STORED total once per
+        # unchanged (skipped) file on the second run -- a container with N
+        # transcript files multiplied its own correct total by N.
+        sessions = Path(tempfile.mkdtemp())
+        container_dir = sessions / "cfg-agent-multi"
+        container_dir.mkdir(parents=True)
+        meta = {"container": "cfg-agent-multi", "mode": "issue", "issue": 99, "pr": None, "branch": "", "started_at": "2026-07-28T10:00:00Z"}
+        (container_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+        (container_dir / "agent-result.json").write_text(json.dumps({"mode": "issue"}), encoding="utf-8")
+        workspace = container_dir / "-workspace"
+        workspace.mkdir()
+        # Two separate top-level session files under the same container --
+        # simulating a main transcript plus a nested/subagent transcript.
+        (workspace / "sess-a.jsonl").write_text(
+            assistant_row("req_multi_a", usage=usage(inp=1000, out=1000)) + "\n", encoding="utf-8"
+        )
+        (workspace / "sess-b.jsonl").write_text(
+            assistant_row("req_multi_b", usage=usage(inp=1000, out=1000)) + "\n", encoding="utf-8"
+        )
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [], sessions, force=False)
+        first_cost = conn.execute(
+            "SELECT cost_usd FROM containers WHERE name = 'cfg-agent-multi'"
+        ).fetchone()[0]
+        self.assertGreater(first_cost, 0)
+
+        # Second run: both files unchanged -- both get skipped.
+        stats = udb.ingest_local_and_containers(conn, PRICING, [], sessions, force=False)
+        self.assertEqual(stats["files_skipped"], 2)
+        second_cost = conn.execute(
+            "SELECT cost_usd FROM containers WHERE name = 'cfg-agent-multi'"
+        ).fetchone()[0]
+        self.assertAlmostEqual(second_cost, first_cost, places=6)
+
+    def test_cost_measured_from_transcript_not_trusted_from_agent_result(self):
+        sessions = Path(tempfile.mkdtemp())
+        container(sessions, "cfg-agent-7", "issue", issue=7)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [], sessions, force=False)
+        cost = conn.execute("SELECT cost_usd FROM containers WHERE name = 'cfg-agent-7'").fetchone()[0]
+        # agent-result.json claimed 99999.0; the real fixture usage is tiny.
+        self.assertLess(cost, 100.0)
+
+    def test_container_with_no_transcript_flagged(self):
+        sessions = Path(tempfile.mkdtemp())
+        container(sessions, "cfg-agent-11", "issue", issue=11, write_transcript=False)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [], sessions, force=False)
+        row = conn.execute(
+            "SELECT has_transcript, cost_usd FROM containers WHERE name = 'cfg-agent-11'"
+        ).fetchone()
+        self.assertEqual(row[0], 0)
+        self.assertEqual(row[1], 0)
+
+    def test_story_resolved_from_branch_when_issue_field_absent(self):
+        sessions = Path(tempfile.mkdtemp())
+        container(sessions, "cfg-agent-branch-x", "branch", issue=None, branch="feature/story-88-x")
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [], sessions, force=False)
+        issue = conn.execute("SELECT issue FROM containers WHERE name = 'cfg-agent-branch-x'").fetchone()[0]
+        self.assertEqual(issue, 88)
+
+
+class TestIngestCycles(unittest.TestCase):
+    def _write_manifest(self, cycles_dir: Path, cycle_id: str, mode: str = "cron") -> Path:
+        cycles_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "cycle_id": cycle_id, "mode": mode, "session": "sess-abc", "host": "pop-os",
+            "start": "2026-07-30T15:01:28Z", "end": "2026-07-30T15:14:54Z",
+            "steps": [
+                {"ts": "2026-07-30T15:01:31Z", "subcommand": "sync", "args": "", "outcome": "work",
+                 "exit_code": 0, "result": "SYNC_OK", "cost_usd": 0.08, "total_tokens": 300000, "calls": 3},
+                {"ts": "2026-07-30T15:04:55Z", "subcommand": "dispatch", "args": "", "outcome": "work",
+                 "exit_code": 0, "result": None, "cost_usd": 1.05, "total_tokens": 2800000, "calls": 40},
+            ],
+            "leases": [],
+            "containers": [
+                {"event": "launch", "ts": "2026-07-30T15:04:23Z", "container": "cfg-agent-review-pr-3146",
+                 "mode": "review", "issue": 3143, "pr": 3146, "branch": "feature/story-3143-agent",
+                 "model": "sonnet", "lease_key": "pr-3146"},
+            ],
+        }
+        path = cycles_dir / f"{cycle_id}.json"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        return path
+
+    def test_cycle_steps_and_containers_ingested(self):
+        cycles_dir = Path(tempfile.mkdtemp()) / "cycles"
+        self._write_manifest(cycles_dir, "cycle-20260730T150128Z-1")
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        n = udb.ingest_cycles(conn, cycles_dir, force=False)
+        self.assertEqual(n, 1)
+
+        cycle = conn.execute(
+            "SELECT mode, session, host FROM cycles WHERE cycle_id = ?", ("cycle-20260730T150128Z-1",)
+        ).fetchone()
+        self.assertEqual(cycle, ("cron", "sess-abc", "pop-os"))
+
+        steps = conn.execute(
+            "SELECT subcommand, cost_usd FROM cycle_steps WHERE cycle_id = ? ORDER BY step_index",
+            ("cycle-20260730T150128Z-1",),
+        ).fetchall()
+        self.assertEqual([s[0] for s in steps], ["sync", "dispatch"])
+
+        containers = conn.execute(
+            "SELECT container, issue, pr FROM cycle_containers WHERE cycle_id = ?",
+            ("cycle-20260730T150128Z-1",),
+        ).fetchall()
+        self.assertEqual(containers, [("cfg-agent-review-pr-3146", 3143, 3146)])
+
+    def test_reingest_cycle_does_not_duplicate_steps(self):
+        cycles_dir = Path(tempfile.mkdtemp()) / "cycles"
+        self._write_manifest(cycles_dir, "cycle-x")
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_cycles(conn, cycles_dir, force=False)
+        udb.ingest_cycles(conn, cycles_dir, force=True)
+        count = conn.execute("SELECT COUNT(*) FROM cycle_steps WHERE cycle_id = 'cycle-x'").fetchone()[0]
+        self.assertEqual(count, 2)
+
+
+class TestReportGroupBy(unittest.TestCase):
+    def test_group_by_segment_sums_correctly(self):
+        root = Path(tempfile.mkdtemp())
+        local_session(root, "proj", "sess1", command="/po", n_calls=2)
+        local_session(root, "proj", "sess2", command="/pipeline", n_calls=1)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [root], Path("/nonexistent"), force=False)
+        rows = udb.query_group_by(conn, "segment")
+        by_key = {r[0]: r for r in rows}
+        self.assertEqual(by_key["/po"][1], 2)  # calls
+        self.assertEqual(by_key["/pipeline"][1], 1)
+
+    def test_group_by_container_isolates_dev_agent_cost(self):
+        sessions = Path(tempfile.mkdtemp())
+        container(sessions, "cfg-agent-1", "issue", issue=1)
+        container(sessions, "cfg-agent-2", "issue", issue=2)
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        udb.ingest_local_and_containers(conn, PRICING, [], sessions, force=False)
+        rows = udb.query_group_by(conn, "container")
+        keys = {r[0] for r in rows}
+        self.assertEqual(keys, {"cfg-agent-1", "cfg-agent-2"})
+
+    def test_unknown_group_by_key_raises(self):
+        conn = udb.open_db(Path(tempfile.mkdtemp()) / "usage.db")
+        with self.assertRaises(ValueError):
+            udb.query_group_by(conn, "not-a-real-key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/metrics/usage_db.py
+++ b/.claude/metrics/usage_db.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Unified SQLite store for Claude Code usage: local sessions, dev-agent
+containers, and po-act.sh cycle manifests, correlated for drill-down reporting.
+
+Three sources, three shapes, one problem: answering "what did the pipeline
+actually cost, and why" today means re-scanning the whole transcript corpus
+with token_report.py for local/po-live sessions, separately re-scanning
+~/.cache/cfgms-agent-sessions for dev/fix/review containers (--story-report),
+and by hand reading ~/.cache/cfgms-po/cycles/*.json to see which cycle
+dispatched which container. None of the three join to each other without
+a person doing it manually (see Issue discussion: a cost-optimization pass
+needed three separate ad hoc scripts to reconstruct one day's picture).
+
+This module ingests all three into one SQLite database, keyed so re-running
+ingest is idempotent (INSERT OR REPLACE on each source's natural key), and
+skips re-parsing a transcript file whose mtime/size haven't changed since the
+last ingest -- the corpus is 2500+ transcripts and growing; re-reading all of
+them on every report call is the exact cost this tool removes.
+
+Reuses token_report.py's own accounting (Pricing, parse_transcript, collect)
+rather than re-deriving token math -- the pricing and cache-TTL rules live in
+exactly one place.
+
+Usage:
+    usage_db.py ingest [--db PATH] [--full]
+    usage_db.py report --group-by segment [--since 3] [--top 20]
+    usage_db.py report --session <session-id>          # drill into one session
+    usage_db.py report --story <issue-num>              # dev/fix/review for one story
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import token_report as tr  # noqa: E402
+
+DEFAULT_DB = Path.home() / ".cache" / "cfgms-usage" / "usage.db"
+DEFAULT_CYCLES_DIR = Path.home() / ".cache" / "cfgms-po" / "cycles"
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS calls (
+    request_id      TEXT PRIMARY KEY,
+    source          TEXT NOT NULL,      -- 'local' | 'container'
+    container       TEXT,               -- container dir name, NULL for local
+    project         TEXT NOT NULL,
+    session         TEXT NOT NULL,
+    transcript      TEXT NOT NULL,
+    segment         TEXT NOT NULL,
+    timestamp       TEXT,
+    model           TEXT,
+    effort          TEXT,
+    skill           TEXT,
+    agent_kind      TEXT,
+    role            TEXT,
+    workflow        TEXT,
+    git_branch      TEXT,
+    input_tokens    INTEGER NOT NULL DEFAULT 0,
+    cache_write_5m  INTEGER NOT NULL DEFAULT 0,
+    cache_write_1h  INTEGER NOT NULL DEFAULT 0,
+    cache_read      INTEGER NOT NULL DEFAULT 0,
+    output_tokens   INTEGER NOT NULL DEFAULT 0,
+    speed           TEXT,
+    cost_usd        REAL
+);
+CREATE INDEX IF NOT EXISTS idx_calls_session ON calls(session);
+CREATE INDEX IF NOT EXISTS idx_calls_segment ON calls(segment);
+CREATE INDEX IF NOT EXISTS idx_calls_timestamp ON calls(timestamp);
+CREATE INDEX IF NOT EXISTS idx_calls_container ON calls(container);
+
+CREATE TABLE IF NOT EXISTS containers (
+    name            TEXT PRIMARY KEY,   -- e.g. cfg-agent-review-pr-3146
+    raw_mode        TEXT,               -- issue|branch|fix-pr|resolve-conflict|review
+    bucket          TEXT,               -- dev|fix|review (token_report._MODE_BUCKET)
+    issue           INTEGER,
+    pr              INTEGER,
+    branch          TEXT,
+    started_at      TEXT,
+    exit_code       INTEGER,
+    has_transcript  INTEGER NOT NULL DEFAULT 0,
+    cost_usd        REAL NOT NULL DEFAULT 0,
+    total_tokens    INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_containers_issue ON containers(issue);
+CREATE INDEX IF NOT EXISTS idx_containers_pr ON containers(pr);
+
+CREATE TABLE IF NOT EXISTS cycles (
+    cycle_id        TEXT PRIMARY KEY,
+    mode            TEXT,
+    session         TEXT,
+    host            TEXT,
+    start           TEXT,
+    end             TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_cycles_session ON cycles(session);
+
+CREATE TABLE IF NOT EXISTS cycle_steps (
+    cycle_id        TEXT NOT NULL REFERENCES cycles(cycle_id),
+    step_index      INTEGER NOT NULL,
+    ts              TEXT,
+    subcommand      TEXT,
+    args            TEXT,
+    outcome         TEXT,
+    exit_code       INTEGER,
+    result          TEXT,
+    cost_usd        REAL,
+    total_tokens    INTEGER,
+    calls           INTEGER,
+    PRIMARY KEY (cycle_id, step_index)
+);
+
+CREATE TABLE IF NOT EXISTS cycle_containers (
+    cycle_id        TEXT NOT NULL REFERENCES cycles(cycle_id),
+    seq             INTEGER NOT NULL,
+    event           TEXT,
+    ts              TEXT,
+    container       TEXT,
+    mode            TEXT,
+    issue           INTEGER,
+    pr              INTEGER,
+    branch          TEXT,
+    model           TEXT,
+    lease_key       TEXT,
+    PRIMARY KEY (cycle_id, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_cycle_containers_container ON cycle_containers(container);
+
+-- Incremental-ingest bookkeeping: skip re-parsing a transcript file whose
+-- mtime/size are unchanged since the last ingest run.
+CREATE TABLE IF NOT EXISTS ingested_files (
+    path            TEXT PRIMARY KEY,
+    mtime           REAL NOT NULL,
+    size            INTEGER NOT NULL,
+    rows            INTEGER NOT NULL
+);
+"""
+
+
+def open_db(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA)
+    return conn
+
+
+def _call_row(call: tr.Call, segment: str, source: str, container: str | None) -> tuple:
+    return (
+        call.request_id,
+        source,
+        container,
+        call.project,
+        call.session,
+        call.transcript,
+        segment,
+        call.timestamp.isoformat() if call.timestamp else None,
+        call.model,
+        call.effort,
+        call.skill,
+        call.agent_kind,
+        call.role,
+        call.workflow,
+        call.git_branch,
+        call.input_tokens,
+        call.cache_write_5m,
+        call.cache_write_1h,
+        call.cache_read,
+        call.output_tokens,
+        call.speed,
+        call.cost_usd,
+    )
+
+
+_INSERT_CALL = """
+INSERT OR REPLACE INTO calls (
+    request_id, source, container, project, session, transcript, segment,
+    timestamp, model, effort, skill, agent_kind, role, workflow, git_branch,
+    input_tokens, cache_write_5m, cache_write_1h, cache_read, output_tokens,
+    speed, cost_usd
+) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+"""
+
+
+def _file_unchanged(conn: sqlite3.Connection, path: Path, force: bool) -> bool:
+    if force:
+        return False
+    row = conn.execute(
+        "SELECT mtime, size FROM ingested_files WHERE path = ?", (str(path),)
+    ).fetchone()
+    if row is None:
+        return False
+    st = path.stat()
+    return row[0] == st.st_mtime and row[1] == st.st_size
+
+
+def _mark_ingested(conn: sqlite3.Connection, path: Path, rows: int) -> None:
+    st = path.stat()
+    conn.execute(
+        "INSERT OR REPLACE INTO ingested_files (path, mtime, size, rows) VALUES (?,?,?,?)",
+        (str(path), st.st_mtime, st.st_size, rows),
+    )
+
+
+def ingest_local_and_containers(
+    conn: sqlite3.Connection,
+    pricing: "tr.Pricing",
+    projects_roots: list[Path],
+    sessions_dir: Path,
+    force: bool,
+) -> dict[str, int]:
+    """Local/po-live sessions (segment-attributed like token_report) plus
+    dev-agent containers (each its own root, tagged with its container name --
+    the same discovery pattern story_cost_report already uses for cost, here
+    extended to persist every call, not just a per-story sum).
+    """
+    stats = {"local_calls": 0, "container_calls": 0, "files_skipped": 0, "containers": 0}
+
+    # -- Local + po-live sessions --------------------------------------
+    for root in projects_roots:
+        if not root.is_dir():
+            continue
+        for project_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+            project = project_dir.name
+            refs = [
+                tr.TranscriptRef.classify(path, project_dir, project)
+                for path in sorted(project_dir.rglob("*.jsonl"))
+            ]
+            refs.sort(key=lambda ref: ref.is_nested)
+            segment_by_session: dict[str, str] = {}
+            for ref in refs:
+                if _file_unchanged(conn, ref.path, force):
+                    stats["files_skipped"] += 1
+                    # A skipped nested file still needs its owning session's
+                    # segment on hand for any later ref in the same session
+                    # (rare: nested changed but parent didn't) -- best-effort
+                    # only, drawn from what's already persisted.
+                    if not ref.is_nested:
+                        existing = conn.execute(
+                            "SELECT segment FROM calls WHERE session = ? LIMIT 1",
+                            (ref.session,),
+                        ).fetchone()
+                        if existing:
+                            segment_by_session[ref.session] = existing[0]
+                    continue
+                calls, meta = tr.parse_transcript(ref, pricing, tr.ParseStats())
+                if ref.is_nested:
+                    segment = segment_by_session.get(ref.session) or meta.segment()
+                else:
+                    segment = meta.segment()
+                    segment_by_session[ref.session] = segment
+                for call in calls:
+                    if call.request_id is None:
+                        continue
+                    conn.execute(_INSERT_CALL, _call_row(call, segment, "local", None))
+                    stats["local_calls"] += 1
+                _mark_ingested(conn, ref.path, len(calls))
+
+    # -- Dev-agent containers ------------------------------------------
+    if sessions_dir.is_dir():
+        for container_dir in sorted(p for p in sessions_dir.iterdir() if p.is_dir()):
+            meta_path = container_dir / "meta.json"
+            if not meta_path.is_file():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            result: dict[str, Any] = {}
+            result_path = container_dir / "agent-result.json"
+            if result_path.is_file():
+                try:
+                    result = json.loads(result_path.read_text())
+                except (OSError, json.JSONDecodeError):
+                    result = {}
+
+            raw_mode = meta.get("mode") or result.get("mode")
+            branch = meta.get("branch") or result.get("branch") or ""
+            issue = meta.get("issue") or result.get("issue")
+            if not issue:
+                match = tr._STORY_BRANCH_RE.search(branch)
+                if match:
+                    issue = int(match.group(1))
+            pr = meta.get("pr") or result.get("pr_num")
+            container = container_dir.name
+            stats["containers"] += 1
+
+            for project_dir in sorted(p for p in container_dir.iterdir() if p.is_dir()):
+                project = project_dir.name
+                refs = [
+                    tr.TranscriptRef.classify(path, project_dir, project)
+                    for path in sorted(project_dir.rglob("*.jsonl"))
+                ]
+                refs.sort(key=lambda ref: ref.is_nested)
+                segment_by_session = {}
+                for ref in refs:
+                    if _file_unchanged(conn, ref.path, force):
+                        stats["files_skipped"] += 1
+                        continue
+                    calls, meta_sess = tr.parse_transcript(ref, pricing, tr.ParseStats())
+                    if ref.is_nested:
+                        segment = segment_by_session.get(ref.session) or meta_sess.segment()
+                    else:
+                        segment = meta_sess.segment()
+                        segment_by_session[ref.session] = segment
+                    for call in calls:
+                        if call.request_id is None:
+                            continue
+                        conn.execute(
+                            _INSERT_CALL, _call_row(call, segment, "container", container)
+                        )
+                        stats["container_calls"] += 1
+                    _mark_ingested(conn, ref.path, len(calls))
+
+            # Rollup is always computed fresh from the calls table itself --
+            # never accumulated file-by-file during the loop above, which
+            # double-counted an unchanged file's contribution once per
+            # skipped file (a container with many nested transcripts
+            # multiplied its own already-correct total by its file count).
+            rollup = conn.execute(
+                "SELECT COUNT(*), SUM(cost_usd), "
+                "SUM(input_tokens+cache_write_5m+cache_write_1h+cache_read+output_tokens) "
+                "FROM calls WHERE container = ?",
+                (container,),
+            ).fetchone()
+            has_transcript = bool(rollup and rollup[0])
+            container_cost = (rollup[1] or 0.0) if rollup else 0.0
+            container_tokens = (rollup[2] or 0) if rollup else 0
+
+            bucket = tr._MODE_BUCKET.get(raw_mode, "fix")
+            conn.execute(
+                """INSERT OR REPLACE INTO containers
+                   (name, raw_mode, bucket, issue, pr, branch, started_at,
+                    exit_code, has_transcript, cost_usd, total_tokens)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    container,
+                    raw_mode,
+                    bucket,
+                    issue,
+                    pr,
+                    branch or None,
+                    meta.get("started_at"),
+                    result.get("exit_code"),
+                    1 if has_transcript else 0,
+                    round(container_cost, 4),
+                    container_tokens,
+                ),
+            )
+
+    conn.commit()
+    return stats
+
+
+def ingest_cycles(conn: sqlite3.Connection, cycles_dir: Path, force: bool) -> int:
+    """po-act.sh cycle manifests -- cycles / cycle_steps / cycle_containers.
+
+    Manifests are small (one per ~20min cycle); re-read on every ingest
+    unless unchanged, same mtime/size skip as transcripts.
+    """
+    if not cycles_dir.is_dir():
+        return 0
+    count = 0
+    for path in sorted(cycles_dir.glob("cycle-*.json")):
+        if _file_unchanged(conn, path, force):
+            continue
+        try:
+            manifest = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        cycle_id = manifest.get("cycle_id") or path.stem
+        conn.execute(
+            """INSERT OR REPLACE INTO cycles (cycle_id, mode, session, host, start, end)
+               VALUES (?,?,?,?,?,?)""",
+            (
+                cycle_id,
+                manifest.get("mode"),
+                manifest.get("session"),
+                manifest.get("host"),
+                manifest.get("start"),
+                manifest.get("end"),
+            ),
+        )
+        conn.execute("DELETE FROM cycle_steps WHERE cycle_id = ?", (cycle_id,))
+        for i, step in enumerate(manifest.get("steps") or []):
+            conn.execute(
+                """INSERT INTO cycle_steps
+                   (cycle_id, step_index, ts, subcommand, args, outcome, exit_code,
+                    result, cost_usd, total_tokens, calls)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    cycle_id, i, step.get("ts"), step.get("subcommand"), step.get("args"),
+                    step.get("outcome"), step.get("exit_code"), step.get("result"),
+                    step.get("cost_usd"), step.get("total_tokens"), step.get("calls"),
+                ),
+            )
+        conn.execute("DELETE FROM cycle_containers WHERE cycle_id = ?", (cycle_id,))
+        for i, c in enumerate(manifest.get("containers") or []):
+            conn.execute(
+                """INSERT INTO cycle_containers
+                   (cycle_id, seq, event, ts, container, mode, issue, pr, branch,
+                    model, lease_key)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    cycle_id, i, c.get("event"), c.get("ts"), c.get("container"),
+                    c.get("mode"), c.get("issue"), c.get("pr"), c.get("branch"),
+                    c.get("model"), c.get("lease_key"),
+                ),
+            )
+        _mark_ingested(conn, path, len(manifest.get("steps") or []))
+        count += 1
+    conn.commit()
+    return count
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+_REPORT_GROUP_KEYS = tr.GROUP_KEYS + ("container", "source")
+
+
+def query_group_by(
+    conn: sqlite3.Connection, key: str, since_days: float | None = None
+) -> list[tuple[str, int, float, int]]:
+    """Return (label, calls, cost_usd, tokens) rows, most expensive first."""
+    if key not in _REPORT_GROUP_KEYS:
+        raise ValueError(f"unknown --group-by: {key} (choices: {', '.join(_REPORT_GROUP_KEYS)})")
+    col = {"day": "substr(timestamp, 1, 10)", "agent": "agent_kind"}.get(key, key)
+    where = ""
+    params: list[Any] = []
+    if since_days is not None:
+        where = "WHERE timestamp >= datetime('now', ?)"
+        params.append(f"-{since_days} days")
+    query = f"""
+        SELECT COALESCE({col}, '(none)') AS k,
+               COUNT(*) AS calls,
+               SUM(cost_usd) AS cost,
+               SUM(input_tokens+cache_write_5m+cache_write_1h+cache_read+output_tokens) AS tokens
+        FROM calls
+        {where}
+        GROUP BY k
+        ORDER BY cost DESC
+    """
+    return conn.execute(query, params).fetchall()
+
+
+def report_group_by(conn: sqlite3.Connection, key: str, since_days: float | None, top: int) -> None:
+    rows = query_group_by(conn, key, since_days)
+    total_cost = sum(r[2] or 0 for r in rows)
+    shown = rows[:top] if top else rows
+    width = max([len(str(r[0])) for r in shown] + [len(key)]) if shown else len(key)
+    print(f"{key:<{width}}  {'calls':>7}  {'tokens':>10}  {'cost $':>10}  {'%':>6}")
+    print("-" * (width + 40))
+    for k, calls, cost, tokens in shown:
+        cost = cost or 0.0
+        share = (cost / total_cost * 100) if total_cost else 0.0
+        print(f"{str(k):<{width}}  {calls:>7}  {tokens or 0:>10}  {cost:>10.2f}  {share:>5.1f}%")
+    print("-" * (width + 40))
+    print(f"{'TOTAL':<{width}}  {sum(r[1] for r in rows):>7}  "
+          f"{sum(r[3] or 0 for r in rows):>10}  {total_cost:>10.2f}")
+
+
+def report_session(conn: sqlite3.Connection, session: str) -> None:
+    """Drill into one session: its calls, its container (if any), its cycle (if any)."""
+    calls = conn.execute(
+        """SELECT source, container, segment, model, role, agent_kind, timestamp,
+                  cost_usd, input_tokens+cache_write_5m+cache_write_1h+cache_read+output_tokens
+           FROM calls WHERE session = ? ORDER BY timestamp""",
+        (session,),
+    ).fetchall()
+    if not calls:
+        print(f"No calls found for session {session}")
+        return
+    total_cost = sum(c[7] or 0 for c in calls)
+    total_tokens = sum(c[8] or 0 for c in calls)
+    print(f"Session {session}: {len(calls)} calls, {total_tokens} tokens, ${total_cost:.2f}")
+    print(f"  segment={calls[0][2]}  source={calls[0][0]}  container={calls[0][1]}")
+    print(f"  span: {calls[0][6]} -> {calls[-1][6]}")
+
+    container = conn.execute(
+        "SELECT name, raw_mode, bucket, issue, pr, branch, cost_usd FROM containers "
+        "WHERE name IN (SELECT DISTINCT container FROM calls WHERE session = ? AND container IS NOT NULL)",
+        (session,),
+    ).fetchall()
+    for name, raw_mode, bucket, issue, pr, branch, cost in container:
+        print(f"  container: {name} mode={raw_mode} ({bucket}) issue=#{issue} pr=#{pr} cost=${cost:.2f}")
+
+    cycles = conn.execute(
+        "SELECT cycle_id, mode, start, end FROM cycles WHERE session = ? ORDER BY start", (session,)
+    ).fetchall()
+    for cycle_id, mode, start, end in cycles:
+        steps = conn.execute(
+            "SELECT subcommand, outcome, cost_usd FROM cycle_steps WHERE cycle_id = ? ORDER BY step_index",
+            (cycle_id,),
+        ).fetchall()
+        print(f"  cycle {cycle_id} (mode={mode}, {start} -> {end}): {len(steps)} steps")
+        for sub, outcome, cost in steps:
+            print(f"      {sub:<20} {outcome:<10} ${cost or 0:.3f}")
+
+
+def report_story(conn: sqlite3.Connection, issue: int) -> None:
+    rows = conn.execute(
+        "SELECT name, raw_mode, bucket, pr, branch, cost_usd, total_tokens, has_transcript "
+        "FROM containers WHERE issue = ? ORDER BY started_at",
+        (issue,),
+    ).fetchall()
+    if not rows:
+        print(f"No containers found for story #{issue}")
+        return
+    buckets: dict[str, float] = {"dev": 0.0, "fix": 0.0, "review": 0.0}
+    for name, raw_mode, bucket, pr, branch, cost, tokens, has_t in rows:
+        buckets[bucket] = buckets.get(bucket, 0.0) + (cost or 0)
+        flag = "" if has_t else "  [PARTIAL: no transcript]"
+        print(f"  {name:<40} mode={raw_mode:<16} ${cost:>7.2f}{flag}")
+    total = sum(buckets.values())
+    print(f"\nStory #{issue}: dev=${buckets['dev']:.2f}  fix=${buckets['fix']:.2f}  "
+          f"review=${buckets['review']:.2f}  total=${total:.2f}")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    ing = sub.add_parser("ingest", help="Ingest local sessions, containers, and cycle manifests into SQLite")
+    ing.add_argument("--db", type=Path, default=DEFAULT_DB)
+    ing.add_argument("--projects-dir", action="append", type=Path, default=None)
+    ing.add_argument("--sessions-dir", type=Path, default=tr.DEFAULT_SESSIONS_DIR)
+    ing.add_argument("--cycles-dir", type=Path, default=DEFAULT_CYCLES_DIR)
+    ing.add_argument("--pricing", type=Path, default=tr.PRICING_PATH)
+    ing.add_argument("--full", action="store_true", help="Ignore mtime/size cache, re-parse everything")
+    ing.add_argument("--quiet", action="store_true")
+
+    rep = sub.add_parser("report", help="Query the ingested SQLite database")
+    rep.add_argument("--db", type=Path, default=DEFAULT_DB)
+    rep.add_argument("--group-by", choices=_REPORT_GROUP_KEYS)
+    rep.add_argument("--since", type=float, default=None, help="Only calls from the last N days")
+    rep.add_argument("--top", type=int, default=25)
+    rep.add_argument("--session", type=str, default=None, help="Drill into one session id")
+    rep.add_argument("--story", type=int, default=None, help="Dev/fix/review cost for one story issue number")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.cmd == "ingest":
+        pricing = tr.Pricing.load(args.pricing)
+        conn = open_db(args.db)
+        projects_roots = args.projects_dir or [tr.DEFAULT_PROJECTS_DIR]
+        stats = ingest_local_and_containers(conn, pricing, projects_roots, args.sessions_dir, args.full)
+        n_cycles = ingest_cycles(conn, args.cycles_dir, args.full)
+        if not args.quiet:
+            print(
+                f"Ingested {stats['local_calls']} local calls, {stats['container_calls']} "
+                f"container calls ({stats['containers']} containers), {n_cycles} cycle manifests "
+                f"({stats['files_skipped']} files unchanged, skipped) -> {args.db}",
+                file=sys.stderr,
+            )
+        conn.close()
+        return 0
+
+    if args.cmd == "report":
+        conn = open_db(args.db)
+        if args.session:
+            report_session(conn, args.session)
+        elif args.story is not None:
+            report_story(conn, args.story)
+        elif args.group_by:
+            report_group_by(conn, args.group_by, args.since, args.top)
+        else:
+            raise SystemExit("report needs --group-by, --session, or --story")
+        conn.close()
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -8,12 +8,28 @@ allowed-tools: Bash
 
 # Usage Report Skill
 
-You answer questions about pipeline token/dollar spend using
-`.claude/metrics/token_report.py`, which reads Claude Code's own transcripts
--- no new instrumentation, no guessing. Produce one concise narrative
-summary back to the caller: total spend, the breakdown that actually answers
-their question, and any caveat that changes how the numbers should be read.
-Do not dump the raw table unless asked for detail.
+You answer questions about pipeline token/dollar spend. Two tools, same
+underlying accounting (`usage_db.py` imports `token_report.py`'s own pricing
+and transcript parsing -- no new math, no guessing):
+
+- **`.claude/metrics/usage_db.py`** (preferred) -- a unified SQLite store
+  covering local/po-live sessions, dispatched dev/fix/review containers, and
+  po-act.sh cycle manifests **in one queryable table**, keyed for idempotent
+  incremental re-ingest (unchanged transcripts are skipped by mtime/size, so
+  a repeat `ingest` after the first is near-instant). Use this for anything
+  involving `--group-by`, a specific session drill-down, or a specific
+  story's cost -- it answers what used to require running `token_report.py`
+  twice (once for the session scan, once for `--story-report`) and manually
+  reconciling the two.
+- **`.claude/metrics/token_report.py`** -- the underlying per-call accounting
+  engine. Still the right tool for `--composition` (cache vs. generation
+  breakdown) and `--cycle-manifest` correlation, which `usage_db.py` doesn't
+  wrap.
+
+Produce one concise narrative summary back to the caller: total spend, the
+breakdown that actually answers their question, and any caveat that changes
+how the numbers should be read. Do not dump the raw table unless asked for
+detail.
 
 This skill is about **usage telemetry** (where did tokens/dollars actually
 go). It is unrelated to `.claude/bench/` (quality-per-dollar benchmarking) --
@@ -58,7 +74,7 @@ already handles arbitrary precision.
 | "which role / review lens / tech-lead / fix round costs what" | `--group-by role` |
 | "main loop vs subagents vs workflow agents" | `--group-by agent` |
 | "where does the money actually go" (cache vs generation) | `--composition` |
-| a specific story/PR number, or "cost per story/PR" | `--story-report` (see caveat below) |
+| a specific story/PR number, or "cost per story/PR" | `usage_db.py report --story <N>` (see caveat below) |
 | ambiguous / caller just says "usage" or "spend" | run composition + `--group-by segment` together and present both |
 
 All non-story-report commands take the same `--since` from Step 1. Add
@@ -66,15 +82,30 @@ All non-story-report commands take the same `--since` from Step 1. Add
 
 ## Step 3: Run it
 
+First, refresh the SQLite store (fast after the first run -- unchanged
+transcripts are skipped):
+
 ```bash
-.claude/metrics/token_report.py --since <N> --composition
-.claude/metrics/token_report.py --since <N> --group-by <key> --top 20
+.claude/metrics/usage_db.py ingest
 ```
 
-For a story/PR question:
+Then query it:
 
 ```bash
-.claude/metrics/token_report.py --story-report --since <N>
+.claude/metrics/usage_db.py report --group-by <key> --since <N> --top 20
+.claude/metrics/usage_db.py report --story <issue-num>       # dev/fix/review split for one story
+.claude/metrics/usage_db.py report --session <session-id>    # drill into one session's calls + its container + its cycle
+```
+
+`<key>` includes everything `token_report.py --group-by` supports (model,
+segment, session, day, skill, agent, project, workflow, role) plus two new
+ones this store adds: `container` (per dispatched dev/fix/review container)
+and `source` (`local` vs `container`).
+
+For cache-composition breakdown (still `token_report.py` only):
+
+```bash
+.claude/metrics/token_report.py --since <N> --composition
 ```
 
 ## Step 4: Report back -- narrative, not a data dump
@@ -91,12 +122,14 @@ be read, not just decorate them:
 - **A model row marked `UNPRICED`** (`*`) in the output means it has no entry
   in `pricing.json`; its tokens are real but its dollar figure is not
   guessed. Say so rather than silently omitting or estimating it.
-- **`--story-report` rows can be `partial`** -- transcript missing, story
-  number unresolved, or (the common case for anything dispatched before dev-agent
-  session persistence landed, or before the `cfg-agent` image was rebuilt
-  after it) no dev-mode launch was found, so the largest cost component is
-  silently absent, not genuinely zero. Never report a partial row's total as
-  complete.
+- **A story's containers can be missing a dev launch, or have no transcript
+  at all** -- transcript missing, story number unresolved, or (the common
+  case for anything dispatched before dev-agent session persistence landed,
+  or before the `cfg-agent` image was rebuilt after it) no dev-mode launch
+  was found, so the largest cost component is silently absent, not genuinely
+  zero. `usage_db.py report --story <N>` flags `[PARTIAL: no transcript]` on
+  any such row inline; `token_report.py --story-report` marks the whole row
+  `partial`. Never report either as a complete total without checking this.
 - **Dispatched dev/fix-agent containers only produce telemetry if the
   `cfg-agent:latest` image was rebuilt after dev-agent session persistence
   (story #3051) landed.** If a window's dispatched-agent numbers look


### PR DESCRIPTION
## Summary
- New `.claude/metrics/usage_db.py` — ingests local/po-live session transcripts, dispatched dev/fix/review container sessions, and `po-act.sh` cycle manifests into one SQLite database (`~/.cache/cfgms-usage/usage.db` by default), correlated by session/container/cycle.
- Reuses `token_report.py`'s own `Pricing`/`parse_transcript`/`collect` rather than re-deriving token math — pricing and cache-TTL rules stay in exactly one place.
- Idempotent (`INSERT OR REPLACE` keyed by `request_id`/`cycle_id`) and incremental (skips re-parsing a transcript whose mtime/size are unchanged since the last ingest).
- `usage-report` SKILL.md updated to prefer this for `--group-by`/session/story queries, keeping `token_report.py` for `--composition` and `--cycle-manifest`.

## Why
Traced during a cost-optimization pass this week: dispatched dev/fix/review container costs live entirely outside `token_report.py`'s normal transcript scan (a separate `~/.cache/cfgms-agent-sessions` tree), so answering "what did this actually cost" required running `token_report.py` once for local/po-live sessions and separately `--story-report` for containers, then manually reconciling cycle manifests by hand to see which cycle dispatched which container. This unifies all three into one queryable table.

## Performance
Full corpus (48.5k local calls, 14.3k container calls across 105 containers, 63 cycle manifests): **4.4s cold ingest, 0.4s warm** (unchanged files skipped).

## A real bug found and fixed during validation
Cross-checked output against `token_report.py`'s existing, trusted `story_cost_report` — story #2761 initially showed a container cost of **$2231.49** against a known-good **$50.15**. Root cause: the per-container cost rollup was re-summing the container's *already-stored* total once per skipped (unchanged) file on repeat ingests, so a container with N transcript files multiplied its own correct total by N. Fixed by computing the rollup fresh via a single aggregate query against the `calls` table instead of accumulating during the file loop. Added a regression test (`test_reingest_does_not_multiply_cost_for_container_with_multiple_files`) before fixing, confirmed it fails on the old code and passes on the new. Re-verified against `story_cost_report` after the fix: exact match ($55.02 total, $50.15 fix, $4.87 review).

## Test plan
- [x] `python3 .claude/metrics/tests/test_usage_db.py` — 16 tests, all passing
- [x] `python3 .claude/metrics/tests/test_token_report.py` — 71 tests, no regression
- [x] Full real-corpus ingest + re-ingest cross-checked against `story_cost_report` for stories #2761, #2906, #2908, #3133, #3143, #2970, #2993 — all exact or near-exact matches
- [ ] Wire `usage_db.py ingest` into a periodic cron step (not done here — this PR is the store + query surface; automatic freshness is a follow-up if wanted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j6h4qSsAWzYNDmKoXFYL9