### PR TITLE
pipeline: refuse review dispatch when PR head is unchanged since last review

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -665,9 +665,64 @@ _review_refusal_hint() {
       echo "another host holds the pr-<N> lease (reviewing/fixing/rebasing this PR) — wait for it to release." ;;
     lease_error)
       echo "lease acquisition failed unexpectedly — check './scripts/pipeline-helper.sh lease-acquire' directly." ;;
+    no_new_commit_since_review)
+      echo "head is unchanged since the last acceptance review — a re-review would re-reach the same verdict. Dispatch a fix (po-act.sh dispatch-fix <PR>) so a commit lands first, or pass --force if the acceptance criteria changed rather than the code." ;;
     *)
       echo "" ;;
   esac
+}
+
+# _review_is_stale <pr_num>
+#   Exit 0 when the PR already carries an acceptance-review comment and no
+#   commit has landed since it — i.e. a re-review would evaluate the exact same
+#   tree and necessarily reach the same verdict. Exit 1 otherwise (reviewable).
+#
+# Why this lives here and not only in the preflight: po-cycle-preflight.py
+# already skips this case, but it is advisory — a direct `review-pr <N>` call
+# bypasses it entirely. Three of six review dispatches in one cron cycle
+# re-confirmed an identical FAIL on an unmoved head because of exactly that
+# bypass, and each wasted review also risks tripping the reviewer's
+# second-failure escalation to Blocked. The dispatcher is the enforcement point.
+#
+# Staleness is decided by comparing the newest commit's committedDate against
+# the newest trusted review comment's createdAt — the same signal
+# fix_landed_after_review() uses in the preflight, kept deliberately identical
+# so the two layers cannot disagree. Trust requires BOTH the machine sentinel
+# (or the legacy '## Acceptance Review' heading) AND a push+ author, mirroring
+# is_trusted_review_comment(): a text match alone would let any commenter forge
+# a review and permanently wedge a PR out of review.
+#
+# Fails OPEN (returns "not stale") whenever the data is missing or unparseable.
+# A wrongly-allowed review costs one cycle; a wrongly-refused one strands a PR.
+_review_is_stale() {
+  local pr_num="$1"
+  local pr_json latest_commit latest_review
+
+  pr_json=$(gh pr view "$pr_num" --repo cfg-is/cfgms \
+    --json comments,commits 2>/dev/null) || return 1
+  [[ -n "$pr_json" ]] || return 1
+
+  latest_commit=$(echo "$pr_json" | jq -r '[.commits[].committedDate] | max // empty' 2>/dev/null || echo "")
+  [[ -n "$latest_commit" ]] || return 1
+
+  # Newest comment that is both sentinel/heading-matched and push+ authored.
+  latest_review=""
+  local c_date c_author c_body
+  while IFS=$'\t' read -r c_date c_author c_body; do
+    [[ -n "$c_date" ]] || continue
+    case "$c_body" in
+      *"<!-- cfgms-acceptance-review -->"*|*"## acceptance review"*) ;;
+      *) continue ;;
+    esac
+    [[ "$(_check_author_permission "$c_author" "$pr_num" "")" == "internal" ]] || continue
+    [[ "$c_date" > "$latest_review" ]] && latest_review="$c_date"
+  done < <(echo "$pr_json" | jq -r '.comments[] | [.createdAt, (.author.login // ""), (.body | ascii_downcase | gsub("\t|\n";" "))] | @tsv' 2>/dev/null)
+
+  [[ -n "$latest_review" ]] || return 1
+
+  # ISO-8601 UTC sorts lexicographically. Stale when no commit is newer.
+  [[ "$latest_commit" > "$latest_review" ]] && return 1
+  return 0
 }
 
 # _emit_review_refused <pr_num> <reason>
@@ -2015,6 +2070,18 @@ PYEOF
     # returns immediately after `docker run -d`; the container does the review
     # and exits when done. Replaces the inline subagent spawn that was hanging
     # on per-tool approval prompts in the host /po cron session.
+    # --force re-reviews a PR whose head has not moved since the last review.
+    # Legitimate when the *criteria* changed rather than the code (e.g. a story's
+    # AC was amended), which the staleness guard below cannot detect.
+    review_force=false
+    review_args=()
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --force) review_force=true; shift ;;
+        *)       review_args+=("$1"); shift ;;
+      esac
+    done
+    set -- "${review_args[@]}"
     [[ $# -eq 1 ]] || { echo "review-pr requires exactly one PR number"; exit 1; }
     pr_num="$1"
     if [[ ! "$pr_num" =~ ^[0-9]+$ ]]; then
@@ -2052,6 +2119,13 @@ PYEOF
     fi
 
     validate_branch "$pr_branch"
+
+    # Stale-head guard: refuse a re-review when no commit has landed since the
+    # last acceptance review. Runs before story resolution / capacity / lease so
+    # a no-op review costs one API call instead of a container.
+    if [[ "$review_force" != "true" ]] && _review_is_stale "$pr_num"; then
+      _emit_review_refused "$pr_num" "no_new_commit_since_review"
+    fi
 
     # Resolve story/item from the branch (authoritative) or, for legacy
     # branches, the body. See resolve_pr_story_or_item() comment header for

--- a/.claude/scripts/tests/review_pr_detection.test.sh
+++ b/.claude/scripts/tests/review_pr_detection.test.sh
@@ -249,6 +249,71 @@ assert_has_hint "already_in_flight" "already_in_flight"
 assert_has_hint "container_exists" "container_exists"
 assert_has_hint "lease_held" "lease_held"
 assert_has_hint "lease_error" "lease_error"
+assert_has_hint "no_new_commit_since_review" "no_new_commit_since_review"
+
+echo
+echo "--- review-pr: stale-head guard (_review_is_stale) ---"
+
+# _review_is_stale reads `gh pr view --json comments,commits`. Stub `gh` on PATH
+# so the guard is exercised against fixture payloads, no network.
+STALE_STUB_DIR=$(mktemp -d)
+trap 'rm -rf "$STALE_STUB_DIR"' EXIT
+cat > "$STALE_STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Only `gh pr view ... --json comments,commits` is used by _review_is_stale.
+cat "$GH_FIXTURE"
+STUB
+chmod +x "$STALE_STUB_DIR/gh"
+
+assert_staleness() {
+  local description="$1" fixture="$2" expected="$3"
+  ran=$((ran + 1))
+  local actual
+  # NOTE: agent-dispatch.sh guards its main dispatch with BASH_SOURCE[0] == $0.
+  # The script path must therefore be interpolated into the command string, NOT
+  # passed as bash -c's $0 argument — doing the latter makes the guard true and
+  # runs the CLI (usage + exit 1) instead of just defining functions.
+  actual=$(GH_FIXTURE="$fixture" PATH="$STALE_STUB_DIR:$PATH" \
+    bash -c "source '$DISPATCH' 2>/dev/null
+             _check_author_permission() { echo internal; }
+             if _review_is_stale 1; then echo stale; else echo reviewable; fi" \
+    2>/dev/null | tail -1) || true
+  if [[ "$actual" == "$expected" ]]; then
+    printf '  ok    %s\n' "$description"
+  else
+    printf '  FAIL  %s\n        expected=%q got=%q\n' "$description" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+write_fixture() {
+  printf '%s' "$2" > "$STALE_STUB_DIR/$1.json"
+  echo "$STALE_STUB_DIR/$1.json"
+}
+
+# Review present, no commit after it → stale (the #3115/#3117/#3121 waste case).
+f=$(write_fixture stale '{"comments":[{"createdAt":"2026-07-30T10:00:00Z","author":{"login":"jrdnr"},"body":"<!-- cfgms-acceptance-review -->\n## Acceptance Review — FAIL"}],"commits":[{"committedDate":"2026-07-30T09:00:00Z"}]}')
+assert_staleness "review present, no newer commit → stale" "$f" "stale"
+
+# Commit landed after the review → reviewable (the normal fix-cycle re-review).
+f=$(write_fixture fresh '{"comments":[{"createdAt":"2026-07-30T10:00:00Z","author":{"login":"jrdnr"},"body":"<!-- cfgms-acceptance-review -->\n## Acceptance Review — FAIL"}],"commits":[{"committedDate":"2026-07-30T11:00:00Z"}]}')
+assert_staleness "commit newer than review → reviewable" "$f" "reviewable"
+
+# No review comment yet → reviewable (first review must never be blocked).
+f=$(write_fixture noreview '{"comments":[],"commits":[{"committedDate":"2026-07-30T09:00:00Z"}]}')
+assert_staleness "no acceptance review yet → reviewable" "$f" "reviewable"
+
+# Non-review chatter must not count as a review (else any comment wedges the PR).
+f=$(write_fixture chatter '{"comments":[{"createdAt":"2026-07-30T10:00:00Z","author":{"login":"jrdnr"},"body":"Acceptance Reviewer — skipping draft PR."}],"commits":[{"committedDate":"2026-07-30T09:00:00Z"}]}')
+assert_staleness "non-review comment ignored → reviewable" "$f" "reviewable"
+
+# Latest of several commits wins, not document order.
+f=$(write_fixture multi '{"comments":[{"createdAt":"2026-07-30T10:00:00Z","author":{"login":"jrdnr"},"body":"<!-- cfgms-acceptance-review -->"}],"commits":[{"committedDate":"2026-07-30T11:30:00Z"},{"committedDate":"2026-07-30T08:00:00Z"}]}')
+assert_staleness "newest commit compared, not last listed → reviewable" "$f" "reviewable"
+
+# Malformed payload → fails open rather than stranding the PR.
+f=$(write_fixture broken '{"comments":[],"commits":[]}')
+assert_staleness "missing commit data → fails open (reviewable)" "$f" "reviewable"
 
 echo
 echo "ran ${ran} assertions; failures: ${fail}"


### PR DESCRIPTION
## Summary

`review-pr` dispatched a review container even when no commit had landed since the last acceptance review. The reviewer then re-read an identical tree and re-reached an identical verdict.

In a single cron cycle on 2026-08-01, **3 of 6** review dispatches did exactly this — PRs #3115, #3117, #3121. Each reviewer detected the condition itself and said so in its own comment (e.g. *"No change since the round-2 review. The PR's `headRefOid` is still `b46caf03` — the exact commit already reviewed and failed"*). Beyond the wasted cycle, a redundant FAIL can trip the reviewer's second-failure escalation and Block a PR that was never given a real fix attempt.

`po-cycle-preflight.py` already skips this case, but it is **advisory** — a direct `agent-dispatch.sh review-pr <N>` call bypasses it entirely, which is how all three slipped through. This moves enforcement to the dispatcher.

## How it works

`_review_is_stale` compares the newest commit's `committedDate` against the newest **trusted** acceptance-review comment's `createdAt` — deliberately the same signal `fix_landed_after_review()` uses in the preflight, so the two layers cannot disagree.

Trust requires **both** the machine sentinel `<!-- cfgms-acceptance-review -->` (or the legacy `## Acceptance Review` heading) **and** a push+ author, mirroring `is_trusted_review_comment()`. A text match alone would let any commenter forge a review comment and wedge a PR out of review permanently.

The guard runs before story resolution, the capacity gate, and the lease — a no-op review now costs one API call instead of a container.

**Fails open.** Missing or unparseable data returns "not stale". A wrongly-allowed review costs one cycle; a wrongly-refused one strands a PR.

## `--force`

Added for the one case the guard cannot detect: the **acceptance criteria** changed rather than the code. This is real — story #3042's AC3 was amended today and PR #3117 legitimately needed a re-review on an unmoved head. Without `--force` this change would have broken that workflow.

Flag position is free (`review-pr --force 3157` and `review-pr 3157 --force` both work).

## Validation

- `make test` — **221 script tests, 0 failures**, full validation complete.
- `review_pr_detection.test.sh` — extended from 37 to **44 assertions**, all passing. New coverage: stale, commit-newer-than-review, no-review-yet, non-review chatter ignored, newest-commit-not-last-listed, and malformed-payload fails-open. Also adds the new refusal reason to the existing "every emitted reason has a hint" test.
- Sibling suites run for regressions — `session_persistence`, `model_routing`, `creds_gate`, `capacity`, `lease` all pass.
- **Live end-to-end**: `review-pr 3157` (open PR, reviewed at 19:57, head unchanged) now returns `REVIEW_REFUSED:3157:no_new_commit_since_review` with **no container created**. Verified the inverse too — #3150 and #3115, which had commits land after their reviews, both correctly evaluate as reviewable.

One implementation note worth flagging for future test authors: `agent-dispatch.sh` guards its CLI with `BASH_SOURCE[0] == $0`, so a test must interpolate the script path into the `bash -c` command string rather than pass it as `$0` — passing it as `$0` makes the guard true and runs the CLI instead of defining functions. That is commented at the call site.

## Test plan

- [x] `make test` passes
- [x] Unit coverage for both verdicts plus the fail-open path
- [x] Smoke-tested against live PR state, both stale and non-stale
- [x] `--force` parsing verified in both flag positions

Relates to the review-cycle waste observed across #3115, #3117, #3121.
