### PR TITLE
deps: bump zizmorcore/zizmor-action v0.6.1 → v0.6.2 (Issue #3210)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           upload: always
         env:


### PR DESCRIPTION
## Summary

Routine SHA-pin bump for `zizmorcore/zizmor-action`:
- **From:** `6fc4b006235f201fdab3722e17240ab420d580e5` (`v0.6.1`)
- **To:** `3dc1ecc9bcb9e94e9b2c709687979e1298497054` (`v0.6.2`)

The `v0.6.2` release ships zizmor analyzer **1.29.0** as the default; the action wrapper itself is unchanged. Cooldown elapsed (5.3 days since 2026-08-01 publication; threshold 3 days). No CVE against the current pin.

SHA independently verified:
```
gh api repos/zizmorcore/zizmor-action/tags?per_page=20 \
  --jq '.[] | select(.name=="v0.6.2") | .commit.sha'
# → 3dc1ecc9bcb9e94e9b2c709687979e1298497054 ✓
```

## Acceptance Criteria Verification

- ✅ Pin updated to `3dc1ecc9bcb9e94e9b2c709687979e1298497054`, comment updated to `# v0.6.2`
- ✅ SHA independently re-resolved and confirmed
- ✅ Old SHA absent: `grep -rn "6fc4b006235f201fdab3722e17240ab420d580e5" .github/` → 0 matches
- ✅ New SHA present: `grep -rn "3dc1ecc9bcb9e94e9b2c709687979e1298497054" .github/` → 1 match
- ✅ `make test`: 208/208 passed
- ✅ No new zizmor findings introduced (zizmor 1.29.0 did not surface additional findings in this repo)

## Specialist Review Results

Story-review workflow (3 lenses, 1 round, 0 fix rounds):
- **Code Review:** PASS
- **Test Quality:** PASS
- **Security:** PASS
- **Remaining findings:** 0

## Files Changed

- `.github/workflows/zizmor.yml` — one-line SHA pin update

Fixes #3210