### PR TITLE
deps: bump github/codeql-action v4.37.3 → v4.37.6 (Issue #3208)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -120,7 +120,7 @@ jobs:
     # run that workflow manually with `--ref <branch>` before re-running
     # this one.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -145,7 +145,7 @@ jobs:
 
     # Perform CodeQL Analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         category: "/language:${{ matrix.language }}"
         # Upload results to GitHub Security tab (SARIF format)

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -98,7 +98,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       if: always()
       with:
         sarif_file: 'trivy-controller-results.sarif'
@@ -188,7 +188,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       if: always()
       with:
         sarif_file: 'trivy-steward-results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         if: always() && hashFiles('scorecard.sarif') != ''
         with:
           sarif_file: scorecard.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -139,7 +139,7 @@ jobs:
         fi
     
     - name: Upload Trivy SARIF
-      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       if: always() && hashFiles('sarif-results/trivy.sarif') != ''
       with:
         sarif_file: sarif-results/trivy.sarif
@@ -268,7 +268,7 @@ jobs:
     # configuration, and results are still available via workflow artifacts.
     #
     # - name: Upload gosec SARIF
-    #   uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+    #   uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
     #   if: always() && hashFiles('sarif-results/gosec.sarif') != ''
     #   with:
     #     sarif_file: sarif-results/gosec.sarif


### PR DESCRIPTION
## Summary

Bump the `github/codeql-action` SHA pin from `v4.37.3` (`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`) to `v4.37.6` (`5595ccaf912efad79be6eef63a5619ff05969be3`) across all 7 occurrences in 4 workflow files.

The story targeted `v4.37.5`, but `v4.37.6` (published `2026-08-04T13:34:40Z`) cleared the 3-day cooldown before implementation — the story explicitly instructs to target the newest cleared version. SHA independently verified via GitHub API.

**Files changed:**
- `.github/workflows/codeql-analysis.yml` — `init` and `analyze` sub-actions
- `.github/workflows/docker-security.yml` — `upload-sarif` (2 occurrences)
- `.github/workflows/scorecard.yml` — `upload-sarif`
- `.github/workflows/security-scan.yml` — `upload-sarif` (1 active + 1 commented-out)

## Verification

- Old SHA absent: `grep -rn "e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81" .github/` → 0 matches ✓
- New SHA present: `grep -rn "5595ccaf912efad79be6eef63a5619ff05969be3" .github/` → 7 matches ✓
- No stale comment: `grep -rn "v4\.37\.3" .github/` → 0 matches ✓
- Actions remain SHA-pinned (zizmor requirement met) ✓
- `make test` passes (208 tests, 0 failures) ✓

## Specialist Review Results

Story-review workflow: **PASSED** (2 review rounds, 1 fix round, 0 remaining findings)
- Code review: PASS
- Test quality: PASS (after 1 fix round)
- Security: PASS

## CI Note

`CodeQL` is a required check that runs for real on both the PR side and the merge-queue side. This PR touches `.github/workflows/**` which is in the CodeQL path filter, so the real analysis job (not `codeql-stub.yml`) must post green before merging.

No open CVE advisory covers `v4.37.x` (GHSA-vqf5-2xx6-9wfm covers `>= 3.26.11, <= 3.28.2` and the pre-3.0 range only).

Fixes #3208

🤖 Generated with [Claude Code](https://claude.com/claude-code)