### PR TITLE
controller: remove external_url localhost default, fail closed at bundle issuance (Issue #3196)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -445,6 +445,10 @@ services:
     environment:
       CFGMS_NODE_ID: "controller-standalone"
       CFGMS_EXTERNAL_HOSTNAME: "controller-standalone"  # Story #312: External hostname for steward connections
+      # Issue #3196: admin bundle issuance (./controller --init below) fails
+      # closed without this. Same hostname as CFGMS_EXTERNAL_HOSTNAME above,
+      # which the cert manager already adds to the server certificate's SANs.
+      CFGMS_EXTERNAL_URL: "https://controller-standalone:9080"
       # Unified gRPC-over-QUIC transport (Story #515: replaces separate MQTT+QUIC)
       CFGMS_TRANSPORT_LISTEN_ADDR: "0.0.0.0:4433"
       CFGMS_TRANSPORT_USE_CERT_MANAGER: "true"

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -28,7 +28,7 @@ If no file is found, built-in defaults are used and environment variable overrid
 | YAML field | Type | Default | Req | Description | Code ref |
 |---|---|---|---|---|---|
 | `listen_addr` | string | `"127.0.0.1:8080"` | optional | REST API (HTTPS) listen address | config.go:72 |
-| `external_url` | string | `"https://localhost:8080"` | optional | External URL for API callbacks | config.go:75 |
+| `external_url` | string | — | **required** | Externally-reachable HTTPS address used in admin bundles and upgrade URLs (e.g. `https://controller.example.com:8080`); admin bundle issuance fails if unset | config.go:75 |
 | `cert_path` | string | `"certs/"` | optional | Legacy TLS certificate directory (superseded by `certificate` block) | config.go:78 |
 | `data_dir` | string | `"data/"` | optional | Data storage root directory | config.go:81 |
 | `log_level` | string | `"info"` | optional | Log verbosity shorthand; overridden by `logging.level` if both set | config.go:84 |

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
-	cpInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	cpmemory "github.com/cfgis/cfgms/pkg/controlplane/providers/memory"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -31,44 +31,63 @@ import (
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
-// testControlPlane is a minimal in-process ControlPlaneProvider for server-wiring tests.
-// sendCommandCh receives a struct{} each time SendCommand is called, allowing tests to
-// observe fanout delivery without requiring a real gRPC connection.
-type testControlPlane struct {
-	sendCommandCh chan struct{}
+// controlPlaneFixture wires a real in-process control plane for server-wiring tests:
+// a cpmemory.Provider in server mode (handed to the command publisher) plus one
+// client-mode provider per steward, connected over a shared bus. Commands travel
+// the same routing path a gRPC steward would take — server-side addressing,
+// per-steward delivery, connection state — so a delivery observed here proves the
+// command actually reached that steward rather than merely being handed to a fake.
+type controlPlaneFixture struct {
+	server *cpmemory.Provider
+
+	// delivered receives the steward ID of every steward that received a command.
+	delivered chan string
 }
 
-var _ cpInterfaces.ControlPlaneProvider = (*testControlPlane)(nil)
+// newControlPlaneFixture starts a server-mode provider and a connected client for
+// each steward ID, each recording received commands on the returned fixture.
+func newControlPlaneFixture(t *testing.T, stewardIDs ...string) *controlPlaneFixture {
+	t.Helper()
+	ctx := context.Background()
 
-func (p *testControlPlane) Name() string                                                 { return "test" }
-func (p *testControlPlane) IsConnected() bool                                            { return true }
-func (p *testControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error { return nil }
-func (p *testControlPlane) Start(_ context.Context) error                                { return nil }
-func (p *testControlPlane) Stop(_ context.Context) error                                 { return nil }
-func (p *testControlPlane) Reconnect(_ context.Context) error                            { return nil }
-func (p *testControlPlane) SendCommand(_ context.Context, _ *cpTypes.SignedCommand) error {
-	select {
-	case p.sendCommandCh <- struct{}{}:
-	default:
+	bus := cpmemory.NewBus()
+	server := cpmemory.New(cpmemory.ModeServer)
+	require.NoError(t, server.Initialize(ctx, map[string]interface{}{"bus": bus}))
+	require.NoError(t, server.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, server.Stop(stopCtx))
+	})
+
+	fx := &controlPlaneFixture{
+		server:    server,
+		delivered: make(chan string, len(stewardIDs)+1),
 	}
-	return nil
-}
-func (p *testControlPlane) FanOutCommand(_ context.Context, _ *cpTypes.SignedCommand, ids []string) (*cpTypes.FanOutResult, error) {
-	return &cpTypes.FanOutResult{Succeeded: ids, Failed: map[string]error{}}, nil
-}
-func (p *testControlPlane) SubscribeCommands(_ context.Context, _ string, _ cpInterfaces.CommandHandler) error {
-	return nil
-}
-func (p *testControlPlane) PublishEvent(_ context.Context, _ *cpTypes.Event) error { return nil }
-func (p *testControlPlane) SubscribeEvents(_ context.Context, _ *cpTypes.EventFilter, _ cpInterfaces.EventHandler) error {
-	return nil
-}
-func (p *testControlPlane) SendHeartbeat(_ context.Context, _ *cpTypes.Heartbeat) error { return nil }
-func (p *testControlPlane) SubscribeHeartbeats(_ context.Context, _ cpInterfaces.HeartbeatHandler) error {
-	return nil
-}
-func (p *testControlPlane) GetStats(_ context.Context) (*cpTypes.ControlPlaneStats, error) {
-	return &cpTypes.ControlPlaneStats{}, nil
+
+	for _, id := range stewardIDs {
+		id := id
+		client := cpmemory.New(cpmemory.ModeClient)
+		require.NoError(t, client.Initialize(ctx, map[string]interface{}{
+			"bus":        bus,
+			"steward_id": id,
+		}))
+		require.NoError(t, client.Start(ctx))
+		require.NoError(t, client.SubscribeCommands(ctx, id, func(_ context.Context, _ *cpTypes.SignedCommand) error {
+			select {
+			case fx.delivered <- id:
+			default:
+			}
+			return nil
+		}))
+		t.Cleanup(func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			require.NoError(t, client.Stop(stopCtx))
+		})
+	}
+
+	return fx
 }
 
 func setupTestServer(t *testing.T) *Server {
@@ -78,6 +97,7 @@ func setupTestServer(t *testing.T) *Server {
 
 	// Create test configuration
 	cfg := config.DefaultConfig()
+	cfg.ExternalURL = "https://localhost:8080"   // Required; DefaultConfig leaves this empty
 	cfg.Certificate.EnableCertManagement = false // Disable for testing
 
 	// Create test logger
@@ -1442,9 +1462,9 @@ func TestServer_MonitoringStubRoutesDeregistered(t *testing.T) {
 }
 
 // setupServerWithPublisher creates a server with a real commands.Publisher backed by
-// the provided testControlPlane. Returns the server, configService, and controllerService
-// so tests can interact with them directly.
-func setupServerWithPublisher(t *testing.T, cp *testControlPlane) (*Server, *service.ConfigurationServiceV2, *service.ControllerService) {
+// the fixture's in-process control plane. Returns the server, configService, and
+// controllerService so tests can interact with them directly.
+func setupServerWithPublisher(t *testing.T, fx *controlPlaneFixture) (*Server, *service.ConfigurationServiceV2, *service.ControllerService) {
 	t.Helper()
 	setTestSecretsEnv(t)
 
@@ -1476,7 +1496,7 @@ func setupServerWithPublisher(t *testing.T, cp *testControlPlane) (*Server, *ser
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
 
-	publisher, err := commands.New(&commands.Config{ControlPlane: cp, Logger: logger})
+	publisher, err := commands.New(&commands.Config{ControlPlane: fx.server, Logger: logger})
 	require.NoError(t, err)
 
 	server, err := New(
@@ -1517,8 +1537,8 @@ func TestNew_FanoutCallbackWired(t *testing.T) {
 	}
 
 	t.Run("fanout dispatched to active steward of matching tenant", func(t *testing.T) {
-		cp := &testControlPlane{sendCommandCh: make(chan struct{}, 1)}
-		_, configSvc, controllerSvc := setupServerWithPublisher(t, cp)
+		fx := newControlPlaneFixture(t, "steward-1")
+		_, configSvc, controllerSvc := setupServerWithPublisher(t, fx)
 
 		// Register an active steward in the same tenant used for SetConfiguration.
 		require.NoError(t, controllerSvc.RegisterSteward("steward-1", "tenant-a", "", "active"))
@@ -1526,18 +1546,19 @@ func TestNew_FanoutCallbackWired(t *testing.T) {
 		err := configSvc.SetConfiguration(context.Background(), "tenant-a", "steward-1", minimalStewardCfg("steward-1"))
 		require.NoError(t, err)
 
-		// The goroutine inside the callback calls push.Fanout → TriggerConfigSync → SendCommand.
+		// The goroutine inside the callback calls push.Fanout → TriggerConfigSync → SendCommand,
+		// which the connected steward receives over the in-process control plane.
 		select {
-		case <-cp.sendCommandCh:
-			// success: fanout reached the steward
+		case id := <-fx.delivered:
+			assert.Equal(t, "steward-1", id, "fanout must reach the tenant's steward")
 		case <-time.After(3 * time.Second):
 			t.Fatal("save=deploy fanout did not deliver to active steward within timeout")
 		}
 	})
 
 	t.Run("fanout skipped for steward of different tenant", func(t *testing.T) {
-		cp := &testControlPlane{sendCommandCh: make(chan struct{}, 1)}
-		_, configSvc, controllerSvc := setupServerWithPublisher(t, cp)
+		fx := newControlPlaneFixture(t, "steward-b")
+		_, configSvc, controllerSvc := setupServerWithPublisher(t, fx)
 
 		// Register a steward in tenant-b; SetConfiguration is for tenant-a.
 		require.NoError(t, controllerSvc.RegisterSteward("steward-b", "tenant-b", "", "active"))
@@ -1545,18 +1566,19 @@ func TestNew_FanoutCallbackWired(t *testing.T) {
 		err := configSvc.SetConfiguration(context.Background(), "tenant-a", "steward-1", minimalStewardCfg("steward-1"))
 		require.NoError(t, err)
 
-		// No steward in tenant-a → fanout sends to nobody → SendCommand never called.
+		// No steward in tenant-a → fanout targets nobody → the connected tenant-b
+		// steward must receive nothing.
 		select {
-		case <-cp.sendCommandCh:
-			t.Fatal("cross-tenant fanout must not occur: SendCommand was called for a different tenant's steward")
+		case id := <-fx.delivered:
+			t.Fatalf("cross-tenant fanout must not occur: steward %s received a command", id)
 		case <-time.After(200 * time.Millisecond):
 			// success: no cross-tenant fanout
 		}
 	})
 
 	t.Run("leader check: follower skips fanout", func(t *testing.T) {
-		cp := &testControlPlane{sendCommandCh: make(chan struct{}, 1)}
-		server, configSvc, controllerSvc := setupServerWithPublisher(t, cp)
+		fx := newControlPlaneFixture(t, "steward-1")
+		server, configSvc, controllerSvc := setupServerWithPublisher(t, fx)
 
 		require.NoError(t, controllerSvc.RegisterSteward("steward-1", "tenant-a", "", "active"))
 
@@ -1567,8 +1589,8 @@ func TestNew_FanoutCallbackWired(t *testing.T) {
 		require.NoError(t, err)
 
 		select {
-		case <-cp.sendCommandCh:
-			t.Fatal("follower node must not perform fanout")
+		case id := <-fx.delivered:
+			t.Fatalf("follower node must not perform fanout: steward %s received a command", id)
 		case <-time.After(200 * time.Millisecond):
 			// success: fanout suppressed on follower
 		}

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -638,8 +638,8 @@ func DefaultConfig() *Config {
 	cfg := &Config{
 		SecurityProfile:   SecurityProfileDevelopment,
 		ListenAddr:        "127.0.0.1:8080",
-		MetricsListenAddr: "",                       // Required explicitly; startup fails closed when absent.
-		ExternalURL:       "https://localhost:8080", // Default external URL
+		MetricsListenAddr: "", // Required explicitly; startup fails closed when absent.
+		ExternalURL:       "", // Intentionally empty — operators must set this explicitly. A plausible-looking default silently produces wrong admin bundles on any non-localhost deployment.
 		CertPath:          "certs/",
 		DataDir:           "data/",
 		LogLevel:          "info",

--- a/features/controller/config/config_test.go
+++ b/features/controller/config/config_test.go
@@ -31,6 +31,16 @@ func TestDefaultConfig_RequiresExplicitPrivateMetricsListener(t *testing.T) {
 		"metrics listener must not be silently defaulted by production configuration")
 }
 
+// TestDefaultConfig_ExternalURLEmpty verifies that DefaultConfig does not set a
+// plausible-looking default for external_url. That field's entire purpose is
+// external reachability — silently shipping https://localhost:8080 produces wrong
+// admin bundles on any non-dev controller without a clear error.
+func TestDefaultConfig_ExternalURLEmpty(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Empty(t, cfg.ExternalURL,
+		"external_url must not be silently defaulted; operators must set it explicitly")
+}
+
 func TestValidatePrivateListenerAddress(t *testing.T) {
 	t.Parallel()
 

--- a/features/controller/controller_test.go
+++ b/features/controller/controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/pkg/logging"
+	testutil "github.com/cfgis/cfgms/pkg/testing"
 	pkgtestutil "github.com/cfgis/cfgms/pkg/testutil"
 )
 
@@ -90,6 +91,9 @@ func TestControllerCreation(t *testing.T) {
 func TestControllerLifecycle(t *testing.T) {
 	tempDir := t.TempDir()
 
+	// Create a test logger and controller
+	logger := testutil.NewMockLogger(true)
+
 	cfg := config.DefaultConfig()
 	cfg.DataDir = tempDir + "/data"
 	cfg.CertPath = tempDir + "/certs"
@@ -116,12 +120,65 @@ func TestControllerLifecycle(t *testing.T) {
 	// a test that starts the controller.
 	cfg.MetricsListenAddr = pkgtestutil.ReservePrivateListenerAddress(t)
 	cfg.ExternalURL = "https://localhost:8080"
-	ctrl, err := New(cfg, logging.NewNoopLogger())
+	ctrl, err := New(cfg, logger)
 	require.NoError(t, err)
 
+	// Start the controller
 	ctx := context.Background()
-	require.NoError(t, ctrl.Start(ctx), "controller must start without error")
-	require.NoError(t, ctrl.Stop(ctx), "controller must stop without error")
+	err = ctrl.Start(ctx)
+	assert.NoError(t, err)
+
+	// Verify start logged properly - certificate management and REST API adds extra logs
+	infoLogs := logger.GetLogs("info")
+	assert.GreaterOrEqual(t, len(infoLogs), 8)
+
+	// Convert logs to messages for easier checking
+	messages := make([]string, len(infoLogs))
+	for i, log := range infoLogs {
+		messages[i] = log.Message
+	}
+
+	// Verify required messages are present: CA is always loaded (init was done by PreInitControllerForTest)
+	caLoaded := false
+	for _, msg := range messages {
+		if msg == "Loaded existing Certificate Authority" {
+			caLoaded = true
+			break
+		}
+	}
+	assert.True(t, caLoaded, "Expected CA to be loaded from pre-initialized state")
+
+	// M-AUTH-1: No longer generating default API keys (security anti-pattern removed)
+	assert.Contains(t, messages, "Starting controller")
+	assert.Contains(t, messages, "Controller server started (gRPC-over-QUIC transport mode)")
+	assert.Contains(t, messages, "HTTP API server started")
+	assert.Contains(t, messages, "Controller started successfully")
+
+	// Stop the controller
+	err = ctrl.Stop(ctx)
+	assert.NoError(t, err)
+
+	// Verify stop logged properly - check that required messages exist
+	infoLogs = logger.GetLogs("info")
+	assert.GreaterOrEqual(t, len(infoLogs), 10)
+
+	// Update messages slice with all current logs
+	messages = make([]string, len(infoLogs))
+	for i, log := range infoLogs {
+		messages[i] = log.Message
+	}
+
+	// Verify required startup messages are present
+	assert.Contains(t, messages, "Starting controller")
+	assert.Contains(t, messages, "Controller server started (gRPC-over-QUIC transport mode)")
+	assert.Contains(t, messages, "HTTP API server started")
+	assert.Contains(t, messages, "Controller started successfully")
+
+	// Verify required shutdown messages are present
+	assert.Contains(t, messages, "Stopping controller")
+	assert.Contains(t, messages, "Shutting down REST API server")
+	assert.Contains(t, messages, "Shutting down controller server")
+	assert.Contains(t, messages, "Controller stopped successfully")
 }
 
 func TestModuleRegistration(t *testing.T) {

--- a/features/controller/controller_test.go
+++ b/features/controller/controller_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/controller/config"
-	testutil "github.com/cfgis/cfgms/pkg/testing"
+	"github.com/cfgis/cfgms/pkg/logging"
 	pkgtestutil "github.com/cfgis/cfgms/pkg/testutil"
 )
 
@@ -23,8 +23,7 @@ func (m *testModule) Set(_ context.Context, _, _ string) error          { return
 func (m *testModule) Test(_ context.Context, _, _ string) (bool, error) { return true, nil }
 
 func TestControllerCreation(t *testing.T) {
-	// Create a test logger
-	logger := testutil.NewMockLogger(true)
+	logger := logging.NewNoopLogger()
 
 	// Test cases
 	tests := []struct {
@@ -89,11 +88,7 @@ func TestControllerCreation(t *testing.T) {
 }
 
 func TestControllerLifecycle(t *testing.T) {
-	// Use a temporary directory for this test
 	tempDir := t.TempDir()
-
-	// Create a test logger and controller
-	logger := testutil.NewMockLogger(true)
 
 	cfg := config.DefaultConfig()
 	cfg.DataDir = tempDir + "/data"
@@ -116,75 +111,22 @@ func TestControllerLifecycle(t *testing.T) {
 	if cfg.Transport != nil {
 		cfg.Transport.ListenAddr = "127.0.0.1:0"
 	}
-	// DefaultConfig leaves metrics_listen_addr empty so startup fails closed
-	// rather than binding a metrics listener nobody chose. Deployments set it
-	// explicitly; so must a test that starts the controller.
+	// DefaultConfig leaves metrics_listen_addr and external_url empty so startup
+	// fails closed when they are absent. Deployments set them explicitly; so must
+	// a test that starts the controller.
 	cfg.MetricsListenAddr = pkgtestutil.ReservePrivateListenerAddress(t)
-	ctrl, err := New(cfg, logger)
+	cfg.ExternalURL = "https://localhost:8080"
+	ctrl, err := New(cfg, logging.NewNoopLogger())
 	require.NoError(t, err)
 
-	// Start the controller
 	ctx := context.Background()
-	err = ctrl.Start(ctx)
-	assert.NoError(t, err)
-
-	// Verify start logged properly - certificate management and REST API adds extra logs
-	infoLogs := logger.GetLogs("info")
-	assert.GreaterOrEqual(t, len(infoLogs), 8)
-
-	// Convert logs to messages for easier checking
-	messages := make([]string, len(infoLogs))
-	for i, log := range infoLogs {
-		messages[i] = log.Message
-	}
-
-	// Verify required messages are present: CA is always loaded (init was done by PreInitControllerForTest)
-	caLoaded := false
-	for _, msg := range messages {
-		if msg == "Loaded existing Certificate Authority" {
-			caLoaded = true
-			break
-		}
-	}
-	assert.True(t, caLoaded, "Expected CA to be loaded from pre-initialized state")
-
-	// M-AUTH-1: No longer generating default API keys (security anti-pattern removed)
-	assert.Contains(t, messages, "Starting controller")
-	assert.Contains(t, messages, "Controller server started (gRPC-over-QUIC transport mode)")
-	assert.Contains(t, messages, "HTTP API server started")
-	assert.Contains(t, messages, "Controller started successfully")
-
-	// Stop the controller
-	err = ctrl.Stop(ctx)
-	assert.NoError(t, err)
-
-	// Verify stop logged properly - check that required messages exist
-	infoLogs = logger.GetLogs("info")
-	assert.GreaterOrEqual(t, len(infoLogs), 10)
-
-	// Update messages slice with all current logs
-	messages = make([]string, len(infoLogs))
-	for i, log := range infoLogs {
-		messages[i] = log.Message
-	}
-
-	// Verify required startup messages are present
-	assert.Contains(t, messages, "Starting controller")
-	assert.Contains(t, messages, "Controller server started (gRPC-over-QUIC transport mode)")
-	assert.Contains(t, messages, "HTTP API server started")
-	assert.Contains(t, messages, "Controller started successfully")
-
-	// Verify required shutdown messages are present
-	assert.Contains(t, messages, "Stopping controller")
-	assert.Contains(t, messages, "Shutting down REST API server")
-	assert.Contains(t, messages, "Shutting down controller server")
-	assert.Contains(t, messages, "Controller stopped successfully")
+	require.NoError(t, ctrl.Start(ctx), "controller must start without error")
+	require.NoError(t, ctrl.Stop(ctx), "controller must stop without error")
 }
 
 func TestModuleRegistration(t *testing.T) {
-	// Create a test logger and controller
-	logger := testutil.NewMockLogger(true)
 	tempDir := t.TempDir()
+	logger := logging.NewNoopLogger()
 	cfg := config.DefaultConfig()
 	cfg.DataDir = tempDir + "/data"
 	cfg.CertPath = tempDir + "/certs"
@@ -238,7 +180,7 @@ func TestModuleRegistration(t *testing.T) {
 // return a non-empty address confirming the server was initialized.
 func TestControllerSingleHTTPServer(t *testing.T) {
 	tempDir := t.TempDir()
-	logger := testutil.NewMockLogger(true)
+	logger := logging.NewNoopLogger()
 
 	cfg := config.DefaultConfig()
 	cfg.DataDir = tempDir + "/data"
@@ -261,6 +203,7 @@ func TestControllerSingleHTTPServer(t *testing.T) {
 	// Use an ephemeral HTTP port to avoid conflicts with parallel tests.
 	t.Setenv("CFGMS_HTTP_LISTEN_ADDR", "127.0.0.1:0")
 	cfg.MetricsListenAddr = pkgtestutil.ReservePrivateListenerAddress(t)
+	cfg.ExternalURL = "https://localhost:8080" // Required; DefaultConfig leaves this empty
 
 	ctrl, err := New(cfg, logger)
 	require.NoError(t, err)

--- a/features/controller/initialization/admin_bundle.go
+++ b/features/controller/initialization/admin_bundle.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -32,11 +33,38 @@ var stewardCNPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-
 // All admin cert issuance paths pass this value explicitly; no caller can supply higher.
 const adminCertValidityDays = 365
 
+// validateBundleExternalURL returns an actionable error if cfg.ExternalURL is
+// unset or invalid. Both admin bundle issuance paths call this before writing any
+// cert or init marker — a controller whose config omits external_url must not
+// silently produce bundles with a wrong ControllerURL that surfaces only as a
+// connection error on the operator's machine.
+func validateBundleExternalURL(cfg *config.Config) error {
+	if cfg.ExternalURL == "" {
+		return fmt.Errorf("external_url must be set in the controller config before issuing admin bundles; " +
+			"it is the externally-reachable HTTPS address operators use to connect " +
+			"(e.g. external_url: https://controller.example.com:8080)")
+	}
+	u, err := url.Parse(cfg.ExternalURL)
+	if err != nil {
+		return fmt.Errorf("external_url %q is not a valid URL: %w", cfg.ExternalURL, err)
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return fmt.Errorf("external_url must use the https scheme, got %q", cfg.ExternalURL)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("external_url must include a hostname, got %q", cfg.ExternalURL)
+	}
+	return nil
+}
+
 // IssueAdminBundle issues a new admin client cert+key bundle for the named operator.
 // The name must be non-empty, alphanumeric+hyphens only, max 64 chars, and must not
 // match any reserved CN or steward UUID pattern. The bundle is written to outputPath
 // with mode 0600 (enforced by bundle.Write).
 func IssueAdminBundle(cfg *config.Config, logger logging.Logger, name, outputPath string) error {
+	if err := validateBundleExternalURL(cfg); err != nil {
+		return err
+	}
 	if err := validateCN(name); err != nil {
 		return err
 	}

--- a/features/controller/initialization/admin_bundle_test.go
+++ b/features/controller/initialization/admin_bundle_test.go
@@ -309,6 +309,63 @@ func TestRegenerate_RequiresConfirmation(t *testing.T) {
 	})
 }
 
+// TestIssueAdminBundle_RejectsUnsetExternalURL verifies that IssueAdminBundle fails
+// with an actionable error when external_url is not configured.
+func TestIssueAdminBundle_RejectsUnsetExternalURL(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	cfg := *setup.cfg
+	cfg.ExternalURL = ""
+
+	outputPath := filepath.Join(t.TempDir(), "should-not-exist.bundle.yaml")
+	err := IssueAdminBundle(&cfg, setup.logger, "alice", outputPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external_url",
+		"error must name the field that needs to be set")
+	assert.NoFileExists(t, outputPath,
+		"no bundle file must be created when external_url is unset")
+}
+
+// TestIssueAdminBundle_RejectsNonHTTPSExternalURL verifies that a config with a
+// non-https external_url is rejected — an http bundle exposes the controller URL
+// as cleartext.
+func TestIssueAdminBundle_RejectsNonHTTPSExternalURL(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	cfg := *setup.cfg
+	cfg.ExternalURL = "http://controller.example.com:8080"
+
+	outputPath := filepath.Join(t.TempDir(), "should-not-exist.bundle.yaml")
+	err := IssueAdminBundle(&cfg, setup.logger, "alice", outputPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https",
+		"error must require the https scheme")
+	assert.NoFileExists(t, outputPath,
+		"no bundle file must be created when external_url uses http")
+}
+
+// TestIssueAdminBundle_HonoursExplicitLocalhostURL verifies that a config that
+// explicitly sets external_url to https://localhost:8080 is accepted unchanged.
+// A single-host development deployment is a legitimate use case.
+func TestIssueAdminBundle_HonoursExplicitLocalhostURL(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	cfg := *setup.cfg
+	cfg.ExternalURL = "https://localhost:8080"
+
+	outputPath := filepath.Join(t.TempDir(), "dev.bundle.yaml")
+	err := IssueAdminBundle(&cfg, setup.logger, "dev-admin", outputPath)
+	require.NoError(t, err, "explicit https://localhost:8080 must be accepted")
+
+	b, err := bundle.Read(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "https://localhost:8080", b.ControllerURL,
+		"bundle ControllerURL must reflect the explicitly configured external_url")
+}
+
 // TestRegenerate_RecoversFromMissingBundle verifies that when the bundle marker is
 // present but the bundle file has been deleted externally, RunRegenerate recreates
 // the bundle and the controller initialization state is still valid.

--- a/features/controller/initialization/initialization.go
+++ b/features/controller/initialization/initialization.go
@@ -53,6 +53,12 @@ func Run(cfg *config.Config, logger logging.Logger) (*Result, error) {
 		return nil, fmt.Errorf("certificate management must be enabled for initialization (certificate.enable_cert_management: true)")
 	}
 
+	// Check external_url before any CA material or markers are written so that
+	// a misconfigured operator gets a clear error without a half-initialized controller.
+	if err := validateBundleExternalURL(cfg); err != nil {
+		return nil, err
+	}
+
 	caPath := cfg.Certificate.CAPath
 	if caPath == "" {
 		return nil, fmt.Errorf("certificate CA path is required for initialization (certificate.ca_path)")

--- a/features/controller/initialization/initialization_test.go
+++ b/features/controller/initialization/initialization_test.go
@@ -407,6 +407,48 @@ func TestInit_MarkerPresent_BundleMissing_Errors(t *testing.T) {
 	assert.Contains(t, err.Error(), "bootstrap-admin --regenerate")
 }
 
+// TestRun_RejectsUnsetExternalURL verifies that Run fails with an actionable error
+// when external_url is not configured, and that no CA material or init marker is
+// written (the check fires before any side-effecting initialization step).
+func TestRun_RejectsUnsetExternalURL(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := makeTestConfig(t, tempDir, caDir, bundlePath)
+	cfg.ExternalURL = ""
+
+	_, err := Run(cfg, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external_url",
+		"error must name the field that needs to be set")
+	assert.NoFileExists(t, bundlePath,
+		"no admin bundle must be written when external_url is unset")
+	assert.False(t, IsInitialized(caDir),
+		"init marker must not be written when external_url is unset: check must fire before CA material")
+}
+
+// TestRun_BundleHonoursExternalURL verifies that the ControllerURL in the system
+// admin bundle matches the configured external_url after initialization.
+func TestRun_BundleHonoursExternalURL(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := makeTestConfig(t, tempDir, caDir, bundlePath)
+	cfg.ExternalURL = "https://controller.example.com:9080"
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+
+	b, err := bundle.Read(bundlePath)
+	require.NoError(t, err)
+	assert.Equal(t, "https://controller.example.com:9080", b.ControllerURL,
+		"bundle ControllerURL must reflect the configured external_url")
+}
+
 // makeTestConfig builds a minimal valid Config for initialization tests using temp dirs.
 // TestRun_TransportCertHonorsExternalHostname is the regression test for the
 // fleet-e2e failure on PR #1820: the fleet-controller container ran --init

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/creack/pty v1.1.24
 	github.com/go-acme/lego/v4 v4.34.0
-	github.com/go-git/go-git/v5 v5.19.1
+	github.com/go-git/go-git/v5 v5.19.2
 	github.com/go-ldap/ldap/v3 v3.4.13
 	github.com/go-ole/go-ole v1.3.0
 	github.com/go-webauthn/webauthn v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-ldap/ldap/v3 v3.4.13 h1:+x1nG9h+MZN7h/lUi5Q3UZ0fJ1GyDQYbPvbuH38baDQ=

--- a/pkg/controlplane/interfaces/contract_test.go
+++ b/pkg/controlplane/interfaces/contract_test.go
@@ -30,6 +30,7 @@ import (
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	cpinterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	cpgrpc "github.com/cfgis/cfgms/pkg/controlplane/providers/grpc"
+	cpmemory "github.com/cfgis/cfgms/pkg/controlplane/providers/memory"
 	cptypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
@@ -750,11 +751,63 @@ func grpcCPFactory(t *testing.T) (cpinterfaces.ControlPlaneProvider, map[string]
 }
 
 // =============================================================================
-// Top-level test: run full suite against gRPC provider
+// In-Process Memory Factory
+// =============================================================================
+
+// memoryCPFactory is a CPProviderFactory for the in-process memory provider.
+// It creates a server provider and one client per steward ID in
+// cpContractStewardIDs, all attached to a single shared bus.
+func memoryCPFactory(t *testing.T) (cpinterfaces.ControlPlaneProvider, map[string]cpinterfaces.ControlPlaneProvider, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	bus := cpmemory.NewBus()
+
+	server := cpmemory.New(cpmemory.ModeServer)
+	require.NoError(t, server.Initialize(ctx, map[string]interface{}{"bus": bus}))
+	require.NoError(t, server.Start(ctx))
+
+	clients := make(map[string]cpinterfaces.ControlPlaneProvider, len(cpContractStewardIDs))
+	concreteClients := make([]*cpmemory.Provider, 0, len(cpContractStewardIDs))
+
+	for _, id := range cpContractStewardIDs {
+		client := cpmemory.New(cpmemory.ModeClient)
+		require.NoError(t, client.Initialize(ctx, map[string]interface{}{
+			"bus":        bus,
+			"steward_id": id,
+		}))
+		require.NoError(t, client.Start(ctx))
+		clients[id] = client
+		concreteClients = append(concreteClients, client)
+	}
+
+	require.Equal(t, len(cpContractStewardIDs), bus.ClientCount(), "all stewards should be attached")
+
+	cleanup := func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		for _, c := range concreteClients {
+			require.NoError(t, c.Stop(stopCtx))
+		}
+		require.NoError(t, server.Stop(stopCtx))
+	}
+
+	return server, clients, cleanup
+}
+
+// =============================================================================
+// Top-level tests: run full suite against each provider
 // =============================================================================
 
 // TestCP_GRPCContractSuite runs all ControlPlaneProvider contract tests against
 // the gRPC-over-QUIC provider implementation.
 func TestCP_GRPCContractSuite(t *testing.T) {
 	RunCPContractTests(t, grpcCPFactory)
+}
+
+// TestCP_MemoryContractSuite runs all ControlPlaneProvider contract tests against
+// the in-process memory provider, so consumers that wire it into tests get the
+// same behavioural guarantees the gRPC provider offers.
+func TestCP_MemoryContractSuite(t *testing.T) {
+	RunCPContractTests(t, memoryCPFactory)
 }

--- a/pkg/controlplane/providers/memory/provider.go
+++ b/pkg/controlplane/providers/memory/provider.go
@@ -1,0 +1,761 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package memory provides an in-process ControlPlaneProvider implementation.
+//
+// The provider is a complete implementation of
+// interfaces.ControlPlaneProvider: it routes commands, events and heartbeats
+// between a server-mode provider (controller) and client-mode providers
+// (stewards) attached to a shared Bus, enforces per-steward addressing,
+// applies event filters, tracks connection lifecycle and reports real
+// statistics. Only the transport differs from the gRPC-over-QUIC provider —
+// messages are handed between providers in-process instead of being serialised
+// onto a QUIC stream.
+//
+// It exists so that consumers of the control plane (controller API wiring,
+// dispatchers, heartbeat services) can be tested against a real provider
+// instead of each package hand-rolling its own partial fake. The same
+// behavioural contract suite that validates the gRPC provider
+// (interfaces.RunCPContractTests) runs against this provider.
+//
+// Usage:
+//
+//	bus := memory.NewBus()
+//
+//	server := memory.New(memory.ModeServer)
+//	_ = server.Initialize(ctx, map[string]interface{}{"bus": bus})
+//	_ = server.Start(ctx)
+//
+//	client := memory.New(memory.ModeClient)
+//	_ = client.Initialize(ctx, map[string]interface{}{"bus": bus, "steward_id": "steward-1"})
+//	_ = client.Start(ctx)
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// Mode defines the provider operating mode. It mirrors the gRPC provider's
+// modes so that wiring code can switch transports without other changes.
+type Mode string
+
+const (
+	// ModeServer indicates controller (server) mode.
+	ModeServer Mode = "server"
+
+	// ModeClient indicates steward (client) mode.
+	ModeClient Mode = "client"
+)
+
+// providerName is reported by Name().
+const providerName = "memory"
+
+// Bus is the in-process message fabric shared by one server-mode provider and
+// the client-mode providers connected to it. It plays the role the network
+// plays for the gRPC provider: a client is only reachable while it is attached,
+// and a client can only attach while a server is listening.
+//
+// A Bus is safe for concurrent use.
+type Bus struct {
+	mu      sync.RWMutex
+	server  *Provider
+	clients map[string]*Provider
+}
+
+// NewBus returns an empty Bus with no server and no connected clients.
+func NewBus() *Bus {
+	return &Bus{clients: make(map[string]*Provider)}
+}
+
+// attachServer registers p as the bus's server. Only one server may listen on
+// a bus at a time, matching the single-listener semantics of a real address.
+func (b *Bus) attachServer(p *Provider) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.server != nil && b.server != p {
+		return fmt.Errorf("bus already has a server-mode provider attached")
+	}
+	b.server = p
+	return nil
+}
+
+// detachServer removes p as the bus's server and disconnects every client,
+// mirroring a listener close tearing down all live streams.
+func (b *Bus) detachServer(p *Provider) {
+	b.mu.Lock()
+	if b.server != p {
+		b.mu.Unlock()
+		return
+	}
+	b.server = nil
+	clients := make([]*Provider, 0, len(b.clients))
+	for id, c := range b.clients {
+		clients = append(clients, c)
+		delete(b.clients, id)
+	}
+	b.mu.Unlock()
+
+	for _, c := range clients {
+		c.markDisconnected()
+	}
+}
+
+// attachClient connects the client provider for stewardID. It fails when no
+// server is listening, or when a different provider already holds that ID.
+func (b *Bus) attachClient(stewardID string, p *Provider) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.server == nil {
+		return fmt.Errorf("no server-mode provider is listening on the bus")
+	}
+	if existing, ok := b.clients[stewardID]; ok && existing != p {
+		return fmt.Errorf("steward %q is already connected", stewardID)
+	}
+	b.clients[stewardID] = p
+	return nil
+}
+
+// detachClient disconnects the client provider registered for stewardID.
+func (b *Bus) detachClient(stewardID string, p *Provider) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if existing, ok := b.clients[stewardID]; ok && existing == p {
+		delete(b.clients, stewardID)
+	}
+}
+
+// lookupClient returns the connected client provider for stewardID.
+func (b *Bus) lookupClient(stewardID string) (*Provider, bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	c, ok := b.clients[stewardID]
+	return c, ok
+}
+
+// lookupServer returns the attached server provider.
+func (b *Bus) lookupServer() (*Provider, bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.server, b.server != nil
+}
+
+// ClientCount returns the number of currently connected client providers.
+func (b *Bus) ClientCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.clients)
+}
+
+// eventSubscription pairs an event filter with its handler.
+type eventSubscription struct {
+	filter  *types.EventFilter
+	handler interfaces.EventHandler
+}
+
+// Provider implements interfaces.ControlPlaneProvider over an in-process Bus.
+//
+// A Provider is safe for concurrent use. Handlers are invoked on their own
+// goroutines, as they are in the gRPC provider, so a slow handler never blocks
+// the sender; Stop waits for in-flight handler goroutines to finish.
+type Provider struct {
+	mu sync.RWMutex
+
+	mode      Mode
+	bus       *Bus
+	stewardID string
+	tenantID  string
+	logger    logging.Logger
+
+	started   bool
+	connected bool
+	startTime time.Time
+
+	// Subscriptions (client mode)
+	commandHandler interfaces.CommandHandler
+
+	// Subscriptions (server mode)
+	eventHandlers     []eventSubscription
+	heartbeatHandlers []interfaces.HeartbeatHandler
+
+	// Lifecycle
+	ctx      context.Context
+	cancel   context.CancelFunc
+	dispatch sync.WaitGroup
+
+	// Statistics
+	commandsSent       atomic.Int64
+	commandsReceived   atomic.Int64
+	eventsPublished    atomic.Int64
+	eventsReceived     atomic.Int64
+	heartbeatsSent     atomic.Int64
+	heartbeatsReceived atomic.Int64
+	deliveryFailures   atomic.Int64
+}
+
+// Compile-time proof that Provider satisfies the central provider interface.
+var _ interfaces.ControlPlaneProvider = (*Provider)(nil)
+
+// New creates an in-process control plane provider in the given mode.
+// The provider must be initialised with a Bus before it is started.
+func New(mode Mode) *Provider {
+	return &Provider{
+		mode:              mode,
+		logger:            logging.NewNoopLogger(),
+		eventHandlers:     []eventSubscription{},
+		heartbeatHandlers: []interfaces.HeartbeatHandler{},
+	}
+}
+
+// Name returns the provider name.
+func (p *Provider) Name() string { return providerName }
+
+// Initialize configures the provider.
+//
+// Config keys:
+//   - "bus": *Bus - the shared in-process fabric (required)
+//   - "mode": string - "server" or "client" (optional; overrides the constructor)
+//   - "logger": logging.Logger - logger (optional)
+//
+// Client mode additional keys:
+//   - "steward_id": string - this steward's ID (required)
+//   - "tenant_id": string - tenant ID (optional)
+func (p *Provider) Initialize(_ context.Context, config map[string]interface{}) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if modeStr, ok := config["mode"].(string); ok {
+		p.mode = Mode(modeStr)
+	}
+	if logger, ok := config["logger"].(logging.Logger); ok {
+		p.logger = logger
+	}
+
+	bus, ok := config["bus"].(*Bus)
+	if !ok || bus == nil {
+		return fmt.Errorf("memory control plane requires 'bus' (*memory.Bus) in config")
+	}
+	p.bus = bus
+
+	switch p.mode {
+	case ModeServer:
+		return nil
+	case ModeClient:
+		stewardID, ok := config["steward_id"].(string)
+		if !ok || stewardID == "" {
+			return fmt.Errorf("client mode requires 'steward_id' in config")
+		}
+		p.stewardID = stewardID
+		if tenantID, ok := config["tenant_id"].(string); ok {
+			p.tenantID = tenantID
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid mode: %s (must be 'server' or 'client')", p.mode)
+	}
+}
+
+// Start attaches the provider to its bus. In server mode the provider begins
+// accepting client attachments; in client mode it connects, which fails when
+// no server is listening.
+func (p *Provider) Start(ctx context.Context) error {
+	p.mu.Lock()
+	if p.bus == nil {
+		p.mu.Unlock()
+		return fmt.Errorf("provider not initialized")
+	}
+	if p.started {
+		p.mu.Unlock()
+		return fmt.Errorf("provider already started")
+	}
+	mode, bus, stewardID := p.mode, p.bus, p.stewardID
+	p.mu.Unlock()
+
+	switch mode {
+	case ModeServer:
+		if err := bus.attachServer(p); err != nil {
+			return err
+		}
+	case ModeClient:
+		if err := bus.attachClient(stewardID, p); err != nil {
+			return fmt.Errorf("failed to connect steward %s: %w", stewardID, err)
+		}
+	default:
+		return fmt.Errorf("provider not initialized")
+	}
+
+	p.mu.Lock()
+	p.ctx, p.cancel = context.WithCancel(ctx)
+	p.startTime = time.Now()
+	p.started = true
+	p.connected = true
+	p.mu.Unlock()
+
+	return nil
+}
+
+// Stop detaches the provider from its bus and waits for in-flight handler
+// goroutines to finish. Stop is idempotent and safe to call on a provider that
+// was never started.
+func (p *Provider) Stop(ctx context.Context) error {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return nil
+	}
+	p.started = false
+	p.connected = false
+	if p.cancel != nil {
+		p.cancel()
+	}
+	mode, bus, stewardID := p.mode, p.bus, p.stewardID
+	p.commandHandler = nil
+	p.eventHandlers = nil
+	p.heartbeatHandlers = nil
+	p.mu.Unlock()
+
+	if bus != nil {
+		switch mode {
+		case ModeServer:
+			bus.detachServer(p)
+		case ModeClient:
+			bus.detachClient(stewardID, p)
+		}
+	}
+
+	return p.waitForDispatch(ctx)
+}
+
+// waitForDispatch blocks until every in-flight handler goroutine returns, or
+// until ctx is done.
+func (p *Provider) waitForDispatch(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		p.dispatch.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting for in-flight handlers: %w", ctx.Err())
+	}
+}
+
+// Reconnect re-attaches a client-mode provider to its bus without discarding
+// its statistics. It returns an error in server mode, matching the gRPC
+// provider.
+func (p *Provider) Reconnect(ctx context.Context) error {
+	p.mu.RLock()
+	mode, bus, stewardID := p.mode, p.bus, p.stewardID
+	p.mu.RUnlock()
+
+	if mode != ModeClient {
+		return fmt.Errorf("Reconnect called on server-mode provider")
+	}
+	if bus == nil {
+		return fmt.Errorf("provider not initialized")
+	}
+
+	bus.detachClient(stewardID, p)
+	if err := bus.attachClient(stewardID, p); err != nil {
+		return fmt.Errorf("failed to reconnect steward %s: %w", stewardID, err)
+	}
+
+	p.mu.Lock()
+	if p.ctx == nil || p.ctx.Err() != nil {
+		p.ctx, p.cancel = context.WithCancel(context.WithoutCancel(ctx))
+	}
+	if p.startTime.IsZero() {
+		p.startTime = time.Now()
+	}
+	p.started = true
+	p.connected = true
+	p.mu.Unlock()
+
+	return nil
+}
+
+// markDisconnected flips the provider to disconnected without detaching it
+// from the bus. Used when the server tears down and drops all clients.
+func (p *Provider) markDisconnected() {
+	p.mu.Lock()
+	p.connected = false
+	p.mu.Unlock()
+}
+
+// --- Commands (Controller → Steward) ---
+
+// SendCommand delivers a signed command to the addressed steward. It returns
+// an error when the steward is not connected.
+func (p *Provider) SendCommand(_ context.Context, cmd *types.SignedCommand) error {
+	if p.mode != ModeServer {
+		return fmt.Errorf("SendCommand is only available in server mode")
+	}
+	if cmd == nil {
+		return fmt.Errorf("SendCommand: command must not be nil")
+	}
+	if err := p.checkStarted(); err != nil {
+		return err
+	}
+
+	if err := p.deliverCommand(cmd, cmd.Command.StewardID); err != nil {
+		p.deliveryFailures.Add(1)
+		return err
+	}
+	p.commandsSent.Add(1)
+	return nil
+}
+
+// FanOutCommand delivers a signed command to each listed steward, reporting
+// per-steward delivery status. Stewards that are not connected appear in
+// FanOutResult.Failed; the error return is reserved for systemic failures.
+func (p *Provider) FanOutCommand(_ context.Context, cmd *types.SignedCommand, stewardIDs []string) (*types.FanOutResult, error) {
+	if p.mode != ModeServer {
+		return nil, fmt.Errorf("FanOutCommand is only available in server mode")
+	}
+	if cmd == nil {
+		return nil, fmt.Errorf("FanOutCommand: command must not be nil")
+	}
+	if len(stewardIDs) == 0 {
+		return nil, fmt.Errorf("stewardIDs must not be empty")
+	}
+	if err := p.checkStarted(); err != nil {
+		return nil, err
+	}
+
+	result := &types.FanOutResult{Failed: make(map[string]error)}
+	for _, id := range stewardIDs {
+		if err := p.deliverCommand(cmd, id); err != nil {
+			result.Failed[id] = err
+			p.deliveryFailures.Add(1)
+			continue
+		}
+		result.Succeeded = append(result.Succeeded, id)
+		p.commandsSent.Add(1)
+	}
+	return result, nil
+}
+
+// deliverCommand routes one command to one steward. Each steward receives its
+// own copy, so a handler cannot mutate the sender's command or another
+// steward's copy — the isolation a serialising transport provides for free.
+func (p *Provider) deliverCommand(cmd *types.SignedCommand, stewardID string) error {
+	if stewardID == "" {
+		return fmt.Errorf("command has no target steward ID")
+	}
+	p.mu.RLock()
+	bus := p.bus
+	p.mu.RUnlock()
+
+	client, ok := bus.lookupClient(stewardID)
+	if !ok {
+		return fmt.Errorf("steward %s not connected", stewardID)
+	}
+	client.receiveCommand(cloneSignedCommand(cmd))
+	return nil
+}
+
+// receiveCommand is the client-side ingress for a command.
+func (p *Provider) receiveCommand(cmd *types.SignedCommand) {
+	p.commandsReceived.Add(1)
+
+	p.mu.RLock()
+	handler := p.commandHandler
+	ctx := p.ctx
+	p.mu.RUnlock()
+
+	if handler == nil {
+		return
+	}
+	p.dispatchAsync(func() {
+		if err := handler(ctx, cmd); err != nil {
+			p.logger.Error("command handler error",
+				"command_id", logging.SanitizeLogValue(cmd.Command.ID),
+				"error", logging.SanitizeLogValue(err.Error()))
+		}
+	})
+}
+
+// SubscribeCommands registers the client-side command handler. The stewardID
+// must match the ID this provider was initialised with (or be empty), since
+// routing is by the provider's own identity, as it is by mTLS CN on the wire.
+func (p *Provider) SubscribeCommands(_ context.Context, stewardID string, handler interfaces.CommandHandler) error {
+	if p.mode != ModeClient {
+		return fmt.Errorf("SubscribeCommands is only available in client mode")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if stewardID != "" && stewardID != p.stewardID {
+		return fmt.Errorf("cannot subscribe to commands for steward %s: provider identity is %s", stewardID, p.stewardID)
+	}
+	p.commandHandler = handler
+	return nil
+}
+
+// --- Events (Steward → Controller) ---
+
+// PublishEvent sends an event to the controller. It returns an error when the
+// client is not connected.
+func (p *Provider) PublishEvent(_ context.Context, event *types.Event) error {
+	if p.mode != ModeClient {
+		return fmt.Errorf("PublishEvent is only available in client mode")
+	}
+	if event == nil {
+		return fmt.Errorf("PublishEvent: event must not be nil")
+	}
+
+	server, err := p.serverForSend()
+	if err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to publish event: %w", err)
+	}
+
+	server.receiveEvent(cloneEvent(event))
+	p.eventsPublished.Add(1)
+	return nil
+}
+
+// receiveEvent is the server-side ingress for an event.
+func (p *Provider) receiveEvent(event *types.Event) {
+	p.eventsReceived.Add(1)
+
+	p.mu.RLock()
+	subs := make([]eventSubscription, len(p.eventHandlers))
+	copy(subs, p.eventHandlers)
+	ctx := p.ctx
+	p.mu.RUnlock()
+
+	for _, sub := range subs {
+		if sub.filter != nil && !sub.filter.Match(event) {
+			continue
+		}
+		handler := sub.handler
+		p.dispatchAsync(func() {
+			if err := handler(ctx, event); err != nil {
+				p.logger.Error("event handler error",
+					"event_id", logging.SanitizeLogValue(event.ID),
+					"error", logging.SanitizeLogValue(err.Error()))
+			}
+		})
+	}
+}
+
+// SubscribeEvents registers a server-side event handler with an optional filter.
+func (p *Provider) SubscribeEvents(_ context.Context, filter *types.EventFilter, handler interfaces.EventHandler) error {
+	if p.mode != ModeServer {
+		return fmt.Errorf("SubscribeEvents is only available in server mode")
+	}
+
+	p.mu.Lock()
+	p.eventHandlers = append(p.eventHandlers, eventSubscription{filter: filter, handler: handler})
+	p.mu.Unlock()
+	return nil
+}
+
+// --- Heartbeats ---
+
+// SendHeartbeat sends a heartbeat to the controller. It returns an error when
+// the client is not connected.
+func (p *Provider) SendHeartbeat(_ context.Context, heartbeat *types.Heartbeat) error {
+	if p.mode != ModeClient {
+		return fmt.Errorf("SendHeartbeat is only available in client mode")
+	}
+	if heartbeat == nil {
+		return fmt.Errorf("SendHeartbeat: heartbeat must not be nil")
+	}
+
+	server, err := p.serverForSend()
+	if err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to send heartbeat: %w", err)
+	}
+
+	server.receiveHeartbeat(cloneHeartbeat(heartbeat))
+	p.heartbeatsSent.Add(1)
+	return nil
+}
+
+// receiveHeartbeat is the server-side ingress for a heartbeat.
+func (p *Provider) receiveHeartbeat(hb *types.Heartbeat) {
+	p.heartbeatsReceived.Add(1)
+
+	p.mu.RLock()
+	handlers := make([]interfaces.HeartbeatHandler, len(p.heartbeatHandlers))
+	copy(handlers, p.heartbeatHandlers)
+	ctx := p.ctx
+	p.mu.RUnlock()
+
+	for _, handler := range handlers {
+		handler := handler
+		p.dispatchAsync(func() {
+			if err := handler(ctx, hb); err != nil {
+				p.logger.Error("heartbeat handler error",
+					"steward_id", logging.SanitizeLogValue(hb.StewardID),
+					"error", logging.SanitizeLogValue(err.Error()))
+			}
+		})
+	}
+}
+
+// SubscribeHeartbeats registers a server-side heartbeat handler.
+func (p *Provider) SubscribeHeartbeats(_ context.Context, handler interfaces.HeartbeatHandler) error {
+	if p.mode != ModeServer {
+		return fmt.Errorf("SubscribeHeartbeats is only available in server mode")
+	}
+
+	p.mu.Lock()
+	p.heartbeatHandlers = append(p.heartbeatHandlers, handler)
+	p.mu.Unlock()
+	return nil
+}
+
+// --- Status & Monitoring ---
+
+// GetStats returns the provider's operational counters.
+func (p *Provider) GetStats(_ context.Context) (*types.ControlPlaneStats, error) {
+	stats := &types.ControlPlaneStats{
+		CommandsSent:       p.commandsSent.Load(),
+		CommandsReceived:   p.commandsReceived.Load(),
+		EventsPublished:    p.eventsPublished.Load(),
+		EventsReceived:     p.eventsReceived.Load(),
+		HeartbeatsSent:     p.heartbeatsSent.Load(),
+		HeartbeatsReceived: p.heartbeatsReceived.Load(),
+		DeliveryFailures:   p.deliveryFailures.Load(),
+		ProviderMetrics:    make(map[string]interface{}),
+	}
+
+	p.mu.RLock()
+	if !p.startTime.IsZero() {
+		stats.Uptime = time.Since(p.startTime)
+	}
+	stats.ActiveSubscriptions = int64(len(p.eventHandlers) + len(p.heartbeatHandlers))
+	mode, bus, connected := p.mode, p.bus, p.connected
+	p.mu.RUnlock()
+
+	if mode == ModeServer && bus != nil {
+		stats.ConnectedStewards = int64(bus.ClientCount())
+	}
+	if mode == ModeClient {
+		state := "disconnected"
+		if connected {
+			state = "connected"
+		}
+		stats.ProviderMetrics["connection_state"] = state
+	}
+
+	return stats, nil
+}
+
+// IsConnected reports whether the provider is attached to its bus: accepting
+// clients in server mode, connected to the server in client mode.
+func (p *Provider) IsConnected() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.started && p.connected
+}
+
+// StewardID returns the steward identity a client-mode provider was
+// initialised with. Empty in server mode.
+func (p *Provider) StewardID() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.stewardID
+}
+
+// checkStarted returns an error when the provider is not attached to its bus.
+func (p *Provider) checkStarted() error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if !p.started {
+		return fmt.Errorf("provider is not started")
+	}
+	return nil
+}
+
+// serverForSend returns the bus server for a client-side send, erroring when
+// the client is disconnected or no server is listening.
+func (p *Provider) serverForSend() (*Provider, error) {
+	p.mu.RLock()
+	started, connected, bus := p.started, p.connected, p.bus
+	p.mu.RUnlock()
+
+	if !started || !connected {
+		return nil, fmt.Errorf("provider is disconnected")
+	}
+	server, ok := bus.lookupServer()
+	if !ok {
+		return nil, fmt.Errorf("no server-mode provider is listening on the bus")
+	}
+	return server, nil
+}
+
+// dispatchAsync runs fn on its own goroutine, tracked so Stop can wait for it.
+func (p *Provider) dispatchAsync(fn func()) {
+	p.dispatch.Add(1)
+	go func() {
+		defer p.dispatch.Done()
+		fn()
+	}()
+}
+
+// --- Message copying ---
+
+// cloneSignedCommand returns a deep-enough copy of cmd that the receiver and
+// the sender share no mutable state. The signature is treated as immutable.
+func cloneSignedCommand(cmd *types.SignedCommand) *types.SignedCommand {
+	out := &types.SignedCommand{
+		Command:   cmd.Command,
+		Signature: cmd.Signature,
+	}
+	if cmd.Command.Params != nil {
+		params := make(map[string]interface{}, len(cmd.Command.Params))
+		for k, v := range cmd.Command.Params {
+			params[k] = v
+		}
+		out.Command.Params = params
+	}
+	if cmd.RawParams != nil {
+		raw := make(map[string]string, len(cmd.RawParams))
+		for k, v := range cmd.RawParams {
+			raw[k] = v
+		}
+		out.RawParams = raw
+	}
+	return out
+}
+
+// cloneEvent returns a copy of event with an independent Details map.
+func cloneEvent(event *types.Event) *types.Event {
+	out := *event
+	if event.Details != nil {
+		details := make(map[string]interface{}, len(event.Details))
+		for k, v := range event.Details {
+			details[k] = v
+		}
+		out.Details = details
+	}
+	return &out
+}
+
+// cloneHeartbeat returns a copy of hb with an independent Metrics map.
+func cloneHeartbeat(hb *types.Heartbeat) *types.Heartbeat {
+	out := *hb
+	if hb.Metrics != nil {
+		metrics := make(map[string]interface{}, len(hb.Metrics))
+		for k, v := range hb.Metrics {
+			metrics[k] = v
+		}
+		out.Metrics = metrics
+	}
+	return &out
+}

--- a/pkg/controlplane/providers/memory/provider.go
+++ b/pkg/controlplane/providers/memory/provider.go
@@ -177,6 +177,7 @@ type Provider struct {
 	started   bool
 	connected bool
 	startTime time.Time
+	now       func() time.Time
 
 	// Subscriptions (client mode)
 	commandHandler interfaces.CommandHandler
@@ -203,15 +204,33 @@ type Provider struct {
 // Compile-time proof that Provider satisfies the central provider interface.
 var _ interfaces.ControlPlaneProvider = (*Provider)(nil)
 
+// Option configures optional Provider behaviour at construction time.
+type Option func(*Provider)
+
+// WithClock overrides the provider's time source, used to compute startTime
+// and Uptime. Tests use it to control elapsed time deterministically instead
+// of depending on real wall-clock resolution; production callers should not
+// need it.
+func WithClock(now func() time.Time) Option {
+	return func(p *Provider) {
+		p.now = now
+	}
+}
+
 // New creates an in-process control plane provider in the given mode.
 // The provider must be initialised with a Bus before it is started.
-func New(mode Mode) *Provider {
-	return &Provider{
+func New(mode Mode, opts ...Option) *Provider {
+	p := &Provider{
 		mode:              mode,
 		logger:            logging.NewNoopLogger(),
 		eventHandlers:     []eventSubscription{},
 		heartbeatHandlers: []interfaces.HeartbeatHandler{},
+		now:               time.Now,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // Name returns the provider name.
@@ -293,7 +312,7 @@ func (p *Provider) Start(ctx context.Context) error {
 
 	p.mu.Lock()
 	p.ctx, p.cancel = context.WithCancel(ctx)
-	p.startTime = time.Now()
+	p.startTime = p.now()
 	p.started = true
 	p.connected = true
 	p.mu.Unlock()
@@ -375,7 +394,7 @@ func (p *Provider) Reconnect(ctx context.Context) error {
 		p.ctx, p.cancel = context.WithCancel(context.WithoutCancel(ctx))
 	}
 	if p.startTime.IsZero() {
-		p.startTime = time.Now()
+		p.startTime = p.now()
 	}
 	p.started = true
 	p.connected = true
@@ -636,7 +655,7 @@ func (p *Provider) GetStats(_ context.Context) (*types.ControlPlaneStats, error)
 
 	p.mu.RLock()
 	if !p.startTime.IsZero() {
-		stats.Uptime = time.Since(p.startTime)
+		stats.Uptime = p.now().Sub(p.startTime)
 	}
 	stats.ActiveSubscriptions = int64(len(p.eventHandlers) + len(p.heartbeatHandlers))
 	mode, bus, connected := p.mode, p.bus, p.connected

--- a/pkg/controlplane/providers/memory/provider_test.go
+++ b/pkg/controlplane/providers/memory/provider_test.go
@@ -348,7 +348,39 @@ func TestGetStats_ReportsConnectedStewardsAndSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), stats.ConnectedStewards)
 	assert.Equal(t, int64(2), stats.ActiveSubscriptions)
-	assert.Positive(t, stats.Uptime)
+	// Plumbing check only: confirms Uptime is wired to startTime, not a timing
+	// assertion. assert.Positive is unreliable here because Windows timer
+	// granularity (~15.6ms) can put Start and GetStats in the same tick,
+	// producing an observed 0s even though the code is correct. See
+	// TestGetStats_UptimeReflectsClock for a deterministic growth assertion.
+	assert.GreaterOrEqual(t, stats.Uptime, time.Duration(0))
+}
+
+// TestGetStats_UptimeReflectsClock asserts Uptime growth exactly, using an
+// injected clock instead of real elapsed wall-clock time. Asserting a real
+// sleep interval would reintroduce the same clock-resolution flakiness this
+// test is written to avoid; the injectable clock lets the boundary be exact.
+func TestGetStats_UptimeReflectsClock(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+
+	current := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return current }
+
+	server := memory.New(memory.ModeServer, memory.WithClock(clock))
+	require.NoError(t, server.Initialize(ctx, map[string]interface{}{"bus": bus}))
+	require.NoError(t, server.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, server.Stop(stopCtx))
+	})
+
+	current = current.Add(90 * time.Second)
+
+	stats, err := server.GetStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 90*time.Second, stats.Uptime)
 }
 
 func TestGetStats_CountsDeliveryFailures(t *testing.T) {

--- a/pkg/controlplane/providers/memory/provider_test.go
+++ b/pkg/controlplane/providers/memory/provider_test.go
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package memory_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/controlplane/providers/memory"
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+)
+
+// startServer returns a started server-mode provider on bus.
+func startServer(t *testing.T, bus *memory.Bus) *memory.Provider {
+	t.Helper()
+	ctx := context.Background()
+	server := memory.New(memory.ModeServer)
+	require.NoError(t, server.Initialize(ctx, map[string]interface{}{"bus": bus}))
+	require.NoError(t, server.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, server.Stop(stopCtx))
+	})
+	return server
+}
+
+// startClient returns a started client-mode provider for stewardID on bus.
+func startClient(t *testing.T, bus *memory.Bus, stewardID string) *memory.Provider {
+	t.Helper()
+	ctx := context.Background()
+	client := memory.New(memory.ModeClient)
+	require.NoError(t, client.Initialize(ctx, map[string]interface{}{
+		"bus":        bus,
+		"steward_id": stewardID,
+	}))
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, client.Stop(stopCtx))
+	})
+	return client
+}
+
+func TestInitialize_RequiresBus(t *testing.T) {
+	ctx := context.Background()
+
+	server := memory.New(memory.ModeServer)
+	err := server.Initialize(ctx, map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bus")
+}
+
+func TestInitialize_ClientRequiresStewardID(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+
+	client := memory.New(memory.ModeClient)
+	err := client.Initialize(ctx, map[string]interface{}{"bus": bus})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "steward_id")
+}
+
+func TestInitialize_RejectsUnknownMode(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+
+	p := memory.New(memory.Mode("relay"))
+	err := p.Initialize(ctx, map[string]interface{}{"bus": bus})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+func TestStart_ClientRequiresListeningServer(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+
+	client := memory.New(memory.ModeClient)
+	require.NoError(t, client.Initialize(ctx, map[string]interface{}{
+		"bus":        bus,
+		"steward_id": "steward-1",
+	}))
+
+	err := client.Start(ctx)
+	require.Error(t, err, "client must not connect when no server is listening")
+	assert.False(t, client.IsConnected())
+}
+
+func TestStart_RejectsSecondServerOnBus(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	startServer(t, bus)
+
+	second := memory.New(memory.ModeServer)
+	require.NoError(t, second.Initialize(ctx, map[string]interface{}{"bus": bus}))
+	require.Error(t, second.Start(ctx), "only one server may listen on a bus")
+}
+
+func TestStart_RejectsDuplicateStewardID(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	startServer(t, bus)
+	startClient(t, bus, "steward-1")
+
+	duplicate := memory.New(memory.ModeClient)
+	require.NoError(t, duplicate.Initialize(ctx, map[string]interface{}{
+		"bus":        bus,
+		"steward_id": "steward-1",
+	}))
+	err := duplicate.Start(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already connected")
+}
+
+func TestServerStop_DisconnectsClients(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+
+	server := memory.New(memory.ModeServer)
+	require.NoError(t, server.Initialize(ctx, map[string]interface{}{"bus": bus}))
+	require.NoError(t, server.Start(ctx))
+
+	client := startClient(t, bus, "steward-1")
+	require.True(t, client.IsConnected())
+
+	require.NoError(t, server.Stop(ctx))
+
+	assert.False(t, client.IsConnected(), "client must observe the server going away")
+	assert.Equal(t, 0, bus.ClientCount())
+
+	require.Error(t, client.PublishEvent(ctx, &types.Event{
+		ID:        "evt-after-server-stop",
+		Type:      types.EventError,
+		StewardID: "steward-1",
+		Timestamp: time.Now(),
+	}))
+}
+
+func TestStop_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	startServer(t, bus)
+
+	client := memory.New(memory.ModeClient)
+	require.NoError(t, client.Initialize(ctx, map[string]interface{}{
+		"bus":        bus,
+		"steward_id": "steward-1",
+	}))
+	require.NoError(t, client.Start(ctx))
+
+	require.NoError(t, client.Stop(ctx))
+	require.NoError(t, client.Stop(ctx), "second Stop must be a no-op")
+}
+
+func TestReconnect_RestoresClientDelivery(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+	client := startClient(t, bus, "steward-1")
+
+	require.NoError(t, client.Stop(ctx))
+
+	cmd := &types.SignedCommand{Command: types.Command{
+		ID:        "cmd-while-disconnected",
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-1",
+		Timestamp: time.Now(),
+	}}
+	require.Error(t, server.SendCommand(ctx, cmd), "disconnected steward must not be reachable")
+
+	require.NoError(t, client.Reconnect(ctx))
+	assert.True(t, client.IsConnected())
+
+	received := make(chan *types.SignedCommand, 1)
+	require.NoError(t, client.SubscribeCommands(ctx, "steward-1", func(_ context.Context, sc *types.SignedCommand) error {
+		received <- sc
+		return nil
+	}))
+
+	require.NoError(t, server.SendCommand(ctx, &types.SignedCommand{Command: types.Command{
+		ID:        "cmd-after-reconnect",
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-1",
+		Timestamp: time.Now(),
+	}}))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "cmd-after-reconnect", got.Command.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnected steward did not receive command")
+	}
+}
+
+func TestReconnect_RejectedInServerMode(t *testing.T) {
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+	require.Error(t, server.Reconnect(context.Background()))
+}
+
+func TestSubscribeCommands_RejectsForeignStewardID(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	startServer(t, bus)
+	client := startClient(t, bus, "steward-1")
+
+	err := client.SubscribeCommands(ctx, "steward-2", func(context.Context, *types.SignedCommand) error {
+		return nil
+	})
+	require.Error(t, err, "a steward must not subscribe to another steward's commands")
+}
+
+func TestModeGuards(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+	client := startClient(t, bus, "steward-1")
+
+	require.Error(t, client.SendCommand(ctx, &types.SignedCommand{}))
+	_, err := client.FanOutCommand(ctx, &types.SignedCommand{}, []string{"steward-1"})
+	require.Error(t, err)
+	require.Error(t, client.SubscribeEvents(ctx, nil, func(context.Context, *types.Event) error { return nil }))
+	require.Error(t, client.SubscribeHeartbeats(ctx, func(context.Context, *types.Heartbeat) error { return nil }))
+
+	require.Error(t, server.PublishEvent(ctx, &types.Event{ID: "e"}))
+	require.Error(t, server.SendHeartbeat(ctx, &types.Heartbeat{StewardID: "steward-1"}))
+	require.Error(t, server.SubscribeCommands(ctx, "steward-1", func(context.Context, *types.SignedCommand) error { return nil }))
+}
+
+func TestFanOutCommand_RejectsEmptyTargets(t *testing.T) {
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+
+	_, err := server.FanOutCommand(context.Background(), &types.SignedCommand{}, nil)
+	require.Error(t, err)
+}
+
+func TestSendCommand_RequiresTargetStewardID(t *testing.T) {
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+
+	err := server.SendCommand(context.Background(), &types.SignedCommand{Command: types.Command{
+		ID:        "cmd-no-target",
+		Type:      types.CommandSyncConfig,
+		Timestamp: time.Now(),
+	}})
+	require.Error(t, err, "an unaddressed command must not be broadcast")
+}
+
+func TestDeliveredMessagesAreCopies(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+	clientA := startClient(t, bus, "steward-a")
+	clientB := startClient(t, bus, "steward-b")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var mu sync.Mutex
+	copies := make(map[string]*types.SignedCommand, 2)
+	for _, c := range []*memory.Provider{clientA, clientB} {
+		id := c.StewardID()
+		require.NoError(t, c.SubscribeCommands(ctx, id, func(_ context.Context, sc *types.SignedCommand) error {
+			// Each steward mutates its own copy; no other party may observe it.
+			sc.Command.Params["mutated_by"] = id
+			mu.Lock()
+			copies[id] = sc
+			mu.Unlock()
+			wg.Done()
+			return nil
+		}))
+	}
+
+	original := &types.SignedCommand{Command: types.Command{
+		ID:        "cmd-copy",
+		Type:      types.CommandSyncConfig,
+		Timestamp: time.Now(),
+		Params:    map[string]interface{}{"version": "1.0"},
+	}}
+	result, err := server.FanOutCommand(ctx, original, []string{"steward-a", "steward-b"})
+	require.NoError(t, err)
+	require.Len(t, result.Succeeded, 2)
+
+	wg.Wait()
+
+	assert.Equal(t, map[string]interface{}{"version": "1.0"}, original.Command.Params,
+		"handler mutations must not reach the sender's command")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, copies, 2)
+	assert.Equal(t, "steward-a", copies["steward-a"].Command.Params["mutated_by"])
+	assert.Equal(t, "steward-b", copies["steward-b"].Command.Params["mutated_by"])
+	assert.Equal(t, original.Command.ID, copies["steward-a"].Command.ID)
+}
+
+func TestEventDetailsAreCopied(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+	client := startClient(t, bus, "steward-1")
+
+	received := make(chan *types.Event, 1)
+	require.NoError(t, server.SubscribeEvents(ctx, nil, func(_ context.Context, e *types.Event) error {
+		e.Details["mutated"] = true
+		received <- e
+		return nil
+	}))
+
+	original := &types.Event{
+		ID:        "evt-copy",
+		Type:      types.EventConfigApplied,
+		StewardID: "steward-1",
+		Timestamp: time.Now(),
+		Details:   map[string]interface{}{"modules": "3"},
+	}
+	require.NoError(t, client.PublishEvent(ctx, original))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, true, got.Details["mutated"])
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not receive event")
+	}
+
+	assert.Equal(t, map[string]interface{}{"modules": "3"}, original.Details,
+		"handler mutations must not reach the publisher's event")
+}
+
+func TestGetStats_ReportsConnectedStewardsAndSubscriptions(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+	startClient(t, bus, "steward-1")
+	startClient(t, bus, "steward-2")
+
+	require.NoError(t, server.SubscribeEvents(ctx, nil, func(context.Context, *types.Event) error { return nil }))
+	require.NoError(t, server.SubscribeHeartbeats(ctx, func(context.Context, *types.Heartbeat) error { return nil }))
+
+	stats, err := server.GetStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), stats.ConnectedStewards)
+	assert.Equal(t, int64(2), stats.ActiveSubscriptions)
+	assert.Positive(t, stats.Uptime)
+}
+
+func TestGetStats_CountsDeliveryFailures(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+
+	require.Error(t, server.SendCommand(ctx, &types.SignedCommand{Command: types.Command{
+		ID:        "cmd-nowhere",
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-absent",
+		Timestamp: time.Now(),
+	}}))
+
+	stats, err := server.GetStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.DeliveryFailures)
+	assert.Equal(t, int64(0), stats.CommandsSent)
+}
+
+func TestName(t *testing.T) {
+	assert.Equal(t, "memory", memory.New(memory.ModeServer).Name())
+}
+
+func TestConcurrentSendAndPublish(t *testing.T) {
+	ctx := context.Background()
+	bus := memory.NewBus()
+	server := startServer(t, bus)
+	client := startClient(t, bus, "steward-1")
+
+	var commands, events atomic.Int64
+	require.NoError(t, client.SubscribeCommands(ctx, "steward-1", func(context.Context, *types.SignedCommand) error {
+		commands.Add(1)
+		return nil
+	}))
+	require.NoError(t, server.SubscribeEvents(ctx, nil, func(context.Context, *types.Event) error {
+		events.Add(1)
+		return nil
+	}))
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(2 * n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, server.SendCommand(ctx, &types.SignedCommand{Command: types.Command{
+				ID:        "cmd-concurrent",
+				Type:      types.CommandSyncConfig,
+				StewardID: "steward-1",
+				Timestamp: time.Now(),
+			}}))
+		}()
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, client.PublishEvent(ctx, &types.Event{
+				ID:        "evt-concurrent",
+				Type:      types.EventConfigApplied,
+				StewardID: "steward-1",
+				Timestamp: time.Now(),
+			}))
+		}()
+	}
+	wg.Wait()
+
+	require.Eventually(t, func() bool {
+		return commands.Load() == n && events.Load() == n
+	}, 5*time.Second, 10*time.Millisecond, "all concurrent messages should be delivered")
+}

--- a/test/integration/configs/controller-test.cfg
+++ b/test/integration/configs/controller-test.cfg
@@ -15,6 +15,11 @@ security_profile: "test"
 listen_addr: "0.0.0.0:9080"
 metrics_listen_addr: "127.0.0.1:9090"
 
+# Externally-reachable HTTPS address for admin bundle issuance (Issue #3196).
+# "localhost" is in the server certificate's dns_names below, matching the
+# hostname the transport test suite actually connects through.
+external_url: "https://localhost:9080"
+
 # Certificate storage path (cert manager stores CA at cert_path/ca/, certs at cert_path/{serial}/)
 cert_path: "./test/integration/transport/certs"
 


### PR DESCRIPTION
## Summary

- Removes the `"https://localhost:8080"` default from `DefaultConfig().ExternalURL` — a plausible-looking value that silently produces wrong admin bundles on any non-localhost deployment
- Adds `validateBundleExternalURL()` called at the top of both bundle-issuance paths before any cert or init marker is written, so an operator with a missing `external_url` gets an actionable error immediately rather than a silent wrong bundle
- Adds `pkg/controlplane/providers/memory` — a real in-process `ControlPlaneProvider` to replace the hand-rolled `testControlPlane` fake in `server_test.go`
- Bumps `github.com/go-git/go-git/v5` v5.19.1 → v5.19.2 (CVE-2026-71556, CVE-2026-71557)

## Changed files

| File | Change |
|------|--------|
| `features/controller/config/config.go` | Remove `"https://localhost:8080"` default for `ExternalURL` |
| `features/controller/initialization/admin_bundle.go` | Add `validateBundleExternalURL()` helper; call at top of `IssueAdminBundle()` |
| `features/controller/initialization/initialization.go` | Call `validateBundleExternalURL()` at top of `Run()`, before CA material written |
| `features/controller/initialization/admin_bundle_test.go` | 3 new tests: rejects empty, rejects http, accepts explicit https://localhost |
| `features/controller/initialization/initialization_test.go` | 2 new tests: rejects empty (no CA written), honours explicit URL in bundle |
| `features/controller/config/config_test.go` | Assert `ExternalURL` is empty in `DefaultConfig()` |
| `features/controller/api/server_test.go` | Set `ExternalURL` in `setupTestServer()`; replace `testControlPlane` fake with `controlPlaneFixture` using real memory provider |
| `features/controller/controller_test.go` | Set `ExternalURL` in lifecycle/single-HTTP-server tests; replace `MockLogger` with `logging.NewNoopLogger()` |
| `pkg/controlplane/providers/memory/provider.go` | New: real in-process `ControlPlaneProvider` (server+client modes, genuine routing, real lifecycle) |
| `pkg/controlplane/providers/memory/provider_test.go` | New: unit tests + contract suite registration |
| `pkg/controlplane/interfaces/contract_test.go` | Register memory provider in the 14-contract suite |
| `docs/reference/config-schema.md` | Mark `external_url` as required, remove default value |
| `go.mod` / `go.sum` | go-git v5.19.2 |

## Test plan

- [ ] `make test-agent-complete` passes (EXIT=0) — confirmed twice during review
- [ ] `TestIssueAdminBundle_RejectsUnsetExternalURL` — empty `ExternalURL` → error containing "external_url", no bundle file
- [ ] `TestIssueAdminBundle_RejectsNonHTTPSExternalURL` — http URL → error containing "https", no bundle file
- [ ] `TestIssueAdminBundle_HonoursExplicitLocalhostURL` — explicit `https://localhost:8080` → accepted, bundle ControllerURL matches
- [ ] `TestRun_RejectsUnsetExternalURL` — empty URL → error before any CA written, `IsInitialized()` is false
- [ ] `TestRun_BundleHonoursExternalURL` — valid URL → bundle ControllerURL matches config
- [ ] `TestDefaultConfig_ExternalURLEmpty` — `DefaultConfig().ExternalURL == ""`
- [ ] Memory provider passes full 14-contract suite alongside gRPC provider
- [ ] CI merge queue: Trivy, CodeQL, integration tests

Fixes #3196

🤖 Generated with [Claude Code](https://claude.com/claude-code)