### PR TITLE
pipeline: fix review round-counting, add reviewer grounding + pre-merge-evidence checks

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -86,11 +86,31 @@ gh pr diff <PR_NUM> --repo cfg-is/cfgms
 # CI status
 gh pr checks <PR_NUM> --repo cfg-is/cfgms
 
-# Story body and review cycle status from the private project
+# Story body from the private project
 ./scripts/project-queue.sh get-item <ITEM_ID>
 # Returns .body (acceptance criteria text) and .status
-# .status == "Fix" means FIX_CYCLE; any other status means FIRST_REVIEW
+
+# Which review round is this? COUNT PRIOR REVIEWS — never infer it from status.
+gh pr view <PR_NUM> --repo cfg-is/cfgms --json comments \
+  --jq '[.comments[] | select(.body | test("<!-- cfgms-acceptance-review -->"; "i"))] | length'
 ```
+
+**Determining the review round (this decides whether a failure escalates to `Blocked`).**
+
+The round is `prior_review_count + 1`, where `prior_review_count` is the number of
+existing `<!-- cfgms-acceptance-review -->` comments on the PR. First review ⇒ 0 prior
+⇒ this is round 1.
+
+**Do NOT infer the round from the project item's status.** Status `Fix` does not imply a
+prior acceptance review: a **CI-driven** fix cycle sets `Fix` too. Reading status as the
+round counter makes the genuinely-first acceptance review believe it is the second, so its
+first real finding escalates straight to `Blocked` and the story never gets the fix cycle
+it was owed. This is not hypothetical — it is what happened to PR #3121, whose fix agent
+ran 38 minutes *before* any acceptance-review comment existed and which was then Blocked on
+review round one.
+
+Count the comments. A PR with no prior `<!-- cfgms-acceptance-review -->` comment is
+**always** a first review, whatever its project status says.
 
 Also read `CLAUDE.md` for architecture rules and testing standards.
 
@@ -267,7 +287,7 @@ Mark the story as done in the project queue:
 ./scripts/project-queue.sh update-field <ITEM_ID> status Done
 ```
 
-### Any Findings — First Review
+### Any Findings — Round 1 (no prior `<!-- cfgms-acceptance-review -->` comment)
 
 Update project item status and post findings:
 
@@ -275,7 +295,7 @@ Update project item status and post findings:
 ./scripts/project-queue.sh update-field <ITEM_ID> status Fix
 ```
 
-### Any Findings — Second Review (Fix Cycle)
+### Any Findings — Round 2 (exactly one prior `<!-- cfgms-acceptance-review -->` comment)
 
 Escalate to founder and clean up the agent container (the dev agent is done regardless):
 
@@ -339,7 +359,10 @@ If there are zero findings, the Findings table should say "None" and the Accepta
 - Never skip acceptance criteria verification — every checkbox must be checked against the diff AND the Code-Reference Verification table
 - **Any FAIL row in Code-Reference Verification forces `## Acceptance Review — FAIL`.** The reviewer CANNOT issue PASS while any reference is failing or unverified. "New functions added + tests pass" is NOT sufficient when the AC names a specific symbol that must change.
 - **Diff-blindness rule**: when an AC names existing code that must change, verify the post-change state by fetching the file from the PR's HEAD ref. Searching only `gh pr diff` will miss unchanged stubs (they're absent from the diff by definition).
-- The fix cycle gets exactly one attempt. First failure = `status Fix`. Second failure = `status Blocked`. No third attempt.
+- **Grounding rule — never assert that something does not exist without searching for it.** Before writing any claim of the form "there is no X", "the type doesn't carry Y", "this would require a new Z", or "this can't be done without <bigger change>", grep the **whole file and the whole package**, not the region you happened to read. A false non-existence claim is worse than no claim: the fix agent treats your review as authoritative and will defer or over-build on it. PR #3115 lost two review rounds and two days because a review asserted the data for a UI element "would require a separate executions fetch" after reading lines 72-110 of a file whose line 353 already exported exactly that fetch hook. If you have not run the search, do not make the claim — say "I did not verify whether X exists" instead.
+- **Never offer a remedy the fix agent cannot perform.** A fix-pr agent can change code, tests, and docs on the PR branch. It **cannot** obtain a Tech Lead sign-off, get a founder decision, change acceptance criteria, merge a dependency, or file an issue. Offering "implement it, or get an explicit Tech Lead scope-down" as the alternative to work you have declared impossible leaves it no reachable action — it will take the unreachable option and be failed on the attempt, which is exactly what happened on #3115. State remedies the agent can actually execute; if the only real remedy is a human decision, say so plainly and escalate rather than dressing it up as an option for the agent.
+- **When an AC cannot be satisfied on this branch at all, say so explicitly and recommend against a fix cycle.** Some ACs demand evidence that cannot exist pre-merge (see the Tech Lead's pre-merge-evidence check). Dispatching a fix agent at an unsatisfiable AC burns a cycle and can escalate a false `Blocked`. Report the gap accurately, then add a clear recommendation that the PO amend the AC or land the PR — a FAIL verdict plus "this is not fixable here" is a legitimate and useful review outcome.
+- The fix cycle gets exactly one attempt. **Round 1** failure = `status Fix`. **Round 2** failure = `status Blocked`. No third attempt. The round is `prior <!-- cfgms-acceptance-review --> comment count + 1` (see Phase 1) — **never** the project status, which a CI-driven fix cycle also sets to `Fix`.
 - Merge enqueue uses `--squash` — merge queue handles the rest (rebase + re-validation + actual merge)
 - **A PASS verdict is not self-executing.** The PR moves only when `po-act.sh enqueue` runs and prints `ENQUEUED:<PR>`. Never write the verdict as though the merge happened without that line in hand — a PASS that was never enqueued is indistinguishable, from the outside, from a review that never ran.
 - Clean up the agent container/worktree only after a confirmed `ENQUEUED:<PR>` — the agent infrastructure is no longer needed at that point

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -29,7 +29,7 @@ Also read `CLAUDE.md` for architecture rules, central providers, and anti-patter
 
 ## Validation Checklist
 
-For each story, run all 9 checks. A story must pass ALL checks to be promoted.
+For each story, run all 10 checks. A story must pass ALL checks to be promoted.
 
 ### 1. Dependency Ordering & File Conflict Detection
 
@@ -172,7 +172,46 @@ Dev agents observed adding the new path alongside the old one ("dual-published")
 
 If the gap is small and obvious (the specific symbol to retire is unambiguous from the story's own Files In Scope), add the missing AC yourself as part of your `## Implementation Notes` write-up rather than blocking — otherwise return to the BA.
 
-### 9. Design Controls (visual stories)
+### 9. Pre-Merge Evidence (satisfiable acceptance criteria)
+
+Every acceptance criterion must be **satisfiable on the story's own branch, before
+merge**. An AC that demands evidence which can only exist *after* the change is on
+`develop` is unsatisfiable by construction: no dev agent can ever close it, every
+review correctly FAILs it, and the story burns its whole fix budget before a human
+notices the criterion — not the code — was the problem.
+
+**The shape to catch:** an AC requiring the change be "demonstrated in production",
+"verified through an actual merge-queue rebase", "observed under real traffic",
+"confirmed after deployment", or otherwise validated by a system that will not see
+the change until it merges.
+
+Issue #3042 shipped exactly this: *"The behaviour is demonstrated through an actual
+merge-queue rebase, not only a local merge."* The `.gitattributes` merge driver it
+declared does not exist on `develop` until the PR merges, so the merge queue cannot
+possibly exercise it while the PR is open. PR #3117 failed three consecutive
+acceptance reviews on that single criterion — every reviewer correct, no fix
+possible — and sat two days before the AC was amended. It then passed with **zero
+code changes**.
+
+**How to fix it rather than block on it.** Split the criterion at the merge boundary:
+
+- **Pre-merge (stays in the AC):** the mechanically provable part — the declaration,
+  config, or code exists, and its behaviour is proven by an automated test that runs
+  in CI. "Proven by a test" is satisfiable; "proven in production" is not.
+- **Post-merge (leaves the story):** the operational observation, recorded as a
+  follow-up item that references this story, along with the decision rule for each
+  outcome and any fallback the story identified.
+
+Rewrite the AC yourself when the split is obvious (it usually is) and note it in
+`## Implementation Notes`. Block only if the story's *entire* value is the post-merge
+observation — that is a founder call about whether the story should exist yet.
+
+**Do not confuse this with an open dependency.** "Needs #3125 merged first" is
+ordinary sequencing that the dispatcher gates automatically (Check 1) and is **not**
+a pre-merge-evidence failure. This check is about evidence that cannot exist until
+*this* story's own change lands.
+
+### 10. Design Controls (visual stories)
 
 A **visual story** is any story whose `## Files In Scope` touches the web UI
 (`web/src/**`, `.tsx`, component styles) or that adds/changes a user-visible
@@ -218,7 +257,7 @@ and overusing it buries real escalations in noise.
 
 | Outcome | Project status | Use when | Who acts next |
 |---|---|---|---|
-| **Ready** | `Ready` | Passes all 9 checks. A well-formed dependency that is merely *open* still passes (Check 1). | Dispatcher (auto, when deps merge) |
+| **Ready** | `Ready` | Passes all 10 checks. A well-formed dependency that is merely *open* still passes (Check 1). | Dispatcher (auto, when deps merge) |
 | **Revision Needed** | `Draft` | A check fails in a way an agent (BA / Planning Team) can fix: missing/malformed sections, vague ACs, oversized / needs-split, wrong refs or paths you could not auto-fix. | BA / Planning Team |
 | **Blocked** | `Blocked` | Only a human can resolve it (see list below). | Founder / PO |
 
@@ -226,7 +265,7 @@ and overusing it buries real escalations in noise.
 
 ### Outcome 1 — Ready (passes)
 
-When all 9 checks pass:
+When all 10 checks pass:
 
 1. Update the issue body with any additions (implementation notes, dependency fixes):
    ```bash
@@ -291,7 +330,7 @@ Reserved for issues **only a human can resolve**. Set status Blocked only when o
 - A constraint or architecture decision: needs a new central provider, crosses the licensing boundary, or requires a `CLAUDE.md` / root Makefile / CI change the epic did not authorize
 - A non-v1 / not-yet-scheduled item with no actionable acceptance criteria (decompose-or-icebox is the founder's call)
 - A circular dependency that a human must break
-- A genuinely new visual surface with no **Reference** mockup in `docs/design/mockups/` — only the founder authors and approves UI mockups (founder-owned design; Check 9)
+- A genuinely new visual surface with no **Reference** mockup in `docs/design/mockups/` — only the founder authors and approves UI mockups (founder-owned design; Check 10)
 
 **Never set Blocked for:** an open (unmerged) dependency — the dispatcher gates
 it (Check 1); a fixable spec gap or an oversized story — those are *Revision
@@ -351,7 +390,7 @@ rm /tmp/tl-summary.md
 
 - Never modify source code — you only read code and write GitHub issues
 - Never promote a story you haven't validated against the actual codebase
-- Never set status to Ready if ANY of the 9 checks fail
+- Never set status to Ready if ANY of the 10 checks fail
 - If you can fix an issue by editing the story body (adding notes, fixing a path), do that rather than blocking
 - Batch multiple stories efficiently — read shared files once, not per-story
 - The story quality bar (self-contained, explicit files, testable criteria, single concern, no vague verbs) is the BA's job. Your job is executability validation on top of that.
@@ -365,7 +404,7 @@ When spawned as a teammate (with a `name`, as a background agent), you operate a
 - **No GitHub writes.** Never call `pipeline-helper.sh` in team mode. The PO handles all GitHub operations after the team reaches consensus.
 - **Input comes from the team.** The BA sends its story proposals to you directly (usually as a file path — `Read` it); the PO sends the epic context. You do NOT read stories from GitHub issues.
 - **Send verdicts directly to the BA (copy the PO).** For each story send a clear verdict to `ba`, and copy `po`:
-  - **APPROVED** — story passes all 9 checks. Include any implementation notes to add.
+  - **APPROVED** — story passes all 10 checks. Include any implementation notes to add.
   - **REVISION NEEDED** — story fails one or more checks. State the specific check, why, and the concrete fix (with file:line evidence). The BA revises and replies to you directly.
   - **Large verdict sets go to a file** (`/tmp/tl-<epic>-verdicts.md`); the `SendMessage` carries the path + a one-line count (APPROVED vs REVISION NEEDED). Long message bodies get truncated to summaries in transit.
 - **Iterate directly with the BA.** Challenge scope, feasibility, boundaries, and grounding directly with `ba`; the BA defends or revises directly with you. Loop until convergence.


### PR DESCRIPTION
## Summary

Three independent defects surfaced by PRs #3115, #3117 and #3121 — each stranded a PR for two days on a gap that was one commit from done.

**They are disjoint.** None of these fixes would have caught the other two. Sliced into one PR because they're all review-cycle correctness and all doc-only, but they address separate failure modes:

| PR | Failure | Fixed by |
|---|---|---|
| #3115 | Review asserted a false fact + offered an unreachable remedy | Fix 2 |
| #3117 | Story shipped a structurally unsatisfiable AC | Fix 3 |
| #3121 | Reviewer mis-counted its own review round | Fix 1 |

## 1. Round-counting (`acceptance-reviewer.md`)

The reviewer inferred its round from project status: `.status == "Fix" means FIX_CYCLE`. **A CI-driven fix cycle also sets `Fix`**, so a genuinely-first acceptance review read itself as the second and escalated its first real finding straight to `Blocked` — skipping the fix cycle the story was owed and converting a two-strike budget into one strike.

This is what happened to #3121: its fix container ran **38 minutes before any acceptance-review comment existed** (`gh pr view 3121 --json reviews` returns empty), so that fix was CI-driven. The first substantive review then Blocked it.

The round is now `prior <!-- cfgms-acceptance-review --> comment count + 1`.

**Verified against the incident** — counting review comments predating #3121's 10:31 review returns `0`, so under the new rule that review is round 1 and sets `Fix`, not `Blocked`.

This is the most systemic of the three: it mis-fires on *every* PR that happens to have a CI fix cycle before its first acceptance review.

## 2. Grounding rule (`acceptance-reviewer.md`)

A review asserted the data for a UI element "would require a separate executions fetch" after reading lines 72-110 of a file whose **line 353 already exported exactly that hook** (`useWorkflowExecutions`). The fix agent treated the review as authoritative and deferred on it, costing two rounds and two days.

Reviews must now grep the whole file and package before asserting non-existence, and say "I did not verify whether X exists" rather than claiming it doesn't.

The same review also offered *"implement it, or get an explicit Tech Lead scope-down"* as the alternative to work it had just declared impossible — but a fix-pr agent **cannot** obtain a Tech Lead sign-off, get a founder decision, amend ACs, or merge a dependency. It had no reachable action, took the unreachable one, and was failed for it. Reviews must only offer remedies the agent can actually execute.

Third clause: when an AC isn't satisfiable on the branch at all, say so and recommend against a fix cycle. A FAIL plus "this is not fixable here" is a legitimate outcome — #3157's reviewer did exactly this and it was the correct call.

## 3. Pre-merge evidence (`tech-lead.md`, new check 9)

Issue #3042's AC3 required a `.gitattributes` merge driver be *"demonstrated through an actual merge-queue rebase, not only a local merge."* The driver doesn't reach `develop` until the PR merges, so the queue cannot exercise it while the PR is open — unsatisfiable by construction.

PR #3117 failed **three consecutive** acceptance reviews on that one criterion. Every reviewer was correct; no fix was possible. Once the AC was amended it passed with **zero code changes**.

The Tech Lead now splits such ACs at the merge boundary — mechanically provable part stays in the AC, operational observation becomes a follow-up item with its decision rule. It rewrites the AC itself when the split is obvious, and blocks only when the story's entire value *is* the post-merge observation.

Explicitly scoped: an open dependency ("needs #3125 merged first") is ordinary sequencing gated by Check 1, **not** this failure mode.

Design Controls renumbered 9 → 10; all six check-count references updated.

## Validation

- `make test` — **221 script tests, 0 failures**, full validation complete.
- Round-counting command smoke-tested against live PRs: #3115→3 prior, #3121→2, #3150→1, #3162→0. Correct in every case.
- Counterfactual replay of the #3121 incident confirms the fix flips its outcome from Blocked to Fix.
- Heading sequence verified 1-10, no stale "9 checks" / "Check 9" references remain anywhere in `.claude/`.

## Test plan

- [x] `make test` passes
- [x] Round-counting query verified against real PR state
- [x] Fix validated against the incident that motivated it
- [x] Checklist renumbering complete and consistent
