### PR TITLE
deps: bump Claude Code CLI to 2.1.222 and teach discover-pins.py to see it (Issue #3212)

### DIFF
--- a/.claude/skills/refresh-pins/references/inventory-schema.md
+++ b/.claude/skills/refresh-pins/references/inventory-schema.md
@@ -7,7 +7,7 @@
 ```jsonc
 {
   "name": "go-toolchain",       // string — stable identifier for this pin (used in story titles, override audit log)
-  "kind": "lockstep",           // "lockstep" | "tool" | "mcp"
+  "kind": "lockstep",           // "lockstep" | "tool" | "mcp" | "npm"
   "current": "1.25.10",         // string — version string as it appears in the source (no leading "v" for Go)
   "release_source": "https://go.dev/dl/?mode=json",  // URL or "gh:<owner>/<repo>"
   "ecosystem": "GO",            // GHSA SecurityAdvisoryEcosystem enum, or null if not GHSA-queryable
@@ -27,10 +27,13 @@
   - **GitHub Action SHA pins** (`uses: <owner>/<name>@<sha>` lines in workflows). The name embeds the short SHA (`gha:actions/checkout@34e11487`) so each unique (action, sha) pair is its own inventory entry. `locations[]` lists every workflow file:line that uses that exact SHA. Multiple entries for the same action with different SHAs is the natural representation of SHA drift across workflows — a drift-finder consumer can group by stripping `@<sha>` from `name`.
 - **`mcp`** — a git-pinned MCP server in `.mcp.json` (`git+https://github.com/<owner>/<repo>@<tag>`, e.g. `serena`). `current` is the git tag (with leading `v`), `release_source` is `gh:<owner>/<repo>`, `locations[]` is the `.mcp.json` line. **Distinct downstream handling:** these are agent *tooling* dependencies — their tool names are consumed by name in `.claude/agents/*.md` (`tools:` allowlists + prose). Phase 3 applies the **blast-radius classification** (see `decision-matrix.md` "MCP server pins"): a non-breaking bump is a one-line `.mcp.json` story; a release that renames/removes/changes a consumed tool is a **rewire story** that also touches every agent file using the affected tool.
 
+- **`npm`** — a version pinned as an npm package version string in a file the repo builds from, rather than declared in `dependency-pin-check.yml`. Currently the Claude Code CLI (`ARG CLAUDE_CODE_VERSION` in `.devcontainer/Dockerfile`, consumed by the `npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"` on the following line). `current` is the bare version (no leading `v`), `release_source` is the npm registry document URL, and `locations[]` is the single `ARG` line. **Freshness is `dist-tags.latest`, not a GitHub release** — an unpinned `npm install -g` resolves to that tag, so it is the authoritative "what would we get if the pin were absent" answer. `dependency-pin-check.yml` does check this pin, but through a bespoke npm block rather than a `check_version` call, which is why it needs its own discoverer: a `check_version` parser cannot see it. Bumping requires the agent image to be rebuilt before the change takes effect — note that in any bump story.
+
 ## `release_source` values
 
 - `https://go.dev/dl/?mode=json` — Go release index. Returns array of versions; `[.[] | select(.stable)][0]` is the latest stable.
 - `gh:<owner>/<repo>` — fetch via `gh api repos/<owner>/<repo>/releases/latest` for `tag_name` and `published_at`.
+- `https://registry.npmjs.org/<package>` — npm registry document. `.["dist-tags"].latest` is the version an unpinned install resolves to; `.time["<version>"]` gives each version's publish timestamp, which is what the 3-day cooldown is measured against.
 
 ## `ecosystem` and `package`
 

--- a/.claude/skills/refresh-pins/scripts/discover-pins.py
+++ b/.claude/skills/refresh-pins/scripts/discover-pins.py
@@ -120,6 +120,49 @@ def discover_go_toolchain(root: Path) -> dict:
     }
 
 
+def discover_claude_code_cli(root: Path) -> list[dict]:
+    """Claude Code CLI pin — `ARG CLAUDE_CODE_VERSION` in .devcontainer/Dockerfile.
+
+    dependency-pin-check.yml does check this pin's freshness, but through a bespoke
+    npm dist-tags block rather than a `check_version` declaration, so
+    discover_tool_pins() — which parses only `check_version` lines — never saw it.
+    The sweep was therefore blind to a pin CI actively tracks. Same root shape as
+    the Go toolchain, which needed its own discoverer for the same reason.
+
+    The version is read from the Dockerfile, matching where
+    dependency-pin-check.yml reads it from, so the two can never disagree about
+    what the image installs. Nothing here hardcodes a version.
+
+    Returns a list so a missing or renamed ARG yields [] rather than a bogus entry
+    with current="unknown" — the workflow already warns loudly in that case, and a
+    silent placeholder in the inventory would invite a story to "bump" a pin that
+    no longer exists.
+    """
+    dockerfile = root / ".devcontainer" / "Dockerfile"
+    if not dockerfile.exists():
+        return []
+
+    arg_re = re.compile(r"^ARG\s+CLAUDE_CODE_VERSION=(\S+)")
+    for i, line in enumerate(dockerfile.read_text().splitlines(), 1):
+        m = arg_re.match(line)
+        if not m:
+            continue
+        return [{
+            "name": "claude-code-cli",
+            "kind": "npm",
+            "current": m.group(1),
+            "release_source": "https://registry.npmjs.org/@anthropic-ai/claude-code",
+            "ecosystem": "NPM",
+            "package": "@anthropic-ai/claude-code",
+            "locations": [{
+                "file": ".devcontainer/Dockerfile",
+                "line": i,
+                "match": line.strip(),
+            }],
+        }]
+    return []
+
+
 def discover_tool_usage_locations(version: str, root: Path) -> list[dict]:
     """Grep in-scope paths for additional usage locations of a tool version string.
 
@@ -359,6 +402,7 @@ def main() -> int:
     root = repo_root()
     inventory = [discover_go_toolchain(root)]
     inventory.extend(discover_tool_pins(root))
+    inventory.extend(discover_claude_code_cli(root))
     inventory.extend(discover_github_actions(root))
     inventory.extend(discover_mcp_pins(root))
     json.dump(inventory, sys.stdout, indent=2)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -152,7 +152,7 @@ RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.9
 # built while `npm latest` moved on. The pin makes the layer key change with
 # the version, and dependency-pin-check.yml files a weekly issue when npm's
 # dist-tags.latest moves ahead of it.
-ARG CLAUDE_CODE_VERSION=2.1.220
+ARG CLAUDE_CODE_VERSION=2.1.222
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
 # Non-root agent user with sudo for iptables only


### PR DESCRIPTION
Two parts; the discovery gap is the substantive one.

## Version — re-derived, not copied

The story's table was advisory and told me to recompute at implementation time. Ran its own query:

| | |
|---|---|
| implementation timestamp | `2026-08-08T13:59:02Z` |
| **target** | **2.1.222** |
| npm publish | `2026-08-04T20:37:17.953Z` |
| age | **3.72 days** (threshold 3) |

So 2.1.222 — not the 2.1.223/2.1.224 the story guessed might be current by now. 2.1.223 published `2026-08-05T22:51:13Z` and is only 2.6 days old, still inside cooldown.

Routine refresh: no CVE against the current pin, no CI-blocking signal, no cooldown override, no audit-log entry.

⚠️ **The agent image must be rebuilt for this to take effect.** The pin only changes what a build installs, and the `npm install -g` RUN layer is what consumes it.

## The discovery gap

`discover_tool_pins()` parses `check_version "<name>" "<repo>" "<version>"` lines out of `dependency-pin-check.yml`. The Claude Code CLI check there is a bespoke npm `dist-tags` block (workflow lines 212–231), **not** a `check_version` call — so the pin was never in the inventory. The `refresh-pins` sweep was blind to a pin CI actively tracks and had already reported `OUTDATED` on.

Same root shape as the Go toolchain, which needed its own `discover_go_toolchain()` for exactly this reason.

`discover_claude_code_cli()` reads `ARG CLAUDE_CODE_VERSION` from `.devcontainer/Dockerfile` — the same place `dependency-pin-check.yml:219` reads it from, so the two can never disagree about what the image installs. Nothing hardcodes a version; **verified behaviourally** by setting the ARG to `9.9.9` and confirming the emitted `current` followed it.

Returns a list, so a missing or renamed ARG yields `[]` rather than an entry with `current: "unknown"`. The workflow already warns loudly in that case, and a placeholder in the inventory would invite a story to "bump" a pin that no longer exists.

### Why a new `kind: "npm"`

`tool` specifically means a `check_version` declaration (or a GitHub Action SHA pin); `lockstep` means a pin spanning multiple files; `mcp` means `.mcp.json`. None describes this. The story sanctioned either a new kind or `tool` — new kind is the honest fit.

Documented in `inventory-schema.md` along with the npm `release_source` form, including that freshness is `dist-tags.latest` (what an unpinned install resolves to, not a GitHub release) and that `.time[<version>]` is what the cooldown is measured against. `ecosystem`/`package` are `NPM` / `@anthropic-ai/claude-code`, so it is GHSA-queryable like the other pins rather than needing a release-notes fallback.

## AC verification

| AC | Check | Result |
|---|---|---|
| 2 | `grep -rn "2\.1\.220" .devcontainer/ .github/ Makefile` | **0 matches** |
| 3 | `grep -c '^ARG CLAUDE_CODE_VERSION=' Dockerfile` | **1**, = `2.1.222` |
| 4 | publish vs implementation timestamps | stated above, 3.72 days |
| 5 | emitted record | `kind=npm`, `current=2.1.222`, npm `release_source`, `.devcontainer/Dockerfile:155` in `locations[]` |
| 6 | `inventory-schema.md` | new kind + release_source form documented |
| 7 | no hardcoded version | none in script; proven by the `9.9.9` substitution |
| 8 | strict superset of names | **30 → 31**, nothing lost, gained `claude-code-cli`; still valid JSON |
| 9 | `make test` | **208/208** |

Fixes #3212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo