### PR TITLE
controller: fix certificate.ca_path silently ignored, always fell back to relative default (Issue #3171)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -575,13 +576,12 @@ func runBootstrapAdmin(configPath, name, outputPath string, regenerate bool, rev
 
 // runBootstrapAdminList prints all issued admin certs and their revocation status.
 func runBootstrapAdminList(cfg *config.Config) error {
-	certPath := cfg.CertPath
-	if certPath == "" && cfg.Certificate != nil {
-		certPath = cfg.Certificate.CAPath
+	if cfg.Certificate == nil || cfg.Certificate.CAPath == "" {
+		return fmt.Errorf("certificate path not configured (certificate.ca_path required)")
 	}
-	if certPath == "" {
-		return fmt.Errorf("certificate path not configured (cert_path or certificate.ca_path required)")
-	}
+	// StoragePath must be the parent of the "ca/" subdirectory; NewManager derives the
+	// real CA directory as filepath.Join(StoragePath,"ca").
+	certPath := filepath.Dir(filepath.Clean(cfg.Certificate.CAPath))
 
 	certManager, err := certpkg.NewManager(&certpkg.ManagerConfig{
 		StoragePath:    certPath,

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1107,7 +1108,31 @@ func LoadWithPath(configPath string) (*Config, error) {
 		return nil, err
 	}
 
+	if cfg.Certificate != nil && cfg.Certificate.CAPath != "" {
+		if err := ValidateCAPath(cfg.Certificate.CAPath); err != nil {
+			return nil, err
+		}
+	}
+
 	return cfg, nil
+}
+
+// ValidateCAPath returns an error when caPath's final component is not "ca".
+// cert.NewManager always derives its real CA directory as filepath.Join(StoragePath,"ca"),
+// so every caller must pass StoragePath = filepath.Dir(caPath). If the final component
+// is not "ca", that derivation produces the wrong parent and the CA lands in the wrong
+// place — or fails to load — without any obvious error message.
+func ValidateCAPath(caPath string) error {
+	clean := filepath.Clean(caPath)
+	if filepath.Base(clean) != "ca" {
+		return fmt.Errorf(
+			"invalid certificate.ca_path %q: the final path component must be \"ca\" "+
+				"(configured path would derive wrong CA storage parent %q; "+
+				"rename the directory or update ca_path to end in /ca)",
+			caPath, filepath.Dir(clean),
+		)
+	}
+	return nil
 }
 
 // ValidateExecutionSecurity enforces the public-beta connected-execution

--- a/features/controller/config/config_security_test.go
+++ b/features/controller/config/config_security_test.go
@@ -51,10 +51,11 @@ func TestLoad_EnvironmentVariableSecurityInjection(t *testing.T) {
 	// Test that environment variables can't be used for injection attacks
 
 	tests := []struct {
-		name     string
-		envVar   string
-		envValue string
-		testFunc func(*testing.T, *Config)
+		name        string
+		envVar      string
+		envValue    string
+		expectError bool
+		testFunc    func(*testing.T, *Config)
 	}{
 		{
 			name:     "path traversal in listen addr",
@@ -93,12 +94,10 @@ func TestLoad_EnvironmentVariableSecurityInjection(t *testing.T) {
 			},
 		},
 		{
-			name:     "malicious CA path",
-			envVar:   "CFGMS_CERT_CA_PATH",
-			envValue: "/dev/null; rm -rf /",
-			testFunc: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, "/dev/null; rm -rf /", cfg.Certificate.CAPath)
-			},
+			name:        "malicious CA path",
+			envVar:      "CFGMS_CERT_CA_PATH",
+			envValue:    "/dev/null; rm -rf /",
+			expectError: true, // ValidateCAPath rejects paths whose final component is not "ca"
 		},
 	}
 
@@ -119,11 +118,17 @@ func TestLoad_EnvironmentVariableSecurityInjection(t *testing.T) {
 
 			// Load configuration
 			config, err := Load()
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			require.NotNil(t, config)
 
 			// Run test-specific validation
-			tt.testFunc(t, config)
+			if tt.testFunc != nil {
+				tt.testFunc(t, config)
+			}
 		})
 	}
 }
@@ -202,14 +207,9 @@ cert_path: "/dev/null"
 certificate:
   ca_path: "/tmp/../../../etc/passwd"
 `,
-			expectError: false,
-			securityChecks: []func(*testing.T, *Config){
-				func(t *testing.T, cfg *Config) {
-					assert.Equal(t, "/dev/null", cfg.CertPath)
-					assert.Equal(t, "/tmp/../../../etc/passwd", cfg.Certificate.CAPath)
-					// Path validation should happen during certificate operations
-				},
-			},
+			// ValidateCAPath now rejects ca_path values whose final component is not "ca",
+			// so traversal paths like "/tmp/../../../etc/passwd" are caught at load time.
+			expectError: true,
 		},
 		{
 			name: "valid secure configuration",

--- a/features/controller/config/config_test.go
+++ b/features/controller/config/config_test.go
@@ -875,3 +875,78 @@ transport:
 	assert.Equal(t, "ctrl.tier1.lab", cfg.Transport.ExternalAddress)
 	assert.Equal(t, "https://ctrl.tier1.lab:9080", cfg.ExternalURL)
 }
+
+// TestValidateCAPath_RejectsNonCAFinalComponent verifies that a ca_path not ending in
+// "ca" is rejected at load time with an actionable error naming both the configured
+// path and the wrongly-derived parent directory — so a misconfiguration that would
+// silently write CA files to the wrong location fails loudly instead.
+func TestValidateCAPath_RejectsNonCAFinalComponent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		caPath     string
+		wantParent string
+	}{
+		{caPath: "/etc/cfgms/my-ca", wantParent: "/etc/cfgms"},
+		{caPath: "/var/lib/cfgms/certs", wantParent: "/var/lib/cfgms"},
+		{caPath: "/tmp/certs/", wantParent: "/tmp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.caPath, func(t *testing.T) {
+			err := ValidateCAPath(tc.caPath)
+			require.Error(t, err, "ca_path %q should be rejected", tc.caPath)
+			assert.Contains(t, err.Error(), tc.caPath, "error must name the configured ca_path")
+			assert.Contains(t, err.Error(), tc.wantParent, "error must name the wrongly-derived parent")
+		})
+	}
+}
+
+// TestValidateCAPath_AcceptsCAFinalComponent verifies that paths ending in "ca"
+// (the only valid convention) pass validation.
+func TestValidateCAPath_AcceptsCAFinalComponent(t *testing.T) {
+	t.Parallel()
+
+	for _, caPath := range []string{
+		"/var/lib/cfgms/certs/ca",
+		"/etc/cfgms/ca",
+		"certs/ca",
+		"/var/lib/cfgms/certs/ca/",
+	} {
+		t.Run(caPath, func(t *testing.T) {
+			assert.NoError(t, ValidateCAPath(caPath), "ca_path %q should be accepted", caPath)
+		})
+	}
+}
+
+// TestLoadWithPath_RejectsCAPathNotEndingInCA verifies that LoadWithPath returns a
+// descriptive error when certificate.ca_path does not end in "ca", naming both the
+// configured value and the wrongly-derived parent — the repro path from Issue #3171
+// (misconfigured ca_path silently fell back to relative defaults).
+func TestLoadWithPath_RejectsCAPathNotEndingInCA(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "controller.cfg")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+certificate:
+  enable_cert_management: true
+  ca_path: "/etc/cfgms/my-ca"
+`), 0600))
+
+	_, err := LoadWithPath(configPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "/etc/cfgms/my-ca", "error must name the configured ca_path")
+	assert.Contains(t, err.Error(), "/etc/cfgms", "error must name the wrongly-derived parent")
+}
+
+// TestLoadWithPath_AcceptsCAPathEndingInCA verifies that LoadWithPath succeeds when
+// certificate.ca_path ends in "ca", the required convention.
+func TestLoadWithPath_AcceptsCAPathEndingInCA(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "controller.cfg")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+certificate:
+  enable_cert_management: true
+  ca_path: "/var/lib/cfgms/certs/ca"
+`), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "/var/lib/cfgms/certs/ca", cfg.Certificate.CAPath)
+}

--- a/features/controller/initialization/admin_bundle.go
+++ b/features/controller/initialization/admin_bundle.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -307,15 +308,14 @@ func isAlphanumHyphen(c rune) bool {
 }
 
 // loadCertManager loads a cert.Manager from an already-initialized controller.
-// The StoragePath is resolved from cfg.CertPath, falling back to cfg.Certificate.CAPath.
+// StoragePath is derived as filepath.Dir(cfg.Certificate.CAPath) — the parent of the
+// "ca/" subdirectory — matching the invariant that cert.NewManager stores the CA at
+// filepath.Join(StoragePath,"ca").
 func loadCertManager(cfg *config.Config) (*cert.Manager, error) {
-	certPath := cfg.CertPath
-	if certPath == "" && cfg.Certificate != nil {
-		certPath = cfg.Certificate.CAPath
+	if cfg.Certificate == nil || cfg.Certificate.CAPath == "" {
+		return nil, fmt.Errorf("certificate path not configured (certificate.ca_path required)")
 	}
-	if certPath == "" {
-		return nil, fmt.Errorf("certificate path not configured (cert_path or certificate.ca_path required)")
-	}
+	certPath := filepath.Dir(filepath.Clean(cfg.Certificate.CAPath))
 	return cert.NewManager(&cert.ManagerConfig{
 		StoragePath:    certPath,
 		LoadExistingCA: true,

--- a/features/controller/initialization/admin_bundle_test.go
+++ b/features/controller/initialization/admin_bundle_test.go
@@ -39,8 +39,10 @@ func setupInitializedController(t *testing.T) (*testControllerSetup, func()) {
 	require.NoError(t, err, "initialization must succeed")
 	require.FileExists(t, bundlePath, "system admin bundle must be created")
 
+	// StoragePath must be the parent of "ca/" — cert.NewManager always derives the CA
+	// directory as filepath.Join(StoragePath,"ca"), matching what initialization.Run does.
 	certManager, err := cert.NewManager(&cert.ManagerConfig{
-		StoragePath:    caDir,
+		StoragePath:    tempDir,
 		LoadExistingCA: true,
 	})
 	require.NoError(t, err, "cert manager must load successfully after init")
@@ -51,6 +53,7 @@ func setupInitializedController(t *testing.T) (*testControllerSetup, func()) {
 		certManager: certManager,
 		bundlePath:  bundlePath,
 		caDir:       caDir,
+		tempDir:     tempDir,
 	}, func() {}
 }
 
@@ -60,6 +63,7 @@ type testControllerSetup struct {
 	certManager *cert.Manager
 	bundlePath  string
 	caDir       string
+	tempDir     string
 }
 
 // parseX509FromBundle reads a bundle file and returns the parsed X.509 cert.
@@ -249,7 +253,7 @@ func TestRevokeAdminBundle_RevokedThenAuthFails(t *testing.T) {
 	// After revocation: a fresh cert manager (simulating controller restart) must
 	// report the serial as revoked (CERT_REVOKED — auth would be rejected)
 	freshManager, err := cert.NewManager(&cert.ManagerConfig{
-		StoragePath:    setup.caDir,
+		StoragePath:    setup.tempDir,
 		LoadExistingCA: true,
 	})
 	require.NoError(t, err)

--- a/features/controller/initialization/initialization.go
+++ b/features/controller/initialization/initialization.go
@@ -116,10 +116,9 @@ func Run(cfg *config.Config, logger logging.Logger) (*Result, error) {
 		return os.RemoveAll(caPath)
 	})
 
-	certPath := cfg.CertPath
-	if certPath == "" {
-		certPath = caPath
-	}
+	// StoragePath for cert.NewManager must be the parent of the "ca/" subdirectory;
+	// NewManager always stores the CA at filepath.Join(StoragePath,"ca").
+	certPath := filepath.Dir(filepath.Clean(caPath))
 
 	caConfig := &cert.CAConfig{
 		Organization: "CFGMS",

--- a/features/controller/initialization/initialization_test.go
+++ b/features/controller/initialization/initialization_test.go
@@ -494,8 +494,9 @@ func TestRun_TransportCertHonorsExternalHostname(t *testing.T) {
 
 	// Reopen the cert manager and inspect the InternalServer (PurposeTransport)
 	// certificate that --init persisted to the store.
+	// StoragePath is the parent of "ca/" — matching the invariant in cert.NewManager.
 	certManager, err := cert.NewManager(&cert.ManagerConfig{
-		StoragePath:    caDir,
+		StoragePath:    tempDir,
 		LoadExistingCA: true,
 	})
 	require.NoError(t, err)
@@ -675,6 +676,112 @@ func TestRun_ClusterMode_UsesDatabaseProvider(t *testing.T) {
 // Regression test for Issue #3170: the bootstrap template omitted the top-level
 // external_url key, so cfg.ExternalURL stayed at its compiled default "https://localhost:8080"
 // and every issued admin bundle pointed at the wrong address.
+// TestRun_HonorsAbsoluteCAPath verifies that initialization.Run writes CA files at
+// exactly the configured certificate.ca_path (an absolute path), regardless of the
+// test process's working directory. This is the core regression test for Issue #3171,
+// where cfg.CertPath (a non-empty compiled relative default) shadowed CAPath and caused
+// CA files to land under <CWD>/certs/ca/ instead of the configured absolute location.
+func TestRun_HonorsAbsoluteCAPath(t *testing.T) {
+	tempDir := t.TempDir()
+	// Use a nested directory to make the absolute path unambiguous.
+	caDir := filepath.Join(tempDir, "certs", "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := &config.Config{
+		ListenAddr:      "127.0.0.1:0",
+		ExternalURL:     "https://controller.test:9080",
+		AdminBundlePath: bundlePath,
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: true,
+			CAPath:               caDir,
+			RenewalThresholdDays: 7,
+			Server: &config.ServerCertificateConfig{
+				CommonName:   "test-controller",
+				DNSNames:     []string{"localhost"},
+				IPAddresses:  []string{"127.0.0.1"},
+				Organization: "Test Org",
+			},
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: filepath.Join(tempDir, "flatfile"),
+			SQLitePath:   filepath.Join(tempDir, "cfgms.db"),
+		},
+	}
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+
+	// CA files must exist at the configured caDir — not at a CWD-relative location.
+	assert.FileExists(t, filepath.Join(caDir, "ca.crt"),
+		"ca.crt must be written at the configured certificate.ca_path, not at a CWD-relative path")
+	assert.FileExists(t, filepath.Join(caDir, "ca.key"),
+		"ca.key must be written at the configured certificate.ca_path")
+
+	// Init marker must be at caDir too (IsInitialized checks caDir/.cfgms-initialized).
+	assert.True(t, IsInitialized(caDir),
+		"init marker must be written at the configured certificate.ca_path")
+
+	// A cert.NewManager using StoragePath=filepath.Dir(caDir) must reload the CA without
+	// error — this mirrors what loadExistingCertificateManager does on server startup,
+	// proving that --init and startup agree on the same storage location.
+	reloadManager, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath:    filepath.Dir(caDir),
+		LoadExistingCA: true,
+	})
+	require.NoError(t, err, "cert manager must reload CA written by initialization.Run")
+	require.NotNil(t, reloadManager)
+}
+
+// TestRun_HonorsTrailingSlashCAPath verifies that a trailing slash in
+// certificate.ca_path is handled correctly by filepath.Clean — the CA must still land
+// at the configured directory, not at a wrong nested path.
+func TestRun_HonorsTrailingSlashCAPath(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "certs", "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := &config.Config{
+		ListenAddr:      "127.0.0.1:0",
+		ExternalURL:     "https://controller.test:9080",
+		AdminBundlePath: bundlePath,
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: true,
+			CAPath:               caDir + "/", // trailing slash — filepath.Clean must normalize it
+			RenewalThresholdDays: 7,
+			Server: &config.ServerCertificateConfig{
+				CommonName:   "test-controller",
+				DNSNames:     []string{"localhost"},
+				IPAddresses:  []string{"127.0.0.1"},
+				Organization: "Test Org",
+			},
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: filepath.Join(tempDir, "flatfile"),
+			SQLitePath:   filepath.Join(tempDir, "cfgms.db"),
+		},
+	}
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+
+	// CA files must exist at caDir (without the trailing slash).
+	assert.FileExists(t, filepath.Join(caDir, "ca.crt"),
+		"trailing slash in ca_path must not change where CA files land")
+	assert.FileExists(t, filepath.Join(caDir, "ca.key"))
+
+	// Server-startup equivalent: reload via StoragePath=filepath.Dir(filepath.Clean(caDir+"/"))=filepath.Dir(caDir).
+	reloadManager, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath:    filepath.Dir(caDir),
+		LoadExistingCA: true,
+	})
+	require.NoError(t, err, "trailing-slash ca_path must not break CA reload")
+	require.NotNil(t, reloadManager)
+}
+
 func TestRun_AdminBundleControllerURLMatchesTier1BootstrapTemplate(t *testing.T) {
 	tempDir := t.TempDir()
 	caDir := filepath.Join(tempDir, "ca")

--- a/features/controller/server/registry_wiring_test.go
+++ b/features/controller/server/registry_wiring_test.go
@@ -28,17 +28,15 @@ func TestServer_New_WiresSharedConnectionRegistry(t *testing.T) {
 	logger := logging.NewNoopLogger()
 
 	tempDir := t.TempDir()
-	certDir := tempDir + "/ca"
-
-	// Create the CA up front so EnableCertManagement startup succeeds without
-	// the init guard rejecting the boot.
+	// cert.NewManager with StoragePath=tempDir stores the CA at tempDir/ca/;
+	// CAPath is tempDir+"/ca" so loadExistingCertificateManager derives StoragePath=tempDir.
+	caDir := tempDir + "/ca"
 	_, err := cert.NewManager(&cert.ManagerConfig{
-		StoragePath: certDir,
+		StoragePath: tempDir,
 		CAConfig: &cert.CAConfig{
 			Organization: "Registry Wiring Test",
 			Country:      "US",
 			ValidityDays: 3650,
-			StoragePath:  certDir,
 		},
 		LoadExistingCA: false,
 	})
@@ -46,10 +44,9 @@ func TestServer_New_WiresSharedConnectionRegistry(t *testing.T) {
 
 	cfg := &config.Config{
 		ListenAddr: "127.0.0.1:0",
-		CertPath:   certDir,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement: true,
-			CAPath:               certDir,
+			CAPath:               caDir,
 			Server: &config.ServerCertificateConfig{
 				CommonName:   "registry-wiring-controller",
 				Organization: "Registry Wiring Test",

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -2398,10 +2398,9 @@ func (s *Server) GetHTTPListenAddr() string {
 // Unlike the old initializeCertificateManager, this never creates a new CA — that
 // responsibility belongs to `controller --init` (initialization.Run).
 func loadExistingCertificateManager(cfg *config.Config, logger logging.Logger) (*cert.Manager, error) {
-	certPath := cfg.CertPath
-	if certPath == "" {
-		certPath = cfg.Certificate.CAPath
-	}
+	// StoragePath must be the parent of the "ca/" subdirectory; NewManager always derives
+	// the real CA directory as filepath.Join(StoragePath,"ca").
+	certPath := filepath.Dir(filepath.Clean(cfg.Certificate.CAPath))
 
 	manager, err := cert.NewManager(&cert.ManagerConfig{
 		StoragePath:          certPath,

--- a/features/controller/server/server_security_test.go
+++ b/features/controller/server/server_security_test.go
@@ -140,14 +140,13 @@ func TestServer_New_SecurityValidation(t *testing.T) {
 			config: func() *config.Config {
 				certDir := tempDir + "/cert-mgmt"
 				_ = os.MkdirAll(certDir, 0700)
-				testutil.PreInitControllerForTest(t, certDir, certDir)
+				testutil.PreInitControllerForTest(t, certDir, filepath.Join(certDir, "ca"))
 				return &config.Config{
 					ListenAddr: "127.0.0.1:0",
-					CertPath:   certDir,
 					Certificate: &config.CertificateConfig{
 						EnableCertManagement:   true,
 						ClientCertValidityDays: 30,
-						CAPath:                 certDir,
+						CAPath:                 filepath.Join(certDir, "ca"),
 						ServerCertValidityDays: 90,
 						RenewalThresholdDays:   7,
 						Server: &config.ServerCertificateConfig{
@@ -380,10 +379,9 @@ func TestServer_SecurityConfiguration(t *testing.T) {
 			config: func() *config.Config {
 				certDir := tempDir + "/prod-certs"
 				_ = os.MkdirAll(certDir, 0700)
-				testutil.PreInitControllerForTest(t, certDir, certDir)
+				testutil.PreInitControllerForTest(t, certDir, filepath.Join(certDir, "ca"))
 				return &config.Config{
 					ListenAddr: "127.0.0.1:0",
-					CertPath:   certDir,
 					Storage: &config.StorageConfig{
 						Provider:     "flatfile",
 						FlatfileRoot: tempDir + "/flatfile",
@@ -393,7 +391,7 @@ func TestServer_SecurityConfiguration(t *testing.T) {
 						EnableCertManagement:   true,
 						ClientCertValidityDays: 30,
 						ServerCertValidityDays: 90,
-						CAPath:                 certDir,
+						CAPath:                 filepath.Join(certDir, "ca"),
 						RenewalThresholdDays:   7,
 						Server: &config.ServerCertificateConfig{
 							CommonName:   "prod-controller",
@@ -505,10 +503,9 @@ func TestServer_SecurityEdgeCases_And_AttackVectors(t *testing.T) {
 			configFunc: func() *config.Config {
 				certDir := tempDir + "/excessive-certs"
 				_ = os.MkdirAll(certDir, 0700)
-				testutil.PreInitControllerForTest(t, certDir, certDir)
+				testutil.PreInitControllerForTest(t, certDir, filepath.Join(certDir, "ca"))
 				return &config.Config{
 					ListenAddr: "127.0.0.1:0",
-					CertPath:   certDir,
 					Storage: &config.StorageConfig{
 						Provider:     "flatfile",
 						FlatfileRoot: tempDir + "/flatfile",
@@ -518,7 +515,7 @@ func TestServer_SecurityEdgeCases_And_AttackVectors(t *testing.T) {
 						EnableCertManagement:   true,
 						ClientCertValidityDays: 36500,
 						ServerCertValidityDays: 36500,
-						CAPath:                 certDir,
+						CAPath:                 filepath.Join(certDir, "ca"),
 						Server: &config.ServerCertificateConfig{
 							CommonName:   "test-controller",
 							Organization: "Test Org",
@@ -572,10 +569,9 @@ func TestServer_SecurityEdgeCases_And_AttackVectors(t *testing.T) {
 			configFunc: func() *config.Config {
 				certDir := tempDir + "/wildcard-certs"
 				_ = os.MkdirAll(certDir, 0700)
-				testutil.PreInitControllerForTest(t, certDir, certDir)
+				testutil.PreInitControllerForTest(t, certDir, filepath.Join(certDir, "ca"))
 				return &config.Config{
 					ListenAddr: "0.0.0.0:0",
-					CertPath:   certDir,
 					Storage: &config.StorageConfig{
 						Provider:     "flatfile",
 						FlatfileRoot: tempDir + "/flatfile",
@@ -583,7 +579,7 @@ func TestServer_SecurityEdgeCases_And_AttackVectors(t *testing.T) {
 					},
 					Certificate: &config.CertificateConfig{
 						EnableCertManagement: true,
-						CAPath:               certDir,
+						CAPath:               filepath.Join(certDir, "ca"),
 						Server: &config.ServerCertificateConfig{
 							CommonName:   "wildcard-controller",
 							Organization: "Test Org",
@@ -830,16 +826,15 @@ func TestServer_CertificateSecurityValidation(t *testing.T) {
 			configFunc: func() *config.Config {
 				certDir := tempDir + "/short-validity-certs"
 				_ = os.MkdirAll(certDir, 0700)
-				testutil.PreInitControllerForTest(t, certDir, certDir)
+				testutil.PreInitControllerForTest(t, certDir, filepath.Join(certDir, "ca"))
 				return &config.Config{
 					ListenAddr: "127.0.0.1:0",
-					CertPath:   certDir,
 					Certificate: &config.CertificateConfig{
 						EnableCertManagement:   true,
 						ClientCertValidityDays: 7,
 						ServerCertValidityDays: 30,
 						RenewalThresholdDays:   3,
-						CAPath:                 certDir,
+						CAPath:                 filepath.Join(certDir, "ca"),
 						Server: &config.ServerCertificateConfig{
 							CommonName:   "secure-controller",
 							DNSNames:     []string{"localhost"},
@@ -866,13 +861,12 @@ func TestServer_CertificateSecurityValidation(t *testing.T) {
 			configFunc: func() *config.Config {
 				certDir := tempDir + "/auto-renewal-certs"
 				_ = os.MkdirAll(certDir, 0700)
-				testutil.PreInitControllerForTest(t, certDir, certDir)
+				testutil.PreInitControllerForTest(t, certDir, filepath.Join(certDir, "ca"))
 				return &config.Config{
 					ListenAddr: "127.0.0.1:0",
-					CertPath:   certDir,
 					Certificate: &config.CertificateConfig{
 						EnableCertManagement: true,
-						CAPath:               certDir,
+						CAPath:               filepath.Join(certDir, "ca"),
 						Server: &config.ServerCertificateConfig{
 							CommonName:   "auto-controller",
 							Organization: "Auto Org",
@@ -930,17 +924,16 @@ func TestServer_EnvironmentSecurityIsolation(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tempDir2) }()
 
 	// Pre-initialize both CA directories before server creation
-	testutil.PreInitControllerForTest(t, tempDir1, tempDir1)
-	testutil.PreInitControllerForTest(t, tempDir2, tempDir2)
+	testutil.PreInitControllerForTest(t, tempDir1, filepath.Join(tempDir1, "ca"))
+	testutil.PreInitControllerForTest(t, tempDir2, filepath.Join(tempDir2, "ca"))
 
 	// Test that servers created with different configurations are properly isolated
 	config1 := &config.Config{
 		ListenAddr: "127.0.0.1:0",
 		DataDir:    tempDir1 + "/data1",
-		CertPath:   tempDir1,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement: true,
-			CAPath:               tempDir1,
+			CAPath:               filepath.Join(tempDir1, "ca"),
 			Server: &config.ServerCertificateConfig{
 				CommonName:   "server1-controller",
 				Organization: "Server1 Org",
@@ -952,10 +945,9 @@ func TestServer_EnvironmentSecurityIsolation(t *testing.T) {
 	config2 := &config.Config{
 		ListenAddr: "127.0.0.1:0",
 		DataDir:    tempDir2 + "/data2",
-		CertPath:   tempDir2,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement: true,
-			CAPath:               tempDir2,
+			CAPath:               filepath.Join(tempDir2, "ca"),
 			Server: &config.ServerCertificateConfig{
 				CommonName:   "server2-controller",
 				Organization: "Server2 Org",
@@ -1066,28 +1058,28 @@ func TestServer_New_LegacyCompatibility(t *testing.T) {
 
 	certDir := tempDir + "/legacy-ca"
 
-	// Create CA files without marker (simulates pre-init deployment)
+	// cert.NewManager with StoragePath=certDir creates CA files at certDir/ca/.
 	_, err = cert.NewManager(&cert.ManagerConfig{
 		StoragePath: certDir,
 		CAConfig: &cert.CAConfig{
 			Organization: "Legacy Org",
 			Country:      "US",
 			ValidityDays: 3650,
-			StoragePath:  certDir,
 		},
 		LoadExistingCA: false,
 	})
 	require.NoError(t, err, "Failed to create legacy CA")
 
-	// Verify no marker exists yet
-	assert.False(t, initialization.IsInitialized(certDir), "Should not have marker before server start")
+	caDir := filepath.Join(certDir, "ca")
+
+	// Verify no marker exists yet at the CA directory.
+	assert.False(t, initialization.IsInitialized(caDir), "Should not have marker before server start")
 
 	cfg := &config.Config{
 		ListenAddr: "127.0.0.1:0",
-		CertPath:   certDir,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement: true,
-			CAPath:               certDir,
+			CAPath:               caDir,
 			Server: &config.ServerCertificateConfig{
 				CommonName:   "legacy-controller",
 				Organization: "Legacy Org",
@@ -1107,8 +1099,8 @@ func TestServer_New_LegacyCompatibility(t *testing.T) {
 		})
 	}
 
-	// Verify marker was created
-	assert.True(t, initialization.IsInitialized(certDir), "Marker should be auto-created for legacy CA")
+	// Verify marker was auto-created at the CA directory.
+	assert.True(t, initialization.IsInitialized(caDir), "Marker should be auto-created for legacy CA")
 }
 
 // TestServer_New_MarkerButNoCA verifies that if the marker exists but CA files
@@ -1120,19 +1112,19 @@ func TestServer_New_MarkerButNoCA(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	certDir := tempDir + "/orphan-marker"
-	require.NoError(t, os.MkdirAll(certDir, 0700))
+	certParent := tempDir + "/orphan-marker"
+	caDir := filepath.Join(certParent, "ca")
+	require.NoError(t, os.MkdirAll(caDir, 0700))
 
-	// Write marker without CA files (simulates deleted/missing CA)
-	err = initialization.CreateLegacyMarker(certDir)
+	// Write marker at caDir (== CAPath) without CA files — simulates deleted/missing CA.
+	err = initialization.CreateLegacyMarker(caDir)
 	require.NoError(t, err)
 
 	cfg := &config.Config{
 		ListenAddr: "127.0.0.1:0",
-		CertPath:   certDir,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement: true,
-			CAPath:               certDir,
+			CAPath:               caDir,
 			Server: &config.ServerCertificateConfig{
 				CommonName:   "orphan-controller",
 				Organization: "Test Org",

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -724,15 +724,15 @@ func TestServerNewPublicBetaRejectsInvalidSigningRoots(t *testing.T) {
 	require.NoError(t, os.MkdirAll(caRoot, 0700))
 	require.NoError(t, os.WriteFile(filepath.Join(caRoot, "ca.crt"), []byte("invalid CA certificate"), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(caRoot, "ca.key"), []byte("invalid CA key"), 0600))
-	require.NoError(t, initialization.CreateLegacyMarker(certRoot))
+	// Marker lives at caRoot (== cfg.Certificate.CAPath) so IsInitialized(caRoot) is true.
+	require.NoError(t, initialization.CreateLegacyMarker(caRoot))
 
 	cfg := config.DefaultConfig()
 	cfg.SecurityProfile = config.SecurityProfilePublicBeta
 	cfg.Execution.RequireSignedAdhoc = true
 	cfg.DataDir = filepath.Join(root, "data")
 	cfg.Storage = createTestStorageConfig(root, "public-beta-invalid-roots")
-	cfg.CertPath = certRoot
-	cfg.Certificate.CAPath = certRoot
+	cfg.Certificate.CAPath = caRoot
 	cfg.Transport.ExternalAddress = "controller.test"
 
 	server, err := New(cfg, logging.NewNoopLogger())
@@ -750,25 +750,26 @@ func TestServerNewPublicBetaRejectsExpiredSigningRoots(t *testing.T) {
 	t.Setenv("CFGMS_SECRETS_REPO_PATH", filepath.Join(root, "secrets"))
 
 	certRoot := filepath.Join(root, "certs")
+	caRoot := filepath.Join(certRoot, "ca")
+	// cert.NewManager stores the CA at certRoot/ca/ (StoragePath/ca/).
 	_, err := cert.NewManager(&cert.ManagerConfig{
 		StoragePath: certRoot,
 		CAConfig: &cert.CAConfig{
 			Organization: "Expired Public Beta Root",
 			Country:      "US",
 			ValidityDays: -1,
-			StoragePath:  certRoot,
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, initialization.CreateLegacyMarker(certRoot))
+	// Marker lives at caRoot (== cfg.Certificate.CAPath) so IsInitialized(caRoot) is true.
+	require.NoError(t, initialization.CreateLegacyMarker(caRoot))
 
 	cfg := config.DefaultConfig()
 	cfg.SecurityProfile = config.SecurityProfilePublicBeta
 	cfg.Execution.RequireSignedAdhoc = true
 	cfg.DataDir = filepath.Join(root, "data")
 	cfg.Storage = createTestStorageConfig(root, "public-beta-expired-roots")
-	cfg.CertPath = certRoot
-	cfg.Certificate.CAPath = certRoot
+	cfg.Certificate.CAPath = caRoot
 	cfg.Transport.ExternalAddress = "controller.test"
 
 	server, err := New(cfg, logging.NewNoopLogger())

--- a/features/controller/server/tag_role_store_wiring_test.go
+++ b/features/controller/server/tag_role_store_wiring_test.go
@@ -26,16 +26,15 @@ func TestServer_New_WiresTagAndRoleConfigStoresIntoAPIServer(t *testing.T) {
 	logger := logging.NewNoopLogger()
 
 	tempDir := t.TempDir()
-	certDir := tempDir + "/ca"
-
-	// Create the CA up front so EnableCertManagement startup succeeds.
+	// cert.NewManager with StoragePath=tempDir stores the CA at tempDir/ca/;
+	// CAPath is tempDir+"/ca" so loadExistingCertificateManager derives StoragePath=tempDir.
+	caDir := tempDir + "/ca"
 	_, err := cert.NewManager(&cert.ManagerConfig{
-		StoragePath: certDir,
+		StoragePath: tempDir,
 		CAConfig: &cert.CAConfig{
 			Organization: "Store Wiring Test",
 			Country:      "US",
 			ValidityDays: 3650,
-			StoragePath:  certDir,
 		},
 		LoadExistingCA: false,
 	})
@@ -43,10 +42,9 @@ func TestServer_New_WiresTagAndRoleConfigStoresIntoAPIServer(t *testing.T) {
 
 	cfg := &config.Config{
 		ListenAddr: "127.0.0.1:0",
-		CertPath:   certDir,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement: true,
-			CAPath:               certDir,
+			CAPath:               caDir,
 			Server: &config.ServerCertificateConfig{
 				CommonName:   "store-wiring-controller",
 				Organization: "Store Wiring Test",

--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -61,7 +61,12 @@ type ManagerConfig struct {
 	// CA configuration (required for new CAs)
 	CAConfig *CAConfig
 
-	// Storage path for certificates and CA
+	// StoragePath is the parent directory that contains (or will contain) the "ca/"
+	// subdirectory where CA cert and key files live.  NewManager always derives the
+	// real CA directory as filepath.Join(StoragePath, "ca"), so callers must pass the
+	// parent of the configured CA path — not the CA path itself.  For example, if
+	// certificate.ca_path is "/var/lib/cfgms/certs/ca", StoragePath must be
+	// "/var/lib/cfgms/certs" (i.e. filepath.Dir(caPath)).
 	StoragePath string
 
 	// Whether to load existing CA or create new one

--- a/scripts/tier1-bootstrap.sh
+++ b/scripts/tier1-bootstrap.sh
@@ -287,7 +287,6 @@ data_dir: "/var/lib/cfgms"
 certificate:
   enable_cert_management: true
   ca_path: "/var/lib/cfgms/certs/ca"
-  cert_path: "/var/lib/cfgms/certs"
   renewal_threshold_days: 30
   server_cert_validity_days: 365
   client_cert_validity_days: 365


### PR DESCRIPTION
## Summary

- `cfg.CertPath` always had a non-empty compiled default (`"certs/"`), so the four call sites checking `if certPath == "" { certPath = cfg.Certificate.CAPath }` never reached the configured value — `certificate.ca_path` was silently ignored.
- `cert.NewManager`'s `StoragePath` must be the **parent** of the `ca/` directory (it always derives `filepath.Join(StoragePath, "ca")`), but all callers were passing the CA directory itself, causing CA files to land in a doubly-nested `ca/ca/` location.

**Changes:**
- Fixed all four call sites (`server.go`, `initialization.go`, `admin_bundle.go`, `main.go`) to use `filepath.Dir(filepath.Clean(cfg.Certificate.CAPath))` as `StoragePath`.
- Added `ValidateCAPath` to `config.LoadWithPath` — fails immediately at config load when `certificate.ca_path` does not end in `"ca"`, preventing silent misconfiguration.
- Added doc comment on `ManagerConfig.StoragePath` in `pkg/cert/manager.go` documenting the parent-directory invariant.
- Removed dead `cert_path: "/var/lib/cfgms/certs"` key from `scripts/tier1-bootstrap.sh` (nested under `certificate:`, never read).
- Updated all affected tests to use the correct `StoragePath`/`CAPath` relationship; added regression tests `TestRun_HonorsAbsoluteCAPath` and `TestRun_HonorsTrailingSlashCAPath`.

## Test plan

- [ ] `go test ./features/controller/...` — all 27 packages pass
- [ ] `go test ./pkg/cert/... ./cmd/controller/...` — all pass
- [ ] `TestRun_HonorsAbsoluteCAPath` — CA files land at the exact configured `certificate.ca_path`
- [ ] `TestRun_HonorsTrailingSlashCAPath` — trailing slash is normalized correctly
- [ ] `TestValidateCAPath_RejectsNonCAFinalComponent` — bad paths caught at load time
- [ ] `TestLoad_ConfigFileSecurityValidation/certificate_paths_with_suspicious_values` — traversal paths rejected
- [ ] Story-review workflow: passed (2 rounds, 1 fix round, 0 remaining findings)

Fixes #3171

🤖 Generated with [Claude Code](https://claude.com/claude-code)