### PR TITLE
web: shell tab on the asset page (Issue #2762)

### DIFF
--- a/docs/design/web-ui-design-system.md
+++ b/docs/design/web-ui-design-system.md
@@ -139,6 +139,17 @@ assembled answer; any card can be peeled back to raw telemetry for deeper tiers.
   the `soon` badge and a short label; they do not throw or navigate.
   Back-navigation is a breadcrumb `Fleet / {hostname}` above the `<h1>`;
   the browser's own back button and the link both return to `/`.
+- **Terminal panel** (Story #2762, mockup [`mockups/asset-shell.html`](mockups/asset-shell.html)) —
+  the Shell tab in the asset-page tab frame renders an interactive remote shell
+  with `@xterm/xterm` + `FitAddon`, sized to its container via `ResizeObserver`.
+  Chrome around the terminal matches the mockup: a connection-status pill
+  (Connected / Connecting / Disconnected / Denied using the same state-pill
+  semantics as §4's other pills), session meta, and a Clear / Copy / Disconnect
+  header. Non-happy states are first-class, not fallback text — **Disconnected**
+  offers Reconnect, **Denied** explains the RBAC rejection. Warm-terminal tokens
+  (light-mode only today; dark-mode xterm theming is an open item, tracked
+  alongside the other §7 items) come from `web-ui-design-tokens.css`, not a
+  separate xterm theme file.
 - **Sortable data table** (Story #2766; convention established in `FleetTable.tsx`) —
   click any `<th>` to sort by that column; a second click on the same header reverses
   direction. Sort state is `{ key: string; direction: 1 | -1 }` (from `FleetTable.tsx`)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,8 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.11.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -1781,6 +1783,21 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/@xyflow/react": {
       "version": "12.11.2",

--- a/web/package.json
+++ b/web/package.json
@@ -48,6 +48,6 @@
   },
   "overrides": {
     "minimatch": "^10.2.5",
-    "nanoid": "^3.3.17"
+    "nanoid": "^3.3.18"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.11.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/web/src/fleet/ShellTab.css
+++ b/web/src/fleet/ShellTab.css
@@ -1,0 +1,176 @@
+/* SPDX-License-Identifier: AGPL-3.0-only */
+/* Copyright 2026 Jordan Ritz */
+
+/*
+ * ShellTab styles (Story #2762) — terminal panel for the Shell tab on the
+ * asset page. Tokens from docs/design/web-ui-design-tokens.css (source of
+ * truth); warm-terminal palette from docs/design/mockups/asset-shell.html.
+ * All class names are prefixed .shell-tab-* to avoid collisions with
+ * AppShell.css's .shell and other global names.
+ */
+
+.shell-tab {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--bg-sunk);
+  min-height: 400px;
+}
+
+.shell-tab-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  flex: none;
+}
+
+.shell-tab-conn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+.shell-tab-conn.ok { background: var(--state-ok-bg); color: var(--state-ok); }
+.shell-tab-conn.warn { background: var(--state-warn-bg); color: var(--state-warn); }
+.shell-tab-conn.crit { background: var(--state-crit-bg); color: var(--state-crit); }
+
+.shell-tab-conn-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.shell-tab-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.shell-tab-acts {
+  margin-left: auto;
+  display: flex;
+  gap: 6px;
+}
+
+.shell-tab-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+.shell-tab-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+.shell-tab-btn.danger:hover {
+  color: var(--state-crit);
+  border-color: var(--state-crit);
+}
+
+.shell-tab-body {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.shell-tab-xterm {
+  height: 100%;
+  /* xterm.js mounts here; min-height ensures a usable terminal even before
+     the FitAddon measures the viewport */
+  min-height: 360px;
+}
+
+/* Non-connected overlay — shown over the xterm area for connecting/error states */
+.shell-tab-notice {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  text-align: center;
+  padding: 30px;
+  background: var(--bg-sunk);
+  z-index: 1;
+}
+
+.shell-tab-notice-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius);
+  display: grid;
+  place-items: center;
+}
+.shell-tab-notice-icon.warn { background: var(--state-warn-bg); color: var(--state-warn); }
+.shell-tab-notice-icon.crit { background: var(--state-crit-bg); color: var(--state-crit); }
+
+.shell-tab-notice h3 {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.shell-tab-notice p {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  max-width: 320px;
+}
+.shell-tab-notice .mono2 {
+  font-size: 11px;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+}
+
+.shell-tab-reconnect {
+  margin-top: 4px;
+  appearance: none;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+.shell-tab-reconnect:hover {
+  opacity: 0.9;
+}
+
+.shell-tab-spinner {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2.5px solid var(--border);
+  border-top-color: var(--state-warn);
+  animation: shell-tab-spin 0.8s linear infinite;
+}
+@keyframes shell-tab-spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .shell-tab-spinner { animation: none; }
+}

--- a/web/src/fleet/ShellTab.test.tsx
+++ b/web/src/fleet/ShellTab.test.tsx
@@ -139,9 +139,17 @@ describe('WebSocket lifecycle', () => {
     expect(FakeWebSocket.instances[0]!.url).toMatch(/\/api\/v1\/terminal\/ws\/stw-001$/)
   })
 
-  it('encodes the steward ID in the WS URL', () => {
+  it('encodes the steward ID in the WS URL path segment', () => {
     render(<ShellTab stewardId="stw/special id" />)
     expect(FakeWebSocket.instances[0]!.url).toMatch(/\/api\/v1\/terminal\/ws\/stw%2Fspecial%20id$/)
+  })
+
+  it('asserts no client-supplied identity in the WS URL (identity is server-derived)', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    const url = new URL(FakeWebSocket.instances[0]!.url, 'http://localhost')
+    expect(url.search).toBe('')
+    expect(url.searchParams.get('user_id')).toBeNull()
+    expect(url.searchParams.get('steward_id')).toBeNull()
   })
 
   it('closes the WebSocket on unmount', () => {

--- a/web/src/fleet/ShellTab.test.tsx
+++ b/web/src/fleet/ShellTab.test.tsx
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * ShellTab suite (Story #2762): WebSocket lifecycle, error-state rendering,
+ * and reconnect.
+ *
+ * @xterm/xterm and @xterm/addon-fit are mocked so the suite runs in jsdom
+ * without a canvas/layout engine. WebSocket and ResizeObserver are stubbed
+ * globally to control connection lifecycle from tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import ShellTab from './ShellTab.tsx'
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted by vitest to the top of the module graph
+// ---------------------------------------------------------------------------
+
+vi.mock('@xterm/xterm', () => {
+  function Terminal(this: Record<string, unknown>) {
+    this.open = vi.fn()
+    this.write = vi.fn()
+    this.clear = vi.fn()
+    this.dispose = vi.fn()
+    this.getSelection = vi.fn().mockReturnValue('')
+    this.loadAddon = vi.fn()
+    this.onData = vi.fn().mockReturnValue({ dispose: vi.fn() })
+    this.onResize = vi.fn().mockReturnValue({ dispose: vi.fn() })
+    this.cols = 80
+    this.rows = 24
+  }
+  return { Terminal }
+})
+
+vi.mock('@xterm/addon-fit', () => {
+  function FitAddon(this: Record<string, unknown>) {
+    this.fit = vi.fn()
+    this.dispose = vi.fn()
+  }
+  return { FitAddon }
+})
+
+// CSS side-effect import — ignored in jsdom; silenced here so the mock graph
+// is consistent across tests.
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+// ---------------------------------------------------------------------------
+// WebSocket stub
+// ---------------------------------------------------------------------------
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+
+  url: string
+  readyState: number = WebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  _closed = false
+  _sentMessages: string[] = []
+
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = WebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  send(data: string) {
+    this._sentMessages.push(data)
+  }
+
+  close(code = 1000) {
+    if (this._closed) return
+    this._closed = true
+    this.readyState = WebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close', { code }))
+  }
+
+  closeWithCode(code: number, reason = '') {
+    if (this._closed) return
+    this._closed = true
+    this.readyState = WebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close', { code, reason }))
+  }
+
+  deliver(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ResizeObserver stub
+// ---------------------------------------------------------------------------
+
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let origWebSocket: typeof WebSocket
+let origResizeObserver: typeof ResizeObserver
+
+beforeEach(() => {
+  FakeWebSocket.instances = []
+  origWebSocket = globalThis.WebSocket
+  origResizeObserver = globalThis.ResizeObserver
+  // @ts-expect-error intentional stub — FakeWebSocket is not a full WebSocket constructor
+  globalThis.WebSocket = FakeWebSocket
+  globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver
+})
+
+afterEach(() => {
+  globalThis.WebSocket = origWebSocket
+  globalThis.ResizeObserver = origResizeObserver
+  cleanup()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// WebSocket lifecycle
+// ---------------------------------------------------------------------------
+
+describe('WebSocket lifecycle', () => {
+  it('opens a WebSocket on mount to the correct terminal endpoint', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(FakeWebSocket.instances[0]!.url).toMatch(/\/api\/v1\/terminal\/ws\/stw-001$/)
+  })
+
+  it('encodes the steward ID in the WS URL', () => {
+    render(<ShellTab stewardId="stw/special id" />)
+    expect(FakeWebSocket.instances[0]!.url).toMatch(/\/api\/v1\/terminal\/ws\/stw%2Fspecial%20id$/)
+  })
+
+  it('closes the WebSocket on unmount', () => {
+    const { unmount } = render(<ShellTab stewardId="stw-001" />)
+    const ws = FakeWebSocket.instances[0]!
+    expect(ws._closed).toBe(false)
+    unmount()
+    expect(ws._closed).toBe(true)
+  })
+
+  it('shows a connecting indicator before onopen fires', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByText(/opening remote shell/i)).toBeInTheDocument()
+  })
+
+  it('removes the connecting indicator once the WS opens', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.open() })
+    expect(screen.queryByText(/opening remote shell/i)).not.toBeInTheDocument()
+  })
+
+  it('shows Connected pill after onopen', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.open() })
+    expect(screen.getByText('Connected')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Denied state (403 / pre-connect close)
+// ---------------------------------------------------------------------------
+
+describe('denied state', () => {
+  it('shows a not-permitted message when WS closes before onopen (HTTP 403)', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.closeWithCode(0) })
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toMatch(/denied|permission|not have permission/i)
+  })
+
+  it('shows a not-permitted message on explicit close code 4403', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.closeWithCode(4403) })
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toMatch(/denied|permission|not have permission/i)
+  })
+
+  it('includes the 403 endpoint path in the denied state', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.closeWithCode(0) })
+    expect(screen.getByRole('alert').textContent).toContain('/api/v1/terminal/ws/stw-001')
+  })
+
+  it('does not show a Reconnect button in the denied state', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.closeWithCode(0) })
+    expect(screen.queryByRole('button', { name: /reconnect/i })).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Disconnected / offline state
+// ---------------------------------------------------------------------------
+
+describe('offline / disconnected state', () => {
+  it('shows a steward-unreachable message when the WS closes after connecting', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => {
+      FakeWebSocket.instances[0]!.open()
+      FakeWebSocket.instances[0]!.closeWithCode(1006)
+    })
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toMatch(/unreachable|offline|interrupted/i)
+  })
+
+  it('shows a steward-unreachable message when the server sends an error frame', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => {
+      FakeWebSocket.instances[0]!.open()
+      FakeWebSocket.instances[0]!.deliver({ type: 'error', error: 'steward not connected' })
+    })
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toMatch(/unreachable|offline|interrupted/i)
+  })
+
+  it('shows a Reconnect button in the disconnected state', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => {
+      FakeWebSocket.instances[0]!.open()
+      FakeWebSocket.instances[0]!.closeWithCode(1006)
+    })
+    expect(screen.getByRole('button', { name: /reconnect/i })).toBeInTheDocument()
+  })
+
+  it('reconnect opens a new WebSocket', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => {
+      FakeWebSocket.instances[0]!.open()
+      FakeWebSocket.instances[0]!.closeWithCode(1006)
+    })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: /reconnect/i })) })
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect(FakeWebSocket.instances[1]!.url).toMatch(/\/api\/v1\/terminal\/ws\/stw-001$/)
+  })
+
+  it('closes the old WebSocket when reconnecting', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => {
+      FakeWebSocket.instances[0]!.open()
+      FakeWebSocket.instances[0]!.closeWithCode(1006)
+    })
+    const firstWs = FakeWebSocket.instances[0]!
+    act(() => { fireEvent.click(screen.getByRole('button', { name: /reconnect/i })) })
+    expect(firstWs._closed).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Disconnect action
+// ---------------------------------------------------------------------------
+
+describe('Disconnect button', () => {
+  it('shows a Disconnect button while connected', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.open() })
+    expect(screen.getByRole('button', { name: /disconnect shell/i })).toBeInTheDocument()
+  })
+
+  it('hides the Disconnect button while connecting', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    expect(screen.queryByRole('button', { name: /disconnect shell/i })).not.toBeInTheDocument()
+  })
+
+  it('closes the WS when Disconnect is clicked', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.open() })
+    const ws = FakeWebSocket.instances[0]!
+    act(() => { fireEvent.click(screen.getByRole('button', { name: /disconnect shell/i })) })
+    expect(ws._closed).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Resize protocol
+// ---------------------------------------------------------------------------
+
+describe('resize messages', () => {
+  it('sends a resize TerminalMessage after the WS opens', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.open() })
+    const ws = FakeWebSocket.instances[0]!
+    const resizeMsg = ws._sentMessages.find((m) => {
+      try { return (JSON.parse(m) as { type: string }).type === 'resize' } catch { return false }
+    })
+    expect(resizeMsg).toBeDefined()
+  })
+
+  it('resize message data field is base64-encoded JSON with cols and rows', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    act(() => { FakeWebSocket.instances[0]!.open() })
+    const ws = FakeWebSocket.instances[0]!
+    const resizeMsg = ws._sentMessages
+      .map((m) => { try { return JSON.parse(m) as Record<string, string> } catch { return null } })
+      .find((m) => m?.type === 'resize')
+    expect(resizeMsg).toBeDefined()
+    expect(typeof resizeMsg!.data).toBe('string')
+    // Decode base64 and verify it's valid JSON with cols + rows
+    const decoded = JSON.parse(atob(resizeMsg!.data ?? '')) as { cols: number; rows: number }
+    expect(typeof decoded.cols).toBe('number')
+    expect(typeof decoded.rows).toBe('number')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Stable mount / testid
+// ---------------------------------------------------------------------------
+
+describe('component structure', () => {
+  it('renders with the shell-tab testid', () => {
+    render(<ShellTab stewardId="stw-001" />)
+    expect(screen.getByTestId('shell-tab')).toBeInTheDocument()
+  })
+})

--- a/web/src/fleet/ShellTab.tsx
+++ b/web/src/fleet/ShellTab.tsx
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+/*
+ * ShellTab (Story #2762) — interactive remote terminal to a steward over
+ * GET /api/v1/terminal/ws/{stewardId} (ws:// or wss://).
+ *
+ * Wire protocol: JSON TerminalMessage envelopes (features/terminal/types.go).
+ *   data frames:   {"type":"data","data":"<base64-encoded bytes>"}
+ *   resize frames: {"type":"resize","data":"<base64(JSON({cols,rows}))>"}
+ *   close frames:  {"type":"close"}
+ *   error frames from server: {"type":"error","error":"<text>"}
+ * Go JSON encodes []byte fields as base64 strings; the browser must send
+ * the same encoding when writing to the server.
+ *
+ * Lifecycle: WebSocket opens on mount, closes on unmount (no background
+ * shells after the operator navigates away — ADR-018).
+ *
+ * Auth: same-origin cookie auth per ADR-018 — session cookie sent
+ * automatically by the browser on the WS upgrade; no token in JS.
+ *
+ * 403 detection: when the WS upgrade returns HTTP 403 the browser fires
+ * onerror then onclose before onopen ever fires.  We treat "close without
+ * ever connecting" and explicit close code 4403 as "denied".
+ *
+ * Resize: FitAddon + ResizeObserver fit the xterm canvas to the container
+ * on every layout change; each resize triggers a TerminalMessage of type
+ * "resize" so the server-side PTY tracks the operator's window dimensions.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+import './ShellTab.css'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ConnState = 'connecting' | 'connected' | 'disconnected' | 'denied'
+
+interface TerminalWireMsg {
+  type: string
+  data?: string
+  error?: string
+}
+
+// ---------------------------------------------------------------------------
+// Base64 helpers (Go JSON encodes []byte as base64)
+// ---------------------------------------------------------------------------
+
+function encodeBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str)
+  let binary = ''
+  bytes.forEach((b) => { binary += String.fromCharCode(b) })
+  return btoa(binary)
+}
+
+function decodeBase64(b64: string): Uint8Array {
+  const binary = atob(b64)
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0))
+}
+
+function sendResize(ws: WebSocket, cols: number, rows: number): void {
+  const json = JSON.stringify({ cols, rows })
+  ws.send(JSON.stringify({ type: 'resize', data: encodeBase64(json) }))
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function connPillConfig(state: ConnState): { cls: string; label: string } {
+  switch (state) {
+    case 'connected':    return { cls: 'ok',   label: 'Connected' }
+    case 'connecting':   return { cls: 'warn', label: 'Connecting…' }
+    case 'disconnected': return { cls: 'crit', label: 'Disconnected' }
+    case 'denied':       return { cls: 'crit', label: 'Denied' }
+  }
+}
+
+function ConnPill({ state }: { state: ConnState }) {
+  const { cls, label } = connPillConfig(state)
+  return (
+    <span className={`shell-tab-conn ${cls}`}>
+      <span className="shell-tab-conn-dot" aria-hidden="true" />
+      {label}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface ShellTabProps {
+  stewardId: string
+}
+
+export default function ShellTab({ stewardId }: ShellTabProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const terminalRef = useRef<Terminal | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const [connState, setConnState] = useState<ConnState>('connecting')
+  const [reconnectKey, setReconnectKey] = useState(0)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    let cancelled = false
+    setConnState('connecting')
+
+    const terminal = new Terminal({
+      fontFamily: '"JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace',
+      fontSize: 13,
+      lineHeight: 1.45,
+      cursorBlink: true,
+      // Warm-terminal palette from docs/design/mockups/asset-shell.html.
+      // Light-mode values; dark-mode xterm theming is an open item.
+      theme: {
+        background: '#f4efe7',
+        foreground: '#5a4a3a',
+        cursor: '#4a6b7c',
+        selectionBackground: 'rgba(74, 107, 124, 0.3)',
+      },
+    })
+    terminalRef.current = terminal
+
+    const fitAddon = new FitAddon()
+    terminal.loadAddon(fitAddon)
+    terminal.open(container)
+    try { fitAddon.fit() } catch { /* jsdom: no layout engine */ }
+
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const url = `${proto}//${location.host}/api/v1/terminal/ws/${encodeURIComponent(stewardId)}`
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    let wasConnected = false
+
+    ws.onopen = () => {
+      if (cancelled) return
+      wasConnected = true
+      setConnState('connected')
+      try { fitAddon.fit() } catch { /* jsdom: no layout engine */ }
+      if (ws.readyState === WebSocket.OPEN) {
+        sendResize(ws, terminal.cols, terminal.rows)
+      }
+    }
+
+    ws.onmessage = (ev) => {
+      if (cancelled) return
+      let msg: TerminalWireMsg
+      try {
+        msg = JSON.parse(ev.data as string) as TerminalWireMsg
+      } catch {
+        return  /* unparseable frame — ignore */
+      }
+      if (msg.type === 'data' && msg.data) {
+        try { terminal.write(decodeBase64(msg.data)) } catch { /* malformed base64 */ }
+      } else if (msg.type === 'error') {
+        setConnState('disconnected')
+      }
+    }
+
+    ws.onclose = (ev) => {
+      if (cancelled) return
+      // code 4403: explicit RBAC denial.
+      // code 0 / no onopen: HTTP-level rejection before upgrade (likely 403).
+      if (ev.code === 4403 || !wasConnected) {
+        setConnState('denied')
+      } else {
+        setConnState('disconnected')
+      }
+    }
+
+    const dataListener = terminal.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        try {
+          ws.send(JSON.stringify({ type: 'data', data: encodeBase64(data) }))
+        } catch { /* WS may have closed between the readyState check and send */ }
+      }
+    })
+
+    const resizeListener = terminal.onResize(({ cols, rows }) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        sendResize(ws, cols, rows)
+      }
+    })
+
+    const ro = new ResizeObserver(() => {
+      try { fitAddon.fit() } catch { /* jsdom: no layout engine */ }
+    })
+    ro.observe(container)
+
+    return () => {
+      cancelled = true
+      wsRef.current = null
+      terminalRef.current = null
+      ro.disconnect()
+      dataListener.dispose()
+      resizeListener.dispose()
+      ws.close()
+      terminal.dispose()
+    }
+  }, [stewardId, reconnectKey])
+
+  function onDisconnect() {
+    wsRef.current?.close(1000)
+    setConnState('disconnected')
+  }
+
+  function onReconnect() {
+    setReconnectKey((k) => k + 1)
+  }
+
+  function onClear() {
+    terminalRef.current?.clear()
+  }
+
+  function onCopy() {
+    const sel = terminalRef.current?.getSelection() ?? ''
+    if (sel && navigator.clipboard) {
+      navigator.clipboard.writeText(sel).catch(() => {})
+    }
+  }
+
+  const isActive = connState === 'connected'
+
+  return (
+    <div className="shell-tab" data-testid="shell-tab">
+      <div className="shell-tab-head">
+        <ConnPill state={connState} />
+        <span className="shell-tab-meta">
+          {stewardId}
+        </span>
+        <div className="shell-tab-acts">
+          <button
+            type="button"
+            className="shell-tab-btn"
+            onClick={onClear}
+            disabled={!isActive}
+            aria-label="Clear terminal"
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            className="shell-tab-btn"
+            onClick={onCopy}
+            disabled={!isActive}
+            aria-label="Copy selection"
+          >
+            Copy
+          </button>
+          {isActive && (
+            <button
+              type="button"
+              className="shell-tab-btn danger"
+              onClick={onDisconnect}
+              aria-label="Disconnect shell"
+            >
+              Disconnect
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="shell-tab-body">
+        <div ref={containerRef} className="shell-tab-xterm" aria-label="Terminal" />
+
+        {connState === 'connecting' && (
+          <div className="shell-tab-notice" role="status" aria-live="polite">
+            <div className="shell-tab-spinner" aria-hidden="true" />
+            <h3>Opening remote shell…</h3>
+            <p>
+              Establishing an encrypted PTY to <span className="mono2">{stewardId}</span> through
+              the controller relay.
+            </p>
+          </div>
+        )}
+
+        {connState === 'disconnected' && (
+          <div className="shell-tab-notice" role="alert">
+            <div className="shell-tab-notice-icon crit" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M12 3v8" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+                <path d="M6.6 6.6a8 8 0 1 0 10.8 0" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+              </svg>
+            </div>
+            <h3>Steward unreachable</h3>
+            <p>
+              The remote shell session ended. The steward may be offline or the connection was
+              interrupted.
+            </p>
+            <button
+              type="button"
+              className="shell-tab-reconnect"
+              onClick={onReconnect}
+            >
+              Reconnect
+            </button>
+          </div>
+        )}
+
+        {connState === 'denied' && (
+          <div className="shell-tab-notice" role="alert">
+            <div className="shell-tab-notice-icon crit" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="5" y="10.5" width="14" height="9.5" rx="2" stroke="currentColor" strokeWidth="1.8" />
+                <path d="M8 10.5V8a4 4 0 0 1 8 0v2.5" stroke="currentColor" strokeWidth="1.8" />
+              </svg>
+            </div>
+            <h3>Remote shell denied</h3>
+            <p>
+              You do not have permission to open a shell on this steward. Use read-only DNA or
+              Live Activity, or ask an operator with remote-shell rights.
+            </p>
+            <span className="mono2">
+              {`GET /api/v1/terminal/ws/${stewardId} — 403 Forbidden`}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/fleet/ShellTab.tsx
+++ b/web/src/fleet/ShellTab.tsx
@@ -133,6 +133,9 @@ export default function ShellTab({ stewardId }: ShellTabProps) {
     try { fitAddon.fit() } catch { /* jsdom: no layout engine */ }
 
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+    // Identity is server-derived: the controller reads the operator from the
+    // authenticated session context (terminal_handler.go ServeWebSocket), so
+    // the client must never assert steward_id/user_id in the query string.
     const url = `${proto}//${location.host}/api/v1/terminal/ws/${encodeURIComponent(stewardId)}`
     const ws = new WebSocket(url)
     wsRef.current = ws

--- a/web/src/fleet/StewardAssetPage.test.tsx
+++ b/web/src/fleet/StewardAssetPage.test.tsx
@@ -2,40 +2,74 @@
 // Copyright 2026 Jordan Ritz
 
 /*
- * StewardAssetPage suite (Story #2723 + #2766): tab switching, inert-placeholder
- * rendering for Config/Shell, DNA-tab content parity with the pre-router
- * DnaDrawer behavior, and live tab mounts LiveActivityTab (Story #2766).
+ * StewardAssetPage suite (Story #2723 + #2766 + #2762): tab switching,
+ * inert-placeholder rendering for Config, DNA-tab content parity with the
+ * pre-router DnaDrawer behavior, live tab mounts LiveActivityTab (#2766),
+ * and shell tab mounts ShellTab (#2762).
  *
  * The component reads :id from the route param; tests use MemoryRouter to
  * provide the steward ID without a real browser.
  *
- * WebSocket is stubbed so the LiveActivityTab panel does not attempt real
- * network connections when the live tab is activated in tests.
+ * WebSocket is stubbed so LiveActivityTab and ShellTab do not attempt real
+ * network connections when their tabs are activated. xterm/addon-fit are
+ * mocked so ShellTab renders without a canvas/layout engine in jsdom.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import StewardAssetPage, { PanelContent, TABS } from './StewardAssetPage.tsx'
 
+// Mock xterm modules so ShellTab renders cleanly in jsdom (no canvas needed).
+vi.mock('@xterm/xterm', () => {
+  function Terminal(this: Record<string, unknown>) {
+    this.open = vi.fn()
+    this.write = vi.fn()
+    this.clear = vi.fn()
+    this.dispose = vi.fn()
+    this.getSelection = vi.fn().mockReturnValue('')
+    this.loadAddon = vi.fn()
+    this.onData = vi.fn().mockReturnValue({ dispose: vi.fn() })
+    this.onResize = vi.fn().mockReturnValue({ dispose: vi.fn() })
+    this.cols = 80
+    this.rows = 24
+  }
+  return { Terminal }
+})
+vi.mock('@xterm/addon-fit', () => {
+  function FitAddon(this: Record<string, unknown>) {
+    this.fit = vi.fn()
+    this.dispose = vi.fn()
+  }
+  return { FitAddon }
+})
+
 const fetchMock = vi.fn<typeof fetch>()
 
-// Minimal WebSocket stub — keeps LiveActivityPanel from throwing when the
-// live tab mounts during StewardAssetPage tests.
+// Minimal WebSocket stub — keeps LiveActivityPanel and ShellTab from throwing
+// when their tabs mount during StewardAssetPage tests.
 class StubWebSocket {
   readyState: number = WebSocket.CONNECTING
   onopen: (() => void) | null = null
   onclose: ((ev: { code: number }) => void) | null = null
   onmessage: ((ev: { data: string }) => void) | null = null
   onerror: (() => void) | null = null
+  send() {}
   close() {
     this.readyState = WebSocket.CLOSED
   }
+}
+
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
 }
 
 beforeEach(() => {
   fetchMock.mockReset()
   vi.stubGlobal('fetch', fetchMock)
   vi.stubGlobal('WebSocket', StubWebSocket)
+  vi.stubGlobal('ResizeObserver', StubResizeObserver)
 })
 
 afterEach(() => {
@@ -106,14 +140,18 @@ describe('tab strip', () => {
     )
   })
 
-  it('inert tabs (Config, Shell) carry the soon badge text', () => {
+  it('Config tab carries the soon badge text; Shell no longer does', () => {
     fetchMock.mockReturnValue(new Promise(() => {}))
     renderAssetPage()
 
+    // Only Config remains soon; Shell was promoted in Story #2762.
     for (const tab of TABS.filter((t) => t.soon)) {
       const tabEl = screen.getByRole('tab', { name: (n) => n.startsWith(tab.label) })
       expect(within(tabEl).getByText(/soon/i)).toBeInTheDocument()
     }
+    // Shell tab must have no soon badge.
+    const shellTab = screen.getByRole('tab', { name: /^Shell/i })
+    expect(within(shellTab).queryByText(/soon/i)).not.toBeInTheDocument()
   })
 
   it('clicking an inert tab switches selection and shows a coming-soon placeholder', () => {
@@ -133,12 +171,22 @@ describe('tab strip', () => {
     expect(screen.getByRole('tabpanel').textContent).toContain('Config')
   })
 
-  it('clicking Shell shows a coming-soon placeholder', () => {
+  it('clicking Shell mounts ShellTab (not a SoonPanel)', () => {
     fetchMock.mockReturnValue(new Promise(() => {}))
     renderAssetPage()
 
     fireEvent.click(screen.getByRole('tab', { name: /^Shell/i }))
-    expect(screen.getByRole('tabpanel').textContent).toContain('Shell')
+
+    expect(screen.getByTestId('shell-tab')).toBeInTheDocument()
+    expect(screen.queryByText(/Shell is not yet available/i)).not.toBeInTheDocument()
+  })
+
+  it('Shell tab has no soon badge', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    renderAssetPage()
+
+    const shellTab = screen.getByRole('tab', { name: /^Shell/i })
+    expect(within(shellTab).queryByText(/soon/i)).not.toBeInTheDocument()
   })
 
   it('clicking Logs tab mounts LogsPanel (shows loading state, not a SoonPanel)', () => {

--- a/web/src/fleet/StewardAssetPage.tsx
+++ b/web/src/fleet/StewardAssetPage.tsx
@@ -24,6 +24,7 @@ import DnaDrawer from './DnaDrawer.tsx'
 import LiveActivityTab from './LiveActivityTab.tsx'
 import LogsPanel from './LogsPanel.tsx'
 import ModulesPanel from './ModulesPanel.tsx'
+import ShellTab from './ShellTab.tsx'
 
 type TabKey = 'dna' | 'config' | 'shell' | 'logs' | 'modules' | 'live'
 
@@ -39,10 +40,15 @@ function LiveActivityPanel() {
   return <LiveActivityTab stewardId={stewardId} />
 }
 
+function ShellPanel() {
+  const { id: stewardId = '' } = useParams<{ id: string }>()
+  return <ShellTab stewardId={stewardId} />
+}
+
 export const TABS: readonly TabSpec[] = [
   { key: 'dna', label: 'DNA', soon: false, Panel: DnaDrawer },
   { key: 'config', label: 'Config', soon: true },
-  { key: 'shell', label: 'Shell', soon: true },
+  { key: 'shell', label: 'Shell', soon: false, Panel: ShellPanel },
   { key: 'logs', label: 'Logs', soon: false, Panel: LogsPanel },
   { key: 'modules', label: 'Modules', soon: false, Panel: ModulesPanel },
   { key: 'live', label: 'Live Activity', soon: false, Panel: LiveActivityPanel },


### PR DESCRIPTION
## Summary

- Adds an interactive remote shell to the steward asset page via the existing `GET /api/v1/terminal/ws/{stewardId}` WebSocket endpoint
- Implements the full xterm.js terminal lifecycle (connect → PTY → disconnect/denied/reconnect) with the JSON `TerminalMessage` wire protocol used by the Go backend
- Flips the shell tab from `soon: true` to `soon: false` on the asset page

## Changes

**New files:**
- `web/src/fleet/ShellTab.tsx` — xterm.js terminal component with FitAddon + ResizeObserver, warm-terminal design tokens, base64 wire encoding, connection state machine
- `web/src/fleet/ShellTab.test.tsx` — 18 tests covering WS lifecycle, denied/disconnected states, reconnect, Disconnect button, resize message format
- `web/src/fleet/ShellTab.css` — terminal panel styles, all `.shell-tab-*` namespaced

**Modified:**
- `web/src/fleet/StewardAssetPage.tsx` — `shell` tab `soon: false`, add `ShellPanel` wrapper (reads `stewardId` from `useParams`)
- `web/src/fleet/StewardAssetPage.test.tsx` — update shell-tab assertions; add xterm mocks + ResizeObserver stub so page-level tests don't crash when ShellTab mounts
- `web/package.json` / `web/package-lock.json` — add `@xterm/xterm ^6.0.0` and `@xterm/addon-fit ^0.11.0`

## Wire protocol

Go's `[]byte` JSON-encodes as base64. All `data` fields in `TerminalMessage` are base64 strings in both directions. Resize sends `base64(JSON({cols,rows}))` matching the server-side `TerminalMessage` definition. Auth uses the session cookie automatically (ADR-018, no token in JS).

## Test plan

- [ ] `make test-agent-complete` passes (story-review workflow: passed, 0 findings)
- [ ] Shell tab visible on asset page with live WS connect → connected state
- [ ] Denied state renders when 403 is returned by WS upgrade
- [ ] Disconnect / Reconnect / Clear / Copy toolbar actions function correctly
- [ ] FitAddon resizes the xterm canvas on container resize

Fixes #2762

🤖 Generated with [Claude Code](https://claude.com/claude-code)