### PR TITLE
feat(api): per-tenant assurance-policy resolver and admin endpoint (Issue #2839)

### DIFF
--- a/docs/architecture/decisions/021-identity-assurance-levels.md
+++ b/docs/architecture/decisions/021-identity-assurance-levels.md
@@ -514,11 +514,42 @@ untouched, matching the precedent set by `RefreshPolicyStore`.
 / PUT semantics). `GetPolicy` returns `{TenantID: id, Overrides: nil}` without
 error when no record exists — absence and "no override" are equivalent.
 
-**Resolution (follow-on story):** A follow-on story resolves the per-tenant
-overrides root→leaf against the global `permissionAssurance` map so that
-`requirePermission` and `scanAPIKeysForPrivilegedAccess` enforce the stricter of
-the global floor and any ancestor-chain override. Until that story lands,
-`permissionAssurance` is the sole source of truth.
+**Resolution (Issue #2839):** `requirePermission` calls
+`s.resolveAssuranceRequirement(ctx, tenantID, permissionID)`, which composes
+the global `permissionAssurance` floor with any per-tenant overrides declared
+along the root→leaf path to the requesting tenant:
+
+- `Min` takes the **maximum** across [global floor, each ancestor, the tenant itself].
+- `RequireUserPresence` is true if true anywhere in that chain (OR, never cleared by a
+  descendant).
+- When `assurancePolicyStore` or `tenantStore` is nil, or `tenantID` is empty, the
+  resolver returns the global floor unchanged — preserving today's exact behaviour for
+  bare `Server` instances (e.g. unit tests that do not wire a store).
+- Store errors cause a Warn log and fall back to the global floor — a storage hiccup
+  must never turn a permitted action into a fleet-wide outage.
+
+**Admin endpoint (Issue #2839):**
+
+- `GET /api/v1/tenants/{tenant_path}/assurance-policy` — reads the stored override set
+  for a tenant. Gated by `requirePermission("assurance-policy", "get")`. `assurance-policy:get`
+  is intentionally absent from `permissionAssurance` so reads stay unrestricted at the
+  assurance layer (matching `refresh:get-policy`'s absence from that map).
+- `PUT /api/v1/tenants/{tenant_path}/assurance-policy` — replaces the full override set
+  (full-replace / PUT semantics). Gated by `requirePermission("assurance-policy", "set")`.
+  `assurance-policy:set` IS in `permissionAssurance` at `Min: AssuranceStrong` — a
+  strongly-authenticated admin is required to raise a tenant's own posture.
+
+**Tighten-only enforcement (Issue #2839):** `handleSetAssurancePolicy` validates each
+requested `MinOverride` against the ancestor-resolved requirement (global floor + ancestor
+path, excluding the tenant being written) **before** calling `SetPolicy`. A `MinOverride`
+below the ancestor-resolved `Min` is rejected with 400. `RequireUserPresence` needs no
+such check — because resolution ORs it across the whole chain including ancestors, a
+leaf tenant structurally cannot lower it by omitting or setting it false.
+
+**Note on `scanAPIKeysForPrivilegedAccess`:** The startup scan reads `permissionAssurance`
+directly (global-only). Overrides only ever tighten, so the global-floor scan remains a
+correct (if conservative) lower bound on which API keys are unreachable. Tenant overrides
+do not affect this scan — they cannot make a key reachable that is already blocked.
 
 ---
 

--- a/features/controller/api/assurance.go
+++ b/features/controller/api/assurance.go
@@ -94,6 +94,13 @@ var permissionAssurance = map[string]Requirement{
 	"module:reject":       {Min: session.AssuranceStrong, RequireUserPresence: true},
 	"publisher-trust:add": {Min: session.AssuranceStrong, RequireUserPresence: true},
 
+	// Per-tenant assurance-policy admin (Issue #2839).
+	// Requires AssuranceStrong so only a strongly-authenticated admin can raise a tenant's
+	// own assurance posture — consistent with refresh:set-policy's existing bar.
+	// assurance-policy:get is intentionally absent (reads stay unrestricted at the assurance
+	// layer, matching refresh:get-policy's absence from this map).
+	"assurance-policy:set": {Min: session.AssuranceStrong}, // PUT /tenants/{tenant_path}/assurance-policy
+
 	// Bulk CIDR registration approval (Issue #2969): RFC1918 ranges collide across tenants,
 	// making this a trust-boundary decision that must not be a convenience gate.
 	// Approve-by-CIDR requires AssuranceStrong + a fresh user-presence proof.

--- a/features/controller/api/assurance_resolve_test.go
+++ b/features/controller/api/assurance_resolve_test.go
@@ -356,4 +356,3 @@ func TestResolveAssurance_UnknownPermission_FoundByOverride(t *testing.T) {
 	require.True(t, found, "tenant-declared perm must be reported as found")
 	assert.Equal(t, session.AssuranceStrong, req.Min)
 }
-

--- a/features/controller/api/assurance_resolve_test.go
+++ b/features/controller/api/assurance_resolve_test.go
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// ---- in-memory test doubles (real implementations, no mocks) ----
+
+// testAssurancePolicyStore is a real in-memory AssurancePolicyStore.
+type testAssurancePolicyStore struct {
+	mu       sync.RWMutex
+	policies map[string]*business.AssurancePolicy
+}
+
+func newTestAssurancePolicyStore() *testAssurancePolicyStore {
+	return &testAssurancePolicyStore{policies: make(map[string]*business.AssurancePolicy)}
+}
+
+func (s *testAssurancePolicyStore) GetPolicy(_ context.Context, tenantID string) (*business.AssurancePolicy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if p, ok := s.policies[tenantID]; ok {
+		cp := *p
+		return &cp, nil
+	}
+	return &business.AssurancePolicy{TenantID: tenantID, Overrides: nil}, nil
+}
+
+func (s *testAssurancePolicyStore) SetPolicy(_ context.Context, p *business.AssurancePolicy) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *p
+	s.policies[p.TenantID] = &cp
+	return nil
+}
+
+// errorAssurancePolicyStore always returns an error from GetPolicy.
+type errorAssurancePolicyStore struct{}
+
+func (errorAssurancePolicyStore) GetPolicy(_ context.Context, _ string) (*business.AssurancePolicy, error) {
+	return nil, errors.New("storage unavailable")
+}
+func (errorAssurancePolicyStore) SetPolicy(_ context.Context, _ *business.AssurancePolicy) error {
+	return errors.New("storage unavailable")
+}
+
+// testTenantStoreWithPath is a real in-memory TenantStore that returns a
+// pre-configured path for GetTenantPath. Unrecognised IDs return an error.
+type testTenantStoreWithPath struct {
+	business.TenantStore // embed for unimplemented methods
+	paths                map[string][]string
+}
+
+func newTestTenantStoreWithPath(paths map[string][]string) *testTenantStoreWithPath {
+	return &testTenantStoreWithPath{paths: paths}
+}
+
+func (s *testTenantStoreWithPath) GetTenantPath(_ context.Context, tenantID string) ([]string, error) {
+	if p, ok := s.paths[tenantID]; ok {
+		return p, nil
+	}
+	return nil, errors.New("tenant not found: " + tenantID)
+}
+
+// errorTenantStore always returns an error from GetTenantPath.
+type errorTenantStore struct {
+	business.TenantStore
+}
+
+func (errorTenantStore) GetTenantPath(_ context.Context, _ string) ([]string, error) {
+	return nil, errors.New("tenant store unavailable")
+}
+
+// ---- tests for resolveAssuranceRequirement ----
+
+// TestResolveAssurance_NilStores verifies that when assurancePolicyStore or
+// tenantStore is nil the resolver returns the global permissionAssurance floor
+// unchanged — preserving backward compatibility for bare Server instances.
+func TestResolveAssurance_NilStores(t *testing.T) {
+	srv := &Server{} // no stores
+
+	// certificate:provision is AssuranceStrong in the global map.
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "some-tenant", "certificate:provision")
+	require.True(t, found)
+	assert.Equal(t, session.AssuranceStrong, req.Min)
+	assert.False(t, req.RequireUserPresence)
+
+	// A permission absent from the global map must return found=false.
+	req2, found2 := srv.resolveAssuranceRequirement(context.Background(), "some-tenant", "nonexistent:perm")
+	assert.False(t, found2)
+	assert.Equal(t, session.AssuranceLevel(0), req2.Min)
+}
+
+// TestResolveAssurance_EmptyTenantID verifies that an empty tenantID causes the
+// resolver to return the global floor (no store lookup).
+func TestResolveAssurance_EmptyTenantID(t *testing.T) {
+	srv := &Server{
+		assurancePolicyStore: newTestAssurancePolicyStore(),
+		tenantStore:          newTestTenantStoreWithPath(map[string][]string{}),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "", "certificate:provision")
+	require.True(t, found)
+	assert.Equal(t, session.AssuranceStrong, req.Min)
+}
+
+// TestResolveAssurance_NoOverride verifies that when no tenant in the path has
+// an override the global floor is returned unchanged.
+func TestResolveAssurance_NoOverride(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/child": {"root", "root/child"},
+	})
+	srv := &Server{
+		assurancePolicyStore: apStore,
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "root/child", "certificate:provision")
+	require.True(t, found)
+	assert.Equal(t, session.AssuranceStrong, req.Min)
+	assert.False(t, req.RequireUserPresence)
+}
+
+// TestResolveAssurance_TenantRaisesMin verifies that a tenant override with a
+// matching permissionID and MinOverride raises the effective Min.
+func TestResolveAssurance_TenantRaisesMin(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	// certificate:provision global floor is AssuranceStrong (the max), so test with
+	// a synthetic low-floor permission injected temporarily into the global map.
+	const testPerm = "test-resolve:low-floor"
+	permissionAssurance[testPerm] = Requirement{Min: session.AssuranceBasic}
+	t.Cleanup(func() { delete(permissionAssurance, testPerm) })
+
+	strongInt := int(session.AssuranceStrong)
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root/child",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: testPerm, MinOverride: &strongInt},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/child": {"root", "root/child"},
+	})
+	srv := &Server{
+		assurancePolicyStore: apStore,
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "root/child", testPerm)
+	require.True(t, found)
+	assert.Equal(t, session.AssuranceStrong, req.Min, "child override must raise Min to Strong")
+	assert.False(t, req.RequireUserPresence)
+}
+
+// TestResolveAssurance_TenantAddsPresence verifies that a tenant override with
+// RequireUserPresence: true adds the presence requirement regardless of Min.
+func TestResolveAssurance_TenantAddsPresence(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root/child",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "certificate:provision", RequireUserPresence: true},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/child": {"root", "root/child"},
+	})
+	srv := &Server{
+		assurancePolicyStore: apStore,
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "root/child", "certificate:provision")
+	require.True(t, found)
+	assert.Equal(t, session.AssuranceStrong, req.Min, "global floor Min must be preserved")
+	assert.True(t, req.RequireUserPresence, "tenant override must add RequireUserPresence")
+}
+
+// TestResolveAssurance_ParentOverrideInherited verifies that a parent tenant's
+// override is inherited by a child tenant that has no override of its own.
+func TestResolveAssurance_ParentOverrideInherited(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	const testPerm = "test-resolve:inherit"
+	permissionAssurance[testPerm] = Requirement{Min: session.AssuranceBasic}
+	t.Cleanup(func() { delete(permissionAssurance, testPerm) })
+
+	strongInt := int(session.AssuranceStrong)
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: testPerm, MinOverride: &strongInt},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/child": {"root", "root/child"},
+	})
+	srv := &Server{
+		assurancePolicyStore: apStore,
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "root/child", testPerm)
+	require.True(t, found, "parent override must be found for child")
+	assert.Equal(t, session.AssuranceStrong, req.Min, "child must inherit parent's raised Min")
+}
+
+// TestResolveAssurance_ChildCanFurtherTighten verifies that a child tenant can raise
+// Min beyond what a parent already set.
+func TestResolveAssurance_ChildCanFurtherTighten(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	const testPerm = "test-resolve:further-tighten"
+	permissionAssurance[testPerm] = Requirement{Min: session.AssuranceBasic}
+	t.Cleanup(func() { delete(permissionAssurance, testPerm) })
+
+	// Parent sets Basic-floor -> Strong; child additionally sets RequireUserPresence.
+	strongInt := int(session.AssuranceStrong)
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: testPerm, MinOverride: &strongInt},
+		},
+	}))
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root/child",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: testPerm, RequireUserPresence: true},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/child": {"root", "root/child"},
+	})
+	srv := &Server{
+		assurancePolicyStore: apStore,
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "root/child", testPerm)
+	require.True(t, found)
+	assert.Equal(t, session.AssuranceStrong, req.Min, "parent Min must carry through")
+	assert.True(t, req.RequireUserPresence, "child RequireUserPresence must be applied on top of parent")
+}
+
+// TestResolveAssurance_SiblingTenantIndependent verifies that an override on one
+// sibling tenant does not affect a sibling that has no override.
+func TestResolveAssurance_SiblingTenantIndependent(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	const testPerm = "test-resolve:sibling"
+	permissionAssurance[testPerm] = Requirement{Min: session.AssuranceBasic}
+	t.Cleanup(func() { delete(permissionAssurance, testPerm) })
+
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root/sibling-a",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: testPerm, RequireUserPresence: true},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/sibling-a": {"root", "root/sibling-a"},
+		"root/sibling-b": {"root", "root/sibling-b"},
+	})
+	srv := &Server{
+		assurancePolicyStore: apStore,
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	// sibling-a: has override with RequireUserPresence.
+	reqA, _ := srv.resolveAssuranceRequirement(context.Background(), "root/sibling-a", testPerm)
+	assert.True(t, reqA.RequireUserPresence, "sibling-a must have RequireUserPresence from its own override")
+
+	// sibling-b: no override — global floor only.
+	reqB, _ := srv.resolveAssuranceRequirement(context.Background(), "root/sibling-b", testPerm)
+	assert.False(t, reqB.RequireUserPresence, "sibling-b must NOT inherit sibling-a's override")
+	assert.Equal(t, session.AssuranceBasic, reqB.Min, "sibling-b must see global floor only")
+}
+
+// TestResolveAssurance_GetTenantPathError_FallsBackToFloor verifies that a
+// GetTenantPath error causes the resolver to log a warning and return the
+// global floor (fail-safe, not fail-open).
+func TestResolveAssurance_GetTenantPathError_FallsBackToFloor(t *testing.T) {
+	srv := &Server{
+		assurancePolicyStore: newTestAssurancePolicyStore(),
+		tenantStore:          errorTenantStore{},
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "some-tenant", "certificate:provision")
+	require.True(t, found, "floor must still be found even on error")
+	assert.Equal(t, session.AssuranceStrong, req.Min, "must fall back to global floor on error")
+	assert.False(t, req.RequireUserPresence)
+}
+
+// TestResolveAssurance_GetPolicyError_FallsBackToFloor verifies that a
+// GetPolicy error causes the resolver to log a warning and return the
+// global floor (fail-safe, not fail-open).
+func TestResolveAssurance_GetPolicyError_FallsBackToFloor(t *testing.T) {
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/child": {"root", "root/child"},
+	})
+	srv := &Server{
+		assurancePolicyStore: errorAssurancePolicyStore{},
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "root/child", "certificate:provision")
+	require.True(t, found, "floor must still be found even on GetPolicy error")
+	assert.Equal(t, session.AssuranceStrong, req.Min, "must fall back to global floor on error")
+}
+
+// TestResolveAssurance_UnknownPermission_FoundByOverride verifies that a permission
+// absent from the global map but declared via a tenant override is reported as found.
+func TestResolveAssurance_UnknownPermission_FoundByOverride(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	strongInt := int(session.AssuranceStrong)
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "new:custom-perm", MinOverride: &strongInt},
+		},
+	}))
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root": {"root"},
+	})
+	srv := &Server{
+		assurancePolicyStore: apStore,
+		tenantStore:          tsStore,
+		logger:               logging.NewNoopLogger(),
+	}
+
+	req, found := srv.resolveAssuranceRequirement(context.Background(), "root", "new:custom-perm")
+	require.True(t, found, "tenant-declared perm must be reported as found")
+	assert.Equal(t, session.AssuranceStrong, req.Min)
+}
+

--- a/features/controller/api/handlers_assurance_policy.go
+++ b/features/controller/api/handlers_assurance_policy.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/session"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// AssurancePolicyOverrideDTO is the wire representation of a single per-permission
+// assurance override. MinOverride, when non-nil, must be "basic" or "strong"
+// (never "machine" — an override can only raise the bar, not lower it past the
+// global floor, and "machine" would be a downgrade for any non-machine permission).
+type AssurancePolicyOverrideDTO struct {
+	PermissionID        string  `json:"permission_id"`
+	MinOverride         *string `json:"min_override,omitempty"`
+	RequireUserPresence bool    `json:"require_user_presence"`
+}
+
+// AdminAssurancePolicyRequest is the body for PUT /api/v1/tenants/{tenant_path}/assurance-policy.
+type AdminAssurancePolicyRequest struct {
+	Overrides []AssurancePolicyOverrideDTO `json:"overrides"`
+}
+
+// AdminAssurancePolicyResponse is returned by GET and PUT /api/v1/tenants/{tenant_path}/assurance-policy.
+type AdminAssurancePolicyResponse struct {
+	TenantID  string                       `json:"tenant_id"`
+	Overrides []AssurancePolicyOverrideDTO `json:"overrides"`
+}
+
+// minOverrideToLevel converts a "basic" / "strong" string to its session.AssuranceLevel.
+// Returns (level, true) on success; (0, false) on unrecognised input.
+func minOverrideToLevel(s string) (session.AssuranceLevel, bool) {
+	switch s {
+	case "basic":
+		return session.AssuranceBasic, true
+	case "strong":
+		return session.AssuranceStrong, true
+	default:
+		return 0, false
+	}
+}
+
+// levelToMinOverride converts a session.AssuranceLevel to its string representation
+// for the DTO ("basic" or "strong"). AssuranceMachine is not a valid MinOverride value.
+func levelToMinOverride(lvl session.AssuranceLevel) string {
+	switch lvl {
+	case session.AssuranceBasic:
+		return "basic"
+	case session.AssuranceStrong:
+		return "strong"
+	default:
+		return ""
+	}
+}
+
+// handleGetAssurancePolicy handles GET /api/v1/tenants/{tenant_path}/assurance-policy.
+func (s *Server) handleGetAssurancePolicy(w http.ResponseWriter, r *http.Request) {
+	tenantID := mux.Vars(r)["tenant_path"]
+
+	// Cross-tenant: a scoped caller may only read policy for their own tenant or descendants.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := tenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(tenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			http.Error(w, "tenant not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	if s.assurancePolicyStore == nil {
+		http.Error(w, "assurance policy store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	policy, err := s.assurancePolicyStore.GetPolicy(r.Context(), tenantID)
+	if err != nil {
+		s.logger.Error("Failed to get assurance policy",
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"error", err,
+		)
+		http.Error(w, "failed to get assurance policy", http.StatusInternalServerError)
+		return
+	}
+
+	resp := AdminAssurancePolicyResponse{
+		TenantID:  policy.TenantID,
+		Overrides: overridesToDTO(policy.Overrides),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Error("Failed to encode assurance policy response", "error", err)
+	}
+}
+
+// handleSetAssurancePolicy handles PUT /api/v1/tenants/{tenant_path}/assurance-policy.
+func (s *Server) handleSetAssurancePolicy(w http.ResponseWriter, r *http.Request) {
+	tenantID := mux.Vars(r)["tenant_path"]
+
+	// Cross-tenant: a scoped caller may only write policy for their own tenant or descendants.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := tenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(tenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			http.Error(w, "tenant not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	var req AdminAssurancePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if s.assurancePolicyStore == nil {
+		http.Error(w, "assurance policy store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Tighten-only validation (ADR-021, Issue #2839): each requested MinOverride must be
+	// >= the ancestor-resolved requirement (global floor + ancestor overrides, excluding the
+	// tenant being written). This is checked at write time so the store never holds a value
+	// that would silently lower the effective bar for any descendant.
+	//
+	// RequireUserPresence needs no such check: resolution ORs it across the whole chain
+	// including ancestors. A leaf tenant structurally cannot lower it by omitting or setting
+	// it false — the ancestor's true survives the OR regardless.
+	if s.tenantStore != nil {
+		path, err := s.tenantStore.GetTenantPath(r.Context(), tenantID)
+		if err != nil {
+			s.logger.Warn("handleSetAssurancePolicy: failed to get tenant path",
+				"tenant_id", logging.SanitizeLogValue(tenantID),
+				"error", err,
+			)
+			http.Error(w, "failed to resolve tenant path", http.StatusInternalServerError)
+			return
+		}
+
+		// ancestorPath is the path excluding the tenant being written.
+		var ancestorPath []string
+		if len(path) > 0 {
+			ancestorPath = path[:len(path)-1]
+		}
+
+		for _, ov := range req.Overrides {
+			if ov.MinOverride == nil {
+				continue
+			}
+			requestedLevel, ok := minOverrideToLevel(*ov.MinOverride)
+			if !ok {
+				http.Error(w, "invalid min_override: must be \"basic\" or \"strong\"", http.StatusBadRequest)
+				return
+			}
+
+			// Resolve the ancestor-only requirement (global floor + ancestor chain, excluding this tenant).
+			ancestorReq, _ := s.resolveAssuranceRequirementForPath(r.Context(), ancestorPath, ov.PermissionID)
+			if requestedLevel < ancestorReq.Min {
+				http.Error(w, "min_override for "+ov.PermissionID+" is below ancestor-resolved requirement: cannot lower the assurance bar", http.StatusBadRequest)
+				return
+			}
+		}
+	}
+
+	// Validate and convert DTOs to store model.
+	overrides, err := dtosToOverrides(req.Overrides)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	policy := &business.AssurancePolicy{
+		TenantID:  tenantID,
+		Overrides: overrides,
+	}
+	if err := s.assurancePolicyStore.SetPolicy(r.Context(), policy); err != nil {
+		s.logger.Error("Failed to set assurance policy",
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"error", err,
+		)
+		http.Error(w, "failed to set assurance policy", http.StatusInternalServerError)
+		return
+	}
+
+	resp := AdminAssurancePolicyResponse{
+		TenantID:  tenantID,
+		Overrides: req.Overrides,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Error("Failed to encode assurance policy response", "error", err)
+	}
+}
+
+// resolveAssuranceRequirementForPath resolves the assurance requirement for a given
+// permission by walking a pre-computed tenant path (rather than looking up the path
+// from the store). Used by handleSetAssurancePolicy to evaluate ancestor requirements
+// without including the tenant being written.
+func (s *Server) resolveAssuranceRequirementForPath(ctx context.Context, path []string, permissionID string) (Requirement, bool) {
+	floor, found := permissionAssurance[permissionID]
+	if s.assurancePolicyStore == nil {
+		return floor, found
+	}
+
+	result := floor
+	for _, t := range path {
+		policy, err := s.assurancePolicyStore.GetPolicy(ctx, t)
+		if err != nil {
+			s.logger.Warn("resolveAssuranceRequirementForPath: failed to get assurance policy; using global floor",
+				"tenant_id", logging.SanitizeLogValue(t),
+				"permission_id", permissionID,
+				"error", err,
+			)
+			return floor, found
+		}
+		for _, ov := range policy.Overrides {
+			if ov.PermissionID != permissionID {
+				continue
+			}
+			found = true
+			if ov.MinOverride != nil {
+				if ovMin := session.AssuranceLevel(*ov.MinOverride); ovMin > result.Min {
+					result.Min = ovMin
+				}
+			}
+			if ov.RequireUserPresence {
+				result.RequireUserPresence = true
+			}
+		}
+	}
+	return result, found
+}
+
+// overridesToDTO converts business model overrides to their DTO representation.
+func overridesToDTO(overrides []business.AssurancePolicyOverride) []AssurancePolicyOverrideDTO {
+	if len(overrides) == 0 {
+		return nil
+	}
+	dtos := make([]AssurancePolicyOverrideDTO, 0, len(overrides))
+	for _, ov := range overrides {
+		dto := AssurancePolicyOverrideDTO{
+			PermissionID:        ov.PermissionID,
+			RequireUserPresence: ov.RequireUserPresence,
+		}
+		if ov.MinOverride != nil {
+			s := levelToMinOverride(session.AssuranceLevel(*ov.MinOverride))
+			if s != "" {
+				dto.MinOverride = &s
+			}
+		}
+		dtos = append(dtos, dto)
+	}
+	return dtos
+}
+
+// dtosToOverrides converts DTO overrides to their business model representation,
+// validating MinOverride values in the process.
+func dtosToOverrides(dtos []AssurancePolicyOverrideDTO) ([]business.AssurancePolicyOverride, error) {
+	overrides := make([]business.AssurancePolicyOverride, 0, len(dtos))
+	for _, dto := range dtos {
+		ov := business.AssurancePolicyOverride{
+			PermissionID:        dto.PermissionID,
+			RequireUserPresence: dto.RequireUserPresence,
+		}
+		if dto.MinOverride != nil {
+			lvl, ok := minOverrideToLevel(*dto.MinOverride)
+			if !ok {
+				return nil, errInvalidMinOverride(*dto.MinOverride)
+			}
+			v := int(lvl)
+			ov.MinOverride = &v
+		}
+		overrides = append(overrides, ov)
+	}
+	return overrides, nil
+}
+
+type invalidMinOverrideError string
+
+func (e invalidMinOverrideError) Error() string {
+	return "invalid min_override \"" + string(e) + "\": must be \"basic\" or \"strong\""
+}
+
+func errInvalidMinOverride(s string) error { return invalidMinOverrideError(s) }

--- a/features/controller/api/handlers_assurance_policy.go
+++ b/features/controller/api/handlers_assurance_policy.go
@@ -220,7 +220,7 @@ func (s *Server) resolveAssuranceRequirementForPath(ctx context.Context, path []
 		if err != nil {
 			s.logger.Warn("resolveAssuranceRequirementForPath: failed to get assurance policy; using global floor",
 				"tenant_id", logging.SanitizeLogValue(t),
-				"permission_id", permissionID,
+				"permission_id", logging.SanitizeLogValue(permissionID),
 				"error", logging.SanitizeLogValue(err.Error()),
 			)
 			return floor, found

--- a/features/controller/api/handlers_assurance_policy.go
+++ b/features/controller/api/handlers_assurance_policy.go
@@ -87,7 +87,7 @@ func (s *Server) handleGetAssurancePolicy(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		s.logger.Error("Failed to get assurance policy",
 			"tenant_id", logging.SanitizeLogValue(tenantID),
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 		)
 		http.Error(w, "failed to get assurance policy", http.StatusInternalServerError)
 		return
@@ -99,7 +99,7 @@ func (s *Server) handleGetAssurancePolicy(w http.ResponseWriter, r *http.Request
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Error("Failed to encode assurance policy response", "error", err)
+		s.logger.Error("Failed to encode assurance policy response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 
@@ -142,7 +142,7 @@ func (s *Server) handleSetAssurancePolicy(w http.ResponseWriter, r *http.Request
 		if err != nil {
 			s.logger.Warn("handleSetAssurancePolicy: failed to get tenant path",
 				"tenant_id", logging.SanitizeLogValue(tenantID),
-				"error", err,
+				"error", logging.SanitizeLogValue(err.Error()),
 			)
 			http.Error(w, "failed to resolve tenant path", http.StatusInternalServerError)
 			return
@@ -187,7 +187,7 @@ func (s *Server) handleSetAssurancePolicy(w http.ResponseWriter, r *http.Request
 	if err := s.assurancePolicyStore.SetPolicy(r.Context(), policy); err != nil {
 		s.logger.Error("Failed to set assurance policy",
 			"tenant_id", logging.SanitizeLogValue(tenantID),
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 		)
 		http.Error(w, "failed to set assurance policy", http.StatusInternalServerError)
 		return
@@ -200,7 +200,7 @@ func (s *Server) handleSetAssurancePolicy(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Error("Failed to encode assurance policy response", "error", err)
+		s.logger.Error("Failed to encode assurance policy response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 
@@ -221,7 +221,7 @@ func (s *Server) resolveAssuranceRequirementForPath(ctx context.Context, path []
 			s.logger.Warn("resolveAssuranceRequirementForPath: failed to get assurance policy; using global floor",
 				"tenant_id", logging.SanitizeLogValue(t),
 				"permission_id", permissionID,
-				"error", err,
+				"error", logging.SanitizeLogValue(err.Error()),
 			)
 			return floor, found
 		}

--- a/features/controller/api/handlers_assurance_policy_test.go
+++ b/features/controller/api/handlers_assurance_policy_test.go
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/session"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newAssuranceTestServer creates a Server with assurancePolicyStore and tenantStore
+// wired, plus a real RBAC service — suitable for handler and middleware tests.
+func newAssuranceTestServer(t *testing.T, apStore business.AssurancePolicyStore, tsStore business.TenantStore) *Server {
+	t.Helper()
+	srv := setupTestServer(t)
+	if apStore != nil {
+		srv.SetAssurancePolicyStore(apStore)
+	}
+	if tsStore != nil {
+		srv.SetTenantStore(tsStore)
+	}
+	return srv
+}
+
+// ---- GET /api/v1/tenants/{tenant_path}/assurance-policy ----
+
+func TestHandleGetAssurancePolicy_NoStore_Returns503(t *testing.T) {
+	srv := setupTestServer(t)
+	// No assurancePolicyStore wired.
+	apiKey := NewTestKey(t, srv, []string{"assurance-policy:get"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/test-tenant/assurance-policy", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleGetAssurancePolicy_ReturnsEmptyOverrides(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"test-tenant": {"test-tenant"},
+	})
+	srv := newAssuranceTestServer(t, apStore, tsStore)
+	apiKey := NewTestKey(t, srv, []string{"assurance-policy:get"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/test-tenant/assurance-policy", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "get must succeed: %s", rec.Body.String())
+	var resp AdminAssurancePolicyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "test-tenant", resp.TenantID)
+	assert.Empty(t, resp.Overrides)
+}
+
+func TestHandleGetAssurancePolicy_ReturnsStoredOverrides(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"test-tenant": {"test-tenant"},
+	})
+	strongStr := "strong"
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "test-tenant",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "certificate:provision", MinOverride: ptrInt(int(session.AssuranceStrong)), RequireUserPresence: true},
+		},
+	}))
+
+	srv := newAssuranceTestServer(t, apStore, tsStore)
+	apiKey := NewTestKey(t, srv, []string{"assurance-policy:get"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/test-tenant/assurance-policy", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp AdminAssurancePolicyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "test-tenant", resp.TenantID)
+	require.Len(t, resp.Overrides, 1)
+	assert.Equal(t, "certificate:provision", resp.Overrides[0].PermissionID)
+	assert.Equal(t, &strongStr, resp.Overrides[0].MinOverride)
+	assert.True(t, resp.Overrides[0].RequireUserPresence)
+}
+
+func TestHandleGetAssurancePolicy_Unauthenticated(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	srv := newAssuranceTestServer(t, apStore, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/test-tenant/assurance-policy", nil)
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandleGetAssurancePolicy_CrossTenantReturns404(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	srv := newAssuranceTestServer(t, apStore, nil)
+	// Scoped API key belonging to "tenant-a".
+	apiKey := NewEphemeralTestKey(t, srv, []string{"assurance-policy:get"}, "tenant-a", 5*time.Minute)
+
+	// Attempt to read policy for an unrelated tenant.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/tenant-b/assurance-policy", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---- PUT /api/v1/tenants/{tenant_path}/assurance-policy ----
+
+func TestHandleSetAssurancePolicy_Unauthenticated(t *testing.T) {
+	srv := setupTestServer(t)
+
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{Overrides: nil})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandleSetAssurancePolicy_RequiresAssuranceStrong(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	srv := newAssuranceTestServer(t, apStore, nil)
+	// API-key principal is AssuranceMachine — cannot satisfy AssuranceStrong requirement.
+	apiKey := NewTestKey(t, srv, []string{"assurance-policy:set"})
+
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{Overrides: nil})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	// API-key principals are AssuranceMachine and get 403, not 401.
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleSetAssurancePolicy_SetsOverride(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"test-tenant": {"test-tenant"},
+	})
+	srv := newAssuranceTestServer(t, apStore, tsStore)
+
+	strong := "strong"
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{
+		Overrides: []AssurancePolicyOverrideDTO{
+			{PermissionID: "certificate:provision", MinOverride: &strong, RequireUserPresence: true},
+		},
+	})
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "set must succeed: %s", rec.Body.String())
+
+	// Verify the store was updated.
+	policy, err := apStore.GetPolicy(context.Background(), "test-tenant")
+	require.NoError(t, err)
+	require.Len(t, policy.Overrides, 1)
+	assert.Equal(t, "certificate:provision", policy.Overrides[0].PermissionID)
+	assert.True(t, policy.Overrides[0].RequireUserPresence)
+}
+
+func TestHandleSetAssurancePolicy_InvalidMinOverride_Returns400(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"test-tenant": {"test-tenant"},
+	})
+	srv := newAssuranceTestServer(t, apStore, tsStore)
+
+	// "machine" is rejected — overrides can only raise the bar.
+	machineStr := "machine"
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{
+		Overrides: []AssurancePolicyOverrideDTO{
+			{PermissionID: "certificate:provision", MinOverride: &machineStr},
+		},
+	})
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSetAssurancePolicy_InvalidBody_Returns400(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	srv := newAssuranceTestServer(t, apStore, nil)
+
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSetAssurancePolicy_CrossTenantReturns403ForAPIKey(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	srv := newAssuranceTestServer(t, apStore, nil)
+	// Scoped API key for tenant-a — AssuranceMachine. assurance-policy:set requires
+	// AssuranceStrong, so the assurance gate fires before the cross-tenant handler check
+	// (consistent with TestHandleApproveRefresh_CrossTenantReturns404 which also gets 403).
+	apiKey := NewEphemeralTestKey(t, srv, []string{"assurance-policy:set"}, "tenant-a", 5*time.Minute)
+
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{Overrides: nil})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/tenant-b/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	// API-key principals are AssuranceMachine; the assurance gate returns 403 (can't step up).
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// ---- [REQUIRED TEST] per-AC: presence override in overriding tenant vs sibling ----
+
+// TestResolveAssurance_PresenceOverride_ChallengingInOverridingTenant verifies that
+// an AssuranceStrong-but-no-fresh-presence principal is challenged (401 + presence="required")
+// on certificate:provision in a tenant that has RequireUserPresence:true on that permission,
+// while the same principal is admitted (no presence challenge) in a sibling tenant without the override.
+//
+// [REQUIRED TEST] per acceptance criterion: the exact AC scenario.
+func TestResolveAssurance_PresenceOverride_ChallengingInOverridingTenant(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+
+	// "tenant-with-override" declares RequireUserPresence on certificate:provision.
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root/tenant-with-override",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "certificate:provision", RequireUserPresence: true},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/tenant-with-override": {"root", "root/tenant-with-override"},
+		"root/sibling-no-override":  {"root", "root/sibling-no-override"},
+	})
+
+	srv := setupTestServer(t)
+	srv.SetAssurancePolicyStore(apStore)
+	srv.SetTenantStore(tsStore)
+
+	// Confirm global map does not have RequireUserPresence for certificate:provision.
+	globalReq := permissionAssurance["certificate:provision"]
+	require.False(t, globalReq.RequireUserPresence, "precondition: global map must not have RequireUserPresence for certificate:provision")
+
+	// Resolve for the overriding tenant — must require presence.
+	reqA, foundA := srv.resolveAssuranceRequirement(context.Background(), "root/tenant-with-override", "certificate:provision")
+	require.True(t, foundA)
+	assert.True(t, reqA.RequireUserPresence, "overriding tenant must have RequireUserPresence=true")
+	assert.Equal(t, session.AssuranceStrong, reqA.Min)
+
+	// Resolve for the sibling tenant — no override, must NOT require presence.
+	reqB, foundB := srv.resolveAssuranceRequirement(context.Background(), "root/sibling-no-override", "certificate:provision")
+	require.True(t, foundB)
+	assert.False(t, reqB.RequireUserPresence, "sibling without override must not require presence")
+	assert.Equal(t, session.AssuranceStrong, reqB.Min)
+}
+
+// ---- [REQUIRED TEST] per-AC: child inherits parent override and can tighten further ----
+
+// TestHandleSetAssurancePolicy_ChildInheritsParentAndCanTighten verifies that:
+//   - A child tenant inherits a parent's Min=strong override.
+//   - The child can additionally set RequireUserPresence=true (tightening further).
+//   - A child PUT attempting to set MinOverride below the parent's resolved value is rejected 400.
+//
+// [REQUIRED TEST] per acceptance criterion.
+func TestHandleSetAssurancePolicy_ChildInheritsParentAndCanTighten(t *testing.T) {
+	const testPerm = "test-child-inherit"
+	// Global floor for testPerm is AssuranceBasic.
+	permissionAssurance[testPerm] = Requirement{Min: session.AssuranceBasic}
+	t.Cleanup(func() { delete(permissionAssurance, testPerm) })
+
+	apStore := newTestAssurancePolicyStore()
+	// Parent sets Min to Strong.
+	strongInt := int(session.AssuranceStrong)
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: testPerm, MinOverride: &strongInt},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/child": {"root", "root/child"},
+	})
+	srv := setupTestServer(t)
+	srv.SetAssurancePolicyStore(apStore)
+	srv.SetTenantStore(tsStore)
+
+	// --- Sub-test 1: child can tighten by adding RequireUserPresence ---
+	strong := "strong"
+	body1, _ := json.Marshal(AdminAssurancePolicyRequest{
+		Overrides: []AssurancePolicyOverrideDTO{
+			{PermissionID: testPerm, MinOverride: &strong, RequireUserPresence: true},
+		},
+	})
+	req1 := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/root/child/assurance-policy", bytes.NewReader(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	rec1 := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec1, req1)
+	require.Equal(t, http.StatusOK, rec1.Code, "child tightening must succeed: %s", rec1.Body.String())
+
+	// Verify both parent's Min and child's RequireUserPresence are in effect.
+	reqChild, foundChild := srv.resolveAssuranceRequirement(context.Background(), "root/child", testPerm)
+	require.True(t, foundChild)
+	assert.Equal(t, session.AssuranceStrong, reqChild.Min, "parent Min must carry through to child")
+	assert.True(t, reqChild.RequireUserPresence, "child RequireUserPresence must apply on top of parent")
+
+	// --- Sub-test 2: child PUT attempting to lower Min below parent is rejected 400 ---
+	basic := "basic"
+	body2, _ := json.Marshal(AdminAssurancePolicyRequest{
+		Overrides: []AssurancePolicyOverrideDTO{
+			{PermissionID: testPerm, MinOverride: &basic},
+		},
+	})
+	req2 := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/root/child/assurance-policy", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	rec2 := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusBadRequest, rec2.Code,
+		"child PUT with MinOverride below parent-resolved value must be rejected 400: %s", rec2.Body.String())
+}
+
+// TestHandleSetAssurancePolicy_NoStore_Returns503 verifies that when the store is
+// not wired the handler returns 503.
+func TestHandleSetAssurancePolicy_NoStore_Returns503(t *testing.T) {
+	srv := setupTestServer(t)
+	// No assurancePolicyStore wired.
+
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{Overrides: nil})
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleSetAssurancePolicy_ClearsOverrides verifies that setting empty overrides
+// clears previously declared overrides (full-replace semantics).
+func TestHandleSetAssurancePolicy_ClearsOverrides(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	strongInt := int(session.AssuranceStrong)
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "test-tenant",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "certificate:provision", MinOverride: &strongInt},
+		},
+	}))
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"test-tenant": {"test-tenant"},
+	})
+	srv := newAssuranceTestServer(t, apStore, tsStore)
+
+	// PUT with empty overrides should clear.
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{Overrides: []AssurancePolicyOverrideDTO{}})
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	policy, err := apStore.GetPolicy(context.Background(), "test-tenant")
+	require.NoError(t, err)
+	assert.Empty(t, policy.Overrides, "PUT with empty overrides must clear existing overrides")
+}
+
+// TestHandleSetAssurancePolicy_NilMinOverride_NoValidation verifies that an override
+// with MinOverride=nil (presence-only) does not trigger tighten-only validation.
+func TestHandleSetAssurancePolicy_NilMinOverride_NoValidation(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"test-tenant": {"test-tenant"},
+	})
+	srv := newAssuranceTestServer(t, apStore, tsStore)
+
+	// No MinOverride, only RequireUserPresence — no validation needed.
+	body, _ := json.Marshal(AdminAssurancePolicyRequest{
+		Overrides: []AssurancePolicyOverrideDTO{
+			{PermissionID: "certificate:provision", RequireUserPresence: true},
+		},
+	})
+	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/test-tenant/assurance-policy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "presence-only override must be accepted: %s", rec.Body.String())
+}
+
+// ptrInt returns a pointer to the given int value.
+func ptrInt(i int) *int { return &i }

--- a/features/controller/api/handlers_assurance_policy_test.go
+++ b/features/controller/api/handlers_assurance_policy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/session"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -279,6 +280,106 @@ func TestResolveAssurance_PresenceOverride_ChallengingInOverridingTenant(t *test
 	require.True(t, foundB)
 	assert.False(t, reqB.RequireUserPresence, "sibling without override must not require presence")
 	assert.Equal(t, session.AssuranceStrong, reqB.Min)
+}
+
+// TestRequirePermission_PresenceOverride_HTTPChallengeAndSiblingAdmission is the
+// HTTP-observable half of the same acceptance criterion.
+//
+// The resolver-level test above proves resolveAssuranceRequirement returns the
+// right struct. That alone cannot show requirePermission ACTS on it: a wiring
+// mistake — wrong argument order, tenantID never threaded through, the challenge
+// branch reading the global map instead of the resolved requirement — would leave
+// the resolver test green while the gate admitted everyone. The AC is phrased as
+// an HTTP outcome (401 plus WWW-Authenticate presence="required" in the
+// overriding tenant, admitted in a sibling), so it is asserted as one here.
+//
+// authenticationMiddleware is deliberately not in the chain: it overwrites
+// ctxkeys.TenantID from the principal it builds off the client cert, which would
+// discard the tenant scope this test varies. requirePermission is the unit under
+// test, so the principal and tenant are placed in the request context directly —
+// the same pattern the tenant-scoped handler tests in this package use.
+//
+// [REQUIRED TEST] per acceptance criterion — HTTP-level companion.
+func TestRequirePermission_PresenceOverride_HTTPChallengeAndSiblingAdmission(t *testing.T) {
+	apStore := newTestAssurancePolicyStore()
+	require.NoError(t, apStore.SetPolicy(context.Background(), &business.AssurancePolicy{
+		TenantID: "root/tenant-with-override",
+		Overrides: []business.AssurancePolicyOverride{
+			{PermissionID: "certificate:provision", RequireUserPresence: true},
+		},
+	}))
+
+	tsStore := newTestTenantStoreWithPath(map[string][]string{
+		"root/tenant-with-override": {"root", "root/tenant-with-override"},
+		"root/sibling-no-override":  {"root", "root/sibling-no-override"},
+	})
+
+	srv := setupTestServer(t)
+	srv.SetAssurancePolicyStore(apStore)
+	srv.SetTenantStore(tsStore)
+
+	// Precondition: the override, not the global map, must be what drives the
+	// challenge. If the global map already required presence the test would pass
+	// for the wrong reason and prove nothing about per-tenant resolution.
+	require.False(t, permissionAssurance["certificate:provision"].RequireUserPresence,
+		"precondition: global map must not require presence for certificate:provision")
+
+	// AssuranceStrong (as an mTLS caller would be) with no fresh presence proof.
+	// Permissions nil is the implicit-admin marker, so authorisation passes and the
+	// only thing that can reject this request is the presence gate.
+	principal := &Principal{
+		ID:           "test-admin",
+		Name:         "test-admin",
+		Assurance:    session.AssuranceStrong,
+		GlobalScope:  true,
+		LastProvenAt: time.Now(),
+	}
+
+	call := func(tenantID string) *httptest.ResponseRecorder {
+		reached := false
+		handler := srv.requirePermission("certificate", "provision")(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				reached = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/certificates/provision", nil)
+		ctx := context.WithValue(req.Context(), principalContextKey, principal)
+		ctx = context.WithValue(ctx, ctxkeys.TenantID, tenantID)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req.WithContext(ctx))
+
+		// Reaching the inner handler and returning 200 must agree; a 200 recorded
+		// without the handler running would mean something else wrote the status.
+		if rec.Code == http.StatusOK {
+			assert.True(t, reached, "200 must mean the wrapped handler actually ran")
+		}
+		return rec
+	}
+
+	t.Run("overriding tenant is challenged", func(t *testing.T) {
+		rec := call("root/tenant-with-override")
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code,
+			"tenant override RequireUserPresence=true must produce a 401 step-up challenge")
+
+		wwwAuth := rec.Header().Get("WWW-Authenticate")
+		assert.Contains(t, wwwAuth, `presence="required"`,
+			`WWW-Authenticate must carry presence="required"`)
+		assert.Contains(t, wwwAuth, "CFGMS-StepUp",
+			"WWW-Authenticate must use the CFGMS-StepUp scheme")
+		assert.Contains(t, rec.Body.String(), "presence_required",
+			"response body must identify presence as the reason")
+	})
+
+	t.Run("sibling tenant without the override is admitted", func(t *testing.T) {
+		rec := call("root/sibling-no-override")
+
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"a sibling tenant without the override must not be challenged")
+		assert.Empty(t, rec.Header().Get("WWW-Authenticate"),
+			"an admitted request must not carry a step-up challenge header")
+	})
 }
 
 // ---- [REQUIRED TEST] per-AC: child inherits parent override and can tighten further ----

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -1182,8 +1182,8 @@ func (s *Server) resolveAssuranceRequirement(ctx context.Context, tenantID, perm
 	if err != nil {
 		s.logger.Warn("resolveAssuranceRequirement: failed to get tenant path; using global floor",
 			"tenant_id", logging.SanitizeLogValue(tenantID),
-			"permission_id", permissionID,
-			"error", err,
+			"permission_id", logging.SanitizeLogValue(permissionID),
+			"error", logging.SanitizeLogValue(err.Error()),
 		)
 		return floor, found
 	}
@@ -1194,8 +1194,8 @@ func (s *Server) resolveAssuranceRequirement(ctx context.Context, tenantID, perm
 		if err != nil {
 			s.logger.Warn("resolveAssuranceRequirement: failed to get assurance policy; using global floor",
 				"tenant_id", logging.SanitizeLogValue(t),
-				"permission_id", permissionID,
-				"error", err,
+				"permission_id", logging.SanitizeLogValue(permissionID),
+				"error", logging.SanitizeLogValue(err.Error()),
 			)
 			return floor, found
 		}

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -683,14 +683,18 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 			// Assurance check (ADR-021 Decision 2): after confirming the principal
 			// holds the permission, verify the assurance level meets the minimum for
 			// this route. This replaces requireTier(TierMTLSOnly) entirely.
-			if req, found := permissionAssurance[permissionID]; found && principal.Assurance < req.Min {
+			// resolveAssuranceRequirement composes the global floor with any per-tenant
+			// overrides declared by ancestors of tenantID (root→leaf), taking the max
+			// of all Min values and OR-ing RequireUserPresence (ADR-021, Issue #2839).
+			assuranceReq, assuranceFound := s.resolveAssuranceRequirement(r.Context(), tenantID, permissionID)
+			if assuranceFound && principal.Assurance < assuranceReq.Min {
 				decision := &AuthorizationDecision{
 					Granted:      false,
 					PermissionID: permissionID,
 					Resource:     resource,
 					Action:       action,
 					Decision:     "DENY",
-					Reason:       fmt.Sprintf("Insufficient assurance: %s < %s required for %s", principal.Assurance, req.Min, permissionID),
+					Reason:       fmt.Sprintf("Insufficient assurance: %s < %s required for %s", principal.Assurance, assuranceReq.Min, permissionID),
 					CheckedAt:    time.Now(),
 					SubjectID:    userID,
 					TenantID:     tenantID,
@@ -703,7 +707,7 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 					return
 				}
 				// All other callers (AssuranceBasic+) receive a step-up challenge (ADR-021 Decision 6).
-				levelName := req.Min.String()
+				levelName := assuranceReq.Min.String()
 				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`CFGMS-StepUp realm="cfgms", required="%s"`, levelName))
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)
@@ -725,8 +729,8 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 			// and is passed in X-Presence-Token. It is single-use (LoadAndDelete) and short-lived
 			// (presenceTokenTTL). Continuity / LastProvenAt alone is insufficient — a hijacked-but-
 			// continuous session cannot fake a present human (ADR-021 Decision 4 threat model).
-			if req, found := permissionAssurance[permissionID]; found && req.RequireUserPresence {
-				levelName := req.Min.String()
+			if assuranceFound && assuranceReq.RequireUserPresence {
+				levelName := assuranceReq.Min.String()
 
 				presenceToken := r.Header.Get(presenceTokenHeader)
 				if presenceToken == "" {
@@ -1151,4 +1155,64 @@ func (s *Server) extractTargetTenantFromRequest(r *http.Request, resourceType st
 		}
 	}
 	return ""
+}
+
+// resolveAssuranceRequirement composes the global permissionAssurance floor with any
+// per-tenant overrides declared along the root→leaf path to tenantID (ADR-021, Issue #2839).
+//
+// Resolution rules:
+//   - Min takes the maximum seen across [global floor, ancestor overrides, tenant override].
+//   - RequireUserPresence is true if true anywhere in the chain (OR, never cleared).
+//
+// When assurancePolicyStore or tenantStore is nil, or tenantID is empty, the method
+// returns the global floor unchanged — preserving today's exact behavior in unit tests
+// that build a bare Server without these stores.
+//
+// GetTenantPath or GetPolicy errors are logged at Warn and cause a fall-back to the
+// global floor: an override-resolution error must never turn a storage hiccup into a
+// fleet-wide outage on every gated endpoint. Falling back to the global floor is safe
+// because the floor is always the tightest guaranteed lower bound.
+func (s *Server) resolveAssuranceRequirement(ctx context.Context, tenantID, permissionID string) (Requirement, bool) {
+	floor, found := permissionAssurance[permissionID]
+	if s.assurancePolicyStore == nil || s.tenantStore == nil || tenantID == "" {
+		return floor, found
+	}
+
+	path, err := s.tenantStore.GetTenantPath(ctx, tenantID)
+	if err != nil {
+		s.logger.Warn("resolveAssuranceRequirement: failed to get tenant path; using global floor",
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"permission_id", permissionID,
+			"error", err,
+		)
+		return floor, found
+	}
+
+	result := floor
+	for _, t := range path {
+		policy, err := s.assurancePolicyStore.GetPolicy(ctx, t)
+		if err != nil {
+			s.logger.Warn("resolveAssuranceRequirement: failed to get assurance policy; using global floor",
+				"tenant_id", logging.SanitizeLogValue(t),
+				"permission_id", permissionID,
+				"error", err,
+			)
+			return floor, found
+		}
+		for _, ov := range policy.Overrides {
+			if ov.PermissionID != permissionID {
+				continue
+			}
+			found = true
+			if ov.MinOverride != nil {
+				if ovMin := session.AssuranceLevel(*ov.MinOverride); ovMin > result.Min {
+					result.Min = ovMin
+				}
+			}
+			if ov.RequireUserPresence {
+				result.RequireUserPresence = true
+			}
+		}
+	}
+	return result, found
 }

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -122,6 +122,9 @@ var knownPermissions = map[string]bool{
 	"module:list-approvals": true,
 	"module:approve":        true,
 	"module:reject":         true,
+	// Per-tenant assurance-policy management (Issue #2839)
+	"assurance-policy:get": true,
+	"assurance-policy:set": true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/route_registry_test.go
+++ b/features/controller/api/route_registry_test.go
@@ -164,6 +164,7 @@ var goldenRouteTable = []string{
 	"GET /api/v1/stewards/{id}/scripts/status",
 	"GET /api/v1/stewards/{id}/tags",
 	"GET /api/v1/tenants/{id}",
+	"GET /api/v1/tenants/{tenant_path:.+}/assurance-policy",
 	"GET /api/v1/tenants/{tenant_path:.+}/refresh-policy",
 	"GET /api/v1/terminal/ws/{steward_id}",
 	"GET /api/v1/web/accounts",
@@ -230,6 +231,7 @@ var goldenRouteTable = []string{
 	"PUT /api/v1/rbac/roles/{id}",
 	"PUT /api/v1/scripts/{id}/privilege",
 	"PUT /api/v1/stewards/{id}/config",
+	"PUT /api/v1/tenants/{tenant_path:.+}/assurance-policy",
 	"PUT /api/v1/tenants/{tenant_path:.+}/refresh-policy",
 }
 

--- a/features/controller/api/routes_tenants.go
+++ b/features/controller/api/routes_tenants.go
@@ -29,4 +29,13 @@ func registerTenantRoutes(s *Server, api *mux.Router) {
 		s.requirePermission("refresh", "get-policy")(http.HandlerFunc(s.handleGetRefreshPolicy))).Methods("GET")
 	tenants.Handle("/{tenant_path:.+}/refresh-policy",
 		s.requirePermission("refresh", "set-policy")(http.HandlerFunc(s.handleSetRefreshPolicy))).Methods("PUT")
+
+	// Per-tenant assurance-policy endpoints (Issue #2839).
+	// assurance-policy:get is an ordinary RBAC gate (not in permissionAssurance), so reads
+	// stay unrestricted at the assurance layer — matching refresh:get-policy's absence from
+	// that map. assurance-policy:set requires AssuranceStrong (declared in assurance.go).
+	tenants.Handle("/{tenant_path:.+}/assurance-policy",
+		s.requirePermission("assurance-policy", "get")(http.HandlerFunc(s.handleGetAssurancePolicy))).Methods("GET")
+	tenants.Handle("/{tenant_path:.+}/assurance-policy",
+		s.requirePermission("assurance-policy", "set")(http.HandlerFunc(s.handleSetAssurancePolicy))).Methods("PUT")
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -160,6 +160,8 @@ type Server struct {
 	telemetryHandler               http.Handler                          // Issue #2765: telemetry fan-out WebSocket handler
 	egConfigstoreWriter            egConfigstoreIngestor                 // Issue #2879: desired-state entity-graph internal writer (nil = disabled)
 	terminalHandler                http.Handler                          // Issue #2761: terminal WebSocket relay handler
+	tenantStore                    business.TenantStore                  // Issue #2839: tenant hierarchy for per-tenant assurance resolution
+	assurancePolicyStore           business.AssurancePolicyStore         // Issue #2839: per-tenant assurance-policy overrides
 
 	// Listeners retained so Close can shut them regardless of whether their serve
 	// goroutine has reached Serve yet: http.Server.Shutdown closes only listeners
@@ -1197,6 +1199,23 @@ func (s *Server) SetRefreshPolicyStore(store business.RefreshPolicyStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.refreshPolicyStore = store
+}
+
+// SetTenantStore wires the TenantStore for tenant-hierarchy resolution (Issue #2839).
+// TenantStore is a core, always-present store — wired unconditionally at startup.
+func (s *Server) SetTenantStore(store business.TenantStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tenantStore = store
+}
+
+// SetAssurancePolicyStore wires the per-tenant AssurancePolicyStore (Issue #2839).
+// When nil (default), resolveAssuranceRequirement returns the global permissionAssurance
+// floor unchanged — no behavior change for existing tests that build a bare Server.
+func (s *Server) SetAssurancePolicyStore(store business.AssurancePolicyStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.assurancePolicyStore = store
 }
 
 // SetAuditStore wires a direct AuditStore reference for the test-mode count endpoint

--- a/features/controller/api/tier_enforcement_test.go
+++ b/features/controller/api/tier_enforcement_test.go
@@ -67,6 +67,7 @@ var strongAssuranceRouteTable = []strongAssuranceRouteEntry{
 	{"POST", "/api/v1/tenants", "tenant:create"},
 	{"POST", "/api/v1/stewards/refresh/pending-123/approve", "refresh:approve"},
 	{"PUT", "/api/v1/tenants/test-tenant/refresh-policy", "refresh:set-policy"},
+	{"PUT", "/api/v1/tenants/test-tenant/assurance-policy", "assurance-policy:set"}, // Issue #2839: per-tenant assurance override — raises tenant's own posture.
 	{"POST", "/api/v1/stewards/test-steward-id/move", "steward:move"},
 	{"DELETE", "/api/v1/stewards/test-steward-id", "steward:decommission"},
 	{"POST", "/api/v1/web/accounts", "web-account:create"},

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -1224,6 +1224,11 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	if rps := storageManager.GetRefreshPolicyStore(); rps != nil {
 		httpServer.SetRefreshPolicyStore(rps)
 	}
+	if aps := storageManager.GetAssurancePolicyStore(); aps != nil {
+		httpServer.SetAssurancePolicyStore(aps)
+	}
+	// TenantStore is core and always present; wire unconditionally for the assurance resolver.
+	httpServer.SetTenantStore(storageManager.GetTenantStore())
 	if as := storageManager.GetAuditStore(); as != nil {
 		httpServer.SetAuditStore(as)
 	}


### PR DESCRIPTION
## Summary

- Replaces direct `permissionAssurance[permissionID]` reads in `requirePermission` with `resolveAssuranceRequirement`, which composes the global floor with per-tenant overrides walked root→leaf: `Min` takes the max across the chain, `RequireUserPresence` ORs. Nil stores / empty tenantID return the global floor unchanged (zero regression for bare-Server unit tests).
- Adds `GET`/`PUT /api/v1/tenants/{tenant_path}/assurance-policy` admin endpoints mirroring the refresh-policy pattern. `PUT` enforces tighten-only at write time (ancestor-resolved Min check before `SetPolicy`). `RequireUserPresence` needs no check — the chain's OR makes it structurally impossible for a leaf to lower it.
- Wires `SetAssurancePolicyStore` (conditional) and `SetTenantStore` (unconditional) in `features/controller/server/server.go` near the existing refresh-store wiring.
- Updates ADR-021 with the concrete endpoint names, resolver semantics, and the rationale for leaving `scanAPIKeysForPrivilegedAccess` global-only.
- 11 resolver unit tests + 12 handler tests; updated golden route table and tier-enforcement parity table.

## Specialist review results

| Lens | Status |
|------|--------|
| Code review | PASS (clean after 3 fix rounds) |
| Security review | PASS (clean after 3 fix rounds) |
| Test quality | PASS on code/logic; BLOCKED on environment issue (see below) |

## Remaining workflow finding (pre-existing environment issue — not caused by this PR)

The `story-review` workflow returned `passed: false` because `make test-agent-complete` calls `check-binary-artifacts`, which requires the `file` system utility. That utility is absent from this container image, causing the Makefile target to exit 2.

**This failure is pre-existing and unrelated to these code changes.** Verified by running the same failing test (`TestSecurityScanReportsSkippedDependencyScan`) on the clean `develop` branch after `git stash`:

```
FAIL    github.com/cfgis/cfgms/test/unit/build    # file utility missing — same failure
```

All other gates passed:
- Go unit tests: all packages `ok` (including `features/controller/api` with 208 tests)
- `golangci-lint`: 0 issues
- SPDX license headers: clean
- Secret scan: no leaks
- Architecture checks: no violations
- Script tests: 208 passed / 0 failed

Fix for the container: `apt-get install -y file` in the image.

## Test plan

- [ ] `go test ./features/controller/api/...` — all green (57s)
- [ ] Resolver unit tests cover: nil stores, empty tenantID, Min raise, presence add, parent inheritance, sibling isolation, store-error fallback to global floor
- [ ] [REQUIRED AC] `TestResolveAssurance_PresenceOverride_ChallengingInOverridingTenant` — presence override challenges in overriding tenant, not in sibling
- [ ] [REQUIRED AC] `TestHandleSetAssurancePolicy_ChildInheritsParentAndCanTighten` — child inherits parent, can tighten, lowering Min below parent is rejected 400
- [ ] `TestRouteTableParity` and `TestF2_AssuranceGate_ParityWithPermissionRegistry` pass with new routes included

Fixes #2839

🤖 Generated with [Claude Code](https://claude.com/claude-code)