### PR TITLE
fix: repair the four merge-queue gates broken by the pre-RC hardening merge

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -234,6 +234,15 @@ jobs:
       if: always()
       run: |
         echo "🧹 Stopping controller..."
+        # Compose interpolates every service in the file even for `down`, and two
+        # of them require CFGMS_SECRETS_KEY_FILE. Without it this aborted before
+        # stopping anything — masked by the `|| true`.
+        if [ -f .env.test ]; then
+          set -a
+          source .env.test
+          set +a
+        fi
+        export CFGMS_SECRETS_KEY_FILE="${CFGMS_SECRETS_KEY_FILE:-/dev/null}"
         docker compose -f docker-compose.test.yml --profile ha down || true
 
     - name: Cleanup Docker Services

--- a/Makefile
+++ b/Makefile
@@ -1623,9 +1623,17 @@ test-integration-setup:
 	@echo ""
 
 # Clean up Docker test environment and generated credentials
+#
+# Compose interpolates the whole file even for `down`, and two services declare
+# ${CFGMS_SECRETS_KEY_FILE:?...}, so tearing down without that variable aborts
+# before removing anything. .env.test carries the ephemeral key when setup ran;
+# when it did not, any value satisfies interpolation because `down` mounts
+# nothing. The :? guard still fails closed on `up`, which is where it matters.
 test-integration-cleanup:
 	@echo "🧹 Cleaning up CFGMS Docker test environment..."
 	@echo "================================================"
+	@if [ -f .env.test ]; then set -a; . ./.env.test; set +a; fi; \
+	export CFGMS_SECRETS_KEY_FILE="$${CFGMS_SECRETS_KEY_FILE:-/dev/null}"; \
 	docker compose -f docker-compose.test.yml -f docker-compose.test.override.yml down -v --remove-orphans 2>/dev/null || \
 	docker compose -f docker-compose.test.yml down -v --remove-orphans
 	@echo "🔐 Removing generated credentials..."

--- a/Makefile
+++ b/Makefile
@@ -916,6 +916,13 @@ test-fast:
 #	not a deadlock. Do not tighten this to track how long the suite currently takes.
 	@CFGMS_TEST_SHORT=1 go test -short -race -timeout=10m ./pkg/... ./features/... ./api/... ./cmd/... || exit 1
 	@echo ""
+#	Build-tagged code is invisible to every target above, so nothing catches a
+#	break in it until an e2e image build fails hours later. The test-endpoint
+#	routes are only compiled by docker-compose.test.yml, which is exactly the
+#	configuration the integration and fleet suites depend on.
+	@echo "🏷️  Vetting build-tagged sources (cfgms_test_endpoints)..."
+	@go vet -tags cfgms_test_endpoints ./features/controller/api/... || exit 1
+	@echo ""
 	@echo "✅ Fast comprehensive tests complete"
 
 # Load testing for production readiness (Story #294 Phase 4)

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -19,11 +19,19 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 # Copy source code
 COPY . .
 
+# Optional build tags. Empty by default so a production image can never contain
+# tag-gated code: the integration-test administration endpoints live behind
+# `cfgms_test_endpoints` and are not compiled into the binary unless a test
+# compose service asks for them (they also require CFGMS_ENABLE_TEST_ENDPOINTS at
+# runtime). Only docker-compose.test.yml sets this.
+ARG GO_BUILD_TAGS=""
+
 # Build controller (GOCACHE + module cache mounts warm across builds; CGO_ENABLED=0
 # already yields a static binary, so -a/-installsuffix are unneeded and only force
 # cold recompiles)
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux go build -trimpath -buildvcs=false \
+    -tags "${GO_BUILD_TAGS}" \
     -ldflags="-s -w" -o controller ./cmd/controller
 
 # Final stage

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -434,6 +434,11 @@ services:
     build:
       context: .
       dockerfile: cmd/controller/Dockerfile
+      args:
+        # Compiles in the /api/v1/test/* administration endpoints the integration
+        # suite drives. CFGMS_ENABLE_TEST_ENDPOINTS below is the second, runtime
+        # gate; without both the routes are absent and every call 404s.
+        GO_BUILD_TAGS: cfgms_test_endpoints
     ports:
       - "4436:4433/udp"   # gRPC-over-QUIC transport (CP+DP on single port, Story #515)
       - "8080:9080"    # HTTP API (unique host port to avoid conflict with controller-east)
@@ -686,6 +691,11 @@ services:
     build:
       context: .
       dockerfile: cmd/controller/Dockerfile
+      args:
+        # Compiles in the /api/v1/test/* administration endpoints the fleet suite
+        # drives. CFGMS_ENABLE_TEST_ENDPOINTS below is the second, runtime gate;
+        # without both the routes are absent and every call 404s.
+        GO_BUILD_TAGS: cfgms_test_endpoints
       x-bake:
         cache-from:
           - type=gha,scope=cfgms-fleet-controller

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -182,7 +182,7 @@ The steward binary is built with the controller's URL compiled in (`-ldflags="-X
 **Steward identity is established at registration.**
 Two credential flavors:
 
-- **Short-lived / single-use registration tokens** — manual onboarding, small fleets, time-bounded provisioning. Generated on the controller, handed to the steward as a string. Consumed at registration; expiry enforces time bounds.
+- **Perennial registration tokens** — manual onboarding, small fleets, time-bounded provisioning. Generated on the controller, handed to the steward as a string. Never consumed at registration: one token enrolls many devices and is spent only by rotation or revocation, with expiry enforcing time bounds. The controller records a per-device claim at the issuance boundary, so a device cannot be issued two certificates on one token.
 - **Long-lived tenant/group registration codes** — RMM/GPO mass deployment. Same string-on-the-wire pattern, baked into deployment scripts and reused by many devices. Encodes tenant/group target.
 
 Both flow through the controller's registration approval workflow (`RegistrationApprovalHook`). The controller ships two built-in workflows selectable via `registration.workflow` in `controller.cfg`:

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -761,16 +760,18 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 			created, claimErr := s.registrationTokenStore.ClaimToken(r.Context(), req.Token, claimID)
 			if claimErr != nil {
-				if errors.Is(claimErr, business.ErrRegistrationTokenAlreadyClaimed) {
-					http.Error(w, "Registration token has already been claimed", http.StatusConflict)
-					return
-				}
 				s.logger.Error("Failed to atomically claim registration token", "error", claimErr)
 				http.Error(w, "Registration service unavailable", http.StatusServiceUnavailable)
 				return
 			}
+
+			// The pending ID is derived from the token and the device identity
+			// rather than from the clock, so a retrying device can be handed back
+			// its own entry. A perennial token quarantines many devices at once,
+			// so a by-token lookup here could return a different device's entry.
+			pendingID := pendingRegistrationID(req.Token, claimID)
 			if !created {
-				existing, existingErr := s.pendingStore.GetPendingByToken(r.Context(), req.Token)
+				existing, existingErr := s.pendingStore.GetPendingByID(r.Context(), pendingID)
 				if existingErr == nil && existing != nil &&
 					(existing.Status == business.PendingRegistrationStatusPending ||
 						existing.Status == business.PendingRegistrationStatusApproved) {
@@ -781,7 +782,6 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			pendingID := fmt.Sprintf("pending-%d", time.Now().UnixNano())
 			pendingEntry := &business.PendingRegistrationEntry{
 				PendingID:    pendingID,
 				StewardID:    stewardID,
@@ -881,15 +881,12 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			"steward_id", stewardID)
 	}
 
-	// This is the REST issuance boundary. Exactly one caller can create the
-	// durable claim, even across controller processes. Same-device retries are
-	// recognized by the store but cannot issue a second private key/certificate.
+	// This is the REST issuance boundary. For a given device identity exactly one
+	// caller can create the durable claim, even across controller processes, so a
+	// concurrent retry cannot obtain a second private key/certificate. The token
+	// itself stays valid for the rest of the fleet (Issue #1690).
 	created, claimErr := s.registrationTokenStore.ClaimToken(r.Context(), req.Token, claimID)
 	if claimErr != nil {
-		if errors.Is(claimErr, business.ErrRegistrationTokenAlreadyClaimed) {
-			http.Error(w, "Registration token has already been claimed", http.StatusConflict)
-			return
-		}
 		s.logger.Error("Failed to atomically claim registration token", "error", claimErr)
 		http.Error(w, "Registration service unavailable", http.StatusServiceUnavailable)
 		return
@@ -993,6 +990,18 @@ func registrationClaimID(deviceID string, identityKey []byte) string {
 	_, _ = h.Write([]byte{0})
 	_, _ = h.Write(identityKey)
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// pendingRegistrationID derives a quarantine entry's identifier from the token
+// and the claiming device, so the same device retrying the same token addresses
+// the same entry and a second device on that token gets its own. Neither the
+// bearer token nor the device identity is recoverable from the result.
+func pendingRegistrationID(tokenStr, claimID string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(business.RegistrationTokenLookupKey(tokenStr)))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(claimID))
+	return "pending-" + hex.EncodeToString(h.Sum(nil))
 }
 
 func (s *Server) writePendingRegistrationResponse(w http.ResponseWriter, entry *business.PendingRegistrationEntry, group string) {

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -270,7 +270,10 @@ func TestHandleRegister_ConcurrentClaimsIssueAtMostOneCertificate(t *testing.T) 
 		Token: tokenStr, TenantID: "test-tenant", ControllerURL: "grpc://controller:7443",
 	}))
 
+	// One device racing itself. Only one of these may receive a private key —
+	// that is the double-issuance the REST claim exists to prevent.
 	const contenders = 16
+	const deviceID = "00000000000000000000000000000000000000000000000000000000000000ab"
 	start := make(chan struct{})
 	recorders := make([]*httptest.ResponseRecorder, contenders)
 	var wg sync.WaitGroup
@@ -281,7 +284,7 @@ func TestHandleRegister_ConcurrentClaimsIssueAtMostOneCertificate(t *testing.T) 
 			<-start
 			recorders[i] = postRegisterWithBody(server, RegistrationRequest{
 				Token:          tokenStr,
-				DeviceID:       fmt.Sprintf("%064x", i+1),
+				DeviceID:       deviceID,
 				IdentityKeyPub: testValidIdentityKeyPub,
 			})
 		}(i)
@@ -308,6 +311,41 @@ func TestHandleRegister_ConcurrentClaimsIssueAtMostOneCertificate(t *testing.T) 
 	}
 	assert.Equal(t, 1, successes)
 	assert.Equal(t, contenders-1, conflicts)
+}
+
+// The claim is scoped to the device, not the token: a perennial fleet token
+// (Issue #1690) must keep enrolling endpoints after the first one registers.
+func TestHandleRegister_PerennialTokenEnrollsManyDevices(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	certMgr := newTestCertManager(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
+	server.SetApprovalHook(&AlwaysApproveHook{})
+
+	const tokenStr = "cfgms_reg_fleet_enrolment"
+	require.NoError(t, tokenStore.SaveToken(context.Background(), &registration.Token{
+		Token: tokenStr, TenantID: "test-tenant", ControllerURL: "grpc://controller:7443",
+	}))
+
+	stewardIDs := make(map[string]bool)
+	for i := 0; i < 5; i++ {
+		rec := postRegisterWithBody(server, RegistrationRequest{
+			Token:          tokenStr,
+			DeviceID:       fmt.Sprintf("%064x", i+1),
+			IdentityKeyPub: testValidIdentityKeyPub,
+		})
+		require.Equal(t, http.StatusOK, rec.Code,
+			"device %d must enrol on the perennial token: %s", i, rec.Body.String())
+
+		var resp RegistrationResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.NotEmpty(t, resp.ClientCert, "device %d must receive its own certificate", i)
+		assert.False(t, stewardIDs[resp.StewardID], "steward IDs must be unique")
+		stewardIDs[resp.StewardID] = true
+	}
+
+	tok, err := tokenStore.GetToken(context.Background(), tokenStr)
+	require.NoError(t, err)
+	assert.True(t, tok.IsValid(), "enrolment must not spend the fleet token")
 }
 
 // kvCapturingLogger captures both Warn message and key-value pairs for security assertions.
@@ -691,7 +729,11 @@ func TestHandleRegister_ConcurrentClaimsCreateAtMostOnePendingRegistration(t *te
 		Token: tokenStr, TenantID: "test-tenant", ControllerURL: "grpc://controller:7443",
 	}))
 
+	// One device racing itself must produce exactly one quarantine entry, and the
+	// retries that lose the race must be handed back that same entry rather than
+	// a second one.
 	const contenders = 16
+	const deviceID = "00000000000000000000000000000000000000000000000000000000000000cd"
 	start := make(chan struct{})
 	recorders := make([]*httptest.ResponseRecorder, contenders)
 	var wg sync.WaitGroup
@@ -702,7 +744,7 @@ func TestHandleRegister_ConcurrentClaimsCreateAtMostOnePendingRegistration(t *te
 			<-start
 			recorders[i] = postRegisterWithBody(server, RegistrationRequest{
 				Token:          tokenStr,
-				DeviceID:       fmt.Sprintf("%064x", i+1),
+				DeviceID:       deviceID,
 				IdentityKeyPub: testValidIdentityKeyPub,
 			})
 		}(i)
@@ -710,25 +752,72 @@ func TestHandleRegister_ConcurrentClaimsCreateAtMostOnePendingRegistration(t *te
 	close(start)
 	wg.Wait()
 
-	accepted := 0
-	conflicts := 0
+	pendingIDs := make(map[string]bool)
 	for _, rec := range recorders {
 		switch rec.Code {
 		case http.StatusAccepted:
-			accepted++
 			assert.NotContains(t, rec.Body.String(), "BEGIN CERTIFICATE")
+			var resp RegistrationPendingResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			pendingIDs[resp.PendingID] = true
 		case http.StatusConflict:
-			conflicts++
+			// A retry that raced the entry's creation.
 		default:
 			t.Errorf("unexpected registration status %d: %s", rec.Code, rec.Body.String())
 		}
 	}
-	assert.Equal(t, 1, accepted)
-	assert.Equal(t, contenders-1, conflicts)
+	assert.Len(t, pendingIDs, 1, "the device must only ever be told about one pending entry")
 
 	entries, err := server.pendingStore.ListPending(context.Background(), "test-tenant")
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)
+}
+
+// Quarantined devices sharing a perennial token must each get their own pending
+// entry — never a handle to another device's registration.
+func TestHandleRegister_QuarantineKeepsPerennialTokenUsableAndDeviceScoped(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	server.SetApprovalHook(&quarantineHookForTest{})
+
+	const tokenStr = "cfgms_reg_quarantine_fleet"
+	require.NoError(t, tokenStore.SaveToken(context.Background(), &registration.Token{
+		Token: tokenStr, TenantID: "test-tenant", ControllerURL: "grpc://controller:7443",
+	}))
+
+	pendingIDs := make(map[string]string)
+	for i := 0; i < 3; i++ {
+		deviceID := fmt.Sprintf("%064x", i+1)
+		rec := postRegisterWithBody(server, RegistrationRequest{
+			Token:          tokenStr,
+			DeviceID:       deviceID,
+			IdentityKeyPub: testValidIdentityKeyPub,
+		})
+		require.Equal(t, http.StatusAccepted, rec.Code,
+			"device %d must be quarantined, not refused: %s", i, rec.Body.String())
+		var resp RegistrationPendingResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.NotEmpty(t, resp.PendingID)
+		pendingIDs[deviceID] = resp.PendingID
+	}
+	assert.Len(t, pendingIDs, 3, "each device must receive a distinct pending_id")
+
+	// A device retrying gets its own entry back, not one of its peers'.
+	for deviceID, want := range pendingIDs {
+		rec := postRegisterWithBody(server, RegistrationRequest{
+			Token:          tokenStr,
+			DeviceID:       deviceID,
+			IdentityKeyPub: testValidIdentityKeyPub,
+		})
+		require.Equal(t, http.StatusAccepted, rec.Code, "retry body: %s", rec.Body.String())
+		var resp RegistrationPendingResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, want, resp.PendingID, "device %s must recover its own pending entry", deviceID)
+	}
+
+	entries, err := server.pendingStore.ListPending(context.Background(), "test-tenant")
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
 }
 
 func TestHandleRegister_ApproveReturns200WithCert(t *testing.T) {

--- a/features/controller/server/installer_blob_root_test.go
+++ b/features/controller/server/installer_blob_root_test.go
@@ -13,14 +13,19 @@ import (
 func TestResolveInstallerBlobRootUsesLoadedDeploymentPaths(t *testing.T) {
 	t.Parallel()
 
+	// A deployment's data directory, spelled the way the host spells paths:
+	// resolveInstallerBlobRoot joins with filepath, so the expectation has to be
+	// built the same way rather than hard-coded to one platform's separator.
+	dataDir := filepath.Join(string(filepath.Separator), "var", "lib", "cfgms")
+
 	cfg := config.DefaultConfig()
-	cfg.DataDir = "/var/lib/cfgms"
-	cfg.Storage.FlatfileRoot = "/var/lib/cfgms/storage"
-	cfg.Storage.SQLitePath = "/var/lib/cfgms/cfgms.db"
+	cfg.DataDir = dataDir
+	cfg.Storage.FlatfileRoot = filepath.Join(dataDir, "storage")
+	cfg.Storage.SQLitePath = filepath.Join(dataDir, "cfgms.db")
 
 	assert.Empty(t, cfg.BlobStorage.Root,
 		"default must not freeze a relative root before YAML overrides are loaded")
-	assert.Equal(t, "/var/lib/cfgms/installers", resolveInstallerBlobRoot(cfg))
+	assert.Equal(t, filepath.Join(dataDir, "installers"), resolveInstallerBlobRoot(cfg))
 }
 
 func TestResolveInstallerBlobRootPrecedence(t *testing.T) {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -361,6 +361,28 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		return nil, fmt.Errorf("storage.flatfile_root is required for OSS composite storage, or storage.provider must be 'database' for commercial single-provider mode. The 'git' storage provider has been removed — run 'cfg storage migrate --from git --to flatfile' to migrate existing data")
 	}
 
+	// From here on New holds open SQLite/Postgres handles. Every remaining failure
+	// returns without a Server, so nothing would ever call Stop to release them —
+	// the handles would leak for the process's life. On Windows that also pins the
+	// database files, so a caller cannot delete the data directory of a controller
+	// that refused to start. Each store below registers itself here as soon as it
+	// is opened, mirroring what Stop releases.
+	constructed := false
+	var openedStores []func() error
+	defer func() {
+		if constructed {
+			return
+		}
+		// Reverse order, so a store closes before anything it was layered onto.
+		for i := len(openedStores) - 1; i >= 0; i-- {
+			if closeErr := openedStores[i](); closeErr != nil {
+				logger.Warn("Failed to release storage after controller initialization failed",
+					"error", closeErr)
+			}
+		}
+	}()
+	openedStores = append(openedStores, storageManager.Close)
+
 	// Initialize RBAC system with pluggable storage only
 	auditStore := storageManager.GetAuditStore()
 	clientTenantStore := storageManager.GetClientTenantStore()
@@ -433,6 +455,9 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	if dnaErr != nil {
 		logger.Warn("Failed to initialize DNA storage; steward registry will not survive a controller restart", "error", dnaErr)
 	}
+	if dnaStorageManager != nil {
+		openedStores = append(openedStores, dnaStorageManager.Close)
+	}
 
 	// Create the controller service. With durable DNA storage its in-memory
 	// steward registry is warm-loaded from a previous run on startup, so a
@@ -457,6 +482,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	// configured (tags API degrades gracefully; SetTagStore is a no-op on nil).
 	tagStoreInstance := initializeTagStore(context.Background(), cfg, logger)
 	if tagStoreInstance != nil {
+		openedStores = append(openedStores, tagStoreInstance.Close)
 		controllerService.SetTagStore(tagStoreInstance)
 	}
 
@@ -1448,6 +1474,8 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		}
 	}
 
+	// The Server now owns the storage manager and releases it in Stop.
+	constructed = true
 	return srv, nil
 }
 

--- a/features/modules/stdlib/patch/module.go
+++ b/features/modules/stdlib/patch/module.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -371,21 +370,14 @@ func (m *PatchModule) executeScript(ctx context.Context, script string) error {
 	logger := m.GetEffectiveLogger(logging.NewNoopLogger())
 	logger.Debug("executing script", "script", logging.SanitizeLogValue(scriptPath))
 
-	var stdoutBuf, stderrBuf bytes.Buffer
-	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
 		if err := validateWindowsScriptPath(scriptPath); err != nil {
 			return err
 		}
-		// #nosec G204 -- cmd.exe is required for .cmd/.bat patch scripts; the
-		// absolute, cleaned path is metacharacter-rejected above and quoted as
-		// the sole /c command, so configured script data cannot add commands.
-		cmd = exec.CommandContext(ctx, "cmd", "/d", "/s", "/c", `"`+scriptPath+`"`)
-	} else {
-		// #nosec G204 -- executing an administrator-configured absolute patch
-		// script is this module's explicit capability; no shell is involved.
-		cmd = exec.CommandContext(ctx, scriptPath)
 	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd := newScriptCommand(ctx, scriptPath)
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 

--- a/features/modules/stdlib/patch/script_exec_other.go
+++ b/features/modules/stdlib/patch/script_exec_other.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package patch
+
+import (
+	"context"
+	"os/exec"
+)
+
+// newScriptCommand executes an administrator-configured absolute patch script
+// directly. No shell is involved, so the path cannot be reinterpreted as a
+// command line.
+func newScriptCommand(ctx context.Context, scriptPath string) *exec.Cmd {
+	// #nosec G204 -- executing an administrator-configured absolute patch script
+	// is this module's explicit capability; the path is cleaned and validated as
+	// absolute by the caller.
+	return exec.CommandContext(ctx, scriptPath)
+}

--- a/features/modules/stdlib/patch/script_exec_windows.go
+++ b/features/modules/stdlib/patch/script_exec_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package patch
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+// newScriptCommand builds the cmd.exe invocation for a .bat/.cmd patch script.
+//
+// The command line is assembled explicitly rather than passed as argv because
+// os/exec applies Windows argument escaping: a quoted path handed to
+// exec.CommandContext arrives at cmd.exe as \"C:\path\x.bat\", which cmd reads as
+// a command name containing backslash-quote and rejects with "is not recognized
+// as an internal or external command".
+//
+// The doubled quotes are required, not redundant. With /s, cmd.exe strips the
+// first and last quote of the remainder and runs what is left verbatim, so
+// ""C:\path with space\x.bat"" reduces to a correctly quoted single command,
+// while a single pair would reduce to a bare path that cmd would split on its
+// spaces. scriptPath is metacharacter-rejected by validateWindowsScriptPath
+// before it reaches here, so it cannot introduce a quote of its own and close
+// the string early.
+//
+// /d skips any AutoRun command registered in the registry, so a compromised
+// HKCU\...\Command Processor\AutoRun value cannot ride along with a patch script.
+func newScriptCommand(ctx context.Context, scriptPath string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "cmd")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine: `cmd /d /s /c ""` + scriptPath + `""`,
+	}
+	return cmd
+}

--- a/features/modules/stdlib/patch/script_exec_windows_test.go
+++ b/features/modules/stdlib/patch/script_exec_windows_test.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package patch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The command line is what cmd.exe actually parses, and os/exec's argument
+// escaping is bypassed to produce it, so it is asserted directly. Passing the
+// quoted path through argv instead yields \"C:\...\x.bat\", which cmd rejects as
+// an unrecognised command.
+func TestNewScriptCommandBuildsCmdLineForCmdExe(t *testing.T) {
+	t.Parallel()
+
+	cmd := newScriptCommand(context.Background(), `C:\patches\update.cmd`)
+
+	require.NotNil(t, cmd.SysProcAttr)
+	require.Equal(t, `cmd /d /s /c ""C:\patches\update.cmd""`, cmd.SysProcAttr.CmdLine)
+}
+
+// A path with spaces is explicitly allowed by validateWindowsScriptPath, and is
+// the case the doubled quotes exist for: /s strips only the outermost pair, so
+// the inner pair still quotes the path when cmd splits the command line.
+func TestNewScriptCommandQuotesPathContainingSpaces(t *testing.T) {
+	t.Parallel()
+
+	const scriptPath = `C:\Program Files\CFGMS Patches\update.cmd`
+	require.NoError(t, validateWindowsScriptPath(scriptPath))
+
+	cmd := newScriptCommand(context.Background(), scriptPath)
+
+	require.NotNil(t, cmd.SysProcAttr)
+	require.Equal(t,
+		`cmd /d /s /c ""C:\Program Files\CFGMS Patches\update.cmd""`,
+		cmd.SysProcAttr.CmdLine)
+}

--- a/pkg/controlplane/providers/grpc/approval_test.go
+++ b/pkg/controlplane/providers/grpc/approval_test.go
@@ -154,10 +154,10 @@ func TestRequiredSecurityStoresFailInitializationClosed(t *testing.T) {
 		require.ErrorContains(t, err, "approval checker")
 	})
 
-	t.Run("token store without atomic consumer", func(t *testing.T) {
+	t.Run("token store without atomic claimer", func(t *testing.T) {
 		provider := New(ModeServer, WithApprovalChecker(approveAll{}))
 		err := provider.Initialize(context.Background(), baseConfig(&nonConsumingRegistrationStore{}))
-		require.ErrorContains(t, err, "atomic registration token consumption")
+		require.ErrorContains(t, err, "atomic registration token claiming")
 	})
 
 	t.Run("complete security services", func(t *testing.T) {

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -285,8 +285,8 @@ func (p *Provider) initializeServer(config map[string]interface{}) error {
 		if p.registrationTokenStore == nil {
 			return fmt.Errorf("server mode requires a registration token store")
 		}
-		if _, ok := p.registrationTokenStore.(business.RegistrationTokenConsumer); !ok {
-			return fmt.Errorf("server mode requires atomic registration token consumption")
+		if _, ok := p.registrationTokenStore.(business.RegistrationTokenClaimer); !ok {
+			return fmt.Errorf("server mode requires atomic registration token claiming")
 		}
 	}
 
@@ -1119,13 +1119,14 @@ func (s *transportServer) Register(ctx context.Context, req *controllerpb.Regist
 			return nil, status.Error(codes.PermissionDenied, "registration rejected: creds.tenant_id does not match registration token")
 		}
 
-		if consumer, ok := ts.(business.RegistrationTokenConsumer); ok {
-			if consumeErr := consumer.ConsumeToken(ctx, tokenStr); consumeErr != nil {
-				return nil, status.Error(codes.PermissionDenied, "registration rejected: token already used or expired")
-			}
-		} else if s.provider.requireSecurityStores {
-			return nil, status.Error(codes.Unavailable, "registration token service lacks atomic consumption")
-		}
+		// The token is not spent here. Registration tokens are perennial
+		// (Issue #1690) — one enrolment token is what an RMM or GPO deployment
+		// bakes into a script for a whole fleet, so revoking it on first use
+		// would lock out every remaining endpoint. At this point the caller has
+		// already presented an mTLS client certificate that only the REST
+		// issuance boundary can mint, and that boundary holds the per-device
+		// single-issuance guard (RegistrationTokenClaimer). The token's role
+		// here is tenant binding, which the checks above enforce.
 	}
 
 	s.provider.logger.Info("steward registered", "steward_id", logging.SanitizeLogValue(stewardID), "version", logging.SanitizeLogValue(req.GetVersion()))

--- a/pkg/controlplane/providers/grpc/provider_register_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_register_identity_test.go
@@ -34,6 +34,7 @@ import (
 type inMemoryTokenStore struct {
 	mu     sync.RWMutex
 	tokens map[string]*business.RegistrationTokenData
+	claims map[string]map[string]struct{} // token string → set of device claim IDs
 }
 
 func newInMemoryTokenStore() *inMemoryTokenStore {
@@ -140,22 +141,43 @@ func (s *inMemoryTokenStore) GetTokenByID(_ context.Context, id string) (*busine
 func (s *inMemoryTokenStore) Initialize(_ context.Context) error { return nil }
 func (s *inMemoryTokenStore) Close() error                       { return nil }
 
-func (s *inMemoryTokenStore) ConsumeToken(_ context.Context, tokenStr string) error {
+// ClaimToken reserves the token for one device identity. Like the durable
+// stores it leaves the token itself valid — registration tokens are perennial
+// (Issue #1690) and one enrolment token serves a whole fleet.
+func (s *inMemoryTokenStore) ClaimToken(_ context.Context, tokenStr, claimID string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	token, ok := s.tokens[tokenStr]
 	if !ok || !token.IsValid() {
-		return fmt.Errorf("token is invalid, expired, or already used")
+		return false, fmt.Errorf("registration token is invalid, expired, or revoked")
 	}
-	now := time.Now()
-	token.Revoked = true
-	token.RevokedAt = &now
+	if s.claims == nil {
+		s.claims = make(map[string]map[string]struct{})
+	}
+	claimed := s.claims[tokenStr]
+	if claimed == nil {
+		claimed = make(map[string]struct{})
+		s.claims[tokenStr] = claimed
+	}
+	if _, exists := claimed[claimID]; exists {
+		return false, nil
+	}
+	claimed[claimID] = struct{}{}
+	return true, nil
+}
+
+func (s *inMemoryTokenStore) ReleaseTokenClaim(_ context.Context, tokenStr, claimID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if claimed, ok := s.claims[tokenStr]; ok {
+		delete(claimed, claimID)
+	}
 	return nil
 }
 
 // compile-time assertion
 var _ business.RegistrationTokenStore = (*inMemoryTokenStore)(nil)
-var _ business.RegistrationTokenConsumer = (*inMemoryTokenStore)(nil)
+var _ business.RegistrationTokenClaimer = (*inMemoryTokenStore)(nil)
 
 func verifiedPeerContext(commonName string) context.Context {
 	leaf := &x509.Certificate{Subject: pkix.Name{CommonName: commonName}}
@@ -169,10 +191,13 @@ func verifiedPeerContext(commonName string) context.Context {
 	})
 }
 
-func TestRegister_ConsumesTokenAtomically(t *testing.T) {
+// gRPC registration binds the caller to the token's tenant; it must not spend
+// the token. Registration tokens are perennial (Issue #1690), so revoking one on
+// first use would lock every remaining endpoint out of the fleet.
+func TestRegister_DoesNotSpendThePerennialToken(t *testing.T) {
 	store := newInMemoryTokenStore()
 	require.NoError(t, store.SaveToken(context.Background(), &business.RegistrationTokenData{
-		Token: "one-use-token", TenantID: "tenant-a",
+		Token: "fleet-token", TenantID: "tenant-a",
 	}))
 	provider := New(ModeServer)
 	provider.registrationTokenStore = store
@@ -181,7 +206,7 @@ func TestRegister_ConsumesTokenAtomically(t *testing.T) {
 	request := &controllerpb.RegisterRequest{
 		Version: "1.0.0",
 		Credentials: &commonpb.Credentials{
-			ClientId: "one-use-token",
+			ClientId: "fleet-token",
 			TenantId: "tenant-a",
 		},
 	}
@@ -191,15 +216,68 @@ func TestRegister_ConsumesTokenAtomically(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < contenders; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
-			if _, err := server.Register(verifiedPeerContext("steward-atomic"), request); err == nil {
+			ctx := verifiedPeerContext(fmt.Sprintf("steward-%d", i))
+			if _, err := server.Register(ctx, request); err == nil {
 				successes.Add(1)
 			}
-		}()
+		}(i)
 	}
 	wg.Wait()
-	assert.Equal(t, int32(1), successes.Load())
+	assert.Equal(t, int32(contenders), successes.Load(),
+		"every steward presenting the fleet token must register")
+
+	tok, err := store.GetToken(context.Background(), "fleet-token")
+	require.NoError(t, err)
+	assert.True(t, tok.IsValid(), "registration must leave the fleet token valid")
+}
+
+// Revocation is how a token is spent, and it must be enforced at the gRPC
+// boundary as well as the REST one.
+func TestRegister_RejectsRevokedToken(t *testing.T) {
+	store := newInMemoryTokenStore()
+	revokedAt := time.Now()
+	require.NoError(t, store.SaveToken(context.Background(), &business.RegistrationTokenData{
+		Token: "revoked-token", TenantID: "tenant-a",
+		Revoked: true, RevokedAt: &revokedAt,
+	}))
+	provider := New(ModeServer)
+	provider.registrationTokenStore = store
+	provider.requireSecurityStores = true
+	server := &transportServer{provider: provider}
+
+	_, err := server.Register(verifiedPeerContext("steward-revoked"), &controllerpb.RegisterRequest{
+		Version: "1.0.0",
+		Credentials: &commonpb.Credentials{
+			ClientId: "revoked-token",
+			TenantId: "tenant-a",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid or expired registration token")
+}
+
+// The token, not the client-supplied field, is the source of truth for tenancy.
+func TestRegister_RejectsTenantMismatch(t *testing.T) {
+	store := newInMemoryTokenStore()
+	require.NoError(t, store.SaveToken(context.Background(), &business.RegistrationTokenData{
+		Token: "tenant-bound-token", TenantID: "tenant-a",
+	}))
+	provider := New(ModeServer)
+	provider.registrationTokenStore = store
+	provider.requireSecurityStores = true
+	server := &transportServer{provider: provider}
+
+	_, err := server.Register(verifiedPeerContext("steward-mismatch"), &controllerpb.RegisterRequest{
+		Version: "1.0.0",
+		Credentials: &commonpb.Credentials{
+			ClientId: "tenant-bound-token",
+			TenantId: "tenant-b",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match registration token")
 }
 
 // dialAndRegister dials the server over QUIC+mTLS and invokes the Register RPC.

--- a/pkg/registration/store.go
+++ b/pkg/registration/store.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // Store defines the interface for registration token storage.
@@ -48,9 +46,9 @@ type Store interface {
 // memoryStore is an in-memory implementation of Store (for use within this package only).
 type memoryStore struct {
 	mu     sync.RWMutex
-	tokens map[string]*Token // keyed by token string
-	byID   map[string]string // id → token string
-	claims map[string]string
+	tokens map[string]*Token              // keyed by token string
+	byID   map[string]string              // id → token string
+	claims map[string]map[string]struct{} // token string → set of device claim IDs
 }
 
 // newMemoryStore creates a new in-memory token store.
@@ -58,7 +56,7 @@ func newMemoryStore() *memoryStore {
 	return &memoryStore{
 		tokens: make(map[string]*Token),
 		byID:   make(map[string]string),
-		claims: make(map[string]string),
+		claims: make(map[string]map[string]struct{}),
 	}
 }
 
@@ -157,7 +155,9 @@ func (s *memoryStore) DeleteToken(ctx context.Context, tokenStr string) error {
 	return nil
 }
 
-// ClaimToken atomically reserves a valid token for one device identity.
+// ClaimToken atomically reserves a valid token for one device identity. The
+// token itself is perennial (Issue #1690) — distinct devices claim it
+// independently; only a repeat claim by the same device returns false.
 func (s *memoryStore) ClaimToken(_ context.Context, tokenStr, claimID string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -166,23 +166,28 @@ func (s *memoryStore) ClaimToken(_ context.Context, tokenStr, claimID string) (b
 	if !ok || !token.IsValid() {
 		return false, fmt.Errorf("registration token is invalid, expired, or revoked")
 	}
-	if existing, ok := s.claims[tokenStr]; ok {
-		if existing == claimID {
-			return false, nil
-		}
-		return false, business.ErrRegistrationTokenAlreadyClaimed
+	claimed := s.claims[tokenStr]
+	if claimed == nil {
+		claimed = make(map[string]struct{})
+		s.claims[tokenStr] = claimed
 	}
-	s.claims[tokenStr] = claimID
+	if _, exists := claimed[claimID]; exists {
+		return false, nil
+	}
+	claimed[claimID] = struct{}{}
 	return true, nil
 }
 
-// ReleaseTokenClaim removes only the matching claim.
+// ReleaseTokenClaim removes only the matching device's claim.
 func (s *memoryStore) ReleaseTokenClaim(_ context.Context, tokenStr, claimID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if existing, ok := s.claims[tokenStr]; ok && existing == claimID {
-		delete(s.claims, tokenStr)
+	if claimed, ok := s.claims[tokenStr]; ok {
+		delete(claimed, claimID)
+		if len(claimed) == 0 {
+			delete(s.claims, tokenStr)
+		}
 	}
 	return nil
 }

--- a/pkg/storage/interfaces/business/pending_registration_store.go
+++ b/pkg/storage/interfaces/business/pending_registration_store.go
@@ -70,8 +70,14 @@ type PendingRegistrationStore interface {
 	// Returns ErrPendingRegistrationNotFound if no record exists.
 	GetPendingByID(ctx context.Context, pendingID string) (*PendingRegistrationEntry, error)
 
-	// GetPendingByToken hashes the supplied raw token and retrieves the matching entry.
-	// Returns ErrPendingRegistrationNotFound if no matching record exists.
+	// GetPendingByToken hashes the supplied raw token and retrieves *an* entry that
+	// matches. Returns ErrPendingRegistrationNotFound if no matching record exists.
+	//
+	// Registration tokens are perennial (Issue #1690), so one token routinely has
+	// several devices quarantined against it and this lookup cannot say which
+	// entry it returned. Never use it to answer a specific device — doing so hands
+	// that device another device's pending_id. Address a known device's entry by
+	// PendingID via GetPendingByID instead.
 	GetPendingByToken(ctx context.Context, tokenStr string) (*PendingRegistrationEntry, error)
 
 	// UpdateStatus updates the status of the entry identified by pendingID.

--- a/pkg/storage/interfaces/business/registration_store.go
+++ b/pkg/storage/interfaces/business/registration_store.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"strings"
 	"time"
 )
@@ -66,26 +65,22 @@ type RegistrationTokenStore interface {
 	Close() error
 }
 
-// RegistrationTokenConsumer is implemented by durable stores that can
-// atomically spend a registration token. Public admission requires this
-// capability so concurrent claims cannot both succeed.
-type RegistrationTokenConsumer interface {
-	ConsumeToken(ctx context.Context, tokenStr string) error
-}
-
-// ErrRegistrationTokenAlreadyClaimed is returned when a registration token has
-// already crossed the REST admission boundary for a different device identity.
-var ErrRegistrationTokenAlreadyClaimed = errors.New("registration token already claimed")
-
 // RegistrationTokenClaimer is implemented by durable stores that can reserve a
-// valid registration token at the REST certificate-issuance boundary without
-// consuming it. The token remains valid for the subsequent mTLS-authenticated
-// gRPC registration, where RegistrationTokenConsumer performs final consumption.
+// registration token for one device identity at the REST certificate-issuance
+// boundary.
+//
+// Registration tokens are perennial (Issue #1690): they survive multiple
+// registrations and are spent only by rotation or revocation, because one
+// enrollment token is what an RMM or GPO deployment bakes into a script for a
+// whole fleet. A claim therefore scopes to the *device*, not to the token — it
+// exists so that two concurrent requests carrying the same token and the same
+// device identity cannot both be issued a private key, including across
+// controller processes. Distinct devices claim the same token independently.
 type RegistrationTokenClaimer interface {
-	// ClaimToken atomically creates a durable claim for tokenStr. It returns true
-	// only to the caller that created the claim. A retry with the same claimID
-	// returns (false, nil); a different claimant receives
-	// ErrRegistrationTokenAlreadyClaimed.
+	// ClaimToken atomically creates a durable claim on tokenStr for claimID. It
+	// returns true only to the caller that created that claim; a retry with the
+	// same claimID returns (false, nil). An invalid, expired, or revoked token is
+	// an error.
 	ClaimToken(ctx context.Context, tokenStr, claimID string) (bool, error)
 
 	// ReleaseTokenClaim removes an exact claim after a failure that occurred

--- a/pkg/storage/providers/database/registration_store.go
+++ b/pkg/storage/providers/database/registration_store.go
@@ -321,37 +321,9 @@ func (s *DatabaseRegistrationTokenStore) DeleteToken(ctx context.Context, tokenS
 	return nil
 }
 
-// ConsumeToken atomically marks one valid token spent.
-func (s *DatabaseRegistrationTokenStore) ConsumeToken(ctx context.Context, tokenStr string) error {
-	now := time.Now().UTC()
-	result, err := s.db.ExecContext(ctx, `
-		UPDATE cfgms_registration_tokens
-		SET revoked = true, revoked_at = $1
-		WHERE (token = $2 OR token = $3)
-		  AND revoked = false
-		  AND (expires_at IS NULL OR expires_at > $1)`,
-		now,
-		business.RegistrationTokenLookupKey(tokenStr),
-		tokenStr,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to consume registration token: %w", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to confirm registration token consumption: %w", err)
-	}
-	if affected != 1 {
-		return fmt.Errorf("registration token is invalid, expired, or already used")
-	}
-	return nil
-}
-
-var _ business.RegistrationTokenConsumer = (*DatabaseRegistrationTokenStore)(nil)
-
-// ClaimToken atomically reserves one valid token at the REST admission boundary.
-// It does not revoke the token; final consumption remains the responsibility of
-// the mTLS-authenticated gRPC registration.
+// ClaimToken atomically reserves a valid token for one device identity at the
+// REST admission boundary. It does not revoke the token: registration tokens are
+// perennial (Issue #1690) and one fleet token enrols many endpoints.
 func (s *DatabaseRegistrationTokenStore) ClaimToken(ctx context.Context, tokenStr, claimID string) (bool, error) {
 	if tokenStr == "" {
 		return false, fmt.Errorf("token string cannot be empty")
@@ -373,9 +345,9 @@ func (s *DatabaseRegistrationTokenStore) ClaimToken(ctx context.Context, tokenSt
 		}
 	}()
 
-	// Serialize with final ConsumeToken's UPDATE of the same token row. This
-	// prevents a claim from observing a stale valid snapshot while another
-	// controller process is consuming the token.
+	// Serialize with any concurrent UPDATE of the same token row, so a claim
+	// cannot observe a stale valid snapshot while another controller process is
+	// revoking or rotating the token.
 	var storedToken string
 	err = tx.QueryRowContext(ctx, `
 		SELECT token FROM cfgms_registration_tokens
@@ -397,7 +369,7 @@ func (s *DatabaseRegistrationTokenStore) ClaimToken(ctx context.Context, tokenSt
 	result, err := tx.ExecContext(ctx, `
 		INSERT INTO cfgms_registration_token_claims (token, claim_id, claimed_at)
 		VALUES ($1, $2, $3)
-		ON CONFLICT (token) DO NOTHING`,
+		ON CONFLICT (token, claim_id) DO NOTHING`,
 		lookupKey, claimID, now)
 	if err != nil {
 		return false, fmt.Errorf("failed to claim registration token: %w", err)
@@ -406,33 +378,14 @@ func (s *DatabaseRegistrationTokenStore) ClaimToken(ctx context.Context, tokenSt
 	if err != nil {
 		return false, fmt.Errorf("failed to confirm registration token claim: %w", err)
 	}
-	if affected == 1 {
-		if err := tx.Commit(); err != nil {
-			return false, fmt.Errorf("failed to commit registration token claim: %w", err)
-		}
-		committed = true
-		return true, nil
-	}
-
-	var existingClaimID string
-	err = tx.QueryRowContext(ctx,
-		`SELECT claim_id FROM cfgms_registration_token_claims WHERE token = $1`,
-		lookupKey,
-	).Scan(&existingClaimID)
-	if err == sql.ErrNoRows {
-		return false, fmt.Errorf("registration token is invalid, expired, or revoked")
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to inspect registration token claim: %w", err)
-	}
 	if err := tx.Commit(); err != nil {
-		return false, fmt.Errorf("failed to commit registration token claim inspection: %w", err)
+		return false, fmt.Errorf("failed to commit registration token claim: %w", err)
 	}
 	committed = true
-	if existingClaimID == claimID {
-		return false, nil
-	}
-	return false, business.ErrRegistrationTokenAlreadyClaimed
+
+	// The token row was locked and valid above, so the only reason the insert
+	// found a conflict is that this same device already holds the claim.
+	return affected == 1, nil
 }
 
 // ReleaseTokenClaim removes only the exact claim made by this REST attempt.

--- a/pkg/storage/providers/database/registration_store_test.go
+++ b/pkg/storage/providers/database/registration_store_test.go
@@ -4,7 +4,6 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -67,43 +66,46 @@ func TestDatabaseRegistrationStore_RESTClaimIsAtomicAndRetryable(t *testing.T) {
 		ControllerURL: "grpc://controller:7443", ExpiresAt: &expires,
 	}))
 
+	// One device, many concurrent attempts: exactly one may create the claim, so
+	// only one private key can ever be issued to it.
 	const contenders = 16
+	const deviceID = "device-under-contention"
 	var successes atomic.Int32
-	var winner atomic.Int32
-	winner.Store(-1)
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for i := 0; i < contenders; i++ {
 		wg.Add(1)
-		go func(i int) {
+		go func() {
 			defer wg.Done()
 			<-start
-			created, err := store.ClaimToken(ctx, "db-rest-claim-canary", fmt.Sprintf("device-%d", i))
+			created, err := store.ClaimToken(ctx, "db-rest-claim-canary", deviceID)
 			if err == nil && created {
 				successes.Add(1)
-				winner.Store(int32(i))
 			}
-		}(i)
+		}()
 	}
 	close(start)
 	wg.Wait()
 	require.Equal(t, int32(1), successes.Load())
 
-	winnerID := fmt.Sprintf("device-%d", winner.Load())
-	created, err := store.ClaimToken(ctx, "db-rest-claim-canary", winnerID)
+	created, err := store.ClaimToken(ctx, "db-rest-claim-canary", deviceID)
 	require.NoError(t, err)
-	assert.False(t, created)
+	assert.False(t, created, "same-device retry must not create another claim")
 
-	_, err = store.ClaimToken(ctx, "db-rest-claim-canary", "different-device")
-	require.ErrorIs(t, err, business.ErrRegistrationTokenAlreadyClaimed)
-
-	require.NoError(t, store.ReleaseTokenClaim(ctx, "db-rest-claim-canary", winnerID))
-	created, err = store.ClaimToken(ctx, "db-rest-claim-canary", "retry-after-pre-issuance-failure")
+	// The token is perennial (Issue #1690): one device's claim must not lock the
+	// rest of the fleet out of the same enrolment token.
+	created, err = store.ClaimToken(ctx, "db-rest-claim-canary", "second-device")
 	require.NoError(t, err)
-	assert.True(t, created)
+	assert.True(t, created, "a second device must enrol on the same perennial token")
 
-	require.NoError(t, store.ConsumeToken(ctx, "db-rest-claim-canary"),
-		"REST claim must leave the bearer valid for final gRPC consumption")
+	require.NoError(t, store.ReleaseTokenClaim(ctx, "db-rest-claim-canary", deviceID))
+	created, err = store.ClaimToken(ctx, "db-rest-claim-canary", deviceID)
+	require.NoError(t, err)
+	assert.True(t, created, "released pre-issuance claim must be retryable")
+
+	got, err := store.GetToken(ctx, "db-rest-claim-canary")
+	require.NoError(t, err)
+	assert.True(t, got.IsValid(), "enrolment must not revoke the fleet token")
 }
 
 func TestDatabaseRegistrationStore_RotateToken_NoActiveTokens(t *testing.T) {

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -616,11 +616,21 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 		return err
 	}
 
+	// A claim gates certificate issuance for one device identity. Registration
+	// tokens are perennial (Issue #1690), so the key is (token, claim_id): many
+	// devices enrol on one fleet token, but a given device can be issued a key
+	// only once per token. A table left over from the original single-column key
+	// is dropped — claims are short-lived in-flight guards, and keeping them
+	// would preserve exactly the rows that block re-enrolment.
+	if err := dropSingleColumnRegistrationClaimKey(ctx, db); err != nil {
+		return err
+	}
 	createClaimsTableQuery := `
 		CREATE TABLE IF NOT EXISTS cfgms_registration_token_claims (
-			token      VARCHAR(255) PRIMARY KEY,
+			token      VARCHAR(255) NOT NULL,
 			claim_id   VARCHAR(255) NOT NULL,
-			claimed_at TIMESTAMP WITH TIME ZONE NOT NULL
+			claimed_at TIMESTAMP WITH TIME ZONE NOT NULL,
+			PRIMARY KEY (token, claim_id)
 		);
 	`
 	if _, err := db.ExecContext(ctx, createClaimsTableQuery); err != nil {
@@ -646,6 +656,39 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 		}
 	}
 
+	return nil
+}
+
+// dropSingleColumnRegistrationClaimKey removes a cfgms_registration_token_claims
+// table that still carries the original single-column `token` primary key. That
+// key admitted one device per token for the token's whole lifetime, which
+// silently reverted the perennial token model (Issue #1690) — a fleet token
+// could enrol exactly one endpoint. CREATE TABLE IF NOT EXISTS alone would leave
+// the old key in place, so the stale table is dropped and recreated with
+// PRIMARY KEY (token, claim_id).
+//
+// Dropping the rows is safe: a claim is a short-lived in-flight admission guard,
+// so any registration still mid-flight simply retries.
+func dropSingleColumnRegistrationClaimKey(ctx context.Context, db *sql.DB) error {
+	var keyColumns int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kcu
+		  ON tc.constraint_name = kcu.constraint_name
+		 AND tc.table_schema = kcu.table_schema
+		WHERE tc.table_name = 'cfgms_registration_token_claims'
+		  AND tc.constraint_type = 'PRIMARY KEY'`).Scan(&keyColumns)
+	if err != nil {
+		return fmt.Errorf("failed to inspect cfgms_registration_token_claims primary key: %w", err)
+	}
+	// 0 = table absent (nothing to migrate); 2 = already the corrected key.
+	if keyColumns != 1 {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE cfgms_registration_token_claims`); err != nil {
+		return fmt.Errorf("failed to drop legacy cfgms_registration_token_claims table: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/storage/providers/sqlite/registration_store.go
+++ b/pkg/storage/providers/sqlite/registration_store.go
@@ -169,37 +169,9 @@ func (s *SQLiteRegistrationTokenStore) DeleteToken(ctx context.Context, tokenStr
 	return nil
 }
 
-// ConsumeToken atomically marks one valid token spent. Concurrent callers race
-// on the conditional UPDATE; exactly one can affect a row.
-func (s *SQLiteRegistrationTokenStore) ConsumeToken(ctx context.Context, tokenStr string) error {
-	now := nowUTC()
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE registration_tokens
-		SET revoked = 1, revoked_at = ?
-		WHERE token IN (?, ?)
-		  AND revoked = 0
-		  AND (expires_at IS NULL OR expires_at > ?)`,
-		formatTime(now),
-		business.RegistrationTokenLookupKey(tokenStr),
-		tokenStr,
-		formatTime(now),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to consume registration token: %w", err)
-	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to confirm registration token consumption: %w", err)
-	}
-	if affected != 1 {
-		return fmt.Errorf("registration token is invalid, expired, or already used")
-	}
-	return nil
-}
-
-// ClaimToken atomically reserves one valid token at the REST admission boundary.
-// The claim is intentionally separate from revoked/consumed state because the
-// steward must present the same bearer during the subsequent gRPC registration.
+// ClaimToken atomically reserves a valid token for one device identity at the
+// REST admission boundary. It does not revoke the token: registration tokens are
+// perennial (Issue #1690) and one fleet token enrols many endpoints.
 func (s *SQLiteRegistrationTokenStore) ClaimToken(ctx context.Context, tokenStr, claimID string) (bool, error) {
 	if tokenStr == "" {
 		return false, fmt.Errorf("token string cannot be empty")
@@ -237,21 +209,21 @@ func (s *SQLiteRegistrationTokenStore) ClaimToken(ctx context.Context, tokenStr,
 		return true, nil
 	}
 
-	var existingClaimID string
+	// No row was inserted: either this device already holds a claim (a retry) or
+	// the token itself is not usable. Distinguishing the two keeps a retry
+	// idempotent without reporting a revoked token as a successful claim.
+	var claimed int
 	err = s.db.QueryRowContext(ctx,
-		`SELECT claim_id FROM registration_token_claims WHERE token = ?`,
-		lookupKey,
-	).Scan(&existingClaimID)
-	if err == sql.ErrNoRows {
-		return false, fmt.Errorf("registration token is invalid, expired, or revoked")
-	}
+		`SELECT COUNT(1) FROM registration_token_claims WHERE token = ? AND claim_id = ?`,
+		lookupKey, claimID,
+	).Scan(&claimed)
 	if err != nil {
 		return false, fmt.Errorf("failed to inspect registration token claim: %w", err)
 	}
-	if existingClaimID == claimID {
+	if claimed == 1 {
 		return false, nil
 	}
-	return false, business.ErrRegistrationTokenAlreadyClaimed
+	return false, fmt.Errorf("registration token is invalid, expired, or revoked")
 }
 
 // ReleaseTokenClaim removes only the exact claim made by this REST attempt.
@@ -478,5 +450,4 @@ func generateTokenID() (string, error) {
 
 // ensure SQLiteRegistrationTokenStore satisfies the interface at compile time
 var _ business.RegistrationTokenStore = (*SQLiteRegistrationTokenStore)(nil)
-var _ business.RegistrationTokenConsumer = (*SQLiteRegistrationTokenStore)(nil)
 var _ business.RegistrationTokenClaimer = (*SQLiteRegistrationTokenStore)(nil)

--- a/pkg/storage/providers/sqlite/registration_store_test.go
+++ b/pkg/storage/providers/sqlite/registration_store_test.go
@@ -224,31 +224,28 @@ func TestRegistrationStore_GetNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestRegistrationStore_ConsumeIsAtomicAndSingleUse(t *testing.T) {
+// A perennial token (Issue #1690) enrols a whole fleet, so claiming it for one
+// device must not lock every other device out.
+func TestRegistrationStore_ClaimDoesNotSpendThePerennialToken(t *testing.T) {
 	store := newRegistrationStore(t)
-	consumer, ok := store.(business.RegistrationTokenConsumer)
+	claimer, ok := store.(business.RegistrationTokenClaimer)
 	require.True(t, ok)
 	ctx := context.Background()
 	expires := time.Now().Add(time.Hour)
 	require.NoError(t, store.SaveToken(ctx, &business.RegistrationTokenData{
-		Token: "single-use-canary", TenantID: "tenant-1",
+		Token: "fleet-enrolment-canary", TenantID: "tenant-1",
 		ControllerURL: "https://controller.example.com", ExpiresAt: &expires,
 	}))
 
-	const contenders = 16
-	var successes atomic.Int32
-	var wg sync.WaitGroup
-	for i := 0; i < contenders; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if consumer.ConsumeToken(ctx, "single-use-canary") == nil {
-				successes.Add(1)
-			}
-		}()
+	for i := 0; i < 5; i++ {
+		created, err := claimer.ClaimToken(ctx, "fleet-enrolment-canary", fmt.Sprintf("device-%d", i))
+		require.NoError(t, err, "device %d must be able to enrol on the fleet token", i)
+		assert.True(t, created, "device %d must win its own claim", i)
 	}
-	wg.Wait()
-	assert.Equal(t, int32(1), successes.Load())
+
+	got, err := store.GetToken(ctx, "fleet-enrolment-canary")
+	require.NoError(t, err)
+	assert.True(t, got.IsValid(), "enrolment must not revoke the fleet token")
 }
 
 func TestRegistrationStore_RESTClaimIsAtomicAndRetryable(t *testing.T) {
@@ -262,45 +259,64 @@ func TestRegistrationStore_RESTClaimIsAtomicAndRetryable(t *testing.T) {
 		ControllerURL: "https://controller.example.com", ExpiresAt: &expires,
 	}))
 
+	// One device, many concurrent attempts: exactly one may create the claim, so
+	// only one private key can ever be issued to it.
 	const contenders = 16
+	const deviceID = "device-under-contention"
 	var successes atomic.Int32
-	var winner atomic.Int32
-	winner.Store(-1)
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for i := 0; i < contenders; i++ {
 		wg.Add(1)
-		go func(i int) {
+		go func() {
 			defer wg.Done()
 			<-start
-			created, err := claimer.ClaimToken(ctx, "rest-claim-canary", fmt.Sprintf("device-%d", i))
+			created, err := claimer.ClaimToken(ctx, "rest-claim-canary", deviceID)
 			if err == nil && created {
 				successes.Add(1)
-				winner.Store(int32(i))
 			}
-		}(i)
+		}()
 	}
 	close(start)
 	wg.Wait()
 	require.Equal(t, int32(1), successes.Load())
 
-	winnerID := fmt.Sprintf("device-%d", winner.Load())
-	created, err := claimer.ClaimToken(ctx, "rest-claim-canary", winnerID)
+	created, err := claimer.ClaimToken(ctx, "rest-claim-canary", deviceID)
 	require.NoError(t, err, "same-device retry must be recognized")
 	assert.False(t, created, "retry must not create another claim")
 
-	_, err = claimer.ClaimToken(ctx, "rest-claim-canary", "different-device")
-	require.ErrorIs(t, err, business.ErrRegistrationTokenAlreadyClaimed)
+	// A different device is unaffected by the first device's claim.
+	created, err = claimer.ClaimToken(ctx, "rest-claim-canary", "second-device")
+	require.NoError(t, err)
+	assert.True(t, created, "a second device must enrol on the same perennial token")
 
-	require.NoError(t, claimer.ReleaseTokenClaim(ctx, "rest-claim-canary", winnerID))
-	created, err = claimer.ClaimToken(ctx, "rest-claim-canary", "retry-after-pre-issuance-failure")
+	require.NoError(t, claimer.ReleaseTokenClaim(ctx, "rest-claim-canary", deviceID))
+	created, err = claimer.ClaimToken(ctx, "rest-claim-canary", deviceID)
 	require.NoError(t, err)
 	assert.True(t, created, "released pre-issuance claim must be retryable")
 
-	consumer, ok := store.(business.RegistrationTokenConsumer)
+	// Releasing one device's claim must not disturb another's.
+	created, err = claimer.ClaimToken(ctx, "rest-claim-canary", "second-device")
+	require.NoError(t, err)
+	assert.False(t, created, "the second device's claim must survive an unrelated release")
+}
+
+// A revoked token must be refused even for a device that never claimed it.
+func TestRegistrationStore_ClaimRejectsRevokedToken(t *testing.T) {
+	store := newRegistrationStore(t)
+	claimer, ok := store.(business.RegistrationTokenClaimer)
 	require.True(t, ok)
-	require.NoError(t, consumer.ConsumeToken(ctx, "rest-claim-canary"),
-		"REST claim must leave the bearer valid for final gRPC consumption")
+	ctx := context.Background()
+	tok := &business.RegistrationTokenData{
+		Token: "revoked-claim-canary", TenantID: "tenant-1",
+		ControllerURL: "https://controller.example.com",
+	}
+	require.NoError(t, store.SaveToken(ctx, tok))
+	tok.Revoke()
+	require.NoError(t, store.UpdateToken(ctx, tok))
+
+	_, err := claimer.ClaimToken(ctx, "revoked-claim-canary", "some-device")
+	require.Error(t, err, "a revoked token must not admit a new device")
 }
 
 func TestRegistrationStore_Update(t *testing.T) {

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 const currentSchemaVersion = 2
@@ -224,6 +225,40 @@ func assignMissingRegistrationTokenIDs(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+// migrateRegistrationTokenClaimKey rebuilds a registration_token_claims table
+// that still carries the original `token TEXT PRIMARY KEY`. That key admitted
+// one device per token for the lifetime of the token, which silently reverted
+// the perennial token model (Issue #1690) — a fleet token could enrol exactly
+// one endpoint. The corrected key is (token, claim_id).
+//
+// Claims are short-lived in-flight admission guards, so the rows are dropped
+// rather than copied: any registration still mid-flight retries, and keeping
+// them would preserve the very rows that block re-enrolment.
+func migrateRegistrationTokenClaimKey(ctx context.Context, db *sql.DB) error {
+	exists, err := tableExists(ctx, db, "registration_token_claims")
+	if err != nil {
+		return fmt.Errorf("sqlite: registration_token_claims probe failed: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+
+	var ddl string
+	if err := db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'registration_token_claims'`,
+	).Scan(&ddl); err != nil {
+		return fmt.Errorf("sqlite: registration_token_claims DDL probe failed: %w", err)
+	}
+	if strings.Contains(ddl, "PRIMARY KEY (token, claim_id)") {
+		return nil
+	}
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE registration_token_claims`); err != nil {
+		return fmt.Errorf("sqlite: registration_token_claims migration failed: %w", err)
+	}
+	return nil
+}
+
 // initializeSchema creates all tables and tracks schema version.
 // It is safe to call multiple times (all statements use IF NOT EXISTS).
 // All DDL statements are executed inside a single transaction to reduce WAL
@@ -237,6 +272,9 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		return err
 	}
 	if err := backfillSessionTokenRecords(ctx, db); err != nil {
+		return err
+	}
+	if err := migrateRegistrationTokenClaimKey(ctx, db); err != nil {
 		return err
 	}
 	if err := backfillRegistrationTokenID(ctx, db); err != nil {
@@ -417,13 +455,15 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_registration_tokens_group_name ON registration_tokens(group_name)`,
 		`CREATE INDEX IF NOT EXISTS idx_registration_tokens_id         ON registration_tokens(id)`,
 
-		// REST registration claims are separate from final token consumption:
-		// a claim gates certificate/pending-record creation, while the token
-		// remains valid until the mTLS-authenticated gRPC registration.
+		// A REST registration claim gates certificate/pending-record creation for
+		// one device identity. Registration tokens are perennial (Issue #1690), so
+		// the key is (token, claim_id) — many devices enroll on one fleet token,
+		// but a given device can be issued a key only once per token.
 		`CREATE TABLE IF NOT EXISTS registration_token_claims (
-				token      TEXT PRIMARY KEY,
+				token      TEXT NOT NULL,
 				claim_id   TEXT NOT NULL,
-				claimed_at TEXT NOT NULL
+				claimed_at TEXT NOT NULL,
+				PRIMARY KEY (token, claim_id)
 			)`,
 
 		// Stewards — durable fleet registry (ADR-003 §2, Issue #663)

--- a/pkg/storage/providers/sqlite/schema_backfill_test.go
+++ b/pkg/storage/providers/sqlite/schema_backfill_test.go
@@ -590,3 +590,48 @@ func TestBackfillRegistrationTokenID_UpdateFailure(t *testing.T) {
 	require.Error(t, err, "UPDATE on read-only DB must return an error")
 	assert.Contains(t, err.Error(), "back-fill update failed", "error must identify the update stage")
 }
+
+// legacySingleDeviceClaimSchema is the registration_token_claims DDL as first
+// shipped: one claim row per token, for the token's whole lifetime.
+const legacySingleDeviceClaimSchema = `CREATE TABLE IF NOT EXISTS registration_token_claims (
+	token      TEXT PRIMARY KEY,
+	claim_id   TEXT NOT NULL,
+	claimed_at TEXT NOT NULL
+)`
+
+// A database created before the fix carries a primary key that admits one device
+// per token forever, so an existing controller would keep refusing to enrol the
+// rest of its fleet even after upgrading. CREATE TABLE IF NOT EXISTS cannot
+// change a key, so the migration has to rebuild the table.
+func TestMigrate_LegacySingleDeviceRegistrationClaimKey(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, legacySingleDeviceClaimSchema)
+	require.NoError(t, err, "seed legacy claims schema")
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO registration_token_claims (token, claim_id, claimed_at) VALUES ('tok', 'device-a', '2026-01-01T00:00:00Z')`)
+	require.NoError(t, err, "seed a claim held under the legacy key")
+
+	require.NoError(t, initializeSchema(ctx, db), "initializeSchema must migrate the claims table")
+
+	// A second device on the same token is the case the legacy key rejected.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO registration_token_claims (token, claim_id, claimed_at) VALUES ('tok', 'device-a', '2026-01-01T00:00:00Z')`)
+	require.NoError(t, err, "first device claims the token")
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO registration_token_claims (token, claim_id, claimed_at) VALUES ('tok', 'device-b', '2026-01-01T00:00:01Z')`)
+	require.NoError(t, err, "a second device must be able to claim the same perennial token")
+
+	// The same device twice must still collide, so it cannot be issued two keys.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO registration_token_claims (token, claim_id, claimed_at) VALUES ('tok', 'device-b', '2026-01-01T00:00:02Z')`)
+	require.Error(t, err, "a device must not hold two claims on one token")
+
+	// Re-running must not drop the migrated table or its rows.
+	require.NoError(t, initializeSchema(ctx, db), "second initializeSchema call (idempotency check)")
+	var claims int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM registration_token_claims WHERE token = 'tok'`).Scan(&claims))
+	assert.Equal(t, 2, claims, "migrated claims must survive a later startup")
+}

--- a/pkg/testutil/secrets.go
+++ b/pkg/testutil/secrets.go
@@ -80,13 +80,24 @@ func writeSecretsKeyFile(base string) (string, error) {
 func ReservePrivateListenerAddress(t *testing.T) string {
 	t.Helper()
 
+	address, err := ReserveLoopbackAddress()
+	if err != nil {
+		t.Fatalf("ReservePrivateListenerAddress: %v", err)
+	}
+	return address
+}
+
+// ReserveLoopbackAddress is ReservePrivateListenerAddress for harness code that
+// builds a controller outside a *testing.T — the e2e framework constructs its
+// controller config in a plain function.
+func ReserveLoopbackAddress() (string, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("ReservePrivateListenerAddress: reserve loopback port: %v", err)
+		return "", fmt.Errorf("reserve loopback port: %w", err)
 	}
 	address := listener.Addr().String()
 	if err := listener.Close(); err != nil {
-		t.Fatalf("ReservePrivateListenerAddress: release loopback port: %v", err)
+		return "", fmt.Errorf("release loopback port: %w", err)
 	}
-	return address
+	return address, nil
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	testutil "github.com/cfgis/cfgms/pkg/testing"
+	pkgtestutil "github.com/cfgis/cfgms/pkg/testutil"
 
 	// Import storage providers for testing
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
@@ -338,11 +339,29 @@ func (f *E2ETestFramework) initializeController() error {
 	// Story #1919 made getHTTPListenAddr() honor cfg.ListenAddr, exposing
 	// the harness bug: with ListenAddr set to ControllerPort=8080, registration
 	// to HTTPPort=9080 was hitting nothing. Bind HTTP on HTTPPort to match.
+	//
+	// The dedicated metrics listener is fail-closed: DefaultConfig leaves it empty
+	// so a deployment has to choose an address, and Server.Start refuses to bind
+	// anything — including the public API this harness registers stewards
+	// against — until one is set. Reserve a concrete loopback port, which is what
+	// a deployment configures.
+	//
+	// external_url is likewise required: the public API refuses to serve TLS
+	// until it can confirm the server certificate actually covers the hostname
+	// clients are told to use. The harness issues its server certificate for
+	// "localhost" below, and registers stewards against that name.
+	metricsAddr, err := pkgtestutil.ReserveLoopbackAddress()
+	if err != nil {
+		return fmt.Errorf("failed to reserve metrics listener address: %w", err)
+	}
+
 	config := &controllerConfig.Config{
-		ListenAddr: fmt.Sprintf("localhost:%d", f.config.HTTPPort),
-		CertPath:   filepath.Join(f.tempDir, "certs"), // Legacy cert path
-		DataDir:    filepath.Join(f.tempDir, "controller-data"),
-		LogLevel:   "info",
+		ListenAddr:        fmt.Sprintf("localhost:%d", f.config.HTTPPort),
+		ExternalURL:       fmt.Sprintf("https://localhost:%d", f.config.HTTPPort),
+		MetricsListenAddr: metricsAddr,
+		CertPath:          filepath.Join(f.tempDir, "certs"), // Legacy cert path
+		DataDir:           filepath.Join(f.tempDir, "controller-data"),
+		LogLevel:          "info",
 		Storage: &controllerConfig.StorageConfig{
 			Provider:     "flatfile",
 			FlatfileRoot: filepath.Join(f.tempDir, "storage-flatfile"),
@@ -389,15 +408,26 @@ func (f *E2ETestFramework) initializeController() error {
 		return fmt.Errorf("failed to create controller: %w", err)
 	}
 
-	// Start controller in background
+	// Start controller in background. Start's error was previously only logged,
+	// which made every fail-closed startup check surface as an unrelated symptom
+	// much later — a refused listener shows up as "connection refused" in whatever
+	// test registers first, and on Windows as a temp-dir cleanup failure, because
+	// Stop short-circuits on a controller that never started and so never releases
+	// its SQLite handles. Capture it and report it as itself.
+	startErr := make(chan error, 1)
 	go func() {
-		if err := ctrl.Start(f.ctx); err != nil {
-			f.logger.Error("Controller start failed", "error", err)
-		}
+		startErr <- ctrl.Start(f.ctx)
 	}()
 
-	// Wait for controller to start (give it some time)
-	time.Sleep(f.config.ComponentStartup)
+	select {
+	case err := <-startErr:
+		if err != nil {
+			return fmt.Errorf("controller failed to start: %w", err)
+		}
+	case <-time.After(f.config.ComponentStartup):
+		// Start blocks while the controller serves; reaching the budget without an
+		// error is the normal path.
+	}
 
 	f.controller = ctrl
 	f.addCleanup(func() error {
@@ -723,11 +753,13 @@ func (f *E2ETestFramework) createTLSConfigFromPEM(caCertPEM, clientCertPEM, clie
 		return nil, fmt.Errorf("failed to load client certificate: %w", err)
 	}
 
-	// Create TLS config with ALPN protocol for gRPC-over-QUIC
+	// Create TLS config with ALPN protocol for gRPC-over-QUIC.
+	// QUIC is TLS 1.3-only and the dialer now rejects anything lower outright, so
+	// TLS 1.2 here is not a weaker-but-working setting — it fails the handshake.
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      caCertPool,
-		MinVersion:   tls.VersionTLS12,
+		MinVersion:   tls.VersionTLS13,
 		ServerName:   "localhost",                          // Connect via localhost in tests
 		NextProtos:   []string{quictransport.ALPNProtocol}, // Required for QUIC transport
 	}


### PR DESCRIPTION
## Summary

The merge queue has been failing for every PR since #3156 landed. #3156 failed its own queue run three times and merged anyway; the last green queue run was #3163 (`05890e63`). Measured on queue commit `9e28760a` (PR #3177): **Cross-Platform Build Validation**, **Production Risk Gates** and **Fleet E2E Tests** all red.

This restores all four gates. Every fix addresses the root cause and keeps the hardening intent — none of them relax a check to get green.

## Root causes

### 1. Registration tokens became single-use again (fleet + integration gates)

#3156 added `ClaimToken` with `token PRIMARY KEY` and a `ConsumeToken` call that **revokes** the token on the first gRPC registration. Issue #1690 deliberately removed exactly that model — it deleted `SingleUse`/`UsedAt`/`UsedBy` so one enrolment token could serve a whole fleet, which is what an RMM or GPO deployment bakes into a script. `docs/deployment/fleet/walkthrough.md` and the controller operating model both state tokens are perennial.

Effect: the first endpoint to register revoked the token for every other endpoint. `fleet-steward-2` never enrolled; `TestPerennialToken` and `TestConcurrentRegistrations` returned 409.

- Claim is now keyed `(token, claim_id)`. `claim_id` already binds `device_id` + identity key, so **one device still cannot be issued two private keys** — concurrent same-device claims still resolve to exactly one winner — while distinct devices claim the same perennial token independently.
- The gRPC path no longer consumes the token. It keeps the checks that gave it its purpose (existence, validity, tenant binding), and the caller has already presented an mTLS certificate only the REST boundary can mint. `RegistrationTokenConsumer` is removed; the fail-closed startup assertion now requires `RegistrationTokenClaimer`, the interface that actually guards issuance.
- Both providers migrate a table still carrying the single-column key — `CREATE TABLE IF NOT EXISTS` cannot change a primary key, so an existing controller would have kept refusing its fleet after upgrading.
- Quarantine retries were resolved via `GetPendingByToken`, which under a perennial token can hand a device **another device's** pending entry. The pending ID is now derived from token + device, so a device addresses its own entry by ID.

### 2. The test-endpoint build tag was never set anywhere (fleet + integration gates)

#3156 put the `/api/v1/test/*` routes behind `//go:build cfgms_test_endpoints`, but nothing in the repo built with that tag. The fleet and integration suites got 404s from a controller that had `CFGMS_ENABLE_TEST_ENDPOINTS=true` set.

`cmd/controller/Dockerfile` takes a `GO_BUILD_TAGS` arg — **empty by default so production images stay clean** — and the two `docker-compose.test.yml` services that already opt in at runtime now opt in at build time too. `test-fast` vets the tagged sources so they cannot rot unbuilt again.

### 3. The e2e harness never started its controller (Production Risk Gates)

Two fail-closed checks reject a config the harness does not set — `metrics_listen_addr` and `external_url` — so `api.Server.Start` returned before binding anything and registration to `localhost:9080` was refused. The harness now reserves a loopback metrics port and declares its external URL, matching what #3156 did for the `features/controller` tests it did reach. Its QUIC client also asked for TLS 1.2, which the hardened dialer now rejects outright.

`Start`'s error was previously only logged, which is why this surfaced as "connection refused" in an unrelated test rather than as itself. It is now returned.

### 4. Three genuine Windows failures

- **Leaked storage handles.** `server.New` opened storage, then returned an error from ~20 later paths without closing it. Nothing calls `Stop` on a controller that never constructed, so handles leaked and pinned the database files — Linux unlinks open files, Windows does not. Every store opened in `New` now registers its `Close`.
- **`.bat` execution.** `executeScript` passed cmd.exe a pre-quoted path through argv, which `os/exec` escapes to `\"C:\...\x.bat\"` → *"is not recognized as an internal or external command"*. The command line is now built explicitly, keeping `/d`, `/s` and the metacharacter validation, with the doubled quotes `/s` requires for the spaced paths `validateWindowsScriptPath` explicitly permits.
- **Path assertion.** `TestResolveInstallerBlobRoot` asserted a POSIX separator against a `filepath.Join` result. The production code was correct; the test was not.

## Testing

| Check | Result |
|---|---|
| `test/integration/transport` `TestRegistration` | all 7 subtests pass against a Docker controller |
| — concurrent registrations | **50 successful / 50 unique steward IDs** (was 1 / 1) |
| — `TestPerennialToken`, `TestStewardIDUniqueness`, `TestHTTPRegistrationEndpoint` | pass (were 409 "already been claimed") |
| `test/e2e/fleet` | `ok`, 372s — both stewards reach healthy |
| — `TestFleetRegistrationRefresh` AutoAccept/Revoked/Archived | pass (were 404) |
| — `TestFleetRotation`, `TestFleetIDSelector`, `TestFleetComposeStartup/fleet-steward-2`, `TestFleetStewardUpgradeHappyPath` | pass |
| `test/e2e` `TestE2EScenarios` | `ok` — `TestFailoverDetection` + `TestTransportCommandResponse` pass (were connection refused) |
| `make test-fast` | exit 0 |
| storage + controller-server, certificate integration steps | `ok` |
| `go build`, `go vet`, `GOOS=windows/darwin go vet` | clean |
| `make check-architecture` | no violations |
| `make security-gosec` | 188 findings, **all** in the in-tree `.cache/go-mod` dependency cache, none in repo source |

**Not verified locally:** the Windows and macOS runners. Those three fixes are covered by cross-compilation plus unit tests that pin the generated command line and the path construction; the Windows job in this PR is the real check.

## Type of Change

- [x] Bug fix

## Security Considerations

- [x] No security control is relaxed. The anti-double-issuance guard is preserved and re-scoped to the unit it protects (the device). Token revocation and expiry remain the only ways to spend a token, and both are still enforced at the REST and gRPC boundaries — covered by new tests.
- [x] A cross-device information leak in #3156's quarantine retry path is closed.
- [x] Production controller images still compile the test endpoints out entirely.

## Documentation

- [x] `docs/architecture/operating-model.md` still described "single-use registration tokens … consumed at registration" — stale since #1690 and the prose that makes this regression easy to reintroduce. Corrected.
- [x] `GetPendingByToken` is documented as unable to identify a specific device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo
