### PR TITLE
logging: stop the provider registry writing to stdout, and name the read patterns that cost most (Issue #3026)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,23 @@ Use the right tool per question; never trust one weak query for "what's been don
 
 Call serena's `initial_instructions` at the start of a coding task to load its manual.
 
+**What a wide read actually costs.** Every tool result stays in context and is re-billed
+on every later call in the session, so a read's price is its size × how many calls
+follow it — not a one-off. Two patterns dominate measured spend, and both have a
+cheap alternative:
+
+- **Re-reading slices of one large file.** Reading a file, then re-reading it around
+  a different line, repeatedly, is the single largest context cost measured (one
+  session read `client_transport.go` 63 times). Get the shape once with
+  `get_symbols_overview`, jump to the symbol with `find_symbol`, and when a raw
+  slice is genuinely needed pass `offset`/`limit` instead of pulling the file again.
+- **Bare `git diff` on a wide change.** The whole diff lands in context and stays
+  there. Use `git diff --stat` to see the shape, then `git diff -- <path>` for the
+  file being worked.
+
+The same reasoning covers any large command output: prefer the narrow query, and
+redirect a long run to a file and grep it rather than inlining the whole thing.
+
 ## Desired State Development (DSD)
 
 Stories are outcome-based. Work is complete only when the entire system reflects the desired end state.

--- a/pkg/logging/interfaces/provider.go
+++ b/pkg/logging/interfaces/provider.go
@@ -15,6 +15,55 @@ import (
 	"time"
 )
 
+// RegistrySink is the minimal logging surface the provider registry needs to
+// report registration events.
+//
+// Declared here rather than reusing pkg/logging.Logger because pkg/logging
+// imports THIS package — taking the dependency the other way is an import cycle.
+// The method set is a subset of pkg/logging.Logger, so a real Logger satisfies
+// this interface implicitly and callers can pass one straight in; that is what
+// SetRegistryLogger is for. pkg/storage/interfaces solves the same problem with a
+// direct pkg/logging import, which is available to it and not to us.
+type RegistrySink interface {
+	Info(msg string, keysAndValues ...interface{})
+	Warn(msg string, keysAndValues ...interface{})
+}
+
+// noopSink discards registration messages. It is the default deliberately: this
+// registry is populated by package init() functions in every binary and in every
+// test binary, and the previous default wrote to stdout with fmt.Printf. That put
+// provider chatter into the output of every `go test` run — 701 such lines were
+// measured being carried through agent context — and a library writing to a
+// process's stdout is wrong regardless of who is reading it.
+type noopSink struct{}
+
+func (noopSink) Info(string, ...interface{}) {}
+func (noopSink) Warn(string, ...interface{}) {}
+
+var (
+	registrySinkMu sync.RWMutex
+	registrySink   RegistrySink = noopSink{}
+)
+
+// SetRegistryLogger routes logging-provider registration messages to a real
+// logger. Safe to call concurrently with the Register* functions. Passing nil
+// restores the no-op sink rather than panicking on the next registration.
+func SetRegistryLogger(l RegistrySink) {
+	registrySinkMu.Lock()
+	defer registrySinkMu.Unlock()
+	if l == nil {
+		registrySink = noopSink{}
+		return
+	}
+	registrySink = l
+}
+
+func getRegistrySink() RegistrySink {
+	registrySinkMu.RLock()
+	defer registrySinkMu.RUnlock()
+	return registrySink
+}
+
 // LoggingProvider defines the interface that all logging backends must implement.
 // Unlike storage providers which handle CRUD operations, logging providers are optimized
 // for high-volume append-only writes with time-based queries and retention policies.
@@ -368,7 +417,7 @@ type loggingProviderRegistry struct {
 func RegisterLoggingProvider(provider LoggingProvider) {
 	if err := validateLoggingProvider(provider); err != nil {
 		// Log the error but don't panic - allows system to start with other providers
-		fmt.Printf("Warning: Failed to register logging provider '%s': %v\n", provider.Name(), err)
+		getRegistrySink().Warn(fmt.Sprintf("Failed to register logging provider '%s': %v", provider.Name(), err))
 		return
 	}
 
@@ -377,13 +426,13 @@ func RegisterLoggingProvider(provider LoggingProvider) {
 
 	// Check for duplicate registration
 	if existing, exists := globalLoggingRegistry.providers[provider.Name()]; exists {
-		fmt.Printf("Warning: Overwriting existing logging provider '%s' (version %s) with version %s\n",
-			provider.Name(), existing.GetVersion(), provider.GetVersion())
+		getRegistrySink().Warn(fmt.Sprintf("Overwriting existing logging provider '%s' (version %s) with version %s",
+			provider.Name(), existing.GetVersion(), provider.GetVersion()))
 	}
 
 	globalLoggingRegistry.providers[provider.Name()] = provider
-	fmt.Printf("Registered logging provider: %s v%s - %s\n",
-		provider.Name(), provider.GetVersion(), provider.Description())
+	getRegistrySink().Info(fmt.Sprintf("Registered logging provider: %s v%s - %s",
+		provider.Name(), provider.GetVersion(), provider.Description()))
 }
 
 // validateLoggingProvider ensures a provider implements all required interfaces correctly
@@ -408,7 +457,7 @@ func validateLoggingProvider(provider LoggingProvider) error {
 	// Test provider availability (non-blocking)
 	if available, err := provider.Available(); !available && err != nil {
 		// Provider not available is OK (might need setup), but returning error suggests implementation issue
-		fmt.Printf("Note: Logging provider '%s' reports as unavailable: %v\n", provider.Name(), err)
+		getRegistrySink().Info(fmt.Sprintf("Logging provider '%s' reports as unavailable: %v", provider.Name(), err))
 	}
 
 	// Validate provider capabilities
@@ -439,11 +488,11 @@ func validateLoggingProvider(provider LoggingProvider) error {
 func RegisterLoggingProviderFactory(factory LoggingProviderFactory) {
 	template := factory()
 	if template == nil {
-		fmt.Printf("Warning: LoggingProviderFactory returned nil instance\n")
+		getRegistrySink().Warn("LoggingProviderFactory returned nil instance")
 		return
 	}
 	if err := validateLoggingProvider(template); err != nil {
-		fmt.Printf("Warning: Failed to register logging provider factory '%s': %v\n", template.Name(), err)
+		getRegistrySink().Warn(fmt.Sprintf("Failed to register logging provider factory '%s': %v", template.Name(), err))
 		return
 	}
 
@@ -452,14 +501,14 @@ func RegisterLoggingProviderFactory(factory LoggingProviderFactory) {
 
 	name := template.Name()
 	if existing, exists := globalLoggingRegistry.providers[name]; exists {
-		fmt.Printf("Warning: Overwriting existing logging provider '%s' (version %s) with factory version %s\n",
-			name, existing.GetVersion(), template.GetVersion())
+		getRegistrySink().Warn(fmt.Sprintf("Overwriting existing logging provider '%s' (version %s) with factory version %s",
+			name, existing.GetVersion(), template.GetVersion()))
 	}
 	// Store the template for capability/availability introspection and the factory for instance creation.
 	globalLoggingRegistry.providers[name] = template
 	globalLoggingRegistry.factories[name] = factory
-	fmt.Printf("Registered logging provider factory: %s v%s - %s\n",
-		name, template.GetVersion(), template.Description())
+	getRegistrySink().Info(fmt.Sprintf("Registered logging provider factory: %s v%s - %s",
+		name, template.GetVersion(), template.Description()))
 }
 
 // GetLoggingProvider retrieves a registered provider by name.

--- a/pkg/logging/interfaces/registry_sink_test.go
+++ b/pkg/logging/interfaces/registry_sink_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package interfaces
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The logging provider registry is populated by package init() functions, so it
+// runs in every binary AND every test binary. It used to report registration with
+// fmt.Printf, putting provider chatter on stdout for every `go test -v` run: two
+// lines per run here, and 701 such lines were measured being carried through
+// agent context. A library writing to a process's stdout is wrong regardless of
+// who reads it.
+//
+// These tests pin both halves of the fix, because a change that only silenced the
+// output would pass a stdout assertion while destroying the diagnostic:
+//   - nothing reaches stdout, and
+//   - the message still reaches a configured sink.
+
+// stubLoggingProvider is a test implementation of LoggingProvider — enough surface
+// to pass validateLoggingProvider and reach the registration message. Zero-value
+// LoggingCapabilities satisfies every bound the validator checks.
+type stubLoggingProvider struct {
+	name      string
+	available bool
+	availErr  error
+}
+
+func (s *stubLoggingProvider) Name() string        { return s.name }
+func (s *stubLoggingProvider) Description() string { return "stub provider for registry tests" }
+func (s *stubLoggingProvider) GetVersion() string  { return "0.0.1" }
+func (s *stubLoggingProvider) Available() (bool, error) {
+	return s.available, s.availErr
+}
+func (s *stubLoggingProvider) GetCapabilities() LoggingCapabilities { return LoggingCapabilities{} }
+func (s *stubLoggingProvider) Initialize(map[string]interface{}) error {
+	return nil
+}
+func (s *stubLoggingProvider) Close() error                               { return nil }
+func (s *stubLoggingProvider) WriteEntry(context.Context, LogEntry) error { return nil }
+func (s *stubLoggingProvider) WriteBatch(context.Context, []LogEntry) error {
+	return nil
+}
+func (s *stubLoggingProvider) QueryTimeRange(context.Context, TimeRangeQuery) ([]LogEntry, error) {
+	return nil, nil
+}
+func (s *stubLoggingProvider) QueryCount(context.Context, CountQuery) (int64, error) {
+	return 0, nil
+}
+func (s *stubLoggingProvider) QueryLevels(context.Context, LevelQuery) ([]LogEntry, error) {
+	return nil, nil
+}
+func (s *stubLoggingProvider) ApplyRetentionPolicy(context.Context, RetentionPolicy) error {
+	return nil
+}
+func (s *stubLoggingProvider) GetStats(context.Context) (ProviderStats, error) {
+	return ProviderStats{}, nil
+}
+func (s *stubLoggingProvider) Flush(context.Context) error { return nil }
+
+// recordingSink captures what the registry reports. Mutex-guarded because
+// SetRegistryLogger advertises concurrency safety.
+type recordingSink struct {
+	mu    sync.Mutex
+	infos []string
+	warns []string
+}
+
+func (r *recordingSink) Info(msg string, _ ...interface{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.infos = append(r.infos, msg)
+}
+
+func (r *recordingSink) Warn(msg string, _ ...interface{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.warns = append(r.warns, msg)
+}
+
+func (r *recordingSink) all() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append(append([]string{}, r.infos...), r.warns...)
+}
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, and returns everything fn
+// wrote. Restores os.Stdout even if fn panics, so one failure cannot silence the
+// rest of the suite.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		_, _ = io.Copy(&sb, r)
+		done <- sb.String()
+	}()
+
+	func() {
+		defer func() {
+			_ = w.Close()
+		}()
+		fn()
+	}()
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+// uniqueName keeps each test's registration out of the others' way: the registry
+// is process-global and shared with whatever the package's init()s registered.
+func uniqueName(t *testing.T) string {
+	t.Helper()
+	return "stub-" + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+func TestRegisterLoggingProvider_WritesNothingToStdout(t *testing.T) {
+	t.Cleanup(func() { SetRegistryLogger(nil) })
+	SetRegistryLogger(&recordingSink{})
+
+	out := captureStdout(t, func() {
+		RegisterLoggingProvider(&stubLoggingProvider{name: uniqueName(t), available: true})
+	})
+	assert.Empty(t, out, "registration must not write to stdout; a library owns no process's stdout")
+}
+
+func TestRegisterLoggingProviderFactory_WritesNothingToStdout(t *testing.T) {
+	t.Cleanup(func() { SetRegistryLogger(nil) })
+	SetRegistryLogger(&recordingSink{})
+
+	name := uniqueName(t)
+	out := captureStdout(t, func() {
+		RegisterLoggingProviderFactory(func() LoggingProvider {
+			return &stubLoggingProvider{name: name, available: true}
+		})
+	})
+	assert.Empty(t, out, "factory registration must not write to stdout")
+}
+
+func TestUnavailableProvider_WritesNothingToStdout(t *testing.T) {
+	// The "reports as unavailable" line was one of the two printed on every run.
+	t.Cleanup(func() { SetRegistryLogger(nil) })
+	sink := &recordingSink{}
+	SetRegistryLogger(sink)
+
+	name := uniqueName(t)
+	out := captureStdout(t, func() {
+		RegisterLoggingProvider(&stubLoggingProvider{
+			name:      name,
+			available: false,
+			availErr:  errors.New("provider not configured"),
+		})
+	})
+	assert.Empty(t, out, "the unavailable notice must not reach stdout")
+	assert.True(t, containsSubstr(sink.all(), "reports as unavailable"),
+		"the unavailable notice must still be reported somewhere: %v", sink.all())
+}
+
+func TestRegistrationIsStillReportedToTheSink(t *testing.T) {
+	// The other half: silencing stdout must not mean losing the diagnostic.
+	t.Cleanup(func() { SetRegistryLogger(nil) })
+	sink := &recordingSink{}
+	SetRegistryLogger(sink)
+
+	name := uniqueName(t)
+	RegisterLoggingProvider(&stubLoggingProvider{name: name, available: true})
+
+	require.NotEmpty(t, sink.infos, "a successful registration must be reported")
+	assert.True(t, containsSubstr(sink.infos, "Registered logging provider: "+name),
+		"the message must name the provider: %v", sink.infos)
+}
+
+func TestInvalidProviderIsReportedAsAWarning(t *testing.T) {
+	t.Cleanup(func() { SetRegistryLogger(nil) })
+	sink := &recordingSink{}
+	SetRegistryLogger(sink)
+
+	// An empty name fails validateLoggingProvider.
+	out := captureStdout(t, func() {
+		RegisterLoggingProvider(&stubLoggingProvider{name: "", available: true})
+	})
+	assert.Empty(t, out, "a rejected registration must not write to stdout either")
+	assert.True(t, containsSubstr(sink.warns, "Failed to register logging provider"),
+		"a rejected registration must warn: %v", sink.warns)
+}
+
+func TestNilFactoryIsReportedAsAWarning(t *testing.T) {
+	t.Cleanup(func() { SetRegistryLogger(nil) })
+	sink := &recordingSink{}
+	SetRegistryLogger(sink)
+
+	out := captureStdout(t, func() {
+		RegisterLoggingProviderFactory(func() LoggingProvider { return nil })
+	})
+	assert.Empty(t, out)
+	assert.True(t, containsSubstr(sink.warns, "returned nil instance"),
+		"a nil factory instance must warn: %v", sink.warns)
+}
+
+func TestSetRegistryLoggerNilRestoresTheNoopSink(t *testing.T) {
+	// Passing nil must not leave a nil interface behind for the next registration
+	// to dereference — every binary that never configures a logger relies on this.
+	SetRegistryLogger(&recordingSink{})
+	SetRegistryLogger(nil)
+
+	name := uniqueName(t)
+	out := captureStdout(t, func() {
+		assert.NotPanics(t, func() {
+			RegisterLoggingProvider(&stubLoggingProvider{name: name, available: true})
+		})
+	})
+	assert.Empty(t, out, "the default sink must be silent, not stdout")
+}
+
+func TestRegistrySinkIsSatisfiedByAFullLogger(t *testing.T) {
+	// RegistrySink exists only because pkg/logging imports this package, so the
+	// dependency cannot run the other way. Its whole value is that a real
+	// pkg/logging.Logger satisfies it implicitly — assert the shape that makes
+	// that true, so a signature drift here is caught in this package rather than
+	// as a confusing failure at a call site.
+	var _ RegistrySink = (*recordingSink)(nil)
+	var sink RegistrySink = &fullLoggerShape{}
+	assert.NotNil(t, sink)
+}
+
+// fullLoggerShape mirrors pkg/logging.Logger's method set. Compiling proves a
+// value with that surface is assignable to RegistrySink.
+type fullLoggerShape struct{}
+
+func (fullLoggerShape) Debug(string, ...interface{})                     {}
+func (fullLoggerShape) Info(string, ...interface{})                      {}
+func (fullLoggerShape) Warn(string, ...interface{})                      {}
+func (fullLoggerShape) Error(string, ...interface{})                     {}
+func (fullLoggerShape) Fatal(string, ...interface{})                     {}
+func (fullLoggerShape) DebugCtx(context.Context, string, ...interface{}) {}
+func (fullLoggerShape) InfoCtx(context.Context, string, ...interface{})  {}
+func (fullLoggerShape) WarnCtx(context.Context, string, ...interface{})  {}
+func (fullLoggerShape) ErrorCtx(context.Context, string, ...interface{}) {}
+func (fullLoggerShape) FatalCtx(context.Context, string, ...interface{}) {}
+
+func containsSubstr(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.Contains(h, needle) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## The defect

`pkg/logging/interfaces/provider.go` reported provider registration with **eight** `fmt.Printf` calls. That registry is populated by package `init()` functions, so it runs in every binary *and* every test binary: `go test -v ./pkg/logging/` printed two chatter lines per run, and **701 such lines** were measured being carried through agent context.

A library writing to a process's stdout is wrong independently of cost.

All eight now route through a `RegistrySink`, defaulting to a no-op.

## Why the sink is declared locally

`pkg/logging` imports **this** package, so the dependency cannot run the other way — which is why `pkg/storage/interfaces`' pattern (import `pkg/logging`, hold a `Logger`) is unavailable here. `RegistrySink`'s method set is a subset of `logging.Logger`, so a real logger satisfies it implicitly and `SetRegistryLogger` takes one directly. A test asserts that shape, so a signature drift is caught in this package rather than as a confusing failure at a call site.

Passing `nil` restores the no-op sink rather than leaving a nil interface for the next registration to dereference.

## Measured

`go test -v ./pkg/logging/`: **2 chatter lines before, 0 after.**

## Tests (8)

They pin **both halves**, because a change that merely silenced the output would pass a stdout assertion while destroying the diagnostic:

- nothing reaches stdout on the success, unavailable, invalid-provider and nil-factory paths
- the message still reaches a configured sink
- `SetRegistryLogger(nil)` is silent and does not panic
- a full `logging.Logger`-shaped value is assignable to `RegistrySink`

stdout is captured via an `os.Pipe` swap that restores `os.Stdout` even if the body panics, so one failure cannot silence the rest of the suite.

## CLAUDE.md: the read patterns that actually cost

A tool result is re-billed on every later call in the session, so a read's price is its size × how many calls follow it — not a one-off. Two patterns dominate measured spend:

- **Re-reading slices of one large file** — the single largest context cost measured; one session read `client_transport.go` **63 times**. Alternative: `get_symbols_overview` for shape, `find_symbol` to jump, `offset`/`limit` when a raw slice is genuinely needed.
- **Bare `git diff` on a wide change** — $16.97 of carry cost across 936 results. Alternative: `git diff --stat`, then `git diff -- <path>`.

Guidance only, deliberately. The measured distribution shows no threshold worth enforcing mechanically: reads ≥10k tokens are only 14.2% of the cost, and byte-identical repeat reads just $4.24 of it — so a size-threshold hook or a dedupe cache would recover almost nothing.

`make test` green (208/208); `go build ./...` and `go vet` clean.

Relates to epic #3026; no story issue exists, so no closing keyword. Third of four PRs from an approved plan on measured fix-round root causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo