### PR TITLE
api: remove stale GlobalScope=true comments in handlers_rollout.go and handlers_runs.go (Issue #3193)

### DIFF
--- a/features/controller/api/handlers_rollout.go
+++ b/features/controller/api/handlers_rollout.go
@@ -105,12 +105,15 @@ func (s *Server) handleStartRollout(w http.ResponseWriter, r *http.Request) {
 	// Tenant scope: a caller may only target its own tenant subtree via req.TenantID; a
 	// caller that supplies a tenant outside that subtree is rejected rather than silently
 	// redirected. Only an unscoped caller (empty tenant — mTLS admin) may target any tenant.
-	// The principal's GlobalScope flag is deliberately NOT consulted: the web-session
-	// middleware sets GlobalScope=true on every session principal regardless of its tenant
-	// scope, so gating on it let a tenant-scoped web caller drive another tenant's rollout
-	// (Issue #3143). This mirrors the cross-tenant guard in handlers_upgrade.go and closes
-	// the isolation gap where a tenant-scoped caller holding installer:dispatch:steward
-	// could drive orchestration against a victim tenant's fleet (Issue #2340).
+	// The principal's GlobalScope flag is deliberately NOT consulted: GlobalScope is a
+	// read-visibility axis (cross-tenant fleet queries), not an authorization gate for
+	// which tenants a caller may target. Both session paths now compute it from actual
+	// scope — web-session from acct.RootScope (middleware.go:433), cfg-CLI Bearer from
+	// sess.TenantID=="" (middleware.go:357) — but using it for write isolation would be
+	// the wrong signal. The explicit callerTenantID + isWithinTenantScope check was the
+	// fix for Issue #3143 (a tenant-scoped caller could drive another tenant's rollout
+	// when GlobalScope was relied on) and is the correct isolation mechanism here. This
+	// mirrors the cross-tenant guard in handlers_upgrade.go (Issue #2340).
 	tenantID := callerTenantID
 	if req.TenantID != "" && req.TenantID != callerTenantID {
 		if !isWithinTenantScope(callerTenantID, req.TenantID) {

--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -166,11 +166,12 @@ func (s *Server) validatePublicBetaCommandSignature(content []byte, shell string
 // Only a machine (API-key) principal with no tenant is a genuine auth failure.
 //
 // This deliberately checks principal.Assurance == session.AssuranceMachine rather
-// than !principal.GlobalScope: middleware.go hardcodes GlobalScope=true on every
-// session principal regardless of its actual tenant scope (Issue #3143), so gating
-// on GlobalScope here would be a dead check that can never fire for a session
-// caller. Assurance is the reliable, orthogonal signal that a principal is
-// machine-authenticated (API key) — see the Principal doc comment.
+// than !principal.GlobalScope: Assurance is the direct signal for machine-authenticated
+// principals; GlobalScope models tenant-visibility breadth — an orthogonal axis that
+// must not be collapsed with authentication method (see Principal doc comment). Both
+// session paths now compute GlobalScope from actual scope (web-session: acct.RootScope
+// at middleware.go:433; cfg-CLI Bearer: sess.TenantID=="" at middleware.go:357), so
+// !GlobalScope is no longer a dead check — but it would answer the wrong question.
 //
 // On failure it writes the 401 and returns ok=false (Issue #1990).
 func (s *Server) authRunAccess(w http.ResponseWriter, r *http.Request) (principal *Principal, tenantID string, ok bool) {


### PR DESCRIPTION
## Summary

Two handler comments claimed that `middleware.go` hardcodes `GlobalScope=true` on every
session principal. That premise was invalidated by two recent merges:
- PR #3156 — web-session path now computes `GlobalScope` from `acct.RootScope` (middleware.go:433)
- PR #3240 / Issue #3194 — cfg-CLI Bearer path now computes `GlobalScope` from `sess.TenantID==""` (middleware.go:357)

A stale comment that is wrong for one principal type but accidentally right for another
is the worst kind — it will be trusted by the next person touching these handlers.

## Changes

- **`handlers_rollout.go` (~108):** Replaced "GlobalScope is hardcoded true so we skip it" with an accurate explanation — GlobalScope is a read-visibility axis, not a write-authorization gate. The `callerTenantID + isWithinTenantScope` check is the correct isolation mechanism (Issue #3143 fix), with current middleware line references.

- **`handlers_runs.go` (~168, `authRunAccess`):** Replaced "!GlobalScope is a dead check because GlobalScope is always true for session callers" with accurate reasoning — both session paths now compute GlobalScope correctly, so it is no longer a dead check; but `Assurance` remains the correct signal because it directly models authentication method while `GlobalScope` models tenant-visibility breadth (see Principal doc comment — the two axes must not be collapsed).

**No logic changes. Comments only.**

## Specialist Review Results

All three lenses (code review, test quality, security) passed in round 1 with zero findings, no fix rounds required.

Fixes #3193