### PR TITLE
modules: tag all modules with observe_when or deliberate omission (Issue #3105)

### DIFF
--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -287,6 +287,32 @@ In addition to the payload boundary, `make check-stdlib-completeness` (also wire
 
 **Adding a new stdlib module:** satisfy all five payload sources *and* all five completeness checks before the PR will merge (checks 2–6).
 
+### `observe_when` classification (ADR-024 §3)
+
+Every steward-pullable module carries either a real `observe_when` declaration or a
+deliberate-omission comment. The table below documents the call for all 15 modules
+and is the auditable summary of those decisions. The 7 `m365/*` workflow-kind modules
+are excluded from this table — they run on the controller workflow engine (never pulled
+by a steward) and have no steward-pull DNA observation path (see Workflow modules below).
+
+| Module | Kind | `observe_when` | Rationale |
+|--------|------|----------------|-----------|
+| `cert_trust` | stdlib | `os=windows\|linux\|darwin` | Bounded: trust-store enumeration is inventory-worthy on every OS |
+| `file` | stdlib | omitted (permanent) | Unbounded / content-bearing: declared resources live in config + drift only, never enumerated into DNA (ADR-024 §3) |
+| `firewall` | stdlib | `os=linux` | Bounded: firewall rule enumeration; Linux-only in current implementation |
+| `hostname` | stdlib | `os=windows\|linux\|darwin` | Bounded: single-value host-identity fact present on every platform |
+| `package` | stdlib | `os=windows\|linux\|darwin` | Bounded: installed-package inventory; universal domain — every OS ships a package manager |
+| `patch` | stdlib | `os=windows` | Bounded: installed-update inventory; Windows-only (Linux/macOS backends not yet implemented) |
+| `script` | stdlib | omitted (permanent) | Execution primitive with no observation domain; executes signed files on demand (ADR-024 §3) |
+| `service` | stdlib | `os=windows\|linux\|darwin` | Bounded: service inventory via systemd/SCM/launchd; present on every platform |
+| `time` | stdlib | `os=windows\|linux\|darwin` | Bounded: single-value timezone + NTP-sync facts; foundational on every platform |
+| `user` | stdlib | `os=windows\|linux\|darwin` | Bounded: local-user inventory; every platform has a local user database |
+| `hyperv` | extended (steward) | `hyperv_enabled=true` | Bounded: VM + cluster inventory; activates on Hyper-V hosts via the already-shipped `hyperv_enabled` DNA fact |
+| `acme` | extended (steward) | `os=linux\|darwin\|windows` | Bounded: ACME cert-store enumeration; applicable on any steward OS |
+| `activedirectory` | extended (steward) | `os=windows` | Bounded: local AD objects via ADSI; Windows-exclusive interface |
+| `github_runner` | extended (steward) | `os=linux\|windows` | Bounded: runner install state + service state; active on supported platforms |
+| `network_activedirectory` | extended (steward→outpost) | omitted | Remote AD objects via LDAP: no steward DNA fact indicates AD connectivity; domain does not fit local host-state inventory model; outpost relocation candidate (ADR-024 §3) |
+
 ### Current stdlib members
 
 Shipped in the steward installer, all `executors: [steward]` (closed set — see ADR-016):
@@ -317,7 +343,7 @@ CFGMS-authored but used on only a subset of the fleet; built as standalone bundl
 
 **Workflow modules:**
 
-- `m365/*` (workflow kind, hosted by the controller workflow engine, at `features/workflow/modules/m365/`) - Microsoft 365 modules: `auth`, `conditional_access`, `entra_admin_unit`, `entra_application`, `entra_group`, `entra_user`, `intune_policy`. The `gdap/` and `graph/` directories under the same parent are shared support packages, not module roots.
+- `m365/*` (workflow kind, hosted by the controller workflow engine, at `features/workflow/modules/m365/`) - Microsoft 365 modules: `auth`, `conditional_access`, `entra_admin_unit`, `entra_application`, `entra_group`, `entra_user`, `intune_policy`. The `gdap/` and `graph/` directories under the same parent are shared support packages, not module roots. These modules declare `executors: [controller]` — they run on the controller workflow engine against cloud APIs and are never pulled by a steward, so `observe_when` and the omission marker do not apply to them.
 
 ## Script Module — Parameter Environment Variables
 

--- a/features/modules/extended/acme/module.yaml
+++ b/features/modules/extended/acme/module.yaml
@@ -22,6 +22,16 @@ interfaces:
   - Set
   - Test
 
+# Bounded, inventory-worthy domain (ACME-managed certificate lifecycle). Active
+# on any steward OS — the ACME store can be enumerated on any platform.
+observe_when:
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: darwin
+  - fact: os
+    equals: windows
+
 security:
   requires_root: false
   capabilities: [net_bind_service]  # HTTP-01 on port 80

--- a/features/modules/extended/activedirectory/module.yaml
+++ b/features/modules/extended/activedirectory/module.yaml
@@ -92,6 +92,12 @@ monitoring:
     - "ad_local_errors_total"
     - "ad_dna_collection_status"
 
+# Bounded, inventory-worthy domain (local AD objects via ADSI/DirectoryServices).
+# Windows-only — the in-process ADSI API is a Windows-exclusive interface.
+observe_when:
+  - fact: os
+    equals: windows
+
 # Security considerations
 security:
   sensitive_fields: []  # No stored credentials

--- a/features/modules/extended/github_runner/module.yaml
+++ b/features/modules/extended/github_runner/module.yaml
@@ -32,6 +32,14 @@ interfaces:
   - Set
   - Test
 
+# Bounded, inventory-worthy domain (runner agent install state + service state).
+# Active on Linux and Windows per the platforms declaration above.
+observe_when:
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: windows
+
 security:
   requires_root: true # service enable/start and writing under work_dir need elevation
   capabilities: []

--- a/features/modules/extended/network_activedirectory/module.yaml
+++ b/features/modules/extended/network_activedirectory/module.yaml
@@ -116,6 +116,14 @@ monitoring:
     - "ad_errors_total"
     - "ad_connection_status"
 
+# observe_when: omitted — module's domain is remote AD objects accessed via
+# network LDAP; no steward DNA fact indicates AD connectivity, and the module
+# requires explicit domain/auth configuration to operate. The module is a
+# candidate for relocation to the outpost executor once that runtime exists;
+# outpost-kind modules have different observe semantics (ADR-024 §5 targets
+# steward-pull) and this domain does not fit the local host-state inventory
+# model (ADR-024 §3).
+
 # Security considerations
 security:
   sensitive_fields:

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -44,6 +44,14 @@ security:
 # re-signed by the publisher and re-approved before module_trust: strict stewards
 # will accept the updated module — strict stewards verify the signature
 # independently of the controller.
+# Bounded, inventory-worthy domain (VM and cluster inventory on Hyper-V hosts).
+# Predicate matches the already-shipped hyperv_enabled fact emitted by
+# features/steward/dna/hardware_windows.go collectHyperVInfo — the authoritative
+# key established by the #3103 fixture and the observe_test.go convention.
+observe_when:
+  - fact: hyperv_enabled
+    equals: "true"
+
 behavioral_envelope:
   shells_out_to:
     - powershell.exe

--- a/features/modules/stdlib/cert_trust/module.yaml
+++ b/features/modules/stdlib/cert_trust/module.yaml
@@ -27,8 +27,15 @@ interfaces:
 owns:
   - kind: cert_trust  # authority over cert_trust:* objects this module manages
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (trusted-cert-store enumeration). Active on
+# any steward OS — every platform ships a system trust store.
+observe_when:
+  - fact: os
+    equals: windows
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: darwin
 
 security:
   requires_root: true  # modifying the system trust store requires elevated privileges

--- a/features/modules/stdlib/firewall/module.yaml
+++ b/features/modules/stdlib/firewall/module.yaml
@@ -24,8 +24,11 @@ owns:
       - hostname  # device identity — required in every full-os-device DNA snapshot
       - os        # device identity — required in every full-os-device DNA snapshot
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (firewall rule enumeration). Currently
+# Linux-only per the platforms declaration above.
+observe_when:
+  - fact: os
+    equals: linux
 
 security:
   requires_root: true

--- a/features/modules/stdlib/hostname/module.yaml
+++ b/features/modules/stdlib/hostname/module.yaml
@@ -28,8 +28,15 @@ interfaces:
 owns:
   - kind: hostname  # authority over hostname:* objects this module manages
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (single-value host-identity fact). Active on
+# any steward OS — every platform has a hostname.
+observe_when:
+  - fact: os
+    equals: windows
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: darwin
 
 security:
   requires_root: true  # writing /etc/hostname and syscall.Sethostname require root on Linux; scutil requires admin on macOS; wmic/netdom require admin on Windows

--- a/features/modules/stdlib/package/module.yaml
+++ b/features/modules/stdlib/package/module.yaml
@@ -26,8 +26,16 @@ owns:
       - hostname  # device identity — required in every full-os-device DNA snapshot
       - os        # device identity — required in every full-os-device DNA snapshot
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (installed-package inventory). Universal —
+# every steward OS ships a package manager. OS predicates cover all three
+# platforms; no capability check needed since this domain is always present.
+observe_when:
+  - fact: os
+    equals: windows
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: darwin
 
 security:
   requires_root: true

--- a/features/modules/stdlib/patch/module.yaml
+++ b/features/modules/stdlib/patch/module.yaml
@@ -29,8 +29,11 @@ owns:
       - hostname  # device identity — required in every full-os-device DNA snapshot
       - os        # device identity — required in every full-os-device DNA snapshot
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (installed-update inventory). Windows-only —
+# the Linux/macOS backends are not yet implemented (requirements.os above).
+observe_when:
+  - fact: os
+    equals: windows
 
 security:
   requires_root: true  # installing patches requires elevated privileges

--- a/features/modules/stdlib/service/module.yaml
+++ b/features/modules/stdlib/service/module.yaml
@@ -29,8 +29,15 @@ owns:
       - hostname  # device identity — required in every full-os-device DNA snapshot
       - os        # device identity — required in every full-os-device DNA snapshot
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (service inventory via systemd/SCM/launchd).
+# Active on any steward OS — every platform ships a service manager.
+observe_when:
+  - fact: os
+    equals: windows
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: darwin
 
 security:
   requires_root: true  # start/stop/enable/disable require elevated privileges

--- a/features/modules/stdlib/time/module.yaml
+++ b/features/modules/stdlib/time/module.yaml
@@ -29,8 +29,15 @@ interfaces:
 owns:
   - kind: time  # authority over time:* objects this module manages
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (single-value timezone + NTP-sync facts).
+# Active on any steward OS — correct time is foundational on every platform.
+observe_when:
+  - fact: os
+    equals: windows
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: darwin
 
 security:
   requires_root: true  # writing /etc/timezone, /etc/systemd/timesyncd.conf, and calling timedatectl require root

--- a/features/modules/stdlib/user/module.yaml
+++ b/features/modules/stdlib/user/module.yaml
@@ -29,8 +29,15 @@ interfaces:
 owns:
   - kind: user  # authority over user:* objects this module manages
 
-# observe_when: omitted — pending module-tagging story (bounded inventory-worthy
-# domain; observe_when predicate will be added by the ADR-024 epic).
+# Bounded, inventory-worthy domain (local-user inventory). Active on any
+# steward OS — every platform has a local user database.
+observe_when:
+  - fact: os
+    equals: windows
+  - fact: os
+    equals: linux
+  - fact: os
+    equals: darwin
 
 security:
   requires_root: true  # creating/modifying/deleting accounts requires elevated privileges


### PR DESCRIPTION
## Summary

- Replaces the 8 temporary "pending module-tagging story" placeholder comments in stdlib `module.yaml` files with real `observe_when` predicates (bounded/inventory-worthy domains: `cert_trust`, `firewall`, `hostname`, `package`, `patch`, `service`, `time`, `user`).
- Adds the first real `observe_when` to `hyperv/module.yaml` (`hyperv_enabled=true`), establishing the ADR-024 pathfinder predicate consistent with `observe_test.go`'s established fact-key convention.
- Classifies all 4 extended modules: `acme`, `activedirectory`, `github_runner` get `observe_when` (bounded domains); `network_activedirectory` gets a deliberate-omission marker (remote LDAP domain, no steward DNA fact for AD connectivity, outpost-relocation candidate).
- Adds an `observe_when` classification table to `docs/architecture/modules/README.md` covering all 15 steward-pullable modules with predicate and one-line rationale; notes that 7 `m365/*` workflow-kind modules are excluded.

Fixes #3105

## Acceptance criteria verification

- [x] All 10 stdlib modules carry `observe_when` or the #3102 omission marker — `make check-stdlib-completeness` passes.
- [x] `hyperv` and all 4 `extended/*` modules carry `observe_when` or the omission marker.
- [x] `file` and `script` carry the permanent omission marker (unchanged).
- [x] The 7 `features/workflow/modules/m365/*` modules are confirmed untouched — `grep -r "observe_when" features/workflow/modules/m365/` returns no results.
- [x] `make check-stdlib-completeness` passes with check-6 active against all 10 stdlib modules.
- [x] Docs updated: `docs/architecture/modules/README.md` classification table added.

## Specialist review results

All three story-review lenses passed in round 1, zero findings:
- **Code review**: PASS
- **Test quality**: PASS
- **Security**: PASS

## m365 modules verification

```
$ grep -r "observe_when" features/workflow/modules/m365/
(no output — zero matches)
```