### PR TITLE
deps: bump actions/attest v4.1.0 → v4.2.2 (Issue #3209)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,13 +320,13 @@ jobs:
 
       - name: Attest release provenance
         id: provenance
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: release-assets/SHA256SUMS
 
       - name: Attest release SBOM
         id: sbom
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: release-assets/SHA256SUMS
           sbom-path: release-assets/cfgms-${{ needs.validate.outputs.version }}.spdx.json


### PR DESCRIPTION
## Summary

Bump `actions/attest` SHA pin from `v4.1.0` (`59d89421`) to `v4.2.2` (`1e69f48a`) in `.github/workflows/release.yml`.

- **Both call sites updated lockstep**: "Attest release provenance" (line 323) and "Attest release SBOM" (line 329)
- **Target version**: `v4.2.2`, published `2026-08-04T20:36:29Z` — cleared the 3-day cooldown as of implementation date (2026-08-08). The story originally targeted `v4.2.1`, but `v4.2.2` had also cleared the window by implementation time, so it is targeted per the story's "if cleared, target that" instruction.
- **SHA independently re-resolved** via `gh api repos/actions/attest/tags?per_page=30 --jq '.[] | select(.name=="v4.2.2") | .commit.sha'` → `1e69f48acb82d1966a394da916b4c1698aa569d6`

## Release notes review (v4.1.1 → v4.2.2)

All changes across the four intermediate releases are dependency bumps and bug fixes:
- **v4.1.1**: `tar`, `csv-parse`, `minimatch`, `brace-expansion`, `undici`, `@sigstore/oci` bumps
- **v4.2.0**: checksums LF/Windows line-ending parse fix; `GITHUB_ARTIFACTS_LIST` subject support; `@actions/glob`, `csv-parse` bumps
- **v4.2.1**: OCI image tag-strip fix when pushing attestation to registry; `tar` bump
- **v4.2.2**: `@sigstore/oci`, `brace-expansion`, `ip-address` bumps

**No input renames or semantic changes.** The `subject-checksums` and `sbom-path` inputs used at both call sites are unchanged across all releases. No call-site updates required.

## Verification

- Old SHA absent: `grep -rn "59d89421af93a897026c735860bf21b6eb4f7b26" .github/` → 0 matches
- New SHA present: `grep -rn "1e69f48acb82d1966a394da916b4c1698aa569d6" .github/` → 2 matches
- No stale `v4.1.0` comment: `grep -rn "actions/attest" .github/ | grep -c "v4\.1\.0"` → 0
- Action remains SHA-pinned (zizmor passes)

## Specialist review results

All three lenses passed in a single round with zero findings:
- **Code review**: PASS
- **Test quality**: PASS
- **Security**: PASS

Fixes #3209