### PR TITLE
docs: correct the required-checks list and record the PR/queue split (Issue #3176)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,21 +4,35 @@ This directory contains automated CI/CD workflows for CFGMS. All workflows are a
 
 ## Required Status Checks (develop ruleset)
 
-These are the exact context names configured as required checks in the develop branch ruleset. All must pass (or be satisfied by a stub) before a PR can merge:
+These are the exact context names configured as required checks in the develop
+branch ruleset. All ten must pass (or be satisfied by a stub) before a PR can
+merge. Verify this list against the ruleset rather than trusting it:
+
+```bash
+gh api repos/cfg-is/cfgms/rulesets/11647684 \
+  --jq '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'
+```
 
 | Context name | Source workflow |
 |---|---|
 | `unit-tests` | `test-suite.yml` (PR/merge_group) or `documentation.yml` stub |
 | `integration-tests` | `test-suite.yml` (PR/merge_group) or `documentation.yml` stub |
-| `Build Gate` | `production-gates.yml` or `documentation.yml` stub |
+| `Build Gate` | `cross-platform-build.yml` or `documentation.yml` stub |
 | `security-deployment-gate` | `production-gates.yml` or `documentation.yml` stub |
-| `Controller Integration Tests (Linux)` | `cross-platform-build.yml` or `documentation.yml` stub |
-| `zizmor` | `zizmor.yml` |
-| `CLA signature check` | `cla-check.yml` |
+| `Controller Integration Tests (Linux)` | `production-gates.yml` or `documentation.yml` stub |
+| `zizmor` | `zizmor.yml` — no stub |
+| `CLA signature check` | `cla-check.yml` — no stub |
+| `frontend-checks` | `frontend-ci.yml` — no stub |
 | `trivy-scan` | `security-scan.yml` or `documentation.yml` stub |
 | `CodeQL` | `codeql-analysis.yml` or `codeql-stub.yml` |
 
-Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to `docs/**`, `*.md`, `.claude/**`) so they clear all nine required contexts without running the full code-validation suite.
+Docs-only PRs are served by stub jobs in `documentation.yml` (paths-filtered to
+`docs/**`, `*.md`, `.claude/**`) for the seven contexts that have one. The other
+three — `zizmor`, `CLA signature check` and `frontend-checks` — carry no path
+filter and no stub: their real job runs on every `pull_request` and every
+`merge_group`. `frontend-ci.yml` deliberately has no workflow-level paths filter
+and detects `web/**` changes inside the job instead, because a required check
+that never creates a check run blocks the merge queue indefinitely.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,9 +126,16 @@ list them. Treat a finding there as real work, not as optional.
 
 **A stub must be mutually exclusive with the job it stands in for.** Two check
 runs sharing one context name is a false-green risk: a passing stub alongside a
-failing real job. The stub's trigger must be the exact complement of the real
-one — see `codeql-stub.yml`, whose `paths-ignore` is the precise inverse of
-`codeql-analysis.yml`'s `paths`, so exactly one of the two ever runs.
+failing real job. Stubs are paired with their real job by inverting the trigger —
+`codeql-stub.yml`'s `paths-ignore` is the inverse of `codeql-analysis.yml`'s
+`paths`, and the PR-time stubs are gated on `github.event_name`.
+
+Event-gated pairs are genuinely exclusive. **Path-gated pairs are not, for a PR
+that touches both sides**: `paths` fires when *any* changed file matches, and
+`paths-ignore` fires when *any* changed file does not, so a PR touching both a
+`.go` file and a `.md` file triggers the real job and its stub. Whether GitHub
+then resolves the shared context to the failing run or the passing one is not
+established — do not rely on a path-gated stub to be exclusive until it is.
 
 Docs-only PRs get instant green checks via stub jobs (<2 min merge path).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,41 +101,74 @@ All must pass before merge to `develop`. Verify this list against the ruleset
 rather than trusting it — `gh api repos/cfg-is/cfgms/rulesets/11647684 --jq
 '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'`.
 
-Most of these run for real on only **one** side of the PR / merge-queue split and
-post a stub context on the other, so the same change is not scanned twice. A
-green check on a PR therefore does not always mean that scan ran — read the
-"Real run" column.
+A green check does not always mean that scan ran. Most of these run for real on
+only **one** side of the PR / merge-queue split and post a stub context on the
+other, so the same change is not scanned twice — read the "Real run" column.
 
 | Check | Real run | What it validates |
 |-------|----------|-------------------|
-| `unit-tests` | PR | Core functionality (~3-5 min) |
-| `integration-tests` | merge queue | Comprehensive + production-critical (~5-10 min) |
-| `Build Gate` | merge queue | Cross-platform compilation + Docker integration (~10-15 min) |
-| `Controller Integration Tests (Linux)` | merge queue | Controller integration suite |
-| `security-deployment-gate` | merge queue | Critical vulnerability blocking (~6-10 min) |
-| `trivy-scan` | merge queue | Filesystem vulnerabilities, secrets, misconfiguration |
-| `CodeQL` | PR + merge queue | Semantic analysis; reports alerts on changed lines only |
-| `zizmor` | PR + merge queue | Workflow security — action pins, cache poisoning, injection |
-| `frontend-checks` | PR + merge queue | `web/` typecheck, lint, and tests |
-| `CLA signature check` | PR + merge queue | Contributor licence agreement |
+| `unit-tests` | PR (queue stubbed) | Core functionality (~3-5 min) |
+| `integration-tests` | merge queue (PR stubbed) | Comprehensive + production-critical (~5-10 min) |
+| `Build Gate` | merge queue (PR stubbed) | Cross-platform compilation + Docker integration (~10-15 min) |
+| `Controller Integration Tests (Linux)` | merge queue (PR stubbed) | Controller integration suite |
+| `security-deployment-gate` | merge queue (PR stubbed) | Critical vulnerability blocking (~6-10 min) |
+| `trivy-scan` | merge queue (PR stubbed) | Filesystem vulnerabilities, secrets, misconfiguration |
+| `CodeQL` | both (stubbed on non-Go PRs) | Semantic analysis; reports alerts on changed lines only |
+| `zizmor` | both (no stub) | Workflow security — action pins, cache poisoning, injection |
+| `frontend-checks` | both (no stub) | `web/` typecheck, lint, and tests |
+| `CLA signature check` | both (no stub) | Contributor licence agreement |
+
+Three shapes sit behind that column:
+
+- **Five run for real in the queue.** Their PR-side stub is a `*-pr-stub` job in
+  the check's own workflow; on a docs-only PR, where that workflow is
+  paths-ignored entirely, `documentation.yml` posts the context instead.
+  `unit-tests` is the inverse — real on the PR, stubbed in the queue by
+  `test-suite.yml`'s `unit-tests-mq-stub`.
+- **`CodeQL` runs for real on both sides,** path-filtered on the PR side to Go
+  sources, the module graph, `.github/codeql/**`, its own workflow file and
+  `web/`. `codeql-stub.yml` covers PRs touching none of those, and deliberately
+  does not trigger on `merge_group`, where the real analysis runs unfiltered.
+- **`zizmor`, `frontend-checks` and `CLA signature check` have no path filter and
+  no stub** — the real job runs on every `pull_request` and every `merge_group`.
 
 **Advisory, not required:** `nancy-scan`, `gosec-scan` and `staticcheck-scan`
-(PR side only), plus `security-validation`, which aggregates them. Their jobs
-fail on findings, but a red one does **not** block a merge — the ruleset does not
-list them. Treat a finding there as real work, not as optional.
+(PR side only), plus `security-validation`, the `security-scan.yml` aggregate
+that evaluates them across the split. Their jobs fail on findings, but a red one
+does **not** block a merge — the ruleset does not list them. Treat a finding
+there as real work, not as optional.
+
+`security-validation`'s merge-queue side is known to work: runs `30906412345`
+and `30906246182`, job `security-validation`, event `merge_group`, branch
+`gh-readonly-queue/develop/pr-3156-…`, conclusion `success`. A docs-only PR is
+not blocked by it either — `security-scan.yml` is paths-ignored for
+documentation changes, so `documentation.yml` posts the `security-validation`
+context for that case.
+
+### Stub exclusivity
 
 **A stub must be mutually exclusive with the job it stands in for.** Two check
 runs sharing one context name is a false-green risk: a passing stub alongside a
-failing real job. Stubs are paired with their real job by inverting the trigger —
-`codeql-stub.yml`'s `paths-ignore` is the inverse of `codeql-analysis.yml`'s
-`paths`, and the PR-time stubs are gated on `github.event_name`.
+failing real job. Not every pair here meets that bar today.
 
-Event-gated pairs are genuinely exclusive. **Path-gated pairs are not, for a PR
-that touches both sides**: `paths` fires when *any* changed file matches, and
-`paths-ignore` fires when *any* changed file does not, so a PR touching both a
-`.go` file and a `.md` file triggers the real job and its stub. Whether GitHub
-then resolves the shared context to the failing run or the passing one is not
-established — do not rely on a path-gated stub to be exclusive until it is.
+**Path-gated pairs overlap when a PR touches both sides.** `paths` fires when
+*any* changed file matches and `paths-ignore` fires when *any* changed file does
+not, so a PR touching both a `.go` file and a `.md` file triggers the real job
+and its stub.
+
+**Four `documentation.yml` stubs also fire in the merge queue,** where they guard
+nothing: `unit-tests`, `integration-tests`, `Build Gate` and `Controller
+Integration Tests (Linux)` are gated `pull_request || merge_group`, and
+`documentation.yml` carries no `paths` filter on `merge_group`. Measured on queue
+commit `c9ac1917`: `documentation.yml` posted all four green while the real
+`Build Gate`, `integration-tests` and `Controller Integration Tests (Linux)` ran
+in parallel. (`unit-tests` is harmless — both its queue-side posters are stubs.)
+The `security-deployment-gate`, `trivy-scan` and `security-validation` stubs are
+correctly `pull_request`-only.
+
+Whether GitHub resolves a shared context to the failing run or the passing one is
+not established. Do not rely on a stub being exclusive until it is — and when a
+queue-real check goes green, confirm the *real* job posted it.
 
 Docs-only PRs get instant green checks via stub jobs (<2 min merge path).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,14 +97,38 @@ Format: `<scope>: <what changed> (Issue #XXX)`. See [commit standards](docs/deve
 
 ## Required CI Checks
 
-All must pass before merge to `develop`:
+All must pass before merge to `develop`. Verify this list against the ruleset
+rather than trusting it — `gh api repos/cfg-is/cfgms/rulesets/11647684 --jq
+'.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'`.
 
-| Check | What it validates |
-|-------|-------------------|
-| `unit-tests` | Core functionality (~3-5 min) |
-| `integration-tests` | Comprehensive + production-critical (~5-10 min) |
-| `Build Gate` | Cross-platform compilation + Docker integration (~10-15 min) |
-| `security-deployment-gate` | Security vulnerability blocking (~6-10 min) |
+Most of these run for real on only **one** side of the PR / merge-queue split and
+post a stub context on the other, so the same change is not scanned twice. A
+green check on a PR therefore does not always mean that scan ran — read the
+"Real run" column.
+
+| Check | Real run | What it validates |
+|-------|----------|-------------------|
+| `unit-tests` | PR | Core functionality (~3-5 min) |
+| `integration-tests` | merge queue | Comprehensive + production-critical (~5-10 min) |
+| `Build Gate` | merge queue | Cross-platform compilation + Docker integration (~10-15 min) |
+| `Controller Integration Tests (Linux)` | merge queue | Controller integration suite |
+| `security-deployment-gate` | merge queue | Critical vulnerability blocking (~6-10 min) |
+| `trivy-scan` | merge queue | Filesystem vulnerabilities, secrets, misconfiguration |
+| `CodeQL` | PR + merge queue | Semantic analysis; reports alerts on changed lines only |
+| `zizmor` | PR + merge queue | Workflow security — action pins, cache poisoning, injection |
+| `frontend-checks` | PR + merge queue | `web/` typecheck, lint, and tests |
+| `CLA signature check` | PR + merge queue | Contributor licence agreement |
+
+**Advisory, not required:** `nancy-scan`, `gosec-scan` and `staticcheck-scan`
+(PR side only), plus `security-validation`, which aggregates them. Their jobs
+fail on findings, but a red one does **not** block a merge — the ruleset does not
+list them. Treat a finding there as real work, not as optional.
+
+**A stub must be mutually exclusive with the job it stands in for.** Two check
+runs sharing one context name is a false-green risk: a passing stub alongside a
+failing real job. The stub's trigger must be the exact complement of the real
+one — see `codeql-stub.yml`, whose `paths-ignore` is the precise inverse of
+`codeql-analysis.yml`'s `paths`, so exactly one of the two ever runs.
 
 Docs-only PRs get instant green checks via stub jobs (<2 min merge path).
 

--- a/docs/development/branch-protection-rules.md
+++ b/docs/development/branch-protection-rules.md
@@ -37,28 +37,23 @@ CFGMS uses GitHub Rulesets to protect branches in a GitFlow-style branching mode
 | Require conversation resolution | ✅ Yes | All PR comments must be resolved |
 | Status checks required | ✅ Yes | All CI checks must pass |
 
-### Required Status Checks (13 total)
+### Required Status Checks (4 total)
 
-**Core Build & Test Checks**:
-- `cross-compile-check` - Cross-platform compilation validation
-- `native-builds` - Native builds (Ubuntu, macOS, Windows)
-- `integration-tests` - Integration test suite
-- `build-gate` - Final build validation
+- `unit-tests` - Core functionality validation
+- `integration-tests` - Fast comprehensive + production-critical tests
+- `Build Gate` - Cross-platform compilation + Docker integration tests
+- `security-deployment-gate` - Security vulnerability blocking
 
-**Security Scans**:
-- `trivy-scan` - Container vulnerability scanning
-- `nancy-scan` - Go dependency scanning
-- `gosec-scan` - Go security analysis
-- `staticcheck-scan` - Static code analysis
-- `security-validation` - Security validation gate
+Read the list from the ruleset rather than trusting this page:
 
-**Code Analysis**:
-- `analyze` - CodeQL security analysis
+```bash
+gh api repos/cfg-is/cfgms/rulesets/11647678 \
+  --jq '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'
+```
 
-**Production Gates** (main only):
-- `security-deployment-gate` - Security deployment readiness
-- `production-risk-assessment` - Production risk evaluation
-- `integration-test-gate` - Integration test validation
+**Note**: `main` is reached only by a `develop → main` release PR, so the content
+has already cleared develop's ten checks. These four re-validate the merge
+commit; they are not the whole of what gated the change.
 
 ---
 
@@ -82,15 +77,36 @@ CFGMS uses GitHub Rulesets to protect branches in a GitFlow-style branching mode
 | Status checks required | ✅ Yes | CI checks must pass |
 | Merge queue | ✅ Enabled | Serialized merge with post-rebase validation (replaces strict mode) |
 
-### Required Status Checks (5 total)
+### Required Status Checks (10 total)
 
 - `unit-tests` - Core functionality validation
 - `integration-tests` - Fast comprehensive + production-critical tests
 - `Build Gate` - Cross-platform compilation + Docker integration tests
 - `security-deployment-gate` - Security vulnerability blocking
 - `Controller Integration Tests (Linux)` - Controller integration test suite
+- `trivy-scan` - Filesystem vulnerabilities, secrets, misconfiguration
+- `CodeQL` - Semantic code analysis
+- `zizmor` - Workflow security (action pins, cache poisoning, injection)
+- `frontend-checks` - `web/` typecheck, lint and tests
+- `CLA signature check` - Contributor licence agreement
 
-**Rationale**: Direct required checks pattern (Story #322) replaced the previous 10-check approach. These checks cover unit tests, integration tests, cross-platform builds, and security scanning. Production-specific gates (`production-risk-assessment`, `integration-test-gate`) are excluded to allow faster iteration.
+Read the list from the ruleset rather than trusting this page:
+
+```bash
+gh api repos/cfg-is/cfgms/rulesets/11647684 \
+  --jq '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'
+```
+
+**Rationale**: Direct required checks pattern (Story #322) replaced the earlier
+approach of gating on aggregate workflow results. The `production-risk-assessment`
+and `integration-test-gate` jobs this list used to name no longer exist — the
+former is commented out in `production-gates.yml`, the latter is absent — so they
+are not "excluded" so much as retired.
+
+**Advisory, not required**: `nancy-scan`, `gosec-scan` and `staticcheck-scan`,
+plus `security-validation`, the `security-scan.yml` aggregate that evaluates them.
+Their jobs fail on findings, but a red one does not block a merge — the ruleset
+does not list them. Treat a finding there as real work, not as optional.
 
 ### Merge Queue
 
@@ -99,7 +115,7 @@ Enabled in Story #801. The merge queue replaces the previous `strict_required_st
 **How it works:**
 1. A PR marked for merge enters a serial queue
 2. GitHub creates a temporary merge-queue branch: current develop tip + the PR's changes
-3. All 5 required checks run against that combined (post-rebase) state
+3. All 10 required checks run against that combined (post-rebase) state
 4. If checks pass, the PR is squash-merged into develop
 5. If checks fail, the PR is ejected from the queue and the author is notified
 
@@ -132,21 +148,23 @@ Enabled in Story #801. The merge queue replaces the previous `strict_required_st
 | Pull request required | ❌ Not required | Release automation pushes directly |
 | Status checks required | ✅ Yes | Full validation before release |
 
-### Required Status Checks (10 total)
+### Required Status Checks (none)
 
-**Core checks + deployment gate**:
-- `cross-compile-check`
-- `native-builds`
-- `integration-tests`
-- `build-gate`
-- `trivy-scan`
-- `nancy-scan`
-- `gosec-scan`
-- `staticcheck-scan`
-- `security-validation`
-- `security-deployment-gate`
+The Release Branch Protection ruleset configures **no** required status checks.
+Deletion and force-push rules apply; CI results do not gate a push to a
+`release/*` branch.
 
-**Note**: Release branches require security deployment gate but exclude `production-risk-assessment` and `integration-test-gate` (already validated in develop). CodeQL analysis (`analyze`) is optional since it was already run on develop.
+```bash
+# Returns nothing — there is no required_status_checks rule on this ruleset.
+gh api repos/cfg-is/cfgms/rulesets/11647689 \
+  --jq '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'
+```
+
+**This is recorded as the measured state, not as an endorsement.** Release
+branches are cut from `develop`, whose ten checks have already run on every
+commit, so content reaching `release/*` has been validated — but nothing
+re-validates the release branch itself. Closing that gap is a ruleset change and
+is tracked separately from this document.
 
 ---
 
@@ -154,21 +172,32 @@ Enabled in Story #801. The merge queue replaces the previous `strict_required_st
 
 ### Status Check Sources
 
-| Check Name | Workflow File | Job Name |
-|------------|---------------|----------|
-| cross-compile-check | cross-platform-build.yml | cross-compile-check |
-| native-builds | cross-platform-build.yml | native-builds |
-| integration-tests | cross-platform-build.yml | integration-tests |
-| build-gate | cross-platform-build.yml | build-gate |
-| trivy-scan | security-scan.yml | trivy-scan |
-| nancy-scan | security-scan.yml | nancy-scan |
-| gosec-scan | security-scan.yml | gosec-scan |
-| staticcheck-scan | security-scan.yml | staticcheck-scan |
-| security-validation | security-scan.yml | security-validation |
-| analyze | codeql-analysis.yml | analyze |
-| security-deployment-gate | production-gates.yml | security-deployment-gate |
-| production-risk-assessment | production-gates.yml | production-risk-assessment |
-| integration-test-gate | production-gates.yml | integration-test-gate |
+The context name is the job's `name:`, not its key — these were measured by
+grepping `name: <context>` across `.github/workflows/`.
+
+**Required on `develop`** (all ten):
+
+| Context name | Real run | Stub |
+|---|---|---|
+| `unit-tests` | `test-suite.yml` | `documentation.yml` |
+| `integration-tests` | `test-suite.yml` | `documentation.yml` |
+| `Build Gate` | `cross-platform-build.yml` | `documentation.yml` |
+| `security-deployment-gate` | `production-gates.yml` | `documentation.yml` |
+| `Controller Integration Tests (Linux)` | `production-gates.yml` | `documentation.yml` |
+| `trivy-scan` | `security-scan.yml` | `documentation.yml` |
+| `CodeQL` | `codeql-analysis.yml` | `codeql-stub.yml` |
+| `zizmor` | `zizmor.yml` | none |
+| `frontend-checks` | `frontend-ci.yml` | none |
+| `CLA signature check` | `cla-check.yml` | none |
+
+**Advisory, not required** — these fail on findings but do not block a merge:
+
+| Context name | Source workflow |
+|---|---|
+| `nancy-scan` | `security-scan.yml` |
+| `gosec-scan` | `security-scan.yml` |
+| `staticcheck-scan` | `security-scan.yml` |
+| `security-validation` | `security-scan.yml` |
 
 ---
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` documented four required CI checks. The `Develop Branch Protection` ruleset requires ten. This corrects the list, records which side of the PR / merge-queue split each check actually runs on, and documents where the stub/real pairing does *not* hold.

Covers acceptance criteria 1-4 of #3176. AC 5 (`make test-complete`) is addressed below with one caveat. The ruleset change itself (`gh api --method PUT` to add `security-validation` to the required contexts) is explicitly Out of Scope in the story — a founder/PO runbook action, not a dev-agent PR.

## Changes Made

- Table lists all ten required contexts, verified by diffing against `gh api repos/cfg-is/cfgms/rulesets/11647684`.
- New "Real run" column records which side of the split each check runs on for real, and whether the other side is stubbed. Six of the ten run on one side only, so a green check on a PR does not always mean that scan executed.
- Separates the three stub shapes rather than two: five queue-real checks with a `*-pr-stub`; `unit-tests` as the inverse (PR-real, `unit-tests-mq-stub` in the queue); `CodeQL`, path-filtered with its own `codeql-stub.yml`; and `zizmor` / `frontend-checks` / `CLA signature check`, which have no path filter and no stub at all.
- States the advisory set explicitly — `nancy-scan`, `gosec-scan`, `staticcheck-scan` and `security-validation` fail their jobs on findings but are absent from the ruleset, so a red one does not block a merge.
- Cites `security-validation`'s observed merge-queue success (AC 3) and states that `documentation.yml` posts the context for docs-only PRs, so a docs PR is not stranded by it (AC 4).

## Measured correction

An earlier commit in this PR asserted that event-gated stub pairs are "genuinely exclusive". That is false, and the section now records the measurement instead.

`documentation.yml`'s `unit-tests`, `integration-tests`, `Build Gate` and `Controller Integration Tests (Linux)` stubs are gated `pull_request || merge_group`, and the workflow carries no `paths` filter on `merge_group` — so all four post green on **every** merge-queue run, in parallel with the real jobs.

Measured on queue commit `c9ac1917`:

| Context | Stub (run 30873310906) | Real job |
|---|---|---|
| `Build Gate` | success | success (run 30873310907) |
| `integration-tests` | success | success (run 30873310891) |
| `Controller Integration Tests (Linux)` | success | success (run 30873310892) |
| `unit-tests` | success | n/a — PR-side real, both queue posters are stubs |

Three of those four are queue-real contexts, which is the exact false-green shape the section warns about. `security-deployment-gate`, `trivy-scan` and `security-validation` stubs are correctly `pull_request`-only.

Closing that overlap is a `.github/workflows/` change and sits outside this story's declared Files In Scope (`CLAUDE.md`). Documented rather than assumed away; worth its own story.

## Testing

- [x] Documented context set diffs clean against the live ruleset (10 == 10, exact match)
- [x] Every "Real run" cell checked against job-level `if:` gating in `test-suite.yml`, `cross-platform-build.yml`, `production-gates.yml`, `security-scan.yml`, `zizmor.yml`, `frontend-ci.yml`, `cla-check.yml`, `codeql-analysis.yml`, `codeql-stub.yml`
- [x] AC 3 citation verified: runs `30906412345` / `30906246182`, job `security-validation`, event `merge_group`, conclusion `success`
- [x] AC 4 stub verified present on `origin/develop` (`documentation.yml`)
- [x] Both content checks `validate-claude-md` applies still pass
- [x] `make test` passes (221 script tests, 0 failures)
- [x] `make test-complete` passes every stage through cross-platform compile and Docker integration tests: pre-commit validation, check-architecture, Trivy, staticcheck, secret scan, unit, fast-comprehensive and production-critical suites
- [ ] `make test-complete` does **not** reach a clean exit on this host. It fails in the final E2E stage (`test-e2e-ci`, Makefile:1910) with `mkdir /.docker: permission denied`. Cause is local and unrelated to this change: that target runs the suite via `docker run --user $(id -u):$(id -g)` without passing `-e HOME`, so `HOME` resolves to `/` inside the container and the docker CLI cannot create its config dir. Reproduced directly — launching `cfgms-test-runner` exactly as the target does yields `HOME=[/]` at uid 1000. A markdown-only diff cannot affect this. Worth its own fix; not bundled into a docs PR that must not touch Makefile root targets.

## Type of Change

- [x] Documentation update

## Security Considerations

- [x] No code, config or credential changes. Corrects documentation that understated which checks gate a merge, and records a false-green risk in the merge queue that was previously undocumented.

## Documentation

- [x] This PR is the documentation change.

## Checklist

- [x] Documentation-only; no code paths affected
- [x] Verified against the live ruleset and live workflow runs rather than assumed

Fixes #3176
