### PR TITLE
test: fix docker-compose steward flags rejected by cobra (Issue #3184)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -537,7 +537,7 @@ services:
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
       CFGMS_LOG_DIR: "/tmp/cfgms"
-    command: ["sh", "-c", "./steward --log-level debug --log-provider file --regtoken $$CFGMS_REGISTRATION_TOKEN"]
+    command: ["sh", "-c", "./steward --regtoken $$CFGMS_REGISTRATION_TOKEN"]
     volumes:
       - steward_standalone_data:/app/data
       - controller_standalone_certs:/app/controller-certs:ro
@@ -577,7 +577,7 @@ services:
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
       CFGMS_LOG_DIR: "/tmp/cfgms"
-    command: ["sh", "-c", "./steward --log-level debug --log-provider file --regtoken $$CFGMS_REGISTRATION_TOKEN --tenant-id tenant1"]
+    command: ["sh", "-c", "./steward --regtoken $$CFGMS_REGISTRATION_TOKEN"]
     volumes:
       - steward_tenant1_data:/app/data
       - ./test/module-execution:/test-workspace:rw
@@ -604,7 +604,7 @@ services:
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
       CFGMS_LOG_DIR: "/tmp/cfgms"
-    command: ["sh", "-c", "./steward --log-level debug --log-provider file --regtoken $$CFGMS_REGISTRATION_TOKEN --tenant-id tenant2"]
+    command: ["sh", "-c", "./steward --regtoken $$CFGMS_REGISTRATION_TOKEN"]
     volumes:
       - steward_tenant2_data:/app/data
       - ./test/module-execution:/test-workspace:rw
@@ -631,7 +631,7 @@ services:
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
       CFGMS_LOG_DIR: "/tmp/cfgms"
-    command: ["sh", "-c", "./steward --log-level debug --log-provider file --regtoken $$CFGMS_REGISTRATION_TOKEN --tenant-id tenant3"]
+    command: ["sh", "-c", "./steward --regtoken $$CFGMS_REGISTRATION_TOKEN"]
     volumes:
       - steward_tenant3_data:/app/data
       - ./test/module-execution:/test-workspace:rw


### PR DESCRIPTION
## Summary

- Removes `--log-level`, `--log-provider`, and `--tenant-id` from all four steward service command lines in `docker-compose.test.yml`. These flags are not registered on the steward cobra root command (guarded by an existing assertion in `TestBuildRootCommandFlags`), so cobra rejected them at parse time, causing all four steward containers to exit immediately and `TestController` to fail on every run.
- The removed flags are already delivered via environment variables (`CFGMS_LOG_LEVEL`, `CFGMS_LOG_PROVIDER`, `CFGMS_LOG_DIR`, `CFGMS_TENANT_ID`) in each service's `environment` block, so no behaviour changes.
- Replaces the `file(1)` dependency in `scripts/check-binary-artifacts.sh` with `od`+`tr` magic-byte matching (`file(1)` is absent from several CI images and caused the gate to abort without evidence). Adds `test/unit/build/binary_artifact_check_test.go` covering all six magic signatures.

## AC#2 — secrets provisioning investigation

No `TestMain` is needed for `test/integration/controller`. Evidence:

1. `docker_helper.go:StartController()` calls `scripts/generate-test-credentials.sh` before starting containers.
2. That script writes `CFGMS_SECRETS_KEY_FILE=...` to `.env.test` (script line 81).
3. Every `docker compose` invocation in the helper passes `--env-file ../../../.env.test`, so containers receive the key through that path.
4. The Go test process in this package only executes `docker`, `curl`, and `docker exec` shell commands; it never calls CFGMS Go code that requires `CFGMS_SECRETS_KEY_FILE`. Adding a `TestMain` would provision a key file that nothing in the Go process consumes.

The sibling `test/integration` package needs `TestMain` because *it* directly invokes controller Go code in-process — that package is a different class of test.

## Specialist review results

- **Code review**: PASS
- **Test quality**: PASS (round 2 after fix to binary artifact check script test coverage)
- **Security**: PASS

## Test plan

- [x] `go test ./test/unit/build/... -run TestBinaryArtifact` — all three new tests pass
- [x] `go build ./test/integration/controller/...` — clean
- [x] `go vet ./test/integration/controller/...` — clean
- [x] `make test-agent-complete` — pass (validated by story-review workflow)
- [ ] `TestController` against clean Docker environment — validates the steward container fix (requires CI; masked gate unblocked by this PR landing with siblings #3185/#3186/#3187)

Fixes #3184

🤖 Generated with [Claude Code](https://claude.com/claude-code)