### PR TITLE
deps: bump actions/download-artifact v7.0.0 → v8.0.1 (Issue #3211)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,7 @@ jobs:
           persist-credentials: false
 
       - name: Download release artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-*
           path: release-assets


### PR DESCRIPTION
## Summary

Bumps the SHA pin for `actions/download-artifact` from `37930b1c2abaa49bbe596cd826c3c89aef350131` (v7.0.0) to `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1) in `.github/workflows/release.yml`. This is a **major-version bump** with documented breaking changes; each is addressed below.

Fixes #3211

## SHA verification

Independently re-resolved before commit:
```
gh api repos/actions/download-artifact/tags?per_page=30 \
  --jq '.[] | select(.name=="v8.0.1") | .commit.sha'
# → 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
```
Matches the pinned value.

## Breaking-change analysis (v8.0.0 release notes)

### 1. `digest-mismatch` now errors by default (AC 5)

v8 introduces a `digest-mismatch` input that defaults to `error`, making hash-mismatched downloads fail the workflow run. We do **not** set this input, so the secure default (`error`) is in effect. A mismatched digest on a release artifact is a supply-chain signal, not noise — keeping the default is correct for this pipeline.

### 2. Non-zipped files are no longer auto-unzipped (AC 6)

v8 checks the `Content-Type` header before decompressing and skips non-zip files. Our release artifacts are uploaded by `actions/upload-artifact@v7.0.1` (SHA: `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`), which stores artifacts as zip archives. The v8 downloader will see `Content-Type: application/zip`, will decompress as before, and individual files will land at `release-assets/` depth 1.

The `pattern: release-*` / `path: release-assets` / `merge-multiple: true` inputs all exist with the same semantics in v8 (verified via `action.yml` at the pinned SHA). The downstream steps are unaffected:
- **"Create release checksums"** — `find . -maxdepth 1 -type f` in `release-assets` still finds the same individual files.
- **"Generate SPDX SBOM"** — `path: release-assets` still resolves to the same directory of individual files.

### 3. ESM module migration

Transparent to callers; noted for completeness.

## upload v7 ↔ download v8 pairing (AC 7)

`actions/upload-artifact@v7.0.1` creates zip-wrapped artifacts (unchanged behaviour from v4). `actions/download-artifact@v8.0.1` checks `Content-Type` before decompressing — a zip artifact from v7 upload gets `Content-Type: application/zip` and is decompressed normally. The v8 release notes confirm the content-type check was introduced specifically to handle **newer** direct-upload formats without breaking existing zip-based uploads. **This pairing is supported; no coordinated upload bump is required.**

## Specialist review results

| Lens | Result |
|------|--------|
| Code review | PASS |
| Test quality | PASS |
| Security | PASS |

`make test` passed locally (208/208).

## Notes

- `release.yml` only fires on release tags, so CI on this PR does not exercise the download step. Verification is documentary per the story implementation notes.
- `zizmor`: action remains SHA-pinned (`@<sha> # v8.0.1`), no tag-only reference introduced.
- This PR should receive a human `/pr-review` per the story notes (breaking major-version bump on the release-signing path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)