### PR TITLE
security: sanitize logged error values and refuse review on conflicted PRs (Issue #3026)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -667,6 +667,8 @@ _review_refusal_hint() {
       echo "lease acquisition failed unexpectedly — check './scripts/pipeline-helper.sh lease-acquire' directly." ;;
     no_new_commit_since_review)
       echo "head is unchanged since the last acceptance review — a re-review would re-reach the same verdict. Dispatch a fix (po-act.sh dispatch-fix <PR>) so a commit lands first, or pass --force if the acceptance criteria changed rather than the code." ;;
+    merge_conflicts)
+      echo "PR conflicts with develop (mergeStateStatus=DIRTY), so GitHub builds no merge ref and NO pull_request workflow runs for it — a reviewer would judge it with zero CI evidence. Clear the conflict first: './.claude/scripts/rebase-pr.sh <PR>', escalating to resolve-conflict on REBASE_CONFLICT, then review." ;;
     *)
       echo "" ;;
   esac
@@ -2112,10 +2114,11 @@ PYEOF
 
     # Validate PR + auto-detect story number.
     pr_meta=$(gh pr view "$pr_num" --repo cfg-is/cfgms \
-      --json state,headRefName,body,labels,headRepositoryOwner,author 2>/dev/null) || {
+      --json state,headRefName,body,labels,headRepositoryOwner,author,mergeStateStatus 2>/dev/null) || {
       _emit_review_refused "$pr_num" "pr_not_found"
     }
     state=$(echo "$pr_meta" | jq -r '.state')
+    merge_state=$(echo "$pr_meta" | jq -r '.mergeStateStatus // empty' | tr '[:lower:]' '[:upper:]')
     pr_branch=$(echo "$pr_meta" | jq -r '.headRefName')
     fork_owner=$(echo "$pr_meta" | jq -r '.headRepositoryOwner.login // empty')
     pr_body=$(echo "$pr_meta" | jq -r '.body // ""')
@@ -2138,6 +2141,25 @@ PYEOF
     fi
 
     validate_branch "$pr_branch"
+
+    # Conflict guard: a DIRTY PR has no merge ref, so GitHub runs NO pull_request
+    # workflow for it and every required check is simply absent. A reviewer handed
+    # that PR has no CI evidence to judge against and reaches for the story's ACs
+    # alone — one such review FAILed a PR partly for checks that could never have
+    # run, then a fix agent was dispatched against a branch whose real problem was
+    # a conflict. Rebase is strictly cheaper than that round trip.
+    #
+    # Lives here for the same reason as _review_is_stale below: the preflight
+    # already recommends `rebase` ahead of review for DIRTY, but that is advisory
+    # and a direct `review-pr <N>` call bypasses it. The dispatcher is the
+    # enforcement point.
+    #
+    # Only exact DIRTY refuses. GitHub reports UNKNOWN while it is still computing
+    # mergeability, and BEHIND/BLOCKED are the merge queue's business, not the
+    # reviewer's — refusing on those would strand reviewable PRs.
+    if [[ "$merge_state" == "DIRTY" ]]; then
+      _emit_review_refused "$pr_num" "merge_conflicts"
+    fi
 
     # Stale-head guard: refuse a re-review when no commit has landed since the
     # last acceptance review. Runs before story resolution / capacity / lease so

--- a/.claude/scripts/tests/review_pr_detection.test.sh
+++ b/.claude/scripts/tests/review_pr_detection.test.sh
@@ -266,6 +266,7 @@ assert_has_hint "container_exists" "container_exists"
 assert_has_hint "lease_held" "lease_held"
 assert_has_hint "lease_error" "lease_error"
 assert_has_hint "no_new_commit_since_review" "no_new_commit_since_review"
+assert_has_hint "merge_conflicts" "merge_conflicts"
 
 echo
 echo "--- review-pr: stale-head guard (_review_is_stale) ---"
@@ -330,6 +331,71 @@ assert_staleness "newest commit compared, not last listed → reviewable" "$f" "
 # Malformed payload → fails open rather than stranding the PR.
 f=$(write_fixture broken '{"comments":[],"commits":[]}')
 assert_staleness "missing commit data → fails open (reviewable)" "$f" "reviewable"
+
+echo
+echo "--- review-pr: conflict guard (mergeStateStatus) ---"
+
+# A DIRTY PR has no merge ref, so GitHub runs no pull_request workflow and every
+# required check is absent. Reviewing it produced a FAIL citing CI that could
+# never have run, then a fix dispatch against a branch whose real problem was a
+# conflict. The preflight already deprioritises it, but a direct `review-pr <N>`
+# bypasses the preflight entirely — hence this guard, and hence this test.
+#
+# End-to-end through the real CLI: the stub answers both gh calls the guard sits
+# behind (the PR view, then the author-permission check) by branching on args.
+CONFLICT_STUB_DIR=$(mktemp -d)
+trap 'rm -rf "$STALE_STUB_DIR" "$CONFLICT_STUB_DIR"' EXIT
+cat > "$CONFLICT_STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# The permission probe runs `gh api ... --jq '.permission // ""'`, so it expects
+# the already-extracted value, not a JSON object.
+for a in "$@"; do
+  case "$a" in
+    *collaborators*permission*) echo admin; exit 0 ;;
+  esac
+done
+# `gh pr view` is the only other call reached before the guard.
+case "$1" in
+  pr) cat "$GH_FIXTURE" ;;
+  *)  exit 0 ;;
+esac
+STUB
+chmod +x "$CONFLICT_STUB_DIR/gh"
+
+assert_review_refusal() {
+  local description="$1" merge_state="$2" expected="$3"
+  ran=$((ran + 1))
+  local fixture actual
+  fixture="${CONFLICT_STUB_DIR}/meta-${merge_state}.json"
+  printf '{"state":"OPEN","headRefName":"feature/story-4242-agent","body":"Fixes #4242","labels":[],"headRepositoryOwner":{"login":"cfg-is"},"author":{"login":"jrdnr"},"mergeStateStatus":"%s"}' \
+    "$merge_state" > "$fixture"
+  actual=$(GH_FIXTURE="$fixture" PATH="$CONFLICT_STUB_DIR:$PATH" \
+    "$DISPATCH" review-pr 4242 2>&1 | head -1) || true
+  case "$expected" in
+    refused)
+      if [[ "$actual" == *"REVIEW_REFUSED:4242:merge_conflicts"* ]]; then
+        printf '  ok    %s\n' "$description"
+      else
+        printf '  FAIL  %s\n        expected merge_conflicts refusal, got=%q\n' "$description" "$actual"
+        fail=$((fail + 1))
+      fi ;;
+    not_refused)
+      if [[ "$actual" == *"merge_conflicts"* ]]; then
+        printf '  FAIL  %s\n        must not refuse on %s, got=%q\n' "$description" "$merge_state" "$actual"
+        fail=$((fail + 1))
+      else
+        printf '  ok    %s\n' "$description"
+      fi ;;
+  esac
+}
+
+assert_review_refusal "DIRTY → refused before any container is launched" "DIRTY" "refused"
+# UNKNOWN is GitHub still computing mergeability; BEHIND/BLOCKED are the merge
+# queue's business. Refusing on any of these would strand reviewable PRs.
+assert_review_refusal "UNKNOWN (still computing) → not refused" "UNKNOWN" "not_refused"
+assert_review_refusal "BEHIND → not refused" "BEHIND" "not_refused"
+assert_review_refusal "BLOCKED → not refused" "BLOCKED" "not_refused"
+assert_review_refusal "CLEAN → not refused" "CLEAN" "not_refused"
 
 echo
 echo "ran ${ran} assertions; failures: ${fail}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,13 @@ Stewards run on hosts that may be compromised. Admin accounts may be phished or 
 - Input validation and sanitization for all user data
 - SQL injection prevention (parameterized queries only)
 - No information disclosure in error messages
-- Use `logging.SanitizeLogValue()` for HTTP params, URL paths, headers
+- Use `logging.SanitizeLogValue()` for HTTP params, URL paths, headers — **and for
+  error values**: `"error", logging.SanitizeLogValue(err.Error())`, never
+  `"error", err`. An error returned from a gRPC, store, or decode call carries the
+  caller's tainted input back out inside its message text, so a sanitized ID
+  beside a raw `err` in the same log call is still a `go/log-injection` finding.
+  Wrapping an error that happens not to be tainted costs nothing; leaving a
+  tainted one bare costs a review round. `make lint-log-injection` flags it.
 - **CodeQL findings:** genuine bug → fix the code; false positive → extend the in-repo data-extension pack `.github/codeql/extensions/` (republished to ghcr.io by `codeql-pack-publish.yml` — local-path packs are unsupported, and this is **not** the upstream `github/codeql` repo). Heuristic-source FPs that can't be modeled → dismiss with justification. See [security-workflow-guide](docs/development/security-workflow-guide.md#5-codeql---semantic-code-analysis).
 - **Dependency scanning needs a credential.** `make security-deps` runs Nancy against Sonatype Guide, which rejects unauthenticated requests with `401` — an anonymous run produces no evidence, not a clean result. Export a free bearer token from https://guide.sonatype.com as `GUIDE_TOKEN` to scan locally. Without it the target **skips loudly and exits 0** so local work isn't blocked; `make security-scan` then reports the dependency scan as SKIPPED rather than passed. The gate fails closed whenever `CI` is set, or on demand via `CFGMS_REQUIRE_GUIDE_TOKEN=1`. CI supplies the repository `GUIDE_TOKEN` secret. Fork pull requests cannot receive it, so `nancy-scan` skips there and the merge queue — which does have the secret — performs the real scan before anything merges.
 

--- a/features/controller/api/handlers_apikeys.go
+++ b/features/controller/api/handlers_apikeys.go
@@ -120,7 +120,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	// Generate new API key (256-bit cryptographically secure)
 	keyBytes := make([]byte, 32)
 	if _, err := rand.Read(keyBytes); err != nil {
-		s.logger.Error("Failed to generate API key", "error", err)
+		s.logger.Error("Failed to generate API key", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to generate API key", "INTERNAL_ERROR")
 		return
 	}
@@ -169,7 +169,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.secretStore.StoreSecret(r.Context(), secretReq); err != nil {
-		s.logger.Error("Failed to persist API key to secret store", "error", err, "id", keyID)
+		s.logger.Error("Failed to persist API key to secret store", "error", logging.SanitizeLogValue(err.Error()), "id", keyID)
 		// Remove from memory cache since we couldn't persist
 		s.mu.Lock()
 		delete(s.apiKeys, keyString)

--- a/features/controller/api/handlers_certificates.go
+++ b/features/controller/api/handlers_certificates.go
@@ -98,7 +98,7 @@ func (s *Server) handleRotateSigningCert(w http.ResponseWriter, r *http.Request)
 		}
 		s.logger.Error("Signing certificate rotation failed",
 			"operator_serial", logging.SanitizeLogValue(principal.CertSerial),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Rotation failed", "ROTATION_ERROR")
 		return
 	}
@@ -316,7 +316,7 @@ func (s *Server) handleProvisionCertificate(w http.ResponseWriter, r *http.Reque
 		s.logger.Error("Failed to provision certificate",
 			"steward_id", logging.SanitizeLogValue(provisionReq.StewardID),
 			"common_name", logging.SanitizeLogValue(provisionReq.CommonName),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to provision certificate", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_fleet.go
+++ b/features/controller/api/handlers_fleet.go
@@ -57,7 +57,7 @@ func (s *Server) handleResolveSelector(w http.ResponseWriter, r *http.Request) {
 	filter, parsedTenantPath, err := selector.Parse(req.Selector)
 	if err != nil {
 		s.logger.Info("Invalid selector expression",
-			"selector", logging.SanitizeLogValue(req.Selector), "error", err)
+			"selector", logging.SanitizeLogValue(req.Selector), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusBadRequest, err.Error(), "INVALID_SELECTOR")
 		return
 	}
@@ -82,7 +82,7 @@ func (s *Server) handleResolveSelector(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.fleetQuery.Search(r.Context(), filter)
 	if err != nil {
-		s.logger.Error("Fleet query failed", "error", err)
+		s.logger.Error("Fleet query failed", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to query fleet", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_ip_trust.go
+++ b/features/controller/api/handlers_ip_trust.go
@@ -67,7 +67,7 @@ func (s *Server) handleAddIPTrust(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("Failed to add IP trust range",
 			"tenant_id", logging.SanitizeLogValue(req.TenantID),
 			"cidr", logging.SanitizeLogValue(req.CIDR),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to add IP trust range", http.StatusInternalServerError)
 		return
 	}

--- a/features/controller/api/handlers_jobs.go
+++ b/features/controller/api/handlers_jobs.go
@@ -110,7 +110,7 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.fleetQuery.Search(r.Context(), filter)
 	if err != nil {
-		s.logger.Error("Fleet query failed during job creation", "error", err)
+		s.logger.Error("Fleet query failed during job creation", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to query fleet", "INTERNAL_ERROR")
 		return
 	}
@@ -139,7 +139,7 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.batchJobStore.CreateBatchJob(r.Context(), job); err != nil {
-		s.logger.Error("Failed to persist batch job", "error", err)
+		s.logger.Error("Failed to persist batch job", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create job", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_push.go
+++ b/features/controller/api/handlers_push.go
@@ -69,7 +69,7 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 	// Decode and validate request body.
 	var req configPushRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.logger.Warn("Failed to decode config push body", "error", err)
+		s.logger.Warn("Failed to decode config push body", "error", logging.SanitizeLogValue(err.Error()))
 		s.respondError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -124,7 +124,7 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.fleetQuery.Search(r.Context(), filter)
 	if err != nil {
-		s.logger.Error("Fleet query failed during config push", "error", err, "selector", safeSelector)
+		s.logger.Error("Fleet query failed during config push", "error", logging.SanitizeLogValue(err.Error()), "selector", safeSelector)
 		s.respondError(w, http.StatusInternalServerError, "fleet query failed")
 		return
 	}
@@ -169,7 +169,7 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 		if err := s.egConfigstoreWriter.Ingest(r.Context(), egRev, eids); err != nil {
 			s.logger.Warn("Failed to ingest desired-state observations into entity graph",
 				"push_id", pushID,
-				"error", err,
+				"error", logging.SanitizeLogValue(err.Error()),
 			)
 		}
 	}
@@ -192,7 +192,7 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 				UpdatedAt: queuedAt,
 			}
 			if err := s.pushStore.CreatePush(r.Context(), record); err != nil {
-				s.logger.Warn("Failed to persist push record", "error", err, "push_id", pushID)
+				s.logger.Warn("Failed to persist push record", "error", logging.SanitizeLogValue(err.Error()), "push_id", pushID)
 			}
 		} else {
 			s.logger.Warn("Failed to marshal push payload for persistence", "error", marshalErr, "push_id", pushID)
@@ -216,7 +216,7 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 				s.logger.Error("Config push fan-out delivery failed",
 					"push_id", pushID,
 					"steward_id", logging.SanitizeLogValue(stewardID),
-					"error", err)
+					"error", logging.SanitizeLogValue(err.Error()))
 			}
 			if s.pushStore != nil {
 				finalStatus := business.PushStatusCompleted
@@ -264,7 +264,7 @@ func (s *Server) handleGetConfigPush(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		s.logger.Error("Failed to retrieve push record",
-			"push_id", logging.SanitizeLogValue(id), "error", err)
+			"push_id", logging.SanitizeLogValue(id), "error", logging.SanitizeLogValue(err.Error()))
 		s.respondError(w, http.StatusInternalServerError, "failed to retrieve push record")
 		return
 	}

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -152,7 +152,7 @@ func (s *Server) handleApproveRegistration(w http.ResponseWriter, r *http.Reques
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
 	}
@@ -190,7 +190,7 @@ func (s *Server) handleDenyRegistration(w http.ResponseWriter, r *http.Request) 
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
 	}
@@ -250,7 +250,7 @@ func (s *Server) handleRegistrationStatus(w http.ResponseWriter, r *http.Request
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to retrieve pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to retrieve pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to retrieve pending registration", http.StatusInternalServerError)
 		return
 	}
@@ -300,7 +300,7 @@ func (s *Server) handleRegistrationStatus(w http.ResponseWriter, r *http.Request
 		resp, err := s.buildClaimResponse(r.Context(), entry, tokenStr)
 		if err != nil {
 			s.logger.Error("Failed to generate cert for claimed registration",
-				"pending_id", logging.SanitizeLogValue(pendingID), "steward_id", logging.SanitizeLogValue(entry.StewardID), "error", err)
+				"pending_id", logging.SanitizeLogValue(pendingID), "steward_id", logging.SanitizeLogValue(entry.StewardID), "error", logging.SanitizeLogValue(err.Error()))
 			// Entry is already "claimed" — steward must re-register if cert was not received.
 			http.Error(w, "Failed to generate client certificate", http.StatusInternalServerError)
 			return
@@ -309,7 +309,7 @@ func (s *Server) handleRegistrationStatus(w http.ResponseWriter, r *http.Request
 		// #nosec G117 -- this authenticated, tenant-bound, atomically one-time
 		// claim response is the intended TLS delivery channel for the new key.
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			s.logger.Error("Failed to encode registration status response", "error", err)
+			s.logger.Error("Failed to encode registration status response", "error", logging.SanitizeLogValue(err.Error()))
 		}
 
 	case business.PendingRegistrationStatusClaimed:
@@ -484,7 +484,7 @@ func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
 	callerTenant := s.callerTenantID(r)
 	entries, err := s.pendingStore.ListPending(r.Context(), callerTenant)
 	if err != nil {
-		s.logger.Error("Failed to list pending registrations for approve-by-cidr", "error", err)
+		s.logger.Error("Failed to list pending registrations for approve-by-cidr", "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
 		return
 	}
@@ -500,7 +500,7 @@ func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := s.pendingStore.UpdateStatus(r.Context(), e.PendingID, business.PendingRegistrationStatusApproved); err != nil {
 			s.logger.Error("Failed to approve pending registration in CIDR bulk",
-				"pending_id", logging.SanitizeLogValue(e.PendingID), "error", err)
+				"pending_id", logging.SanitizeLogValue(e.PendingID), "error", logging.SanitizeLogValue(err.Error()))
 			continue
 		}
 		approved++
@@ -512,7 +512,7 @@ func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
 		map[string]interface{}{"cidr": req.CIDR, "approved_count": approved})
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(approveAllResponse{Approved: approved}); err != nil {
-		s.logger.Error("Failed to encode approve-by-cidr response", "error", err)
+		s.logger.Error("Failed to encode approve-by-cidr response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 
@@ -606,7 +606,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	var req RegistrationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.logger.Warn("Failed to parse registration request", "error", err)
+		s.logger.Warn("Failed to parse registration request", "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -629,7 +629,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Retrieve token metadata (tenant, group, controller URL) for building the response
 	token, err := s.registrationTokenStore.GetToken(r.Context(), req.Token)
 	if err != nil {
-		s.logger.Warn("Invalid registration token", "error", err)
+		s.logger.Warn("Invalid registration token", "error", logging.SanitizeLogValue(err.Error()))
 		// emitRegistrationAudit calls logging.RedactedID internally; raw token is not stored
 		s.emitRegistrationAudit(r.Context(), req.Token, "unknown", "unknown",
 			business.AuditEventSecurityEvent, "registration_rejected",
@@ -760,7 +760,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 			created, claimErr := s.registrationTokenStore.ClaimToken(r.Context(), req.Token, claimID)
 			if claimErr != nil {
-				s.logger.Error("Failed to atomically claim registration token", "error", claimErr)
+				s.logger.Error("Failed to atomically claim registration token", "error", logging.SanitizeLogValue(claimErr.Error()))
 				http.Error(w, "Registration service unavailable", http.StatusServiceUnavailable)
 				return
 			}
@@ -795,10 +795,10 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			if err := s.pendingStore.AddPending(r.Context(), pendingEntry); err != nil {
 				if releaseErr := s.registrationTokenStore.ReleaseTokenClaim(r.Context(), req.Token, claimID); releaseErr != nil {
 					s.logger.Error("Failed to release registration token claim after pending-store failure",
-						"pending_id", pendingID, "error", releaseErr)
+						"pending_id", pendingID, "error", logging.SanitizeLogValue(releaseErr.Error()))
 				}
 				s.logger.Error("Failed to persist pending registration",
-					"pending_id", pendingID, "steward_id", stewardID, "error", err)
+					"pending_id", pendingID, "steward_id", stewardID, "error", logging.SanitizeLogValue(err.Error()))
 				http.Error(w, "Registration admission service unavailable", http.StatusServiceUnavailable)
 				return
 			}
@@ -808,7 +808,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 				"pending_id", pendingID)
 			if err := s.controllerService.RegisterStewardWithAttributes(stewardID, token.TenantID, quarantineTransportAddr, "quarantined", initialAttrs); err != nil {
 				s.logger.Error("Failed to register quarantined steward in controller service",
-					"steward_id", stewardID, "error", err)
+					"steward_id", stewardID, "error", logging.SanitizeLogValue(err.Error()))
 			}
 
 			// emitRegistrationAudit calls logging.RedactedID internally; raw token is not stored
@@ -855,7 +855,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Get CA certificate (required for certificate chain validation)
 	caCert, err := s.certManager.GetCACertificate()
 	if err != nil || len(caCert) == 0 {
-		s.logger.Error("Failed to get CA certificate", "error", err, "steward_id", stewardID)
+		s.logger.Error("Failed to get CA certificate", "error", logging.SanitizeLogValue(err.Error()), "steward_id", stewardID)
 		http.Error(w, "CA certificate unavailable", http.StatusInternalServerError)
 		return
 	}
@@ -871,7 +871,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 				"cert_serial", s.signerCertSerial)
 		} else {
 			s.logger.Warn("Failed to export signer certificate from cert manager",
-				"error", err, "steward_id", stewardID, "cert_serial", s.signerCertSerial)
+				"error", logging.SanitizeLogValue(err.Error()), "steward_id", stewardID, "cert_serial", s.signerCertSerial)
 		}
 	} else if s.signerCertSerial == "" {
 		s.logger.Warn("Signer certificate serial not available (signer may not be initialized)",
@@ -887,7 +887,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// itself stays valid for the rest of the fleet (Issue #1690).
 	created, claimErr := s.registrationTokenStore.ClaimToken(r.Context(), req.Token, claimID)
 	if claimErr != nil {
-		s.logger.Error("Failed to atomically claim registration token", "error", claimErr)
+		s.logger.Error("Failed to atomically claim registration token", "error", logging.SanitizeLogValue(claimErr.Error()))
 		http.Error(w, "Registration service unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -905,9 +905,9 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if releaseErr := s.registrationTokenStore.ReleaseTokenClaim(r.Context(), req.Token, claimID); releaseErr != nil {
 			s.logger.Error("Failed to release registration token claim after certificate failure",
-				"steward_id", stewardID, "error", releaseErr)
+				"steward_id", stewardID, "error", logging.SanitizeLogValue(releaseErr.Error()))
 		}
-		s.logger.Error("Failed to generate client certificate", "error", err, "steward_id", stewardID)
+		s.logger.Error("Failed to generate client certificate", "error", logging.SanitizeLogValue(err.Error()), "steward_id", stewardID)
 		http.Error(w, "Failed to generate client certificate", http.StatusInternalServerError)
 		return
 	}
@@ -942,7 +942,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.controllerService.RegisterStewardWithAttributes(stewardID, token.TenantID, resp.TransportAddress, "registered", initialAttrs); err != nil {
 		s.logger.Error("Failed to register steward in controller service",
-			"steward_id", stewardID, "error", err)
+			"steward_id", stewardID, "error", logging.SanitizeLogValue(err.Error()))
 	}
 
 	// Persist device identity to the durable StewardStore so the S3b PoP verification
@@ -963,7 +963,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("Failed to persist device identity to steward store",
 				"steward_id", stewardID,
 				"device_id", logging.SanitizeLogValue(req.DeviceID),
-				"error", storeErr)
+				"error", logging.SanitizeLogValue(storeErr.Error()))
 		}
 	}
 
@@ -978,7 +978,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// #nosec G117 -- successful authenticated registration intentionally returns
 	// the freshly issued client key once over the required TLS endpoint.
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Error("Failed to encode registration response", "error", err)
+		s.logger.Error("Failed to encode registration response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -116,7 +116,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 			http.Error(w, "device not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
+		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", logging.SanitizeLogValue(err.Error()))
 		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 			business.AuditEventSystemEvent, "refresh_challenge_error",
 			business.AuditResultError, business.AuditSeverityMedium,
@@ -148,7 +148,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 	// Generate 32-byte cryptographically random nonce.
 	nonceBytes := make([]byte, 32)
 	if _, err := rand.Read(nonceBytes); err != nil {
-		s.logger.Error("Failed to generate refresh nonce", "error", err)
+		s.logger.Error("Failed to generate refresh nonce", "error", logging.SanitizeLogValue(err.Error()))
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSystemEvent, "refresh_challenge_error",
 			business.AuditResultError, business.AuditSeverityMedium,
@@ -173,7 +173,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 		ServerTS:   serverTS,
 		IssuedAt:   issuedAt,
 	}, nonceTTL); err != nil {
-		s.logger.Error("Failed to store nonce in cache", "error", err)
+		s.logger.Error("Failed to store nonce in cache", "error", logging.SanitizeLogValue(err.Error()))
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSystemEvent, "refresh_challenge_error",
 			business.AuditResultError, business.AuditSeverityMedium,
@@ -192,7 +192,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 		Nonce:    base64.RawURLEncoding.EncodeToString(nonceBytes),
 		ServerTS: serverTS,
 	}); err != nil {
-		s.logger.Error("Failed to encode challenge response", "error", err)
+		s.logger.Error("Failed to encode challenge response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 
@@ -225,7 +225,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "device not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
+		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", logging.SanitizeLogValue(err.Error()))
 		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 			business.AuditEventSystemEvent, "refresh_error",
 			business.AuditResultError, business.AuditSeverityMedium,
@@ -352,7 +352,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 		}
 		policy, err := s.refreshPolicyStore.GetPolicy(r.Context(), record.TenantID)
 		if err != nil {
-			s.logger.Error("Failed to get refresh policy", "tenant_id", logging.SanitizeLogValue(record.TenantID), "error", err)
+			s.logger.Error("Failed to get refresh policy", "tenant_id", logging.SanitizeLogValue(record.TenantID), "error", logging.SanitizeLogValue(err.Error()))
 			s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 				business.AuditEventSystemEvent, "refresh_error",
 				business.AuditResultError, business.AuditSeverityMedium,
@@ -658,7 +658,7 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "pending refresh not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to get pending refresh", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to get pending refresh", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "failed to get pending refresh", http.StatusInternalServerError)
 		return
 	}
@@ -695,7 +695,7 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "steward not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to get steward for refresh approval", "device_id", logging.SanitizeLogValue(entry.DeviceID), "error", err)
+		s.logger.Error("Failed to get steward for refresh approval", "device_id", logging.SanitizeLogValue(entry.DeviceID), "error", logging.SanitizeLogValue(err.Error()))
 		s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
 			business.AuditEventSystemEvent, "refresh_admin_approve_error",
 			business.AuditResultError, business.AuditSeverityMedium,
@@ -720,7 +720,7 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 
 	certResp, err := s.buildRefreshClaimResponse(r.Context(), record)
 	if err != nil {
-		s.logger.Error("Failed to build refresh cert for approval", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to build refresh cert for approval", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
 			business.AuditEventSystemEvent, "refresh_admin_approve_error",
 			business.AuditResultError, business.AuditSeverityMedium,
@@ -733,19 +733,19 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 	// secure store for one-time authenticated retrieval; it is not logged.
 	bundle, err := json.Marshal(certResp)
 	if err != nil {
-		s.logger.Error("Failed to marshal claim bundle", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to marshal claim bundle", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "internal error serializing cert bundle", http.StatusInternalServerError)
 		return
 	}
 
 	if err := s.pendingRefreshStore.StoreClaimBundle(r.Context(), pendingID, bundle); err != nil {
-		s.logger.Error("Failed to store claim bundle", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to store claim bundle", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "failed to store claim bundle", http.StatusInternalServerError)
 		return
 	}
 
 	if err := s.pendingRefreshStore.UpdateRefreshStatus(r.Context(), pendingID, business.PendingRefreshStatusApproved); err != nil {
-		s.logger.Error("Failed to update refresh status to approved", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to update refresh status to approved", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "failed to update refresh status", http.StatusInternalServerError)
 		return
 	}
@@ -773,7 +773,7 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 		CACert:      certResp.CACert,
 		SigningCert: certResp.SigningCert,
 	}); err != nil {
-		s.logger.Error("Failed to encode approve response", "error", err)
+		s.logger.Error("Failed to encode approve response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 
@@ -796,7 +796,7 @@ func (s *Server) handleRejectRefresh(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "pending refresh not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to get pending refresh for rejection", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to get pending refresh for rejection", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "failed to get pending refresh", http.StatusInternalServerError)
 		return
 	}
@@ -818,7 +818,7 @@ func (s *Server) handleRejectRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.pendingRefreshStore.UpdateRefreshStatus(r.Context(), pendingID, business.PendingRefreshStatusRejected); err != nil {
-		s.logger.Error("Failed to update refresh status to rejected", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to update refresh status to rejected", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "failed to update refresh status", http.StatusInternalServerError)
 		return
 	}
@@ -859,7 +859,7 @@ func (s *Server) handleGetRefreshPolicy(w http.ResponseWriter, r *http.Request) 
 
 	policy, err := s.refreshPolicyStore.GetPolicy(r.Context(), tenantID)
 	if err != nil {
-		s.logger.Error("Failed to get refresh policy", "tenant_id", logging.SanitizeLogValue(tenantID), "error", err)
+		s.logger.Error("Failed to get refresh policy", "tenant_id", logging.SanitizeLogValue(tenantID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "failed to get refresh policy", http.StatusInternalServerError)
 		return
 	}
@@ -870,7 +870,7 @@ func (s *Server) handleGetRefreshPolicy(w http.ResponseWriter, r *http.Request) 
 		Mode:            policy.Mode,
 		MaxDormancyDays: policy.MaxDormancyDays,
 	}); err != nil {
-		s.logger.Error("Failed to encode refresh policy", "error", err)
+		s.logger.Error("Failed to encode refresh policy", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 
@@ -913,7 +913,7 @@ func (s *Server) handleSetRefreshPolicy(w http.ResponseWriter, r *http.Request) 
 		MaxDormancyDays: req.MaxDormancyDays,
 	}
 	if err := s.refreshPolicyStore.SetPolicy(r.Context(), policy); err != nil {
-		s.logger.Error("Failed to set refresh policy", "tenant_id", logging.SanitizeLogValue(tenantID), "error", err)
+		s.logger.Error("Failed to set refresh policy", "tenant_id", logging.SanitizeLogValue(tenantID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "failed to set refresh policy", http.StatusInternalServerError)
 		return
 	}
@@ -925,7 +925,7 @@ func (s *Server) handleSetRefreshPolicy(w http.ResponseWriter, r *http.Request) 
 		Mode:            req.Mode,
 		MaxDormancyDays: req.MaxDormancyDays,
 	}); err != nil {
-		s.logger.Error("Failed to encode refresh policy response", "error", err)
+		s.logger.Error("Failed to encode refresh policy response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -59,7 +59,7 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 	// Parse request body; detect removed single_use field.
 	var req createTokenRequestWithSingleUseCheck
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.logger.Warn("Failed to parse token create request", "error", err)
+		s.logger.Warn("Failed to parse token create request", "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -100,14 +100,14 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 	// Create token using registration package
 	token, err := registration.CreateToken(&req.TokenCreateRequest)
 	if err != nil {
-		s.logger.Error("Failed to create registration token", "error", err)
+		s.logger.Error("Failed to create registration token", "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to create token", http.StatusInternalServerError)
 		return
 	}
 
 	// Save token to store
 	if err := s.registrationTokenStore.SaveToken(r.Context(), token); err != nil {
-		s.logger.Error("Failed to save registration token", "error", err)
+		s.logger.Error("Failed to save registration token", "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to save token", http.StatusInternalServerError)
 		return
 	}
@@ -123,7 +123,7 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Error("Failed to encode token response", "error", err)
+		s.logger.Error("Failed to encode token response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 
@@ -425,7 +425,7 @@ func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Error("Failed to encode rotate token response", "error", err)
+		s.logger.Error("Failed to encode rotate token response", "error", logging.SanitizeLogValue(err.Error()))
 	}
 }
 

--- a/features/controller/api/handlers_roles.go
+++ b/features/controller/api/handlers_roles.go
@@ -124,7 +124,7 @@ func (s *Server) handleCreateRoleConfig(w http.ResponseWriter, r *http.Request) 
 
 	data, err := json.Marshal(rc)
 	if err != nil {
-		s.logger.Error("Failed to marshal role config", "error", err)
+		s.logger.Error("Failed to marshal role config", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to store role config", "INTERNAL_ERROR")
 		return
 	}
@@ -147,7 +147,7 @@ func (s *Server) handleCreateRoleConfig(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := s.roleConfigStore.StoreConfig(r.Context(), entry); err != nil {
-		s.logger.Error("Failed to store role config", "name", logging.SanitizeLogValue(req.Name), "error", err)
+		s.logger.Error("Failed to store role config", "name", logging.SanitizeLogValue(req.Name), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to store role config", "INTERNAL_ERROR")
 		return
 	}
@@ -189,14 +189,14 @@ func (s *Server) handleGetRoleConfig(w http.ResponseWriter, r *http.Request) {
 			s.writeErrorResponse(w, http.StatusNotFound, "Role config not found", "NOT_FOUND")
 			return
 		}
-		s.logger.Error("Failed to get role config", "name", logging.SanitizeLogValue(name), "error", err)
+		s.logger.Error("Failed to get role config", "name", logging.SanitizeLogValue(name), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to get role config", "INTERNAL_ERROR")
 		return
 	}
 
 	rc, err := unmarshalRoleConfig(entry)
 	if err != nil {
-		s.logger.Error("Failed to decode role config", "name", logging.SanitizeLogValue(name), "error", err)
+		s.logger.Error("Failed to decode role config", "name", logging.SanitizeLogValue(name), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decode role config", "INTERNAL_ERROR")
 		return
 	}
@@ -277,7 +277,7 @@ func (s *Server) handleDeleteRoleConfig(w http.ResponseWriter, r *http.Request) 
 			s.writeErrorResponse(w, http.StatusNotFound, "Role config not found", "NOT_FOUND")
 			return
 		}
-		s.logger.Error("Failed to delete role config", "name", logging.SanitizeLogValue(name), "error", err)
+		s.logger.Error("Failed to delete role config", "name", logging.SanitizeLogValue(name), "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to delete role config", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_rollout.go
+++ b/features/controller/api/handlers_rollout.go
@@ -86,7 +86,7 @@ func (s *Server) handleStartRollout(w http.ResponseWriter, r *http.Request) {
 
 	var req startRolloutRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.logger.Warn("Failed to decode start rollout body", "error", err)
+		s.logger.Warn("Failed to decode start rollout body", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_BODY")
 		return
 	}
@@ -144,7 +144,7 @@ func (s *Server) handleStartRollout(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.rolloutStore.CreateRollout(r.Context(), record); err != nil {
 		s.logger.Error("Failed to create rollout record",
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 			"target_version", logging.SanitizeLogValue(req.TargetVersion))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create rollout record", "CREATE_RECORD_ERROR")
 		return
@@ -201,7 +201,7 @@ func (s *Server) handleGetRollout(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.logger.Error("Failed to retrieve rollout record",
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 			"rollout_id", logging.SanitizeLogValue(rolloutID))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve rollout record", "GET_RECORD_ERROR")
 		return
@@ -282,7 +282,7 @@ func (s *Server) handleHaltRollout(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.logger.Error("Failed to retrieve rollout record for halt",
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 			"rollout_id", logging.SanitizeLogValue(rolloutID))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve rollout record", "GET_RECORD_ERROR")
 		return
@@ -318,7 +318,7 @@ func (s *Server) handleHaltRollout(w http.ResponseWriter, r *http.Request) {
 		business.RolloutStatusHalted, record.CurrentRing, record.RingsCompleted,
 		&now, "halted by operator"); updErr != nil {
 		s.logger.Warn("Failed to persist halt for rollout",
-			"rollout_id", logging.SanitizeLogValue(rolloutID), "error", updErr)
+			"rollout_id", logging.SanitizeLogValue(rolloutID), "error", logging.SanitizeLogValue(updErr.Error()))
 	}
 
 	s.logger.Info("Rollout halted by operator",

--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -275,7 +275,7 @@ func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Error("Failed to synthesize script run",
 			"script_id", logging.SanitizeLogValue(req.ScriptID),
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 		)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create run", "INTERNAL_ERROR")
 		return
@@ -393,7 +393,7 @@ func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Error("Failed to synthesize command run",
 			"shell", logging.SanitizeLogValue(req.Shell),
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 		)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create run", "INTERNAL_ERROR")
 		return

--- a/features/controller/api/handlers_scripts.go
+++ b/features/controller/api/handlers_scripts.go
@@ -177,7 +177,7 @@ func (s *Server) handlePutScriptPrivilege(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.storePrivilegeMetadata(r.Context(), tenantID, id, meta); err != nil {
-		s.logger.Error("Failed to store privilege metadata", "id", sanitizedID, "error", err)
+		s.logger.Error("Failed to store privilege metadata", "id", sanitizedID, "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to store privilege metadata", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_sessions.go
+++ b/features/controller/api/handlers_sessions.go
@@ -55,7 +55,7 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Error("Failed to issue session",
 			"principal_id", logging.SanitizeLogValue(principal.ID),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create session", "SESSION_CREATE_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_steward_binary.go
+++ b/features/controller/api/handlers_steward_binary.go
@@ -149,7 +149,7 @@ func (s *Server) handlePublishStewardBinary(w http.ResponseWriter, r *http.Reque
 	// Buffer the binary body to compute SHA-256 for signature verification.
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		s.logger.Error("Failed to read request body", "error", err)
+		s.logger.Error("Failed to read request body", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read request body", "READ_ERROR")
 		return
 	}
@@ -241,7 +241,7 @@ func (s *Server) handlePublishStewardBinary(w http.ResponseWriter, r *http.Reque
 	rc, storedMeta, err := s.blobStore.GetBlob(r.Context(), key)
 	if err != nil {
 		s.logger.Error("Failed to retrieve stored steward binary metadata",
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 			"version", logging.SanitizeLogValue(version),
 			"platform", logging.SanitizeLogValue(platform),
 			"arch", logging.SanitizeLogValue(arch))

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -157,7 +157,7 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 			s.logger.Warn("Rejected steward list pagination params",
 				"limit", logging.SanitizeLogValue(r.URL.Query().Get("limit")),
 				"offset", logging.SanitizeLogValue(r.URL.Query().Get("offset")),
-				"error", paginErr)
+				"error", logging.SanitizeLogValue(paginErr.Error()))
 			s.writeErrorResponse(w, http.StatusBadRequest, paginErr.Error(), "INVALID_PAGINATION")
 			return
 		}
@@ -221,7 +221,7 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 		s.logger.Warn("Rejected steward list pagination params",
 			"limit", logging.SanitizeLogValue(r.URL.Query().Get("limit")),
 			"offset", logging.SanitizeLogValue(r.URL.Query().Get("offset")),
-			"error", err)
+			"error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusBadRequest, err.Error(), "INVALID_PAGINATION")
 		return
 	}
@@ -230,7 +230,7 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 	if !isEmptyFilter(filter) {
 		results, err := s.fleetQuery.Search(r.Context(), filter)
 		if err != nil {
-			s.logger.Error("Fleet query failed", "error", err)
+			s.logger.Error("Fleet query failed", "error", logging.SanitizeLogValue(err.Error()))
 			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to query fleet", "INTERNAL_ERROR")
 			return
 		}
@@ -804,7 +804,7 @@ func (s *Server) handleValidateConfig(w http.ResponseWriter, r *http.Request) {
 	// Call gRPC service
 	validationResp, err := s.configService.ValidateConfig(context.Background(), req)
 	if err != nil {
-		s.logger.Error("Failed to validate configuration", "steward_id", stewardIDForLog, "error", err)
+		s.logger.Error("Failed to validate configuration", "steward_id", stewardIDForLog, "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to validate configuration", "INTERNAL_ERROR")
 		return
 	}

--- a/features/controller/api/handlers_upgrade.go
+++ b/features/controller/api/handlers_upgrade.go
@@ -91,7 +91,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 
 	var req dispatchUpgradeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.logger.Warn("Failed to decode dispatch upgrade body", "error", err)
+		s.logger.Warn("Failed to decode dispatch upgrade body", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_BODY")
 		return
 	}
@@ -147,7 +147,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 	// Resolve matching stewards.
 	stewards, err := s.fleetQuery.Search(r.Context(), filter)
 	if err != nil {
-		s.logger.Error("Fleet query failed during upgrade dispatch", "error", err)
+		s.logger.Error("Fleet query failed during upgrade dispatch", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Fleet query failed", "FLEET_QUERY_ERROR")
 		return
 	}
@@ -169,7 +169,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 				"BINARY_NOT_FOUND")
 			return
 		}
-		s.logger.Error("Failed to retrieve steward binary", "error", err)
+		s.logger.Error("Failed to retrieve steward binary", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve binary", "GET_BINARY_ERROR")
 		return
 	}
@@ -178,7 +178,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 	blobContent, err := io.ReadAll(rc)
 	_ = rc.Close()
 	if err != nil {
-		s.logger.Error("Failed to read steward binary for SHA-256 recompute", "error", err)
+		s.logger.Error("Failed to read steward binary for SHA-256 recompute", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read binary", "READ_BINARY_ERROR")
 		return
 	}
@@ -201,7 +201,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 	if sigBase64 != "" {
 		bundleSig, err = base64.RawURLEncoding.DecodeString(sigBase64)
 		if err != nil {
-			s.logger.Error("Failed to decode bundle signature from blob label", "error", err)
+			s.logger.Error("Failed to decode bundle signature from blob label", "error", logging.SanitizeLogValue(err.Error()))
 			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decode signature", "SIGNATURE_DECODE_ERROR")
 			return
 		}
@@ -413,7 +413,7 @@ func (s *Server) handleUpgradeStatus(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.logger.Error("Failed to retrieve upgrade record",
-			"error", err,
+			"error", logging.SanitizeLogValue(err.Error()),
 			"upgrade_id", logging.SanitizeLogValue(upgradeID))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve upgrade record", "GET_RECORD_ERROR")
 		return
@@ -467,7 +467,7 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 			s.writeErrorResponse(w, http.StatusNotFound, "Upgrade record not found", "UPGRADE_NOT_FOUND")
 			return
 		}
-		s.logger.Error("Failed to retrieve upgrade record for rollback", "error", err)
+		s.logger.Error("Failed to retrieve upgrade record for rollback", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve upgrade record", "GET_RECORD_ERROR")
 		return
 	}
@@ -516,7 +516,7 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 				"BINARY_NOT_FOUND")
 			return
 		}
-		s.logger.Error("Failed to retrieve rollback binary", "error", err)
+		s.logger.Error("Failed to retrieve rollback binary", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve binary", "GET_BINARY_ERROR")
 		return
 	}
@@ -524,7 +524,7 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 	blobContent, err := io.ReadAll(rc)
 	_ = rc.Close()
 	if err != nil {
-		s.logger.Error("Failed to read rollback binary for SHA-256 recompute", "error", err)
+		s.logger.Error("Failed to read rollback binary for SHA-256 recompute", "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read binary", "READ_BINARY_ERROR")
 		return
 	}
@@ -545,7 +545,7 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 	if sigBase64 != "" {
 		bundleSig, err = base64.RawURLEncoding.DecodeString(sigBase64)
 		if err != nil {
-			s.logger.Error("Failed to decode bundle signature for rollback", "error", err)
+			s.logger.Error("Failed to decode bundle signature for rollback", "error", logging.SanitizeLogValue(err.Error()))
 			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decode signature", "SIGNATURE_DECODE_ERROR")
 			return
 		}

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -192,7 +192,7 @@ func (h *WorkflowHandler) handleCreateWorkflow(w http.ResponseWriter, r *http.Re
 	store := h.workflowStoreForRequest(r)
 	nameForLog := logging.SanitizeLogValue(req.Name)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
-		h.logger.Error("Failed to create workflow", "name", nameForLog, "error", err)
+		h.logger.Error("Failed to create workflow", "name", nameForLog, "error", logging.SanitizeLogValue(err.Error()))
 		h.sendError(w, http.StatusInternalServerError, "failed to create workflow")
 		return
 	}
@@ -217,7 +217,7 @@ func (h *WorkflowHandler) handleGetWorkflow(w http.ResponseWriter, r *http.Reque
 	store := h.workflowStoreForRequest(r)
 	vw, err := store.GetLatestWorkflow(r.Context(), name)
 	if err != nil {
-		h.logger.Error("Failed to get workflow", "name", nameForLog, "error", err)
+		h.logger.Error("Failed to get workflow", "name", nameForLog, "error", logging.SanitizeLogValue(err.Error()))
 		h.sendError(w, http.StatusNotFound, fmt.Sprintf("workflow %q not found", name))
 		return
 	}
@@ -275,7 +275,7 @@ func (h *WorkflowHandler) handleUpdateWorkflow(w http.ResponseWriter, r *http.Re
 	nameForLog := logging.SanitizeLogValue(name)
 	store := h.workflowStoreForRequest(r)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
-		h.logger.Error("Failed to update workflow", "name", nameForLog, "error", err)
+		h.logger.Error("Failed to update workflow", "name", nameForLog, "error", logging.SanitizeLogValue(err.Error()))
 		h.sendError(w, http.StatusInternalServerError, "failed to update workflow")
 		return
 	}
@@ -302,7 +302,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 	// Retrieve all versions to delete
 	versions, err := store.ListWorkflowVersions(r.Context(), name)
 	if err != nil {
-		h.logger.Error("Failed to list workflow versions for deletion", "name", nameForLog, "error", err)
+		h.logger.Error("Failed to list workflow versions for deletion", "name", nameForLog, "error", logging.SanitizeLogValue(err.Error()))
 		h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 		return
 	}
@@ -314,7 +314,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 	for _, vw := range versions {
 		if err := store.DeleteWorkflow(r.Context(), name, vw.SemanticVersion); err != nil {
 			versionForLog := logging.SanitizeLogValue(vw.SemanticVersion.String())
-			h.logger.Error("Failed to delete workflow version", "name", nameForLog, "version", versionForLog, "error", err)
+			h.logger.Error("Failed to delete workflow version", "name", nameForLog, "version", versionForLog, "error", logging.SanitizeLogValue(err.Error()))
 			h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 			return
 		}
@@ -360,7 +360,7 @@ func (h *WorkflowHandler) handleExecuteWorkflow(w http.ResponseWriter, r *http.R
 	nameForLog := logging.SanitizeLogValue(name)
 	execution, err := h.engine.ExecuteWorkflow(r.Context(), vw.Workflow, req.Variables)
 	if err != nil {
-		h.logger.Error("Failed to execute workflow", "name", nameForLog, "error", err)
+		h.logger.Error("Failed to execute workflow", "name", nameForLog, "error", logging.SanitizeLogValue(err.Error()))
 		h.sendError(w, http.StatusInternalServerError, "failed to start workflow execution")
 		return
 	}

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -493,7 +493,7 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 		if !exists {
 			loadedKey, err := s.loadAPIKeyFromStore(r.Context(), apiKeyStr)
 			if err != nil {
-				s.logger.Debug("Failed to load API key from store", "error", err)
+				s.logger.Debug("Failed to load API key from store", "error", logging.SanitizeLogValue(err.Error()))
 				s.writeErrorResponse(w, http.StatusUnauthorized, "Invalid API key", "INVALID_API_KEY")
 				return
 			}

--- a/features/controller/api/rollback_handler.go
+++ b/features/controller/api/rollback_handler.go
@@ -239,7 +239,7 @@ func (h *RollbackHandler) ExecuteRollback(w http.ResponseWriter, r *http.Request
 		if err := h.auditManager.RecordEvent(ctx, event); err != nil {
 			h.logger.Warn("Failed to emit rollback audit event",
 				"rollback_id", logging.SanitizeLogValue(operation.ID),
-				"error", err)
+				"error", logging.SanitizeLogValue(err.Error()))
 		}
 	}
 

--- a/features/reports/api/handlers.go
+++ b/features/reports/api/handlers.go
@@ -85,7 +85,7 @@ func (h *Handler) generateReport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	h.setExportHeaders(w, req.Format, report.ID)
 	if _, err := w.Write(exportData); err != nil {
-		h.logger.Error("failed to write export data", "error", err)
+		h.logger.Error("failed to write export data", "error", logging.SanitizeLogValue(err.Error()))
 		// Can't return error to client at this point as headers are already sent
 	}
 

--- a/scripts/lint-log-injection/main.go
+++ b/scripts/lint-log-injection/main.go
@@ -390,7 +390,123 @@ func collectTaintedVars(root ast.Node) map[string]struct{} {
 		return true
 	})
 
+	// Propagate taint through error returns. An error produced by a call that
+	// received tainted input carries that input back out inside its message
+	// text -- a gRPC status, a store lookup, or a decode all quote the offending
+	// value -- so logging that error bare is the same injection as logging the
+	// value. This is the shape that kept reaching acceptance review: the obvious
+	// taint (a path var) gets sanitized and `err` beside it does not.
+	//
+	// Iterated to a fixed point so a chain (tainted arg -> err -> wrapped err)
+	// resolves. Five rounds is far beyond any real handler's depth and bounds a
+	// pathological input.
+	for i := 0; i < 5; i++ {
+		changed := false
+		ast.Inspect(root, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok || len(assign.Rhs) != 1 {
+				return true
+			}
+			call, ok := assign.Rhs[0].(*ast.CallExpr)
+			if !ok || transmitsWithoutEchoing(call) || !anyArgTainted(call.Args, tainted) {
+				return true
+			}
+			for _, lhs := range assign.Lhs {
+				id, ok := lhs.(*ast.Ident)
+				if !ok || !looksLikeErrorVar(id.Name) {
+					continue
+				}
+				if _, already := tainted[id.Name]; already {
+					continue
+				}
+				tainted[id.Name] = struct{}{}
+				changed = true
+			}
+			return true
+		})
+		if !changed {
+			break
+		}
+	}
+
 	return tainted
+}
+
+// transmitOnlyMethods send bytes somewhere. Their errors describe the transport
+// -- a closed socket, a short write -- and never quote the payload, so a tainted
+// argument does not make the returned error tainted. Distinguishing these from
+// calls that parse or look up the value (a decode error quotes the offending
+// input, a gRPC status quotes the rejected field) is what keeps this rule from
+// flagging every `w.Write` error in the codebase.
+var transmitOnlyMethods = map[string]struct{}{
+	"Write": {}, "WriteString": {}, "WriteHeader": {}, "Writeln": {},
+	"Flush": {}, "Close": {}, "Copy": {}, "CopyN": {},
+	"Fprint": {}, "Fprintf": {}, "Fprintln": {}, "Print": {}, "Printf": {}, "Println": {},
+}
+
+// transmitsWithoutEchoing reports whether a call only ships its arguments
+// onward, so its error cannot carry them back.
+func transmitsWithoutEchoing(call *ast.CallExpr) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		_, ok := transmitOnlyMethods[fn.Sel.Name]
+		return ok
+	case *ast.Ident:
+		_, ok := transmitOnlyMethods[fn.Name]
+		return ok
+	}
+	return false
+}
+
+// looksLikeErrorVar reports whether a variable name denotes an error value.
+// Name-based rather than type-based because this linter parses without type
+// information; Go's own naming convention makes it reliable in practice.
+func looksLikeErrorVar(name string) bool {
+	return name == "err" || strings.HasSuffix(name, "Err") || strings.HasSuffix(name, "Error")
+}
+
+// anyArgTainted reports whether any argument carries tainted data, looking
+// through the wrappers a request argument is normally built with: `&pb.Req{...}`,
+// a composite literal's field values, and nested calls like `proto.String(id)`.
+func anyArgTainted(args []ast.Expr, tainted map[string]struct{}) bool {
+	for _, a := range args {
+		if exprCarriesTaint(a, tainted) {
+			return true
+		}
+	}
+	return false
+}
+
+func exprCarriesTaint(e ast.Expr, tainted map[string]struct{}) bool {
+	if e == nil {
+		return false
+	}
+	if isTaintedExpr(e, tainted) {
+		return true
+	}
+	switch v := e.(type) {
+	case *ast.UnaryExpr:
+		return exprCarriesTaint(v.X, tainted)
+	case *ast.ParenExpr:
+		return exprCarriesTaint(v.X, tainted)
+	case *ast.CompositeLit:
+		for _, el := range v.Elts {
+			if kv, ok := el.(*ast.KeyValueExpr); ok {
+				if exprCarriesTaint(kv.Value, tainted) {
+					return true
+				}
+				continue
+			}
+			if exprCarriesTaint(el, tainted) {
+				return true
+			}
+		}
+	case *ast.CallExpr:
+		return anyArgTainted(v.Args, tainted)
+	case *ast.BinaryExpr:
+		return exprCarriesTaint(v.X, tainted) || exprCarriesTaint(v.Y, tainted)
+	}
+	return false
 }
 
 // isTaintSourceExpr returns true if the expression is a known HTTP taint source.

--- a/scripts/lint-log-injection/main_test.go
+++ b/scripts/lint-log-injection/main_test.go
@@ -187,6 +187,96 @@ func TestIsScalarType(t *testing.T) {
 // analyzeSnippet writes src to a temp file and runs the linter against it,
 // returning the findings. This avoids exporting analyzeFile's internals while
 // letting each table-test case use a focused, readable fixture inline.
+// TestAnalyzeFile_FlagsBareErrorFromTaintedCall covers the defect class that kept
+// reaching acceptance review: the obvious taint gets sanitized and the error
+// returned by the same call does not. An error from a decode, lookup, or gRPC
+// call quotes the offending value in its message, so logging it bare is the same
+// injection as logging the value.
+func TestAnalyzeFile_FlagsBareErrorFromTaintedCall(t *testing.T) {
+	src := `package api
+import "net/http"
+import "github.com/gorilla/mux"
+type S struct{ logger logger; client client }
+type client interface{ GetRole(string) (string, error) }
+type logger interface{ Error(string, ...any) }
+func (s *S) handle(w http.ResponseWriter, r *http.Request) {
+	roleID := mux.Vars(r)["id"]
+	_, err := s.client.GetRole(roleID)
+	s.logger.Error("Failed to get role", "role_id", logging.SanitizeLogValue(roleID), "error", err)
+}
+`
+	findings := analyzeSnippet(t, src)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for the bare err, got %d: %v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].msg, `"err"`) {
+		t.Errorf("expected the finding to name err, got %q", findings[0].msg)
+	}
+}
+
+// TestAnalyzeFile_AcceptsSanitizedError is the negative half: the documented
+// remedy must actually clear the finding, or the rule is unsatisfiable.
+func TestAnalyzeFile_AcceptsSanitizedError(t *testing.T) {
+	src := `package api
+import "net/http"
+import "github.com/gorilla/mux"
+type S struct{ logger logger; client client }
+type client interface{ GetRole(string) (string, error) }
+type logger interface{ Error(string, ...any) }
+func (s *S) handle(w http.ResponseWriter, r *http.Request) {
+	roleID := mux.Vars(r)["id"]
+	_, err := s.client.GetRole(roleID)
+	s.logger.Error("Failed to get role", "error", logging.SanitizeLogValue(err.Error()))
+}
+`
+	if findings := analyzeSnippet(t, src); len(findings) != 0 {
+		t.Fatalf("expected no findings for a sanitized error, got %v", findings)
+	}
+}
+
+// TestAnalyzeFile_SkipsErrorFromTransmitOnlyCall guards the false positive found
+// while building this rule: `w.Write(taintedBytes)` fails because the socket
+// closed, not because of the payload, so its error cannot carry the payload back.
+// Flagging every response-write error would put the lint back in the category
+// developers learn to bypass.
+func TestAnalyzeFile_SkipsErrorFromTransmitOnlyCall(t *testing.T) {
+	src := `package api
+import "net/http"
+import "github.com/gorilla/mux"
+type S struct{ logger logger }
+type logger interface{ Error(string, ...any) }
+func (s *S) handle(w http.ResponseWriter, r *http.Request) {
+	body := []byte(mux.Vars(r)["id"])
+	if _, err := w.Write(body); err != nil {
+		s.logger.Error("failed to write response", "error", err)
+	}
+}
+`
+	if findings := analyzeSnippet(t, src); len(findings) != 0 {
+		t.Fatalf("expected no findings for a transmit-only error, got %v", findings)
+	}
+}
+
+// TestAnalyzeFile_SkipsErrorFromUntaintedCall keeps the rule from degenerating
+// into "sanitize every error everywhere": a call that never saw user input
+// produces an error that cannot carry it.
+func TestAnalyzeFile_SkipsErrorFromUntaintedCall(t *testing.T) {
+	src := `package api
+import "net/http"
+type S struct{ logger logger; store store }
+type store interface{ Ping() error }
+type logger interface{ Error(string, ...any) }
+func (s *S) handle(w http.ResponseWriter, r *http.Request) {
+	if err := s.store.Ping(); err != nil {
+		s.logger.Error("store unreachable", "error", err)
+	}
+}
+`
+	if findings := analyzeSnippet(t, src); len(findings) != 0 {
+		t.Fatalf("expected no findings for an untainted error, got %v", findings)
+	}
+}
+
 func analyzeSnippet(t *testing.T, src string) []finding {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
Two root causes behind measured fix-round spend, found by classifying all 26 fix rounds in the dispatch ledger.

## Why

Across 60 stories: rework is **$238.69 of $710.87 (33.6%)**. 35% of stories need a fix round, and those roughly double in cost. **Only 2 of 16 fix rounds were triggered by failing CI** — thirteen had every required check green.

| Root cause | Cost | PRs |
|---|---|---|
| AC not satisfied despite green CI | ~$131.68 | 3087, 3119, 3050, 3146, 3144, 3021, 3121, 3122, 3117 |
| **GHAS log-injection (mechanical, repeating)** | **~$68.62** | 2896, 3142, 3145 |
| `frontend-checks` failure | $15.67 | 3008, 3115 |
| **Review ran on a CONFLICTING PR** | **$10.97** | 3049 |
| Merge-queue eviction, Windows-only test | $7.93 | 3139 |
| Merge conflicts only (`resolve-conflict`) | $3.74 | 5 PRs |

This PR addresses rows 2 and 4. Actual conflict resolution is nearly free ($3.74 across 5 PRs) — conflicts are not the problem; *reviewing around* one is.

## 1. Logged error values

CLAUDE.md named only "HTTP params, URL paths, headers" as needing `SanitizeLogValue`, so agents sanitized the ID and left `err` bare in the same call. PR #3145 carried four such High findings. An error from a gRPC, store, or decode call quotes the offending value in its message, so logging it bare is the same injection.

`scripts/lint-log-injection` already existed as a Go AST linter wired into `make test-commit` and the pre-commit hook, but never marked an error tainted — taint flowed from HTTP sources into variables and stopped. This adds propagation through error returns, iterated to a fixed point.

**Transmit-only calls are excluded.** `w.Write(taintedBytes)` fails because the socket closed, not because of the payload, so its error cannot carry the payload back. Found as a false positive while building this; flagging every response-write error would put the lint in the category developers learn to bypass.

Enabling the rule surfaced **100 pre-existing sites across 21 files** under `features/**/api/` that would have broken `make test-commit`. Per the DSD rule they were in scope — all fixed here, 100 insertions / 100 deletions, 1:1.

Documented limitation: taint is keyed by variable name and `err` is reused throughout a handler, so one tainted assignment marks every `err` in that function. That is why the count is 100 rather than a handful.

## 2. Reviewing a conflicted PR

A DIRTY PR has no merge ref, so GitHub runs **no** `pull_request` workflow and every required check is absent. #3049 was reviewed in that state, FAILed partly for CI that could never have run, and a fix agent was dispatched against a branch whose real problem was a conflict.

`po-cycle-preflight.py:1400` already ranks `rebase` ahead of review for DIRTY, but that is advisory and a direct `review-pr <N>` bypasses it — the same argument documented on `_review_is_stale`, which this guard sits beside. The dispatcher is the enforcement point.

`mergeStateStatus` rides along in the `gh pr view` call `review-pr` already makes, so no extra API request. **Only exact `DIRTY` refuses:** `UNKNOWN` means GitHub is still computing mergeability, and `BEHIND`/`BLOCKED` are the merge queue's business — refusing on those would strand reviewable PRs.

## Deliberately not included

A grep check for "new exported function nothing calls" was built and dropped:

- It never caught its motivating case (**PR #3087** — two new methods delegate to each other, so each has a genuine non-test reference and the pair looks wired while the outermost is never reached from production).
- Its true false-positive rate is **34.2%** of plain functions once doc comments are excluded from the reference count. Go opens a doc comment with the function's own name, which had masked the rate as 0.5%. Unused public API is normal in a pluggable-provider codebase.

Proving reachability from a production entry point needs call-graph analysis, not grep. Tracked separately.

## Validation

- 4 new linter cases: the flagged shape, the documented remedy, the transmit-only exclusion, an untainted error (**11 pass**)
- 5 new `review-pr` cases: DIRTY refusal plus the four states that must not refuse (**54 pass**)
- `make test` green (208/208 script tests) · `lint-log-injection` green · `check-architecture` clean · `gofmt` clean

Relates to epic #3026 (pipeline cost engineering); no story issue exists, so no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo