### PR TITLE
metrics: bound cycle cost correlation to the cycle's own window (Issue #3026)

### DIFF
--- a/.claude/metrics/token_report.py
+++ b/.claude/metrics/token_report.py
@@ -667,13 +667,18 @@ def correlate_cycle_manifest(
     output but not cache-read traffic, ~95% of the bill). Self-reporting is
     not a substitute for this.
 
+    Only calls inside the manifest's own [start, end] window count toward the
+    cycle -- see the comment on the window filter below for why session alone is
+    not enough.
+
     Writes cycle_cost_usd, cycle_total_tokens, per-step cost_usd/total_tokens/
     calls, the nested agents spawned during the cycle with their roles and
-    their own measured cost, and an "unattributed" bucket (calls before the
-    first step boundary, or with no timestamp) back into the same manifest
-    file. Returns (call_count, note) for the caller to log; never raises on a
-    malformed or half-written manifest -- a cycle that failed partway still has
-    one to read, and correlation failing must not destroy it.
+    their own measured cost, an "unattributed" bucket (in-window calls that fall
+    before the first step boundary) and an "excluded_calls" record (in-session
+    calls the window rejected, plus undated ones that cannot be placed) back into
+    the same manifest file. Returns (call_count, note) for the caller to log;
+    never raises on a malformed or half-written manifest -- a cycle that failed
+    partway still has one to read, and correlation failing must not destroy it.
     """
     manifest = json.loads(manifest_path.read_text())
 
@@ -689,8 +694,40 @@ def correlate_cycle_manifest(
             step_bounds.append((ts, i))
     step_bounds.sort()
 
+    # A cycle owns only the calls inside its own [start, end] window. Filtering
+    # on session alone also attributes every EARLIER cycle in the same session
+    # to this one, so a long-lived session (what a `/loop` creates) reports a
+    # running total that climbs regardless of the work done. Measured on
+    # 2026-08-07: three back-to-back cycles reported $6.36 / $9.43 / $11.30 for
+    # true costs of $6.36 / $3.06 / $1.87, and their "unattributed" buckets grew
+    # 2 -> 109 -> 169 calls purely because the prior cycles' calls fall before
+    # this cycle's first step boundary. Same window the `containers` and
+    # `agents` records below already apply.
+    cycle_start = _parse_time(manifest.get("start"))
+    cycle_end = _parse_time(manifest.get("end"))
+
+    def in_window(ts: datetime) -> bool:
+        if cycle_start is not None and ts < cycle_start:
+            return False
+        if cycle_end is not None and ts > cycle_end:
+            return False
+        return True
+
     calls, _stats = collect(roots, pricing, None, None)
-    session_calls = [c for c, _ in calls if c.session == session]
+    session_calls: list[Call] = []
+    excluded_undated = 0
+    excluded_outside = 0
+    for c, _ in calls:
+        if c.session != session:
+            continue
+        if c.timestamp is None:
+            # An undated call cannot be placed in any one cycle. Counted and
+            # dropped rather than leaked into every cycle of the session.
+            excluded_undated += 1
+        elif not in_window(c.timestamp):
+            excluded_outside += 1
+        else:
+            session_calls.append(c)
 
     def bucket_for(ts: datetime | None) -> int | None:
         if ts is None:
@@ -736,8 +773,6 @@ def correlate_cycle_manifest(
         bucket["cost_usd"] += call.cost_usd or 0.0
         bucket["total_tokens"] += call.total_tokens
 
-    cycle_start = _parse_time(manifest.get("start"))
-    cycle_end = _parse_time(manifest.get("end"))
     main_transcript = _find_session_transcript(session, roots)
     agents: list[dict[str, Any]] = []
     if main_transcript is not None:
@@ -768,6 +803,12 @@ def correlate_cycle_manifest(
         "calls": unattributed["calls"],
         "cost_usd": round(unattributed["cost_usd"], 4),
         "total_tokens": unattributed["total_tokens"],
+    }
+    # Visible rather than silent: what the cycle window excluded, so a surprising
+    # cycle_cost_usd can be told apart from a windowing problem.
+    manifest["excluded_calls"] = {
+        "outside_window": excluded_outside,
+        "undated": excluded_undated,
     }
 
     manifest_path.write_text(json.dumps(manifest, indent=2))

--- a/.claude/scripts/tests/cycle_manifest.test.sh
+++ b/.claude/scripts/tests/cycle_manifest.test.sh
@@ -307,6 +307,84 @@ check_eq "CYCLE_DIR is distinct from the dispatch ledger dir" \
 check_contains "CYCLE_DIR sits beside CACHE_DIR, not under it via retention pruning" "$poact_src" \
   'CYCLE_DIR="${CFGMS_CYCLE_DIR:-${CACHE_DIR}/cycles}"'
 
+printf '\n== a cycle counts only its own [start, end] window (regression) ==\n'
+# Two back-to-back cycles in ONE session -- what a `/loop` produces. Filtering
+# calls on session alone made every cycle report itself PLUS every earlier cycle,
+# so reported cost climbed monotonically no matter how little work was done, and
+# the prior cycles' calls all landed in "unattributed" (they precede this cycle's
+# first step boundary). Measured on 2026-08-07 before the fix: three cycles
+# reported $6.36 / $9.43 / $11.30 for true costs of $6.36 / $3.06 / $1.87, with
+# unattributed growing 2 -> 109 -> 169 calls.
+TC_SESSION="two-cycle-session"
+TC_PROJECTS="${SANDBOX}/tc-projects"
+mkdir -p "${TC_PROJECTS}/-workspace"
+python3 - "${TC_PROJECTS}/-workspace" "$TC_SESSION" "$SANDBOX" <<'PYEOF'
+import json, sys
+from datetime import datetime, timedelta, timezone
+tc_dir, session, sandbox = sys.argv[1:4]
+def ago(seconds):
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%SZ")
+def row(request_id, ts, inp, out):
+    return json.dumps({
+        "type": "assistant", "requestId": request_id, "timestamp": ts,
+        "gitBranch": "develop", "cwd": "/workspace", "isSidechain": False,
+        "message": {"model": "claude-sonnet-4-6", "usage": {
+            "input_tokens": inp, "cache_read_input_tokens": 0, "output_tokens": out,
+        }},
+    })
+# Cycle A owns [600s, 500s] ago; cycle B owns [200s, 100s] ago. B's rows are
+# deliberately 4x A's tokens so a leaked total is visible as a cost, not just a
+# count. Each cycle's single step boundary sits mid-window, so one row lands in
+# the step and one before it (unattributed) on both sides.
+with open(f"{tc_dir}/{session}.jsonl", "w") as f:
+    f.write(row("tc_a1", ago(590), 1000, 500) + "\n")
+    f.write(row("tc_a2", ago(520), 1000, 500) + "\n")
+    f.write(row("tc_b1", ago(190), 4000, 2000) + "\n")
+    f.write(row("tc_b2", ago(120), 4000, 2000) + "\n")
+for name, (start, boundary, end) in {
+    "cycle-A": (600, 550, 500),
+    "cycle-B": (200, 150, 100),
+}.items():
+    with open(f"{sandbox}/{name}.json", "w") as f:
+        json.dump({
+            "cycle_id": name, "mode": "pipeline", "session": session, "host": "test",
+            "start": ago(start), "end": ago(end),
+            "steps": [{"ts": ago(boundary), "subcommand": "merge-queue", "args": "",
+                       "outcome": "work", "exit_code": 0, "result": None}],
+        }, f, indent=2)
+PYEOF
+
+for c in cycle-A cycle-B; do
+  python3 "$TOKEN_REPORT" --cycle-manifest "${SANDBOX}/${c}.json" \
+    --projects-dir "$TC_PROJECTS" --quiet >/dev/null 2>&1 || true
+done
+a_json="${SANDBOX}/cycle-A.json"; b_json="${SANDBOX}/cycle-B.json"
+
+check_eq "cycle A counts only its own 2 calls" \
+  "$(jf "$a_json" 'd["steps"][0]["calls"] + d["unattributed"]["calls"]')" "2"
+check_eq "cycle B counts only its own 2 calls, not the session's 4" \
+  "$(jf "$b_json" 'd["steps"][0]["calls"] + d["unattributed"]["calls"]')" "2"
+check_eq "cycle A excludes the later cycle's calls from its window" \
+  "$(jf "$a_json" 'd["excluded_calls"]["outside_window"]')" "2"
+check_eq "cycle B excludes the earlier cycle's calls from its window" \
+  "$(jf "$b_json" 'd["excluded_calls"]["outside_window"]')" "2"
+check_eq "an earlier cycle's calls no longer masquerade as this cycle's unattributed" \
+  "$(jf "$b_json" 'd["unattributed"]["calls"]')" "1"
+# The load-bearing assertion: B is not a running total. B's rows carry 4x A's
+# tokens, so a leak would make B strictly greater than A+B's true sum.
+check_eq "the two cycles' token totals are disjoint, summing to the session's" \
+  "$(python3 -c "
+import json
+a=json.load(open('$a_json')); b=json.load(open('$b_json'))
+print(a['cycle_total_tokens'] + b['cycle_total_tokens'] == 15000
+      and b['cycle_total_tokens'] == 12000)")" "True"
+if [[ "$(jf "$b_json" 'd["cycle_cost_usd"] > 0')" == "True" ]]; then
+  ok "windowed correlation still produces real measured dollars"
+else
+  bad "windowed correlation still produces real measured dollars" \
+    "got: $(jf "$b_json" 'd["cycle_cost_usd"]')"
+fi
+
 printf '\n%s\n' "-----------------------------------------"
 if [[ "$fail" -eq 0 ]]; then
   printf 'PASS: %d checks\n' "$ran"; exit 0


### PR DESCRIPTION
## Problem

`correlate_cycle_manifest` filtered calls by session but never by the manifest's `[start, end]` window, so every cycle's reported cost included **each earlier cycle in the same session**. In a long-lived session — what a `/loop` produces — the figure climbed monotonically regardless of work done, and prior cycles' calls landed in `unattributed` because they precede the current cycle's first step boundary.

Measured on three back-to-back `/pipeline` cycles, 2026-08-07:

| Cycle | Dispatched | Reported | True |
|---|---|---|---|
| 10:22 | 6 | $6.36 | $6.36 |
| 11:01 | 0 | $9.43 | **$3.06** |
| 11:31 | 0 | $11.30 | **$1.87** |

`unattributed` grew 2 → 109 → 169 calls for the same reason. The third cycle dispatched nothing and reported the highest cost of the three, which is how the bug surfaced: it made a capacity-blocked cycle look 6x more expensive than a productive one and pointed optimization work at the wrong target.

## Fix

Bound `session_calls` to the manifest's own window. `cycle_start`/`cycle_end` were already parsed in this function for the nested-agent filter, and the `containers` record in `po-act.sh` applies the same `start <= ts <= end` bound — the cost loop was the one place that skipped it.

Adds `excluded_calls {outside_window, undated}` so a surprising `cycle_cost_usd` is distinguishable from a windowing problem rather than silently dropping calls. Undated calls cannot be placed in any one cycle, so they are counted and excluded rather than leaked into all of them.

## Verification

Against the pre-fix script on one fixture, cycle B (which owns 2 calls / 12000 tokens / \$0.0840):

| | counted calls | tokens | cost | unattributed |
|---|---|---|---|---|
| before | 4 | 15,000 | \$0.1050 | 3 |
| after | 2 | 12,000 | \$0.0840 | 1 |

- 7 new checks in `cycle_manifest.test.sh` asserting two cycles in one session report disjoint costs — 55 checks pass
- Existing suites unchanged: 71 metrics, 16 usage_db, 53 preflight
- `make test` green; pre-push validation passed

## Notes

Relates to epic #3026 (pipeline cost engineering); no story issue exists for this, so no closing keyword. The bug was introduced with the manifest itself (#3053).

**Known gap, not addressed here:** `.claude/scripts/tests/` and `.claude/metrics/tests/` are wired into no Makefile target and no CI workflow — confirmed from a full `make test` run, where 208 script tests passed and none touched `token_report` or `cycle_manifest`. The regression test added here will only run when invoked by hand. Same shape as the `check-architecture` CI gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo