### PR TITLE
security: clear the five open Dependabot alerts and two more npm audit finds

### DIFF
--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -144,7 +144,7 @@ cat > "$HOOKS_DIR/pre-commit" << 'HOOK_EOF'
 #
 
 # Allowed root-level directories
-ALLOWED_DIRS="^(api|cmd|commercial|docs|examples|features|internal|pkg|scripts|templates|test|\.claude|\.devcontainer|\.github)/"
+ALLOWED_DIRS="^(api|cmd|commercial|docs|examples|features|internal|pkg|scripts|templates|test|web|\.claude|\.devcontainer|\.github)/"
 
 # Allowed root-level files (config, docs, build files)
 ALLOWED_FILES="^(\.|CLAUDE|README|CHANGELOG|CONTRIBUTING|CONTRIBUTORS|CODE_OF_CONDUCT|CODEOWNERS|DEVELOPMENT|ARCHITECTURE|LICENSING|QUICK_START|SECURITY|LICENSE|Makefile|Dockerfile|docker-compose|go\.(mod|sum)|buf\.(gen\.)?yaml|staticcheck\.conf|windows-setup\.ps1|\.agent-dispatch\.yaml|codeql-workspace\.yml)"
@@ -189,7 +189,8 @@ if [ $blocked -ne 0 ]; then
     echo -e "$blocked_files"
     echo ""
     echo "Allowed directories: api/ cmd/ commercial/ docs/ examples/ features/"
-    echo "                     internal/ pkg/ scripts/ templates/ test/"
+    echo "                     internal/ pkg/ scripts/ templates/ test/ web/"
+    echo "                     .claude/ .devcontainer/ .github/"
     echo ""
     echo "If these are test artifacts, unstage them:"
     echo "  git reset HEAD <file>"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4135,9 +4135,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -6048,9 +6048,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What

Clears every open Dependabot alert on `develop`, plus two more that `npm audit`
raised once the first was fixed.

All five Dependabot alerts were the same package — `undici@7.28.0`, a transitive
**dev** dependency of `jsdom` (vitest's DOM environment):

| Alert | Severity | Advisory |
|---|---|---|
| #18 | high | GHSA-4cwx-7wf7-3272 |
| #19–#22 | moderate | GHSA-8xcm-r25x-g524, GHSA-v3r7-h72x-cjcm, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5 |

All fixed in 7.29.0. Bumping it surfaced two further **high** advisories
Dependabot had not raised, both fixable inside their existing semver ranges:
`brace-expansion` (GHSA-rgw5-rvv9-x895, DoS via unbounded intermediate arrays)
and `js-yaml` (GHSA-5p4m-2wfm-xmqj, quadratic CPU in `!!omap` resolution).

Three patch-level bumps, **lockfile only** — `package.json` is untouched:

```
undici          7.28.0 -> 7.29.0
brace-expansion 5.0.8  -> 5.0.9
js-yaml         4.3.0  -> 4.3.1
```

`npm audit` now reports **0 vulnerabilities**, down from 7.

## Also: the pre-commit hook allowlist

This is known work item 2 under epic #3175. The artifact-check allowlist omitted
`web/`, so this very commit — a one-file lockfile change — was rejected as a
misplaced artifact and would have needed `--no-verify`, which disables the check
for the entire commit rather than for those paths. Added `web/`.

The help text was also out of sync with the pattern it describes: it never
listed `.claude/`, `.devcontainer/` or `.github/`, which the regex has always
allowed. Fixed both, and re-ran `./scripts/install-git-hooks.sh` to confirm the
generated hook picks up the change.

## Verification

`make test-frontend` passes end to end on the updated lockfile — `npm ci`, lint,
typecheck, **1193 tests across 52 files**, and the production build.

GitHub Actions is degraded, so `frontend-checks` could not run in CI; the local
target runs the same commands.

## One thing deliberately left alone

`npm run build` regenerates `web/dist/index.html` with fresh asset content
hashes. That file is tracked, but the `web/dist/assets/*.js|.css` files it
references are **not** in the repo — so the committed copy points at build
output that does not exist, and every frontend PR re-commits it with new hashes.
I reverted it rather than fold build-output churn into a dependency bump. Worth
a separate look at whether it should be tracked at all.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo
