### PR TITLE
metrics: report per-story Read carry cost, and harden the acceptance checker against the defects it missed (Issue #3026)

### DIFF
--- a/.claude/agents/acceptance-checker.md
+++ b/.claude/agents/acceptance-checker.md
@@ -89,6 +89,35 @@ For each reference recorded in Phase 2:
    ```
    If the test exists but fails or wasn't exercised, record FAIL.
 
+6. **Every named site, not just the file.** When the story names several locations
+   in one file (`handlers_runs.go — lines 114, 126: same replacement`), check each
+   one. A file appearing in the diff is not evidence that every site in it was
+   done — this is the single most common way a PR reaches review looking complete:
+   in one measured case the reviewer found one of two named sites changed while
+   every declared file had been touched, so nothing at file granularity could have
+   caught it. Report each unhandled site individually with its line.
+
+7. **Account for every declared file — do not require every one to be touched.**
+   Walk `## Files In Scope` against `git diff --name-only develop...HEAD` and, for
+   each declared file NOT in the diff, decide which it is:
+   - work the story required and the change omits → FAIL, naming the file; or
+   - a file the story listed that genuinely needed no change → note it and move on.
+
+   Both outcomes are legitimate, which is exactly why this is your judgement and
+   not a mechanical gate: a file-level coverage check was measured against four
+   historical fix-round PRs and produced zero true catches and one false positive
+   — it would have failed a correct PR because its story declared a file that
+   rightly went untouched. State which case each one is; never treat "declared but
+   untouched" as automatically either.
+
+8. **Verify the PR's own claims against the code.** Read the PR/commit description
+   and treat every behavioural claim in it as a hypothesis to check, not as
+   evidence. In one measured case a summary stated the audit event recorded a
+   token ID and no call site did — the claim was reviewed as though it were the
+   implementation. Any claim you cannot confirm in the code is a FAIL, quoting the
+   claim and what the code actually does. A PR that admits in its own body that an
+   AC is "approximated" or unmet is a FAIL on that AC, not a judgement call.
+
 ## Phase 4: Verify Deferred annotations are legitimate
 
 If a banned-phrase match is preceded by `// Deferred: tracked in #NNN`, verify the tracking issue is valid:

--- a/.claude/metrics/tests/test_token_report.py
+++ b/.claude/metrics/tests/test_token_report.py
@@ -20,9 +20,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from token_report import (  # noqa: E402
+    CACHE_READ_MULT,
     Bucket,
     ParseStats,
     Pricing,
+    read_carry_cost_est,
     SessionMeta,
     TranscriptRef,
     build_parser,
@@ -966,6 +968,139 @@ class TestStoryCostReport(unittest.TestCase):
         args = parser.parse_args(["--story-report", "--sessions-dir", "/tmp/x"])
         self.assertTrue(args.story_report)
         self.assertEqual(str(args.sessions_dir), "/tmp/x")
+
+
+
+
+class TestReadCarryCostEstimate(unittest.TestCase):
+    """A Read's real price is its size times the calls that follow it.
+
+    A tool result stays in the conversation and is re-sent as cache-read input on
+    every later call in the session, so the same read costs far more early in a
+    long session than late in a short one. That is invisible per-call, and it is
+    the largest single component of dev-agent spend.
+
+    Every factor here is exact except the token count of the read itself
+    (transcripts record the text, not a per-tool token count) — which is why the
+    figure is labelled `_est` wherever it surfaces.
+    """
+
+    def _tree(self, rows: list[str]) -> Path:
+        root = Path(tempfile.mkdtemp())
+        (root / "sess.jsonl").write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return root
+
+    @staticmethod
+    def _read_use(tool_id: str) -> str:
+        return json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": tool_id, "name": "Read",
+                 "input": {"file_path": "/workspace/big.go"}}]},
+        })
+
+    @staticmethod
+    def _read_result(tool_id: str, text: str) -> str:
+        return json.dumps({
+            "type": "user",
+            "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": tool_id, "content": text}]},
+        })
+
+    @staticmethod
+    def _call(request_id: str, model: str = "claude-opus-5") -> str:
+        return json.dumps({
+            "type": "assistant", "requestId": request_id,
+            "timestamp": "2026-08-07T10:00:00Z",
+            "message": {"model": model, "usage": {
+                "input_tokens": 1, "cache_read_input_tokens": 0, "output_tokens": 1}},
+        })
+
+    def test_carry_equals_tokens_times_following_call_rates(self):
+        # 3700 chars / 3.7 = 1000 tokens. The result lands after call 1, so it is
+        # carried by calls 2 and 3 — two opus-5 cache reads, nothing else.
+        text = "x" * 3700
+        root = self._tree([
+            self._call("req_1"),
+            self._read_use("toolu_1"),
+            self._read_result("toolu_1", text),
+            self._call("req_2"),
+            self._call("req_3"),
+        ])
+        carry, reads = read_carry_cost_est([root], Pricing.load())
+        self.assertEqual(reads, 1)
+        opus_input = 5.0  # pricing.json, claude-opus-5
+        expected = 1000 * 2 * (opus_input * CACHE_READ_MULT / 1_000_000)
+        self.assertAlmostEqual(carry, expected, places=10)
+
+    def test_a_read_on_the_last_call_carries_nothing(self):
+        # Nothing follows it, so it is billed once as part of that call and never
+        # re-read. Charging for it here would inflate every short session.
+        root = self._tree([
+            self._call("req_1"),
+            self._read_use("toolu_1"),
+            self._read_result("toolu_1", "y" * 3700),
+        ])
+        carry, reads = read_carry_cost_est([root], Pricing.load())
+        self.assertEqual(reads, 1)
+        self.assertEqual(carry, 0.0)
+
+    def test_each_following_call_is_priced_at_its_own_model_rate(self):
+        # A transcript can mix models (a sonnet subagent under an opus parent) and
+        # they differ several-fold, so one blended rate would be wrong. sonnet-4-6
+        # input is 3.0, opus-5 is 5.0.
+        root = self._tree([
+            self._call("req_1"),
+            self._read_use("toolu_1"),
+            self._read_result("toolu_1", "z" * 3700),
+            self._call("req_2", model="claude-sonnet-4-6"),
+            self._call("req_3", model="claude-opus-5"),
+        ])
+        carry, _ = read_carry_cost_est([root], Pricing.load())
+        expected = 1000 * ((3.0 + 5.0) * CACHE_READ_MULT / 1_000_000)
+        self.assertAlmostEqual(carry, expected, places=10)
+
+    def test_non_read_tool_results_are_not_counted(self):
+        # The figure is specifically about Read. Bash output carries too, but is
+        # reported separately; conflating them would misdirect the fix.
+        bash_use = json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "toolu_b", "name": "Bash",
+                 "input": {"command": "ls"}}]},
+        })
+        root = self._tree([
+            self._call("req_1"),
+            bash_use,
+            self._read_result("toolu_b", "q" * 3700),
+            self._call("req_2"),
+        ])
+        carry, reads = read_carry_cost_est([root], Pricing.load())
+        self.assertEqual((carry, reads), (0.0, 0))
+
+    def test_transcript_with_no_reads_is_skipped_cheaply(self):
+        root = self._tree([self._call("req_1"), self._call("req_2")])
+        self.assertEqual(read_carry_cost_est([root], Pricing.load()), (0.0, 0))
+
+    def test_malformed_and_missing_input_never_raises(self):
+        root = Path(tempfile.mkdtemp())
+        (root / "broken.jsonl").write_text("not json\n{}\n", encoding="utf-8")
+        (root / "empty.jsonl").write_text("", encoding="utf-8")
+        carry, reads = read_carry_cost_est([root, Path("/nonexistent-path")], Pricing.load())
+        self.assertEqual((carry, reads), (0.0, 0))
+
+    def test_unpriced_model_contributes_zero_not_a_crash(self):
+        # Consistent with the rest of the tool: an unpriced model's tokens are
+        # counted, its dollars are never guessed.
+        root = self._tree([
+            self._call("req_1"),
+            self._read_use("toolu_1"),
+            self._read_result("toolu_1", "w" * 3700),
+            self._call("req_2", model="some-local-model:27b"),
+        ])
+        carry, reads = read_carry_cost_est([root], Pricing.load())
+        self.assertEqual(reads, 1)
+        self.assertEqual(carry, 0.0)
 
 
 if __name__ == "__main__":

--- a/.claude/metrics/token_report.py
+++ b/.claude/metrics/token_report.py
@@ -793,6 +793,108 @@ _MODE_BUCKET = {
 }
 
 
+#: Characters per token. Only used by read_carry_cost_est below, and the reason
+#: that figure is labelled `_est` everywhere it surfaces: transcripts record a
+#: tool result's text but no per-tool token count, so its size has to be
+#: approximated. Every other number this tool reports comes from a recorded
+#: `usage` object and is exact.
+_CHARS_PER_TOKEN = 3.7
+
+
+def read_carry_cost_est(roots: list[Path], pricing: Pricing) -> tuple[float, int]:
+    """Estimated dollars spent re-reading `Read` output that is already in context.
+
+    Returns (dollars, number_of_reads).
+
+    A tool result is not billed once. It stays in the conversation and is re-sent
+    as cache-read input on every later call in that session, so a read's real
+    price is its size times the calls that follow it -- which makes an early read
+    in a long session far more expensive than the same read at the end. That is
+    invisible in a per-call view, and it is the largest single component of
+    dev-agent spend: measured at $145.55 across 611 container transcripts, of
+    which $108.76 was first reads of a path and $36.79 re-reads of one already
+    read in that session.
+
+    Each following call's OWN rate is used, via a suffix sum, rather than one
+    blended rate for the session: a transcript can mix models (a sonnet subagent
+    under an opus parent), and pricing differs several-fold between them.
+
+    Exact in every factor except the token count of the read itself -- hence
+    `_est`. Reported separately from the cost columns rather than folded into
+    them, so an estimate is never summed with measured dollars.
+    """
+    total = 0.0
+    reads = 0
+    for root in roots:
+        for transcript in sorted(root.rglob("*.jsonl")):
+            try:
+                rows = [
+                    json.loads(line)
+                    for line in transcript.read_text(errors="replace").splitlines()
+                    if line.strip()
+                ]
+            except (OSError, json.JSONDecodeError):
+                continue
+
+            # Which tool_use ids were Reads, so results can be attributed.
+            read_ids: set[str] = set()
+            for row in rows:
+                content = (row.get("message") or {}).get("content")
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if (
+                        isinstance(block, dict)
+                        and block.get("type") == "tool_use"
+                        and block.get("name") == "Read"
+                        and block.get("id")
+                    ):
+                        read_ids.add(block["id"])
+            if not read_ids:
+                continue
+
+            # Per-call cache-read rate, in call order, deduped on requestId.
+            rates: list[float] = []
+            seen: set[str] = set()
+            for row in rows:
+                rid = row.get("requestId")
+                if not rid or rid in seen:
+                    continue
+                seen.add(rid)
+                message = row.get("message") or {}
+                usage = message.get("usage") or {}
+                model = message.get("model") or ""
+                resolved = pricing.rates(model, _parse_time(row.get("timestamp")), usage.get("speed"))
+                rates.append((resolved[0] * CACHE_READ_MULT / 1_000_000) if resolved else 0.0)
+
+            # suffix[k] = cost per token of being in context for calls k..end.
+            suffix = [0.0] * (len(rates) + 1)
+            for i in range(len(rates) - 1, -1, -1):
+                suffix[i] = suffix[i + 1] + rates[i]
+
+            k = 0
+            seen.clear()
+            for row in rows:
+                rid = row.get("requestId")
+                if rid and rid not in seen:
+                    seen.add(rid)
+                    k += 1
+                content = (row.get("message") or {}).get("content")
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if not (isinstance(block, dict) and block.get("type") == "tool_result"):
+                        continue
+                    if block.get("tool_use_id") not in read_ids:
+                        continue
+                    payload = block.get("content")
+                    text = payload if isinstance(payload, str) else json.dumps(payload)
+                    tokens = len(text) / _CHARS_PER_TOKEN
+                    total += tokens * suffix[min(k, len(rates))]
+                    reads += 1
+    return total, reads
+
+
 def story_cost_report(
     sessions_base: Path, pricing: Pricing, since: datetime | None = None
 ) -> list[dict[str, Any]]:
@@ -870,6 +972,7 @@ def story_cost_report(
         container_calls, _ = collect([container_dir], pricing, None, None)
         cost = sum((c.cost_usd or 0.0) for c, _ in container_calls)
         has_transcript = len(container_calls) > 0
+        carry, n_reads = read_carry_cost_est([container_dir], pricing)
 
         key = str(issue) if issue else (f"pr-{pr}" if pr else f"container:{container_dir.name}")
         story = stories.setdefault(
@@ -881,6 +984,8 @@ def story_cost_report(
                 "fix_cost_usd": 0.0,
                 "review_cost_usd": 0.0,
                 "fix_rounds": 0,
+                "read_carry_usd_est": 0.0,
+                "reads": 0,
                 "containers": 0,
                 "has_dev": False,
                 "partial": False,
@@ -890,6 +995,8 @@ def story_cost_report(
         if pr and not story["pr"]:
             story["pr"] = pr
         story["containers"] += 1
+        story["read_carry_usd_est"] = round(story["read_carry_usd_est"] + carry, 4)
+        story["reads"] += n_reads
         if not has_transcript:
             story["partial"] = True
 
@@ -1026,22 +1133,33 @@ def render_story_report(stories: list[dict[str, Any]], out) -> None:
     """Human-readable form of story_cost_report's output (Issue #3055)."""
     print(
         f"\n{'story':>7}  {'pr':>7}  {'dev $':>8}  {'fix $':>8}  {'review $':>9}  "
-        f"{'total $':>8}  {'rounds':>6}  {'partial':>7}",
+        f"{'total $':>8}  {'rounds':>6}  {'reads':>6}  {'read~$':>7}  {'partial':>7}",
         file=out,
     )
-    print("-" * 76, file=out)
+    print("-" * 94, file=out)
     for story in stories:
         print(
             f"{str(story['story'] or '-'):>7}  {str(story['pr'] or '-'):>7}  "
             f"{story['dev_cost_usd']:>8.2f}  {story['fix_cost_usd']:>8.2f}  "
             f"{story['review_cost_usd']:>9.2f}  {story['total_cost_usd']:>8.2f}  "
-            f"{story['fix_rounds']:>6}  {('yes' if story['partial'] else ''):>7}",
+            f"{story['fix_rounds']:>6}  {story['reads']:>6}  "
+            f"{story['read_carry_usd_est']:>7.2f}  "
+            f"{('yes' if story['partial'] else ''):>7}",
             file=out,
         )
-    print("-" * 76, file=out)
+    print("-" * 94, file=out)
     total = sum(s["total_cost_usd"] for s in stories)
+    carry = sum(s["read_carry_usd_est"] for s in stories)
     partial_count = sum(1 for s in stories if s["partial"])
     print(f"{len(stories)} stories, ${total:.2f} total, {partial_count} partial", file=out)
+    # Deliberately not added to the total: read~$ is a component OF the measured
+    # cost columns (context re-read is part of what dev/fix/review already
+    # charged), not spend alongside them. Summing the two would double-count.
+    print(
+        f"read~$ = estimated cost of carrying Read output for the rest of its session: "
+        f"${carry:.2f} across {sum(s['reads'] for s in stories)} reads",
+        file=out,
+    )
     print("excludes: cron orchestration's own share of cost", file=out)
 
 


### PR DESCRIPTION
Two halves of one finding: rework is **33.6% of dev-agent spend** ($238.69 of $723.70 across 60 stories) and **only 2 of 16 fix rounds were triggered by failing CI**. What CI cannot see, the checker has to.

## Read carry cost, per story

A tool result is not billed once. It stays in the conversation and is re-sent as cache-read input on every later call in that session — so a read's real price is its size × the calls that follow it, and the same read costs far more early in a long session than late in a short one. That is invisible in a per-call view.

`--story-report` gains `reads` and `read~$`. Measured across 611 container transcripts: **$94.18 over 3,668 reads.**

Each following call is priced at its **own** model rate via a suffix sum, not one blended session rate — a transcript can mix models (a sonnet subagent under an opus parent) and they differ several-fold. An earlier hand calculation of this figure assumed opus throughout and produced $145.55; **$94.18 supersedes it.**

Reported as `read~$` and deliberately **not** added to the total: context re-read is a component *of* the measured dev/fix/review columns, not spend alongside them, so summing would double-count. `_est` because every factor is exact except the read's own token count — transcripts record the text, not a per-tool count — and this tool does not present an estimate as a measurement.

## Acceptance-checker hardening

Three Phase-3 additions, each from a case the checker passed and the reviewer then failed:

- **Check every named site, not just the file.** One PR had one of two named sites changed while every declared file appeared in the diff — nothing at file granularity could have caught it.
- **Account for each declared file without requiring all be touched**, and say which case each is. Both "omitted work" and "legitimately needed no change" are real.
- **Treat the PR's own claims as hypotheses.** One PR summary stated the audit event recorded a token ID when no call site did. A PR admitting an AC is "approximated" is a FAIL on that AC, not a judgement call.

## The mechanical gate this replaces, and why it was dropped

A `check-files-in-scope.sh` comparing declared files against the branch diff was planned. It was built against a fixture corpus of the four historical fix-round PRs **first**, and produced **zero true catches and one false positive**:

| PR | Result |
|---|---|
| #3146 | every declared file touched; defect was line-level (`lines 114, 126`) → no catch |
| #3144 | every declared file touched → no catch |
| #3050 | story declares 0 parseable paths → no catch |
| #3119 | flags `handlers_registration.go` as untouched — but the **merged** state never touches it either, so the gate fails the known-good state |

A gate that fails a correct PR and catches none of the real defects trains bypassing. The AC-verification gap is line-level and semantic, so it belongs in the checker's reasoning — and the dropped gate's own false positive is cited in the checker text so it is not later "fixed" back into a hard rule.

## Tests

7 new cases (78 total) asserting exact arithmetic: carry equals tokens × following-call rates; a read on the final call carries nothing; mixed models are priced individually; non-`Read` results are excluded; unpriced models contribute zero; malformed input never raises.

**Mutation-checked** — substituting a flat blended rate is caught by 2 of them.

`make test` green (208/208).

Relates to epic #3026; no story issue exists, so no closing keyword. Last of four PRs from an approved plan on measured fix-round root causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo