### PR TITLE
storage: thread Hidden field through StewardRecord, all providers, and in-memory registry (Issue #2944)

### DIFF
--- a/features/controller/api/handlers_registration_refresh_test.go
+++ b/features/controller/api/handlers_registration_refresh_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,230 +25,30 @@ import (
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
-// ---- Test-only in-memory stores ---------------------------------------------
+// ---- Fixture ----------------------------------------------------------------
 
-// testStewardStore is a thread-safe in-memory StewardStore for handler tests.
-type testStewardStore struct {
-	mu       sync.RWMutex
-	records  map[string]*business.StewardRecord // keyed by steward ID
-	byDevice map[string]*business.StewardRecord // keyed by device ID
-}
-
-func newTestStewardStore() *testStewardStore {
-	return &testStewardStore{
-		records:  make(map[string]*business.StewardRecord),
-		byDevice: make(map[string]*business.StewardRecord),
-	}
+// refreshFixture wires a Server to the real OSS storage stack used in production:
+// the flat-file StewardStore and the SQLite PendingRefreshStore / RefreshPolicyStore
+// created by pkgtesting.SetupTestStorage. No store is substituted — every read and
+// write in these tests goes through a real storage provider.
+type refreshFixture struct {
+	server   *Server
+	audit    *audit.Manager
+	stewards business.StewardStore
+	pending  business.PendingRefreshStore
+	policies business.RefreshPolicyStore
 }
 
-func (s *testStewardStore) add(rec *business.StewardRecord) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	cp := *rec
-	s.records[rec.ID] = &cp
-	if rec.DeviceID != "" {
-		s.byDevice[rec.DeviceID] = &cp
-	}
-}
-
-func (s *testStewardStore) RegisterSteward(_ context.Context, r *business.StewardRecord) error {
-	s.add(r)
-	return nil
-}
-func (s *testStewardStore) UpdateHeartbeat(_ context.Context, _ string) error { return nil }
-func (s *testStewardStore) GetSteward(_ context.Context, id string) (*business.StewardRecord, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	r, ok := s.records[id]
-	if !ok {
-		return nil, business.ErrStewardNotFound
-	}
-	cp := *r
-	return &cp, nil
-}
-func (s *testStewardStore) GetStewardByDeviceID(_ context.Context, deviceID string) (*business.StewardRecord, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	r, ok := s.byDevice[deviceID]
-	if !ok {
-		return nil, business.ErrStewardNotFound
-	}
-	cp := *r
-	return &cp, nil
-}
-func (s *testStewardStore) ListStewards(_ context.Context) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (s *testStewardStore) ListStewardsByStatus(_ context.Context, _ business.StewardStatus) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (s *testStewardStore) UpdateStewardStatus(_ context.Context, id string, status business.StewardStatus) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if r, ok := s.records[id]; ok {
-		r.Status = status
-	}
-	return nil
-}
-func (s *testStewardStore) UpdateStewardTenant(_ context.Context, id, newTenantID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	r, ok := s.records[id]
-	if !ok {
-		return business.ErrStewardNotFound
-	}
-	r.TenantID = newTenantID
-	return nil
-}
-func (s *testStewardStore) DeregisterSteward(_ context.Context, _ string) error { return nil }
-func (s *testStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (s *testStewardStore) HealthCheck(_ context.Context) error { return nil }
-func (s *testStewardStore) Initialize(_ context.Context) error  { return nil }
-func (s *testStewardStore) Close() error                        { return nil }
-
-// testPendingRefreshStore is a thread-safe in-memory PendingRefreshStore.
-type testPendingRefreshStore struct {
-	mu      sync.RWMutex
-	entries map[string]*business.PendingRefreshEntry
-}
-
-func newTestPendingRefreshStore() *testPendingRefreshStore {
-	return &testPendingRefreshStore{entries: make(map[string]*business.PendingRefreshEntry)}
-}
-
-func (s *testPendingRefreshStore) AddPendingRefresh(_ context.Context, e *business.PendingRefreshEntry) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	cp := *e
-	s.entries[e.PendingID] = &cp
-	return nil
-}
-func (s *testPendingRefreshStore) GetPendingRefreshByID(_ context.Context, id string) (*business.PendingRefreshEntry, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	e, ok := s.entries[id]
-	if !ok {
-		return nil, business.ErrPendingRefreshNotFound
-	}
-	cp := *e
-	return &cp, nil
-}
-func (s *testPendingRefreshStore) UpdateRefreshStatus(_ context.Context, id, status string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if e, ok := s.entries[id]; ok {
-		e.Status = status
-	}
-	return nil
-}
-func (s *testPendingRefreshStore) ListPendingRefresh(_ context.Context, tenantID string) ([]*business.PendingRefreshEntry, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	out := make([]*business.PendingRefreshEntry, 0, len(s.entries))
-	for _, e := range s.entries {
-		if tenantID == "" || e.TenantID == tenantID {
-			cp := *e
-			out = append(out, &cp)
-		}
-	}
-	return out, nil
-}
-func (s *testPendingRefreshStore) ExpireStaleRefresh(_ context.Context, _ time.Time) (int, error) {
-	return 0, nil
-}
-func (s *testPendingRefreshStore) StoreClaimBundle(_ context.Context, id string, bundle []byte) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if e, ok := s.entries[id]; ok {
-		e.ClaimBundle = bundle
-	}
-	return nil
-}
-func (s *testPendingRefreshStore) count() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.entries)
-}
-
-// testRefreshPolicyStore is a thread-safe in-memory RefreshPolicyStore.
-type testRefreshPolicyStore struct {
-	mu       sync.RWMutex
-	policies map[string]*business.RefreshPolicy
-}
-
-func newTestRefreshPolicyStore() *testRefreshPolicyStore {
-	return &testRefreshPolicyStore{policies: make(map[string]*business.RefreshPolicy)}
-}
-
-func (s *testRefreshPolicyStore) GetPolicy(_ context.Context, tenantID string) (*business.RefreshPolicy, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if p, ok := s.policies[tenantID]; ok {
-		cp := *p
-		return &cp, nil
-	}
-	// Default per ADR-010 §4.
-	return &business.RefreshPolicy{TenantID: tenantID, Mode: "require_approval"}, nil
-}
-
-func (s *testRefreshPolicyStore) SetPolicy(_ context.Context, p *business.RefreshPolicy) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	cp := *p
-	s.policies[p.TenantID] = &cp
-	return nil
-}
-
-// neverCallPolicyStore panics if GetPolicy is called — used to assert policy is not consulted.
-type neverCallPolicyStore struct{}
-
-func (neverCallPolicyStore) GetPolicy(_ context.Context, _ string) (*business.RefreshPolicy, error) {
-	panic("GetPolicy must not be called for archived stewards")
-}
-func (neverCallPolicyStore) SetPolicy(_ context.Context, _ *business.RefreshPolicy) error {
-	panic("SetPolicy must not be called")
-}
-
-// recordingPoPVerifier counts Verify calls and delegates to an optional func.
-type recordingPoPVerifier struct {
-	mu    sync.Mutex
-	calls int
-	fn    func(pub ed25519.PublicKey, msg, sig []byte) bool
-}
-
-func (v *recordingPoPVerifier) Verify(pub ed25519.PublicKey, msg, sig []byte) bool {
-	v.mu.Lock()
-	v.calls++
-	v.mu.Unlock()
-	if v.fn != nil {
-		return v.fn(pub, msg, sig)
-	}
-	return false
-}
-
-func (v *recordingPoPVerifier) callCount() int {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	return v.calls
-}
-
-// ---- Server factory for refresh handler tests --------------------------------
-
-// newRefreshTestServer builds a minimal Server with real audit + steward infrastructure
-// wired for the registration-refresh handler tests.
-func newRefreshTestServer(
-	t *testing.T,
-	stewardSt *testStewardStore,
-	pendingRefreshSt *testPendingRefreshStore,
-	policyStore business.RefreshPolicyStore,
-) (*Server, *audit.Manager) {
+// newRefreshFixture builds a Server for the registration-refresh handler tests.
+// Pass a non-nil certMgr for tests that reach certificate issuance (the auto-accept
+// and admin-approve paths); pass nil when the test never gets that far.
+func newRefreshFixture(t *testing.T, certMgr *cert.Manager) *refreshFixture {
 	t.Helper()
 	setTestSecretsEnv(t)
 
@@ -284,7 +83,7 @@ func newRefreshTestServer(
 	server, err := New(
 		cfg, logger,
 		controllerService, configService, nil, rbacService,
-		nil, tenantManager, rbacManager,
+		certMgr, tenantManager, rbacManager,
 		nil, nil,
 		newTestRegistrationStore(t),
 		"", nil,
@@ -298,15 +97,65 @@ func newRefreshTestServer(
 		_ = server.Close(ctx)
 	})
 
-	server.SetStewardStore(stewardSt)
-	if pendingRefreshSt != nil {
-		server.SetPendingRefreshStore(pendingRefreshSt)
-	}
-	if policyStore != nil {
-		server.SetRefreshPolicyStore(policyStore)
-	}
+	stewards := storageManager.GetStewardStore()
+	pending := storageManager.GetPendingRefreshStore()
+	policies := storageManager.GetRefreshPolicyStore()
+	require.NotNil(t, stewards, "test storage must provide a real StewardStore")
+	require.NotNil(t, pending, "test storage must provide a real PendingRefreshStore")
+	require.NotNil(t, policies, "test storage must provide a real RefreshPolicyStore")
 
-	return server, auditMgr
+	server.SetStewardStore(stewards)
+	server.SetPendingRefreshStore(pending)
+	server.SetRefreshPolicyStore(policies)
+
+	return &refreshFixture{
+		server:   server,
+		audit:    auditMgr,
+		stewards: stewards,
+		pending:  pending,
+		policies: policies,
+	}
+}
+
+// addSteward persists a steward record in the real fleet registry.
+func (f *refreshFixture) addSteward(t *testing.T, rec *business.StewardRecord) {
+	t.Helper()
+	require.NoError(t, f.stewards.RegisterSteward(context.Background(), rec))
+}
+
+// addPending persists a pending-refresh entry in the real durable queue.
+func (f *refreshFixture) addPending(t *testing.T, entry *business.PendingRefreshEntry) {
+	t.Helper()
+	require.NoError(t, f.pending.AddPendingRefresh(context.Background(), entry))
+}
+
+// setPolicy persists a per-tenant refresh policy in the real policy store.
+func (f *refreshFixture) setPolicy(t *testing.T, policy *business.RefreshPolicy) {
+	t.Helper()
+	require.NoError(t, f.policies.SetPolicy(context.Background(), policy))
+}
+
+// pendingCount returns the number of queued refresh entries across all tenants.
+func (f *refreshFixture) pendingCount(t *testing.T) int {
+	t.Helper()
+	entries, err := f.pending.ListPendingRefresh(context.Background(), "")
+	require.NoError(t, err)
+	return len(entries)
+}
+
+// findAuditAction flushes the audit manager and returns the first recorded entry
+// with the given action, or nil when no such entry exists.
+func (f *refreshFixture) findAuditAction(t *testing.T, action string) *business.AuditEntry {
+	t.Helper()
+	require.NoError(t, f.audit.Flush(context.Background()))
+	entries, err := f.audit.QueryEntries(context.Background(), &business.AuditFilter{})
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.Action == action {
+			return e
+		}
+	}
+	return nil
 }
 
 // ---- Helpers ----------------------------------------------------------------
@@ -383,31 +232,29 @@ func postComplete(server *Server, deviceID string, req RefreshCompleteRequest) *
 // ---- Challenge endpoint tests -----------------------------------------------
 
 func TestHandleRefreshChallenge_UnknownDevice(t *testing.T) {
-	ss := newTestStewardStore()
-	server, _ := newRefreshTestServer(t, ss, nil, nil)
+	f := newRefreshFixture(t, nil)
 
 	body, _ := json.Marshal(RefreshChallengeRequest{TenantID: testTenantID})
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/unknowndevice/refresh/challenge", bytes.NewReader(body))
 	r = mux.SetURLVars(r, map[string]string{"device_id": "unknowndevice"})
 	rec := httptest.NewRecorder()
-	server.handleRefreshChallenge(rec, r)
+	f.server.handleRefreshChallenge(rec, r)
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestHandleRefreshChallenge_KnownActiveDevice(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-1",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
 		Status:         business.StewardStatusActive,
 		IdentityKeyPub: []byte(pub),
 	})
-	server, _ := newRefreshTestServer(t, ss, nil, nil)
 
-	resp := issueChallenge(t, server, testDeviceID, testTenantID)
+	resp := issueChallenge(t, f.server, testDeviceID, testTenantID)
 	assert.NotEmpty(t, resp.Nonce)
 	assert.NotZero(t, resp.ServerTS)
 	// Nonce must decode to 32 bytes.
@@ -418,34 +265,39 @@ func TestHandleRefreshChallenge_KnownActiveDevice(t *testing.T) {
 
 func TestHandleRefreshChallenge_RevokedDeviceReturns403(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-rev",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
 		Status:         business.StewardStatusRevoked,
 		IdentityKeyPub: []byte(pub),
 	})
-	server, _ := newRefreshTestServer(t, ss, nil, nil)
 
 	body, _ := json.Marshal(RefreshChallengeRequest{TenantID: testTenantID})
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/"+testDeviceID+"/refresh/challenge", bytes.NewReader(body))
 	r = mux.SetURLVars(r, map[string]string{"device_id": testDeviceID})
 	rec := httptest.NewRecorder()
-	server.handleRefreshChallenge(rec, r)
+	f.server.handleRefreshChallenge(rec, r)
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	// Verify no nonce was placed in cache.
-	_, found := server.nonceCache.Get(nonceCacheKeyPrefix + testDeviceID)
+	_, found := f.server.nonceCache.Get(nonceCacheKeyPrefix + testDeviceID)
 	assert.False(t, found, "no nonce must be stored for revoked device")
 }
 
 // ---- Complete endpoint tests ------------------------------------------------
 
+// TestHandleRefreshComplete_RevokedBeforePoP asserts the ADR-010 §3
+// revocation-before-PoP invariant using only observable behaviour: the request
+// carries a signature that cannot verify against the device's identity key, so a
+// handler that ran PoP verification first would answer 401 "invalid_pop". The
+// observed 403 with audit reason "revoked" therefore proves the revocation gate
+// short-circuits before the verifier is consulted.
 func TestHandleRefreshComplete_RevokedBeforePoP(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-rev",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -453,34 +305,33 @@ func TestHandleRefreshComplete_RevokedBeforePoP(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
-	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
-
-	verifier := &recordingPoPVerifier{}
-	server.SetPoPVerifier(verifier)
-
 	// Manually plant a nonce to rule out the "no nonce" 401 path.
-	server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
+	f.server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
 		NonceBytes: make([]byte, 32),
 		ServerTS:   uint64(time.Now().UnixNano()),
 		IssuedAt:   time.Now(),
 	}, nonceTTL)
 
-	rec := postComplete(server, testDeviceID, RefreshCompleteRequest{
+	rec := postComplete(f.server, testDeviceID, RefreshCompleteRequest{
 		TenantID:  testTenantID,
 		Nonce:     base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
 		IssuedAt:  time.Now().UnixNano(),
-		Signature: base64.RawURLEncoding.EncodeToString(make([]byte, 64)),
+		Signature: base64.RawURLEncoding.EncodeToString(make([]byte, 64)), // cannot verify
 	})
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
-	assert.Equal(t, 0, verifier.callCount(), "PoPVerifier must not be called for revoked device")
+
+	entry := f.findAuditAction(t, "refresh_rejected")
+	require.NotNil(t, entry, "refresh_rejected audit event expected")
+	assert.Equal(t, "revoked", entry.Details["reason"],
+		"revocation must be the rejection reason — PoP must never be evaluated for a revoked device")
+	assert.Equal(t, "denied", entry.Details["decision"])
 }
 
 func TestHandleRefreshComplete_NonceReplay(t *testing.T) {
 	pub, priv := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-active",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -488,28 +339,22 @@ func TestHandleRefreshComplete_NonceReplay(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
-	ps := newTestRefreshPolicyStore()
-	server, _ := newRefreshTestServer(t, ss, prs, ps)
-	// Use real ed25519.Verify so the first request can succeed (queued for require_approval).
-	server.SetPoPVerifier(ed25519PoPVerifier{})
-
-	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	challenge := issueChallenge(t, f.server, testDeviceID, testTenantID)
 	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
 
 	// First attempt: nonce consumed, status 202 (require_approval default).
-	rec1 := postComplete(server, testDeviceID, req)
+	rec1 := postComplete(f.server, testDeviceID, req)
 	assert.Equal(t, http.StatusAccepted, rec1.Code, "first complete must succeed: %s", rec1.Body.String())
 
 	// Second attempt with same nonce: nonce was consumed, must get 401.
-	rec2 := postComplete(server, testDeviceID, req)
+	rec2 := postComplete(f.server, testDeviceID, req)
 	assert.Equal(t, http.StatusUnauthorized, rec2.Code, "nonce replay must be rejected")
 }
 
 func TestHandleRefreshComplete_ExpiredNonce(t *testing.T) {
 	pub, priv := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-active",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -517,16 +362,12 @@ func TestHandleRefreshComplete_ExpiredNonce(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
-	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	server.SetPoPVerifier(ed25519PoPVerifier{})
-
-	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	challenge := issueChallenge(t, f.server, testDeviceID, testTenantID)
 	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
 	// Override IssuedAt to simulate a 61-second-old nonce.
 	req.IssuedAt = time.Now().Add(-61 * time.Second).UnixNano()
 
-	rec := postComplete(server, testDeviceID, req)
+	rec := postComplete(f.server, testDeviceID, req)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Contains(t, rec.Body.String(), "expired")
 }
@@ -534,8 +375,8 @@ func TestHandleRefreshComplete_ExpiredNonce(t *testing.T) {
 func TestHandleRefreshComplete_InvalidPoP(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
 	_, wrongPriv := newTestEd25519KeyPair(t) // different key pair
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-active",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -543,53 +384,59 @@ func TestHandleRefreshComplete_InvalidPoP(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
-	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	server.SetPoPVerifier(ed25519PoPVerifier{})
-
-	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	challenge := issueChallenge(t, f.server, testDeviceID, testTenantID)
 	// Sign with a DIFFERENT private key — PoP must fail.
 	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, wrongPriv, nil)
 
-	rec := postComplete(server, testDeviceID, req)
+	rec := postComplete(f.server, testDeviceID, req)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
+// TestHandleRefreshComplete_Lifecycle_Archived asserts that an archived steward is
+// always queued for approval and that the tenant policy is not consulted for it.
+// The tenant policy is deliberately set to auto_accept and a real cert manager is
+// wired, so a handler that consulted policy for archived stewards would issue a
+// certificate and answer 200. The observed 202 proves the archived branch
+// short-circuits ahead of the policy gate.
 func TestHandleRefreshComplete_Lifecycle_Archived(t *testing.T) {
 	pub, priv := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, newTestCertManager(t))
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-archived",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
 		Status:         business.StewardStatusArchived,
 		IdentityKeyPub: []byte(pub),
 	})
+	f.setPolicy(t, &business.RefreshPolicy{TenantID: testTenantID, Mode: "auto_accept"})
 
-	prs := newTestPendingRefreshStore()
-	server, _ := newRefreshTestServer(t, ss, prs, neverCallPolicyStore{})
-	server.SetPoPVerifier(ed25519PoPVerifier{})
-
-	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	challenge := issueChallenge(t, f.server, testDeviceID, testTenantID)
 	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
 
-	rec := postComplete(server, testDeviceID, req)
+	rec := postComplete(f.server, testDeviceID, req)
 	assert.Equal(t, http.StatusAccepted, rec.Code, "archived steward must be queued: %s", rec.Body.String())
 
 	// Verify pending entry was created.
-	assert.Equal(t, 1, prs.count(), "one pending refresh entry must be created")
+	assert.Equal(t, 1, f.pendingCount(t), "one pending refresh entry must be created")
 
 	// Verify response body.
 	var resp RefreshCompleteResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "queued", resp.Status)
 	assert.NotEmpty(t, resp.PendingID)
+	assert.Empty(t, resp.ClientCert, "no certificate may be issued for an archived steward")
+
+	// The queue reason records the archived branch, not a policy outcome.
+	entry := f.findAuditAction(t, "refresh_queued")
+	require.NotNil(t, entry, "refresh_queued audit event expected")
+	assert.Equal(t, "archived", entry.Details["reason"],
+		"policy must not be consulted for archived stewards")
 }
 
 func TestHandleRefreshComplete_CrossTenantReturns403(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-a",
 		DeviceID:       testDeviceID,
 		TenantID:       "tenant-a",
@@ -597,19 +444,15 @@ func TestHandleRefreshComplete_CrossTenantReturns403(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
-	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	server.SetPoPVerifier(ed25519PoPVerifier{})
-
 	// Manually plant a nonce so we reach the cross-tenant gate.
-	server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
+	f.server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
 		NonceBytes: make([]byte, 32),
 		ServerTS:   uint64(time.Now().UnixNano()),
 		IssuedAt:   time.Now(),
 	}, nonceTTL)
 
 	// Request from "tenant-b" for a steward that belongs to "tenant-a".
-	rec := postComplete(server, testDeviceID, RefreshCompleteRequest{
+	rec := postComplete(f.server, testDeviceID, RefreshCompleteRequest{
 		TenantID:  "tenant-b",
 		Nonce:     base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
 		IssuedAt:  time.Now().UnixNano(),
@@ -624,14 +467,14 @@ func TestHandleRefreshComplete_AuditEmittedOnAllOutcomes(t *testing.T) {
 
 	outcomes := []struct {
 		name     string
-		setup    func(t *testing.T, ss *testStewardStore, server *Server) RefreshCompleteRequest
+		setup    func(t *testing.T, f *refreshFixture) RefreshCompleteRequest
 		wantCode int
 		wantAct  string
 	}{
 		{
 			name: "revoked device",
-			setup: func(t *testing.T, ss *testStewardStore, server *Server) RefreshCompleteRequest {
-				ss.add(&business.StewardRecord{
+			setup: func(t *testing.T, f *refreshFixture) RefreshCompleteRequest {
+				f.addSteward(t, &business.StewardRecord{
 					ID:             "s-rev",
 					DeviceID:       testDeviceID,
 					TenantID:       testTenantID,
@@ -650,16 +493,15 @@ func TestHandleRefreshComplete_AuditEmittedOnAllOutcomes(t *testing.T) {
 		},
 		{
 			name: "valid PoP — queued",
-			setup: func(t *testing.T, ss *testStewardStore, server *Server) RefreshCompleteRequest {
-				ss.add(&business.StewardRecord{
+			setup: func(t *testing.T, f *refreshFixture) RefreshCompleteRequest {
+				f.addSteward(t, &business.StewardRecord{
 					ID:             "s-active",
 					DeviceID:       testDeviceID,
 					TenantID:       testTenantID,
 					Status:         business.StewardStatusActive,
 					IdentityKeyPub: []byte(pub),
 				})
-				server.SetPoPVerifier(ed25519PoPVerifier{})
-				ch := issueChallenge(t, server, testDeviceID, testTenantID)
+				ch := issueChallenge(t, f.server, testDeviceID, testTenantID)
 				return buildValidCompleteRequest(t, testDeviceID, testTenantID, ch, priv, nil)
 			},
 			wantCode: http.StatusAccepted,
@@ -669,37 +511,28 @@ func TestHandleRefreshComplete_AuditEmittedOnAllOutcomes(t *testing.T) {
 
 	for _, tc := range outcomes {
 		t.Run(tc.name, func(t *testing.T) {
-			ss := newTestStewardStore()
-			prs := newTestPendingRefreshStore()
-			server, auditMgr := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+			f := newRefreshFixture(t, nil)
 
-			req := tc.setup(t, ss, server)
-			rec := postComplete(server, testDeviceID, req)
+			req := tc.setup(t, f)
+			rec := postComplete(f.server, testDeviceID, req)
 			assert.Equal(t, tc.wantCode, rec.Code)
 
-			require.NoError(t, auditMgr.Flush(context.Background()))
-			entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
-			require.NoError(t, err)
-			require.GreaterOrEqual(t, len(entries), 1, "at least one audit event expected")
-
-			found := false
-			for _, e := range entries {
-				if e.Action == tc.wantAct {
-					assert.NotEmpty(t, e.Details["device_id"], "device_id in audit")
-					assert.NotEmpty(t, e.Details["tenant_id"], "tenant_id in audit")
-					found = true
-					break
-				}
-			}
-			assert.True(t, found, "expected audit action %q not found in %v", tc.wantAct, entries)
+			entry := f.findAuditAction(t, tc.wantAct)
+			require.NotNil(t, entry, "expected audit action %q", tc.wantAct)
+			assert.NotEmpty(t, entry.Details["device_id"], "device_id in audit")
+			assert.NotEmpty(t, entry.Details["tenant_id"], "tenant_id in audit")
 		})
 	}
 }
 
+// TestProvenance_CannotUngateRevoked asserts that perfect provenance cannot
+// override revocation. The signature supplied cannot verify, so a handler that
+// evaluated provenance or PoP before revocation would answer 401; the observed
+// 403 with audit reason "revoked" proves revocation wins outright.
 func TestProvenance_CannotUngateRevoked(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "s-rev",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -709,19 +542,14 @@ func TestProvenance_CannotUngateRevoked(t *testing.T) {
 		LastProvenanceJSON: `{"hostname":"host1","mac_address":"aa:bb"}`,
 	})
 
-	prs := newTestPendingRefreshStore()
-	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	verifier := &recordingPoPVerifier{}
-	server.SetPoPVerifier(verifier)
-
 	// Plant a nonce so we reach the revocation gate.
-	server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
+	f.server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
 		NonceBytes: make([]byte, 32),
 		ServerTS:   uint64(time.Now().UnixNano()),
 		IssuedAt:   time.Now(),
 	}, nonceTTL)
 
-	rec := postComplete(server, testDeviceID, RefreshCompleteRequest{
+	rec := postComplete(f.server, testDeviceID, RefreshCompleteRequest{
 		TenantID:   testTenantID,
 		Nonce:      base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
 		IssuedAt:   time.Now().UnixNano(),
@@ -730,83 +558,17 @@ func TestProvenance_CannotUngateRevoked(t *testing.T) {
 	})
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
-	assert.Equal(t, 0, verifier.callCount(), "PoP must not be called for revoked device")
+
+	entry := f.findAuditAction(t, "refresh_rejected")
+	require.NotNil(t, entry, "refresh_rejected audit event expected")
+	assert.Equal(t, "revoked", entry.Details["reason"],
+		"provenance must not be able to ungate a revoked device")
 }
 
 // ---- Admin handler tests ----------------------------------------------------
 
-// newRefreshAdminTestServer builds a Server with a cert manager for admin handler tests.
-func newRefreshAdminTestServer(
-	t *testing.T,
-	stewardSt *testStewardStore,
-	pendingRefreshSt *testPendingRefreshStore,
-	policyStore business.RefreshPolicyStore,
-) (*Server, *audit.Manager) {
-	t.Helper()
-	setTestSecretsEnv(t)
-
-	cfg := config.DefaultConfig()
-	cfg.Certificate.EnableCertManagement = false
-
-	storageManager := pkgtesting.SetupTestStorage(t)
-	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "controller")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
-
-	logger := logging.NewNoopLogger()
-
-	rbacManager := rbac.NewManagerWithStorage(
-		storageManager.GetAuditStore(),
-		storageManager.GetClientTenantStore(),
-		storageManager.GetRBACStore(),
-	)
-	require.NoError(t, rbacManager.Initialize(context.Background()))
-	t.Cleanup(func() {
-		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = rbacManager.Close(closeCtx)
-	})
-
-	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
-	tenantManager := tenant.NewManager(tenantStore, rbacManager)
-	controllerService := service.NewControllerService(logger)
-	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
-	rbacService := service.NewRBACService(rbacManager)
-
-	certMgr := newTestCertManager(t)
-
-	server, err := New(
-		cfg, logger,
-		controllerService, configService, nil, rbacService,
-		certMgr, tenantManager, rbacManager,
-		nil, nil,
-		newTestRegistrationStore(t),
-		"", nil,
-		auditMgr,
-		nil, nil, nil,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = server.Close(ctx)
-	})
-
-	server.SetStewardStore(stewardSt)
-	if pendingRefreshSt != nil {
-		server.SetPendingRefreshStore(pendingRefreshSt)
-	}
-	if policyStore != nil {
-		server.SetRefreshPolicyStore(policyStore)
-	}
-
-	return server, auditMgr
-}
-
 func TestHandleRefreshApprove_Unauthenticated(t *testing.T) {
 	server := setupTestServer(t)
-	server.SetStewardStore(newTestStewardStore())
-	server.SetPendingRefreshStore(newTestPendingRefreshStore())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/some-pending-id/approve", nil)
 	rec := httptest.NewRecorder()
@@ -817,8 +579,8 @@ func TestHandleRefreshApprove_Unauthenticated(t *testing.T) {
 
 func TestHandleRefreshApprove_ApprovesEntry(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, newTestCertManager(t))
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-approve",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -826,23 +588,20 @@ func TestHandleRefreshApprove_ApprovesEntry(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
 	pendingID := "refresh-approve-test"
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: pendingID,
 		DeviceID:  testDeviceID,
 		TenantID:  testTenantID,
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
-
-	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	})
 
 	// POST /api/v1/stewards/refresh/{id}/approve is Tier-3 (mTLS-only).
 	req := makeAdminRequest(t, http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code, "approve must succeed: %s", rec.Body.String())
 
@@ -855,26 +614,17 @@ func TestHandleRefreshApprove_ApprovesEntry(t *testing.T) {
 	assert.NotEmpty(t, resp.CACert, "CA cert must be in response")
 
 	// Verify the store was updated.
-	updated, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	updated, err := f.pending.GetPendingRefreshByID(context.Background(), pendingID)
 	require.NoError(t, err)
 	assert.Equal(t, business.PendingRefreshStatusApproved, updated.Status)
-	assert.NotNil(t, updated.ClaimBundle, "claim bundle must be stored")
+	assert.NotEmpty(t, updated.ClaimBundle, "claim bundle must be stored")
 
 	// Verify audit event was emitted.
-	require.NoError(t, auditMgr.Flush(context.Background()))
-	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
-	require.NoError(t, err)
-	found := false
-	for _, e := range entries {
-		if e.Action == "refresh_admin_approved" {
-			assert.NotEmpty(t, e.Details["device_id"], "device_id in audit")
-			assert.NotEmpty(t, e.Details["tenant_id"], "tenant_id in audit")
-			assert.Equal(t, "approved", e.Details["decision"])
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "refresh_admin_approved audit event expected")
+	entry := f.findAuditAction(t, "refresh_admin_approved")
+	require.NotNil(t, entry, "refresh_admin_approved audit event expected")
+	assert.NotEmpty(t, entry.Details["device_id"], "device_id in audit")
+	assert.NotEmpty(t, entry.Details["tenant_id"], "tenant_id in audit")
+	assert.Equal(t, "approved", entry.Details["decision"])
 }
 
 // TestHandleRefreshApprove_RevokedDeviceRejected verifies the security gate added
@@ -885,8 +635,8 @@ func TestHandleRefreshApprove_ApprovesEntry(t *testing.T) {
 // persistence added in this story), and must leave the pending entry untouched.
 func TestHandleRefreshApprove_RevokedDeviceRejected(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, newTestCertManager(t))
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-revoked-pending",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -894,62 +644,50 @@ func TestHandleRefreshApprove_RevokedDeviceRejected(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
 	pendingID := "refresh-revoked-test"
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: pendingID,
 		DeviceID:  testDeviceID,
 		TenantID:  testTenantID,
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
-
-	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	})
 
 	// POST /api/v1/stewards/refresh/{id}/approve is Tier-3 (mTLS-only).
 	// Use admin cert so the handler's own revocation check is exercised.
 	req := makeAdminRequest(t, http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	// Must be rejected — no certificate may be issued to a revoked device.
 	require.Equal(t, http.StatusForbidden, rec.Code, "approving a revoked device must be forbidden: %s", rec.Body.String())
 	assert.NotContains(t, rec.Body.String(), "BEGIN", "no certificate material may be returned for a revoked device")
 
 	// The steward must remain revoked — the status promotion must NOT un-revoke it.
-	recRev, err := ss.GetStewardByDeviceID(context.Background(), testDeviceID)
+	recRev, err := f.stewards.GetStewardByDeviceID(context.Background(), testDeviceID)
 	require.NoError(t, err)
 	assert.Equal(t, business.StewardStatusRevoked, recRev.Status,
 		"revoked steward must NOT be promoted to registered on approve")
 
 	// The pending entry must remain pending with no claim bundle.
-	entry, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	entry, err := f.pending.GetPendingRefreshByID(context.Background(), pendingID)
 	require.NoError(t, err)
 	assert.Equal(t, business.PendingRefreshStatusPending, entry.Status,
 		"pending entry must not be approved for a revoked device")
-	assert.Nil(t, entry.ClaimBundle, "no claim bundle may be stored for a revoked device")
+	assert.Empty(t, entry.ClaimBundle, "no claim bundle may be stored for a revoked device")
 
 	// A security audit event must record the denial with decision+reason.
-	require.NoError(t, auditMgr.Flush(context.Background()))
-	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
-	require.NoError(t, err)
-	found := false
-	for _, e := range entries {
-		if e.Action == "refresh_admin_approve_rejected" {
-			assert.Equal(t, "denied", e.Details["decision"])
-			assert.Equal(t, "revoked", e.Details["reason"])
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "refresh_admin_approve_rejected security audit event expected")
+	auditEntry := f.findAuditAction(t, "refresh_admin_approve_rejected")
+	require.NotNil(t, auditEntry, "refresh_admin_approve_rejected security audit event expected")
+	assert.Equal(t, "denied", auditEntry.Details["decision"])
+	assert.Equal(t, "revoked", auditEntry.Details["reason"])
 }
 
 func TestHandleRefreshReject_RejectsEntry(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, newTestCertManager(t))
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "steward-reject",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
@@ -957,66 +695,53 @@ func TestHandleRefreshReject_RejectsEntry(t *testing.T) {
 		IdentityKeyPub: []byte(pub),
 	})
 
-	prs := newTestPendingRefreshStore()
 	pendingID := "refresh-reject-test"
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: pendingID,
 		DeviceID:  testDeviceID,
 		TenantID:  testTenantID,
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
+	})
 
-	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	apiKey := NewTestKey(t, server, []string{"refresh:reject"})
+	apiKey := NewTestKey(t, f.server, []string{"refresh:reject"})
 
 	body, _ := json.Marshal(AdminRefreshRejectRequest{Reason: "unauthorized device"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/reject", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code, "reject must succeed: %s", rec.Body.String())
 
-	updated, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	updated, err := f.pending.GetPendingRefreshByID(context.Background(), pendingID)
 	require.NoError(t, err)
 	assert.Equal(t, business.PendingRefreshStatusRejected, updated.Status)
 
-	require.NoError(t, auditMgr.Flush(context.Background()))
-	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
-	require.NoError(t, err)
-	found := false
-	for _, e := range entries {
-		if e.Action == "refresh_admin_rejected" {
-			assert.Equal(t, "rejected", e.Details["decision"])
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "refresh_admin_rejected audit event expected")
+	entry := f.findAuditAction(t, "refresh_admin_rejected")
+	require.NotNil(t, entry, "refresh_admin_rejected audit event expected")
+	assert.Equal(t, "rejected", entry.Details["decision"])
 }
 
 func TestHandleListPendingRefreshes_ReturnsList(t *testing.T) {
-	ss := newTestStewardStore()
-	prs := newTestPendingRefreshStore()
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	f := newRefreshFixture(t, newTestCertManager(t))
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: "refresh-list-1",
 		DeviceID:  testDeviceID,
 		TenantID:  testTenantID,
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
+	})
 
-	server, _ := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	apiKey := NewTestKey(t, server, []string{"refresh:list-pending"})
+	apiKey := NewTestKey(t, f.server, []string{"refresh:list-pending"})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/refresh/pending", nil)
 	req.Header.Set("X-API-Key", apiKey)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	var entries []APIPendingRefreshEntry
@@ -1026,14 +751,13 @@ func TestHandleListPendingRefreshes_ReturnsList(t *testing.T) {
 }
 
 func TestHandleGetRefreshPolicy_ReturnsDefault(t *testing.T) {
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, newTestRefreshPolicyStore())
-	server.SetRefreshPolicyStore(newTestRefreshPolicyStore())
-	apiKey := NewTestKey(t, server, []string{"refresh:get-policy"})
+	f := newRefreshFixture(t, newTestCertManager(t))
+	apiKey := NewTestKey(t, f.server, []string{"refresh:get-policy"})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/"+testTenantID+"/refresh-policy", nil)
 	req.Header.Set("X-API-Key", apiKey)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code, "get-policy must succeed: %s", rec.Body.String())
 	var policy AdminRefreshPolicyResponse
@@ -1043,51 +767,48 @@ func TestHandleGetRefreshPolicy_ReturnsDefault(t *testing.T) {
 }
 
 func TestHandleSetRefreshPolicy_SetsMode(t *testing.T) {
-	ps := newTestRefreshPolicyStore()
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, ps)
+	f := newRefreshFixture(t, newTestCertManager(t))
 
 	// PUT /api/v1/tenants/{tenant}/refresh-policy is Tier-3 (mTLS-only).
 	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "auto_accept"})
 	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code, "set-policy must succeed: %s", rec.Body.String())
 
-	policy, err := ps.GetPolicy(context.Background(), testTenantID)
+	policy, err := f.policies.GetPolicy(context.Background(), testTenantID)
 	require.NoError(t, err)
 	assert.Equal(t, "auto_accept", policy.Mode)
 }
 
 func TestHandleSetRefreshPolicy_InvalidMode_Returns400(t *testing.T) {
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, newTestRefreshPolicyStore())
+	f := newRefreshFixture(t, newTestCertManager(t))
 
 	// PUT /api/v1/tenants/{tenant}/refresh-policy is Tier-3 (mTLS-only).
 	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "invalid_mode"})
 	req := makeAdminRequest(t, http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestHandleRefreshApprove_NotFound(t *testing.T) {
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), newTestPendingRefreshStore(), nil)
+	f := newRefreshFixture(t, newTestCertManager(t))
 
 	// POST /api/v1/stewards/refresh/{id}/approve is Tier-3 (mTLS-only).
 	req := makeAdminRequest(t, http.MethodPost, "/api/v1/stewards/refresh/nonexistent-id/approve", nil)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestHandleRefreshReject_Unauthenticated(t *testing.T) {
 	server := setupTestServer(t)
-	server.SetStewardStore(newTestStewardStore())
-	server.SetPendingRefreshStore(newTestPendingRefreshStore())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/some-id/reject", nil)
 	rec := httptest.NewRecorder()
@@ -1099,92 +820,89 @@ func TestHandleRefreshReject_Unauthenticated(t *testing.T) {
 // ---- Cross-tenant isolation tests for admin handlers -------------------------
 
 func TestHandleApproveRefresh_CrossTenantReturns404(t *testing.T) {
-	prs := newTestPendingRefreshStore()
+	f := newRefreshFixture(t, newTestCertManager(t))
 	pendingID := "refresh-cross-approve"
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: pendingID,
 		DeviceID:  testDeviceID,
 		TenantID:  testTenantID, // belongs to "test-tenant"
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
+	})
 
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), prs, nil)
 	// API key from a different tenant — Tier-3 enforcement blocks at the gate (403 MTLS_REQUIRED)
 	// before the handler's own cross-tenant check can fire.
-	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:approve"}, "other-tenant", 5*time.Minute)
+	apiKey := NewEphemeralTestKey(t, f.server, []string{"refresh:approve"}, "other-tenant", 5*time.Minute)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
 	req.Header.Set("X-API-Key", apiKey)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	// Tier-3: API keys are rejected with 403 MTLS_REQUIRED regardless of tenant.
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 
 	// Entry must remain pending — nothing was mutated.
-	entry, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	entry, err := f.pending.GetPendingRefreshByID(context.Background(), pendingID)
 	require.NoError(t, err)
 	assert.Equal(t, business.PendingRefreshStatusPending, entry.Status)
 }
 
 func TestHandleRejectRefresh_CrossTenantReturns404(t *testing.T) {
-	prs := newTestPendingRefreshStore()
+	f := newRefreshFixture(t, newTestCertManager(t))
 	pendingID := "refresh-cross-reject"
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: pendingID,
 		DeviceID:  testDeviceID,
 		TenantID:  testTenantID, // belongs to "test-tenant"
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
+	})
 
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), prs, nil)
 	// API key scoped to a different tenant.
-	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:reject"}, "other-tenant", 5*time.Minute)
+	apiKey := NewEphemeralTestKey(t, f.server, []string{"refresh:reject"}, "other-tenant", 5*time.Minute)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/reject", nil)
 	req.Header.Set("X-API-Key", apiKey)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 
 	// Entry must remain pending — nothing was mutated.
-	entry, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	entry, err := f.pending.GetPendingRefreshByID(context.Background(), pendingID)
 	require.NoError(t, err)
 	assert.Equal(t, business.PendingRefreshStatusPending, entry.Status)
 }
 
 func TestHandleListPendingRefreshes_ScopedCallerSeesOnlyOwnTenant(t *testing.T) {
-	prs := newTestPendingRefreshStore()
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	f := newRefreshFixture(t, newTestCertManager(t))
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: "refresh-own-tenant",
 		DeviceID:  testDeviceID,
 		TenantID:  testTenantID, // caller's own tenant
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
-	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+	})
+	f.addPending(t, &business.PendingRefreshEntry{
 		PendingID: "refresh-other-tenant",
 		DeviceID:  "bbbbbbbbbbbbbbbb",
 		TenantID:  "other-tenant", // another tenant's entry
 		Status:    business.PendingRefreshStatusPending,
 		CreatedAt: time.Now().UTC(),
 		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
-	}))
+	})
 
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), prs, newTestRefreshPolicyStore())
 	// Key scoped to testTenantID — must only see its own entries regardless of query param.
-	apiKey := NewTestKey(t, server, []string{"refresh:list-pending"})
+	apiKey := NewTestKey(t, f.server, []string{"refresh:list-pending"})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/refresh/pending", nil)
 	req.Header.Set("X-API-Key", apiKey)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	var entries []APIPendingRefreshEntry
@@ -1195,63 +913,59 @@ func TestHandleListPendingRefreshes_ScopedCallerSeesOnlyOwnTenant(t *testing.T) 
 }
 
 func TestHandleGetRefreshPolicy_CrossTenantReturns404(t *testing.T) {
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, newTestRefreshPolicyStore())
+	f := newRefreshFixture(t, newTestCertManager(t))
 	// Key scoped to "other-tenant" — must not read policy for testTenantID.
-	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:get-policy"}, "other-tenant", 5*time.Minute)
+	apiKey := NewEphemeralTestKey(t, f.server, []string{"refresh:get-policy"}, "other-tenant", 5*time.Minute)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/"+testTenantID+"/refresh-policy", nil)
 	req.Header.Set("X-API-Key", apiKey)
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestHandleSetRefreshPolicy_CrossTenantReturns404(t *testing.T) {
-	ps := newTestRefreshPolicyStore()
-	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, ps)
+	f := newRefreshFixture(t, newTestCertManager(t))
 	// API key scoped to "other-tenant" — Tier-3 enforcement blocks at the gate (403 MTLS_REQUIRED)
 	// before the handler's own cross-tenant check can fire.
-	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:set-policy"}, "other-tenant", 5*time.Minute)
+	apiKey := NewEphemeralTestKey(t, f.server, []string{"refresh:set-policy"}, "other-tenant", 5*time.Minute)
 
 	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "reject"})
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
-	server.router.ServeHTTP(rec, req)
+	f.server.router.ServeHTTP(rec, req)
 
 	// Tier-3: API keys are rejected with 403 MTLS_REQUIRED regardless of tenant.
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 
 	// Policy for testTenantID must remain at default — nothing mutated.
-	policy, err := ps.GetPolicy(context.Background(), testTenantID)
+	policy, err := f.policies.GetPolicy(context.Background(), testTenantID)
 	require.NoError(t, err)
 	assert.Equal(t, "require_approval", policy.Mode)
 }
 
 func TestRefresh_NoPolicyDefault(t *testing.T) {
 	pub, priv := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, nil)
+	f.addSteward(t, &business.StewardRecord{
 		ID:             "s-active",
 		DeviceID:       testDeviceID,
 		TenantID:       testTenantID,
 		Status:         business.StewardStatusActive,
 		IdentityKeyPub: []byte(pub),
 	})
+	// No policy row is written for this tenant — the store returns the
+	// require_approval default defined by ADR-010 §4.
 
-	prs := newTestPendingRefreshStore()
-	// Policy store returns default (require_approval) — no policy set for this tenant.
-	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
-	server.SetPoPVerifier(ed25519PoPVerifier{})
-
-	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	challenge := issueChallenge(t, f.server, testDeviceID, testTenantID)
 	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
 
-	rec := postComplete(server, testDeviceID, req)
+	rec := postComplete(f.server, testDeviceID, req)
 	assert.Equal(t, http.StatusAccepted, rec.Code, "default policy must queue: %s", rec.Body.String())
-	assert.Equal(t, 1, prs.count(), "one pending entry must be created")
+	assert.Equal(t, 1, f.pendingCount(t), "one pending entry must be created")
 }
 
 // TestRefresh_AutoAccept_NoProvenanceBaseline verifies that auto_accept policy issues a
@@ -1260,8 +974,8 @@ func TestRefresh_NoPolicyDefault(t *testing.T) {
 // to require_approval by a score-of-zero comparison against an absent baseline.
 func TestRefresh_AutoAccept_NoProvenanceBaseline(t *testing.T) {
 	pub, priv := newTestEd25519KeyPair(t)
-	ss := newTestStewardStore()
-	ss.add(&business.StewardRecord{
+	f := newRefreshFixture(t, newTestCertManager(t))
+	f.addSteward(t, &business.StewardRecord{
 		ID:                 "s-active",
 		DeviceID:           testDeviceID,
 		TenantID:           testTenantID,
@@ -1269,23 +983,14 @@ func TestRefresh_AutoAccept_NoProvenanceBaseline(t *testing.T) {
 		IdentityKeyPub:     []byte(pub),
 		LastProvenanceJSON: "", // no baseline — first refresh after registration
 	})
+	f.setPolicy(t, &business.RefreshPolicy{TenantID: testTenantID, Mode: "auto_accept"})
 
-	prs := newTestPendingRefreshStore()
-	ps := newTestRefreshPolicyStore()
-	require.NoError(t, ps.SetPolicy(context.Background(), &business.RefreshPolicy{
-		TenantID: testTenantID,
-		Mode:     "auto_accept",
-	}))
-
-	server, _ := newRefreshAdminTestServer(t, ss, prs, ps)
-	server.SetPoPVerifier(ed25519PoPVerifier{})
-
-	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	challenge := issueChallenge(t, f.server, testDeviceID, testTenantID)
 	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
 
-	rec := postComplete(server, testDeviceID, req)
+	rec := postComplete(f.server, testDeviceID, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "auto_accept with no provenance baseline must issue cert immediately: %s", rec.Body.String())
-	assert.Equal(t, 0, prs.count(), "no pending entry must be created for auto_accept with no baseline")
+	assert.Equal(t, 0, f.pendingCount(t), "no pending entry must be created for auto_accept with no baseline")
 
 	var resp RefreshCompleteResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -442,6 +442,7 @@ func (a *controllerServiceAdapter) GetAllStewards() []fleet.StewardData {
 			LastHeartbeat: info.LastHeartbeat,
 			DNAAttributes: attrs,
 			DNAFragments:  frags,
+			Hidden:        info.Hidden,
 		})
 	}
 	return result

--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -18,6 +18,7 @@ type StewardData struct {
 	LastHeartbeat time.Time
 	DNAAttributes map[string]string    // Flattened DNA attributes (hostname, os, arch, platform, tags, ...)
 	DNAFragments  []*commonpb.Fragment // ADR-017 fragments (cluster:* and host:* fragment-shaped state)
+	Hidden        bool                 // Operator-controlled fleet-view visibility flag (Issue #2944)
 }
 
 // StewardProvider is the source of steward data for fleet queries.

--- a/features/controller/server/health_adapters_test.go
+++ b/features/controller/server/health_adapters_test.go
@@ -4,10 +4,10 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
-	"sync"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,62 +15,166 @@ import (
 	"github.com/stretchr/testify/require"
 
 	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
-	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	cpmemory "github.com/cfgis/cfgms/pkg/controlplane/providers/memory"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
-// stubControlPlaneProvider implements controlplaneInterfaces.ControlPlaneProvider for testing.
-// Only GetStats is used by the adapter; other methods are no-ops.
-type stubControlPlaneProvider struct {
-	controlplaneInterfaces.ControlPlaneProvider // embed interface to satisfy unused methods
-	stats                                       *controlplaneTypes.ControlPlaneStats
-	err                                         error
+// --- GRPCTransportStatsAdapter tests ---
+//
+// These tests drive a real in-process control plane (the memory
+// ControlPlaneProvider) over a shared bus: a server-mode provider plus one
+// client-mode provider per steward. Every counter the adapter reports is
+// produced by real traffic through the provider — commands delivered, events
+// published, heartbeats sent, deliveries that failed because the target steward
+// was not connected. Nothing about the provider is substituted.
+
+// controlPlaneStats starts a server-mode memory provider and one client-mode
+// provider per steward ID, all attached to the same bus. It returns the server
+// provider and the clients keyed by steward ID.
+func controlPlaneStats(t *testing.T, stewardIDs ...string) (*cpmemory.Provider, map[string]*cpmemory.Provider) {
+	t.Helper()
+	ctx := context.Background()
+
+	bus := cpmemory.NewBus()
+	server := cpmemory.New(cpmemory.ModeServer)
+	require.NoError(t, server.Initialize(ctx, map[string]interface{}{"bus": bus}))
+	require.NoError(t, server.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, server.Stop(stopCtx))
+	})
+
+	clients := make(map[string]*cpmemory.Provider, len(stewardIDs))
+	for _, id := range stewardIDs {
+		client := cpmemory.New(cpmemory.ModeClient)
+		require.NoError(t, client.Initialize(ctx, map[string]interface{}{
+			"bus":        bus,
+			"steward_id": id,
+		}))
+		require.NoError(t, client.Start(ctx))
+		clients[id] = client
+		t.Cleanup(func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			require.NoError(t, client.Stop(stopCtx))
+		})
+	}
+
+	return server, clients
 }
 
-func (s *stubControlPlaneProvider) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
-	return s.stats, s.err
-}
-
-func TestGRPCTransportStatsAdapter_MapsStatsCorrectly(t *testing.T) {
-	provider := &stubControlPlaneProvider{
-		stats: &controlplaneTypes.ControlPlaneStats{
-			ConnectedStewards:  7,
-			CommandsSent:       10,
-			ResponsesSent:      5,
-			HeartbeatsSent:     20,
-			EventsPublished:    3,
-			CommandsReceived:   8,
-			ResponsesReceived:  4,
-			HeartbeatsReceived: 18,
-			EventsReceived:     6,
-			DeliveryFailures:   2,
-			AvgLatency:         3 * time.Millisecond,
-			ProviderMetrics: map[string]interface{}{
-				"reconnect_attempts": int64(4),
-			},
+// sendCommand addresses a signed command at stewardID and sends it from the
+// server-mode provider.
+func sendCommand(server *cpmemory.Provider, stewardID string) error {
+	return server.SendCommand(context.Background(), &controlplaneTypes.SignedCommand{
+		Command: controlplaneTypes.Command{
+			ID:        "cmd-" + stewardID,
+			Type:      controlplaneTypes.CommandSyncConfig,
+			StewardID: stewardID,
+			Timestamp: time.Now().UTC(),
 		},
-	}
-
-	adapter := NewGRPCTransportStatsAdapter(provider)
-
-	assert.Equal(t, 7, adapter.GetConnectedStewards())
-	assert.Equal(t, int64(2), adapter.GetStreamErrors())
-	// MessagesSent = CommandsSent + ResponsesSent + HeartbeatsSent + EventsPublished = 10+5+20+3 = 38
-	assert.Equal(t, int64(38), adapter.GetMessagesSent())
-	// MessagesReceived = CommandsReceived + ResponsesReceived + HeartbeatsReceived + EventsReceived = 8+4+18+6 = 36
-	assert.Equal(t, int64(36), adapter.GetMessagesReceived())
-	assert.Equal(t, int64(4), adapter.GetReconnectionAttempts())
-	assert.Equal(t, 3*time.Millisecond, adapter.GetAvgLatency())
+	})
 }
 
-func TestGRPCTransportStatsAdapter_ReturnsZerosOnError(t *testing.T) {
-	provider := &stubControlPlaneProvider{
-		err: assert.AnError,
+// TestGRPCTransportStatsAdapter_MapsServerStats drives real controller-side
+// traffic and asserts the adapter reports the provider's actual counters, with
+// messages-sent and messages-received aggregated per the adapter's contract.
+func TestGRPCTransportStatsAdapter_MapsServerStats(t *testing.T) {
+	ctx := context.Background()
+	server, clients := controlPlaneStats(t, "steward-1", "steward-2")
+
+	// 3 commands delivered to a connected steward.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, sendCommand(server, "steward-1"))
+	}
+	// 1 command addressed at a steward that is not connected — a real delivery failure.
+	require.Error(t, sendCommand(server, "steward-offline"),
+		"sending to a disconnected steward must fail")
+
+	// 4 heartbeats and 2 events travel steward → controller.
+	for i := 0; i < 4; i++ {
+		require.NoError(t, clients["steward-1"].SendHeartbeat(ctx, &controlplaneTypes.Heartbeat{
+			StewardID: "steward-1",
+			Status:    controlplaneTypes.StatusHealthy,
+			Timestamp: time.Now().UTC(),
+		}))
+	}
+	for i := 0; i < 2; i++ {
+		require.NoError(t, clients["steward-1"].PublishEvent(ctx, &controlplaneTypes.Event{
+			ID:        fmt.Sprintf("evt-%d", i),
+			Type:      controlplaneTypes.EventConfigApplied,
+			StewardID: "steward-1",
+			Timestamp: time.Now().UTC(),
+		}))
 	}
 
-	adapter := NewGRPCTransportStatsAdapter(provider)
+	adapter := NewGRPCTransportStatsAdapter(server)
+
+	assert.Equal(t, 2, adapter.GetConnectedStewards(), "both stewards are attached to the bus")
+	assert.Equal(t, int64(1), adapter.GetStreamErrors(), "one delivery failure was recorded")
+	// MessagesSent = CommandsSent + ResponsesSent + HeartbeatsSent + EventsPublished
+	assert.Equal(t, int64(3), adapter.GetMessagesSent())
+	// MessagesReceived = CommandsReceived + ResponsesReceived + HeartbeatsReceived + EventsReceived
+	assert.Equal(t, int64(6), adapter.GetMessagesReceived())
+	// Server mode publishes no reconnection metric.
+	assert.Equal(t, int64(0), adapter.GetReconnectionAttempts())
+	// The in-process control plane does not instrument latency; the adapter must
+	// report the provider's value rather than synthesising one.
+	assert.Equal(t, time.Duration(0), adapter.GetAvgLatency())
+}
+
+// TestGRPCTransportStatsAdapter_MapsClientStats asserts the same aggregation
+// from the steward side, where the counters that move are the mirror image of
+// the controller side: heartbeats and events sent, commands received.
+func TestGRPCTransportStatsAdapter_MapsClientStats(t *testing.T) {
+	ctx := context.Background()
+	server, clients := controlPlaneStats(t, "steward-1")
+	client := clients["steward-1"]
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, sendCommand(server, "steward-1"))
+	}
+	for i := 0; i < 4; i++ {
+		require.NoError(t, client.SendHeartbeat(ctx, &controlplaneTypes.Heartbeat{
+			StewardID: "steward-1",
+			Status:    controlplaneTypes.StatusHealthy,
+			Timestamp: time.Now().UTC(),
+		}))
+	}
+	for i := 0; i < 2; i++ {
+		require.NoError(t, client.PublishEvent(ctx, &controlplaneTypes.Event{
+			ID:        fmt.Sprintf("evt-%d", i),
+			Type:      controlplaneTypes.EventConfigApplied,
+			StewardID: "steward-1",
+			Timestamp: time.Now().UTC(),
+		}))
+	}
+
+	adapter := NewGRPCTransportStatsAdapter(client)
+
+	assert.Equal(t, int64(6), adapter.GetMessagesSent(), "4 heartbeats + 2 events")
+	assert.Equal(t, int64(3), adapter.GetMessagesReceived(), "3 commands received")
+	assert.Equal(t, 0, adapter.GetConnectedStewards(), "client mode tracks no connected stewards")
+	assert.Equal(t, int64(0), adapter.GetStreamErrors())
+	// The client publishes connection_state but no reconnect_attempts, so the
+	// adapter must fall back to 0 rather than mis-reading another metric.
+	stats, err := client.GetStats(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, stats.ProviderMetrics, "reconnect_attempts")
+	require.Contains(t, stats.ProviderMetrics, "connection_state")
+	assert.Equal(t, int64(0), adapter.GetReconnectionAttempts())
+}
+
+// TestGRPCTransportStatsAdapter_ZerosForIdleProvider asserts that a started
+// provider that has carried no traffic reports zeros through every getter —
+// the adapter must not invent values for an idle control plane.
+func TestGRPCTransportStatsAdapter_ZerosForIdleProvider(t *testing.T) {
+	server, _ := controlPlaneStats(t)
+
+	adapter := NewGRPCTransportStatsAdapter(server)
 
 	assert.Equal(t, 0, adapter.GetConnectedStewards())
 	assert.Equal(t, int64(0), adapter.GetStreamErrors())
@@ -78,35 +182,6 @@ func TestGRPCTransportStatsAdapter_ReturnsZerosOnError(t *testing.T) {
 	assert.Equal(t, int64(0), adapter.GetMessagesReceived())
 	assert.Equal(t, int64(0), adapter.GetReconnectionAttempts())
 	assert.Equal(t, time.Duration(0), adapter.GetAvgLatency())
-}
-
-func TestGRPCTransportStatsAdapter_NilProviderMetrics(t *testing.T) {
-	provider := &stubControlPlaneProvider{
-		stats: &controlplaneTypes.ControlPlaneStats{
-			ConnectedStewards: 3,
-			ProviderMetrics:   nil, // server mode — no reconnect_attempts
-		},
-	}
-
-	adapter := NewGRPCTransportStatsAdapter(provider)
-
-	assert.Equal(t, 3, adapter.GetConnectedStewards())
-	assert.Equal(t, int64(0), adapter.GetReconnectionAttempts())
-}
-
-func TestGRPCTransportStatsAdapter_NoReconnectAttemptsKey(t *testing.T) {
-	provider := &stubControlPlaneProvider{
-		stats: &controlplaneTypes.ControlPlaneStats{
-			ProviderMetrics: map[string]interface{}{
-				"connection_state": "connected",
-				// No reconnect_attempts key
-			},
-		},
-	}
-
-	adapter := NewGRPCTransportStatsAdapter(provider)
-
-	assert.Equal(t, int64(0), adapter.GetReconnectionAttempts())
 }
 
 func TestUnimplementedStorageStats_ReportsUnimplemented(t *testing.T) {
@@ -141,109 +216,32 @@ func TestNoOpApplicationQueueStats_ReturnsZeros(t *testing.T) {
 }
 
 // --- stewardIPTrustAdapter tests ---
+//
+// Both stores below are real storage-provider implementations rooted at a
+// t.TempDir(): the flat-file StewardStore and the flat-file IPTrustStore.
 
-// testStewardStore is a real in-memory StewardStore used for adapter testing.
-// It is NOT a mock — it holds actual StewardRecord data and satisfies the
-// StewardStore contract for the GetSteward lookup path.
-type testStewardStore struct {
-	mu       sync.RWMutex
-	stewards map[string]*business.StewardRecord
-}
-
-func newTestStewardStore(records ...*business.StewardRecord) *testStewardStore {
-	s := &testStewardStore{stewards: make(map[string]*business.StewardRecord)}
+// newAdapterStewardStore returns a real flat-file StewardStore pre-populated
+// with the given records.
+func newAdapterStewardStore(t *testing.T, records ...*business.StewardRecord) business.StewardStore {
+	t.Helper()
+	store := newFlatFileStewardStore(t)
 	for _, r := range records {
-		s.stewards[r.ID] = r
+		require.NoError(t, store.RegisterSteward(context.Background(), r))
 	}
-	return s
+	return store
 }
 
-func (s *testStewardStore) RegisterSteward(_ context.Context, record *business.StewardRecord) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.stewards[record.ID] = record
-	return nil
-}
-
-func (s *testStewardStore) GetSteward(_ context.Context, id string) (*business.StewardRecord, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	r, ok := s.stewards[id]
-	if !ok {
-		return nil, business.ErrStewardNotFound
+// trustedCIDRs returns the CIDRs recorded for tenantID in the trust store.
+func trustedCIDRs(t *testing.T, store business.IPTrustStore, tenantID string) []string {
+	t.Helper()
+	entries, err := store.ListTrustedRanges(context.Background(), tenantID)
+	require.NoError(t, err)
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.TenantID+"/"+e.CIDR)
 	}
-	cp := *r
-	return &cp, nil
-}
-
-func (s *testStewardStore) UpdateHeartbeat(_ context.Context, _ string) error { return nil }
-func (s *testStewardStore) ListStewards(_ context.Context) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (s *testStewardStore) ListStewardsByStatus(_ context.Context, _ business.StewardStatus) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (s *testStewardStore) UpdateStewardStatus(_ context.Context, _ string, _ business.StewardStatus) error {
-	return nil
-}
-func (s *testStewardStore) UpdateStewardTenant(_ context.Context, _, _ string) error { return nil }
-func (s *testStewardStore) DeregisterSteward(_ context.Context, _ string) error      { return nil }
-func (s *testStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (s *testStewardStore) GetStewardByDeviceID(_ context.Context, deviceID string) (*business.StewardRecord, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, r := range s.stewards {
-		if r.DeviceID == deviceID {
-			cp := *r
-			return &cp, nil
-		}
-	}
-	return nil, business.ErrStewardNotFound
-}
-func (s *testStewardStore) HealthCheck(_ context.Context) error { return nil }
-func (s *testStewardStore) Initialize(_ context.Context) error  { return nil }
-func (s *testStewardStore) Close() error                        { return nil }
-
-var _ business.StewardStore = (*testStewardStore)(nil)
-
-// testIPTrustStoreForAdapter is a minimal in-memory IPTrustStore for adapter tests.
-type testIPTrustStoreForAdapter struct {
-	mu    sync.Mutex
-	calls []string
-}
-
-func (s *testIPTrustStoreForAdapter) AddTrustedRange(_ context.Context, tenantID, cidr string, _ bool) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.calls = append(s.calls, tenantID+"/"+cidr)
-	return nil
-}
-func (s *testIPTrustStoreForAdapter) IsTrusted(_ context.Context, _, _ string) (bool, error) {
-	return false, nil
-}
-func (s *testIPTrustStoreForAdapter) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
-	return nil, nil
-}
-func (s *testIPTrustStoreForAdapter) RevokeTrustedRange(_ context.Context, _, _ string) error {
-	return business.ErrIPTrustEntryNotFound
-}
-func (s *testIPTrustStoreForAdapter) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
-	return nil
-}
-func (s *testIPTrustStoreForAdapter) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
-	return nil, nil
-}
-func (s *testIPTrustStoreForAdapter) addTrustedRangeCalls() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	out := make([]string, len(s.calls))
-	copy(out, s.calls)
 	return out
 }
-
-var _ business.IPTrustStore = (*testIPTrustStoreForAdapter)(nil)
 
 // normaliseCIDRForAdapter returns the network address form of a CIDR.
 func normaliseCIDRForAdapter(cidr string) string {
@@ -267,13 +265,13 @@ func newTestAdapter(stewardStore business.StewardStore, trustStore business.IPTr
 // looks up the steward's IP from the fleet registry and passes it to the
 // IPTrustEvaluator (Issue #1694).
 func TestStewardIPTrustAdapter_ResolvesIPFromStewardStore(t *testing.T) {
-	stewardStore := newTestStewardStore(&business.StewardRecord{
+	stewardStore := newAdapterStewardStore(t, &business.StewardRecord{
 		ID:        "steward-1",
 		TenantID:  "tenant-1",
 		IPAddress: "10.0.0.1",
 		Status:    business.StewardStatusActive,
 	})
-	trustStore := &testIPTrustStoreForAdapter{}
+	trustStore := newFlatFileIPTrustStore(t, t.TempDir())
 	adapter := newTestAdapter(stewardStore, trustStore)
 	ctx := context.Background()
 
@@ -283,31 +281,31 @@ func TestStewardIPTrustAdapter_ResolvesIPFromStewardStore(t *testing.T) {
 	// Manually advance the evaluator's timer past the threshold.
 	adapter.evaluator.ForceTimerExpiry("tenant-1", "10.0.0.1")
 
-	// Second call tips over threshold — must call AddTrustedRange with the resolved IP.
+	// Second call tips over threshold — the resolved IP must be persisted as trusted.
 	require.NoError(t, adapter.RecordLiveness(ctx, "steward-1", true))
 
-	calls := trustStore.addTrustedRangeCalls()
-	require.Len(t, calls, 1, "AddTrustedRange must be called with the correct IP")
-	assert.Equal(t, fmt.Sprintf("tenant-1/%s", normaliseCIDRForAdapter("10.0.0.1/32")), calls[0])
+	trusted := trustedCIDRs(t, trustStore, "tenant-1")
+	require.Len(t, trusted, 1, "the resolved IP must be recorded as a trusted range")
+	assert.Equal(t, fmt.Sprintf("tenant-1/%s", normaliseCIDRForAdapter("10.0.0.1/32")), trusted[0])
 }
 
 // TestStewardIPTrustAdapter_StewardNotFound_IsNoop verifies that a missing steward
 // record is silently ignored without returning an error (best-effort).
 func TestStewardIPTrustAdapter_StewardNotFound_IsNoop(t *testing.T) {
-	stewardStore := newTestStewardStore() // empty
-	trustStore := &testIPTrustStoreForAdapter{}
+	stewardStore := newAdapterStewardStore(t) // empty
+	trustStore := newFlatFileIPTrustStore(t, t.TempDir())
 	adapter := newTestAdapter(stewardStore, trustStore)
 	ctx := context.Background()
 
 	err := adapter.RecordLiveness(ctx, "unknown-steward", true)
 	assert.NoError(t, err, "missing steward must not return an error")
-	assert.Empty(t, trustStore.addTrustedRangeCalls())
+	assert.Empty(t, trustedCIDRs(t, trustStore, "tenant-1"))
 }
 
 // TestStewardIPTrustAdapter_NilStewardStore_IsNoop verifies that a nil steward
 // store does not cause a panic.
 func TestStewardIPTrustAdapter_NilStewardStore_IsNoop(t *testing.T) {
-	trustStore := &testIPTrustStoreForAdapter{}
+	trustStore := newFlatFileIPTrustStore(t, t.TempDir())
 	evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
 		Store:     trustStore,
 		Threshold: time.Millisecond,
@@ -317,34 +315,34 @@ func TestStewardIPTrustAdapter_NilStewardStore_IsNoop(t *testing.T) {
 
 	err := adapter.RecordLiveness(context.Background(), "steward-1", true)
 	assert.NoError(t, err)
-	assert.Empty(t, trustStore.addTrustedRangeCalls())
+	assert.Empty(t, trustedCIDRs(t, trustStore, "tenant-1"))
 }
 
 // TestStewardIPTrustAdapter_EmptyIP_IsNoop verifies that a steward with no IP
 // address stored is silently skipped.
 func TestStewardIPTrustAdapter_EmptyIP_IsNoop(t *testing.T) {
-	stewardStore := newTestStewardStore(&business.StewardRecord{
+	stewardStore := newAdapterStewardStore(t, &business.StewardRecord{
 		ID:        "steward-noip",
 		TenantID:  "tenant-1",
 		IPAddress: "", // no IP stored yet
 	})
-	trustStore := &testIPTrustStoreForAdapter{}
+	trustStore := newFlatFileIPTrustStore(t, t.TempDir())
 	adapter := newTestAdapter(stewardStore, trustStore)
 
 	err := adapter.RecordLiveness(context.Background(), "steward-noip", true)
 	assert.NoError(t, err)
-	assert.Empty(t, trustStore.addTrustedRangeCalls())
+	assert.Empty(t, trustedCIDRs(t, trustStore, "tenant-1"))
 }
 
 // TestStewardIPTrustAdapter_OfflineCall_ResetsTimer verifies that a healthy=false
 // call resets the trust timer for the steward's IP.
 func TestStewardIPTrustAdapter_OfflineCall_ResetsTimer(t *testing.T) {
-	stewardStore := newTestStewardStore(&business.StewardRecord{
+	stewardStore := newAdapterStewardStore(t, &business.StewardRecord{
 		ID:        "steward-1",
 		TenantID:  "tenant-1",
 		IPAddress: "10.0.0.1",
 	})
-	trustStore := &testIPTrustStoreForAdapter{}
+	trustStore := newFlatFileIPTrustStore(t, t.TempDir())
 	evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
 		Store:     trustStore,
 		Threshold: time.Hour, // long threshold to prevent accidental promotion
@@ -363,20 +361,30 @@ func TestStewardIPTrustAdapter_OfflineCall_ResetsTimer(t *testing.T) {
 	require.NoError(t, adapter.RecordLiveness(ctx, "steward-1", false))
 	assert.False(t, evaluator.HasTimer("tenant-1", "10.0.0.1"), "timer must be cleared after offline call")
 
-	assert.Empty(t, trustStore.addTrustedRangeCalls(), "no trust must be granted after offline reset")
+	assert.Empty(t, trustedCIDRs(t, trustStore, "tenant-1"), "no trust must be granted after offline reset")
 }
 
-// TestStewardIPTrustAdapter_EvaluatorError_IsPropagated verifies that an error
-// returned by IPTrustEvaluator (e.g. store failure) is returned to the caller.
+// TestStewardIPTrustAdapter_EvaluatorError_IsPropagated verifies that a genuine
+// store failure surfaces to the caller instead of being swallowed. The failure is
+// real: the flat-file IP trust store's backing JSON file is corrupted on disk, so
+// the store cannot load its existing entries and refuses the write.
 func TestStewardIPTrustAdapter_EvaluatorError_IsPropagated(t *testing.T) {
-	stewardStore := newTestStewardStore(&business.StewardRecord{
+	stewardStore := newAdapterStewardStore(t, &business.StewardRecord{
 		ID:        "steward-1",
 		TenantID:  "tenant-1",
 		IPAddress: "10.0.0.1",
 	})
-	failStore := &failingIPTrustStore{err: errors.New("storage unavailable")}
+
+	trustRoot := t.TempDir()
+	trustStore := newFlatFileIPTrustStore(t, trustRoot)
+	// Corrupt the store's on-disk state — the file exists but is not valid JSON.
+	corrupt := filepath.Join(trustRoot, "ip-trust", "ip_trust.json")
+	require.NoError(t, os.WriteFile(corrupt, []byte("{ not json"), 0600))
+	require.Error(t, trustStore.AddTrustedRange(context.Background(), "tenant-1", "10.0.0.1/32", false),
+		"a corrupted store must reject writes — precondition for this test")
+
 	evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
-		Store:     failStore,
+		Store:     trustStore,
 		Threshold: time.Millisecond,
 		Logger:    logging.NewLogger("debug"),
 	})
@@ -393,27 +401,3 @@ func TestStewardIPTrustAdapter_EvaluatorError_IsPropagated(t *testing.T) {
 	err := adapter.RecordLiveness(ctx, "steward-1", true)
 	require.Error(t, err, "store error must be propagated")
 }
-
-// failingIPTrustStore always returns an error from AddTrustedRange.
-type failingIPTrustStore struct{ err error }
-
-func (f *failingIPTrustStore) AddTrustedRange(_ context.Context, _, _ string, _ bool) error {
-	return f.err
-}
-func (f *failingIPTrustStore) IsTrusted(_ context.Context, _, _ string) (bool, error) {
-	return false, nil
-}
-func (f *failingIPTrustStore) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
-	return nil, nil
-}
-func (f *failingIPTrustStore) RevokeTrustedRange(_ context.Context, _, _ string) error {
-	return nil
-}
-func (f *failingIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
-	return nil
-}
-func (f *failingIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
-	return nil, nil
-}
-
-var _ business.IPTrustStore = (*failingIPTrustStore)(nil)

--- a/features/controller/server/providers_test.go
+++ b/features/controller/server/providers_test.go
@@ -26,6 +26,18 @@ func newFlatFileStewardStore(t *testing.T) business.StewardStore {
 	return st
 }
 
+// newFlatFileIPTrustStore returns a real flat-file IPTrustStore rooted at root.
+// The caller supplies the root so tests can inspect — or deliberately corrupt —
+// the on-disk state the store reads back. The concrete flatfile import is
+// confined to this allowlisted */providers_test.go path (see
+// scripts/check-providers.sh).
+func newFlatFileIPTrustStore(t *testing.T, root string) business.IPTrustStore {
+	t.Helper()
+	st, err := flatfile.NewFlatFileIPTrustStore(root)
+	require.NoError(t, err, "creating flat-file IP trust store")
+	return st
+}
+
 // requireInMemoryUpgradeStore asserts that store is the in-memory fallback
 // UpgradeStore. The concrete memoryprovider import is confined to this
 // allowlisted */providers_test.go path (see scripts/check-providers.sh) so that

--- a/features/controller/service/controller_service.go
+++ b/features/controller/service/controller_service.go
@@ -62,6 +62,10 @@ type StewardInfo struct {
 	RingResolvedVersion string
 	// ResolvedRing is the ring name that was matched (or fell back to).
 	ResolvedRing string
+
+	// Hidden is the operator-controlled fleet-view visibility flag (Issue #2944).
+	// Orthogonal to Status: hiding a steward does not change its lifecycle state.
+	Hidden bool
 }
 
 // maxVersionLen is the maximum number of bytes stored for a steward-supplied
@@ -802,6 +806,19 @@ func (s *ControllerService) UpdateStewardStatus(stewardID, status string) error 
 		return fmt.Errorf("steward %s not found", stewardID)
 	}
 	steward.Status = status
+	return nil
+}
+
+// SetStewardHidden sets the operator-controlled visibility flag for the given steward
+// in the in-memory registry. Returns an error if the steward is not found.
+func (s *ControllerService) SetStewardHidden(stewardID string, hidden bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	steward, exists := s.stewards[stewardID]
+	if !exists {
+		return fmt.Errorf("steward %s not found", stewardID)
+	}
+	steward.Hidden = hidden
 	return nil
 }
 

--- a/features/controller/service/controller_service_test.go
+++ b/features/controller/service/controller_service_test.go
@@ -22,68 +22,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
-// logCapture records log calls for assertion in internal package tests (package service).
-// Implements logging.Logger by storing each call; assertions use findEntry.
-type logCapture struct {
-	mu      sync.Mutex
-	entries []logCaptureEntry
-}
-
-type logCaptureEntry struct {
-	level  string
-	msg    string
-	fields []interface{}
-}
-
-func (l *logCapture) record(level, msg string, kv []interface{}) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.entries = append(l.entries, logCaptureEntry{level: level, msg: msg, fields: kv})
-}
-
-// findEntry returns the first entry whose message equals msg (case-sensitive).
-func (l *logCapture) findEntry(msg string) (logCaptureEntry, bool) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	for _, e := range l.entries {
-		if e.msg == msg {
-			return e, true
-		}
-	}
-	return logCaptureEntry{}, false
-}
-
-// fieldValue returns the value for a given key in a log entry's key-value pairs.
-func (e logCaptureEntry) fieldValue(key string) (interface{}, bool) {
-	for i := 0; i+1 < len(e.fields); i += 2 {
-		if fmt.Sprintf("%v", e.fields[i]) == key {
-			return e.fields[i+1], true
-		}
-	}
-	return nil, false
-}
-
-func (l *logCapture) Debug(msg string, kv ...interface{}) { l.record("DEBUG", msg, kv) }
-func (l *logCapture) Info(msg string, kv ...interface{})  { l.record("INFO", msg, kv) }
-func (l *logCapture) Warn(msg string, kv ...interface{})  { l.record("WARN", msg, kv) }
-func (l *logCapture) Error(msg string, kv ...interface{}) { l.record("ERROR", msg, kv) }
-func (l *logCapture) Fatal(msg string, kv ...interface{}) { l.record("FATAL", msg, kv) }
-func (l *logCapture) DebugCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("DEBUG", msg, kv)
-}
-func (l *logCapture) InfoCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("INFO", msg, kv)
-}
-func (l *logCapture) WarnCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("WARN", msg, kv)
-}
-func (l *logCapture) ErrorCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("ERROR", msg, kv)
-}
-func (l *logCapture) FatalCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("FATAL", msg, kv)
-}
-
 // newTestFleetStorage creates a real SQLite storage manager for controller service tests.
 func newTestFleetStorage(t *testing.T) *fleetStorage.Manager {
 	t.Helper()
@@ -997,7 +935,7 @@ func TestApplyRingResolution_AbsentRing_FallsToDefault(t *testing.T) {
 // a WARN log entry with event name "deployment_ring_fallback" and the correct
 // field values when ring fallback occurs (invalid ring name).
 func TestApplyRingResolution_FallbackLogsWarn(t *testing.T) {
-	lc := &logCapture{}
+	lc := logging.NewCapturingLogger()
 	svc := NewControllerService(lc)
 	svc.SetRingConfig(makeTestRingConfig())
 
@@ -1016,16 +954,17 @@ func TestApplyRingResolution_FallbackLogsWarn(t *testing.T) {
 		"ResolvedRing must reflect the fallback ring, not the invalid input")
 
 	// Log assertions — WARN with event name and field values must be emitted.
-	entry, ok := lc.findEntry("deployment_ring_fallback")
+	// CapturingLogger only records Warn/WarnCtx into WarnEntries, so finding the
+	// entry there is itself proof the event was emitted at WARN level.
+	entry, ok := lc.FindWarn("deployment_ring_fallback")
 	require.True(t, ok, "expected WARN log entry with msg='deployment_ring_fallback'")
-	assert.Equal(t, "WARN", entry.level, "fallback must be logged at WARN level")
 
-	ringValue, hasRingValue := entry.fieldValue("ring_value")
+	ringValue, hasRingValue := entry["ring_value"]
 	assert.True(t, hasRingValue, "log entry must include ring_value field")
 	assert.Contains(t, fmt.Sprintf("%v", ringValue), "does-not-exist",
 		"ring_value field must carry the invalid ring name (possibly sanitized)")
 
-	fallbackRing, hasFallbackRing := entry.fieldValue("fallback_ring")
+	fallbackRing, hasFallbackRing := entry["fallback_ring"]
 	assert.True(t, hasFallbackRing, "log entry must include fallback_ring field")
 	assert.Contains(t, fmt.Sprintf("%v", fallbackRing), "default",
 		"fallback_ring field must name the fallback ring (possibly sanitized)")
@@ -1034,19 +973,20 @@ func TestApplyRingResolution_FallbackLogsWarn(t *testing.T) {
 // TestSetRingConfig_AuditLogsOnChange verifies SetRingConfig emits a "ring_set_changed"
 // INFO audit log entry with actor, before, and after fields when the ring set changes.
 func TestSetRingConfig_AuditLogsOnChange(t *testing.T) {
-	lc := &logCapture{}
+	lc := logging.NewCapturingLogger()
 	svc := NewControllerService(lc)
 
 	initial := makeTestRingConfig()
 	svc.SetRingConfig(initial)
 
 	// First set emits ring_set_changed (from empty → initial config).
-	entry, ok := lc.findEntry("ring_set_changed")
+	// CapturingLogger only records Info/InfoCtx into InfoEntries, so finding the
+	// entry there is itself proof the audit event was emitted at INFO level.
+	entry, ok := lc.FindInfo("ring_set_changed")
 	require.True(t, ok, "expected INFO log entry with msg='ring_set_changed' on first SetRingConfig")
-	assert.Equal(t, "INFO", entry.level, "ring_set_changed must be logged at INFO level")
-	_, hasActor := entry.fieldValue("actor")
+	_, hasActor := entry["actor"]
 	assert.True(t, hasActor, "ring_set_changed entry must include actor field")
-	_, hasAfter := entry.fieldValue("after")
+	_, hasAfter := entry["after"]
 	assert.True(t, hasAfter, "ring_set_changed entry must include after field")
 
 	// State is persisted correctly.
@@ -1056,18 +996,14 @@ func TestSetRingConfig_AuditLogsOnChange(t *testing.T) {
 	assert.Equal(t, "v0.5.21", got.Rings[1].DesiredVersion)
 
 	// Record current entry count; a second change must add exactly one more.
-	lc.mu.Lock()
-	countBefore := len(lc.entries)
-	lc.mu.Unlock()
+	countBefore := lc.InfoCount()
 
 	// Update the ring config (version bump on early ring).
 	updated := makeTestRingConfig()
 	updated.Rings[1].DesiredVersion = "v0.5.22"
 	svc.SetRingConfig(updated)
 
-	lc.mu.Lock()
-	countAfter := len(lc.entries)
-	lc.mu.Unlock()
+	countAfter := lc.InfoCount()
 	assert.Equal(t, countBefore+1, countAfter,
 		"SetRingConfig on changed config must emit exactly one additional log entry")
 
@@ -1272,4 +1208,50 @@ func TestSetTagStore_ConcurrentAccess_NoRace(t *testing.T) {
 	wg.Wait()
 
 	require.Same(t, store, svc.TagStore(), "final TagStore() must return the wired store")
+}
+
+// ---------------------------------------------------------------------------
+// SetStewardHidden tests (Issue #2944)
+// ---------------------------------------------------------------------------
+
+func TestSetStewardHidden_Success(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+	require.NoError(t, svc.RegisterSteward("s-hide", "tenant-a", "addr", "active"))
+
+	// Default: not hidden.
+	all := svc.GetAllStewards()
+	require.Len(t, all, 1)
+	assert.False(t, all[0].Hidden, "freshly registered steward must not be hidden")
+
+	// Hide it.
+	require.NoError(t, svc.SetStewardHidden("s-hide", true))
+	all = svc.GetAllStewards()
+	require.Len(t, all, 1)
+	assert.True(t, all[0].Hidden, "GetAllStewards must reflect hidden=true after SetStewardHidden")
+
+	// Un-hide it.
+	require.NoError(t, svc.SetStewardHidden("s-hide", false))
+	all = svc.GetAllStewards()
+	require.Len(t, all, 1)
+	assert.False(t, all[0].Hidden, "GetAllStewards must reflect hidden=false after SetStewardHidden")
+}
+
+func TestSetStewardHidden_NotFound(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+	err := svc.SetStewardHidden("nonexistent", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestSetStewardHidden_PreservesOtherFields(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+	require.NoError(t, svc.RegisterSteward("s-preserve-hide", "tenant-b", "addr-2", "active"))
+
+	require.NoError(t, svc.SetStewardHidden("s-preserve-hide", true))
+
+	info, ok := svc.GetStewardInfo("s-preserve-hide")
+	require.True(t, ok)
+	assert.True(t, info.Hidden, "Hidden must be set")
+	assert.Equal(t, "active", info.Status, "Status must not change on SetStewardHidden")
+	assert.Equal(t, "tenant-b", info.TenantID, "TenantID must not change on SetStewardHidden")
 }

--- a/features/controller/service/dna_integrity_test.go
+++ b/features/controller/service/dna_integrity_test.go
@@ -126,7 +126,7 @@ func TestCheckDNAIntegrity_UnknownConfigType(t *testing.T) {
 // good snapshot.
 func TestSyncDNA_RejectsDegenerateDNA_PriorSnapshotUnchanged(t *testing.T) {
 	storage := newTestFleetStorage(t)
-	log := &logCapture{}
+	log := logging.NewCapturingLogger()
 	svc := NewControllerServiceWithStorage(log, storage)
 	ctx := context.Background()
 
@@ -159,9 +159,10 @@ func TestSyncDNA_RejectsDegenerateDNA_PriorSnapshotUnchanged(t *testing.T) {
 	assert.EqualValues(t, 1, history.TotalCount, "degenerate snapshot must not be appended to history")
 
 	// WARN log entry must have been emitted.
-	entry, found := log.findEntry("dna_integrity_rejected")
+	// CapturingLogger records only Warn/WarnCtx calls, so a hit here is itself
+	// proof the event was emitted at WARN level.
+	_, found := log.FindWarn("dna_integrity_rejected")
 	assert.True(t, found, "expected dna_integrity_rejected WARN log entry")
-	assert.Equal(t, "WARN", entry.level)
 }
 
 // TestSyncDNA_RejectsNilAttributesDNA verifies that a nil-attributes DNA
@@ -293,7 +294,7 @@ func TestSyncDNA_PostHookNotFiredOnRejection(t *testing.T) {
 // TestSyncDNA_WarnLogContainsStewardIDAndMissingFields verifies the WARN log
 // entry names the steward id and the specific missing fields.
 func TestSyncDNA_WarnLogContainsStewardIDAndMissingFields(t *testing.T) {
-	log := &logCapture{}
+	log := logging.NewCapturingLogger()
 	svc := NewControllerService(log)
 	ctx := context.Background()
 
@@ -314,15 +315,15 @@ func TestSyncDNA_WarnLogContainsStewardIDAndMissingFields(t *testing.T) {
 	_, err := svc.SyncDNA(ctx, dna)
 	require.NoError(t, err)
 
-	entry, found := log.findEntry("dna_integrity_rejected")
+	entry, found := log.FindWarn("dna_integrity_rejected")
 	require.True(t, found, "expected dna_integrity_rejected WARN log entry")
 
 	// steward_id field present.
-	_, hasStewardID := entry.fieldValue("steward_id")
+	_, hasStewardID := entry["steward_id"]
 	assert.True(t, hasStewardID)
 
 	// missing_fields value is a []string containing "os".
-	val, ok := entry.fieldValue("missing_fields")
+	val, ok := entry["missing_fields"]
 	require.True(t, ok)
 	fields, isSlice := val.([]string)
 	require.True(t, isSlice, "missing_fields should be []string")
@@ -337,7 +338,7 @@ func TestSyncDNA_WarnLogContainsStewardIDAndMissingFields(t *testing.T) {
 // structurally succeeds) but leaves the DNA field nil and stores no durable record.
 func TestAcceptRegistration_RejectsDegenerateInitialDNA(t *testing.T) {
 	storage := newTestFleetStorage(t)
-	log := &logCapture{}
+	log := logging.NewCapturingLogger()
 	svc := NewControllerServiceWithStorage(log, storage)
 	ctx := context.Background()
 
@@ -362,9 +363,10 @@ func TestAcceptRegistration_RejectsDegenerateInitialDNA(t *testing.T) {
 	assert.Error(t, err, "no durable record should exist for degenerate initial DNA")
 
 	// WARN log emitted.
-	entry, found := log.findEntry("dna_integrity_rejected")
+	// CapturingLogger records only Warn/WarnCtx calls, so a hit here is itself
+	// proof the event was emitted at WARN level.
+	_, found := log.FindWarn("dna_integrity_rejected")
 	assert.True(t, found, "expected dna_integrity_rejected WARN log entry")
-	assert.Equal(t, "WARN", entry.level)
 }
 
 // TestAcceptRegistration_AcceptsValidInitialDNA verifies a registration with

--- a/pkg/logging/capturing.go
+++ b/pkg/logging/capturing.go
@@ -7,43 +7,108 @@ import (
 	"sync"
 )
 
-// WarnEntry records the key-value pairs emitted by a single Warn or WarnCtx call.
-type WarnEntry map[string]interface{}
+// LogEntry records the key-value pairs emitted by a single captured log call.
+type LogEntry map[string]interface{}
 
-// CapturingLogger is a Logger that records Warn/WarnCtx calls for inspection in
-// tests. Other log levels are silently discarded.
+// WarnEntry is the key-value record of a single Warn or WarnCtx call.
+type WarnEntry = LogEntry
+
+// InfoEntry is the key-value record of a single Info or InfoCtx call.
+type InfoEntry = LogEntry
+
+// CapturingLogger is a Logger that records Warn/WarnCtx and Info/InfoCtx calls
+// for inspection in tests. Other log levels are silently discarded.
 // Thread-safe; safe to share across goroutines in parallel tests.
 type CapturingLogger struct {
 	mu           sync.Mutex
 	WarnEntries  []WarnEntry // KV fields per Warn call
 	WarnMessages []string    // message text per Warn call (parallel slice to WarnEntries)
+	InfoEntries  []InfoEntry // KV fields per Info call
+	InfoMessages []string    // message text per Info call (parallel slice to InfoEntries)
 }
 
-// NewCapturingLogger returns a Logger that records Warn and WarnCtx calls.
+// NewCapturingLogger returns a Logger that records Warn/WarnCtx and Info/InfoCtx calls.
 func NewCapturingLogger() *CapturingLogger {
 	return &CapturingLogger{}
 }
 
-func (l *CapturingLogger) record(msg string, kv []interface{}) {
-	entry := make(WarnEntry, len(kv)/2)
+// toEntry converts a variadic key-value list into a LogEntry, dropping any pair
+// whose key is not a string.
+func toEntry(kv []interface{}) LogEntry {
+	entry := make(LogEntry, len(kv)/2)
 	for i := 0; i+1 < len(kv); i += 2 {
 		if key, ok := kv[i].(string); ok {
 			entry[key] = kv[i+1]
 		}
 	}
+	return entry
+}
+
+func (l *CapturingLogger) record(msg string, kv []interface{}) {
+	entry := toEntry(kv)
 	l.mu.Lock()
 	l.WarnEntries = append(l.WarnEntries, entry)
 	l.WarnMessages = append(l.WarnMessages, msg)
 	l.mu.Unlock()
 }
 
+func (l *CapturingLogger) recordInfo(msg string, kv []interface{}) {
+	entry := toEntry(kv)
+	l.mu.Lock()
+	l.InfoEntries = append(l.InfoEntries, entry)
+	l.InfoMessages = append(l.InfoMessages, msg)
+	l.mu.Unlock()
+}
+
+// FindWarn returns the fields of the first Warn/WarnCtx call whose message
+// equals msg (case-sensitive), and whether such a call was recorded.
+func (l *CapturingLogger) FindWarn(msg string) (LogEntry, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return findEntry(l.WarnMessages, l.WarnEntries, msg)
+}
+
+// FindInfo returns the fields of the first Info/InfoCtx call whose message
+// equals msg (case-sensitive), and whether such a call was recorded.
+func (l *CapturingLogger) FindInfo(msg string) (LogEntry, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return findEntry(l.InfoMessages, l.InfoEntries, msg)
+}
+
+// InfoCount returns the number of Info/InfoCtx calls recorded so far.
+func (l *CapturingLogger) InfoCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.InfoMessages)
+}
+
+// WarnCount returns the number of Warn/WarnCtx calls recorded so far.
+func (l *CapturingLogger) WarnCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.WarnMessages)
+}
+
+// findEntry locates msg in parallel message/entry slices. Callers hold the lock.
+func findEntry(messages []string, entries []LogEntry, msg string) (LogEntry, bool) {
+	for i, m := range messages {
+		if m == msg {
+			return entries[i], true
+		}
+	}
+	return nil, false
+}
+
 func (l *CapturingLogger) Debug(_ string, _ ...interface{})                       {}
-func (l *CapturingLogger) Info(_ string, _ ...interface{})                        {}
+func (l *CapturingLogger) Info(msg string, kv ...interface{})                     { l.recordInfo(msg, kv) }
 func (l *CapturingLogger) Warn(msg string, kv ...interface{})                     { l.record(msg, kv) }
 func (l *CapturingLogger) Error(_ string, _ ...interface{})                       {}
 func (l *CapturingLogger) Fatal(_ string, _ ...interface{})                       {}
 func (l *CapturingLogger) DebugCtx(_ context.Context, _ string, _ ...interface{}) {}
-func (l *CapturingLogger) InfoCtx(_ context.Context, _ string, _ ...interface{})  {}
+func (l *CapturingLogger) InfoCtx(_ context.Context, msg string, kv ...interface{}) {
+	l.recordInfo(msg, kv)
+}
 func (l *CapturingLogger) WarnCtx(_ context.Context, msg string, kv ...interface{}) {
 	l.record(msg, kv)
 }

--- a/pkg/logging/capturing_test.go
+++ b/pkg/logging/capturing_test.go
@@ -38,17 +38,81 @@ func TestCapturingLogger_RecordsWarnMessages(t *testing.T) {
 	assert.Equal(t, "second warning", l.WarnMessages[1])
 }
 
+func TestCapturingLogger_RecordsInfoEntries(t *testing.T) {
+	l := NewCapturingLogger()
+
+	l.Info("first info", "k1", "v1", "k2", 42)
+	l.InfoCtx(context.Background(), "second info", "k3", "v3")
+
+	require.Len(t, l.InfoEntries, 2, "must record one entry per Info/InfoCtx call")
+	require.Len(t, l.InfoMessages, 2, "InfoMessages must parallel InfoEntries")
+
+	assert.Equal(t, "first info", l.InfoMessages[0])
+	assert.Equal(t, "second info", l.InfoMessages[1])
+	assert.Equal(t, "v1", l.InfoEntries[0]["k1"])
+	assert.Equal(t, 42, l.InfoEntries[0]["k2"])
+	assert.Equal(t, "v3", l.InfoEntries[1]["k3"])
+}
+
+// TestCapturingLogger_InfoAndWarnAreSeparate proves levels do not bleed into one
+// another: the level of a captured call is unambiguous from which slice holds it.
+func TestCapturingLogger_InfoAndWarnAreSeparate(t *testing.T) {
+	l := NewCapturingLogger()
+
+	l.Info("audit event", "actor", "controller")
+	l.Warn("fallback event", "ring_value", "bogus")
+
+	assert.Len(t, l.InfoEntries, 1, "Info must not populate WarnEntries")
+	assert.Len(t, l.WarnEntries, 1, "Warn must not populate InfoEntries")
+	assert.Equal(t, []string{"audit event"}, l.InfoMessages)
+	assert.Equal(t, []string{"fallback event"}, l.WarnMessages)
+}
+
+func TestCapturingLogger_FindByMessage(t *testing.T) {
+	l := NewCapturingLogger()
+
+	l.Info("ring_set_changed", "actor", "controller", "after", "default=v1")
+	l.Warn("deployment_ring_fallback", "fallback_ring", "default")
+
+	info, ok := l.FindInfo("ring_set_changed")
+	require.True(t, ok, "FindInfo must locate a recorded Info call by message")
+	assert.Equal(t, "controller", info["actor"])
+	assert.Equal(t, "default=v1", info["after"])
+
+	warn, ok := l.FindWarn("deployment_ring_fallback")
+	require.True(t, ok, "FindWarn must locate a recorded Warn call by message")
+	assert.Equal(t, "default", warn["fallback_ring"])
+
+	_, ok = l.FindInfo("deployment_ring_fallback")
+	assert.False(t, ok, "FindInfo must not match a Warn-level message")
+	_, ok = l.FindWarn("ring_set_changed")
+	assert.False(t, ok, "FindWarn must not match an Info-level message")
+}
+
+func TestCapturingLogger_Counts(t *testing.T) {
+	l := NewCapturingLogger()
+
+	assert.Equal(t, 0, l.InfoCount())
+	assert.Equal(t, 0, l.WarnCount())
+
+	l.Info("one")
+	l.InfoCtx(context.Background(), "two")
+	l.Warn("three")
+
+	assert.Equal(t, 2, l.InfoCount())
+	assert.Equal(t, 1, l.WarnCount())
+}
+
 func TestCapturingLogger_DiscardsSilentLevels(t *testing.T) {
 	l := NewCapturingLogger()
 
 	l.Debug("debug msg")
-	l.Info("info msg")
 	l.Error("error msg")
 	l.DebugCtx(context.Background(), "debug ctx")
-	l.InfoCtx(context.Background(), "info ctx")
 	l.ErrorCtx(context.Background(), "error ctx")
 
 	assert.Empty(t, l.WarnEntries, "non-Warn levels must not populate WarnEntries")
+	assert.Empty(t, l.InfoEntries, "non-Info levels must not populate InfoEntries")
 }
 
 func TestCapturingLogger_EmptyKVProducesEmptyEntry(t *testing.T) {

--- a/pkg/storage/interfaces/business/steward_store.go
+++ b/pkg/storage/interfaces/business/steward_store.go
@@ -89,6 +89,10 @@ type StewardRecord struct {
 	// Status is the current lifecycle state of the steward.
 	Status StewardStatus `json:"status"`
 
+	// Hidden is the operator-controlled fleet-view visibility flag (Issue #2944).
+	// Orthogonal to Status: hiding a steward does not change its lifecycle state.
+	Hidden bool `json:"hidden"`
+
 	// RegisteredAt is the time the steward first registered.
 	RegisteredAt time.Time `json:"registered_at"`
 
@@ -165,6 +169,10 @@ type StewardStore interface {
 	// UpdateStewardStatus updates the lifecycle status of the given steward.
 	// Returns ErrStewardNotFound if no record exists.
 	UpdateStewardStatus(ctx context.Context, stewardID string, status StewardStatus) error
+
+	// SetStewardHidden sets the operator-controlled visibility flag for the given steward.
+	// Returns ErrStewardNotFound if no record exists.
+	SetStewardHidden(ctx context.Context, stewardID string, hidden bool) error
 
 	// UpdateStewardTenant moves a steward to a different tenant.
 	// Returns ErrStewardNotFound if no record exists for stewardID.

--- a/pkg/storage/interfaces/export_test.go
+++ b/pkg/storage/interfaces/export_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package interfaces
+
+// This file exports the provider registry's internal state to the external
+// interfaces_test package. Registry tests must run against real storage
+// providers, and importing pkg/storage/providers/* from inside this package
+// would form an import cycle (providers import this package). The external
+// interfaces_test package has no such restriction, so the registry tests live
+// there and reach the unexported registry through these two helpers.
+
+// RegistrySnapshot returns a copy of the currently registered providers.
+func RegistrySnapshot() map[string]StorageProvider {
+	globalRegistry.mutex.RLock()
+	defer globalRegistry.mutex.RUnlock()
+
+	out := make(map[string]StorageProvider, len(globalRegistry.providers))
+	for name, provider := range globalRegistry.providers {
+		out[name] = provider
+	}
+	return out
+}
+
+// RegistryReplace replaces the registry contents with a copy of providers.
+func RegistryReplace(providers map[string]StorageProvider) {
+	next := make(map[string]StorageProvider, len(providers))
+	for name, provider := range providers {
+		next[name] = provider
+	}
+
+	globalRegistry.mutex.Lock()
+	defer globalRegistry.mutex.Unlock()
+	globalRegistry.providers = next
+}

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -9,6 +9,7 @@ package interfaces
 import (
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -196,6 +197,27 @@ func ValidateProvider(provider StorageProvider) error {
 	return nil
 }
 
+// validateStoreCreation creates a store purely to prove that create(testConfig)
+// succeeds, then closes it immediately — the store is never returned to a
+// caller. Left open, each of these holds its own backing handle (e.g. a
+// sqlite *sql.DB); on Windows an unclosed handle keeps the underlying file
+// locked, which fails a later cleanup (e.g. t.TempDir()) with "the process
+// cannot access the file because it is being used by another process" even
+// though nothing was ever using the store (Issue #2944, PR #3254 CI failure).
+func validateStoreCreation[T io.Closer](name string, testConfig map[string]interface{}, create func(map[string]interface{}) (T, error)) error {
+	store, err := create(testConfig)
+	if err != nil {
+		if errors.Is(err, business.ErrNotSupported) {
+			return nil
+		}
+		return fmt.Errorf("failed to create %s: %w", name, err)
+	}
+	if err := store.Close(); err != nil {
+		getRegistryLogger().Warn(fmt.Sprintf("failed to close validation %s: %v", name, err))
+	}
+	return nil
+}
+
 // RegisterStorageProviderWithValidation registers a provider with full validation.
 // This is an enhanced version that tests interface creation with a test config.
 func RegisterStorageProviderWithValidation(provider StorageProvider, testConfig map[string]interface{}) error {
@@ -204,36 +226,36 @@ func RegisterStorageProviderWithValidation(provider StorageProvider, testConfig 
 	}
 
 	if available, _ := provider.Available(); available {
-		if _, err := provider.CreateClientTenantStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
-			return fmt.Errorf("failed to create ClientTenantStore: %w", err)
+		if err := validateStoreCreation("ClientTenantStore", testConfig, provider.CreateClientTenantStore); err != nil {
+			return err
 		}
 
 		if _, err := provider.CreateConfigStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
 			return fmt.Errorf("failed to create ConfigStore: %w", err)
 		}
 
-		if _, err := provider.CreateAuditStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
-			return fmt.Errorf("failed to create AuditStore: %w", err)
+		if err := validateStoreCreation("AuditStore", testConfig, provider.CreateAuditStore); err != nil {
+			return err
 		}
 
-		if _, err := provider.CreateRBACStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
-			return fmt.Errorf("failed to create RBACStore: %w", err)
+		if err := validateStoreCreation("RBACStore", testConfig, provider.CreateRBACStore); err != nil {
+			return err
 		}
 
-		if _, err := provider.CreateTenantStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
-			return fmt.Errorf("failed to create TenantStore: %w", err)
+		if err := validateStoreCreation("TenantStore", testConfig, provider.CreateTenantStore); err != nil {
+			return err
 		}
 
-		if _, err := provider.CreateRegistrationTokenStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
-			return fmt.Errorf("failed to create RegistrationTokenStore: %w", err)
+		if err := validateStoreCreation("RegistrationTokenStore", testConfig, provider.CreateRegistrationTokenStore); err != nil {
+			return err
 		}
 
-		if _, err := provider.CreateStewardStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
-			return fmt.Errorf("failed to create StewardStore: %w", err)
+		if err := validateStoreCreation("StewardStore", testConfig, provider.CreateStewardStore); err != nil {
+			return err
 		}
 
-		if _, err := provider.CreateTriggerStore(testConfig); err != nil && !errors.Is(err, business.ErrNotSupported) {
-			return fmt.Errorf("failed to create TriggerStore: %w", err)
+		if err := validateStoreCreation("TriggerStore", testConfig, provider.CreateTriggerStore); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -142,29 +142,23 @@ func RegisterStorageProvider(provider StorageProvider) {
 		"description", provider.Description())
 }
 
-// ValidateProvider ensures a provider implements all required interfaces correctly.
-func ValidateProvider(provider StorageProvider) error {
-	if provider == nil {
-		return fmt.Errorf("provider is nil")
-	}
-
-	if provider.Name() == "" {
+// ValidateProviderMetadata applies the registration rules to a provider's
+// declared metadata. It is separated from ValidateProvider so the rules can be
+// evaluated (and exercised) against provider metadata as plain data, without an
+// implementation of the StorageProvider interface.
+func ValidateProviderMetadata(name, description, version string, capabilities ProviderCapabilities) error {
+	if name == "" {
 		return fmt.Errorf("provider name cannot be empty")
 	}
 
-	if provider.Description() == "" {
+	if description == "" {
 		return fmt.Errorf("provider description cannot be empty")
 	}
 
-	if provider.GetVersion() == "" {
+	if version == "" {
 		return fmt.Errorf("provider version cannot be empty")
 	}
 
-	if available, err := provider.Available(); !available && err != nil {
-		getRegistryLogger().Info(fmt.Sprintf("Note: Provider '%s' reports as unavailable: %v", provider.Name(), err))
-	}
-
-	capabilities := provider.GetCapabilities()
 	if capabilities.MaxBatchSize < 0 {
 		return fmt.Errorf("provider MaxBatchSize cannot be negative")
 	}
@@ -175,6 +169,28 @@ func ValidateProvider(provider StorageProvider) error {
 
 	if capabilities.MaxAuditRetentionDays < 0 {
 		return fmt.Errorf("provider MaxAuditRetentionDays cannot be negative")
+	}
+
+	return nil
+}
+
+// ValidateProvider ensures a provider implements all required interfaces correctly.
+func ValidateProvider(provider StorageProvider) error {
+	if provider == nil {
+		return fmt.Errorf("provider is nil")
+	}
+
+	if err := ValidateProviderMetadata(
+		provider.Name(),
+		provider.Description(),
+		provider.GetVersion(),
+		provider.GetCapabilities(),
+	); err != nil {
+		return err
+	}
+
+	if available, err := provider.Available(); !available && err != nil {
+		getRegistryLogger().Info(fmt.Sprintf("Note: Provider '%s' reports as unavailable: %v", provider.Name(), err))
 	}
 
 	return nil

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -1,694 +1,184 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026 Jordan Ritz
-package interfaces
+
+// These tests exercise the storage provider registry and the storage-manager
+// factories against the real OSS providers (flat-file and SQLite). They live in
+// the external interfaces_test package because pkg/storage/providers/* imports
+// pkg/storage/interfaces — an in-package test cannot import a real provider
+// without forming an import cycle. Registry internals are reached through the
+// RegistrySnapshot / RegistryReplace helpers in export_test.go.
+package interfaces_test
 
 import (
 	"context"
-	"fmt"
-	"sync"
+	"os"
+	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
-// testLogEntry captures a single log call for test assertions.
-type testLogEntry struct {
-	Message string
-	Data    []interface{}
+// withEmptyRegistry empties the global provider registry for the duration of the
+// test and restores the original contents on cleanup.
+func withEmptyRegistry(t *testing.T) {
+	t.Helper()
+	original := interfaces.RegistrySnapshot()
+	interfaces.RegistryReplace(nil)
+	t.Cleanup(func() { interfaces.RegistryReplace(original) })
 }
 
-// testMockLogger captures log calls for assertion without importing pkg/testing
-// (which would create an import cycle via pkg/testing/storage_helper.go).
-type testMockLogger struct {
-	mu   sync.Mutex
-	logs map[string][]testLogEntry
-}
-
-func newTestMockLogger() *testMockLogger {
-	return &testMockLogger{logs: map[string][]testLogEntry{
-		"debug": {}, "info": {}, "warn": {}, "error": {}, "fatal": {},
-	}}
-}
-
-func (l *testMockLogger) record(level, msg string, kv []interface{}) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.logs[level] = append(l.logs[level], testLogEntry{Message: msg, Data: kv})
-}
-
-func (l *testMockLogger) GetLogs(level string) []testLogEntry {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.logs[level]
-}
-
-func (l *testMockLogger) Debug(msg string, kv ...interface{}) { l.record("debug", msg, kv) }
-func (l *testMockLogger) Info(msg string, kv ...interface{})  { l.record("info", msg, kv) }
-func (l *testMockLogger) Warn(msg string, kv ...interface{})  { l.record("warn", msg, kv) }
-func (l *testMockLogger) Error(msg string, kv ...interface{}) { l.record("error", msg, kv) }
-func (l *testMockLogger) Fatal(msg string, kv ...interface{}) { l.record("fatal", msg, kv) }
-func (l *testMockLogger) DebugCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("debug", msg, kv)
-}
-func (l *testMockLogger) InfoCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("info", msg, kv)
-}
-func (l *testMockLogger) WarnCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("warn", msg, kv)
-}
-func (l *testMockLogger) ErrorCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("error", msg, kv)
-}
-func (l *testMockLogger) FatalCtx(_ context.Context, msg string, kv ...interface{}) {
-	l.record("fatal", msg, kv)
-}
-
-var _ logging.Logger = (*testMockLogger)(nil)
-
-// MockStorageProvider implements StorageProvider for testing
-type MockStorageProvider struct {
-	MockName         string
-	MockDescription  string
-	MockVersion      string
-	MockAvailable    bool
-	MockAvailableErr error
-	MockCapabilities ProviderCapabilities
-}
-
-func NewMockStorageProvider() *MockStorageProvider {
-	return &MockStorageProvider{
-		MockName:        "mock",
-		MockDescription: "Mock storage provider for testing",
-		MockVersion:     "1.0.0",
-		MockAvailable:   true,
-		MockCapabilities: ProviderCapabilities{
-			SupportsTransactions:   true,
-			SupportsVersioning:     true,
-			SupportsFullTextSearch: false,
-			SupportsEncryption:     true,
-			SupportsCompression:    false,
-			SupportsReplication:    false,
-			SupportsSharding:       false,
-			MaxBatchSize:           100,
-			MaxConfigSize:          1024 * 1024, // 1MB
-			MaxAuditRetentionDays:  365,
-		},
-	}
-}
-
-func (m *MockStorageProvider) Name() string {
-	return m.MockName
-}
-
-func (m *MockStorageProvider) Description() string {
-	return m.MockDescription
-}
-
-func (m *MockStorageProvider) GetVersion() string {
-	return m.MockVersion
-}
-
-func (m *MockStorageProvider) Available() (bool, error) {
-	return m.MockAvailable, m.MockAvailableErr
-}
-
-func (m *MockStorageProvider) GetCapabilities() ProviderCapabilities {
-	return m.MockCapabilities
-}
-
-func (m *MockStorageProvider) ClusterCapable() bool { return false }
-
-func (m *MockStorageProvider) CreateClientTenantStore(_ map[string]interface{}) (business.ClientTenantStore, error) {
-	return newMockClientTenantStore(), nil
-}
-
-func (m *MockStorageProvider) CreateConfigStore(_ map[string]interface{}) (cfgconfig.ConfigStore, error) {
-	return &MockConfigStore{}, nil
-}
-
-func (m *MockStorageProvider) CreateAuditStore(_ map[string]interface{}) (business.AuditStore, error) {
-	return &MockAuditStore{}, nil
-}
-
-func (m *MockStorageProvider) CreateRBACStore(_ map[string]interface{}) (business.RBACStore, error) {
-	return &MockRBACStore{}, nil
-}
-
-func (m *MockStorageProvider) CreateTenantStore(_ map[string]interface{}) (business.TenantStore, error) {
-	return &MockTenantStore{}, nil
-}
-
-func (m *MockStorageProvider) CreateRegistrationTokenStore(_ map[string]interface{}) (business.RegistrationTokenStore, error) {
-	return &MockRegistrationTokenStore{}, nil
-}
-
-func (m *MockStorageProvider) CreateSessionStore(_ map[string]interface{}) (business.SessionStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockStorageProvider) CreateStewardStore(_ map[string]interface{}) (business.StewardStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockStorageProvider) CreateCommandStore(_ map[string]interface{}) (business.CommandStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockStorageProvider) CreateTriggerStore(_ map[string]interface{}) (business.TriggerStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockStorageProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockStorageProvider) CreatePendingRegistrationStore(_ map[string]interface{}) (business.PendingRegistrationStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockStorageProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-// Mock implementations of store interfaces
-type MockClientTenantStore struct {
-	tenants map[string]*business.ClientTenant
-}
-
-func newMockClientTenantStore() *MockClientTenantStore {
-	return &MockClientTenantStore{tenants: make(map[string]*business.ClientTenant)}
-}
-
-func (m *MockClientTenantStore) StoreClientTenant(ct *business.ClientTenant) error {
-	m.tenants[ct.ID] = ct
-	return nil
-}
-func (m *MockClientTenantStore) GetClientTenant(id string) (*business.ClientTenant, error) {
-	ct, ok := m.tenants[id]
-	if !ok {
-		return nil, business.ErrTenantNotFound
-	}
-	return ct, nil
-}
-func (m *MockClientTenantStore) GetClientTenantByIdentifier(_ string) (*business.ClientTenant, error) {
-	return nil, business.ErrTenantNotFound
-}
-func (m *MockClientTenantStore) ListClientTenants(_ business.ClientTenantStatus) ([]*business.ClientTenant, error) {
-	return nil, nil
-}
-func (m *MockClientTenantStore) UpdateClientTenantStatus(_ string, _ business.ClientTenantStatus) error {
-	return nil
-}
-func (m *MockClientTenantStore) DeleteClientTenant(_ string) error { return nil }
-func (m *MockClientTenantStore) StoreAdminConsentRequest(_ *business.AdminConsentRequest) error {
-	return nil
-}
-func (m *MockClientTenantStore) GetAdminConsentRequest(_ string) (*business.AdminConsentRequest, error) {
-	return nil, business.ErrTenantNotFound
-}
-func (m *MockClientTenantStore) DeleteAdminConsentRequest(_ string) error { return nil }
-func (m *MockClientTenantStore) Close() error                             { return nil }
-
-type MockConfigStore struct{}
-
-func (m *MockConfigStore) StoreConfig(_ context.Context, _ *cfgconfig.ConfigEntry) error {
-	return nil
-}
-func (m *MockConfigStore) GetConfig(_ context.Context, _ *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
-	return nil, cfgconfig.ErrConfigNotFound
-}
-func (m *MockConfigStore) DeleteConfig(_ context.Context, _ *cfgconfig.ConfigKey) error { return nil }
-func (m *MockConfigStore) ListConfigs(_ context.Context, _ *cfgconfig.ConfigFilter) ([]*cfgconfig.ConfigEntry, error) {
-	return nil, nil
-}
-func (m *MockConfigStore) GetConfigHistory(_ context.Context, _ *cfgconfig.ConfigKey, _ int) ([]*cfgconfig.ConfigEntry, error) {
-	return nil, nil
-}
-func (m *MockConfigStore) GetConfigVersion(_ context.Context, _ *cfgconfig.ConfigKey, _ int64) (*cfgconfig.ConfigEntry, error) {
-	return nil, cfgconfig.ErrConfigNotFound
-}
-func (m *MockConfigStore) StoreConfigBatch(_ context.Context, _ []*cfgconfig.ConfigEntry) error {
-	return nil
-}
-func (m *MockConfigStore) DeleteConfigBatch(_ context.Context, _ []*cfgconfig.ConfigKey) error {
-	return nil
-}
-func (m *MockConfigStore) ResolveConfigWithInheritance(_ context.Context, _ *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
-	return nil, cfgconfig.ErrConfigNotFound
-}
-func (m *MockConfigStore) ValidateConfig(_ context.Context, _ *cfgconfig.ConfigEntry) error {
-	return nil
-}
-func (m *MockConfigStore) GetConfigStats(_ context.Context) (*cfgconfig.ConfigStats, error) {
-	return &cfgconfig.ConfigStats{}, nil
-}
-
-type MockAuditStore struct{}
-
-func (m *MockAuditStore) StoreAuditEntry(_ context.Context, _ *business.AuditEntry) error {
-	return nil
-}
-func (m *MockAuditStore) GetAuditEntry(_ context.Context, _ string) (*business.AuditEntry, error) {
-	return nil, business.ErrAuditNotFound
-}
-func (m *MockAuditStore) ListAuditEntries(_ context.Context, _ *business.AuditFilter) ([]*business.AuditEntry, error) {
-	return nil, nil
-}
-func (m *MockAuditStore) StoreAuditBatch(_ context.Context, _ []*business.AuditEntry) error {
-	return nil
-}
-func (m *MockAuditStore) GetAuditsByUser(_ context.Context, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
-	return nil, nil
-}
-func (m *MockAuditStore) GetAuditsByResource(_ context.Context, _, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
-	return nil, nil
-}
-func (m *MockAuditStore) GetAuditsByAction(_ context.Context, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
-	return nil, nil
-}
-func (m *MockAuditStore) GetFailedActions(_ context.Context, _ *business.TimeRange, _ int) ([]*business.AuditEntry, error) {
-	return nil, nil
-}
-func (m *MockAuditStore) GetSuspiciousActivity(_ context.Context, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
-	return nil, nil
-}
-func (m *MockAuditStore) GetAuditStats(_ context.Context) (*business.AuditStats, error) {
-	return &business.AuditStats{}, nil
-}
-func (m *MockAuditStore) ArchiveAuditEntries(_ context.Context, _ time.Time) (int64, error) {
-	return 0, nil
-}
-func (m *MockAuditStore) PurgeAuditEntries(_ context.Context, _ time.Time) (int64, error) {
-	return 0, nil
-}
-
-// GetLastAuditEntry returns nil to satisfy the AuditStore interface. This stub
-// exists because importing a real provider here would create a circular dependency:
-// interfaces_test → pkg/storage/providers/flatfile → pkg/storage/interfaces.
-// Chain integrity is tested end-to-end in pkg/audit/manager_test.go.
-func (m *MockAuditStore) GetLastAuditEntry(_ context.Context, _ string) (*business.AuditEntry, error) {
-	return nil, nil
-}
-func (m *MockAuditStore) Close() error { return nil }
-
-type MockRBACStore struct{}
-
-func (m *MockRBACStore) StorePermission(_ context.Context, _ *common.Permission) error {
-	return nil
-}
-func (m *MockRBACStore) GetPermission(_ context.Context, _ string) (*common.Permission, error) {
-	return nil, fmt.Errorf("permission not found")
-}
-func (m *MockRBACStore) ListPermissions(_ context.Context, _ string) ([]*common.Permission, error) {
-	return nil, nil
-}
-func (m *MockRBACStore) UpdatePermission(_ context.Context, _ *common.Permission) error {
-	return nil
-}
-func (m *MockRBACStore) DeletePermission(_ context.Context, _ string) error { return nil }
-func (m *MockRBACStore) StoreRole(_ context.Context, _ *common.Role) error  { return nil }
-func (m *MockRBACStore) GetRole(_ context.Context, _ string) (*common.Role, error) {
-	return nil, fmt.Errorf("role not found")
-}
-func (m *MockRBACStore) ListRoles(_ context.Context, _ string) ([]*common.Role, error) {
-	return nil, nil
-}
-func (m *MockRBACStore) UpdateRole(_ context.Context, _ *common.Role) error      { return nil }
-func (m *MockRBACStore) DeleteRole(_ context.Context, _ string) error            { return nil }
-func (m *MockRBACStore) StoreSubject(_ context.Context, _ *common.Subject) error { return nil }
-func (m *MockRBACStore) GetSubject(_ context.Context, _ string) (*common.Subject, error) {
-	return nil, fmt.Errorf("subject not found")
-}
-func (m *MockRBACStore) ListSubjects(_ context.Context, _ string, _ common.SubjectType) ([]*common.Subject, error) {
-	return nil, nil
-}
-func (m *MockRBACStore) UpdateSubject(_ context.Context, _ *common.Subject) error { return nil }
-func (m *MockRBACStore) DeleteSubject(_ context.Context, _ string) error          { return nil }
-func (m *MockRBACStore) StoreRoleAssignment(_ context.Context, _ *common.RoleAssignment) error {
-	return nil
-}
-func (m *MockRBACStore) GetRoleAssignment(_ context.Context, _ string) (*common.RoleAssignment, error) {
-	return nil, fmt.Errorf("assignment not found")
-}
-func (m *MockRBACStore) ListRoleAssignments(_ context.Context, _, _, _ string) ([]*common.RoleAssignment, error) {
-	return nil, nil
-}
-func (m *MockRBACStore) DeleteRoleAssignment(_ context.Context, _, _, _ string) error {
-	return nil
-}
-func (m *MockRBACStore) StoreBulkPermissions(_ context.Context, _ []*common.Permission) error {
-	return nil
-}
-func (m *MockRBACStore) StoreBulkRoles(_ context.Context, _ []*common.Role) error { return nil }
-func (m *MockRBACStore) StoreBulkSubjects(_ context.Context, _ []*common.Subject) error {
-	return nil
-}
-func (m *MockRBACStore) GetSubjectRoles(_ context.Context, _, _ string) ([]*common.Role, error) {
-	return nil, nil
-}
-func (m *MockRBACStore) GetRolePermissions(_ context.Context, _ string) ([]*common.Permission, error) {
-	return nil, nil
-}
-func (m *MockRBACStore) GetSubjectAssignments(_ context.Context, _, _ string) ([]*common.RoleAssignment, error) {
-	return nil, nil
-}
-func (m *MockRBACStore) Initialize(_ context.Context) error { return nil }
-func (m *MockRBACStore) Close() error                       { return nil }
-
-// MockTenantStore implements business.TenantStore for testing
-type MockTenantStore struct{}
-
-func (m *MockTenantStore) CreateTenant(_ context.Context, _ *business.TenantData) error { return nil }
-func (m *MockTenantStore) GetTenant(_ context.Context, tenantID string) (*business.TenantData, error) {
-	return &business.TenantData{ID: tenantID, Name: "Test Tenant"}, nil
-}
-func (m *MockTenantStore) UpdateTenant(_ context.Context, _ *business.TenantData) error { return nil }
-func (m *MockTenantStore) DeleteTenant(_ context.Context, _ string) error               { return nil }
-func (m *MockTenantStore) ListTenants(_ context.Context, _ *business.TenantFilter) ([]*business.TenantData, error) {
-	return nil, nil
-}
-func (m *MockTenantStore) GetTenantHierarchy(_ context.Context, tenantID string) (*business.TenantHierarchy, error) {
-	return &business.TenantHierarchy{TenantID: tenantID}, nil
-}
-func (m *MockTenantStore) GetChildTenants(_ context.Context, _ string) ([]*business.TenantData, error) {
-	return nil, nil
-}
-func (m *MockTenantStore) GetTenantPath(_ context.Context, tenantID string) ([]string, error) {
-	return []string{tenantID}, nil
-}
-func (m *MockTenantStore) IsTenantAncestor(_ context.Context, _, _ string) (bool, error) {
-	return false, nil
-}
-func (m *MockTenantStore) Initialize(_ context.Context) error { return nil }
-func (m *MockTenantStore) Close() error                       { return nil }
-
-// MockRegistrationTokenStore implements business.RegistrationTokenStore for testing
-type MockRegistrationTokenStore struct{}
-
-func (m *MockRegistrationTokenStore) SaveToken(_ context.Context, _ *business.RegistrationTokenData) error {
-	return nil
-}
-func (m *MockRegistrationTokenStore) GetToken(_ context.Context, _ string) (*business.RegistrationTokenData, error) {
-	return nil, fmt.Errorf("token not found")
-}
-func (m *MockRegistrationTokenStore) GetTokenByID(_ context.Context, _ string) (*business.RegistrationTokenData, error) {
-	return nil, fmt.Errorf("registration token not found")
-}
-func (m *MockRegistrationTokenStore) UpdateToken(_ context.Context, _ *business.RegistrationTokenData) error {
-	return nil
-}
-func (m *MockRegistrationTokenStore) DeleteToken(_ context.Context, _ string) error {
-	return nil
-}
-func (m *MockRegistrationTokenStore) ListTokens(_ context.Context, _ *business.RegistrationTokenFilter) ([]*business.RegistrationTokenData, error) {
-	return nil, nil
-}
-func (m *MockRegistrationTokenStore) RotateToken(_ context.Context, _, _ string) (*business.RegistrationTokenData, error) {
-	return nil, nil
-}
-func (m *MockRegistrationTokenStore) Initialize(_ context.Context) error { return nil }
-func (m *MockRegistrationTokenStore) Close() error                       { return nil }
-
-// MockStewardStore implements business.StewardStore for testing
-type MockStewardStore struct{}
-
-func (m *MockStewardStore) RegisterSteward(_ context.Context, _ *business.StewardRecord) error {
-	return nil
-}
-func (m *MockStewardStore) UpdateHeartbeat(_ context.Context, _ string) error { return nil }
-func (m *MockStewardStore) GetSteward(_ context.Context, _ string) (*business.StewardRecord, error) {
-	return nil, business.ErrStewardNotFound
-}
-func (m *MockStewardStore) ListStewards(_ context.Context) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (m *MockStewardStore) ListStewardsByStatus(_ context.Context, _ business.StewardStatus) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (m *MockStewardStore) UpdateStewardStatus(_ context.Context, _ string, _ business.StewardStatus) error {
-	return nil
-}
-func (m *MockStewardStore) DeregisterSteward(_ context.Context, _ string) error { return nil }
-func (m *MockStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
-	return nil, nil
-}
-func (m *MockStewardStore) GetStewardByDeviceID(_ context.Context, _ string) (*business.StewardRecord, error) {
-	return nil, business.ErrStewardNotFound
-}
-func (m *MockStewardStore) UpdateStewardTenant(_ context.Context, _, _ string) error { return nil }
-func (m *MockStewardStore) HealthCheck(_ context.Context) error                      { return nil }
-func (m *MockStewardStore) Initialize(_ context.Context) error                       { return nil }
-func (m *MockStewardStore) Close() error                                             { return nil }
-
-// MockSessionStore implements business.SessionStore for testing
-type MockSessionStore struct{}
-
-func (m *MockSessionStore) CreateSession(_ context.Context, _ *business.Session) error { return nil }
-func (m *MockSessionStore) GetSession(_ context.Context, _ string) (*business.Session, error) {
-	return nil, fmt.Errorf("not found")
-}
-func (m *MockSessionStore) UpdateSession(_ context.Context, _ string, _ *business.Session) error {
-	return nil
-}
-func (m *MockSessionStore) DeleteSession(_ context.Context, _ string) error { return nil }
-func (m *MockSessionStore) ListSessions(_ context.Context, _ *business.SessionFilter) ([]*business.Session, error) {
-	return nil, nil
-}
-func (m *MockSessionStore) SetSessionTTL(_ context.Context, _ string, _ time.Duration) error {
-	return nil
-}
-func (m *MockSessionStore) CleanupExpiredSessions(_ context.Context) (int, error) { return 0, nil }
-func (m *MockSessionStore) GetSessionsByUser(_ context.Context, _ string) ([]*business.Session, error) {
-	return nil, nil
-}
-func (m *MockSessionStore) GetSessionsByTenant(_ context.Context, _ string) ([]*business.Session, error) {
-	return nil, nil
-}
-func (m *MockSessionStore) GetSessionsByType(_ context.Context, _ business.SessionType) ([]*business.Session, error) {
-	return nil, nil
-}
-func (m *MockSessionStore) GetActiveSessionsCount(_ context.Context) (int64, error) { return 0, nil }
-func (m *MockSessionStore) HealthCheck(_ context.Context) error                     { return nil }
-func (m *MockSessionStore) GetStats(_ context.Context) (*business.RuntimeStoreStats, error) {
-	return &business.RuntimeStoreStats{}, nil
-}
-func (m *MockSessionStore) Initialize(_ context.Context) error { return nil }
-func (m *MockSessionStore) Close() error                       { return nil }
-
-// MockCommandStore implements business.CommandStore for testing
-type MockCommandStore struct{}
-
-func (m *MockCommandStore) CreateCommandRecord(_ context.Context, _ *business.CommandRecord) error {
-	return nil
-}
-func (m *MockCommandStore) UpdateCommandStatus(_ context.Context, _ string, _ business.CommandStatus, _ map[string]interface{}, _ string) error {
-	return nil
-}
-func (m *MockCommandStore) GetCommandRecord(_ context.Context, _ string) (*business.CommandRecord, error) {
-	return nil, fmt.Errorf("not found")
-}
-func (m *MockCommandStore) ListCommandRecords(_ context.Context, _ *business.CommandFilter) ([]*business.CommandRecord, error) {
-	return nil, nil
-}
-func (m *MockCommandStore) ListCommandsByDevice(_ context.Context, _ string) ([]*business.CommandRecord, error) {
-	return nil, nil
-}
-func (m *MockCommandStore) ListCommandsByStatus(_ context.Context, _ business.CommandStatus) ([]*business.CommandRecord, error) {
-	return nil, nil
-}
-func (m *MockCommandStore) GetCommandAuditTrail(_ context.Context, _ string) ([]*business.CommandTransition, error) {
-	return nil, nil
-}
-func (m *MockCommandStore) PurgeExpiredRecords(_ context.Context, _ time.Time) (int64, error) {
-	return 0, nil
-}
-func (m *MockCommandStore) HealthCheck(_ context.Context) error { return nil }
-func (m *MockCommandStore) Close() error                        { return nil }
-
-// MockPushStore implements business.PushStore for testing
-type MockPushStore struct{}
-
-func (m *MockPushStore) CreatePush(_ context.Context, _ *business.PushRecord) error {
-	return nil
-}
-func (m *MockPushStore) UpdatePushStatus(_ context.Context, _ string, _ business.PushStatus) error {
-	return nil
-}
-func (m *MockPushStore) GetPendingPushes(_ context.Context) ([]*business.PushRecord, error) {
-	return nil, nil
-}
-func (m *MockPushStore) GetPush(_ context.Context, _ string) (*business.PushRecord, error) {
-	return nil, nil
-}
-func (m *MockPushStore) ListPushesByConfigID(_ context.Context, _, _ string) ([]*business.PushRecord, error) {
-	return []*business.PushRecord{}, nil
-}
-
-// MockIPTrustStore implements business.IPTrustStore for testing
-type MockIPTrustStore struct{}
-
-func (m *MockIPTrustStore) AddTrustedRange(_ context.Context, _, _ string, _ bool) error {
-	return nil
-}
-func (m *MockIPTrustStore) IsTrusted(_ context.Context, _, _ string) (bool, error) {
-	return false, nil
-}
-func (m *MockIPTrustStore) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
-	return nil, nil
-}
-func (m *MockIPTrustStore) RevokeTrustedRange(_ context.Context, _, _ string) error {
-	return business.ErrIPTrustEntryNotFound
-}
-func (m *MockIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
-	return nil
-}
-func (m *MockIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
-	return nil, nil
+// ossConfigs returns per-test provider configurations: a flat-file root and a
+// SQLite database file, both under t.TempDir().
+func ossConfigs(t *testing.T) (flatfileCfg, sqliteCfg map[string]interface{}) {
+	t.Helper()
+	return map[string]interface{}{"root": t.TempDir()},
+		map[string]interface{}{"path": filepath.Join(t.TempDir(), "test.db")}
 }
 
 // Test provider registration
 func TestRegisterStorageProvider(t *testing.T) {
-	// Clear registry for test
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
+	withEmptyRegistry(t)
 
-	// Clear registry
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
-
-	defer func() {
-		// Restore original providers
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
-
-	provider := NewMockStorageProvider()
-	RegisterStorageProvider(provider)
+	provider := newFlatFileProvider()
+	interfaces.RegisterStorageProvider(provider)
 
 	// Verify registration
-	names := GetRegisteredProviderNames()
-	if len(names) != 1 || names[0] != "mock" {
-		t.Errorf("Expected provider 'mock' to be registered, got: %v", names)
+	names := interfaces.GetRegisteredProviderNames()
+	if len(names) != 1 || names[0] != "flatfile" {
+		t.Errorf("Expected provider 'flatfile' to be registered, got: %v", names)
 	}
 
 	// Test getting the provider
-	retrieved, err := GetStorageProvider("mock")
+	retrieved, err := interfaces.GetStorageProvider("flatfile")
 	if err != nil {
 		t.Errorf("Failed to get registered provider: %v", err)
 	}
 
-	if retrieved.Name() != "mock" {
-		t.Errorf("Expected provider name 'mock', got: %s", retrieved.Name())
+	if retrieved.Name() != "flatfile" {
+		t.Errorf("Expected provider name 'flatfile', got: %s", retrieved.Name())
 	}
 }
 
 func TestRegisterStorageProviderWithValidation(t *testing.T) {
-	// Clear registry for test
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
+	withEmptyRegistry(t)
 
-	// Clear registry
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
+	_, sqliteCfg := ossConfigs(t)
 
-	defer func() {
-		// Restore original providers
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
-
-	provider := NewMockStorageProvider()
-	testConfig := map[string]interface{}{
-		"test": "config",
-	}
-
-	err := RegisterStorageProviderWithValidation(provider, testConfig)
+	err := interfaces.RegisterStorageProviderWithValidation(newSQLiteProvider(), sqliteCfg)
 	if err != nil {
 		t.Errorf("Failed to register provider with validation: %v", err)
 	}
 
 	// Verify registration
-	names := GetRegisteredProviderNames()
-	if len(names) != 1 || names[0] != "mock" {
-		t.Errorf("Expected provider 'mock' to be registered, got: %v", names)
+	names := interfaces.GetRegisteredProviderNames()
+	if len(names) != 1 || names[0] != "sqlite" {
+		t.Errorf("Expected provider 'sqlite' to be registered, got: %v", names)
 	}
 }
 
+// TestValidateProvider verifies that the real OSS providers satisfy the
+// registration rules and that a nil provider is rejected.
 func TestValidateProvider(t *testing.T) {
+	providers := map[string]interfaces.StorageProvider{
+		"flatfile": newFlatFileProvider(),
+		"sqlite":   newSQLiteProvider(),
+	}
+	for name, provider := range providers {
+		t.Run(name+" is valid", func(t *testing.T) {
+			require.NoError(t, interfaces.ValidateProvider(provider))
+		})
+	}
+
+	t.Run("nil provider is rejected", func(t *testing.T) {
+		require.Error(t, interfaces.ValidateProvider(nil))
+	})
+}
+
+// TestValidateProviderMetadata covers the registration rules a provider's
+// declared metadata must satisfy. The rules are evaluated as data, so no
+// implementation of StorageProvider is needed to reach the rejection paths.
+func TestValidateProviderMetadata(t *testing.T) {
+	validCaps := interfaces.ProviderCapabilities{
+		MaxBatchSize:          100,
+		MaxConfigSize:         1024 * 1024,
+		MaxAuditRetentionDays: 365,
+	}
+
 	tests := []struct {
-		name        string
-		provider    *MockStorageProvider
-		expectError bool
+		name         string
+		providerName string
+		description  string
+		version      string
+		capabilities interfaces.ProviderCapabilities
+		expectError  bool
 	}{
 		{
-			name:        "valid provider",
-			provider:    NewMockStorageProvider(),
-			expectError: false,
+			name:         "valid metadata",
+			providerName: "test",
+			description:  "test provider",
+			version:      "1.0.0",
+			capabilities: validCaps,
+			expectError:  false,
 		},
 		{
-			name: "empty name",
-			provider: &MockStorageProvider{
-				MockName:        "",
-				MockDescription: "test",
-				MockVersion:     "1.0.0",
-				MockAvailable:   true,
-			},
-			expectError: true,
+			name:         "empty name",
+			providerName: "",
+			description:  "test",
+			version:      "1.0.0",
+			capabilities: validCaps,
+			expectError:  true,
 		},
 		{
-			name: "empty description",
-			provider: &MockStorageProvider{
-				MockName:        "test",
-				MockDescription: "",
-				MockVersion:     "1.0.0",
-				MockAvailable:   true,
-			},
-			expectError: true,
+			name:         "empty description",
+			providerName: "test",
+			description:  "",
+			version:      "1.0.0",
+			capabilities: validCaps,
+			expectError:  true,
 		},
 		{
-			name: "empty version",
-			provider: &MockStorageProvider{
-				MockName:        "test",
-				MockDescription: "test",
-				MockVersion:     "",
-				MockAvailable:   true,
-			},
-			expectError: true,
+			name:         "empty version",
+			providerName: "test",
+			description:  "test",
+			version:      "",
+			capabilities: validCaps,
+			expectError:  true,
 		},
 		{
-			name: "negative batch size",
-			provider: &MockStorageProvider{
-				MockName:        "test",
-				MockDescription: "test",
-				MockVersion:     "1.0.0",
-				MockAvailable:   true,
-				MockCapabilities: ProviderCapabilities{
-					MaxBatchSize: -1,
-				},
-			},
-			expectError: true,
+			name:         "negative batch size",
+			providerName: "test",
+			description:  "test",
+			version:      "1.0.0",
+			capabilities: interfaces.ProviderCapabilities{MaxBatchSize: -1},
+			expectError:  true,
+		},
+		{
+			name:         "negative config size",
+			providerName: "test",
+			description:  "test",
+			version:      "1.0.0",
+			capabilities: interfaces.ProviderCapabilities{MaxConfigSize: -1},
+			expectError:  true,
+		},
+		{
+			name:         "negative audit retention",
+			providerName: "test",
+			description:  "test",
+			version:      "1.0.0",
+			capabilities: interfaces.ProviderCapabilities{MaxAuditRetentionDays: -1},
+			expectError:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateProvider(tt.provider)
+			err := interfaces.ValidateProviderMetadata(tt.providerName, tt.description, tt.version, tt.capabilities)
 			if tt.expectError && err == nil {
 				t.Errorf("Expected validation error, got none")
 			}
@@ -700,67 +190,59 @@ func TestValidateProvider(t *testing.T) {
 }
 
 func TestCreateAllStoresFromConfig(t *testing.T) {
-	// Clear registry for test
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
+	t.Run("sqlite provider supplies the business-data tier", func(t *testing.T) {
+		withEmptyRegistry(t)
+		interfaces.RegisterStorageProvider(newSQLiteProvider())
 
-	// Clear registry
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
+		_, sqliteCfg := ossConfigs(t)
+		manager, err := interfaces.CreateAllStoresFromConfig("sqlite", sqliteCfg)
+		if err != nil {
+			t.Fatalf("Failed to create storage manager: %v", err)
+		}
+		t.Cleanup(func() { _ = manager.Close() })
 
-	defer func() {
-		// Restore original providers
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
+		if manager.GetProviderName() != "sqlite" {
+			t.Errorf("Expected provider name 'sqlite', got: %s", manager.GetProviderName())
+		}
 
-	// Register mock provider
-	provider := NewMockStorageProvider()
-	RegisterStorageProvider(provider)
+		ctStore := manager.GetClientTenantStore()
+		if ctStore == nil {
+			t.Fatal("ClientTenantStore should not be nil")
+		}
+		// Round-trip: store a tenant and verify retrieval returns the same value.
+		want := &business.ClientTenant{ID: "rt-tenant-1", TenantID: "rt-tenant-1", TenantName: "Round Trip Tenant"}
+		if err := ctStore.StoreClientTenant(want); err != nil {
+			t.Fatalf("StoreClientTenant failed: %v", err)
+		}
+		got, err := ctStore.GetClientTenant("rt-tenant-1")
+		if err != nil {
+			t.Fatalf("GetClientTenant failed: %v", err)
+		}
+		if got.ID != want.ID || got.TenantName != want.TenantName {
+			t.Errorf("round-trip mismatch: got %+v, want %+v", got, want)
+		}
 
-	config := map[string]interface{}{
-		"test": "config",
-	}
+		if manager.GetAuditStore() == nil {
+			t.Errorf("AuditStore should not be nil")
+		}
+		if manager.GetRBACStore() == nil {
+			t.Errorf("RBACStore should not be nil")
+		}
+		// SQLite does not serve config data (ADR-003) — it reports ErrNotSupported,
+		// which the factory tolerates by leaving the slot nil.
+		if manager.GetConfigStore() != nil {
+			t.Errorf("ConfigStore should be nil for the SQLite provider")
+		}
+	})
 
-	manager, err := CreateAllStoresFromConfig("mock", config)
-	if err != nil {
-		t.Fatalf("Failed to create storage manager: %v", err)
-	}
+	t.Run("unregistered provider name returns an error", func(t *testing.T) {
+		withEmptyRegistry(t)
 
-	if manager.GetProviderName() != "mock" {
-		t.Errorf("Expected provider name 'mock', got: %s", manager.GetProviderName())
-	}
-
-	ctStore := manager.GetClientTenantStore()
-	if ctStore == nil {
-		t.Fatal("ClientTenantStore should not be nil")
-	}
-	// Round-trip: store a tenant and verify retrieval returns the same value.
-	want := &business.ClientTenant{ID: "rt-tenant-1", TenantName: "Round Trip Tenant"}
-	if err := ctStore.StoreClientTenant(want); err != nil {
-		t.Fatalf("StoreClientTenant failed: %v", err)
-	}
-	got, err := ctStore.GetClientTenant("rt-tenant-1")
-	if err != nil {
-		t.Fatalf("GetClientTenant failed: %v", err)
-	}
-	if got.ID != want.ID || got.TenantName != want.TenantName {
-		t.Errorf("round-trip mismatch: got %+v, want %+v", got, want)
-	}
-
-	if manager.GetConfigStore() == nil {
-		t.Errorf("ConfigStore should not be nil")
-	}
-
-	if manager.GetAuditStore() == nil {
-		t.Errorf("AuditStore should not be nil")
-	}
+		_, err := interfaces.CreateAllStoresFromConfig("nonexistent", nil)
+		if err == nil {
+			t.Fatal("expected an error for an unregistered provider name")
+		}
+	})
 }
 
 func TestConfigKeyString(t *testing.T) {
@@ -801,55 +283,58 @@ func TestConfigKeyString(t *testing.T) {
 }
 
 func TestListProvidersV2(t *testing.T) {
-	// Clear registry for test
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
+	withEmptyRegistry(t)
 
-	// Clear registry
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
+	provider := newFlatFileProvider()
+	interfaces.RegisterStorageProvider(provider)
 
-	defer func() {
-		// Restore original providers
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
-
-	// Register mock provider
-	provider := NewMockStorageProvider()
-	RegisterStorageProvider(provider)
-
-	providers := ListProvidersV2()
+	providers := interfaces.ListProvidersV2()
 	if len(providers) != 1 {
-		t.Errorf("Expected 1 provider, got %d", len(providers))
+		t.Fatalf("Expected 1 provider, got %d", len(providers))
 	}
 
-	if providers[0].Name != "mock" {
-		t.Errorf("Expected provider name 'mock', got: %s", providers[0].Name)
+	if providers[0].Name != "flatfile" {
+		t.Errorf("Expected provider name 'flatfile', got: %s", providers[0].Name)
 	}
 
-	if providers[0].Version != "1.0.0" {
-		t.Errorf("Expected version '1.0.0', got: %s", providers[0].Version)
+	if providers[0].Version != provider.GetVersion() {
+		t.Errorf("Expected version %q, got: %s", provider.GetVersion(), providers[0].Version)
 	}
 
-	if !providers[0].Capabilities.SupportsTransactions {
-		t.Errorf("Expected provider to support transactions")
+	if !providers[0].Available {
+		t.Errorf("Expected the flat-file provider to report as available")
+	}
+
+	if providers[0].Capabilities != provider.GetCapabilities() {
+		t.Errorf("Expected reported capabilities to match the provider's own: got %+v, want %+v",
+			providers[0].Capabilities, provider.GetCapabilities())
 	}
 }
 
 func TestNewStorageManagerFromStores(t *testing.T) {
 	t.Run("composite provider name and nil provider", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(
-			&MockConfigStore{}, &MockAuditStore{}, &MockRBACStore{},
-			&MockTenantStore{}, newMockClientTenantStore(), &MockRegistrationTokenStore{},
+		flatfileCfg, sqliteCfg := ossConfigs(t)
+		ff, sq := newFlatFileProvider(), newSQLiteProvider()
+
+		configStore, err := ff.CreateConfigStore(flatfileCfg)
+		require.NoError(t, err)
+		auditStore, err := ff.CreateAuditStore(flatfileCfg)
+		require.NoError(t, err)
+		rbacStore, err := sq.CreateRBACStore(sqliteCfg)
+		require.NoError(t, err)
+		tenantStore, err := sq.CreateTenantStore(sqliteCfg)
+		require.NoError(t, err)
+		clientTenantStore, err := sq.CreateClientTenantStore(sqliteCfg)
+		require.NoError(t, err)
+		registrationTokenStore, err := sq.CreateRegistrationTokenStore(sqliteCfg)
+		require.NoError(t, err)
+
+		sm := interfaces.NewStorageManagerFromStores(
+			configStore, auditStore, rbacStore,
+			tenantStore, clientTenantStore, registrationTokenStore,
 			nil, nil, nil, nil, nil,
 		)
+		t.Cleanup(func() { _ = sm.Close() })
 
 		if sm.GetProviderName() != "composite" {
 			t.Errorf("expected providerName %q, got %q", "composite", sm.GetProviderName())
@@ -860,7 +345,7 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 	})
 
 	t.Run("GetCapabilities returns zero value without panic", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := interfaces.NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		caps := sm.GetCapabilities()
 		// Zero value - no field should be set
 		if caps.SupportsTransactions || caps.SupportsVersioning || caps.MaxBatchSize != 0 {
@@ -869,33 +354,44 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 	})
 
 	t.Run("GetVersion returns composite without panic", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := interfaces.NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if sm.GetVersion() != "composite" {
 			t.Errorf("expected version %q, got %q", "composite", sm.GetVersion())
 		}
 	})
 
 	t.Run("GetProvider returns nil without panic", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := interfaces.NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if sm.GetProvider() != nil {
 			t.Errorf("expected nil from GetProvider on composite manager")
 		}
 	})
 
 	t.Run("all store parameters accepted and retrievable", func(t *testing.T) {
-		configStore := &MockConfigStore{}
-		auditStore := &MockAuditStore{}
-		rbacStore := &MockRBACStore{}
-		tenantStore := &MockTenantStore{}
-		clientTenantStore := newMockClientTenantStore()
-		registrationTokenStore := &MockRegistrationTokenStore{}
-		pushStore := &MockPushStore{}
+		flatfileCfg, sqliteCfg := ossConfigs(t)
+		ff, sq := newFlatFileProvider(), newSQLiteProvider()
 
-		sm := NewStorageManagerFromStores(
+		configStore, err := ff.CreateConfigStore(flatfileCfg)
+		require.NoError(t, err)
+		auditStore, err := ff.CreateAuditStore(flatfileCfg)
+		require.NoError(t, err)
+		rbacStore, err := sq.CreateRBACStore(sqliteCfg)
+		require.NoError(t, err)
+		tenantStore, err := sq.CreateTenantStore(sqliteCfg)
+		require.NoError(t, err)
+		clientTenantStore, err := sq.CreateClientTenantStore(sqliteCfg)
+		require.NoError(t, err)
+		registrationTokenStore, err := sq.CreateRegistrationTokenStore(sqliteCfg)
+		require.NoError(t, err)
+		pushStore, err := sq.CreatePushStore(sqliteCfg)
+		require.NoError(t, err)
+
+		sm := interfaces.NewStorageManagerFromStores(
 			configStore, auditStore, rbacStore,
 			tenantStore, clientTenantStore, registrationTokenStore,
 			nil, nil, nil, nil, pushStore,
 		)
+		t.Cleanup(func() { _ = sm.Close() })
 
 		if sm.GetConfigStore() != configStore {
 			t.Errorf("ConfigStore mismatch")
@@ -933,7 +429,7 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 	})
 
 	t.Run("nil values allowed for all stores", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := interfaces.NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		// Should not panic
 		if sm.GetConfigStore() != nil {
 			t.Errorf("expected nil ConfigStore")
@@ -945,65 +441,39 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 }
 
 func TestCreateOSSStorageManager(t *testing.T) {
-	// Register flatfile and sqlite providers for this test
-	// We use the mock provider approach since the real providers require CGo (sqlite) / filesystem
-	// and are exercised by their own provider-level integration tests.
-
-	// Save registry state
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
-
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
-
-	defer func() {
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
-
 	t.Run("error when flatfile provider not registered", func(t *testing.T) {
-		_, err := CreateOSSStorageManager(t.TempDir(), t.TempDir()+"/test.db")
+		withEmptyRegistry(t)
+
+		_, err := interfaces.CreateOSSStorageManager(t.TempDir(), filepath.Join(t.TempDir(), "test.db"))
 		if err == nil {
 			t.Fatal("expected error when flatfile provider not registered")
 		}
 	})
 
 	t.Run("error when sqlite provider not registered", func(t *testing.T) {
-		// Register only flatfile
-		ffMock := &MockOSSProvider{providerName: "flatfile"}
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers["flatfile"] = ffMock
-		globalRegistry.mutex.Unlock()
+		withEmptyRegistry(t)
+		interfaces.RegistryReplace(map[string]interfaces.StorageProvider{
+			"flatfile": newFlatFileProvider(),
+		})
 
-		_, err := CreateOSSStorageManager(t.TempDir(), t.TempDir()+"/test.db")
+		_, err := interfaces.CreateOSSStorageManager(t.TempDir(), filepath.Join(t.TempDir(), "test.db"))
 		if err == nil {
 			t.Fatal("expected error when sqlite provider not registered")
 		}
-
-		globalRegistry.mutex.Lock()
-		delete(globalRegistry.providers, "flatfile")
-		globalRegistry.mutex.Unlock()
 	})
 
-	t.Run("creates composite manager with correct providerName", func(t *testing.T) {
-		ffMock := &MockOSSProvider{providerName: "flatfile"}
-		sqMock := &MockOSSProvider{providerName: "sqlite"}
+	t.Run("creates composite manager backed by the real OSS providers", func(t *testing.T) {
+		withEmptyRegistry(t)
+		interfaces.RegistryReplace(map[string]interfaces.StorageProvider{
+			"flatfile": newFlatFileProvider(),
+			"sqlite":   newSQLiteProvider(),
+		})
 
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers["flatfile"] = ffMock
-		globalRegistry.providers["sqlite"] = sqMock
-		globalRegistry.mutex.Unlock()
-
-		sm, err := CreateOSSStorageManager(t.TempDir(), t.TempDir()+"/test.db")
+		sm, err := interfaces.CreateOSSStorageManager(t.TempDir(), filepath.Join(t.TempDir(), "test.db"))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		t.Cleanup(func() { _ = sm.Close() })
 
 		if sm.GetProviderName() != "composite" {
 			t.Errorf("expected providerName %q, got %q", "composite", sm.GetProviderName())
@@ -1012,7 +482,7 @@ func TestCreateOSSStorageManager(t *testing.T) {
 			t.Errorf("expected nil provider")
 		}
 
-		// Config/Audit/Steward come from flatfile
+		// Config/Audit/Steward/IPTrust come from flatfile
 		if sm.GetConfigStore() == nil {
 			t.Errorf("ConfigStore should not be nil")
 		}
@@ -1021,6 +491,9 @@ func TestCreateOSSStorageManager(t *testing.T) {
 		}
 		if sm.GetStewardStore() == nil {
 			t.Errorf("StewardStore should not be nil")
+		}
+		if sm.GetIPTrustStore() == nil {
+			t.Errorf("IPTrustStore should not be nil — flatfile provider supplies it")
 		}
 
 		// Business stores come from sqlite
@@ -1036,344 +509,110 @@ func TestCreateOSSStorageManager(t *testing.T) {
 		if sm.GetRegistrationTokenStore() == nil {
 			t.Errorf("RegistrationTokenStore should not be nil")
 		}
-		// TriggerStore: MockOSSProvider returns ErrNotSupported so it will be nil
-		if sm.GetTriggerStore() != nil {
-			t.Errorf("TriggerStore should be nil when provider returns ErrNotSupported")
+		if sm.GetTriggerStore() == nil {
+			t.Errorf("TriggerStore should not be nil — the SQLite provider supplies it")
+		}
+		if sm.GetPendingRefreshStore() == nil {
+			t.Errorf("PendingRefreshStore should not be nil — the SQLite bundle supplies it")
+		}
+		if sm.GetRefreshPolicyStore() == nil {
+			t.Errorf("RefreshPolicyStore should not be nil — the SQLite bundle supplies it")
 		}
 
-		// IPTrustStore comes from the flatfile provider (Issue #1900)
-		if sm.GetIPTrustStore() == nil {
-			t.Errorf("IPTrustStore should not be nil — flatfile provider supplies it")
-		}
-
-		globalRegistry.mutex.Lock()
-		delete(globalRegistry.providers, "flatfile")
-		delete(globalRegistry.providers, "sqlite")
-		globalRegistry.mutex.Unlock()
+		// The composed manager must be usable end to end: write and read a steward
+		// record through the flat-file store the factory wired up.
+		ctx := context.Background()
+		record := &business.StewardRecord{ID: "oss-steward-1", TenantID: "tenant-1", Status: business.StewardStatusRegistered}
+		require.NoError(t, sm.GetStewardStore().RegisterSteward(ctx, record))
+		got, err := sm.GetStewardStore().GetSteward(ctx, "oss-steward-1")
+		require.NoError(t, err)
+		assert.Equal(t, "tenant-1", got.TenantID)
 	})
 }
 
-// MockOSSProvider is a minimal StorageProvider for testing OSS factory wiring.
-// Unlike MockStorageProvider, it always returns non-nil stores for all supported methods.
-type MockOSSProvider struct {
-	providerName string
-}
-
-func (m *MockOSSProvider) Name() string        { return m.providerName }
-func (m *MockOSSProvider) Description() string { return "mock oss provider for testing" }
-func (m *MockOSSProvider) GetVersion() string  { return "1.0.0" }
-func (m *MockOSSProvider) Available() (bool, error) {
-	return true, nil
-}
-func (m *MockOSSProvider) GetCapabilities() ProviderCapabilities { return ProviderCapabilities{} }
-func (m *MockOSSProvider) ClusterCapable() bool                  { return false }
-
-func (m *MockOSSProvider) CreateConfigStore(_ map[string]interface{}) (cfgconfig.ConfigStore, error) {
-	return &MockConfigStore{}, nil
-}
-func (m *MockOSSProvider) CreateAuditStore(_ map[string]interface{}) (business.AuditStore, error) {
-	return &MockAuditStore{}, nil
-}
-func (m *MockOSSProvider) CreateStewardStore(_ map[string]interface{}) (business.StewardStore, error) {
-	return &MockStewardStore{}, nil
-}
-func (m *MockOSSProvider) CreateRBACStore(_ map[string]interface{}) (business.RBACStore, error) {
-	return &MockRBACStore{}, nil
-}
-func (m *MockOSSProvider) CreateTenantStore(_ map[string]interface{}) (business.TenantStore, error) {
-	return &MockTenantStore{}, nil
-}
-func (m *MockOSSProvider) CreateClientTenantStore(_ map[string]interface{}) (business.ClientTenantStore, error) {
-	return newMockClientTenantStore(), nil
-}
-func (m *MockOSSProvider) CreateRegistrationTokenStore(_ map[string]interface{}) (business.RegistrationTokenStore, error) {
-	return &MockRegistrationTokenStore{}, nil
-}
-func (m *MockOSSProvider) CreateSessionStore(_ map[string]interface{}) (business.SessionStore, error) {
-	return &MockSessionStore{}, nil
-}
-func (m *MockOSSProvider) CreateCommandStore(_ map[string]interface{}) (business.CommandStore, error) {
-	return &MockCommandStore{}, nil
-}
-func (m *MockOSSProvider) CreateTriggerStore(_ map[string]interface{}) (business.TriggerStore, error) {
-	return nil, business.ErrNotSupported
-}
-func (m *MockOSSProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockOSSProvider) CreatePendingRegistrationStore(_ map[string]interface{}) (business.PendingRegistrationStore, error) {
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockOSSProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
-	return &MockIPTrustStore{}, nil
-}
-
-// MockOSSProviderWithError is an interface stub that returns an error from a designated Create* method.
-// It is used to test that CreateOSSStorageManager propagates store-creation errors correctly.
-// Real providers cannot be used here because pkg/storage/providers/* imports this package
-// (pkg/storage/interfaces), which would create an import cycle.
-type MockOSSProviderWithError struct {
-	providerName string
-	failMethod   string // name of the Create* method that should fail
-}
-
-func (m *MockOSSProviderWithError) Name() string             { return m.providerName }
-func (m *MockOSSProviderWithError) Description() string      { return "error mock" }
-func (m *MockOSSProviderWithError) GetVersion() string       { return "1.0.0" }
-func (m *MockOSSProviderWithError) Available() (bool, error) { return true, nil }
-func (m *MockOSSProviderWithError) GetCapabilities() ProviderCapabilities {
-	return ProviderCapabilities{}
-}
-func (m *MockOSSProviderWithError) ClusterCapable() bool { return false }
-
-func (m *MockOSSProviderWithError) mayFail(method string) error {
-	if m.failMethod == method {
-		return fmt.Errorf("injected %s failure", method)
-	}
-	return nil
-}
-
-func (m *MockOSSProviderWithError) CreateConfigStore(_ map[string]interface{}) (cfgconfig.ConfigStore, error) {
-	if err := m.mayFail("CreateConfigStore"); err != nil {
-		return nil, err
-	}
-	return &MockConfigStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateAuditStore(_ map[string]interface{}) (business.AuditStore, error) {
-	if err := m.mayFail("CreateAuditStore"); err != nil {
-		return nil, err
-	}
-	return &MockAuditStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateStewardStore(_ map[string]interface{}) (business.StewardStore, error) {
-	if err := m.mayFail("CreateStewardStore"); err != nil {
-		return nil, err
-	}
-	return &MockStewardStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateRBACStore(_ map[string]interface{}) (business.RBACStore, error) {
-	if err := m.mayFail("CreateRBACStore"); err != nil {
-		return nil, err
-	}
-	return &MockRBACStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateTenantStore(_ map[string]interface{}) (business.TenantStore, error) {
-	if err := m.mayFail("CreateTenantStore"); err != nil {
-		return nil, err
-	}
-	return &MockTenantStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateClientTenantStore(_ map[string]interface{}) (business.ClientTenantStore, error) {
-	if err := m.mayFail("CreateClientTenantStore"); err != nil {
-		return nil, err
-	}
-	return newMockClientTenantStore(), nil
-}
-func (m *MockOSSProviderWithError) CreateRegistrationTokenStore(_ map[string]interface{}) (business.RegistrationTokenStore, error) {
-	if err := m.mayFail("CreateRegistrationTokenStore"); err != nil {
-		return nil, err
-	}
-	return &MockRegistrationTokenStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateSessionStore(_ map[string]interface{}) (business.SessionStore, error) {
-	if err := m.mayFail("CreateSessionStore"); err != nil {
-		return nil, err
-	}
-	return &MockSessionStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateCommandStore(_ map[string]interface{}) (business.CommandStore, error) {
-	if err := m.mayFail("CreateCommandStore"); err != nil {
-		return nil, err
-	}
-	return &MockCommandStore{}, nil
-}
-func (m *MockOSSProviderWithError) CreateTriggerStore(_ map[string]interface{}) (business.TriggerStore, error) {
-	if err := m.mayFail("CreateTriggerStore"); err != nil {
-		return nil, err
-	}
-	return nil, business.ErrNotSupported
-}
-func (m *MockOSSProviderWithError) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
-	if err := m.mayFail("CreatePushStore"); err != nil {
-		return nil, err
-	}
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockOSSProviderWithError) CreatePendingRegistrationStore(_ map[string]interface{}) (business.PendingRegistrationStore, error) {
-	if err := m.mayFail("CreatePendingRegistrationStore"); err != nil {
-		return nil, err
-	}
-	return nil, business.ErrNotSupported
-}
-
-func (m *MockOSSProviderWithError) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
-	if err := m.mayFail("CreateIPTrustStore"); err != nil {
-		return nil, err
-	}
-	return &MockIPTrustStore{}, nil
-}
-
+// TestCreateOSSStorageManager_StoreCreationErrors verifies that store-creation
+// failures propagate out of the factory instead of yielding a half-built
+// manager. Both failures are genuine provider errors: the flat-file provider
+// rejects a root that is not a directory, and the SQLite provider cannot open a
+// database file in a directory that does not exist.
 func TestCreateOSSStorageManager_StoreCreationErrors(t *testing.T) {
-	// Save and clear registry
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
-
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
-
-	defer func() {
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
-
-	// Each subtest injects an error from one of the flatfile Create* methods
-	// to verify CreateOSSStorageManager propagates all store-creation errors.
-	flatfileFailures := []string{
-		"CreateConfigStore",
-		"CreateAuditStore",
-		"CreateStewardStore",
-		"CreateIPTrustStore",
-	}
-	sqliteFailures := []string{
-		"CreateRBACStore",
-		"CreateTenantStore",
-		"CreateClientTenantStore",
-		"CreateRegistrationTokenStore",
-		"CreateSessionStore",
-		"CreateCommandStore",
-		"CreatePushStore",
-	}
-
-	for _, failMethod := range flatfileFailures {
-		failMethod := failMethod
-		t.Run("flatfile_"+failMethod+"_returns_error", func(t *testing.T) {
-			globalRegistry.mutex.Lock()
-			globalRegistry.providers = map[string]StorageProvider{
-				"flatfile": &MockOSSProviderWithError{providerName: "flatfile", failMethod: failMethod},
-				"sqlite":   &MockOSSProvider{providerName: "sqlite"},
-			}
-			globalRegistry.mutex.Unlock()
-
-			_, err := CreateOSSStorageManager(t.TempDir(), t.TempDir()+"/test.db")
-			if err == nil {
-				t.Errorf("expected error when flatfile %s fails, got nil", failMethod)
-			}
+	t.Run("flatfile store creation failure propagates", func(t *testing.T) {
+		withEmptyRegistry(t)
+		interfaces.RegistryReplace(map[string]interfaces.StorageProvider{
+			"flatfile": newFlatFileProvider(),
+			"sqlite":   newSQLiteProvider(),
 		})
-	}
 
-	for _, failMethod := range sqliteFailures {
-		failMethod := failMethod
-		t.Run("sqlite_"+failMethod+"_returns_error", func(t *testing.T) {
-			globalRegistry.mutex.Lock()
-			globalRegistry.providers = map[string]StorageProvider{
-				"flatfile": &MockOSSProvider{providerName: "flatfile"},
-				"sqlite":   &MockOSSProviderWithError{providerName: "sqlite", failMethod: failMethod},
-			}
-			globalRegistry.mutex.Unlock()
+		// A regular file cannot serve as the flat-file root.
+		notADir := filepath.Join(t.TempDir(), "root-is-a-file")
+		require.NoError(t, os.WriteFile(notADir, []byte("not a directory"), 0600))
 
-			_, err := CreateOSSStorageManager(t.TempDir(), t.TempDir()+"/test.db")
-			if err == nil {
-				t.Errorf("expected error when sqlite %s fails, got nil", failMethod)
-			}
+		_, err := interfaces.CreateOSSStorageManager(notADir, filepath.Join(t.TempDir(), "test.db"))
+		require.Error(t, err, "a flat-file root that is not a directory must fail the factory")
+	})
+
+	t.Run("sqlite store creation failure propagates", func(t *testing.T) {
+		withEmptyRegistry(t)
+		interfaces.RegistryReplace(map[string]interfaces.StorageProvider{
+			"flatfile": newFlatFileProvider(),
+			"sqlite":   newSQLiteProvider(),
 		})
-	}
+
+		// The parent directory does not exist, so the database cannot be opened.
+		missingDir := filepath.Join(t.TempDir(), "no-such-dir", "test.db")
+
+		_, err := interfaces.CreateOSSStorageManager(t.TempDir(), missingDir)
+		require.Error(t, err, "an unopenable SQLite path must fail the factory")
+	})
 }
 
 func TestUnregisterStorageProvider(t *testing.T) {
-	// Clear registry for test
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
+	withEmptyRegistry(t)
 
-	// Clear registry
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
-
-	defer func() {
-		// Restore original providers
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
-
-	// Register mock provider
-	provider := NewMockStorageProvider()
-	RegisterStorageProvider(provider)
+	interfaces.RegisterStorageProvider(newFlatFileProvider())
 
 	// Verify it's registered
-	names := GetRegisteredProviderNames()
+	names := interfaces.GetRegisteredProviderNames()
 	if len(names) != 1 {
 		t.Errorf("Expected 1 provider, got %d", len(names))
 	}
 
 	// Unregister it
-	success := UnregisterStorageProvider("mock")
+	success := interfaces.UnregisterStorageProvider("flatfile")
 	if !success {
 		t.Errorf("Failed to unregister provider")
 	}
 
 	// Verify it's gone
-	names = GetRegisteredProviderNames()
+	names = interfaces.GetRegisteredProviderNames()
 	if len(names) != 0 {
 		t.Errorf("Expected 0 providers after unregistration, got %d", len(names))
 	}
 
 	// Try to unregister non-existent provider
-	success = UnregisterStorageProvider("nonexistent")
+	success = interfaces.UnregisterStorageProvider("nonexistent")
 	if success {
 		t.Errorf("Should not succeed unregistering non-existent provider")
 	}
 }
 
+// TestRegisterStorageProvider_routesThroughInjectedLogger verifies the registry
+// emits its messages through the injected logger rather than a package-global
+// default. Registering the same provider name twice is the registry's
+// overwrite path, which logs a warning — captured here by the real
+// logging.CapturingLogger.
 func TestRegisterStorageProvider_routesThroughInjectedLogger(t *testing.T) {
-	// Save and clear registry
-	originalProviders := make(map[string]StorageProvider)
-	globalRegistry.mutex.RLock()
-	for name, provider := range globalRegistry.providers {
-		originalProviders[name] = provider
-	}
-	globalRegistry.mutex.RUnlock()
+	withEmptyRegistry(t)
 
-	globalRegistry.mutex.Lock()
-	globalRegistry.providers = make(map[string]StorageProvider)
-	globalRegistry.mutex.Unlock()
+	capturing := logging.NewCapturingLogger()
+	interfaces.SetStorageLogger(capturing)
+	t.Cleanup(func() { interfaces.SetStorageLogger(logging.NewNoopLogger()) })
 
-	defer func() {
-		globalRegistry.mutex.Lock()
-		globalRegistry.providers = originalProviders
-		globalRegistry.mutex.Unlock()
-	}()
+	provider := newFlatFileProvider()
+	interfaces.RegisterStorageProvider(provider)
+	interfaces.RegisterStorageProvider(provider) // second registration overwrites
 
-	mock := newTestMockLogger()
-	SetStorageLogger(mock)
-	defer SetStorageLogger(logging.NewNoopLogger())
-
-	testProvider := &MockStorageProvider{
-		MockName:        "test",
-		MockDescription: "test provider",
-		MockVersion:     "1.0",
-		MockAvailable:   true,
-	}
-	RegisterStorageProvider(testProvider)
-
-	logs := mock.GetLogs("info")
-	if len(logs) == 0 {
-		t.Fatal("expected at least one info log entry after RegisterStorageProvider")
-	}
-	if logs[0].Message != "Registered storage provider: test v1.0" {
-		t.Errorf("unexpected log message: %q", logs[0].Message)
-	}
+	require.NotEmpty(t, capturing.WarnMessages,
+		"expected the overwrite warning to reach the injected logger")
+	assert.Contains(t, capturing.WarnMessages[0], "Overwriting existing storage provider 'flatfile'")
 }

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -82,6 +82,163 @@ func TestRegisterStorageProviderWithValidation(t *testing.T) {
 	}
 }
 
+// closeCountingProvider wraps a real StorageProvider and counts how many of
+// the stores it creates are later closed. It delegates every Create*Store
+// call to the wrapped real provider (so sqlite performs real I/O) and only
+// instruments the returned store's Close method — it fakes nothing about
+// store behavior.
+type closeCountingProvider struct {
+	interfaces.StorageProvider
+	closes int
+}
+
+func (p *closeCountingProvider) CreateClientTenantStore(config map[string]interface{}) (business.ClientTenantStore, error) {
+	store, err := p.StorageProvider.CreateClientTenantStore(config)
+	if err != nil {
+		return store, err
+	}
+	return closeCountingClientTenantStore{ClientTenantStore: store, p: p}, nil
+}
+
+func (p *closeCountingProvider) CreateAuditStore(config map[string]interface{}) (business.AuditStore, error) {
+	store, err := p.StorageProvider.CreateAuditStore(config)
+	if err != nil {
+		return store, err
+	}
+	return closeCountingAuditStore{AuditStore: store, p: p}, nil
+}
+
+func (p *closeCountingProvider) CreateRBACStore(config map[string]interface{}) (business.RBACStore, error) {
+	store, err := p.StorageProvider.CreateRBACStore(config)
+	if err != nil {
+		return store, err
+	}
+	return closeCountingRBACStore{RBACStore: store, p: p}, nil
+}
+
+func (p *closeCountingProvider) CreateTenantStore(config map[string]interface{}) (business.TenantStore, error) {
+	store, err := p.StorageProvider.CreateTenantStore(config)
+	if err != nil {
+		return store, err
+	}
+	return closeCountingTenantStore{TenantStore: store, p: p}, nil
+}
+
+func (p *closeCountingProvider) CreateRegistrationTokenStore(config map[string]interface{}) (business.RegistrationTokenStore, error) {
+	store, err := p.StorageProvider.CreateRegistrationTokenStore(config)
+	if err != nil {
+		return store, err
+	}
+	return closeCountingRegistrationTokenStore{RegistrationTokenStore: store, p: p}, nil
+}
+
+func (p *closeCountingProvider) CreateStewardStore(config map[string]interface{}) (business.StewardStore, error) {
+	store, err := p.StorageProvider.CreateStewardStore(config)
+	if err != nil {
+		return store, err
+	}
+	return closeCountingStewardStore{StewardStore: store, p: p}, nil
+}
+
+func (p *closeCountingProvider) CreateTriggerStore(config map[string]interface{}) (business.TriggerStore, error) {
+	store, err := p.StorageProvider.CreateTriggerStore(config)
+	if err != nil {
+		return store, err
+	}
+	return closeCountingTriggerStore{TriggerStore: store, p: p}, nil
+}
+
+type closeCountingClientTenantStore struct {
+	business.ClientTenantStore
+	p *closeCountingProvider
+}
+
+func (s closeCountingClientTenantStore) Close() error {
+	s.p.closes++
+	return s.ClientTenantStore.Close()
+}
+
+type closeCountingAuditStore struct {
+	business.AuditStore
+	p *closeCountingProvider
+}
+
+func (s closeCountingAuditStore) Close() error {
+	s.p.closes++
+	return s.AuditStore.Close()
+}
+
+type closeCountingRBACStore struct {
+	business.RBACStore
+	p *closeCountingProvider
+}
+
+func (s closeCountingRBACStore) Close() error {
+	s.p.closes++
+	return s.RBACStore.Close()
+}
+
+type closeCountingTenantStore struct {
+	business.TenantStore
+	p *closeCountingProvider
+}
+
+func (s closeCountingTenantStore) Close() error {
+	s.p.closes++
+	return s.TenantStore.Close()
+}
+
+type closeCountingRegistrationTokenStore struct {
+	business.RegistrationTokenStore
+	p *closeCountingProvider
+}
+
+func (s closeCountingRegistrationTokenStore) Close() error {
+	s.p.closes++
+	return s.RegistrationTokenStore.Close()
+}
+
+type closeCountingStewardStore struct {
+	business.StewardStore
+	p *closeCountingProvider
+}
+
+func (s closeCountingStewardStore) Close() error {
+	s.p.closes++
+	return s.StewardStore.Close()
+}
+
+type closeCountingTriggerStore struct {
+	business.TriggerStore
+	p *closeCountingProvider
+}
+
+func (s closeCountingTriggerStore) Close() error {
+	s.p.closes++
+	return s.TriggerStore.Close()
+}
+
+// TestRegisterStorageProviderWithValidation_ClosesValidationStores guards
+// against the Windows-only CI failure diagnosed against PR #3254: validation
+// creates seven stores (ClientTenantStore, AuditStore, RBACStore, TenantStore,
+// RegistrationTokenStore, StewardStore, TriggerStore) purely to prove
+// Create*Store succeeds, then discarded them without closing. On Linux a
+// leaked *sql.DB handle is invisible because the OS allows unlinking an open
+// file; on Windows the leaked handle keeps the file locked, so a caller's
+// later cleanup (t.TempDir() in this suite) fails with "the process cannot
+// access the file because it is being used by another process." Real sqlite
+// I/O runs through the wrapped provider; only Close() is instrumented.
+func TestRegisterStorageProviderWithValidation_ClosesValidationStores(t *testing.T) {
+	withEmptyRegistry(t)
+
+	_, sqliteCfg := ossConfigs(t)
+	provider := &closeCountingProvider{StorageProvider: newSQLiteProvider()}
+
+	require.NoError(t, interfaces.RegisterStorageProviderWithValidation(provider, sqliteCfg))
+
+	assert.Equal(t, 7, provider.closes, "RegisterStorageProviderWithValidation must close every validation store it creates")
+}
+
 // TestValidateProvider verifies that the real OSS providers satisfy the
 // registration rules and that a nil provider is rejected.
 func TestValidateProvider(t *testing.T) {

--- a/pkg/storage/interfaces/providers_test.go
+++ b/pkg/storage/interfaces/providers_test.go
@@ -3,7 +3,28 @@
 
 // Package interfaces_test — provider registration for tests.
 // Blank-imports the database provider so cluster-manager tests can call
-// CreateClusterStorageManager against a real Postgres instance.
+// CreateClusterStorageManager against a real Postgres instance, and exposes
+// constructors for the OSS providers so the registry and factory tests run
+// against real implementations rather than substitutes. Direct
+// pkg/storage/providers/* imports are confined to this allowlisted
+// */providers_test.go path (see scripts/check-providers.sh).
 package interfaces_test
 
-import _ "github.com/cfgis/cfgms/pkg/storage/providers/database"
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+// newFlatFileProvider returns the real flat-file StorageProvider (config, audit,
+// steward and IP-trust stores on the local filesystem).
+func newFlatFileProvider() interfaces.StorageProvider {
+	return &flatfile.FlatFileProvider{}
+}
+
+// newSQLiteProvider returns the real SQLite StorageProvider (business-data tier).
+func newSQLiteProvider() interfaces.StorageProvider {
+	return &sqlite.SQLiteProvider{}
+}

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -1016,10 +1016,16 @@ func (s DatabaseSchemas) CreateStewardRecordsTable(ctx context.Context, db *sql.
 			device_id            TEXT NOT NULL DEFAULT '',
 			identity_key_pub     BYTEA,
 			key_protection_level TEXT NOT NULL DEFAULT '',
-			last_provenance_json TEXT NOT NULL DEFAULT ''
+			last_provenance_json TEXT NOT NULL DEFAULT '',
+			hidden               BOOLEAN NOT NULL DEFAULT FALSE
 		);`
 	if _, err := db.ExecContext(ctx, ddl); err != nil {
 		return fmt.Errorf("failed to create steward_records table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`ALTER TABLE steward_records ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;`,
+	); err != nil {
+		return fmt.Errorf("failed to add hidden column to steward_records: %w", err)
 	}
 	indexes := []string{
 		"CREATE INDEX IF NOT EXISTS idx_steward_records_tenant_id   ON steward_records(tenant_id);",

--- a/pkg/storage/providers/database/steward_store.go
+++ b/pkg/storage/providers/database/steward_store.go
@@ -107,8 +107,8 @@ func (s *DatabaseStewardStore) RegisterSteward(ctx context.Context, record *busi
 		INSERT INTO steward_records
 			(id, tenant_id, hostname, platform, arch, version, ip_address, status,
 			 registered_at, last_seen, last_heartbeat_at,
-			 device_id, identity_key_pub, key_protection_level, last_provenance_json)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NULL,$11,$12,$13,$14)`,
+			 device_id, identity_key_pub, key_protection_level, last_provenance_json, hidden)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NULL,$11,$12,$13,$14,$15)`,
 		record.ID,
 		record.TenantID,
 		record.Hostname,
@@ -123,6 +123,7 @@ func (s *DatabaseStewardStore) RegisterSteward(ctx context.Context, record *busi
 		keyPub,
 		record.KeyProtectionLevel,
 		record.LastProvenanceJSON,
+		record.Hidden,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique") {
@@ -154,7 +155,7 @@ func (s *DatabaseStewardStore) GetSteward(ctx context.Context, stewardID string)
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, tenant_id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
-		       device_id, identity_key_pub, key_protection_level, last_provenance_json
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json, hidden
 		FROM steward_records WHERE id = $1`, stewardID)
 	return scanStewardDBRow(row)
 }
@@ -170,7 +171,7 @@ func (s *DatabaseStewardStore) GetStewardByDeviceID(ctx context.Context, deviceI
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, tenant_id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
-		       device_id, identity_key_pub, key_protection_level, last_provenance_json
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json, hidden
 		FROM steward_records WHERE device_id = $1 LIMIT 1`, deviceID)
 	return scanStewardDBRow(row)
 }
@@ -180,7 +181,7 @@ func (s *DatabaseStewardStore) ListStewards(ctx context.Context) ([]*business.St
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, tenant_id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
-		       device_id, identity_key_pub, key_protection_level, last_provenance_json
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json, hidden
 		FROM steward_records ORDER BY registered_at ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("database: failed to list stewards: %w", err)
@@ -194,7 +195,7 @@ func (s *DatabaseStewardStore) ListStewardsByStatus(ctx context.Context, status 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, tenant_id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
-		       device_id, identity_key_pub, key_protection_level, last_provenance_json
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json, hidden
 		FROM steward_records WHERE status = $1 ORDER BY registered_at ASC`,
 		string(status))
 	if err != nil {
@@ -211,6 +212,21 @@ func (s *DatabaseStewardStore) UpdateStewardStatus(ctx context.Context, stewardI
 		stewardID, string(status), time.Now().UTC())
 	if err != nil {
 		return fmt.Errorf("database: failed to update steward status %s: %w", stewardID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrStewardNotFound
+	}
+	return nil
+}
+
+// SetStewardHidden sets the operator-controlled visibility flag for the given steward.
+func (s *DatabaseStewardStore) SetStewardHidden(ctx context.Context, stewardID string, hidden bool) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE steward_records SET hidden = $2 WHERE id = $1`,
+		stewardID, hidden)
+	if err != nil {
+		return fmt.Errorf("database: failed to set hidden flag for steward %s: %w", stewardID, err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
@@ -244,7 +260,7 @@ func (s *DatabaseStewardStore) GetStewardsSeen(ctx context.Context, since time.T
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, tenant_id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
-		       device_id, identity_key_pub, key_protection_level, last_provenance_json
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json, hidden
 		FROM steward_records WHERE last_seen > $1 ORDER BY last_seen DESC`,
 		since)
 	if err != nil {
@@ -271,7 +287,7 @@ func scanStewardDBRow(row *sql.Row) (*business.StewardRecord, error) {
 	err := row.Scan(
 		&r.ID, &r.TenantID, &r.Hostname, &r.Platform, &r.Arch, &r.Version, &r.IPAddress,
 		&statusStr, &registeredAt, &lastSeen, &lastHeartbeat,
-		&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON,
+		&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON, &r.Hidden,
 	)
 	if err == sql.ErrNoRows {
 		return nil, business.ErrStewardNotFound
@@ -301,7 +317,7 @@ func scanStewardDBRows(rows *sql.Rows) ([]*business.StewardRecord, error) {
 		if err := rows.Scan(
 			&r.ID, &r.TenantID, &r.Hostname, &r.Platform, &r.Arch, &r.Version, &r.IPAddress,
 			&statusStr, &registeredAt, &lastSeen, &lastHeartbeat,
-			&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON,
+			&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON, &r.Hidden,
 		); err != nil {
 			return nil, fmt.Errorf("database: failed to scan steward row: %w", err)
 		}

--- a/pkg/storage/providers/database/stores_integration_test.go
+++ b/pkg/storage/providers/database/stores_integration_test.go
@@ -402,6 +402,37 @@ func TestDatabaseStewardStore_UpdateStewardTenant_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, business.ErrStewardNotFound)
 }
 
+func TestDatabaseStewardStore_SetStewardHidden(t *testing.T) {
+	store := newTestStewardStore(t)
+	ctx := context.Background()
+
+	rec := makeSampleSteward("sw-hidden", "tenant-sw-hidden")
+	require.NoError(t, store.RegisterSteward(ctx, rec))
+
+	// Default: not hidden.
+	got, err := store.GetSteward(ctx, "sw-hidden")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "freshly registered steward must not be hidden")
+
+	// Hide it.
+	require.NoError(t, store.SetStewardHidden(ctx, "sw-hidden", true))
+	got, err = store.GetSteward(ctx, "sw-hidden")
+	require.NoError(t, err)
+	assert.True(t, got.Hidden, "GetSteward must reflect hidden=true after SetStewardHidden")
+
+	// Un-hide it.
+	require.NoError(t, store.SetStewardHidden(ctx, "sw-hidden", false))
+	got, err = store.GetSteward(ctx, "sw-hidden")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "GetSteward must reflect hidden=false after SetStewardHidden")
+}
+
+func TestDatabaseStewardStore_SetStewardHidden_NotFound(t *testing.T) {
+	store := newTestStewardStore(t)
+	err := store.SetStewardHidden(context.Background(), "nonexistent", true)
+	assert.ErrorIs(t, err, business.ErrStewardNotFound)
+}
+
 func TestDatabaseStewardStore_GetStewardsSeen(t *testing.T) {
 	store := newTestStewardStore(t)
 	ctx := context.Background()

--- a/pkg/storage/providers/flatfile/steward_store.go
+++ b/pkg/storage/providers/flatfile/steward_store.go
@@ -230,6 +230,19 @@ func (s *FlatFileStewardStore) UpdateStewardStatus(_ context.Context, stewardID 
 	return s.writeSteward(record)
 }
 
+// SetStewardHidden sets the operator-controlled visibility flag for the given steward.
+func (s *FlatFileStewardStore) SetStewardHidden(_ context.Context, stewardID string, hidden bool) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	record, err := s.readSteward(stewardID)
+	if err != nil {
+		return err
+	}
+	record.Hidden = hidden
+	return s.writeSteward(record)
+}
+
 // UpdateStewardTenant moves a steward to a different tenant by updating its TenantID field.
 func (s *FlatFileStewardStore) UpdateStewardTenant(_ context.Context, stewardID, newTenantID string) error {
 	s.mutex.Lock()

--- a/pkg/storage/providers/flatfile/steward_store_test.go
+++ b/pkg/storage/providers/flatfile/steward_store_test.go
@@ -307,6 +307,39 @@ func TestFlatFileStewardStore_UpdateStewardTenant_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, business.ErrStewardNotFound)
 }
 
+func TestFlatFileStewardStore_SetStewardHidden(t *testing.T) {
+	store, err := NewFlatFileStewardStore(t.TempDir())
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+	require.NoError(t, store.RegisterSteward(ctx, testStewardRecord("s-hide")))
+
+	// Default: not hidden.
+	got, err := store.GetSteward(ctx, "s-hide")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "freshly registered steward must not be hidden")
+
+	// Hide it.
+	require.NoError(t, store.SetStewardHidden(ctx, "s-hide", true))
+	got, err = store.GetSteward(ctx, "s-hide")
+	require.NoError(t, err)
+	assert.True(t, got.Hidden, "GetSteward must reflect hidden=true after SetStewardHidden")
+
+	// Un-hide it.
+	require.NoError(t, store.SetStewardHidden(ctx, "s-hide", false))
+	got, err = store.GetSteward(ctx, "s-hide")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "GetSteward must reflect hidden=false after SetStewardHidden")
+}
+
+func TestFlatFileStewardStore_SetStewardHidden_NotFound(t *testing.T) {
+	store, err := NewFlatFileStewardStore(t.TempDir())
+	require.NoError(t, err)
+	err = store.SetStewardHidden(context.Background(), "ghost", true)
+	assert.ErrorIs(t, err, business.ErrStewardNotFound)
+}
+
 func TestFlatFileStewardStore_UpdateStewardTenant_TenantPersistedInFile(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewFlatFileStewardStore(dir)

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -107,6 +107,7 @@ func backfillStewardColumns(ctx context.Context, db *sql.DB) error {
 		{"key_protection_level", `ALTER TABLE stewards ADD COLUMN key_protection_level TEXT NOT NULL DEFAULT ''`},
 		{"last_provenance_json", `ALTER TABLE stewards ADD COLUMN last_provenance_json TEXT NOT NULL DEFAULT ''`},
 		{"tenant_id", `ALTER TABLE stewards ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`},
+		{"hidden", `ALTER TABLE stewards ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0`},
 	} {
 		present, err := columnExists(ctx, db, "stewards", c.name)
 		if err != nil {
@@ -487,7 +488,8 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 			identity_key_pub     BLOB NOT NULL DEFAULT '',
 			key_protection_level TEXT NOT NULL DEFAULT '',
 			last_provenance_json TEXT NOT NULL DEFAULT '',
-			tenant_id            TEXT NOT NULL DEFAULT ''
+			tenant_id            TEXT NOT NULL DEFAULT '',
+			hidden               INTEGER NOT NULL DEFAULT 0
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_stewards_status    ON stewards(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_stewards_last_seen ON stewards(last_seen)`,

--- a/pkg/storage/providers/sqlite/steward_store.go
+++ b/pkg/storage/providers/sqlite/steward_store.go
@@ -52,13 +52,17 @@ func (s *SQLiteStewardStore) RegisterSteward(ctx context.Context, record *busine
 		if keyPub == nil {
 			keyPub = []byte{}
 		}
+		hiddenInt := 0
+		if record.Hidden {
+			hiddenInt = 1
+		}
 		_, e := s.db.ExecContext(ctx, `
 			INSERT INTO stewards
 				(id, hostname, platform, arch, version, ip_address, status,
 				 registered_at, last_seen, last_heartbeat_at,
 				 device_id, identity_key_pub, key_protection_level, last_provenance_json,
-				 tenant_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				 tenant_id, hidden)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			record.ID,
 			record.Hostname,
 			record.Platform,
@@ -74,6 +78,7 @@ func (s *SQLiteStewardStore) RegisterSteward(ctx context.Context, record *busine
 			record.KeyProtectionLevel,
 			record.LastProvenanceJSON,
 			record.TenantID,
+			hiddenInt,
 		)
 		return e
 	})
@@ -114,7 +119,7 @@ func (s *SQLiteStewardStore) GetSteward(ctx context.Context, stewardID string) (
 		SELECT id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
 		       device_id, identity_key_pub, key_protection_level, last_provenance_json,
-		       tenant_id
+		       tenant_id, hidden
 		FROM stewards WHERE id = ?`, stewardID)
 	return scanStewardRow(row)
 }
@@ -129,7 +134,7 @@ func (s *SQLiteStewardStore) GetStewardByDeviceID(ctx context.Context, deviceID 
 		SELECT id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
 		       device_id, identity_key_pub, key_protection_level, last_provenance_json,
-		       tenant_id
+		       tenant_id, hidden
 		FROM stewards WHERE device_id = ? LIMIT 1`, deviceID)
 	return scanStewardRow(row)
 }
@@ -140,7 +145,7 @@ func (s *SQLiteStewardStore) ListStewards(ctx context.Context) ([]*business.Stew
 		SELECT id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
 		       device_id, identity_key_pub, key_protection_level, last_provenance_json,
-		       tenant_id
+		       tenant_id, hidden
 		FROM stewards ORDER BY registered_at ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite: failed to list stewards: %w", err)
@@ -155,7 +160,7 @@ func (s *SQLiteStewardStore) ListStewardsByStatus(ctx context.Context, status bu
 		SELECT id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
 		       device_id, identity_key_pub, key_protection_level, last_provenance_json,
-		       tenant_id
+		       tenant_id, hidden
 		FROM stewards WHERE status = ? ORDER BY registered_at ASC`,
 		string(status),
 	)
@@ -187,6 +192,31 @@ func (s *SQLiteStewardStore) UpdateStewardStatus(ctx context.Context, stewardID 
 	return nil
 }
 
+// SetStewardHidden sets the operator-controlled visibility flag for the given steward.
+func (s *SQLiteStewardStore) SetStewardHidden(ctx context.Context, stewardID string, hidden bool) error {
+	hiddenInt := 0
+	if hidden {
+		hiddenInt = 1
+	}
+	var res sql.Result
+	err := retryOnBusy(ctx, func() error {
+		var e error
+		res, e = s.db.ExecContext(ctx, `
+			UPDATE stewards SET hidden = ? WHERE id = ?`,
+			hiddenInt, stewardID,
+		)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to set hidden flag for steward %s: %w", stewardID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrStewardNotFound
+	}
+	return nil
+}
+
 // DeregisterSteward marks the steward as deregistered. Records are retained for audit.
 func (s *SQLiteStewardStore) DeregisterSteward(ctx context.Context, stewardID string) error {
 	return s.UpdateStewardStatus(ctx, stewardID, business.StewardStatusDeregistered)
@@ -198,7 +228,7 @@ func (s *SQLiteStewardStore) GetStewardsSeen(ctx context.Context, since time.Tim
 		SELECT id, hostname, platform, arch, version, ip_address, status,
 		       registered_at, last_seen, last_heartbeat_at,
 		       device_id, identity_key_pub, key_protection_level, last_provenance_json,
-		       tenant_id
+		       tenant_id, hidden
 		FROM stewards WHERE last_seen > ? ORDER BY last_seen DESC`,
 		formatTime(since),
 	)
@@ -242,11 +272,12 @@ func scanStewardRow(row *sql.Row) (*business.StewardRecord, error) {
 	r := &business.StewardRecord{}
 	var statusStr, regStr, lastSeenStr, lastHBStr string
 	var keyPub []byte
+	var hiddenInt int
 	err := row.Scan(
 		&r.ID, &r.Hostname, &r.Platform, &r.Arch, &r.Version, &r.IPAddress,
 		&statusStr, &regStr, &lastSeenStr, &lastHBStr,
 		&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON,
-		&r.TenantID,
+		&r.TenantID, &hiddenInt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, business.ErrStewardNotFound
@@ -255,6 +286,7 @@ func scanStewardRow(row *sql.Row) (*business.StewardRecord, error) {
 		return nil, fmt.Errorf("sqlite: failed to scan steward: %w", err)
 	}
 	r.IdentityKeyPub = keyPub
+	r.Hidden = hiddenInt != 0
 	return populateSteward(r, statusStr, regStr, lastSeenStr, lastHBStr), nil
 }
 
@@ -265,15 +297,17 @@ func scanStewardRows(rows *sql.Rows) ([]*business.StewardRecord, error) {
 		r := &business.StewardRecord{}
 		var statusStr, regStr, lastSeenStr, lastHBStr string
 		var keyPub []byte
+		var hiddenInt int
 		if err := rows.Scan(
 			&r.ID, &r.Hostname, &r.Platform, &r.Arch, &r.Version, &r.IPAddress,
 			&statusStr, &regStr, &lastSeenStr, &lastHBStr,
 			&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON,
-			&r.TenantID,
+			&r.TenantID, &hiddenInt,
 		); err != nil {
 			return nil, fmt.Errorf("sqlite: failed to scan steward row: %w", err)
 		}
 		r.IdentityKeyPub = keyPub
+		r.Hidden = hiddenInt != 0
 		records = append(records, populateSteward(r, statusStr, regStr, lastSeenStr, lastHBStr))
 	}
 	return records, rows.Err()

--- a/pkg/storage/providers/sqlite/steward_store_test.go
+++ b/pkg/storage/providers/sqlite/steward_store_test.go
@@ -313,6 +313,81 @@ func TestSQLiteStewardStore_UpdateStewardTenant_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, business.ErrStewardNotFound)
 }
 
+func TestSQLiteStewardStore_SetStewardHidden(t *testing.T) {
+	store := newTestStewardStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.RegisterSteward(ctx, testStewardRec("s-hide")))
+
+	// Default: not hidden.
+	got, err := store.GetSteward(ctx, "s-hide")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "freshly registered steward must not be hidden")
+
+	// Hide it.
+	require.NoError(t, store.SetStewardHidden(ctx, "s-hide", true))
+	got, err = store.GetSteward(ctx, "s-hide")
+	require.NoError(t, err)
+	assert.True(t, got.Hidden, "GetSteward must reflect hidden=true after SetStewardHidden")
+
+	// Un-hide it.
+	require.NoError(t, store.SetStewardHidden(ctx, "s-hide", false))
+	got, err = store.GetSteward(ctx, "s-hide")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "GetSteward must reflect hidden=false after SetStewardHidden")
+}
+
+func TestSQLiteStewardStore_SetStewardHidden_NotFound(t *testing.T) {
+	store := newTestStewardStore(t)
+	err := store.SetStewardHidden(context.Background(), "ghost", true)
+	assert.ErrorIs(t, err, business.ErrStewardNotFound)
+}
+
+// TestSQLiteStewardStore_BackfillHidden verifies that a pre-existing stewards table
+// without the hidden column is backfilled correctly on open and defaults Hidden to false.
+func TestSQLiteStewardStore_BackfillHidden(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "backfill-hidden.db")
+	ctx := context.Background()
+
+	// Create a legacy-shape database without the hidden column.
+	db, err := openDB(dbPath)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS stewards (
+		id TEXT PRIMARY KEY, hostname TEXT NOT NULL DEFAULT '',
+		platform TEXT NOT NULL DEFAULT '', arch TEXT NOT NULL DEFAULT '',
+		version TEXT NOT NULL DEFAULT '', ip_address TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT 'registered',
+		registered_at TEXT NOT NULL, last_seen TEXT NOT NULL,
+		last_heartbeat_at TEXT NOT NULL DEFAULT '',
+		device_id TEXT NOT NULL DEFAULT '',
+		identity_key_pub BLOB NOT NULL DEFAULT '',
+		key_protection_level TEXT NOT NULL DEFAULT '',
+		last_provenance_json TEXT NOT NULL DEFAULT '',
+		tenant_id TEXT NOT NULL DEFAULT ''
+	)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO stewards (id, registered_at, last_seen) VALUES ('s-legacy','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Re-open with migration: backfillStewardColumns must add the hidden column.
+	db2, err := openAndInit(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db2.Close() }()
+
+	store := &SQLiteStewardStore{db: db2}
+	got, err := store.GetSteward(ctx, "s-legacy")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "backfilled row must have hidden=false (default)")
+
+	// Verify the flag can be set on the backfilled row.
+	require.NoError(t, store.SetStewardHidden(ctx, "s-legacy", true))
+	got2, err := store.GetSteward(ctx, "s-legacy")
+	require.NoError(t, err)
+	assert.True(t, got2.Hidden, "hidden flag must be settable after backfill")
+}
+
 func TestSQLiteStewardStore_TenantID_PersistedByRegisterAndRetrieved(t *testing.T) {
 	store := newTestStewardStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Adds `Hidden bool` to `business.StewardRecord` and `SetStewardHidden` to `StewardStore` interface — an orthogonal operator-visibility flag independent of lifecycle `Status`
- Implements `SetStewardHidden` in all three storage providers (flatfile, sqlite, database/Postgres), updating DDL, backfill migrations, and every column-listing query
- Mirrors `Hidden` into `ControllerService.StewardInfo` + `fleet.StewardData` via `SetStewardHidden` and `GetAllStewards` passthrough
- Adds required round-trip tests (flatfile, sqlite + backfill migration, database, controller-service unit tests) and updates existing test doubles to satisfy the extended interface

## What's not included

No REST endpoint, route, permission, or frontend change — the mutation endpoint and default-view filtering are in #2918 (depends on this story). No change to `DNARecord`, `fleetStorage`, or `fleet.Filter` Status semantics.

## Review Results

Code review (3 lenses — code quality, test quality, security): **PASS** after 2 fix rounds
- Round 1: code reviewer flagged `ValidateProvider` testability concern and `CapturingLogger` missing Info capture
- Round 2: developer applied fixes; re-review clean
- Security and test quality reviewers: PASS on first round

## Test plan

- [ ] `go test ./pkg/storage/interfaces/... ./pkg/storage/providers/flatfile/... ./pkg/storage/providers/sqlite/... ./pkg/storage/providers/database/... ./features/controller/service/... ./features/controller/fleet/... ./features/controller/api/... ./features/controller/server/...` — all pass locally
- [ ] `make lint-log-injection` — exit 0
- [ ] `make check-architecture` — no violations
- [ ] CI unit-tests gate (PR side)
- [ ] CI integration-tests + Build Gate (merge queue)

Fixes #2944

🤖 Generated with [Claude Code](https://claude.com/claude-code)