### PR TITLE
test: fix two Windows timing flakes that eject PRs from the merge queue

### DIFF
--- a/features/controller/registration/ip_trust_evaluator_test.go
+++ b/features/controller/registration/ip_trust_evaluator_test.go
@@ -153,10 +153,17 @@ func TestIPTrustEvaluator_ThresholdNotMet_NoTrust(t *testing.T) {
 	// Start the liveness clock.
 	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
 
-	// Simulate multiple healthy calls but back-date firstSeen to just under threshold.
+	// Back-date firstSeen to the middle of the window. The margin is deliberately
+	// large: the evaluator measures with time.Since against the wall clock, so a
+	// margin near the boundary asserts a distinction finer than the platform's
+	// timer can resolve. This test previously used threshold-1ms and failed on
+	// Windows, whose timer granularity is ~15.6 ms — the evaluator was correct
+	// (it logged elapsed=5.0004936s against a 5s threshold), the assertion was
+	// not. Testing the exact boundary needs an injectable clock, not a tighter
+	// margin.
 	ev.mu.Lock()
 	key := "tenant-1\x0010.0.0.1"
-	ev.timers[key] = time.Now().Add(-(threshold - time.Millisecond))
+	ev.timers[key] = time.Now().Add(-threshold / 2)
 	ev.mu.Unlock()
 
 	// One more healthy call — elapsed is still < threshold.

--- a/features/steward/client/telemetry_stream_test.go
+++ b/features/steward/client/telemetry_stream_test.go
@@ -321,28 +321,36 @@ func TestTelemetryStream_NoSnapshotAfterUnsubscribe(t *testing.T) {
 		Collector: col,
 		Logger:    logging.NewNoopLogger(),
 	})
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// These waits are hang detectors, not performance budgets, and they have to
+	// clear the operation's own floor: the server sends unsubscribe only after
+	// receiving two snapshots, and the requested 50 ms interval is clamped to
+	// 1000 ms, so unsubscribe cannot arrive sooner than ~2 s by construction —
+	// before QUIC connection setup. The previous 5 s budget was ~2.5x that floor
+	// and failed on a cold Windows runner at 5.41 s. What this test asserts is
+	// behavioural (no snapshots after unsubscribe); it is not a timing assertion,
+	// so the waits are set far above the floor and a genuine hang still fails.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	ts.Start(ctx)
 
 	// Wait for the subscribe request to have been sent.
 	select {
 	case <-subscribed:
-	case <-time.After(3 * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatal("timeout waiting for subscribe signal")
 	}
 
 	// Wait for unsubscribe to be sent.
 	select {
 	case <-unsubscribed:
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("timeout waiting for unsubscribe signal")
 	}
 	// Block until the server's observation loop returns (its 500 ms window has
 	// elapsed with no further frames), signalled by serverDone — no time.Sleep.
 	select {
 	case <-serverDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatal("timeout waiting for server observation window to close")
 	}
 	ts.Close()


### PR DESCRIPTION
## Summary

Two Windows-only timing flakes that eject PRs from the merge queue. Both hit #3200 — a **markdown-only** change against a develop tip that had just passed the queue twice. Re-enqueueing the identical commit passed (merged as `d1ae10ec`), confirming both as intermittent rather than regressions.

Each ejection costs a full queue cycle, so these are a throughput tax on every PR, not just an annoyance.

## `TestIPTrustEvaluator_ThresholdNotMet_NoTrust`

Flaky by construction. It back-dated `firstSeen` to `threshold - time.Millisecond` — a **1 ms** margin — then asserted trust was not granted. The evaluator measures with `time.Since` against the wall clock, and Windows timer granularity is ~15.6 ms.

The failing run logged:

```
[INFO] IP promoted to trusted status [... cidr=10.0.0.1/32 elapsed=5.0004936s]
--- FAIL: TestIPTrustEvaluator_ThresholdNotMet_NoTrust
    AddTrustedRange must not be called when threshold is not yet met
```

Elapsed genuinely exceeded the 5 s threshold. **The evaluator was correct; the assertion was not.**

Back-dating to `threshold/2` keeps what the test is for — elapsed under the threshold grants no trust — without depending on clock resolution. Asserting the exact boundary would need an injectable clock, which the evaluator doesn't have; a tighter margin can't substitute for one.

## `TestTelemetryStream_NoSnapshotAfterUnsubscribe`

Waited 5 s for an unsubscribe that **cannot arrive sooner than ~2 s by construction**: the server sends it only after receiving two snapshots, and the requested 50 ms interval is clamped to 1000 ms — before QUIC connection setup. Observed failure took 5.41 s.

That budget is ~2.5× the operation's own floor. Its two siblings in the same file sit at ~4× (12 s for a 3 s floor; 8 s for a 2 s floor) and **both passed on the same runner**, so this test was the outlier rather than the budgets being wrong generally. The siblings are deliberately left alone.

### On raising a timeout

This is the one thing to scrutinise, since bumping timeouts is normally how flakes get papered over. The distinction here: the waits are **hang detectors, not performance budgets**. What the test asserts is behavioural — no snapshot frames after unsubscribe — and no assertion depends on how long anything took. The old value sat below the operation's own floor plus setup, so it was failing on runner speed rather than on the property under test. Raised to 20 s / 30 s / 20 s (context 60 s) so a genuine hang still fails.

## Testing

- `./features/controller/registration` `-count=5` — pass
- `./features/steward/client` `-count=2` — pass
- Both packages under `-race` — pass
- `GOOS=windows go vet` both packages — clean

The real proof is the Windows leg of this PR's own queue run.

## Type of Change

- [x] Bug fix (test correctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo
