### PR TITLE
pipeline: auto-reap cleanly-exited review containers instead of refusing

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -660,7 +660,7 @@ _review_refusal_hint() {
     already_in_flight)
       echo "a review container for this PR is still running — another review is genuinely in progress. Check /isoagents; no action needed." ;;
     container_exists)
-      echo "a review container for this PR exists but has exited — run './.claude/scripts/agent-dispatch.sh cleanup-stale-reviews', then retry." ;;
+      echo "a review container for this PR exited NON-ZERO (crashed) and is kept for diagnosis — inspect it with './.claude/scripts/agent-dispatch.sh inspect-container cfg-agent-review-pr-<PR>', then clear it with 'cleanup-container cfg-agent-review-pr-<PR>' and retry. (A cleanly-exited container is reaped automatically and never reaches this refusal.)" ;;
     lease_held)
       echo "another host holds the pr-<N> lease (reviewing/fixing/rebasing this PR) — wait for it to release." ;;
     lease_error)
@@ -743,18 +743,37 @@ _emit_review_refused() {
 # Classify an existing cfg-agent-review-pr-<N> container's `docker ps`
 # `.State` value into the REVIEW_REFUSED reason review-pr should emit.
 #
-# Args: <docker_state>  (e.g. "running", "exited", "restarting", "created")
-# Stdout: "already_in_flight" (still alive — caller should just wait) or
-#   "container_exists" (leftover from a crash — caller should run
-#   `cleanup-stale-reviews` first)
+# Args: <docker_state> [exit_code]
+#   docker_state — e.g. "running", "exited", "restarting", "created"
+#   exit_code    — the container's `.State.ExitCode`; optional. Omit it (or pass
+#                  a non-zero/unknown value) to get the conservative answer.
+# Stdout, one of:
+#   already_in_flight — still alive; the caller should wait, not act
+#   reap_clean        — exited 0: finished its review, posted its comment, and
+#                       released its lease. Nothing to preserve — the caller
+#                       should remove it and proceed.
+#   container_exists  — exited non-zero (or state unknown): a crash. Preserve it
+#                       for inspection and refuse.
 #
-# Split out so the running-vs-leftover distinction is a plain lookup instead
-# of an inline conditional a caller has to re-derive from `docker ps` output —
-# and so it's unit-testable without a live docker daemon.
+# Why `reap_clean` exists: `cleanup-stale-reviews` only reaps review containers
+# that exited more than 30 minutes ago, so for 30 minutes after ANY successful
+# review the same PR could not be re-reviewed — and the `container_exists` hint
+# pointed at `cleanup-stale-reviews`, which is guaranteed to no-op inside that
+# window. During an active drain a PR routinely gets a fix or rebase well inside
+# 30 minutes, so this blocked legitimate re-reviews (hit on PR #3150). The
+# 30-minute grace exists to keep a *crashed* container around for diagnosis; a
+# clean exit has already produced its artifact and has nothing to diagnose.
+#
+# Split out so the distinction is a plain lookup instead of an inline
+# conditional a caller has to re-derive from `docker ps` output — and so it's
+# unit-testable without a live docker daemon.
 _classify_review_container_state() {
   local state="$1"
+  local exit_code="${2-}"
   case "$state" in
     running|restarting|created) echo "already_in_flight" ;;
+    exited)
+      if [[ "$exit_code" == "0" ]]; then echo "reap_clean"; else echo "container_exists"; fi ;;
     *)                          echo "container_exists" ;;
   esac
 }
@@ -2150,11 +2169,23 @@ PYEOF
     container_name="cfg-agent-review-pr-${pr_num}"
     clone_dir="${WORKTREE_BASE}/review-pr-${pr_num}"
 
-    # Container conflict gate: refuse if the review container already exists.
+    # Container conflict gate. A live container means wait; a crashed one is
+    # preserved for diagnosis and refuses; a cleanly-exited one is reaped here
+    # and we proceed (see _classify_review_container_state for why).
     # (Same-host fast path; the cross-host interlock is the pr-<N> lease below.)
     existing_state=$(docker ps -a --filter "name=^/${container_name}$" --format "{{.State}}" 2>/dev/null | head -1)
     if [[ -n "$existing_state" ]]; then
-      _emit_review_refused "$pr_num" "$(_classify_review_container_state "$existing_state")"
+      existing_exit=$(docker inspect "$container_name" --format '{{.State.ExitCode}}' 2>/dev/null || echo "")
+      case "$(_classify_review_container_state "$existing_state" "$existing_exit")" in
+        reap_clean)
+          echo "REAPED_CLEAN_REVIEW_CONTAINER:${pr_num}:${container_name}"
+          docker rm -f "$container_name" >/dev/null 2>&1 || true
+          rm -rf "$clone_dir" 2>/dev/null || true
+          ;;
+        *)
+          _emit_review_refused "$pr_num" "$(_classify_review_container_state "$existing_state" "$existing_exit")"
+          ;;
+      esac
     fi
 
     PROJECT_QUEUE="${REPO_ROOT}/scripts/project-queue.sh"
@@ -2606,9 +2637,10 @@ PROMPT_EOF
   _test-classify-container-state)
     # Hidden test hook for review_pr_detection.test.sh. Calls
     # _classify_review_container_state() with the supplied docker `.State`
-    # value and prints its result. Safe (no docker, no gh, no writes).
-    [[ $# -eq 1 ]] || { echo "_test-classify-container-state requires <state>"; exit 1; }
-    _classify_review_container_state "$1"
+    # value and optional exit code, and prints its result.
+    # Safe (no docker, no gh, no writes).
+    [[ $# -ge 1 ]] || { echo "_test-classify-container-state requires <state> [exit_code]"; exit 1; }
+    _classify_review_container_state "$1" "${2-}"
     ;;
 
   _test-review-refusal-hint)

--- a/.claude/scripts/tests/review_pr_detection.test.sh
+++ b/.claude/scripts/tests/review_pr_detection.test.sh
@@ -191,9 +191,10 @@ assert_container_classification() {
   local description="$1"
   local docker_state="$2"
   local expected="$3"
+  local exit_code="${4-}"
   ran=$((ran + 1))
   local actual
-  actual=$("$DISPATCH" _test-classify-container-state "$docker_state")
+  actual=$("$DISPATCH" _test-classify-container-state "$docker_state" "$exit_code")
   if [[ "$actual" == "$expected" ]]; then
     printf '  ok    %s\n' "$description"
   else
@@ -211,13 +212,28 @@ assert_container_classification "restarting container → already_in_flight" \
 assert_container_classification "created (not yet started) → already_in_flight" \
   "created" "already_in_flight"
 
-# Leftover from a crash — the caller should run cleanup-stale-reviews.
-assert_container_classification "exited container → container_exists" \
+# Exited 0 — review finished, comment posted, lease released. Nothing to
+# preserve, so the caller reaps it and proceeds instead of refusing. Without
+# this, cleanup-stale-reviews' 30-minute threshold made a PR un-re-reviewable
+# for 30 minutes after every successful review (hit on PR #3150).
+assert_container_classification "exited 0 → reap_clean" \
+  "exited" "reap_clean" "0"
+
+# Exited non-zero — a crash. Keep it for diagnosis and refuse.
+assert_container_classification "exited 1 → container_exists" \
+  "exited" "container_exists" "1"
+assert_container_classification "exited 137 (OOM-kill) → container_exists" \
+  "exited" "container_exists" "137"
+# Unknown exit code must fall back to the conservative answer, never reap.
+assert_container_classification "exited, exit code unknown → container_exists" \
   "exited" "container_exists"
 assert_container_classification "dead container → container_exists" \
   "dead" "container_exists"
 assert_container_classification "paused container → container_exists" \
   "paused" "container_exists"
+# A live container is never reaped, whatever stale exit code docker reports.
+assert_container_classification "running with stale exit code 0 → already_in_flight" \
+  "running" "already_in_flight" "0"
 
 echo
 echo "--- review-pr: refusal-reason hint coverage (every emitted reason has a hint) ---"


### PR DESCRIPTION
## Summary

`cleanup-stale-reviews` only reaps review containers that exited **more than 30 minutes ago**. Because `review-pr` refused whenever *any* container for the PR existed, a PR was **un-re-reviewable for 30 minutes after every successful review** — and the `container_exists` refusal hint pointed at `cleanup-stale-reviews`, which is guaranteed to no-op inside exactly that window.

During an active drain a PR routinely gets a fix or rebase well inside 30 minutes, so this blocked legitimate re-reviews.

**Hit for real on PR #3150** tonight: its review container had exited `0` twenty-eight minutes earlier, having already posted its review comment, and the recommended remedy returned `cleaned=0`. The PR could not be re-reviewed until the container was cleared by hand with `cleanup-container`.

## Why reaping is safe here

The 30-minute grace exists to keep a **crashed** container around for diagnosis. A container that exited `0` has already:
- posted its acceptance-review comment (its entire artifact), and
- released its `pr-<N>` lease.

There is nothing to preserve and nothing to diagnose.

## Change

`_classify_review_container_state` now takes the container's exit code and returns a third outcome:

| State | Exit code | Outcome |
|---|---|---|
| `running` / `restarting` / `created` | any | `already_in_flight` — wait (unchanged) |
| `exited` | `0` | **`reap_clean`** — remove and proceed (new) |
| `exited` | non-zero | `container_exists` — preserve, refuse (unchanged) |
| `exited` | unknown/omitted | `container_exists` — conservative fallback |
| `dead` / `paused` | any | `container_exists` (unchanged) |

On `reap_clean`, `review-pr` removes the container and its clone, prints `REAPED_CLEAN_REVIEW_CONTAINER:<pr>:<name>`, and continues.

Crash forensics are unaffected: non-zero exits still refuse and are still preserved. A live container is never reaped regardless of any stale exit code docker reports for it.

The `container_exists` hint no longer recommends `cleanup-stale-reviews` — which could never have helped in the case that now reaches it — and points at `inspect-container` / `cleanup-container` instead.

## Validation

- `make test` — **221 script tests, 0 failures**.
- `review_pr_detection.test.sh` — **44 → 48 assertions**, all passing. New cases: exited-0 reaps, exited-1 refuses, exited-137 (OOM-kill) refuses, unknown exit code falls back conservatively, and a running container with a stale exit code of 0 is still `already_in_flight`.
- **Live end-to-end, both paths.** Staged a real container named `cfg-agent-review-pr-3163` and held the `pr-3163` lease so the run would refuse *after* the reap gate, proving the reap fired without dispatching anything:
  - **Exited 0** → `REAPED_CLEAN_REVIEW_CONTAINER:3163:cfg-agent-review-pr-3163`, then `REVIEW_REFUSED:3163:lease_held`. Container confirmed gone.
  - **Exited 1** → `REVIEW_REFUSED:3163:container_exists` with the new hint. Container confirmed still present.
  - Test container and lease cleaned up afterwards.

## Test plan

- [x] `make test` passes
- [x] Unit coverage for every state/exit-code combination, including the conservative fallback
- [x] Live end-to-end verification of both the reap and the preserve path
- [x] Verified no dispatch occurs on the reap path (forced a later-gate refusal)

Follow-up to #3164 and #3165. Found while draining tonight's PR queue.
