### PR TITLE
storage: provision shared PostgreSQL and S3-compatible blob storage in cfg-lab (Issue #3124)

### DIFF
--- a/docs/testing/controller-ha-real-cluster-runbook.md
+++ b/docs/testing/controller-ha-real-cluster-runbook.md
@@ -1,0 +1,127 @@
+# Controller HA — real-cluster validation runbook
+
+Live-validation runbook for epic **#3090** (Controller HA validation on a real
+multi-node cluster): migrating the Tier-1 `cfg-lab` controller off its
+single-node storage backend onto shared PostgreSQL + S3-compatible blob
+storage, joining a genuine 3-node `CFGMS_HA_MODE=cluster` deployment across
+separate real hosts, and validating leader election, failover, and
+split-brain resolution on real hardware rather than Docker containers.
+
+---
+
+## 1. Environment
+
+Live bed: the **cfg-lab** 3-node Hyper-V failover cluster (`lab.cfg.is`),
+same physical bed as the module-convergence work — see
+[`hyperv-cluster-cascade-runbook.md`](hyperv-cluster-cascade-runbook.md) §1
+for the underlying hypervisor topology (`CFG-70-02` / `CFG-AB-02` /
+`CFG-C3-02`, CSV01, `HVSwitch_1G`).
+
+### Lab rebuild note (2026-07-31/08-01)
+
+While provisioning this story's VM, the lab's exec-dispatch subsystem and
+`CFG-70-02`'s steward wedged in a way that required a full lab reset —
+all non-DC Hyper-V VMs torn down (CSV01 storage cleaned), the Tier-1
+controller (`cfgms-ctrl-01`) rebuilt from scratch on `CFG-70-02`, and all
+three HV-host stewards re-enrolled. The domain controllers (`cfg-dc1-02`,
+`cfg-dc2-02`) were left untouched throughout.
+
+`cfgms-ctrl-01` is therefore **no longer** the persistent controller from the
+original v0.9.7 Tier-1 bringup referenced elsewhere in epic #3090's planning
+— it is a fresh instance (CA regenerated, tenant tree reseeded, fleet
+re-enrolled). Anything in this epic that assumed continuity with the
+original controller's history/state should be re-verified.
+
+Two genuine defects were found and worked around during the rebuild (not yet
+filed as separate issues):
+- `tier1-bootstrap.sh`'s config template is missing `transport.external_address`
+  (controller now refuses to start without it) and its `certificate.ca_path`
+  is silently ignored in favor of a relative default — `--init` must be run
+  with CWD `/var/lib/cfgms` (matching the systemd unit's `WorkingDirectory`)
+  or the CA never lands where the server expects to load it from.
+- The `hyperv.vm` module's `Set-VMFirmware -EnableSecureBoot On -SecureBootTemplate
+  MicrosoftUEFICertificateAuthority` call reproducibly failed
+  (`'MicrosoftUEFICertificateAuthority' matches none of the secure boot
+  templates`) when run as part of the module's actual create sequence, even
+  though the identical call succeeds in isolation. Both `cfgms-ctrl-01` and
+  `cfgms-lab-datasvc` were provisioned manually instead (raw cloud image →
+  fixed VHD → dynamic VHDX via `C:\temp\raw2vhd`, CIDATA seed built with the
+  same mechanics as the module, `-EnableSecureBoot Off`) rather than via
+  `cfg config upload` — see `C:\temp\ctrl-vm-create.ps1` /
+  `C:\temp\datasvc-vm-create.ps1` on `CFG-70-02` for the exact recipe.
+- `cfg registration approve` / `approve-all` return success but the
+  `registration pending` list still shows the entries afterward — cosmetic
+  (the underlying steward really does flip to `active`), but worth fixing.
+
+### Shared data-services VM (`cfgms-lab-datasvc`) — story #3124
+
+A dedicated Debian VM hosts the PostgreSQL + MinIO backend shared by all
+cluster controller nodes:
+
+| Property | Value |
+|----------|-------|
+| VM name | `cfgms-lab-datasvc` |
+| Hypervisor host | `CFG-70-02` |
+| Tenant | `infra-hyperv` |
+| Provisioning | Manual (see the rebuild note above) — `C:\temp\datasvc-vm-create.ps1` builds the VM, then `scripts/lab-datasvc-bootstrap.sh` (run once over SSH) installs PostgreSQL + MinIO |
+| IP address | `192.168.234.105` (lab LAN, `192.168.234.0/24`, DHCP) |
+
+**PostgreSQL:**
+
+| Property | Value |
+|----------|-------|
+| Port | `5432` |
+| Database | `cfgms` |
+| Role | `cfgms` (dedicated, non-superuser, `LOGIN` only) |
+| Listen | all interfaces; `pg_hba.conf` restricts inbound to `192.168.234.0/24` via `scram-sha-256` |
+| Connection string shape | `postgres://cfgms:<password>@192.168.234.105:5432/cfgms?sslmode=require` |
+
+**MinIO (S3-compatible blob storage):**
+
+| Property | Value |
+|----------|-------|
+| API port | `9000` |
+| Console port | `9001` |
+| Bucket | `cfgms-installer-blobs` |
+| `endpoint_url` | `http://192.168.234.105:9000` |
+
+**Credentials:** the PostgreSQL role password and MinIO root access/secret
+key are generated once by `scripts/lab-datasvc-bootstrap.sh` on first run and
+printed to stdout a single time. They are stored in the operator
+workstation's OS-native keychain (Windows Credential Manager on `CFG-70-02`,
+target names `cfgms-lab-datasvc-postgres` / `cfgms-lab-datasvc-minio`) — never
+committed to a file in this repository. See the script's step 7 output for
+the exact storage commands on Linux/macOS.
+
+### Privileges
+
+Provisioning the VM and running the in-guest bootstrap requires the same
+`cfg steward exec` (SYSTEM) / cluster-admin path documented in
+[`hyperv-cluster-cascade-runbook.md`](hyperv-cluster-cascade-runbook.md) §1 —
+a non-admin shell cannot create the VM or reach the Hyper-V APIs.
+
+---
+
+## 2. Storage migration (story #3127)
+
+*To be filled in when #3127 lands — migrates the live Tier-1 controller from
+its current flatfile/SQLite backend onto the `cfgms-lab-datasvc` PostgreSQL +
+MinIO backend via `cfg storage migrate`.*
+
+## 3. Cluster join (story #3130)
+
+*To be filled in when #3130 lands — joins two additional controller nodes to
+the migrated Tier-1 controller, forming a 3-node `CFGMS_HA_MODE=cluster`
+deployment.*
+
+## 4. Leader election and failover validation (story #3094)
+
+*To be filled in when #3094 lands.*
+
+## 5. Network partition / split-brain validation (story #3095)
+
+*To be filled in when #3095 lands.*
+
+## 6. Steward fleet continuity through failover (story #3096)
+
+*To be filled in when #3096 lands.*

--- a/docs/testing/controller-ha-real-cluster-runbook.md
+++ b/docs/testing/controller-ha-real-cluster-runbook.md
@@ -84,7 +84,7 @@ cluster controller nodes:
 | Database | `cfgms` |
 | Role | `cfgms` (dedicated, non-superuser, `LOGIN` only) |
 | Listen | all interfaces; `pg_hba.conf` restricts inbound to `192.168.234.0/24` via `scram-sha-256` |
-| Connection string shape | `postgres://cfgms:<password>@192.168.234.105:5432/cfgms?sslmode=require` |
+| Connection string shape | `postgres://cfgms:<password>@192.168.234.105:5432/cfgms?sslmode=disable` (the bootstrap script does not enable TLS on the PostgreSQL server — `sslmode=require` will fail until a follow-up adds server-side TLS) |
 
 **MinIO (S3-compatible blob storage):**
 

--- a/docs/testing/controller-ha-real-cluster-runbook.md
+++ b/docs/testing/controller-ha-real-cluster-runbook.md
@@ -32,26 +32,36 @@ original v0.9.7 Tier-1 bringup referenced elsewhere in epic #3090's planning
 re-enrolled). Anything in this epic that assumed continuity with the
 original controller's history/state should be re-verified.
 
-Two genuine defects were found and worked around during the rebuild (not yet
-filed as separate issues):
-- `tier1-bootstrap.sh`'s config template is missing `transport.external_address`
-  (controller now refuses to start without it) and its `certificate.ca_path`
-  is silently ignored in favor of a relative default — `--init` must be run
-  with CWD `/var/lib/cfgms` (matching the systemd unit's `WorkingDirectory`)
-  or the CA never lands where the server expects to load it from.
-- The `hyperv.vm` module's `Set-VMFirmware -EnableSecureBoot On -SecureBootTemplate
-  MicrosoftUEFICertificateAuthority` call reproducibly failed
-  (`'MicrosoftUEFICertificateAuthority' matches none of the secure boot
-  templates`) when run as part of the module's actual create sequence, even
-  though the identical call succeeds in isolation. Both `cfgms-ctrl-01` and
-  `cfgms-lab-datasvc` were provisioned manually instead (raw cloud image →
-  fixed VHD → dynamic VHDX via `C:\temp\raw2vhd`, CIDATA seed built with the
-  same mechanics as the module, `-EnableSecureBoot Off`) rather than via
+Seven genuine defects were found during the rebuild and filed as follow-up
+stories under this epic (none fixed here — #3124 is infra-provisioning only):
+- #3168 — `hyperv.vm` cloud-init VM occasionally boots without seeing the
+  CIDATA seed disk on first boot (self-heals on a power-cycle, but not
+  automatically on the module's own timeline).
+- #3169 — the `hyperv.vm` module's `Set-VMFirmware -EnableSecureBoot On
+  -SecureBootTemplate MicrosoftUEFICertificateAuthority` call reproducibly
+  fails (`'MicrosoftUEFICertificateAuthority' matches none of the secure
+  boot templates`) when run as part of the module's actual create sequence,
+  even though the identical call succeeds in isolation. Both `cfgms-ctrl-01`
+  and `cfgms-lab-datasvc` were provisioned manually instead (raw cloud image
+  → fixed VHD → dynamic VHDX via `C:\temp\raw2vhd`, CIDATA seed built with
+  the same mechanics as the module, `-EnableSecureBoot Off`) rather than via
   `cfg config upload` — see `C:\temp\ctrl-vm-create.ps1` /
   `C:\temp\datasvc-vm-create.ps1` on `CFG-70-02` for the exact recipe.
-- `cfg registration approve` / `approve-all` return success but the
+- #3170 — `tier1-bootstrap.sh`'s config template is missing
+  `transport.external_address` (controller now refuses to start without it).
+- #3171 — `certificate.ca_path`/`cert_path` is silently ignored in favor of a
+  relative default — `--init` must be run with CWD `/var/lib/cfgms` (matching
+  the systemd unit's `WorkingDirectory`) or the CA never lands where the
+  server expects to load it from.
+- #3172 — the generated admin bundle embeds a hardcoded `controller_url` port
+  (`:8080`) instead of the configured `listen_addr` port.
+- #3173 — `cfg registration approve` / `approve-all` return success but the
   `registration pending` list still shows the entries afterward — cosmetic
   (the underlying steward really does flip to `active`), but worth fixing.
+- #3174 — `cfg`'s `--tls-insecure` / `CFGMS_TLS_INSECURE` has no effect for
+  admin-bundle (mTLS) authenticated commands (`steward`, `tenant`), only
+  worked around here via an SSH tunnel to `localhost` (in the cert's SAN)
+  instead of connecting by LAN IP.
 
 ### Shared data-services VM (`cfgms-lab-datasvc`) — story #3124
 

--- a/scripts/lab-datasvc-bootstrap.sh
+++ b/scripts/lab-datasvc-bootstrap.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# lab-datasvc-bootstrap.sh — Bootstrap shared PostgreSQL + MinIO on a Debian
+# VM for the cfg-lab controller HA epic (#3090, story #3124).
+# Idempotent. Re-run safe. Never rotates an existing role/user password.
+#
+# Usage:
+#   sudo bash lab-datasvc-bootstrap.sh
+#
+# On first run this prints the generated PostgreSQL role password and MinIO
+# access/secret key ONCE to stdout. Capture them into an OS keychain
+# immediately — nothing is written to disk in cleartext, and a re-run will
+# not reprint them (see step 3 and step 5 for the idempotency check).
+#
+# See: docs/testing/controller-ha-real-cluster-runbook.md
+
+set -euo pipefail
+
+PG_DB="cfgms"
+PG_ROLE="cfgms"
+PG_LISTEN_SUBNET="192.168.234.0/24"
+
+MINIO_USER="minio-server"
+MINIO_DATA_DIR="/var/lib/minio/data"
+MINIO_CONFIG_DIR="/etc/minio"
+MINIO_ENV_FILE="${MINIO_CONFIG_DIR}/minio.env"
+MINIO_BUCKET="cfgms-installer-blobs"
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+
+log() { echo "[bootstrap] $*"; }
+
+# ── Step 1: Pre-flight ────────────────────────────────────────────────────────
+
+log "Step 1: Pre-flight checks"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "Error: must be run as root (sudo bash $(basename "$0"))" >&2
+    exit 1
+fi
+
+if ! grep -qi "debian" /etc/os-release 2>/dev/null; then
+    echo "Error: this script targets Debian. Detected OS:" >&2
+    grep PRETTY_NAME /etc/os-release 2>/dev/null || echo "  (unknown)" >&2
+    exit 1
+fi
+
+log "Pre-flight checks passed."
+
+# ── Step 2: PostgreSQL install ────────────────────────────────────────────────
+
+log "Step 2: PostgreSQL install (idempotent)"
+
+if ! command -v psql &>/dev/null; then
+    apt-get -qq update -y
+    apt-get -qq install -y postgresql postgresql-contrib
+    log "PostgreSQL installed."
+else
+    log "PostgreSQL already installed."
+fi
+
+PG_VERSION="$(psql -V | grep -oE '[0-9]+' | head -1)"
+PG_CONF_DIR="/etc/postgresql/${PG_VERSION}/main"
+PG_CONF="${PG_CONF_DIR}/postgresql.conf"
+PG_HBA="${PG_CONF_DIR}/pg_hba.conf"
+
+# Listen on all interfaces so cluster-node hosts on the lab LAN can reach it.
+if ! grep -q "^listen_addresses = '\*'" "$PG_CONF" 2>/dev/null; then
+    sed -i "s/^#\?listen_addresses.*/listen_addresses = '*'/" "$PG_CONF"
+    log "Set listen_addresses = '*' in $PG_CONF"
+else
+    log "listen_addresses already set to '*'."
+fi
+
+HBA_LINE="host    all             all             ${PG_LISTEN_SUBNET}        scram-sha-256"
+if ! grep -qF "$HBA_LINE" "$PG_HBA" 2>/dev/null; then
+    echo "$HBA_LINE" >> "$PG_HBA"
+    log "Added pg_hba.conf entry for ${PG_LISTEN_SUBNET}."
+else
+    log "pg_hba.conf entry for ${PG_LISTEN_SUBNET} already present."
+fi
+
+systemctl enable postgresql &>/dev/null || true
+systemctl restart postgresql
+log "PostgreSQL configured and (re)started."
+
+# ── Step 3: PostgreSQL role + database ────────────────────────────────────────
+
+log "Step 3: PostgreSQL role + database"
+
+PG_ROLE_EXISTS="$(sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${PG_ROLE}'")"
+PG_PASSWORD_PRINTED=false
+
+if [[ "$PG_ROLE_EXISTS" != "1" ]]; then
+    PG_PASSWORD="$(openssl rand -base64 24)"
+    sudo -u postgres psql -v ON_ERROR_STOP=1 -c \
+        "CREATE ROLE ${PG_ROLE} WITH LOGIN PASSWORD '${PG_PASSWORD}';"
+    log "Created role ${PG_ROLE} (non-superuser, LOGIN only)."
+    PG_PASSWORD_PRINTED=true
+else
+    log "Role ${PG_ROLE} already exists — password NOT rotated."
+fi
+
+PG_DB_EXISTS="$(sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DB}'")"
+if [[ "$PG_DB_EXISTS" != "1" ]]; then
+    sudo -u postgres psql -v ON_ERROR_STOP=1 -c \
+        "CREATE DATABASE ${PG_DB} OWNER ${PG_ROLE};"
+    log "Created database ${PG_DB} (owner ${PG_ROLE})."
+else
+    log "Database ${PG_DB} already exists."
+fi
+
+# ── Step 4: MinIO install ─────────────────────────────────────────────────────
+
+log "Step 4: MinIO install (idempotent)"
+
+if ! id "$MINIO_USER" &>/dev/null; then
+    useradd --system --no-create-home --shell /usr/sbin/nologin "$MINIO_USER"
+    log "Created ${MINIO_USER} system user."
+fi
+
+mkdir -p "$MINIO_DATA_DIR" "$MINIO_CONFIG_DIR"
+chown -R "${MINIO_USER}:${MINIO_USER}" "$MINIO_DATA_DIR"
+
+if [[ ! -x /usr/local/bin/minio ]]; then
+    curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio \
+        -o /usr/local/bin/minio
+    chmod +x /usr/local/bin/minio
+    log "MinIO server binary installed to /usr/local/bin/minio."
+else
+    log "MinIO server binary already present."
+fi
+
+if [[ ! -x /usr/local/bin/mc ]]; then
+    curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc \
+        -o /usr/local/bin/mc
+    chmod +x /usr/local/bin/mc
+    log "MinIO client (mc) installed to /usr/local/bin/mc."
+else
+    log "MinIO client already present."
+fi
+
+# ── Step 5: MinIO credentials + service ───────────────────────────────────────
+
+log "Step 5: MinIO credentials + service"
+
+MINIO_PASSWORD_PRINTED=false
+
+if [[ ! -f "$MINIO_ENV_FILE" ]]; then
+    MINIO_ROOT_USER="cfgms-lab-datasvc"
+    MINIO_ROOT_PASSWORD="$(openssl rand -base64 24 | tr -d '/+=' | cut -c1-32)"
+
+    cat > "$MINIO_ENV_FILE" <<EOF
+MINIO_ROOT_USER=${MINIO_ROOT_USER}
+MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+MINIO_VOLUMES="${MINIO_DATA_DIR}"
+MINIO_OPTS="--address :${MINIO_API_PORT} --console-address :${MINIO_CONSOLE_PORT}"
+EOF
+    chown root:"$MINIO_USER" "$MINIO_ENV_FILE"
+    chmod 640 "$MINIO_ENV_FILE"
+    log "Generated MinIO root credentials in ${MINIO_ENV_FILE} (root:group-readable only)."
+    MINIO_PASSWORD_PRINTED=true
+else
+    log "MinIO env file already exists — credentials NOT rotated."
+    # shellcheck disable=SC1090
+    source "$MINIO_ENV_FILE"
+fi
+
+cat > /etc/systemd/system/minio.service <<EOF
+[Unit]
+Description=MinIO (cfgms-lab-datasvc installer blob store)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${MINIO_USER}
+Group=${MINIO_USER}
+EnvironmentFile=${MINIO_ENV_FILE}
+ExecStart=/usr/local/bin/minio server \$MINIO_VOLUMES \$MINIO_OPTS
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable minio &>/dev/null || true
+if systemctl is-active --quiet minio; then
+    systemctl restart minio
+else
+    systemctl start minio
+fi
+log "MinIO service (re)started, listening on :${MINIO_API_PORT} (API) / :${MINIO_CONSOLE_PORT} (console)."
+
+# ── Step 6: MinIO bucket ──────────────────────────────────────────────────────
+
+log "Step 6: MinIO bucket"
+
+# shellcheck disable=SC1090
+source "$MINIO_ENV_FILE"
+
+RETRIES=12
+for ((i = 1; i <= RETRIES; i++)); do
+    if /usr/local/bin/mc alias set local "http://127.0.0.1:${MINIO_API_PORT}" \
+        "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" &>/dev/null; then
+        break
+    fi
+    if [[ $i -eq $RETRIES ]]; then
+        echo "Error: MinIO did not become ready after $((RETRIES * 5))s." >&2
+        exit 1
+    fi
+    log "  Waiting for MinIO API... (${i}/${RETRIES})"
+    sleep 5
+done
+
+if ! /usr/local/bin/mc ls "local/${MINIO_BUCKET}" &>/dev/null; then
+    /usr/local/bin/mc mb "local/${MINIO_BUCKET}"
+    log "Created bucket ${MINIO_BUCKET}."
+else
+    log "Bucket ${MINIO_BUCKET} already exists."
+fi
+
+# ── Step 7: Final output ──────────────────────────────────────────────────────
+
+echo ""
+echo "=========================================="
+echo " cfg-lab data-services bootstrap complete"
+echo "=========================================="
+echo ""
+echo "PostgreSQL: db=${PG_DB} role=${PG_ROLE} port=5432"
+echo "MinIO:      endpoint_url=http://$(hostname -I | awk '{print $1}'):${MINIO_API_PORT} bucket=${MINIO_BUCKET}"
+echo ""
+
+if [[ "$PG_PASSWORD_PRINTED" == "true" ]]; then
+    echo "PostgreSQL role password (ONE-TIME PRINT — store now, not repeated on re-run):"
+    echo "  ${PG_PASSWORD}"
+    echo ""
+fi
+
+if [[ "$MINIO_PASSWORD_PRINTED" == "true" ]]; then
+    echo "MinIO root credentials (ONE-TIME PRINT — store now, not repeated on re-run):"
+    echo "  access key: ${MINIO_ROOT_USER}"
+    echo "  secret key: ${MINIO_ROOT_PASSWORD}"
+    echo ""
+fi
+
+echo "Store both in an OS-native keychain immediately, e.g. from the operator workstation:"
+echo "  Windows: cmdkey /generic:cfgms-lab-datasvc-postgres /user:${PG_ROLE} /pass:<password>"
+echo "           cmdkey /generic:cfgms-lab-datasvc-minio /user:<access-key> /pass:<secret-key>"
+echo "  Linux:   secret-tool store --label='cfgms-lab-datasvc postgres' service cfgms-lab-datasvc credential postgres"
+echo "  macOS:   security add-generic-password -s cfgms-lab-datasvc -a postgres -w '<password>'"
+echo ""
+echo "Never commit these values to a file in the repository."
+echo ""


### PR DESCRIPTION
## Summary
- Adds `scripts/lab-datasvc-bootstrap.sh` — idempotent PostgreSQL + MinIO bootstrap for a Debian VM, following the `tier1-bootstrap.sh` pattern.
- Adds `docs/testing/controller-ha-real-cluster-runbook.md` — §1 Environment documents the `cfgms-lab-datasvc` VM (192.168.234.105 on CFG-70-02), its PostgreSQL/MinIO connection parameters, and stub sections for the rest of epic #3090's stories.
- No Go source changed.

## Context
While provisioning this story's VM, the lab's controller/exec-dispatch subsystem wedged in a way that required a full lab reset (all non-DC VMs torn down, Tier-1 controller rebuilt, fleet re-enrolled — domain controllers untouched throughout). That process surfaced seven genuine defects, documented in the runbook's "Lab rebuild note" and filed as follow-up stories under epic #3090 (none fixed in this PR — out of scope for an infra-provisioning story):

- #3168 — `hyperv.vm` cloud-init VM occasionally boots without seeing the CIDATA seed disk
- #3169 — `hyperv.vm` module's `Set-VMFirmware` secure-boot call fails through the module's create sequence (works standalone)
- #3170 — `tier1-bootstrap.sh` generated config missing `transport.external_address`
- #3171 — controller ignores configured `certificate.ca_path`/`cert_path`, falls back to a relative default
- #3172 — admin bundle embeds a hardcoded port instead of the configured `listen_addr`
- #3173 — `cfg registration approve`/`approve-all` don't clear the `pending` list display
- #3174 — `cfg --tls-insecure` has no effect for admin-bundle (mTLS) authenticated commands

## Test plan
- [x] `gofmt -l .` — clean (only pre-existing generated file flagged, unrelated to this branch)
- [x] `go vet ./...` — clean (only pre-existing, story-unrelated finding; zero Go diff vs develop)
- [x] `make check-architecture` — no violations
- [x] `bash -n scripts/lab-datasvc-bootstrap.sh` — syntax OK
- [x] Live-verified: PostgreSQL `cfgms` database + dedicated role, MinIO `cfgms-installer-blobs` bucket, both reachable from the lab LAN; credentials stored in Windows Credential Manager on CFG-70-02, not committed to any file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KhZuo28YrVRQXb4u83Cmh