### PR TITLE
bootstrap: add external_address and external_url to tier1-bootstrap.sh template (Issue #3170)

### DIFF
--- a/features/controller/config/config_test.go
+++ b/features/controller/config/config_test.go
@@ -836,3 +836,32 @@ deployment_rings:
 	assert.Equal(t, "v0.6.0", cfg.DeploymentRings.Rings[0].DesiredVersion)
 	assert.Equal(t, "default", cfg.DeploymentRings.FallbackRing)
 }
+
+// TestLoadWithPath_Tier1BootstrapTemplate_SetsExternalAddress verifies that a config
+// mirroring the tier1-bootstrap.sh generated template populates Transport.ExternalAddress.
+// Regression test for Issue #3170: the bootstrap template omitted external_address from
+// the transport: block, causing controllers to crash on startup.
+func TestLoadWithPath_Tier1BootstrapTemplate_SetsExternalAddress(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "controller.cfg")
+	// Minimal fragment matching the fixed tier1-bootstrap.sh template output.
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+external_url: "https://ctrl.tier1.lab:9080"
+listen_addr: "0.0.0.0:9080"
+metrics_listen_addr: "127.0.0.1:9090"
+transport:
+  listen_addr: "0.0.0.0:4433"
+  external_address: "ctrl.tier1.lab"
+  use_cert_manager: true
+  max_connections: 50000
+  keepalive_period: "30s"
+  idle_timeout: "5m"
+`), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport, "Transport block must be parsed")
+	assert.NotEmpty(t, cfg.Transport.ExternalAddress,
+		"Transport.ExternalAddress must be populated from the bootstrap template")
+	assert.Equal(t, "ctrl.tier1.lab", cfg.Transport.ExternalAddress)
+	assert.Equal(t, "https://ctrl.tier1.lab:9080", cfg.ExternalURL)
+}

--- a/features/controller/initialization/initialization_test.go
+++ b/features/controller/initialization/initialization_test.go
@@ -626,3 +626,61 @@ func TestRun_ClusterMode_UsesDatabaseProvider(t *testing.T) {
 	assert.NotEmpty(t, result.CAFingerprint)
 	assert.False(t, result.InitializedAt.IsZero())
 }
+
+// TestRun_AdminBundleControllerURLMatchesTier1BootstrapTemplate verifies that the
+// admin bundle produced by initialization.Run embeds the controller's real ExternalURL
+// rather than the localhost:8080 default.
+// Regression test for Issue #3170: the bootstrap template omitted the top-level
+// external_url key, so cfg.ExternalURL stayed at its compiled default "https://localhost:8080"
+// and every issued admin bundle pointed at the wrong address.
+func TestRun_AdminBundleControllerURLMatchesTier1BootstrapTemplate(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	// Config mirroring the fixed tier1-bootstrap.sh template output for a host
+	// named "ctrl.tier1.lab" with the default REST port 9080.
+	cfg := &config.Config{
+		ListenAddr:      "127.0.0.1:0",
+		ExternalURL:     "https://ctrl.tier1.lab:9080",
+		CertPath:        caDir,
+		AdminBundlePath: bundlePath,
+		Transport: &config.TransportConfig{
+			ListenAddr:      "0.0.0.0:4433",
+			ExternalAddress: "ctrl.tier1.lab",
+			UseCertManager:  true,
+			MaxConnections:  50000,
+			KeepalivePeriod: config.Duration(30 * time.Second),
+			IdleTimeout:     config.Duration(5 * time.Minute),
+		},
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement:   true,
+			CAPath:                 caDir,
+			ServerCertValidityDays: 90,
+			RenewalThresholdDays:   7,
+			Server: &config.ServerCertificateConfig{
+				CommonName:   "ctrl.tier1.lab",
+				DNSNames:     []string{"ctrl.tier1.lab", "localhost"},
+				IPAddresses:  []string{"127.0.0.1"},
+				Organization: "CFGMS Tier 1",
+			},
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: filepath.Join(tempDir, "flatfile"),
+			SQLitePath:   filepath.Join(tempDir, "cfgms.db"),
+		},
+	}
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+
+	b, err := bundle.Read(bundlePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://ctrl.tier1.lab:9080", b.ControllerURL,
+		"admin bundle controller_url must embed the configured ExternalURL, not localhost:8080")
+	assert.NotContains(t, b.ControllerURL, "localhost:8080",
+		"admin bundle must not embed the compiled default ExternalURL")
+}

--- a/scripts/check-binary-artifacts.sh
+++ b/scripts/check-binary-artifacts.sh
@@ -3,22 +3,42 @@
 # Copyright 2026 Jordan Ritz
 set -euo pipefail
 
-if ! command -v file >/dev/null 2>&1; then
-    echo "binary-artifact check requires the 'file' utility" >&2
-    exit 2
-fi
+# Compiled artifacts are identified from their leading magic bytes rather than by
+# shelling out to file(1). This gate runs in CI, in dev containers and from the
+# Makefile security targets; file(1) is an optional distro package, and a gate
+# that hard-fails wherever it is absent is a gate that gets bypassed or ignored.
+# Header bytes are read with od(1), which ships with coreutils and is present
+# anywhere git is.
+#
+# Magic values:
+#   7f454c46  \x7fELF                      ELF executable / shared object / object file
+#   feedface  feedfacf cefaedfe cffaedfe   Mach-O 32/64-bit, both byte orders
+#   cafebabe  bebafeca                     Mach-O universal binary (also Java class data)
+#   4d5a....  MZ                           PE32/PE32+ and MS-DOS executables
+#   0061736d  \0asm                        WebAssembly binary module
+artifact_kind() {
+    local header
+    header="$(od -An -v -tx1 -N4 -- "$1" | tr -d ' \n')"
+
+    case "$header" in
+        7f454c46) echo "ELF binary" ;;
+        feedface|feedfacf|cefaedfe|cffaedfe) echo "Mach-O binary" ;;
+        cafebabe|bebafeca) echo "Mach-O universal binary or Java class data" ;;
+        4d5a*) echo "PE32/MS-DOS executable" ;;
+        0061736d) echo "WebAssembly binary module" ;;
+        *) return 0 ;;
+    esac
+}
 
 blocked=0
 while IFS= read -r -d '' tracked; do
     [[ -f "$tracked" ]] || continue
 
-    description="$(file --brief -- "$tracked")"
-    case "$description" in
-        *"ELF "*|*"Mach-O "*|*"PE32 "*|*"MS-DOS executable"*|*"WebAssembly binary module"*)
-            echo "tracked compiled artifact: $tracked ($description)" >&2
-            blocked=1
-            ;;
-    esac
+    kind="$(artifact_kind "$tracked")"
+    if [[ -n "$kind" ]]; then
+        echo "tracked compiled artifact: $tracked ($kind)" >&2
+        blocked=1
+    fi
 
     case "$tracked" in
         *.a|*.o|*.obj|*.lib|*.dll|*.dylib|*.so|*.wasm|*.exe)

--- a/scripts/tier1-bootstrap.sh
+++ b/scripts/tier1-bootstrap.sh
@@ -281,6 +281,7 @@ execution:
 
 listen_addr: "0.0.0.0:9080"
 metrics_listen_addr: "127.0.0.1:9090"
+external_url: "https://${HOSTNAME_FLAG}:9080"
 data_dir: "/var/lib/cfgms"
 
 certificate:
@@ -313,6 +314,7 @@ logging:
 
 transport:
   listen_addr: "0.0.0.0:4433"
+  external_address: "${HOSTNAME_FLAG}"
   use_cert_manager: true
   max_connections: 50000
   keepalive_period: "30s"

--- a/scripts/tier1-bootstrap_test.sh
+++ b/scripts/tier1-bootstrap_test.sh
@@ -175,6 +175,12 @@ else
     elif ! grep -Fxq 'metrics_listen_addr: "127.0.0.1:9090"' "$CFG_FILE"; then
         fail "test2: controller.cfg does not bind metrics to the private loopback listener"
         PASS_THIS=false
+    elif ! grep -Fxq 'external_url: "https://ctrl.test.lab:9080"' "$CFG_FILE"; then
+        fail "test2: controller.cfg missing top-level external_url with hostname and REST port (Issue #3170)"
+        PASS_THIS=false
+    elif ! grep -Fxq '  external_address: "ctrl.test.lab"' "$CFG_FILE"; then
+        fail "test2: controller.cfg missing transport.external_address (Issue #3170)"
+        PASS_THIS=false
     fi
 
     # Init marker created

--- a/test/unit/build/binary_artifact_check_test.go
+++ b/test/unit/build/binary_artifact_check_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package build_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newArtifactRepo creates a throwaway git repository whose index contains the
+// supplied files, so the check script has a real `git ls-files` surface to walk.
+func newArtifactRepo(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	for _, args := range [][]string{
+		{"init", "--quiet"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, content, 0o644))
+	}
+
+	add := exec.Command("git", "add", "--all")
+	add.Dir = dir
+	out, err := add.CombinedOutput()
+	require.NoError(t, err, "git add: %s", out)
+
+	return dir
+}
+
+func runArtifactCheck(t *testing.T, repo string, extraEnv ...string) (int, string) {
+	t.Helper()
+	script := filepath.Join(repoRoot(t), "scripts", "check-binary-artifacts.sh")
+	cmd := exec.Command("bash", script)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	return exitErr.ExitCode(), string(out)
+}
+
+func TestBinaryArtifactCheckPassesOnSourceOnlyTree(t *testing.T) {
+	repo := newArtifactRepo(t, map[string][]byte{
+		"main.go":   []byte("package main\n\nfunc main() {}\n"),
+		"README.md": []byte("# docs\n"),
+		"empty.txt": {},
+		"short.txt": []byte("hi"),
+	})
+
+	code, output := runArtifactCheck(t, repo)
+
+	require.Equal(t, 0, code, output)
+	assert.Contains(t, output, "binary-artifact check passed")
+}
+
+func TestBinaryArtifactCheckDetectsCompiledArtifactsByMagicBytes(t *testing.T) {
+	cases := map[string]struct {
+		file   string
+		header []byte
+	}{
+		"elf":      {"bin/controller", []byte{0x7f, 'E', 'L', 'F', 0x02, 0x01}},
+		"machO64":  {"bin/steward-darwin", []byte{0xcf, 0xfa, 0xed, 0xfe, 0x0c}},
+		"machOFat": {"bin/steward-universal", []byte{0xca, 0xfe, 0xba, 0xbe, 0x00}},
+		"pe":       {"bin/cfg-windows", []byte{'M', 'Z', 0x90, 0x00, 0x03}},
+		"wasm":     {"bin/module.bin", []byte{0x00, 'a', 's', 'm', 0x01}},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			repo := newArtifactRepo(t, map[string][]byte{
+				"main.go": []byte("package main\n"),
+				tc.file:   tc.header,
+			})
+
+			code, output := runArtifactCheck(t, repo)
+
+			assert.Equal(t, 1, code, "a tracked compiled artifact must fail the gate\n%s", output)
+			assert.Contains(t, output, "tracked compiled artifact: "+tc.file)
+			assert.Contains(t, output, "compiled artifacts must be produced by the release pipeline")
+		})
+	}
+}
+
+func TestBinaryArtifactCheckDetectsCompiledArtifactsByExtension(t *testing.T) {
+	repo := newArtifactRepo(t, map[string][]byte{
+		"main.go":       []byte("package main\n"),
+		"pkg/vendor.so": []byte("not actually a binary\n"),
+	})
+
+	code, output := runArtifactCheck(t, repo)
+
+	assert.Equal(t, 1, code, "a compiled-artifact extension must fail the gate\n%s", output)
+	assert.Contains(t, output, "tracked compiled artifact extension: pkg/vendor.so")
+}
+
+// The gate runs in CI, in dev containers, and on developer workstations. It must
+// not depend on the optional file(1) package: a security gate that cannot run
+// wherever it is invoked is a gate that gets bypassed. Shimming file(1) to
+// misreport every input proves detection does not consult it.
+func TestBinaryArtifactCheckDoesNotDependOnFileUtility(t *testing.T) {
+	shimDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(shimDir, "file"),
+		[]byte("#!/bin/sh\necho 'ASCII text'\n"), 0o755))
+
+	repo := newArtifactRepo(t, map[string][]byte{
+		"main.go":        []byte("package main\n"),
+		"bin/controller": {0x7f, 'E', 'L', 'F', 0x02},
+	})
+
+	code, output := runArtifactCheck(t, repo,
+		"PATH="+shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	assert.Equal(t, 1, code, "detection must not rely on file(1) output\n%s", output)
+	assert.Contains(t, output, "tracked compiled artifact: bin/controller")
+}


### PR DESCRIPTION
## Summary

- Added `external_url: "https://${HOSTNAME_FLAG}:9080"` at the top level of the generated `controller.cfg` template so that `cfg.ExternalURL` is set correctly at `--init` time, and the admin bundle's `controller_url` reflects the real controller address instead of the compiled default `https://localhost:8080`.
- Added `external_address: "${HOSTNAME_FLAG}"` under the `transport:` block so the controller starts cleanly when `listen_addr` binds `0.0.0.0`, preventing the crash-loop on first boot.
- Added regression tests covering both fixes across three layers: shell (bootstrap test), config loading (LoadWithPath), and full init path (initialization.Run → bundle controller_url).

## Reviewer notes

**Code review**: PASS  
**Test quality review**: PASS (one fix round — the test reviewer flagged the `check-binary-artifacts.sh` gate's dependency on `file(1)`, which is an optional package; the script was refactored to use magic-byte detection via `od(1)` which is universally available, with full test coverage added in `test/unit/build/binary_artifact_check_test.go`)  
**Security review**: PASS

## Test plan

- [ ] `bash scripts/tier1-bootstrap_test.sh` — all 8 tests pass, including new assertions for `external_address:` under `transport:` and `external_url:` at the top level
- [ ] `go test ./features/controller/config/... -run TestLoadWithPath_Tier1BootstrapTemplate_SetsExternalAddress` — verifies config loading populates `Transport.ExternalAddress`
- [ ] `go test ./features/controller/initialization/... -run TestRun_AdminBundleControllerURLMatchesTier1BootstrapTemplate` — verifies the admin bundle's `controller_url` matches the configured hostname and port, not `localhost:8080`
- [ ] `go test ./test/unit/build/... -run TestBinaryArtifactCheck` — four subtests covering the refactored magic-byte detection gate

Fixes #3170

🤖 Generated with [Claude Code](https://claude.com/claude-code)