### PR TITLE
security: bump nanoid to 3.3.18 for CVE-2026-67213 (HIGH)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4715,9 +4715,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
-    "minimatch": "^10.2.5"
+    "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
## The vulnerability

`web/package-lock.json` carried `nanoid` **3.3.16** as a transitive dev dependency.

| | |
|---|---|
| Advisory | GHSA-2v37-7h3g-55p8 / **CVE-2026-67213** |
| Severity | **HIGH** |
| Summary | custom generators can loop indefinitely when size is zero |
| Affected | `< 3.3.17` |
| First patched | `3.3.17` |

Confirmed against the GitHub advisory API rather than taken from the `npm audit` text alone.

## The fix

Three lines of substance. `nanoid` joins the `overrides` block in `web/package.json`
alongside the existing `minimatch` entry, and the lockfile was regenerated with
`npm install --package-lock-only`. Resolved version is **3.3.18**, the current 3.3.x
release. No other dependency moved:

```
web/package-lock.json | 6 +++---
web/package.json      | 3 ++-
```

**Rejected alternatives:** lowering `--audit-level` below `high`, and adding `--omit=dev`
to the audit. Both hide the finding instead of fixing it, and the dev-dependency graph is
what builds the shipped bundle.

## Why it went unnoticed

The vulnerability was on `develop` — no open PR introduced it. It surfaced on PR #3235 only
because that branch happens to touch `web/`: at `.github/workflows/frontend-ci.yml:86-89`
the audit step is gated on `steps.changes.outputs.has_changes == 'true'`, so it runs **only
for web-touching PRs**, while `frontend-checks` is a *required* context with **no path
filter**. Merge-queue runs at 19:25Z and 19:28Z passed on byte-identical lockfile content
while #3235 failed at 19:23Z — the difference was whether the audit executed at all, not
what it found.

That is a gate-correctness hole of exactly the shape CLAUDE.md warns about ("A green check
does not always mean that scan ran"), and it is separate work — logged against Epic #3175.
**This PR fixes only the vulnerability.** It also unblocks every web-touching PR, which was
red on a finding none of them caused.

## Validation

All five `frontend-checks` steps run locally against this lockfile. Local toolchain was
node 22.17.0 / npm 10.9.2; CI pins node 26 via `web/.nvmrc`, so CI is the authority on the
install step:

| Step | Result |
|---|---|
| `npm ci` | 0 vulnerabilities |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run test` | 52 files, **1193 tests, all passed** |
| `npm run build` | built, 447.20 kB bundle |
| `npm audit --audit-level=high` | **found 0 vulnerabilities**, exit 0 |

The pre-fix state fails that last command — that is the whole reason this PR exists, so the
check is not one that passes either way.

## Incidental finding, deliberately not fixed here

`web/dist/index.html` is **tracked** while `web/dist/assets/*` is not, so the committed copy
references asset hashes (`index-DLA4F6vx.js`, `index-Csqy_JQl.css`) that exist nowhere in
the repo — and any local `npm run build` dirties the working tree. I reverted my build's
change to it rather than carry a rebuilt artifact in a dependency bump. Worth its own
cleanup.
