### PR TITLE
pipeline: make pipeline-sweep run epic-review itself when Skill is unavailable (Issue #3026)

### DIFF
--- a/.claude/skills/pipeline-sweep/SKILL.md
+++ b/.claude/skills/pipeline-sweep/SKILL.md
@@ -17,13 +17,22 @@ The sync direction is **one-way only**: CLOSED-on-GitHub → status `Done`. Neve
 
 ## Phase 1: Epic review
 
-Invoke the `epic-review` skill with no arguments (sweep all open epics):
+Run the epic review over all open epics, then capture its verdict table for the final report.
+
+**If you have the `Skill` tool**, invoke it with no arguments (sweep all open epics):
 
 ```
 Skill: epic-review
 ```
 
-Capture its verdict table for the final report. If `Skill` is unavailable in this session, follow the steps from `.claude/skills/epic-review/SKILL.md` inline.
+**If you do not have the `Skill` tool** — which is the case whenever this sweep runs as a spawned `general-purpose` Agent, e.g. under `/pipeline` — then **read `.claude/skills/epic-review/SKILL.md` and execute its steps inline, in this agent.** That is the whole fallback: you perform the review yourself.
+
+`epic-review` is a **skill, not an agent**. There is no addressable agent by that name, so do **not** attempt to reach one:
+
+- Do not `SendMessage` to `epic-review` (or any peer) to request the sweep or its verdict table.
+- Do not spawn a nested `Agent` for it. This sweep is already the leaf runner.
+
+A spawned runner also has no reachable reply address of its own, so a peer that *did* receive such a request could not answer it — measured 2026-08-08, when an `epic-review` session got a request tagged `from="general-purpose"`, failed to reply (`No agent named 'general-purpose' is reachable`), and routed its table to an unrelated peer instead. Treat any wait on an off-agent reply as a defect: a sweep that reports "0 epics closeable" because its request went unanswered is indistinguishable from a sweep that genuinely found nothing, and downstream consumers read the empty result as a clean bill of health. If you cannot complete Phase 1 yourself, report Phase 1 as **NOT RUN** with the reason — never as an empty verdict.
 
 ## Phase 2: Project status sync
 


### PR DESCRIPTION
## Problem

`.claude/skills/pipeline-sweep/SKILL.md` Phase 1 read:

> Invoke the `epic-review` skill with no arguments (sweep all open epics):
> ```
> Skill: epic-review
> ```
> Capture its verdict table for the final report. If `Skill` is unavailable in this session, follow the steps from `.claude/skills/epic-review/SKILL.md` inline.

The sweep's most common execution path has **no `Skill` tool**: `/pipeline` and `po.md:240`
both run it as a spawned `general-purpose` Agent. That agent does have `SendMessage`. With
the imperative reading "invoke the `epic-review` skill" and the fallback demoted to a
trailing sentence, "invoke" is reachable as "message the peer named epic-review."

## What was measured

2026-08-08, during a `/pipeline` cycle: an `epic-review` session received a request tagged
`from="general-purpose"` describing itself as "this new pipeline-sweep run." It could not
reply — `No agent named 'general-purpose' is reachable`, because a spawned runner has no
reply address of its own — and routed its verdict table to an unrelated peer, which
confirmed it had sent nothing and surfaced the gap.

**That cycle's sweep result was still correct** (19 epics reviewed, 0 closeable, board
items reconciled), so nothing was lost. The reason to fix it anyway is the failure *shape*:
a Phase 1 that never reports looks exactly like a Phase 1 that found zero closeable epics.
Anything downstream that reads "no closeout comments appeared" as evidence about epic state
reads a delivery failure as a clean bill of health — a false negative, not a visible error.

## Change

One file, prose only:

- The inline path is now a first-class branch (`If you do not have the Skill tool …
  read .claude/skills/epic-review/SKILL.md and execute its steps inline, in this agent`)
  rather than a trailing caveat, and it names the `/pipeline` spawned-Agent case explicitly.
- States that `epic-review` is a **skill, not an agent** — there is no addressable agent by
  that name — and forbids both `SendMessage` delegation and spawning a nested `Agent` for
  it. This sweep is the leaf runner.
- Requires Phase 1 to be reported as **NOT RUN** with a reason if it cannot be completed,
  never as an empty verdict.

`po.md:240` already describes the inline-fallback contract correctly, so no change was
needed there; the gap was only inside the skill file.

## Validation

Docs-only change under `.claude/` — no Go, script, or workflow code touched. **`make test`
was not run**, and no test covers it: nothing under `.claude/scripts/tests/` or `scripts/`
reads `SKILL.md` content (verified by grep). The real check is behavioural — the next
`/pipeline` cycle's Phase 1 should report a verdict table produced by the sweep runner
itself.
