### PR TITLE
entitygraph: controller-side DNA fragment ingest writer (Issue #2907)

### DIFF
--- a/features/controller/transport/dna_handler.go
+++ b/features/controller/transport/dna_handler.go
@@ -25,6 +25,8 @@ import (
 	sdna "github.com/cfgis/cfgms/features/steward/dna"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	dptypes "github.com/cfgis/cfgms/pkg/dataplane/types"
+	egtypes "github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/cfgis/cfgms/pkg/entitygraph/writers/dnasync"
 	"github.com/cfgis/cfgms/pkg/logging"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 )
@@ -122,6 +124,13 @@ type DNAHandler struct {
 	// for. Set in HandleHeartbeatRoot; consumed and cleared in the delta branch
 	// of HandleGRPC.
 	pendingDeltas sync.Map
+
+	// Entity-graph writer fields (ADR-022 §9, Story #2907). Both nil when the
+	// entity-graph write path is not wired; only set via WithEntityGraph.
+	// The write is additive — alongside the existing ApplyDelta manifest path,
+	// never replacing it.
+	egWriter   *dnasync.Writer
+	egTaxonomy *egtypes.Taxonomy
 }
 
 // deltaRequest is the controller-side record of one outstanding partial-sync
@@ -166,6 +175,26 @@ func NewDNAHandler(logger logging.Logger, queue *TenantQueue, persister DNAPersi
 func (h *DNAHandler) WithPartialSync(store FragmentDeltaStore, publisher CommandPublisher) *DNAHandler {
 	h.store = store
 	h.publisher = publisher
+	return h
+}
+
+// WithEntityGraph wires the DNA-sync → entity-graph writer and the taxonomy
+// required for authority-class-based EID scoping (Story #2907, ADR-022 §9).
+// Returns h for chaining.
+//
+// Both arguments must be non-nil. Calling with either nil is a no-op to avoid
+// a nil-dereference in handleDeltaGRPC; the entity-graph write is then skipped
+// silently (a missing writer is a configuration error, not a data error, and the
+// caller's ApplyDelta write already committed the fragment manifest).
+//
+// The entity-graph write is ADDITIVE: it runs after ApplyDelta succeeds and
+// on failure only emits a warning — the steward's stream is not failed and the
+// committed manifest is not rolled back. Authority confusion (SE threat #1) is
+// structurally impossible: the EID authority segment is built entirely from the
+// mTLS-verified peerID, never from steward-supplied fragment data.
+func (h *DNAHandler) WithEntityGraph(writer *dnasync.Writer, taxonomy *egtypes.Taxonomy) *DNAHandler {
+	h.egWriter = writer
+	h.egTaxonomy = taxonomy
 	return h
 }
 
@@ -526,6 +555,17 @@ func (h *DNAHandler) handleDeltaGRPC(ctx context.Context, stream grpc.ClientStre
 		return fmt.Errorf("failed to apply delta for %s: %w", safePeerID, applyErr)
 	}
 	h.pendingDeltas.Delete(peerID)
+
+	// Entity-graph write (Story #2907, ADR-022 §9). Additive alongside ApplyDelta
+	// — a write failure emits a warning but does NOT fail the stream or roll back
+	// the committed manifest. peerID is the mTLS-verified identity; no fragment
+	// field can influence the EID authority segment (SE threat #1).
+	if h.egWriter != nil && h.egTaxonomy != nil {
+		if egErr := h.egWriter.WriteFragmentDelta(ctx, peerID, receivedFragments, nil, h.egTaxonomy); egErr != nil {
+			h.logger.Warn("entity-graph write failed for delta; manifest committed, graph may lag",
+				"peer_id", safePeerID, "error", logging.SanitizeLogValue(egErr.Error()))
+		}
+	}
 
 	h.logger.Info("DNA delta sync accepted",
 		"peer_id", safePeerID, "fragment_count", len(receivedFragments))

--- a/features/controller/transport/dna_handler_entitygraph_test.go
+++ b/features/controller/transport/dna_handler_entitygraph_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package transport — entity-graph integration tests for the DNA delta handler.
+//
+// This file exercises the authority-boundary invariant (SE threat #1) through the
+// full delta receive path: a real mTLS-authenticated context + in-process gRPC
+// stream → handleDeltaGRPC → WithEntityGraph → entity-graph writer.
+//
+// The security property being tested: no steward-supplied string (fragment_id,
+// canonical_bytes) can produce an entity-graph observation whose EID authority
+// segment names any steward other than the mTLS-verified peer.
+package transport
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	common "github.com/cfgis/cfgms/api/proto/common"
+	sdna "github.com/cfgis/cfgms/features/steward/dna"
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	sqliteprovider "github.com/cfgis/cfgms/pkg/entitygraph/providers/sqlite"
+	egtypes "github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/cfgis/cfgms/pkg/entitygraph/writers/dnasync"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// newTestEGProvider opens a fresh SQLite entity graph provider backed by a temp file.
+func newTestEGProvider(t *testing.T) *sqliteprovider.SQLiteEntityGraphProvider {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "eg.db")
+	p, err := sqliteprovider.NewSQLiteEntityGraphProvider(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+// egStateHistory returns only ObservationKindState records for the given EID.
+func egStateHistory(t *testing.T, p *sqliteprovider.SQLiteEntityGraphProvider, eid egtypes.EID) []*interfaces.ObservationRecord {
+	t.Helper()
+	wide := interfaces.TimeRange{
+		From: time.Unix(0, 0).UTC(),
+		To:   time.Now().UTC().Add(time.Hour),
+	}
+	records, err := p.GetHistory(context.Background(), eid, wide)
+	require.NoError(t, err)
+	var out []*interfaces.ObservationRecord
+	for _, r := range records {
+		if r.Observation.Kind == egtypes.ObservationKindState {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// adversarialFrag builds a fragment whose fragment_id is shaped to look like
+// another steward's EID ("host:<otherSteward>/..."). The canonical bytes and
+// FragmentHash are valid so the fragment passes verifyFragmentLeaves.
+func adversarialFrag(fragmentID, authority string) *common.Fragment {
+	canon := []byte(`{"adversarial":"payload","host_target":"steward-B"}`)
+	return &common.Fragment{
+		FragmentId:     fragmentID,
+		Authority:      authority,
+		CanonicalBytes: canon,
+		FragmentHash:   sdna.FragmentHash(canon),
+	}
+}
+
+// TestDNAHandler_DeltaGRPC_EntityGraph_B1_AdversarialFragmentID is the SE threat
+// #1 regression test through the full delta transport path.
+//
+// A steward authenticated as "steward-A" sends a fragment whose fragment_id is
+// "host:steward-B/evil:path" — shaped to look like a different steward's EID.
+// The handler must route the entity-graph observation to host:steward-A (the
+// mTLS-verified authority), never to host:steward-B. Authority confusion is
+// structurally unrepresentable: the EID authority segment is built from the
+// mTLS-verified peerID, never from the fragment_id field.
+func TestDNAHandler_DeltaGRPC_EntityGraph_B1_AdversarialFragmentID(t *testing.T) {
+	ca := newTestCA(t)
+	p := newTestEGProvider(t)
+	egWriter, err := dnasync.New(p)
+	require.NoError(t, err)
+	taxonomy := egtypes.DefaultTaxonomy()
+
+	// Adversarial fragment whose fragment_id contains a foreign steward identity.
+	evil := adversarialFrag("host:steward-B/evil:path", "test-authority")
+
+	manifest := fragmentsToManifest([]*common.Fragment{evil})
+	claimedRoot, err := sdna.AggregateRoot(manifest)
+	require.NoError(t, err)
+
+	store := NewInMemoryFragmentDeltaStore()
+	store.SetManifest("steward-A", manifest)
+
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil).
+		WithPartialSync(store, nil).
+		WithEntityGraph(egWriter, taxonomy)
+	h.recordDeltaRequest("steward-A", claimedRoot, manifestIDs(manifest))
+
+	ctx := peerContextWithCA(t, ca, "steward-A")
+	stream := newTestDNAStream(ctx, deltaChunksFor(t, "steward-A", []*common.Fragment{evil})...)
+	require.NoError(t, h.HandleGRPC(stream))
+	require.NotNil(t, stream.resp)
+	require.True(t, stream.resp.GetAccepted())
+
+	// The observation MUST land under steward-A's authority — the fragment_id
+	// "host:steward-B/evil:path" goes into the localID, not the authority segment.
+	// EID = "host:steward-A/host:steward-B/evil:path"
+	eidStewardA, parseErr := egtypes.ParseEID("host:steward-A/host:steward-B/evil:path")
+	require.NoError(t, parseErr)
+	recordsA := egStateHistory(t, p, eidStewardA)
+	require.Len(t, recordsA, 1,
+		"exactly one state observation must land under host:steward-A authority")
+	require.Equal(t, "host:steward-A/host:steward-B/evil:path", recordsA[0].Observation.Subject,
+		"Subject must be rooted under the mTLS-verified steward-A, not steward-B")
+
+	// No observation may exist under steward-B's namespace.
+	eidStewardB, parseErr := egtypes.ParseEID("host:steward-B/evil:path")
+	require.NoError(t, parseErr)
+	recordsB := egStateHistory(t, p, eidStewardB)
+	require.Empty(t, recordsB,
+		"adversarial fragment_id must never produce an observation under host:steward-B")
+}
+
+// TestDNAHandler_DeltaGRPC_EntityGraph_NormalFragmentsLandCorrectly verifies that
+// after a valid delta the entity-graph observations for normal host-scoped fragments
+// land under the authenticated steward's host authority and have the correct Kind.
+func TestDNAHandler_DeltaGRPC_EntityGraph_NormalFragmentsLandCorrectly(t *testing.T) {
+	ca := newTestCA(t)
+	p := newTestEGProvider(t)
+	egWriter, err := dnasync.New(p)
+	require.NoError(t, err)
+	taxonomy := egtypes.DefaultTaxonomy()
+
+	// Three standard host-scoped fragments.
+	frags := []*common.Fragment{
+		adversarialFrag("file:/etc/hosts", "enforcing-module:file"),
+		adversarialFrag("service:sshd", "enforcing-module:service"),
+		adversarialFrag("patch:kb5042099", "enforcing-module:patch"),
+	}
+
+	manifest := fragmentsToManifest(frags)
+	claimedRoot, err := sdna.AggregateRoot(manifest)
+	require.NoError(t, err)
+
+	store := NewInMemoryFragmentDeltaStore()
+	store.SetManifest("steward-Z", manifest)
+
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil).
+		WithPartialSync(store, nil).
+		WithEntityGraph(egWriter, taxonomy)
+	h.recordDeltaRequest("steward-Z", claimedRoot, manifestIDs(manifest))
+
+	ctx := peerContextWithCA(t, ca, "steward-Z")
+	stream := newTestDNAStream(ctx, deltaChunksFor(t, "steward-Z", frags)...)
+	require.NoError(t, h.HandleGRPC(stream))
+	require.True(t, stream.resp.GetAccepted())
+
+	// All three fragments must produce state observations under steward-Z.
+	for _, frag := range frags {
+		eid, parseErr := egtypes.ParseEID("host:steward-Z/" + frag.GetFragmentId())
+		require.NoError(t, parseErr)
+		records := egStateHistory(t, p, eid)
+		require.Len(t, records, 1,
+			"fragment %q must have exactly one state observation under host:steward-Z",
+			frag.GetFragmentId())
+		require.Equal(t, egtypes.ObservationKindState, records[0].Observation.Kind)
+	}
+}
+
+// TestDNAHandler_DeltaGRPC_EntityGraph_WriterFailureNonFatal verifies that an
+// entity-graph write failure does NOT fail the delta RPC. The steward's stream
+// must still receive Accepted=true and the manifest must be committed.
+func TestDNAHandler_DeltaGRPC_EntityGraph_WriterFailureNonFatal(t *testing.T) {
+	ca := newTestCA(t)
+
+	// Use a nil provider to trigger the egWriter constructor to fail — instead,
+	// we wire a writer backed by a closed provider so the write itself fails.
+	p := newTestEGProvider(t)
+	// Close the provider immediately so writes fail.
+	_ = p.Close()
+
+	egWriter, err := dnasync.New(p)
+	require.NoError(t, err, "New must succeed — the close error only surfaces on write")
+	taxonomy := egtypes.DefaultTaxonomy()
+
+	frags := makeTestFragments(2)
+	manifest := fragmentsToManifest(frags)
+	claimedRoot, rootErr := sdna.AggregateRoot(manifest)
+	require.NoError(t, rootErr)
+
+	store := NewInMemoryFragmentDeltaStore()
+	store.SetManifest("steward-nonfatal", manifest)
+
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil).
+		WithPartialSync(store, nil).
+		WithEntityGraph(egWriter, taxonomy)
+	h.recordDeltaRequest("steward-nonfatal", claimedRoot, manifestIDs(manifest))
+
+	ctx := peerContextWithCA(t, ca, "steward-nonfatal")
+	stream := newTestDNAStream(ctx, deltaChunksFor(t, "steward-nonfatal", frags)...)
+
+	// The handler must succeed even though the entity-graph write fails.
+	require.NoError(t, h.HandleGRPC(stream),
+		"a failed entity-graph write must not fail the delta RPC")
+	require.NotNil(t, stream.resp)
+	require.True(t, stream.resp.GetAccepted(),
+		"the steward must still receive Accepted=true when the eg write fails")
+
+	// The manifest must have been committed (pendingDeltas cleared).
+	_, stillPending := h.pendingDeltas.Load("steward-nonfatal")
+	require.False(t, stillPending,
+		"pendingDeltas must be cleared even when the entity-graph write fails")
+}
+
+// TestDNAHandler_DeltaGRPC_EntityGraph_NoWriterSkipsGracefully verifies that a
+// DNAHandler WITHOUT WithEntityGraph wired still accepts the delta normally.
+func TestDNAHandler_DeltaGRPC_EntityGraph_NoWriterSkipsGracefully(t *testing.T) {
+	ca := newTestCA(t)
+
+	frags := makeTestFragments(2)
+	manifest := fragmentsToManifest(frags)
+	claimedRoot, err := sdna.AggregateRoot(manifest)
+	require.NoError(t, err)
+
+	store := NewInMemoryFragmentDeltaStore()
+	store.SetManifest("steward-nowire", manifest)
+
+	// Handler with WithPartialSync but no WithEntityGraph.
+	h := NewDNAHandler(logging.NewNoopLogger(), NewTenantQueue(), nil).
+		WithPartialSync(store, nil)
+	h.recordDeltaRequest("steward-nowire", claimedRoot, manifestIDs(manifest))
+
+	ctx := peerContextWithCA(t, ca, "steward-nowire")
+	stream := newTestDNAStream(ctx, deltaChunksFor(t, "steward-nowire", frags)...)
+	require.NoError(t, h.HandleGRPC(stream),
+		"a handler without entity-graph wired must still accept the delta")
+	require.True(t, stream.resp.GetAccepted())
+}

--- a/pkg/entitygraph/writers/dnasync/decode.go
+++ b/pkg/entitygraph/writers/dnasync/decode.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dnasync
+
+// This file contains a self-contained decoder for the ADR-017 canonical fragment
+// byte encoding. The encoding is defined in features/steward/dna/canonical.go and
+// reproduced here because pkg/ must never import features/ (import direction rule).
+// The algorithm is identical; only the package-private helper names differ.
+//
+// Format (from CanonicalizeFragment):
+//
+//	[uint32 BE: stable-field count]
+//	For each field, sorted ascending by key:
+//	  [uint32 BE: key byte-length] [key bytes]
+//	  [1 byte: type tag]
+//	  [type-specific value bytes]
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+)
+
+// decodeCanonicalFragment reverses the canonical encoding, recovering the
+// stable key-value pairs from canonical bytes.
+//
+// Returns an error when bytes are malformed or exceed maxDecodePayloadSize.
+// On error callers should fall back to a minimal payload rather than failing
+// the entire delta ingest.
+func decodeCanonicalFragment(b []byte) (map[string]interface{}, error) {
+	if len(b) > maxDecodePayloadSize {
+		return nil, fmt.Errorf("dnasync/decode: %d bytes exceeds maximum %d", len(b), maxDecodePayloadSize)
+	}
+	m, n, err := decodeMap(b, 0)
+	if err != nil {
+		return nil, fmt.Errorf("dnasync/decode: %w", err)
+	}
+	if n != len(b) {
+		return nil, fmt.Errorf("dnasync/decode: %d bytes consumed, %d total", n, len(b))
+	}
+	return m, nil
+}
+
+// maxDecodePayloadSize matches features/steward/dna.MaxCanonicalFragmentSize.
+const maxDecodePayloadSize = 8 * 1024 * 1024
+
+// maxDecodeDepth prevents stack overflow from adversarially nested maps.
+const maxDecodeDepth = 32
+
+// minMapEntrySize is the smallest number of bytes one map entry can occupy
+// (4-byte key length + 1-byte type tag), used to bound declared counts.
+const minMapEntrySize = 5
+
+// canonTag* are the wire-format type tags matching CanonicalizeFragment's encoding.
+const (
+	canonTagNull   = byte('N')
+	canonTagBool   = byte('B')
+	canonTagInt    = byte('I')
+	canonTagUint   = byte('U')
+	canonTagFloat  = byte('F')
+	canonTagString = byte('S')
+	canonTagMap    = byte('M')
+	canonTagSlice  = byte('L')
+	canonTagOther  = byte('O')
+)
+
+// canonSpan converts a declared uint32 length to an int, validating it fits
+// within the remaining buffer. Running in uint64 prevents signed overflow on
+// 32-bit platforms.
+//
+// #nosec G115 -- conversions are safe: remaining is a non-negative slice length
+// and declared is bounded by remaining before narrowing to int.
+func canonSpan(declared uint32, remaining int) (int, bool) {
+	if remaining < 0 {
+		return 0, false
+	}
+	if uint64(declared) > uint64(remaining) {
+		return 0, false
+	}
+	return int(declared), true
+}
+
+// decodeMap decodes [uint32 count][entries...] from b at the given nesting depth.
+func decodeMap(b []byte, depth int) (map[string]interface{}, int, error) {
+	if depth > maxDecodeDepth {
+		return nil, 0, fmt.Errorf("decodeMap: nesting depth exceeds %d", maxDecodeDepth)
+	}
+	if len(b) < 4 {
+		return nil, 0, fmt.Errorf("decodeMap: need 4 bytes for count, have %d", len(b))
+	}
+	declaredCount := binary.BigEndian.Uint32(b[:4])
+	pos := 4
+	count, ok := canonSpan(declaredCount, len(b)-pos)
+	if !ok || count > (len(b)-pos)/minMapEntrySize {
+		return nil, 0, fmt.Errorf("decodeMap: declared %d entries exceeds %d possible in %d remaining bytes",
+			declaredCount, (len(b)-pos)/minMapEntrySize, len(b)-pos)
+	}
+	m := make(map[string]interface{})
+	for i := 0; i < count; i++ {
+		if pos+4 > len(b) {
+			return nil, 0, fmt.Errorf("decodeMap: key length truncated at entry %d", i)
+		}
+		klen, ok := canonSpan(binary.BigEndian.Uint32(b[pos:pos+4]), len(b)-pos-4)
+		if !ok {
+			return nil, 0, fmt.Errorf("decodeMap: key bytes truncated at entry %d", i)
+		}
+		pos += 4
+		key := string(b[pos : pos+klen])
+		pos += klen
+		v, n, err := decodeValue(b[pos:], depth)
+		if err != nil {
+			return nil, 0, fmt.Errorf("decodeMap: entry %q: %w", key, err)
+		}
+		m[key] = v
+		pos += n
+	}
+	return m, pos, nil
+}
+
+// decodeValue decodes one type-tagged value from b at the given nesting depth.
+func decodeValue(b []byte, depth int) (interface{}, int, error) {
+	if depth > maxDecodeDepth {
+		return nil, 0, fmt.Errorf("decodeValue: nesting depth exceeds %d", maxDecodeDepth)
+	}
+	if len(b) == 0 {
+		return nil, 0, fmt.Errorf("decodeValue: empty buffer")
+	}
+	switch b[0] {
+	case canonTagNull:
+		return nil, 1, nil
+
+	case canonTagBool:
+		if len(b) < 2 {
+			return nil, 0, fmt.Errorf("decodeValue: bool truncated")
+		}
+		return b[1] != 0x00, 2, nil
+
+	case canonTagInt:
+		if len(b) < 9 {
+			return nil, 0, fmt.Errorf("decodeValue: int64 truncated")
+		}
+		// #nosec G115 -- reinterprets the same two's-complement bits written by the encoder.
+		return int64(binary.BigEndian.Uint64(b[1:9])), 9, nil
+
+	case canonTagUint:
+		if len(b) < 9 {
+			return nil, 0, fmt.Errorf("decodeValue: uint64 truncated")
+		}
+		return binary.BigEndian.Uint64(b[1:9]), 9, nil
+
+	case canonTagFloat:
+		if len(b) < 5 {
+			return nil, 0, fmt.Errorf("decodeValue: float length truncated")
+		}
+		slen, ok := canonSpan(binary.BigEndian.Uint32(b[1:5]), len(b)-5)
+		if !ok {
+			return nil, 0, fmt.Errorf("decodeValue: float string truncated")
+		}
+		s := string(b[5 : 5+slen])
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, 0, fmt.Errorf("decodeValue: parse float %q: %w", s, err)
+		}
+		return v, 5 + slen, nil
+
+	case canonTagString, canonTagOther:
+		if len(b) < 5 {
+			return nil, 0, fmt.Errorf("decodeValue: string/other length truncated")
+		}
+		slen, ok := canonSpan(binary.BigEndian.Uint32(b[1:5]), len(b)-5)
+		if !ok {
+			return nil, 0, fmt.Errorf("decodeValue: string/other bytes truncated")
+		}
+		return string(b[5 : 5+slen]), 5 + slen, nil
+
+	case canonTagMap:
+		m, n, err := decodeMap(b[1:], depth+1)
+		if err != nil {
+			return nil, 0, fmt.Errorf("decodeValue: nested map: %w", err)
+		}
+		return m, 1 + n, nil
+
+	case canonTagSlice:
+		if len(b) < 5 {
+			return nil, 0, fmt.Errorf("decodeValue: slice count truncated")
+		}
+		declaredCount := binary.BigEndian.Uint32(b[1:5])
+		pos := 5
+		count, ok := canonSpan(declaredCount, len(b)-pos)
+		if !ok {
+			return nil, 0, fmt.Errorf("decodeValue: declared %d slice elements exceeds %d remaining bytes",
+				declaredCount, len(b)-pos)
+		}
+		elems := make([]interface{}, 0)
+		for i := 0; i < count; i++ {
+			v, n, err := decodeValue(b[pos:], depth+1)
+			if err != nil {
+				return nil, 0, fmt.Errorf("decodeValue: slice element %d: %w", i, err)
+			}
+			elems = append(elems, v)
+			pos += n
+		}
+		return elems, pos, nil
+
+	default:
+		return nil, 0, fmt.Errorf("decodeValue: unknown tag 0x%02x", b[0])
+	}
+}

--- a/pkg/entitygraph/writers/dnasync/writer.go
+++ b/pkg/entitygraph/writers/dnasync/writer.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package dnasync implements the DNA-sync → entity-graph internal writer
+// (ADR-022 §9, ADR-023 §2). It translates fragment deltas received from
+// stewards into entity-graph observations, scoped per peer authority.
+//
+// Authority-boundary invariant (SE threat #1 — authority confusion): the eid
+// authority segment is built entirely from the mTLS-verified peerHostAuthority
+// argument. No field the steward supplies in fragment data (fragment_id,
+// authority, payload) can reach the eid authority segment — the attack is
+// structurally unrepresentable, not detected-and-rejected.
+//
+// EID construction branches on taxonomy AuthorityClasses (Finding 1 fix):
+//   - Host-scoped kinds (AuthorityClasses contains "host"): eid = host:<peerHostAuthority>/<fragment_id>
+//   - Cluster-kind fragments (AuthorityClasses does NOT contain "host"): eid = cluster:<clusterName> (bare)
+//
+// Source attribution for host-scoped observations uses peerHostAuthority (not
+// the module authority) so that ClaimScope.Source and Observation.Source remain
+// equal, enabling the retraction machinery to fire correctly.
+package dnasync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+)
+
+// Writer is the DNA-sync → entity-graph internal writer.
+type Writer struct {
+	provider interfaces.EntityGraphProvider
+}
+
+// New returns a Writer backed by provider. provider must not be nil.
+func New(provider interfaces.EntityGraphProvider) (*Writer, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("dnasync/writer: provider must not be nil")
+	}
+	return &Writer{provider: provider}, nil
+}
+
+// WriteFragmentDelta ingests a set of fragment deltas from a single peer into
+// the entity graph as ObservationKindState observations.
+//
+// Host-scoped fragments (taxonomy AuthorityClasses contains "host") produce
+// eid = host:<peerHostAuthority>/<fragment_id>, Observation.Source = peerHostAuthority,
+// and a ClaimScope covering host:<peerHostAuthority> for retraction semantics (#2874).
+// Module identity is preserved in Payload["module_authority"] rather than in
+// Observation.Source so that ClaimScope source matching works correctly.
+//
+// Cluster-kind fragments (AuthorityClasses does NOT contain "host") produce
+// eid = cluster:<clusterName> (bare, no local_id, no ClaimScope). Multiple
+// stewards reporting the same cluster fragment converge on the same eid —
+// the intended behaviour for shared multi-observer entities. The Observation.Source
+// for cluster-kind observations is peerHostAuthority + "/" + fragment.Authority
+// so clusterregistry's split-brain/dead-owner detection can attribute each claim.
+//
+// The envelopes map is keyed by fragment_id and carries per-fragment provenance
+// metadata (confidence, observed_at). It may be nil when the caller has no
+// envelope data (e.g., the partial-sync delta path).
+func (w *Writer) WriteFragmentDelta(
+	ctx context.Context,
+	peerHostAuthority string,
+	fragments []*commonpb.Fragment,
+	envelopes map[string]*commonpb.FragmentEnvelope,
+	taxonomy *types.Taxonomy,
+) error {
+	if len(fragments) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+
+	var hostObs []types.Observation
+	var clusterObs []types.Observation
+
+	for _, frag := range fragments {
+		fragID := frag.GetFragmentId()
+
+		// Parse kind: the substring of fragment_id before the first ':'.
+		kind := fragID
+		if idx := strings.Index(fragID, ":"); idx >= 0 {
+			kind = fragID[:idx]
+		}
+
+		// Resolve confidence from envelope; default to high per PO ruling.
+		confidence := types.ConfidenceHigh
+		observedAt := now
+		if envelopes != nil {
+			if env, ok := envelopes[fragID]; ok && env != nil {
+				if c := env.GetConfidence(); c != "" {
+					confidence = resolveConfidence(c)
+				}
+				if ts := env.GetObservedAt(); ts != nil {
+					if t := ts.AsTime(); !t.IsZero() {
+						observedAt = t.UTC()
+					}
+				}
+			}
+		}
+
+		// Build observation payload: decoded canonical fields merged with
+		// fragment metadata. confidence is always persisted (PO ruling, AC A2).
+		payload := buildPayload(frag, confidence)
+
+		// Branch on taxonomy AuthorityClasses (Finding 1 fix).
+		desc, ok := taxonomy.LookupEntityType(kind)
+		isHostScoped := !ok || containsString(desc.AuthorityClasses, "host")
+
+		if isHostScoped {
+			// Host-scoped: eid = host:<peerHostAuthority>/<fragment_id>.
+			//
+			// Source MUST be peerHostAuthority (not frag.GetAuthority()) for the
+			// ClaimScope retraction to fire. collectScopeSubjects matches
+			// obs.Source against ClaimScope.Source with string equality, and
+			// retractEntityProjection DELETEs rows by (subject, source). If the
+			// observation source were the module identity (e.g. "enforcing-module:file")
+			// and the claim scope source were peerHostAuthority (e.g. "steward-A"),
+			// the match would always fail and nothing would ever be retracted.
+			// Module identity is preserved in Payload["module_authority"] instead.
+			eid, err := types.NewEID("host", peerHostAuthority, fragID)
+			if err != nil {
+				return fmt.Errorf("dnasync/writer: eid for %q: %w", fragID, err)
+			}
+			hostObs = append(hostObs, types.Observation{
+				Source:     peerHostAuthority,
+				ObservedAt: observedAt,
+				RecordedAt: now,
+				Subject:    eid.String(),
+				Kind:       types.ObservationKindState,
+				Confidence: confidence,
+				Payload:    payload,
+			})
+		} else {
+			// Cluster-scoped: eid = cluster:<clusterName> (bare authority, no local_id).
+			// No ClaimScope: a single steward's view is not the complete picture for a
+			// shared multi-observer entity. Staleness is handled by clusterregistry's
+			// existing dead-owner/orphan detection (flagged open item).
+			clusterName := fragID
+			if idx := strings.Index(fragID, ":"); idx >= 0 {
+				clusterName = fragID[idx+1:]
+			}
+			eid, err := types.NewEID("cluster", clusterName, "")
+			if err != nil {
+				return fmt.Errorf("dnasync/writer: cluster eid for %q: %w", fragID, err)
+			}
+			// Observation.Source for cluster-kind MUST carry the reporting steward's
+			// identity so clusterregistry can attribute each claim after the move to
+			// entitygraph (split-brain/dead-owner detection needs per-steward attribution).
+			clusterSrc := peerHostAuthority
+			if auth := frag.GetAuthority(); auth != "" {
+				clusterSrc = peerHostAuthority + "/" + auth
+			}
+			clusterObs = append(clusterObs, types.Observation{
+				Source:     clusterSrc,
+				ObservedAt: observedAt,
+				RecordedAt: now,
+				Subject:    eid.String(),
+				Kind:       types.ObservationKindState,
+				Confidence: confidence,
+				Payload:    payload,
+			})
+		}
+	}
+
+	allObs := make([]types.Observation, 0, len(hostObs)+len(clusterObs))
+	allObs = append(allObs, hostObs...)
+	allObs = append(allObs, clusterObs...)
+
+	if len(allObs) == 0 {
+		return nil
+	}
+
+	batch := interfaces.ObservationBatch{
+		// Source is the reporting steward's own identity for the entire batch,
+		// regardless of per-fragment Observation.Source values (ADR-022 §4).
+		Source:       peerHostAuthority,
+		Observations: allObs,
+	}
+
+	// Host-scoped fragments get a ClaimScope: "peerHostAuthority has reported
+	// its complete current fragment set under host:<peerHostAuthority>". This
+	// lets #2874's retraction logic drop fragments this steward no longer reports.
+	// Cluster-scoped fragments deliberately omit a ClaimScope (see above).
+	if len(hostObs) > 0 {
+		batch.ClaimScopes = []types.ClaimScope{{
+			Source: peerHostAuthority,
+			Pattern: types.ClaimScopePattern{
+				Entity: &types.EntityScopePattern{
+					AuthorityPrefix: "host:" + peerHostAuthority,
+				},
+			},
+			AsOf: now,
+		}}
+	}
+
+	return w.provider.ReportObservations(ctx, batch)
+}
+
+// buildPayload constructs the observation payload for a fragment.
+// It includes the decoded canonical fields (best-effort), the fragment hash,
+// the fragment_id, and the confidence (persisted per PO ruling).
+func buildPayload(frag *commonpb.Fragment, confidence types.Confidence) map[string]interface{} {
+	payload := make(map[string]interface{})
+
+	// Decode canonical bytes into state fields. This is best-effort; if the
+	// bytes are malformed or use an unknown encoding the payload still carries
+	// the mandatory fragment metadata below.
+	if cb := frag.GetCanonicalBytes(); len(cb) > 0 {
+		if fields, err := decodeCanonicalFragment(cb); err == nil {
+			for k, v := range fields {
+				payload[k] = v
+			}
+		}
+		// Derive fragment hash from canonical bytes (never copy the asserted value).
+		sum := sha256.Sum256(cb)
+		payload["fragment_hash"] = hex.EncodeToString(sum[:])
+	}
+
+	// Always set these — they are the non-negotiable provenance fields.
+	payload["fragment_id"] = frag.GetFragmentId()
+	payload["confidence"] = string(confidence)
+	// Preserve module identity in the payload. This keeps module attribution
+	// visible in entity attributes without coupling Observation.Source to the
+	// module identity (which would break ClaimScope source matching — see the
+	// comment in WriteFragmentDelta above the host-scoped observation).
+	if auth := frag.GetAuthority(); auth != "" {
+		payload["module_authority"] = auth
+	}
+
+	return payload
+}
+
+// resolveConfidence converts a string from FragmentEnvelope into a typed
+// Confidence value, defaulting to high for unrecognised strings.
+func resolveConfidence(s string) types.Confidence {
+	switch types.Confidence(s) {
+	case types.ConfidenceHigh, types.ConfidenceMedium, types.ConfidenceLow:
+		return types.Confidence(s)
+	default:
+		return types.ConfidenceHigh
+	}
+}
+
+// containsString reports whether ss contains s.
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/entitygraph/writers/dnasync/writer_test.go
+++ b/pkg/entitygraph/writers/dnasync/writer_test.go
@@ -1,0 +1,590 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package dnasync_test
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/entitygraph/interfaces"
+	sqliteprovider "github.com/cfgis/cfgms/pkg/entitygraph/providers/sqlite"
+	"github.com/cfgis/cfgms/pkg/entitygraph/types"
+	"github.com/cfgis/cfgms/pkg/entitygraph/writers/dnasync"
+)
+
+// --- test helpers ---
+
+func newTestProvider(t *testing.T) *sqliteprovider.SQLiteEntityGraphProvider {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "eg.db")
+	p, err := sqliteprovider.NewSQLiteEntityGraphProvider(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func newTestWriter(t *testing.T, p *sqliteprovider.SQLiteEntityGraphProvider) *dnasync.Writer {
+	t.Helper()
+	w, err := dnasync.New(p)
+	require.NoError(t, err)
+	return w
+}
+
+func mustParseEID(t *testing.T, s string) types.EID {
+	t.Helper()
+	eid, err := types.ParseEID(s)
+	require.NoError(t, err)
+	return eid
+}
+
+func wideRange() interfaces.TimeRange {
+	return interfaces.TimeRange{
+		From: time.Unix(0, 0).UTC(),
+		To:   time.Now().UTC().Add(time.Hour),
+	}
+}
+
+// makeTestCanonBytes builds a valid canonical byte encoding for a string-keyed
+// map with string values. It mirrors the format of CanonicalizeFragment without
+// importing features/ (pkg/ import direction rule). The format is:
+//
+//	[uint32 BE: count][sorted entries: [uint32 key-len][key]['S'][uint32 val-len][val]]
+func makeTestCanonBytes(fields map[string]string) []byte {
+	type kv struct{ k, v string }
+	pairs := make([]kv, 0, len(fields))
+	for k, v := range fields {
+		pairs = append(pairs, kv{k, v})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].k < pairs[j].k })
+
+	var buf []byte
+	hdr := make([]byte, 4)
+	binary.BigEndian.PutUint32(hdr, uint32(len(pairs)))
+	buf = append(buf, hdr...)
+	for _, p := range pairs {
+		klen := make([]byte, 4)
+		binary.BigEndian.PutUint32(klen, uint32(len(p.k)))
+		buf = append(buf, klen...)
+		buf = append(buf, p.k...)
+		vlen := make([]byte, 4)
+		binary.BigEndian.PutUint32(vlen, uint32(len(p.v)))
+		buf = append(buf, 'S')
+		buf = append(buf, vlen...)
+		buf = append(buf, p.v...)
+	}
+	return buf
+}
+
+// makeHostFrag creates a Fragment with a host-scoped fragment_id, an authority,
+// and valid canonical bytes encoding one string field.
+func makeHostFrag(fragID, authority string) *commonpb.Fragment {
+	return &commonpb.Fragment{
+		FragmentId:     fragID,
+		Authority:      authority,
+		CanonicalBytes: makeTestCanonBytes(map[string]string{"path": fragID}),
+	}
+}
+
+// stateHistory returns the state-kind observation records for eid.
+func stateHistory(t *testing.T, p *sqliteprovider.SQLiteEntityGraphProvider, eid types.EID) []*interfaces.ObservationRecord {
+	t.Helper()
+	records, err := p.GetHistory(context.Background(), eid, wideRange())
+	require.NoError(t, err)
+	var out []*interfaces.ObservationRecord
+	for _, r := range records {
+		if r.Observation.Kind == types.ObservationKindState {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// --- constructor tests ---
+
+// TestNewWriterNilProvider verifies that New rejects a nil provider.
+func TestNewWriterNilProvider(t *testing.T) {
+	_, err := dnasync.New(nil)
+	require.Error(t, err)
+}
+
+// TestWriteEmptyFragmentsIsNoop verifies that an empty fragment list returns nil
+// and produces no observations.
+func TestWriteEmptyFragmentsIsNoop(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	err := w.WriteFragmentDelta(context.Background(), "steward-A", nil, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	err = w.WriteFragmentDelta(context.Background(), "steward-A", []*commonpb.Fragment{}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+}
+
+// --- AC Group A: observation construction ---
+
+// TestA1_HostScopedSubjectEID verifies that host-scoped fragments produce
+// Subject = "host:<peerHostAuthority>/<fragment_id>", Source = peerHostAuthority
+// (not the module authority), and preserve module identity in Payload["module_authority"].
+//
+// Using peerHostAuthority as Source keeps ClaimScope.Source and Observation.Source
+// equal, which is required for the retraction machinery to fire (see the
+// claimscope.go collectScopeSubjects / retractEntityProjection source-equality check).
+func TestA1_HostScopedSubjectEID(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	frag := makeHostFrag("file:/etc/hosts", "enforcing-module:file")
+	err := w.WriteFragmentDelta(ctx, "steward-A", []*commonpb.Fragment{frag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	eid := mustParseEID(t, "host:steward-A/file:/etc/hosts")
+	records := stateHistory(t, p, eid)
+	require.Len(t, records, 1, "exactly one state observation expected")
+
+	obs := records[0].Observation
+	require.Equal(t, "host:steward-A/file:/etc/hosts", obs.Subject)
+	require.Equal(t, types.ObservationKindState, obs.Kind)
+	// Source MUST be peerHostAuthority for ClaimScope retraction to work.
+	require.Equal(t, "steward-A", obs.Source,
+		"host-scoped Observation.Source must be peerHostAuthority, not module identity")
+	// Module identity is preserved in the payload instead.
+	require.Equal(t, "enforcing-module:file", obs.Payload["module_authority"],
+		"module identity must be preserved in Payload[module_authority]")
+}
+
+// TestA1_EmptyFragmentAuthorityPreservesModuleAttributionInPayload verifies that
+// when a fragment carries no authority, Payload["module_authority"] is absent (not
+// set to an empty string), and Source is still peerHostAuthority.
+func TestA1_EmptyFragmentAuthorityPreservesModuleAttributionInPayload(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	frag := &commonpb.Fragment{
+		FragmentId:     "service:sshd",
+		Authority:      "", // no module identity
+		CanonicalBytes: makeTestCanonBytes(map[string]string{"state": "active"}),
+	}
+	err := w.WriteFragmentDelta(ctx, "steward-B", []*commonpb.Fragment{frag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	eid := mustParseEID(t, "host:steward-B/service:sshd")
+	records := stateHistory(t, p, eid)
+	require.Len(t, records, 1)
+	// Source is always peerHostAuthority for host-scoped fragments.
+	require.Equal(t, "steward-B", records[0].Observation.Source)
+	// No module_authority in payload when fragment has no authority.
+	_, hasModAuth := records[0].Observation.Payload["module_authority"]
+	require.False(t, hasModAuth, "module_authority must not be set in payload when fragment authority is empty")
+}
+
+// TestA2_ConfidencePersistedInPayload verifies that confidence from the envelope
+// (or the default when no envelope is present) is stored in Payload["confidence"].
+func TestA2_ConfidencePersistedInPayload(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	frag := makeHostFrag("patch:kb5042099", "enforcing-module:patch")
+	envelopes := map[string]*commonpb.FragmentEnvelope{
+		"patch:kb5042099": {Confidence: "medium"},
+	}
+	err := w.WriteFragmentDelta(ctx, "steward-C", []*commonpb.Fragment{frag}, envelopes, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	eid := mustParseEID(t, "host:steward-C/patch:kb5042099")
+	records := stateHistory(t, p, eid)
+	require.Len(t, records, 1)
+
+	got, ok := records[0].Observation.Payload["confidence"]
+	require.True(t, ok, "confidence must be present in observation payload")
+	require.Equal(t, "medium", got)
+}
+
+// TestA2_DefaultConfidenceIsHigh verifies that the confidence defaults to "high"
+// when no envelope is provided (PO ruling: all fragments are high confidence
+// unless the producer declares otherwise).
+func TestA2_DefaultConfidenceIsHigh(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	frag := makeHostFrag("hostname:thehost", "enforcing-module:hostname")
+	err := w.WriteFragmentDelta(ctx, "steward-D", []*commonpb.Fragment{frag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	eid := mustParseEID(t, "host:steward-D/hostname:thehost")
+	records := stateHistory(t, p, eid)
+	require.Len(t, records, 1)
+
+	got := records[0].Observation.Payload["confidence"]
+	require.Equal(t, "high", got)
+}
+
+// TestA3_ClusterKindEID verifies that cluster-kind fragments produce a bare
+// cluster EID ("cluster:<clusterName>") rather than a host-scoped one (Finding 1 fix).
+func TestA3_ClusterKindEID(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	clusterFrag := &commonpb.Fragment{
+		FragmentId:     "cluster:prod-cluster",
+		Authority:      "observer:hyperv",
+		CanonicalBytes: makeTestCanonBytes(map[string]string{"resource_owner": "tenant-x"}),
+	}
+	err := w.WriteFragmentDelta(ctx, "steward-E", []*commonpb.Fragment{clusterFrag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	clusterEID := mustParseEID(t, "cluster:prod-cluster")
+	records := stateHistory(t, p, clusterEID)
+	require.Len(t, records, 1, "one state observation expected on the cluster EID")
+
+	obs := records[0].Observation
+	require.Equal(t, "cluster:prod-cluster", obs.Subject)
+	require.Equal(t, types.ObservationKindState, obs.Kind)
+
+	// Source must carry peerHostAuthority attribution (split-brain detection).
+	require.Contains(t, obs.Source, "steward-E")
+}
+
+// TestA3_ClusterNotWrittenUnderHostAuthority verifies that after a cluster-kind
+// delta, no observation lands under host:<peerHostAuthority>/cluster:* — cluster
+// entities are never wrapped in the host namespace (Finding 1 fix).
+func TestA3_ClusterNotWrittenUnderHostAuthority(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	clusterFrag := &commonpb.Fragment{
+		FragmentId:     "cluster:mycluster",
+		Authority:      "observer:hyperv",
+		CanonicalBytes: makeTestCanonBytes(map[string]string{"node_count": "3"}),
+	}
+	err := w.WriteFragmentDelta(ctx, "steward-F", []*commonpb.Fragment{clusterFrag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	// There must be NO observation under the host-namespaced EID.
+	hostWrappedEID := mustParseEID(t, "host:steward-F/cluster:mycluster")
+	hostRecords := stateHistory(t, p, hostWrappedEID)
+	require.Empty(t, hostRecords, "cluster fragment must never land under host:<peerHostAuthority>")
+
+	// Confirm it IS under the bare cluster EID.
+	clusterEID := mustParseEID(t, "cluster:mycluster")
+	clusterRecords := stateHistory(t, p, clusterEID)
+	require.Len(t, clusterRecords, 1)
+}
+
+// TestA4_SameClusterEIDFromTwoStewards verifies that two stewards reporting the
+// same cluster fragment_id converge on the same cluster EID. Each contributes one
+// state observation attributing the reporting steward in Source.
+func TestA4_SameClusterEIDFromTwoStewards(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	makeClusterFrag := func(authority string) *commonpb.Fragment {
+		return &commonpb.Fragment{
+			FragmentId:     "cluster:shared",
+			Authority:      authority,
+			CanonicalBytes: makeTestCanonBytes(map[string]string{"resource_owner": "tenant-a"}),
+		}
+	}
+
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-G1",
+		[]*commonpb.Fragment{makeClusterFrag("observer:hyperv")}, nil, types.DefaultTaxonomy()))
+
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-G2",
+		[]*commonpb.Fragment{makeClusterFrag("observer:hyperv")}, nil, types.DefaultTaxonomy()))
+
+	clusterEID := mustParseEID(t, "cluster:shared")
+	records := stateHistory(t, p, clusterEID)
+
+	// Two distinct source observations must exist on the single cluster EID.
+	require.Len(t, records, 2, "one observation per reporting steward on the shared cluster EID")
+
+	sources := map[string]struct{}{}
+	for _, r := range records {
+		sources[r.Observation.Source] = struct{}{}
+	}
+	_, hasG1 := sources["steward-G1/observer:hyperv"]
+	_, hasG2 := sources["steward-G2/observer:hyperv"]
+	require.True(t, hasG1, "steward-G1 attribution must appear in source")
+	require.True(t, hasG2, "steward-G2 attribution must appear in source")
+}
+
+// TestA5_BitIdenticalFragmentDedup verifies that two calls with bit-identical
+// fragments produce exactly one observation in GetHistory (content-hash dedup,
+// ADR-022 §4).
+func TestA5_BitIdenticalFragmentDedup(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	canon := makeTestCanonBytes(map[string]string{"state": "active"})
+	frag := &commonpb.Fragment{
+		FragmentId:     "service:sshd",
+		Authority:      "enforcing-module:service",
+		CanonicalBytes: canon,
+	}
+
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-H", []*commonpb.Fragment{frag}, nil, types.DefaultTaxonomy()))
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-H", []*commonpb.Fragment{frag}, nil, types.DefaultTaxonomy()))
+
+	eid := mustParseEID(t, "host:steward-H/service:sshd")
+	records := stateHistory(t, p, eid)
+	require.Len(t, records, 1, "bit-identical observations must be deduped by the entity graph provider")
+}
+
+// TestA5_DifferentCanonBytesProducesNewObservation verifies that a second call
+// with changed canonical bytes produces a second observation (state change landed).
+func TestA5_DifferentCanonBytesProducesNewObservation(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	frag1 := &commonpb.Fragment{
+		FragmentId:     "service:sshd",
+		Authority:      "enforcing-module:service",
+		CanonicalBytes: makeTestCanonBytes(map[string]string{"state": "active"}),
+	}
+	frag2 := &commonpb.Fragment{
+		FragmentId:     "service:sshd",
+		Authority:      "enforcing-module:service",
+		CanonicalBytes: makeTestCanonBytes(map[string]string{"state": "inactive"}),
+	}
+
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-I", []*commonpb.Fragment{frag1}, nil, types.DefaultTaxonomy()))
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-I", []*commonpb.Fragment{frag2}, nil, types.DefaultTaxonomy()))
+
+	eid := mustParseEID(t, "host:steward-I/service:sshd")
+	records := stateHistory(t, p, eid)
+	require.Len(t, records, 2, "changed canonical bytes must produce a second observation")
+}
+
+// --- AC Group B: authority-boundary enforcement ---
+
+// TestB1_AdversarialFragmentID_NoAuthoritySegmentInfluence is the key
+// SE-threat-#1 regression test. A fragment whose fragment_id contains a
+// steward identity ("host:steward-B/evil:path") must NEVER produce an
+// observation under host:steward-B when the mTLS-verified peerHostAuthority
+// is steward-A. The authority segment is built entirely from peerHostAuthority
+// — authority confusion is structurally unrepresentable, not detected-and-rejected.
+func TestB1_AdversarialFragmentID_NoAuthoritySegmentInfluence(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	// A fragment_id shaped to look like a different steward's EID.
+	adversarialFrag := &commonpb.Fragment{
+		FragmentId:     "host:steward-B/evil:path",
+		Authority:      "enforcing-module:file",
+		CanonicalBytes: makeTestCanonBytes(map[string]string{"x": "y"}),
+	}
+
+	err := w.WriteFragmentDelta(ctx, "steward-A",
+		[]*commonpb.Fragment{adversarialFrag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	// The observation MUST land under steward-A's authority, not steward-B's.
+	// EID = "host:steward-A/host:steward-B/evil:path"
+	expectedEID := mustParseEID(t, "host:steward-A/host:steward-B/evil:path")
+	records := stateHistory(t, p, expectedEID)
+	require.Len(t, records, 1, "observation must land under host:steward-A authority")
+	require.Equal(t, "host:steward-A/host:steward-B/evil:path", records[0].Observation.Subject)
+
+	// Crucially, NOTHING must land under steward-B's EID.
+	// Construct any EID that would be in steward-B's authority segment.
+	// GetHistory with an EID not in the graph must return empty, not an error.
+	stewardBEID, parseErr := types.ParseEID("host:steward-B/evil:path")
+	require.NoError(t, parseErr)
+	stealthRecords := stateHistory(t, p, stewardBEID)
+	require.Empty(t, stealthRecords, "no observation must ever land under host:steward-B authority")
+}
+
+// TestB2_AdversarialPayload_EIDUnaffected verifies that adversarial canonical
+// bytes whose decoded fields include a "fragment_id" key pointing to a different
+// steward's namespace cannot influence the observation's Subject or the entity
+// attribute values: the writer always overwrites fragment_id in the payload from
+// the verified frag.GetFragmentId() field, and the EID is built before the payload.
+func TestB2_AdversarialPayload_EIDUnaffected(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	// Canonical bytes that encode {"fragment_id": "host:steward-B/evil"} — an attempt
+	// to poison the fragment_id attribute stored in the entity graph.
+	poisonedCanon := makeTestCanonBytes(map[string]string{
+		"fragment_id": "host:steward-B/evil",
+		"state":       "active",
+	})
+
+	frag := &commonpb.Fragment{
+		FragmentId:     "file:/etc/hosts",
+		Authority:      "enforcing-module:file",
+		CanonicalBytes: poisonedCanon,
+	}
+
+	err := w.WriteFragmentDelta(ctx, "steward-A",
+		[]*commonpb.Fragment{frag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	// The observation must land on the correct EID.
+	eid := mustParseEID(t, "host:steward-A/file:/etc/hosts")
+	records := stateHistory(t, p, eid)
+	require.Len(t, records, 1)
+
+	obs := records[0].Observation
+	require.Equal(t, "host:steward-A/file:/etc/hosts", obs.Subject,
+		"Subject must reflect the verified fragment_id, not the adversarial payload value")
+
+	// The fragment_id in the payload must be the real value, not the adversarial one.
+	gotFragID, ok := obs.Payload["fragment_id"]
+	require.True(t, ok, "fragment_id must be present in the observation payload")
+	require.Equal(t, "file:/etc/hosts", gotFragID,
+		"payload fragment_id must be the verified value, never the adversarial canonical-bytes value")
+
+	// No observation may exist under steward-B.
+	stewardBEID, parseErr := types.ParseEID("host:steward-B/evil")
+	require.NoError(t, parseErr)
+	require.Empty(t, stateHistory(t, p, stewardBEID),
+		"adversarial payload fragment_id must not create an entity under host:steward-B")
+}
+
+// TestGetEntityAfterWrite verifies the E2E path: WriteFragmentDelta followed by
+// GetEntity returns a non-nil view with the expected entity attributes.
+func TestGetEntityAfterWrite(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	frag := makeHostFrag("firewall:default", "enforcing-module:firewall")
+	err := w.WriteFragmentDelta(ctx, "steward-J",
+		[]*commonpb.Fragment{frag}, nil, types.DefaultTaxonomy())
+	require.NoError(t, err)
+
+	eid := mustParseEID(t, "host:steward-J/firewall:default")
+	view, err := p.GetEntity(ctx, eid, interfaces.GetEntityOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, view, "GetEntity must return a non-nil view after WriteFragmentDelta")
+	require.NotNil(t, view.Entity)
+
+	// The fragment_id attribute must be present in the merged entity state.
+	fragIDAttr, ok := view.Entity.Attributes["fragment_id"]
+	require.True(t, ok, "fragment_id attribute must be present in entity view")
+	require.Equal(t, "firewall:default", fragIDAttr)
+}
+
+// TestClaimScopeOnHostFragments verifies that the batch carries a ClaimScope
+// covering the host authority, enabling retraction semantics (#2874).
+// We exercise this indirectly: two calls with DIFFERENT host-scoped fragment sets
+// from the same steward. The second call's ClaimScope should cause the entity
+// graph to retract the observation from the first set. This test only verifies
+// the positive case (new fragments appear) since retraction rollout depends on
+// the provider's implementation of ClaimScope semantics.
+func TestClaimScopeOnHostFragments(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	// First delta: one host-scoped fragment.
+	frag1 := makeHostFrag("service:sshd", "enforcing-module:service")
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-K",
+		[]*commonpb.Fragment{frag1}, nil, types.DefaultTaxonomy()))
+
+	eid1 := mustParseEID(t, "host:steward-K/service:sshd")
+	records1 := stateHistory(t, p, eid1)
+	require.Len(t, records1, 1, "first fragment must have one state observation")
+
+	// Second delta: different host-scoped fragment.
+	frag2 := makeHostFrag("service:httpd", "enforcing-module:service")
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-K",
+		[]*commonpb.Fragment{frag2}, nil, types.DefaultTaxonomy()))
+
+	eid2 := mustParseEID(t, "host:steward-K/service:httpd")
+	records2 := stateHistory(t, p, eid2)
+	require.Len(t, records2, 1, "second fragment must have one state observation")
+}
+
+// TestRetraction_HostScopedFragmentDropped is the key retraction correctness test.
+// It verifies that when a steward stops reporting a fragment, the entity graph
+// retracts the prior observation so stale state does not persist indefinitely.
+//
+// This test would FAIL with Observation.Source = frag.GetAuthority() because
+// collectScopeSubjects requires obs.Source == ClaimScope.Source (string equality),
+// and retractEntityProjection deletes rows by (subject, source). If Source were
+// the module identity, neither step would match the claim scope source.
+func TestRetraction_HostScopedFragmentDropped(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	// Delta 1: steward reports both file:/etc/hosts AND service:sshd.
+	fragFile := makeHostFrag("file:/etc/hosts", "enforcing-module:file")
+	fragSSHD := makeHostFrag("service:sshd", "enforcing-module:service")
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-ret",
+		[]*commonpb.Fragment{fragFile, fragSSHD}, nil, types.DefaultTaxonomy()))
+
+	eidFile := mustParseEID(t, "host:steward-ret/file:/etc/hosts")
+	eidSSHD := mustParseEID(t, "host:steward-ret/service:sshd")
+
+	require.Len(t, stateHistory(t, p, eidFile), 1, "file fragment must have one state observation after delta 1")
+	require.Len(t, stateHistory(t, p, eidSSHD), 1, "sshd fragment must have one state observation after delta 1")
+
+	// Delta 2: steward reports ONLY service:sshd — file:/etc/hosts is dropped.
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-ret",
+		[]*commonpb.Fragment{fragSSHD}, nil, types.DefaultTaxonomy()))
+
+	// service:sshd must still be active.
+	require.Len(t, stateHistory(t, p, eidSSHD), 1, "sshd observation must survive delta 2")
+
+	// file:/etc/hosts must have been retracted: the provider writes an absence
+	// observation and removes the entity projection. GetEntity must return nil or
+	// ErrNotFound (both signal retraction; the provider returns ErrNotFound when
+	// the entity projection row is gone).
+	fileView, fileErr := p.GetEntity(ctx, eidFile, interfaces.GetEntityOpts{})
+	retracted := fileView == nil || errors.Is(fileErr, sqliteprovider.ErrNotFound)
+	require.True(t, retracted,
+		"file:/etc/hosts entity must be retracted (nil view or ErrNotFound) after it is dropped from the delta set; got view=%v err=%v",
+		fileView, fileErr)
+}
+
+// TestClusterFragmentHasNoClaimScope verifies that cluster-kind fragments do NOT
+// produce a host-authority ClaimScope. The batch for a cluster-only delta should
+// report zero ClaimScopes so that concurrent stewards' observations are preserved.
+// We verify this indirectly: two stewards report the same cluster, then we
+// confirm both observations survive after the second write (no implicit retraction).
+func TestClusterFragmentHasNoClaimScope(t *testing.T) {
+	p := newTestProvider(t)
+	w := newTestWriter(t, p)
+	ctx := context.Background()
+
+	clusterFrag := func(authority string) *commonpb.Fragment {
+		return &commonpb.Fragment{
+			FragmentId:     "cluster:shared-cluster",
+			Authority:      authority,
+			CanonicalBytes: makeTestCanonBytes(map[string]string{"state": "healthy"}),
+		}
+	}
+
+	// Steward-L1 writes first.
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-L1",
+		[]*commonpb.Fragment{clusterFrag("observer:hyperv")}, nil, types.DefaultTaxonomy()))
+
+	// Steward-L2 writes second — must NOT retract steward-L1's observation.
+	require.NoError(t, w.WriteFragmentDelta(ctx, "steward-L2",
+		[]*commonpb.Fragment{clusterFrag("observer:hyperv")}, nil, types.DefaultTaxonomy()))
+
+	clusterEID := mustParseEID(t, "cluster:shared-cluster")
+	records := stateHistory(t, p, clusterEID)
+	require.Len(t, records, 2,
+		"both stewards' cluster observations must survive — no implicit retraction on cluster-kind")
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/entitygraph/writers/dnasync` with `Writer.WriteFragmentDelta()` that translates fragment deltas from stewards into entity-graph observations (ADR-022 §9, ADR-017)
- Host-scoped fragments get `eid = host:<peerHostAuthority>/<fragment_id>`; cluster-kind fragments get bare `cluster:<name>` EIDs (Finding 1 fix)
- `Observation.Source = peerHostAuthority` for all host-scoped observations so `ClaimScope` source matching works correctly — prior approach using `frag.GetAuthority()` made retraction permanently inert (security finding from story-review fixed before commit)
- Wires `WithEntityGraph()` onto `DNAHandler` additively alongside `ApplyDelta`; failure is non-fatal and does not fail the steward's stream
- Self-contained canonical binary decoder (`decode.go`) avoids importing `features/` from `pkg/`

## Test plan

- [x] 17 unit tests in `pkg/entitygraph/writers/dnasync/writer_test.go` covering host/cluster EID construction, confidence persistence, bit-identical dedup, authority-boundary enforcement (B1 adversarial fragment_id, B2 adversarial payload), and `TestRetraction_HostScopedFragmentDropped` verifying claim scope fires
- [x] 4 E2E handler tests in `features/controller/transport/dna_handler_entitygraph_test.go` including the SE threat #1 B1 regression test through full delta transport path with mTLS peer context
- [x] All existing transport tests pass (no regressions)
- [x] `make test-agent-complete` passes (all platforms compile, all tests pass, lint clean)

Fixes #2907

🤖 Generated with [Claude Code](https://claude.com/claude-code)