### PR TITLE
test: fix goroutine t.Fatalf deadlock hanging the transport suite to its 10-minute timeout (Issue #3186)

### DIFF
--- a/test/integration/transport/config_sync_test.go
+++ b/test/integration/transport/config_sync_test.go
@@ -39,8 +39,9 @@ func (s *ConfigSyncTestSuite) SetupSuite() {
 func (s *ConfigSyncTestSuite) TestConfigSyncCommand() {
 	s.T().Log("Testing config sync command flow")
 
-	token := s.helper.CreateToken(s.T(), "default", "integration-test")
-	regResp := s.helper.RegisterSteward(s.T(), token)
+	token := s.helper.CreateToken("default", "integration-test")
+	regResp, err := s.helper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 
 	s.NotEmpty(regResp.StewardID, "Steward ID should be generated")
 	s.NotEmpty(regResp.TransportAddress, "Transport address required for gRPC DP config sync")
@@ -52,8 +53,9 @@ func (s *ConfigSyncTestSuite) TestConfigSyncCommand() {
 // TestConfigUploadAPI tests that configuration can be uploaded via the HTTP test endpoint.
 // The controller will then push the config to connected stewards via gRPC.
 func (s *ConfigSyncTestSuite) TestConfigUploadAPI() {
-	token := s.helper.CreateToken(s.T(), "default", "integration-test")
-	regResp := s.helper.RegisterSteward(s.T(), token)
+	token := s.helper.CreateToken("default", "integration-test")
+	regResp, err := s.helper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 	s.NotEmpty(regResp.StewardID)
 
 	config := map[string]interface{}{
@@ -171,8 +173,9 @@ func (s *ConfigSyncTestSuite) TestLargeConfigPayload() {
 // TestConfigSyncTransportAddressFormat tests that the transport_address in the
 // registration response has the correct format for gRPC-over-QUIC connections.
 func (s *ConfigSyncTestSuite) TestConfigSyncTransportAddressFormat() {
-	token := s.helper.CreateToken(s.T(), "default", "integration-test")
-	regResp := s.helper.RegisterSteward(s.T(), token)
+	token := s.helper.CreateToken("default", "integration-test")
+	regResp, err := s.helper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 
 	s.NotEmpty(regResp.TransportAddress,
 		"Registration must return transport_address for gRPC-over-QUIC data plane")

--- a/test/integration/transport/heartbeat_test.go
+++ b/test/integration/transport/heartbeat_test.go
@@ -3,6 +3,7 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,7 +33,31 @@ func (s *HeartbeatTestSuite) SetupSuite() {
 		s.T().Skip("Skipping heartbeat tests in short mode - requires controller infrastructure")
 	}
 
-	s.helper = NewTestHelper(GetTestHTTPAddr("https://localhost:8080"))
+	baseURL := GetTestHTTPAddr("https://localhost:8080")
+	s.helper = NewTestHelper(baseURL)
+
+	// Verify the controller is reachable before running any test in this suite.
+	// Without this bound, a goroutine in TestConcurrentHeartbeatConnections can
+	// call t.Fatalf (which invokes runtime.Goexit on the goroutine), exit without
+	// writing to the results channel, and leave the outer receive loop blocked
+	// for the full 10-minute test timeout. Fail here quickly instead.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	healthURL := fmt.Sprintf("%s/api/v1/health", baseURL)
+	for {
+		resp, err := s.helper.httpClient.Get(healthURL)
+		if err == nil {
+			_ = resp.Body.Close()
+			return
+		}
+		select {
+		case <-ctx.Done():
+			s.T().Skipf("controller not reachable at %s within 30s — heartbeat suite requires a running controller (set CFGMS_TEST_HTTP_ADDR to override); skipping to avoid 10-minute hang (Issue #3186)", baseURL)
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
 // TestRegistrationProvidesTransportAddress verifies that a registered steward
@@ -105,9 +130,18 @@ func (s *HeartbeatTestSuite) TestConcurrentHeartbeatConnections() {
 
 	for i := 0; i < numStewards; i++ {
 		go func(idx int) {
+			// Deferred send guarantees the channel always receives a value even when
+			// RegisterSteward calls t.Fatalf. t.Fatalf invokes runtime.Goexit on the
+			// calling goroutine; runtime.Goexit runs deferred functions before
+			// terminating, so this defer executes even on an early exit. Without it,
+			// the goroutine exits silently and the outer receive loop blocks forever
+			// until the 10-minute test timeout fires (Issue #3186).
+			var r result
+			defer func() { results <- r }()
+
 			token := s.helper.CreateToken(s.T(), "default", fmt.Sprintf("group-%d", idx))
 			regResp := s.helper.RegisterSteward(s.T(), token)
-			results <- result{
+			r = result{
 				stewardID:        regResp.StewardID,
 				transportAddress: regResp.TransportAddress,
 			}

--- a/test/integration/transport/heartbeat_test.go
+++ b/test/integration/transport/heartbeat_test.go
@@ -3,11 +3,9 @@
 package transport
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -33,39 +31,16 @@ func (s *HeartbeatTestSuite) SetupSuite() {
 		s.T().Skip("Skipping heartbeat tests in short mode - requires controller infrastructure")
 	}
 
-	baseURL := GetTestHTTPAddr("https://localhost:8080")
-	s.helper = NewTestHelper(baseURL)
-
-	// Verify the controller is reachable before running any test in this suite.
-	// Without this bound, a goroutine in TestConcurrentHeartbeatConnections can
-	// call t.Fatalf (which invokes runtime.Goexit on the goroutine), exit without
-	// writing to the results channel, and leave the outer receive loop blocked
-	// for the full 10-minute test timeout. Fail here quickly instead.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	healthURL := fmt.Sprintf("%s/api/v1/health", baseURL)
-	for {
-		resp, err := s.helper.httpClient.Get(healthURL)
-		if err == nil {
-			_ = resp.Body.Close()
-			return
-		}
-		select {
-		case <-ctx.Done():
-			s.T().Skipf("controller not reachable at %s within 30s — heartbeat suite requires a running controller (set CFGMS_TEST_HTTP_ADDR to override); skipping to avoid 10-minute hang (Issue #3186)", baseURL)
-			return
-		case <-time.After(2 * time.Second):
-		}
-	}
+	s.helper = NewTestHelper(GetTestHTTPAddr("https://localhost:8080"))
 }
 
 // TestRegistrationProvidesTransportAddress verifies that a registered steward
 // receives a gRPC transport address for establishing the control plane stream.
 // This is the prerequisite for all heartbeat and failover functionality.
 func (s *HeartbeatTestSuite) TestRegistrationProvidesTransportAddress() {
-	token := s.helper.CreateToken(s.T(), "default", "integration-test")
-	regResp := s.helper.RegisterSteward(s.T(), token)
+	token := s.helper.CreateToken("default", "integration-test")
+	regResp, err := s.helper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 
 	s.NotEmpty(regResp.StewardID, "Steward ID should be generated")
 	s.NotEmpty(regResp.TransportAddress, "Transport address should be provided for gRPC stream")
@@ -99,14 +74,16 @@ func (s *HeartbeatTestSuite) TestFailoverDetectionReconnection() {
 	s.T().Log("Testing failover detection via stream break + re-registration")
 
 	// Register first steward
-	token1 := s.helper.CreateToken(s.T(), "default", "integration-test")
-	resp1 := s.helper.RegisterSteward(s.T(), token1)
+	token1 := s.helper.CreateToken("default", "integration-test")
+	resp1, err := s.helper.RegisterSteward(token1)
+	s.Require().NoError(err, "First steward registration should succeed")
 	s.NotEmpty(resp1.StewardID)
 	s.T().Logf("Steward 1 registered: %s", resp1.StewardID)
 
 	// Register second steward — simulates reconnection after failover
-	token2 := s.helper.CreateToken(s.T(), "default", "integration-test")
-	resp2 := s.helper.RegisterSteward(s.T(), token2)
+	token2 := s.helper.CreateToken("default", "integration-test")
+	resp2, err := s.helper.RegisterSteward(token2)
+	s.Require().NoError(err, "Second steward registration should succeed")
 	s.NotEmpty(resp2.StewardID)
 	s.T().Logf("Steward 2 registered: %s", resp2.StewardID)
 
@@ -128,20 +105,20 @@ func (s *HeartbeatTestSuite) TestConcurrentHeartbeatConnections() {
 
 	results := make(chan result, numStewards)
 
+	// Registration runs on worker goroutines, so it must never call a Fatal-family
+	// method: the testing package requires FailNow/Fatal/Fatalf to be called only
+	// from the goroutine running the test function. Each worker therefore reports
+	// success or failure over the buffered channel, and the test goroutine below
+	// does the asserting.
 	for i := 0; i < numStewards; i++ {
 		go func(idx int) {
-			// Deferred send guarantees the channel always receives a value even when
-			// RegisterSteward calls t.Fatalf. t.Fatalf invokes runtime.Goexit on the
-			// calling goroutine; runtime.Goexit runs deferred functions before
-			// terminating, so this defer executes even on an early exit. Without it,
-			// the goroutine exits silently and the outer receive loop blocks forever
-			// until the 10-minute test timeout fires (Issue #3186).
-			var r result
-			defer func() { results <- r }()
-
-			token := s.helper.CreateToken(s.T(), "default", fmt.Sprintf("group-%d", idx))
-			regResp := s.helper.RegisterSteward(s.T(), token)
-			r = result{
+			token := s.helper.CreateToken("default", fmt.Sprintf("group-%d", idx))
+			regResp, err := s.helper.RegisterSteward(token)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			results <- result{
 				stewardID:        regResp.StewardID,
 				transportAddress: regResp.TransportAddress,
 			}
@@ -151,16 +128,11 @@ func (s *HeartbeatTestSuite) TestConcurrentHeartbeatConnections() {
 	seen := make(map[string]bool)
 	for i := 0; i < numStewards; i++ {
 		r := <-results
-		if r.err != nil {
-			s.T().Logf("Registration %d failed: %v", i, r.err)
-			continue
-		}
+		s.Require().NoErrorf(r.err, "Concurrent registration %d should succeed", i)
 		s.NotEmpty(r.stewardID)
 		s.NotEmpty(r.transportAddress)
 		s.False(seen[r.stewardID], "Each steward should have a unique ID")
 		seen[r.stewardID] = true
-
-		time.Sleep(10 * time.Millisecond) // slight delay to prevent log spam
 	}
 
 	s.Equal(numStewards, len(seen), "All concurrent registrations should produce unique steward IDs")

--- a/test/integration/transport/helpers_test.go
+++ b/test/integration/transport/helpers_test.go
@@ -76,27 +76,39 @@ func (h *TestHelper) BaseURL() string {
 // use the same shared token with pre-configured metadata. Multi-tenant isolation
 // tests verify unique steward IDs but do NOT validate per-tenant token boundaries.
 // Per-tenant tokens require seeding distinct tokens in the controller test setup.
-func (h *TestHelper) CreateToken(_ *testing.T, _, _ string) string {
+//
+// It takes no *testing.T: suites call it from worker goroutines, where the
+// testing package forbids Fatal-family calls, so no test handle is handed out.
+func (h *TestHelper) CreateToken(_, _ string) string {
 	return "integration_reusable" //nolint:gosec // test-only token, requires CFGMS_SEED_TEST_TOKENS=1 on the controller
 }
 
 // generateTestDeviceIdentity generates a fresh Ed25519 key pair for integration test device identity.
 // Each call produces unique credentials to prevent DeviceID conflicts within the same tenant.
-func generateTestDeviceIdentity(t *testing.T) (deviceID, identityKeyPub string) {
-	t.Helper()
+// It returns an error instead of failing the test so that callers running on a
+// goroutine other than the test goroutine can propagate the failure back.
+func generateTestDeviceIdentity() (deviceID, identityKeyPub string, err error) {
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("Failed to generate Ed25519 key for device identity: %v", err)
+		return "", "", fmt.Errorf("generate Ed25519 key for device identity: %w", err)
 	}
 	h := sha256.Sum256(pub)
-	return hex.EncodeToString(h[:]), base64.StdEncoding.EncodeToString(pub)
+	return hex.EncodeToString(h[:]), base64.StdEncoding.EncodeToString(pub), nil
 }
 
 // RegisterSteward registers a steward via HTTP API and returns the response.
-func (h *TestHelper) RegisterSteward(t *testing.T, token string) *RegistrationResponse {
-	t.Helper()
+//
+// It reports failures as an error rather than calling t.Fatalf. The testing
+// package requires FailNow/Fatal/Fatalf to be called only from the goroutine
+// running the test function; several suites register stewards concurrently from
+// their own goroutines, so this helper must be safe to call from any goroutine.
+// Callers assert on the returned error from the test goroutine.
+func (h *TestHelper) RegisterSteward(token string) (*RegistrationResponse, error) {
+	deviceID, identityKeyPub, err := generateTestDeviceIdentity()
+	if err != nil {
+		return nil, err
+	}
 
-	deviceID, identityKeyPub := generateTestDeviceIdentity(t)
 	reqBody := map[string]string{
 		"token":            token,
 		"device_id":        deviceID,
@@ -104,31 +116,31 @@ func (h *TestHelper) RegisterSteward(t *testing.T, token string) *RegistrationRe
 	}
 	reqJSON, err := json.Marshal(reqBody)
 	if err != nil {
-		t.Fatalf("Failed to marshal registration request: %v", err)
+		return nil, fmt.Errorf("marshal registration request: %w", err)
 	}
 
 	url := fmt.Sprintf("%s/api/v1/register", h.baseURL)
 	resp, err := h.httpClient.Post(url, "application/json", bytes.NewBuffer(reqJSON))
 	if err != nil {
-		t.Fatalf("HTTP registration request failed: %v", err)
+		return nil, fmt.Errorf("HTTP registration request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatalf("Failed to read response body: %v", err)
+		return nil, fmt.Errorf("read registration response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Registration failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("registration failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var regResp RegistrationResponse
 	if err := json.Unmarshal(body, &regResp); err != nil {
-		t.Fatalf("Failed to parse registration response: %v", err)
+		return nil, fmt.Errorf("parse registration response: %w", err)
 	}
 
-	return &regResp
+	return &regResp, nil
 }
 
 // RegistrationResponse represents the registration API response.
@@ -147,8 +159,11 @@ type RegistrationResponse struct {
 func (h *TestHelper) GetTLSConfigFromRegistration(t *testing.T, tenantID, group string) (*tls.Config, string) {
 	t.Helper()
 
-	token := h.CreateToken(t, tenantID, group)
-	resp := h.RegisterSteward(t, token)
+	token := h.CreateToken(tenantID, group)
+	resp, err := h.RegisterSteward(token)
+	if err != nil {
+		t.Fatalf("Failed to register steward: %v", err)
+	}
 
 	if resp.ClientCert == "" || resp.ClientKey == "" || resp.CACert == "" {
 		t.Fatalf("Registration did not return certificates (ClientCert=%v, ClientKey=%v, CACert=%v)",

--- a/test/integration/transport/module_execution_test.go
+++ b/test/integration/transport/module_execution_test.go
@@ -82,8 +82,9 @@ func (s *ModuleExecutionTestSuite) SetupSuite() {
 	s.testHelper = NewTestHelper(GetTestHTTPAddr("https://localhost:8080"))
 
 	// Register a steward to get credentials
-	token := s.testHelper.CreateToken(s.T(), "default", "integration-test")
-	regResp := s.testHelper.RegisterSteward(s.T(), token)
+	token := s.testHelper.CreateToken("default", "integration-test")
+	regResp, err := s.testHelper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 	s.stewardID = regResp.StewardID
 
 	s.helper = NewModuleTestHelper(GetTestHTTPAddr("https://localhost:8080"), []byte(regResp.CACert))

--- a/test/integration/transport/multi_tenant_test.go
+++ b/test/integration/transport/multi_tenant_test.go
@@ -43,16 +43,24 @@ func (s *MultiTenantTestSuite) TestSimultaneousTenants() {
 		{"tenant3", "integration-test"},
 	}
 
-	var wg sync.WaitGroup
-	registrations := make(chan *RegistrationResponse, len(tenants))
+	type registrationResult struct {
+		resp *RegistrationResponse
+		err  error
+	}
 
+	var wg sync.WaitGroup
+	registrations := make(chan registrationResult, len(tenants))
+
+	// Workers must not call a Fatal-family method: the testing package requires
+	// FailNow/Fatal/Fatalf to be called only from the test goroutine. Failures are
+	// carried back over the channel and asserted below.
 	for _, tenant := range tenants {
 		wg.Add(1)
 		go func(tenantID, group string) {
 			defer wg.Done()
-			token := s.helper.CreateToken(s.T(), tenantID, group)
-			resp := s.helper.RegisterSteward(s.T(), token)
-			registrations <- resp
+			token := s.helper.CreateToken(tenantID, group)
+			resp, err := s.helper.RegisterSteward(token)
+			registrations <- registrationResult{resp: resp, err: err}
 		}(tenant.tenantID, tenant.group)
 	}
 
@@ -61,9 +69,10 @@ func (s *MultiTenantTestSuite) TestSimultaneousTenants() {
 
 	stewardIDs := make(map[string]bool)
 	for reg := range registrations {
-		s.NotEmpty(reg.StewardID, "Each tenant registration should produce a steward ID")
-		s.NotEmpty(reg.TransportAddress, "Each steward should receive transport address")
-		stewardIDs[reg.StewardID] = true
+		s.Require().NoError(reg.err, "Each tenant registration should succeed")
+		s.NotEmpty(reg.resp.StewardID, "Each tenant registration should produce a steward ID")
+		s.NotEmpty(reg.resp.TransportAddress, "Each steward should receive transport address")
+		stewardIDs[reg.resp.StewardID] = true
 	}
 
 	s.Equal(len(tenants), len(stewardIDs), "All tenant registrations should produce unique steward IDs")
@@ -77,11 +86,13 @@ func (s *MultiTenantTestSuite) TestConnectionIsolation() {
 	s.T().Log("AC2/AC3: Testing connection isolation via unique steward IDs")
 
 	// Register two stewards
-	token1 := s.helper.CreateToken(s.T(), "tenant1", "integration-test")
-	resp1 := s.helper.RegisterSteward(s.T(), token1)
+	token1 := s.helper.CreateToken("tenant1", "integration-test")
+	resp1, err := s.helper.RegisterSteward(token1)
+	s.Require().NoError(err, "Steward registration should succeed")
 
-	token2 := s.helper.CreateToken(s.T(), "tenant2", "integration-test")
-	resp2 := s.helper.RegisterSteward(s.T(), token2)
+	token2 := s.helper.CreateToken("tenant2", "integration-test")
+	resp2, err := s.helper.RegisterSteward(token2)
+	s.Require().NoError(err, "Steward registration should succeed")
 
 	// Each steward has a unique transport address and steward ID
 	// The connection registry uses steward ID as the key, ensuring isolation
@@ -100,12 +111,14 @@ func (s *MultiTenantTestSuite) TestConfigRoutingBoundaries() {
 	s.T().Log("AC4: Testing config routing tenant boundary enforcement")
 
 	// Register stewards in different "tenants" (via different group labels)
-	token1 := s.helper.CreateToken(s.T(), "tenant-a", "integration-test")
-	resp1 := s.helper.RegisterSteward(s.T(), token1)
+	token1 := s.helper.CreateToken("tenant-a", "integration-test")
+	resp1, err := s.helper.RegisterSteward(token1)
+	s.Require().NoError(err, "Steward registration should succeed")
 	s.NotEmpty(resp1.StewardID)
 
-	token2 := s.helper.CreateToken(s.T(), "tenant-b", "integration-test")
-	resp2 := s.helper.RegisterSteward(s.T(), token2)
+	token2 := s.helper.CreateToken("tenant-b", "integration-test")
+	resp2, err := s.helper.RegisterSteward(token2)
+	s.Require().NoError(err, "Steward registration should succeed")
 	s.NotEmpty(resp2.StewardID)
 
 	// Config routing boundaries are enforced by the controller's tenant path matching.
@@ -125,15 +138,22 @@ func (s *MultiTenantTestSuite) TestHeartbeatIsolation() {
 	type registration struct {
 		stewardID string
 		tenant    string
+		err       error
 	}
 
 	results := make(chan registration, numTenants)
 
+	// Workers report errors over the channel instead of calling a Fatal-family
+	// method, which the testing package permits only on the test goroutine.
 	for i := 0; i < numTenants; i++ {
 		go func(idx int) {
 			tenantID := fmt.Sprintf("heartbeat-tenant-%d", idx)
-			token := s.helper.CreateToken(s.T(), tenantID, "integration-test")
-			resp := s.helper.RegisterSteward(s.T(), token)
+			token := s.helper.CreateToken(tenantID, "integration-test")
+			resp, err := s.helper.RegisterSteward(token)
+			if err != nil {
+				results <- registration{tenant: tenantID, err: err}
+				return
+			}
 			results <- registration{stewardID: resp.StewardID, tenant: tenantID}
 		}(i)
 	}
@@ -141,6 +161,7 @@ func (s *MultiTenantTestSuite) TestHeartbeatIsolation() {
 	seen := make(map[string]bool)
 	for i := 0; i < numTenants; i++ {
 		r := <-results
+		s.Require().NoErrorf(r.err, "Registration for tenant %s should succeed", r.tenant)
 		s.NotEmpty(r.stewardID, "Each tenant should have a steward ID")
 		s.False(seen[r.stewardID], "Each steward ID should be unique (isolation via connection registry)")
 		seen[r.stewardID] = true
@@ -157,15 +178,22 @@ func (s *MultiTenantTestSuite) TestCrossTenantsProduceUniqueIDs() {
 	const numConcurrent = 10
 	type result struct {
 		stewardID string
+		err       error
 	}
 
 	results := make(chan result, numConcurrent)
 
+	// Workers report errors over the channel instead of calling a Fatal-family
+	// method, which the testing package permits only on the test goroutine.
 	for i := 0; i < numConcurrent; i++ {
 		go func(idx int) {
 			tenantID := fmt.Sprintf("cross-tenant-%d", idx%3) // 3 different tenants
-			token := s.helper.CreateToken(s.T(), tenantID, fmt.Sprintf("group-%d", idx))
-			resp := s.helper.RegisterSteward(s.T(), token)
+			token := s.helper.CreateToken(tenantID, fmt.Sprintf("group-%d", idx))
+			resp, err := s.helper.RegisterSteward(token)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
 			results <- result{stewardID: resp.StewardID}
 		}(i)
 	}
@@ -173,6 +201,7 @@ func (s *MultiTenantTestSuite) TestCrossTenantsProduceUniqueIDs() {
 	seen := make(map[string]bool)
 	for i := 0; i < numConcurrent; i++ {
 		r := <-results
+		s.Require().NoErrorf(r.err, "Concurrent registration %d should succeed", i)
 		s.NotEmpty(r.stewardID)
 		s.False(seen[r.stewardID], "Steward ID must be globally unique across all tenants")
 		seen[r.stewardID] = true

--- a/test/integration/transport/registration_test.go
+++ b/test/integration/transport/registration_test.go
@@ -39,13 +39,14 @@ func (s *RegistrationTestSuite) TearDownSuite() {}
 
 // TestHTTPRegistrationEndpoint tests the HTTP registration endpoint returns transport_address.
 func (s *RegistrationTestSuite) TestHTTPRegistrationEndpoint() {
-	token := s.helper.CreateToken(s.T(), "", "")
+	token := s.helper.CreateToken("", "")
 	expectedTenantID := "test-tenant-integration"
 	expectedGroup := "production"
 
 	s.T().Logf("Using test token: %s", token)
 
-	regResp := s.helper.RegisterSteward(s.T(), token)
+	regResp, err := s.helper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 
 	s.NotEmpty(regResp.StewardID, "Steward ID should be generated")
 	s.Equal(expectedTenantID, regResp.TenantID, "Tenant ID should match")
@@ -126,8 +127,9 @@ func (s *RegistrationTestSuite) TestStewardIDUniqueness() {
 	stewardIDs := make([]string, 0, numStewards)
 
 	for i := 0; i < numStewards; i++ {
-		token := s.helper.CreateToken(s.T(), "test-tenant-integration", "production")
-		regResp := s.helper.RegisterSteward(s.T(), token)
+		token := s.helper.CreateToken("test-tenant-integration", "production")
+		regResp, err := s.helper.RegisterSteward(token)
+		s.Require().NoErrorf(err, "Registration #%d should succeed", i+1)
 
 		s.Equal("test-tenant-integration", regResp.TenantID, "Response should have correct tenant ID")
 		stewardIDs = append(stewardIDs, regResp.StewardID)

--- a/test/integration/transport/tls_security_test.go
+++ b/test/integration/transport/tls_security_test.go
@@ -158,8 +158,9 @@ func (s *TLSSecurityTestSuite) TestTLSConfigFromRegistration() {
 func (s *TLSSecurityTestSuite) TestRegistrationReturnsCertificates() {
 	s.T().Log("Testing certificate distribution via registration API")
 
-	token := s.helper.CreateToken(s.T(), "default", "integration-test")
-	resp := s.helper.RegisterSteward(s.T(), token)
+	token := s.helper.CreateToken("default", "integration-test")
+	resp, err := s.helper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 
 	require.NotEmpty(s.T(), resp.StewardID, "Registration should return steward ID")
 	require.NotEmpty(s.T(), resp.ClientCert, "Registration should return client certificate")
@@ -173,15 +174,16 @@ func (s *TLSSecurityTestSuite) TestRegistrationReturnsCertificates() {
 // TestClientCertificateFromRegistration verifies that the client certificate returned
 // during registration is valid and can be loaded for mTLS connections.
 func (s *TLSSecurityTestSuite) TestClientCertificateFromRegistration() {
-	token := s.helper.CreateToken(s.T(), "default", "integration-test")
-	resp := s.helper.RegisterSteward(s.T(), token)
+	token := s.helper.CreateToken("default", "integration-test")
+	resp, err := s.helper.RegisterSteward(token)
+	s.Require().NoError(err, "Steward registration should succeed")
 
 	certDir := s.T().TempDir()
 	clientCertPath := filepath.Join(certDir, "client.crt")
 	clientKeyPath := filepath.Join(certDir, "client.key")
 	caCertPath := filepath.Join(certDir, "ca.crt")
 
-	err := os.WriteFile(clientCertPath, []byte(resp.ClientCert), 0600)
+	err = os.WriteFile(clientCertPath, []byte(resp.ClientCert), 0600)
 	require.NoError(s.T(), err)
 	err = os.WriteFile(clientKeyPath, []byte(resp.ClientKey), 0600)
 	require.NoError(s.T(), err)


### PR DESCRIPTION
## Summary

`test/integration/transport` hung to its 10-minute timeout in CI. The hang is a
`testing`-package misuse, not a network or container problem.

`TestHelper.RegisterSteward` called `t.Fatalf` on failure. Several suites call it from
worker goroutines they spawn themselves. `t.Fatalf` ends the **calling** goroutine via
`runtime.Goexit()` — so a worker that failed registration died *without ever sending to
the results channel*, and the test goroutine blocked forever on `<-results`. That is
exactly the reported stack: `TestConcurrentHeartbeatConnections` parked at
`heartbeat_test.go:119`, the channel receive.

**Fix:** `RegisterSteward` and `generateTestDeviceIdentity` now return an `error` instead
of calling a Fatal-family method, and `CreateToken` no longer takes a `*testing.T` it
cannot legally use off the test goroutine. Every worker reports success or failure over
its channel; the test goroutine does the asserting with `s.Require().NoError`.

This converts an unbounded hang into a fast, descriptive failure — the suite can no
longer consume the full 10-minute budget on a registration error.

Also removed a `time.Sleep(10 * time.Millisecond)` in the result-collection loop that
served only to reduce log spam.

## Acceptance criteria evidence

Measured locally on this branch (`3b992833`) against the real Docker stack
(`make test-transport-setup`), not estimated.

**AC1 — hang localized.** Localized to `TestHelper.RegisterSteward`'s `t.Fatalf` called
from a non-test goroutine, blocking the test goroutine's channel receive at
`heartbeat_test.go:119`. Confirmed by re-running under a materially shorter
`-timeout=90s`: the previously-hanging suites now complete in under 5s rather than
parking until the deadline.

**AC2 — `CFGMS_SECRETS_KEY_FILE`/`TestMain` gap ruled out, no `TestMain` added.**
`test/integration/transport` has no `TestMain` and does not need one. The controller
under test runs in Docker, and `docker-compose.test.yml` supplies the key by bind-mount
(`${CFGMS_SECRETS_KEY_FILE:?...}:/run/secrets/cfgms-secrets-key:ro`, lines 507/758) from
`.env.test`, with a `:?` guard that hard-fails compose if it is unset. The Go test
process never reads the key itself. The suite passes green with no `TestMain`, so this
gap is not a contributing cause — ruled out, not deferred.

**AC3 — repeated green runs, well under the 10-minute limit.**

Full package, default timeout:

```
--- PASS: TestConfigSync (0.22s)
--- PASS: TestHeartbeat (0.44s)
--- PASS: TestModuleExecution (457.12s)
--- PASS: TestMultiTenant (0.68s)
--- PASS: TestRegistration (0.93s)
--- PASS: TestTLSSecurity (2.09s)
ok  github.com/cfgis/cfgms/test/integration/transport  462.503s
```

37 subtests, 0 failures. `TestHeartbeat` — the suite that previously consumed the whole
600s budget — completes in 0.44s. The 462s total is dominated by `TestModuleExecution`,
which restarts the steward container and waits ~30s per test; that is pre-existing
behaviour untouched by this PR.

Three consecutive uncached runs of the previously-hanging suites at `-timeout=90s`
(`-count=1 -race`, so no cached results):

```
run1 exit=0  ok  ...  4.470s
run2 exit=0  ok  ...  4.971s
run3 exit=0  ok  ...  4.576s
```

**AC4 — not applicable.** The cause was confirmed and fixed, so no quarantine is needed.
No `t.Skip` was added.

## Completeness of the fix

`git grep` over the package confirms the remaining Fatal-family calls are all on the test
goroutine and none are reachable from a worker: `module_execution_test.go:70`
(`SetupSuite`), `tls_security_test.go:55,136` (test bodies), and
`helpers_test.go:165-201` inside `GetTLSConfigFromRegistration`, whose only three callers
(`tls_security_test.go:145,241,245`) invoke it directly from the test goroutine.

Fixes #3186
