### PR TITLE
pipeline: resolve decorated section headers in the story-body parser (Issue #3026)

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -1015,17 +1015,54 @@ def code_health_check():
     return result
 
 
+#: Characters that may begin a decoration after a section name. A real body writes
+#: `## Files In Scope (2 occurrences — lockstep required)` and means the Files In
+#: Scope section; anything starting with a word character (`## Files In Scope Notes`)
+#: is a different section and must not match.
+_HEADER_DECORATION = r"(?:\s*[(\[{:,—–-].*)?$"
+
+
+def _header_matches(header_text, section_name):
+    """Whether a `## ` header names this section, decorated or not.
+
+    Exact equality alone was the original rule, which made a decorated header
+    invisible: `extract_section` returned None and callers read the section as
+    ABSENT. For `## Files In Scope` that is the dangerous direction — the dispatch
+    gate then hits `if not my_files:` and dispatches with file-overlap conflict
+    detection disabled. Measured on four open workflow-pin stories (#3208-#3211),
+    which conflict with each other and so were the worst possible set to lose
+    conflict checking on.
+    """
+    return bool(re.match(
+        re.escape(section_name.strip().lower()) + _HEADER_DECORATION,
+        header_text.strip().lower(),
+    ))
+
+
 def extract_section(body, section_name):
-    """Extract text under `## <section_name>` until the next `## ` or EOF."""
+    """Extract text under `## <section_name>` until the next `## ` or EOF.
+
+    A decorated header (`## Dependencies (none)`) resolves to the section it names.
+    An exact header wins over a decorated one when a body carries both, so adding
+    a decorated variant can never steal the section from the plain heading.
+    """
     if not body:
         return None
     headers = list(SECTION_RE.finditer(body))
+
+    def _slice(i):
+        start = headers[i].end()
+        end = headers[i + 1].start() if i + 1 < len(headers) else len(body)
+        return body[start:end].strip()
+
+    decorated = None
     for i, m in enumerate(headers):
-        if m.group(1).strip().lower() == section_name.lower():
-            start = m.end()
-            end = headers[i + 1].start() if i + 1 < len(headers) else len(body)
-            return body[start:end].strip()
-    return None
+        text = m.group(1).strip().lower()
+        if text == section_name.strip().lower():
+            return _slice(i)
+        if decorated is None and _header_matches(m.group(1), section_name):
+            decorated = i
+    return _slice(decorated) if decorated is not None else None
 
 
 def extract_scope_paths(section):

--- a/.claude/scripts/tests/test-preflight-files-in-scope.py
+++ b/.claude/scripts/tests/test-preflight-files-in-scope.py
@@ -222,6 +222,71 @@ class TestPreviouslyWorkingForms(unittest.TestCase):
         self.assertEqual(scope(None), [])
 
 
+class TestDecoratedSectionHeaders(unittest.TestCase):
+    """A decorated `## ` header must still resolve to the section it names.
+
+    Exact equality was the original rule, so `## Files In Scope (2 occurrences —
+    lockstep required)` made the section read as ABSENT — and absent is the
+    dangerous direction: the dispatch gate hits `if not my_files:` and dispatches
+    with file-overlap conflict detection disabled.
+
+    Measured on four live stories (#3208-#3211) whose bodies all decorate the
+    header. Two of them (#3209, #3211) edit the same workflow file, so the bug
+    would have let them run in parallel on `release.yml`.
+    """
+
+    def test_parenthetical_decoration(self):
+        body = "## Files In Scope (2 occurrences — lockstep required)\n\n- `a/b.go`\n"
+        self.assertEqual(PF.extract_section(body, "Files In Scope"), "- `a/b.go`")
+
+    def test_em_dash_and_colon_decorations(self):
+        for header in (
+            "## Files In Scope — lockstep required",
+            "## Files In Scope: two files",
+            "## Files In Scope [draft]",
+            "## Files In Scope, plus tests",
+        ):
+            body = header + "\n\n- `a/b.go`\n"
+            self.assertEqual(
+                PF.extract_section(body, "Files In Scope"), "- `a/b.go`", header
+            )
+
+    def test_a_longer_section_name_is_not_a_decoration(self):
+        # `## Files In Scope Notes` is a DIFFERENT section. Matching it here would
+        # silently attribute another section's content to this one.
+        body = "## Files In Scope Notes\n\n- `a/b.go`\n"
+        self.assertIsNone(PF.extract_section(body, "Files In Scope"))
+
+    def test_exact_header_wins_over_a_decorated_one(self):
+        body = (
+            "## Files In Scope (extra)\n\n- `x/decorated.go`\n\n"
+            "## Files In Scope\n\n- `y/plain.go`\n"
+        )
+        self.assertEqual(PF.extract_section(body, "Files In Scope"), "- `y/plain.go`")
+
+    def test_decoration_applies_to_dependencies_too(self):
+        body = "## Dependencies (none — self-contained)\n\n- #1140\n"
+        parsed = PF.parse_story(
+            {"number": 1, "title": "t", "state": "OPEN",
+             "body": body + "\n## Files In Scope\n\n- `a/b.go`\n"}
+        )
+        self.assertEqual(parsed["deps_parsed"], [1140])
+
+    def test_the_live_3209_header_yields_its_file(self):
+        # Verbatim from story #3209, the shape that was silently losing conflict
+        # detection in production.
+        body = (
+            "## Files In Scope (2 occurrences — lockstep required)\n\n"
+            "- `.github/workflows/release.yml:323` — `uses: actions/attest@59d89421`\n"
+        )
+        parsed = PF.parse_story(
+            {"number": 3209, "title": "t", "state": "OPEN",
+             "body": "## Dependencies\n\nNone\n\n" + body}
+        )
+        self.assertEqual(parsed["files_parsed"], [".github/workflows/release.yml"])
+        self.assertEqual(parsed["parse_warnings"], [])
+
+
 class TestParseStoryIntegration(unittest.TestCase):
     """The strict set feeds files_parsed; the loose body scan stays permissive."""
 


### PR DESCRIPTION
`extract_section()` matched a `## ` header by **exact equality**, so a decorated header was invisible and the section read as *absent*:

```
## Files In Scope                                     -> found
## Files In Scope (2 occurrences — lockstep required) -> None
```

Absent is the dangerous direction — the asymmetry #3192 documents. The dispatch gate then hits `if not my_files:` and emits `action: "dispatch"` carrying `no_files_parsed_cannot_check_conflicts`: the story is dispatched **with file-overlap conflict detection disabled**.

## Found by checking, not reported

This surfaced while verifying whether #3192's documentation change mattered in practice. Four open stories decorate the header — **#3208, #3209, #3210, #3211** — the workflow-pin bumps, which is the worst possible set to lose conflict checking on because they conflict *with each other*. It is why the 2026-08-08 cycle had to hand-verify three dispatch candidates.

**Two of them genuinely collide.** With the header resolved:

| Story | Files now parsed |
|---|---|
| #3208 | `codeql-analysis.yml`, `docker-security.yml`, `scorecard.yml`, `security-scan.yml` |
| #3209 | `release.yml` |
| #3210 | `zizmor.yml` |
| #3211 | **`release.yml`** ← same file as #3209 |

So the bug would have allowed #3209 and #3211 to run in parallel on `release.yml`. After the fix the gate serialises them.

Measured on the live preflight: recommendations carrying `no_files_parsed` went **3 → 0**, and **14** file-conflict holds are detected.

## Matching rule

The section name, followed by end-of-header or a decoration opening with one of `( [ { : , — – -`.

A header that continues with a **word character is a different section**: `## Files In Scope Notes` still does not match, because attributing another section's content to this one would be worse than missing it. An exact header also **wins over** a decorated one when a body carries both, so adding a decorated variant can never steal the section from the plain heading.

## Not a duplicate of #3223

Distinct from the three defects that PR fixed (`:line` suffix, bare paths in prose, explicit `None`). Those were all about extracting paths *within* a section that was found. This is the section not being found at all.

## Tests

6 new cases (29 total in the file), including the verbatim #3209 header. **Four of the six fail against the pre-fix parser**; the two that pass both ways are the negative cases, which is correct.

Existing suites unchanged: 53 external-PR, 23 path-regex, 13 stalled-dispatch, 38 diagnose-merge-group, 55 cycle-manifest. A real `po-act.sh preflight` run completed clean.

Relates to epic #3026 (pipeline cost engineering) — the cost here is throughput: a story dispatched without conflict checking produces colliding PRs, manual rebases and merge-queue churn. No story issue exists for this, so no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C2mtevKPnY4TR8TNUJQuo