### PR TITLE
web/api: hide quarantined/hidden stewards from default fleet view + visibility endpoint (Issue #2918)

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -130,8 +130,21 @@ List registered stewards. The returned set depends on the session's tenant scope
 
 Use the `?q=` selector parameter to narrow further (e.g. `?q=root/msp-a/all` or `?q=hostname:web-01`). The selector grammar is defined in `pkg/fleet/selector`.
 
+By default, **operator-hidden** and **quarantined** stewards are excluded from the response. Use the visibility query parameters to re-include them.
+
 **Authentication:** Required  
 **Required permission:** `steward:list`
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `q` | (none) | Selector string — see `pkg/fleet/selector` |
+| `limit` | 50 | Page size |
+| `offset` | 0 | Page offset |
+| `include_hidden` | `false` | Set `true` to include operator-hidden stewards |
+| `include_quarantined` | `false` | Set `true` to include quarantined stewards |
+| `include_deregistered` | `false` | Set `true` to include deregistered stewards |
 
 **Response:**
 
@@ -143,6 +156,7 @@ Use the `?q=` selector parameter to narrow further (e.g. `?q=root/msp-a/all` or 
       "status": "connected",
       "last_seen": "2025-01-12T10:29:30Z",
       "version": "0.2.0",
+      "hidden": false,
       "metrics": {
         "cpu_usage": "45%",
         "memory_usage": "512MB"
@@ -250,6 +264,44 @@ Refresh the mTLS credentials for a steward. Called when the steward's certificat
 
 - `id` (path): Steward ID
 
+#### PATCH /api/v1/stewards/{id}/visibility
+
+Set the operator-controlled visibility flag on a steward. Hidden stewards are excluded from the default list response and health tile counts, but their count is always surfaced in `GET /api/v1/fleet/health` as the non-suppressible `hidden` field.
+
+**Reversible:** call again with `{"hidden": false}` to restore normal visibility.
+
+**Authentication:** Required (web session or mTLS admin; API keys are rejected with `403`)  
+**Required permission:** `steward:visibility` (`AssuranceBasic` minimum — API keys cannot hide stewards)  
+**Audit:** emitted at `Medium` severity as `steward.visibility_changed`
+
+**Parameters:**
+
+- `id` (path): Steward ID
+
+**Request body:**
+
+```json
+{ "hidden": true }
+```
+
+**Response:**
+
+```json
+{
+  "id": "steward-001",
+  "hidden": true
+}
+```
+
+**Error responses:**
+
+| Code | Condition |
+|------|-----------|
+| `400` | Malformed request body or invalid steward ID format |
+| `403` | API key (machine-assurance) caller — use a web session |
+| `404` | Steward not found, or steward belongs to a different tenant |
+| `503` | Durable store unavailable |
+
 #### GET /api/v1/stewards/{id}/connection
 
 Get transport-level connection detail for a specific steward: whether it is currently streaming, when it connected, its remote network address, and the last-activity timestamp. Sourced from the live connection registry.
@@ -333,8 +385,11 @@ Return tenant-scoped counts of stewards by health classification.
 | `healthy` | `status == "active"` and heartbeat within 5 minutes |
 | `degraded` | `status == "active"` and heartbeat older than 5 minutes |
 | `unreachable` | `status == "lost"` |
+| `hidden` | `hidden == true` (excluded from healthy/degraded/unreachable buckets) |
 
 Lifecycle terminal states (registered, deregistered, archived, dormant, revoked) are not counted in any bucket. Scoping includes the caller's full tenant subtree (caller plus all descendants).
+
+The `hidden` field is **non-suppressible** — it is always present in the response regardless of query parameters. A non-zero value signals that concealment is in effect, so operators are never blind to hidden stewards even when the default list view excludes them.
 
 **Response:**
 
@@ -343,7 +398,8 @@ Lifecycle terminal states (registered, deregistered, archived, dormant, revoked)
   "data": {
     "healthy": 42,
     "degraded": 3,
-    "unreachable": 1
+    "unreachable": 1,
+    "hidden": 2
   },
   "timestamp": "2026-07-18T10:30:05Z"
 }

--- a/features/controller/api/assurance.go
+++ b/features/controller/api/assurance.go
@@ -77,6 +77,11 @@ var permissionAssurance = map[string]Requirement{
 	// before they can perform a fresh presence ceremony.
 	"webauthn:assert-presence": {Min: session.AssuranceStrong}, // POST /webauthn/presence/begin|finish
 
+	// Steward visibility toggle (Issue #2918): AssuranceBasic (not Machine) so bare/compromised
+	// API keys cannot hide an active steward. Reachable from web-session cookies and cfg Bearer
+	// sessions. scanAPIKeysForPrivilegedAccess warns at boot on any key granted this permission.
+	"steward:visibility": {Min: session.AssuranceBasic}, // PATCH /stewards/{id}/visibility
+
 	// WebAuthn step-up elevation endpoint (ADR-021 Amendment 2, Issue #2965).
 	// Callable at AssuranceBasic: this IS the step-up path (the caller cannot already be
 	// at AssuranceStrong via a different path to reach here). AssuranceMachine principals

--- a/features/controller/api/handlers_fleet.go
+++ b/features/controller/api/handlers_fleet.go
@@ -23,10 +23,13 @@ import (
 const DegradedHeartbeatAge = 5 * time.Minute
 
 // FleetHealthResponse is the response payload for GET /api/v1/fleet/health.
+// Hidden is always present (non-suppressible) regardless of include_hidden:
+// an operator must always see that concealment is in effect (Issue #2918).
 type FleetHealthResponse struct {
 	Healthy     int `json:"healthy"`
 	Degraded    int `json:"degraded"`
 	Unreachable int `json:"unreachable"`
+	Hidden      int `json:"hidden"`
 }
 
 // SelectorResolveRequest is the request body for POST /api/v1/fleet/resolve.
@@ -140,6 +143,12 @@ func (s *Server) handleFleetHealth(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
 	resp := FleetHealthResponse{}
 	for _, res := range results {
+		// Count hidden stewards in the caller's scope regardless of include_hidden
+		// (non-suppressible: the operator must always see that concealment is in effect).
+		if res.Hidden {
+			resp.Hidden++
+			continue
+		}
 		switch res.Status {
 		case "active":
 			if now.Sub(res.LastHeartbeat) <= DegradedHeartbeatAge {
@@ -157,6 +166,7 @@ func (s *Server) handleFleetHealth(w http.ResponseWriter, r *http.Request) {
 		"healthy", resp.Healthy,
 		"degraded", resp.Degraded,
 		"unreachable", resp.Unreachable,
+		"hidden", resp.Hidden,
 	)
 	s.writeSuccessResponse(w, resp)
 }

--- a/features/controller/api/handlers_fleet_test.go
+++ b/features/controller/api/handlers_fleet_test.go
@@ -679,3 +679,64 @@ func TestHandleResolveSelector_TenantIDPresentInResponse(t *testing.T) {
 	assert.Equal(t, "tenant-a", item["tenant_id"],
 		"tenant_id must be present in the resolve response so the CLI can derive it without a second round-trip")
 }
+
+// TestHandleFleetHealth_HiddenExcludedFromCounts verifies that a hidden active steward
+// is NOT counted in Healthy/Degraded but IS counted in the non-suppressible Hidden field.
+func TestHandleFleetHealth_HiddenExcludedFromCounts(t *testing.T) {
+	now := time.Now()
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{
+		stewards: []fleet.StewardData{
+			// visible active steward — counted Healthy
+			{ID: "s-visible", TenantID: "t", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute)},
+			// hidden active steward — must NOT be counted Healthy; counted in Hidden
+			{ID: "s-hidden", TenantID: "t", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute), Hidden: true},
+		},
+	})
+
+	rec := getFleetHealth(server)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	raw, err := json.Marshal(resp.Data)
+	require.NoError(t, err)
+	var h struct {
+		Healthy     int `json:"healthy"`
+		Degraded    int `json:"degraded"`
+		Unreachable int `json:"unreachable"`
+		Hidden      int `json:"hidden"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &h))
+
+	assert.Equal(t, 1, h.Healthy, "only visible active steward counted Healthy")
+	assert.Equal(t, 0, h.Degraded)
+	assert.Equal(t, 0, h.Unreachable)
+	assert.Equal(t, 1, h.Hidden, "hidden steward must be counted in hidden field")
+}
+
+// TestHandleFleetHealth_HiddenCountNonSuppressible verifies that the hidden count appears
+// in the response regardless of any include_hidden param (it is non-suppressible by design).
+func TestHandleFleetHealth_HiddenCountNonSuppressible(t *testing.T) {
+	now := time.Now()
+	server := setupTestServer(t)
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{
+		stewards: []fleet.StewardData{
+			{ID: "s-hidden-2", TenantID: "t", Status: "active", LastHeartbeat: now.Add(-1 * time.Minute), Hidden: true},
+		},
+	})
+
+	// No include_hidden param — hidden count must still be present.
+	rec := getFleetHealth(server)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	raw, err := json.Marshal(resp.Data)
+	require.NoError(t, err)
+	var h struct {
+		Hidden int `json:"hidden"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &h))
+	assert.Equal(t, 1, h.Hidden, "hidden count must be in health response even without include_hidden")
+}

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -1112,9 +1112,18 @@ func (s *Server) handleSetStewardVisibility(w http.ResponseWriter, r *http.Reque
 	}
 	s.emitVisibilityAudit(r.Context(), auditTenantID, principalID, stewardID, req.Hidden)
 
+	// The logged state is selected through control flow rather than read off the
+	// decoded request body: req is populated from the untrusted HTTP body, so any
+	// field read of it is a taint source into the log sink. Branching to a literal
+	// keeps request-controlled bytes out of the sink entirely.
+	visibilityState := "visible"
+	if req.Hidden {
+		visibilityState = "hidden"
+	}
+
 	s.logger.Info("Steward visibility updated",
 		"steward_id", logging.SanitizeLogValue(stewardID),
-		"hidden", req.Hidden,
+		"visibility", visibilityState,
 		"principal_id", logging.SanitizeLogValue(principalID))
 
 	s.writeSuccessResponse(w, map[string]interface{}{
@@ -1141,7 +1150,7 @@ func (s *Server) emitVisibilityAudit(ctx context.Context, tenantID, principalID,
 		Detail("hidden", hidden)
 	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
 		s.logger.Warn("Failed to emit visibility audit event",
-			"error", err, "steward_id", logging.SanitizeLogValue(stewardID))
+			"error", logging.SanitizeLogValue(err.Error()), "steward_id", logging.SanitizeLogValue(stewardID))
 	}
 }
 

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -273,13 +273,22 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 
 	// No filter: return all stewards including registered-but-not-connected.
 	// Deregistered stewards are excluded by default; pass ?include_deregistered=true to restore them.
+	// Hidden and quarantined stewards are excluded by default (Issue #2918).
 	includeDeregistered := r.URL.Query().Get("include_deregistered") == "true"
+	includeQuarantined := r.URL.Query().Get("include_quarantined") == "true"
+	includeHidden := r.URL.Query().Get("include_hidden") == "true"
 	stewards := s.controllerService.GetAllStewards()
 
 	stewardList := make([]StewardInfo, 0, len(stewards))
 
 	for _, steward := range stewards {
 		if !includeDeregistered && steward.Status == string(business.StewardStatusDeregistered) {
+			continue
+		}
+		if !includeQuarantined && steward.Status == "quarantined" {
+			continue
+		}
+		if !includeHidden && steward.Hidden {
 			continue
 		}
 		info := StewardInfo{
@@ -290,6 +299,7 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 			LastSeen:    steward.LastHeartbeat,
 			ConnectedAt: steward.LastHeartbeat,
 			Metrics:     steward.Metrics,
+			Hidden:      steward.Hidden,
 		}
 
 		if steward.DNA != nil {
@@ -1018,6 +1028,119 @@ func (s *Server) emitDecommissionAudit(ctx context.Context, tenantID, principalI
 		Severity(business.AuditSeverityHigh)
 	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
 		s.logger.Warn("Failed to emit decommission audit event",
+			"error", err, "steward_id", logging.SanitizeLogValue(stewardID))
+	}
+}
+
+// setVisibilityRequest is the JSON body for PATCH /api/v1/stewards/{id}/visibility.
+type setVisibilityRequest struct {
+	Hidden bool `json:"hidden"`
+}
+
+// handleSetStewardVisibility handles PATCH /api/v1/stewards/{id}/visibility.
+// Reversibly hides or unhides a steward from the default fleet view.
+// Requires steward:visibility permission at AssuranceBasic (Issue #2918).
+func (s *Server) handleSetStewardVisibility(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	stewardID := vars["id"]
+
+	if !identifierRegex.MatchString(stewardID) {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid steward ID format", "INVALID_STEWARD_ID")
+		return
+	}
+
+	if s.stewardStore == nil {
+		s.logger.Error("visibility update failed: steward store not configured",
+			"steward_id", logging.SanitizeLogValue(stewardID))
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Fleet store unavailable", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	var req setVisibilityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid JSON body", "INVALID_JSON")
+		return
+	}
+
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
+	record, err := s.stewardStore.GetSteward(r.Context(), stewardID)
+	if err != nil {
+		if errors.Is(err, business.ErrStewardNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+			return
+		}
+		s.logger.Error("visibility update failed: store lookup error",
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to look up steward", "INTERNAL_ERROR")
+		return
+	}
+
+	// Tenant-scope check: 404 instead of 403 to avoid existence disclosure across tenant boundaries.
+	if callerTenant != "" {
+		sameTenant := record.TenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(record.TenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+			return
+		}
+	}
+
+	// Durable write first — hard-fail the request on error.
+	if err := s.stewardStore.SetStewardHidden(r.Context(), stewardID, req.Hidden); err != nil {
+		s.logger.Error("visibility update failed: durable write error",
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to update steward visibility", "INTERNAL_ERROR")
+		return
+	}
+
+	// Best-effort in-memory update — log-and-continue on error.
+	if err := s.controllerService.SetStewardHidden(stewardID, req.Hidden); err != nil {
+		s.logger.Warn("visibility update: in-memory update failed (non-fatal)",
+			"steward_id", logging.SanitizeLogValue(stewardID), "error", logging.SanitizeLogValue(err.Error()))
+	}
+
+	// Emit audit event at Medium severity: concealment-capable but reversible (Issue #2918 security ruling).
+	auditTenantID := callerTenant
+	if auditTenantID == "" {
+		auditTenantID = audit.SystemTenantID
+	}
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	principalID := ""
+	if principal != nil {
+		principalID = principal.ID
+	}
+	s.emitVisibilityAudit(r.Context(), auditTenantID, principalID, stewardID, req.Hidden)
+
+	s.logger.Info("Steward visibility updated",
+		"steward_id", logging.SanitizeLogValue(stewardID),
+		"hidden", req.Hidden,
+		"principal_id", logging.SanitizeLogValue(principalID))
+
+	s.writeSuccessResponse(w, map[string]interface{}{
+		"id":     stewardID,
+		"hidden": req.Hidden,
+	})
+}
+
+// emitVisibilityAudit records a steward visibility-changed audit event.
+// Severity: Medium — concealment-capable (drops device from default view) but reversible.
+// No-op when auditManager is nil.
+func (s *Server) emitVisibilityAudit(ctx context.Context, tenantID, principalID, stewardID string, hidden bool) {
+	if s.auditManager == nil {
+		return
+	}
+	b := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(business.AuditEventDataModification).
+		Action("steward.visibility_changed").
+		User(principalID, business.AuditUserTypeHuman).
+		Resource("steward", stewardID, "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityMedium).
+		Detail("hidden", hidden)
+	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
+		s.logger.Warn("Failed to emit visibility audit event",
 			"error", err, "steward_id", logging.SanitizeLogValue(stewardID))
 	}
 }

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -3531,3 +3531,366 @@ func TestListStewards_NonRootAccount_NoCrossTenantLeakage(t *testing.T) {
 	assert.Len(t, resp.Data, 1, "msp-a-scoped account must see only msp-a stewards")
 	assert.Equal(t, "msp-a", resp.Data[0].TenantID, "returned steward must be in msp-a")
 }
+
+// ---- handleSetStewardVisibility tests (Issue #2918) ----
+
+// setupVisibilityServer creates a test server wired with a real flat-file steward
+// store and a real audit manager, suitable for visibility handler tests.
+func setupVisibilityServer(t *testing.T) (*Server, business.StewardStore) {
+	t.Helper()
+	server := setupTestServer(t)
+	st, _ := newTestStewardDurableStore(t)
+	server.SetStewardStore(st)
+	return server, st
+}
+
+// patchVisibility calls handleSetStewardVisibility directly with an admin mTLS principal.
+func patchVisibility(server *Server, stewardID string, hidden bool) *httptest.ResponseRecorder {
+	body := fmt.Sprintf(`{"hidden":%v}`, hidden)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/stewards/"+stewardID+"/visibility",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withPrincipal(req, &Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""})
+	req = withVars(req, map[string]string{"id": stewardID})
+	rec := httptest.NewRecorder()
+	server.handleSetStewardVisibility(rec, req)
+	return rec
+}
+
+// TestHandleSetStewardVisibility_HappyPath verifies that a known steward can be hidden
+// and the response contains {"id":"...","hidden":true}.
+func TestHandleSetStewardVisibility_HappyPath(t *testing.T) {
+	server, st := setupVisibilityServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-vis-ok",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	rec := patchVisibility(server, "s-vis-ok", true)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "s-vis-ok", resp.Data["id"])
+	assert.Equal(t, true, resp.Data["hidden"])
+}
+
+// TestHandleSetStewardVisibility_Reversibility verifies that a steward can be hidden
+// and then unhidden.
+func TestHandleSetStewardVisibility_Reversibility(t *testing.T) {
+	server, st := setupVisibilityServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-vis-rev",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	// Hide the steward.
+	rec := patchVisibility(server, "s-vis-rev", true)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Unhide the steward.
+	rec2 := patchVisibility(server, "s-vis-rev", false)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&resp))
+	assert.Equal(t, false, resp.Data["hidden"])
+
+	// Verify durable store reflects the unhidden state.
+	got, err := st.GetSteward(context.Background(), "s-vis-rev")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden)
+}
+
+// TestHandleSetStewardVisibility_CrossTenant verifies that a scoped admin receives 404
+// when trying to set visibility on a steward in a different tenant.
+func TestHandleSetStewardVisibility_CrossTenant(t *testing.T) {
+	server, st := setupVisibilityServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-vis-cross",
+		TenantID: "tenant-b",
+		Status:   business.StewardStatusActive,
+	}))
+
+	body := `{"hidden":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/stewards/s-vis-cross/visibility",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withPrincipal(req, &Principal{ID: "tenant-a-admin", Assurance: session.AssuranceBasic, TenantID: "tenant-a"})
+	req = withVars(req, map[string]string{"id": "s-vis-cross"})
+	rec := httptest.NewRecorder()
+	server.handleSetStewardVisibility(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant visibility must return 404, not 403")
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "STEWARD_NOT_FOUND", errResp.Error.Code)
+}
+
+// TestHandleSetStewardVisibility_AuditEmitted verifies that a successful visibility change
+// writes an audit entry with action "steward.visibility_changed" and AuditSeverityMedium.
+func TestHandleSetStewardVisibility_AuditEmitted(t *testing.T) {
+	server, st := setupVisibilityServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-vis-audit",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	rec := patchVisibility(server, "s-vis-audit", true)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, server.auditManager.Flush(context.Background()))
+	entries, err := server.auditManager.QueryEntries(context.Background(), &business.AuditFilter{
+		Actions: []string{"steward.visibility_changed"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "visibility audit entry must be written")
+
+	e := entries[0]
+	assert.Equal(t, "steward.visibility_changed", e.Action)
+	assert.Equal(t, business.AuditSeverityMedium, e.Severity)
+	assert.Equal(t, "steward", e.ResourceType)
+	assert.Equal(t, "s-vis-audit", e.ResourceID)
+	assert.Equal(t, business.AuditResultSuccess, e.Result)
+}
+
+// TestHandleSetStewardVisibility_NilStore verifies 503 when stewardStore is nil.
+func TestHandleSetStewardVisibility_NilStore(t *testing.T) {
+	server := setupTestServer(t)
+
+	body := `{"hidden":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/stewards/some-steward/visibility",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withPrincipal(req, &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""})
+	req = withVars(req, map[string]string{"id": "some-steward"})
+	rec := httptest.NewRecorder()
+	server.handleSetStewardVisibility(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "SERVICE_UNAVAILABLE", errResp.Error.Code)
+}
+
+// TestHandleSetStewardVisibility_InvalidID verifies 400 for a malformed steward ID.
+func TestHandleSetStewardVisibility_InvalidID(t *testing.T) {
+	server, _ := setupVisibilityServer(t)
+
+	body := `{"hidden":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/stewards/bad.id:here/visibility",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withPrincipal(req, &Principal{ID: "admin", Assurance: session.AssuranceBasic, TenantID: ""})
+	req = withVars(req, map[string]string{"id": "bad.id:here"})
+	rec := httptest.NewRecorder()
+	server.handleSetStewardVisibility(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "INVALID_STEWARD_ID", errResp.Error.Code)
+}
+
+// TestHandleSetStewardVisibility_AssuranceMachineRejected verifies that a bare API-key
+// caller (AssuranceMachine) cannot use the visibility endpoint (via the full router).
+// AssuranceBasic is the floor for steward:visibility (Issue #2918 security ruling).
+func TestHandleSetStewardVisibility_AssuranceMachineRejected(t *testing.T) {
+	server, _ := setupVisibilityServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:visibility"})
+
+	body := `{"hidden":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/stewards/any-steward/visibility",
+		strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code, "API-key callers must be rejected at AssuranceBasic gate")
+}
+
+// TestHandleSetStewardVisibility_ListExclusion verifies that hidden/quarantined stewards
+// are excluded from the default list and restored with the include params.
+func TestHandleSetStewardVisibility_ListExclusion(t *testing.T) {
+	server, st := setupVisibilityServer(t)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-hidden-list",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+	require.NoError(t, server.controllerService.RegisterSteward("s-hidden-list", "test-tenant", "addr", "active"))
+	require.NoError(t, server.controllerService.RegisterSteward("s-quarantined-list", "test-tenant", "addr", "quarantined"))
+
+	// Hide s-hidden-list via the handler.
+	rec := patchVisibility(server, "s-hidden-list", true)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Default list must exclude hidden and quarantined stewards.
+	req := httptest.NewRequest("GET", "/api/v1/stewards", nil)
+	req = withTenant(req, "")
+	rec2 := httptest.NewRecorder()
+	server.handleListStewards(rec2, req)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&resp))
+	for _, s := range resp.Data {
+		assert.NotEqual(t, "s-hidden-list", s.ID, "hidden steward must not appear in default list")
+		assert.NotEqual(t, "s-quarantined-list", s.ID, "quarantined steward must not appear in default list")
+	}
+
+	// With include_hidden=true and include_quarantined=true, both must reappear.
+	req3 := httptest.NewRequest("GET", "/api/v1/stewards?include_hidden=true&include_quarantined=true", nil)
+	req3 = withTenant(req3, "")
+	rec3 := httptest.NewRecorder()
+	server.handleListStewards(rec3, req3)
+	require.Equal(t, http.StatusOK, rec3.Code)
+	var resp3 struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec3.Body).Decode(&resp3))
+	foundHidden := false
+	foundQuarantined := false
+	for _, s := range resp3.Data {
+		if s.ID == "s-hidden-list" {
+			foundHidden = true
+			assert.True(t, s.Hidden, "hidden steward must have Hidden=true in response")
+		}
+		if s.ID == "s-quarantined-list" {
+			foundQuarantined = true
+		}
+	}
+	assert.True(t, foundHidden, "hidden steward must appear with ?include_hidden=true")
+	assert.True(t, foundQuarantined, "quarantined steward must appear with ?include_quarantined=true")
+}
+
+// TestHandleSetStewardVisibility_MalformedBody verifies 400 INVALID_JSON when the request
+// body is not valid JSON, covering the decode error branch at handlers_stewards.go:1060.
+func TestHandleSetStewardVisibility_MalformedBody(t *testing.T) {
+	server, st := setupVisibilityServer(t)
+
+	// Register the steward so the only reason for failure is the malformed body.
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-vis-badjson",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/stewards/s-vis-badjson/visibility",
+		strings.NewReader("not-json{"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withPrincipal(req, &Principal{ID: "cfgms-admin", Assurance: session.AssuranceBasic, TenantID: ""})
+	req = withVars(req, map[string]string{"id": "s-vis-badjson"})
+	rec := httptest.NewRecorder()
+	server.handleSetStewardVisibility(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "INVALID_JSON", errResp.Error.Code)
+
+	// Durable state must be untouched by a rejected request.
+	got, err := st.GetSteward(context.Background(), "s-vis-badjson")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "malformed body must not change stored visibility")
+}
+
+// TestHandleSetStewardVisibility_NotFound verifies 404 STEWARD_NOT_FOUND when the steward
+// is absent from the durable store (GetSteward returns ErrStewardNotFound), covering the
+// branch at handlers_stewards.go:1069. Distinct from _CrossTenant, where GetSteward
+// succeeds and the tenant-scope check rejects.
+func TestHandleSetStewardVisibility_NotFound(t *testing.T) {
+	server, _ := setupVisibilityServer(t)
+
+	rec := patchVisibility(server, "s-vis-absent", true)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "STEWARD_NOT_FOUND", errResp.Error.Code)
+}
+
+// TestHandleSetStewardVisibility_StoreLookupFails verifies 500 INTERNAL_ERROR when
+// GetSteward fails with a non-NotFound store error, covering the branch at
+// handlers_stewards.go:1073. The failure is genuine: the steward's on-disk record is
+// corrupted so the flat-file store's unmarshal fails, which is neither ErrStewardNotFound
+// nor a synthetic injected error.
+func TestHandleSetStewardVisibility_StoreLookupFails(t *testing.T) {
+	server := setupTestServer(t)
+	st, root := newTestStewardDurableStore(t)
+	server.SetStewardStore(st)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-vis-corrupt",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	// Corrupt the backing record: the file exists (so os.IsNotExist is false) but does not
+	// contain a decodable steward record, so GetSteward returns an unmarshal error.
+	recordPath := filepath.Join(root, "stewards", "s-vis-corrupt.json")
+	require.NoError(t, os.WriteFile(recordPath, []byte("{not valid json"), 0o600))
+
+	rec := patchVisibility(server, "s-vis-corrupt", true)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "INTERNAL_ERROR", errResp.Error.Code)
+	assert.NotContains(t, errResp.Error.Message, "unmarshal",
+		"error response must not disclose internal store details")
+}
+
+// TestHandleSetStewardVisibility_DurableStoreWriteFails verifies that when the durable
+// write (SetStewardHidden) fails after lookup and scope checks pass, the handler returns
+// 500 INTERNAL_ERROR and leaves visibility unchanged — the visibility-handler mirror of
+// TestHandleDecommissionSteward_DurableStoreWriteFails, covering handlers_stewards.go:1090.
+func TestHandleSetStewardVisibility_DurableStoreWriteFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not enforce POSIX directory permissions on Windows")
+	}
+	server := setupTestServer(t)
+	st, root := newTestStewardDurableStore(t)
+	server.SetStewardStore(st)
+
+	require.NoError(t, st.RegisterSteward(context.Background(), &business.StewardRecord{
+		ID:       "s-vis-writefail",
+		TenantID: "test-tenant",
+		Status:   business.StewardStatusActive,
+	}))
+
+	// Induce a genuine durable-store write failure: make the flat-file store's backing
+	// directory read-only. The record was already written, so GetSteward (a pure read)
+	// still succeeds and the handler reaches SetStewardHidden, whose atomic write
+	// (temp-file creation in the directory) then fails with a permission error. Restore
+	// the mode on cleanup so t.TempDir() removal can delete the tree.
+	stewardDir := filepath.Join(root, "stewards")
+	require.NoError(t, os.Chmod(stewardDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(stewardDir, 0o750) })
+
+	rec := patchVisibility(server, "s-vis-writefail", true)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "INTERNAL_ERROR", errResp.Error.Code)
+
+	// Visibility must not have been persisted: restore write access and confirm the record
+	// is still visible (the failed write left durable state unchanged).
+	require.NoError(t, os.Chmod(stewardDir, 0o750))
+	got, err := st.GetSteward(context.Background(), "s-vis-writefail")
+	require.NoError(t, err)
+	assert.False(t, got.Hidden, "record must remain visible when the durable write fails")
+}

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -23,6 +23,7 @@ var knownPermissions = map[string]bool{
 	"steward:delete-config":   true,
 	"steward:move":            true,
 	"steward:decommission":    true,
+	"steward:visibility":      true, // Issue #2918: hide/unhide steward from default fleet view
 	// Config management
 	"config:list":             true,
 	"config:list-deployments": true,

--- a/features/controller/api/route_registry_test.go
+++ b/features/controller/api/route_registry_test.go
@@ -189,6 +189,7 @@ var goldenRouteTable = []string{
 	"OPTIONS /api/v1/register",
 	"OPTIONS /api/v1/stewards/{device_id}/refresh/challenge",
 	"OPTIONS /api/v1/stewards/{device_id}/refresh/complete",
+	"PATCH /api/v1/stewards/{id}/visibility",
 	"POST /api/v1/api-keys",
 	"POST /api/v1/certificates/provision",
 	"POST /api/v1/certificates/signing/rotate",

--- a/features/controller/api/routes_stewards.go
+++ b/features/controller/api/routes_stewards.go
@@ -22,8 +22,9 @@ func registerStewardRoutes(s *Server, api *mux.Router) {
 	stewards.Handle("/{id}/dna", s.requirePermission("steward", "read-dna")(http.HandlerFunc(s.handleGetStewardDNA))).Methods("GET")
 	stewards.Handle("/{id}/logs", s.requirePermission("steward", "read-logs")(http.HandlerFunc(s.handleGetStewardLogs))).Methods("GET")
 	stewards.Handle("/{id}/auth/refresh", s.requirePermission("steward", "auth-refresh")(http.HandlerFunc(s.handleStewardAuthRefresh))).Methods("POST")
-	stewards.Handle("/{id}/move", s.requirePermission("steward", "move")(http.HandlerFunc(s.handleMoveSteward))).Methods("POST")              // Issue #2341, #2780: AssuranceStrong via permissionAssurance
-	stewards.Handle("/{id}", s.requirePermission("steward", "decommission")(http.HandlerFunc(s.handleDecommissionSteward))).Methods("DELETE") // Issue #2408, #2780: AssuranceStrong via permissionAssurance
+	stewards.Handle("/{id}/move", s.requirePermission("steward", "move")(http.HandlerFunc(s.handleMoveSteward))).Methods("POST")                       // Issue #2341, #2780: AssuranceStrong via permissionAssurance
+	stewards.Handle("/{id}/visibility", s.requirePermission("steward", "visibility")(http.HandlerFunc(s.handleSetStewardVisibility))).Methods("PATCH") // Issue #2918: AssuranceBasic via permissionAssurance
+	stewards.Handle("/{id}", s.requirePermission("steward", "decommission")(http.HandlerFunc(s.handleDecommissionSteward))).Methods("DELETE")          // Issue #2408, #2780: AssuranceStrong via permissionAssurance
 
 	// Configuration management endpoints
 	stewards.Handle("/{id}/config", s.requirePermission("steward", "read-config")(http.HandlerFunc(s.handleGetStewardConfig))).Methods("GET")

--- a/features/controller/api/tier_enforcement_test.go
+++ b/features/controller/api/tier_enforcement_test.go
@@ -104,6 +104,9 @@ var strongAssuranceRouteTable = []strongAssuranceRouteEntry{
 	// Terminal WebSocket relay (Issue #2761) — browser must hold AssuranceStrong before
 	// an interactive terminal to a steward is opened.
 	{"GET", "/api/v1/terminal/ws/test-steward-id", "terminal:create"},
+	// Steward visibility toggle (Issue #2918) — Min=AssuranceBasic: API keys get 403,
+	// web sessions pass, Strong passes. Part (d) uses assertBasicPassesFromRequirePermission.
+	{"PATCH", "/api/v1/stewards/test-steward-id/visibility", "steward:visibility"},
 }
 
 // knownFuturePermissions lists permissionAssurance entries with Min > Machine

--- a/features/controller/api/types.go
+++ b/features/controller/api/types.go
@@ -38,6 +38,8 @@ type StewardInfo struct {
 	ConnectedAt time.Time         `json:"connected_at"`
 	Metrics     map[string]string `json:"metrics,omitempty"`
 	DNA         *DNAInfo          `json:"dna,omitempty"`
+	// Hidden is the operator-controlled fleet-view visibility flag (Issue #2918).
+	Hidden bool `json:"hidden,omitempty"`
 	// ActiveSessions is 1 when the steward has an active ControlChannel stream,
 	// 0 otherwise. Each steward holds at most one stream at a time, so this is
 	// a binary sentinel, not a real connection count.

--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -55,6 +55,7 @@ type StewardResult struct {
 	LastHeartbeat  time.Time
 	DNAAttributes  map[string]string
 	RunningVersion string // populated from the steward.version DNA attribute (Issue #2260)
+	Hidden         bool   // operator-controlled fleet-view visibility flag (Issue #2918)
 }
 
 // FleetQuery is the single query path for all device filtering.

--- a/features/controller/fleet/memory.go
+++ b/features/controller/fleet/memory.go
@@ -139,5 +139,6 @@ func toStewardResult(s StewardData) StewardResult {
 		LastHeartbeat:  s.LastHeartbeat,
 		DNAAttributes:  attrs,
 		RunningVersion: attrs["steward.version"],
+		Hidden:         s.Hidden,
 	}
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -3022,6 +3022,7 @@ func (p *serverFleetStewardProvider) GetAllStewards() []controllerFleet.StewardD
 			Status:        info.Status,
 			LastHeartbeat: info.LastHeartbeat,
 			DNAAttributes: attrs,
+			Hidden:        info.Hidden,
 		})
 	}
 	return result

--- a/web/src/fleet/FleetOverview.test.tsx
+++ b/web/src/fleet/FleetOverview.test.tsx
@@ -855,3 +855,163 @@ describe('bulk selection (Story #2939)', () => {
     expect(screen.getByRole('checkbox', { name: 'Select host-1' })).not.toBeChecked()
   })
 })
+
+/**
+ * Mock fleet list + fleet health with a hidden count.
+ * The visibility PATCH endpoint is handled separately by the caller.
+ */
+function mockFleetWithHiddenHealth(
+  stewards: Steward[],
+  health: { healthy: number; degraded: number; unreachable: number; hidden: number },
+) {
+  fetchMock.mockImplementation((input) => {
+    const url = new URL(String(input), 'https://controller.test')
+
+    if (url.pathname === '/api/v1/fleet/health') {
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: health }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    }
+
+    if (url.pathname.endsWith('/visibility') && url.pathname.startsWith('/api/v1/stewards/')) {
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+    }
+
+    const limit = Number(url.searchParams.get('limit'))
+    const offset = Number(url.searchParams.get('offset'))
+    const body = {
+      data: {
+        stewards: stewards.slice(offset, offset + limit),
+        total: stewards.length,
+        limit,
+        offset,
+      },
+      timestamp: new Date().toISOString(),
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+}
+
+describe('hidden steward toggle and count (Story #2918 AC)', () => {
+  it('renders a "Show hidden / quarantined" checkbox toggle', async () => {
+    mockFleet([makeSteward({ id: 's1', hostname: 'host-1' })])
+    renderFleet()
+    await screen.findByRole('table')
+
+    expect(screen.getByTestId('hidden-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('hidden-toggle-label').textContent).toContain(
+      'Show hidden / quarantined',
+    )
+  })
+
+  it('default (toggle off) — does not append include_hidden to the stewards request', async () => {
+    mockFleet([makeSteward({ id: 's1', hostname: 'host-1' })])
+    renderFleet()
+    await screen.findByRole('table')
+
+    const stewardsCall = fetchMock.mock.calls.find((args) =>
+      String(args[0]).includes('/api/v1/stewards'),
+    )
+    expect(String(stewardsCall?.[0])).not.toContain('include_hidden')
+    expect(String(stewardsCall?.[0])).not.toContain('include_quarantined')
+  })
+
+  it('toggle on — appends include_hidden=true and include_quarantined=true to stewards request', async () => {
+    mockFleet([makeSteward({ id: 's1', hostname: 'host-1' })])
+    renderFleet()
+    await screen.findByRole('table')
+
+    fetchMock.mockReset()
+    // Re-supply mock so the refetch after toggle works.
+    mockFleet([makeSteward({ id: 's1', hostname: 'host-1' })])
+
+    fireEvent.click(screen.getByTestId('hidden-toggle'))
+
+    await waitFor(() => {
+      const hiddenCall = fetchMock.mock.calls.find((args) =>
+        String(args[0]).includes('include_hidden=true'),
+      )
+      expect(hiddenCall).toBeDefined()
+    })
+
+    const hiddenCallUrl = fetchMock.mock.calls.find((args) =>
+      String(args[0]).includes('include_hidden=true'),
+    )
+    expect(String(hiddenCallUrl?.[0])).toContain('include_quarantined=true')
+  })
+
+  it('shows "(N hidden)" count when health reports hidden > 0 and toggle is off', async () => {
+    mockFleetWithHiddenHealth(
+      [makeSteward({ id: 's1', hostname: 'host-1' })],
+      { healthy: 1, degraded: 0, unreachable: 0, hidden: 3 },
+    )
+    renderFleet()
+    await screen.findByRole('table')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hidden-count')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('hidden-count').textContent).toContain('3')
+    expect(screen.getByTestId('hidden-count').textContent).toContain('hidden')
+  })
+
+  it('hides the "(N hidden)" count when toggle is on (hidden entries are visible)', async () => {
+    mockFleetWithHiddenHealth(
+      [makeSteward({ id: 's1', hostname: 'host-1' })],
+      { healthy: 1, degraded: 0, unreachable: 0, hidden: 3 },
+    )
+    renderFleet()
+    await screen.findByRole('table')
+
+    await waitFor(() => expect(screen.getByTestId('hidden-count')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('hidden-toggle'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('hidden-count')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows hidden health tile when health reports hidden > 0', async () => {
+    mockFleetWithHiddenHealth(
+      [makeSteward({ id: 's1', hostname: 'host-1' })],
+      { healthy: 2, degraded: 0, unreachable: 0, hidden: 5 },
+    )
+    renderFleet()
+    await screen.findByRole('table')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('health-tile-hidden')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('health-tile-hidden').textContent).toContain('5')
+  })
+
+  it('clicking the hide button on a row calls PATCH /api/v1/stewards/{id}/visibility', async () => {
+    mockFleetWithHiddenHealth(
+      [makeSteward({ id: 'stw-abc', hostname: 'my-server' })],
+      { healthy: 1, degraded: 0, unreachable: 0, hidden: 0 },
+    )
+    renderFleet()
+    await screen.findByRole('table')
+
+    const btn = await screen.findByTestId('visibility-btn-stw-abc')
+    fireEvent.click(btn)
+
+    await waitFor(() => {
+      const patchCall = fetchMock.mock.calls.find(
+        (args) => String(args[0]).includes('/api/v1/stewards/stw-abc/visibility'),
+      )
+      expect(patchCall).toBeDefined()
+      const opts = patchCall?.[1] as RequestInit | undefined
+      expect(opts?.method).toBe('PATCH')
+    })
+  })
+})

--- a/web/src/fleet/FleetOverview.tsx
+++ b/web/src/fleet/FleetOverview.tsx
@@ -22,8 +22,9 @@
  * change); middle-click/Ctrl+click on the name-cell anchor opens the full
  * page at /stewards/:id in a new tab.
  */
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useOutletContext } from 'react-router'
+import { apiFetch } from '../api/client.ts'
 import { useTenantScope } from '../shell/TenantScopeContext.tsx'
 import StewardDrawer from './StewardDrawer.tsx'
 import {
@@ -34,6 +35,7 @@ import {
   type ColumnKey,
   type Steward,
 } from './columns.ts'
+
 import { deriveHealth, fetchFleetHealth, parseLastSeen, type FleetHealth } from './health.ts'
 import BulkActionBar from './BulkActionBar.tsx'
 import ColumnPicker from './ColumnPicker.tsx'
@@ -89,6 +91,7 @@ export default function FleetOverview() {
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set())
 
   const [fleetHealth, setFleetHealth] = useState<FleetHealth | null>(null)
+  const [showHidden, setShowHidden] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -122,6 +125,7 @@ export default function FleetOverview() {
     pageSize,
     pageIndex * pageSize,
     search,
+    showHidden,
   )
 
   // Relative times and staleness anchor at fetch time — the moment the data
@@ -166,6 +170,17 @@ export default function FleetOverview() {
       return next
     })
   }
+
+  const onToggleVisibility = useCallback((steward: Steward) => {
+    const newHidden = !steward.hidden
+    apiFetch(`/api/v1/stewards/${encodeURIComponent(steward.id)}/visibility`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hidden: newHidden }),
+    }).then((resp) => {
+      if (resp.ok) retry()
+    }).catch(() => { /* best-effort; user can retry */ })
+  }, [retry])
 
   function toggleAll() {
     const allIds = displayRows.map((s) => s.id)
@@ -250,6 +265,12 @@ export default function FleetOverview() {
             <span className="ht-count">{formatCount.format(fleetHealth.unreachable)}</span>
             <span className="ht-label">Unreachable</span>
           </div>
+          {fleetHealth.hidden > 0 && (
+            <div className="ht neutral" data-testid="health-tile-hidden">
+              <span className="ht-count">{formatCount.format(fleetHealth.hidden)}</span>
+              <span className="ht-label">Hidden</span>
+            </div>
+          )}
         </div>
       )}
 
@@ -257,6 +278,20 @@ export default function FleetOverview() {
         <div className="ptool">
           <SavedViews current={currentConfig} onApply={applyView} />
           <ColumnPicker visible={visible} onToggle={onToggleColumn} />
+          <label className="hidden-toggle" data-testid="hidden-toggle-label">
+            <input
+              type="checkbox"
+              data-testid="hidden-toggle"
+              checked={showHidden}
+              onChange={(e) => setShowHidden(e.target.checked)}
+            />
+            {' '}Show hidden / quarantined
+          </label>
+          {fleetHealth !== null && !showHidden && fleetHealth.hidden > 0 && (
+            <span className="hidden-count" data-testid="hidden-count">
+              ({formatCount.format(fleetHealth.hidden)} hidden)
+            </span>
+          )}
           <span className="cnt" data-testid="fleet-count">
             {page === null ? '' : countText}
           </span>
@@ -291,6 +326,7 @@ export default function FleetOverview() {
               selectedIds={selectedIds}
               onToggleRow={toggleRow}
               onToggleAll={toggleAll}
+              onToggleVisibility={onToggleVisibility}
             />
           </>
         )}

--- a/web/src/fleet/FleetTable.test.tsx
+++ b/web/src/fleet/FleetTable.test.tsx
@@ -312,3 +312,74 @@ describe('checkbox column (Story #2939 AC)', () => {
     expect(screen.getByRole('button', { name: 'Actions' })).toBeInTheDocument()
   })
 })
+
+describe('per-row visibility button (Story #2918 AC)', () => {
+  function makeHiddenSteward(id: string, hostname = `host-${id}`): Steward {
+    return { ...makeSteward(id, hostname), hidden: true }
+  }
+
+  function renderWithVisibility(stewards: Steward[], onToggleVisibility: (s: Steward) => void) {
+    return render(
+      <MemoryRouter>
+        <FleetTable
+          stewards={stewards}
+          columns={defaultColumns}
+          sort={null}
+          onSort={() => {}}
+          nowMs={NOW_MS}
+          onRowSelect={() => {}}
+          onToggleVisibility={onToggleVisibility}
+        />
+      </MemoryRouter>,
+    )
+  }
+
+  it('no visibility button when onToggleVisibility is not provided', () => {
+    renderTable([makeSteward('stw-1', 'host1')], vi.fn())
+    expect(screen.queryByTestId('visibility-btn-stw-1')).not.toBeInTheDocument()
+  })
+
+  it('shows "Hide" button for a visible (not hidden) steward', () => {
+    renderWithVisibility([makeSteward('stw-1', 'host1')], vi.fn())
+    const btn = screen.getByTestId('visibility-btn-stw-1')
+    expect(btn).toHaveTextContent('Hide')
+    expect(btn).toHaveAttribute('aria-label', 'Hide steward')
+  })
+
+  it('shows "Unhide" button for a hidden steward', () => {
+    renderWithVisibility([makeHiddenSteward('stw-2', 'host2')], vi.fn())
+    const btn = screen.getByTestId('visibility-btn-stw-2')
+    expect(btn).toHaveTextContent('Unhide')
+    expect(btn).toHaveAttribute('aria-label', 'Unhide steward')
+  })
+
+  it('clicking the visibility button calls onToggleVisibility with the steward', () => {
+    const onToggleVisibility = vi.fn()
+    renderWithVisibility([makeSteward('stw-3', 'host3')], onToggleVisibility)
+
+    fireEvent.click(screen.getByTestId('visibility-btn-stw-3'))
+
+    expect(onToggleVisibility).toHaveBeenCalledTimes(1)
+    expect(onToggleVisibility.mock.calls[0]?.[0].id).toBe('stw-3')
+  })
+
+  it('clicking the visibility button does NOT call onRowSelect (drawer stays closed)', () => {
+    const onRowSelect = vi.fn()
+    render(
+      <MemoryRouter>
+        <FleetTable
+          stewards={[makeSteward('stw-4', 'host4')]}
+          columns={defaultColumns}
+          sort={null}
+          onSort={() => {}}
+          nowMs={NOW_MS}
+          onRowSelect={onRowSelect}
+          onToggleVisibility={() => {}}
+        />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByTestId('visibility-btn-stw-4'))
+    expect(onRowSelect).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/fleet/FleetTable.tsx
+++ b/web/src/fleet/FleetTable.tsx
@@ -131,6 +131,7 @@ export default function FleetTable({
   selectedIds,
   onToggleRow,
   onToggleAll,
+  onToggleVisibility,
 }: {
   stewards: Steward[]
   columns: ColumnDef[]
@@ -141,6 +142,7 @@ export default function FleetTable({
   selectedIds?: ReadonlySet<string>
   onToggleRow?: (stewardId: string) => void
   onToggleAll?: () => void
+  onToggleVisibility?: (steward: Steward) => void
 }) {
   const hasSelection = selectedIds !== undefined
   const allOnPage =
@@ -233,6 +235,23 @@ export default function FleetTable({
               ))}
               {onRowSelect !== undefined && (
                 <td className="c-act">
+                  {onToggleVisibility !== undefined && (
+                    <button
+                      type="button"
+                      className="row-vis-btn"
+                      aria-label={steward.hidden ? 'Unhide steward' : 'Hide steward'}
+                      data-testid={`visibility-btn-${steward.id}`}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onToggleVisibility(steward)
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') e.stopPropagation()
+                      }}
+                    >
+                      {steward.hidden ? 'Unhide' : 'Hide'}
+                    </button>
+                  )}
                   <RowActionMenu stewardId={steward.id} />
                 </td>
               )}

--- a/web/src/fleet/columns.ts
+++ b/web/src/fleet/columns.ts
@@ -31,6 +31,7 @@ export interface Steward {
   last_seen?: string
   version?: string
   dna?: StewardDNA | null
+  hidden?: boolean
 }
 
 export interface StewardPage {

--- a/web/src/fleet/health.test.ts
+++ b/web/src/fleet/health.test.ts
@@ -197,18 +197,31 @@ describe('fetchFleetHealth', () => {
       ),
     )
     const result = await fetchFleetHealth()
-    expect(result).toEqual({ healthy: 5, degraded: 2, unreachable: 1 })
+    // A response without `hidden` (older controller) maps to hidden: 0 (Issue #2918).
+    expect(result).toEqual({ healthy: 5, degraded: 2, unreachable: 1, hidden: 0 })
+  })
+
+  it('returns the hidden count when the server reports one', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: { healthy: 5, degraded: 2, unreachable: 1, hidden: 5 } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    const result = await fetchFleetHealth()
+    expect(result.hidden).toBe(5)
+    expect(result).toEqual({ healthy: 5, degraded: 2, unreachable: 1, hidden: 5 })
   })
 
   it('returns zeros when all counts are zero', async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(
-        JSON.stringify({ data: { healthy: 0, degraded: 0, unreachable: 0 } }),
+        JSON.stringify({ data: { healthy: 0, degraded: 0, unreachable: 0, hidden: 0 } }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     )
     const result = await fetchFleetHealth()
-    expect(result).toEqual({ healthy: 0, degraded: 0, unreachable: 0 })
+    expect(result).toEqual({ healthy: 0, degraded: 0, unreachable: 0, hidden: 0 })
   })
 
   it('throws when the server returns a non-2xx status', async () => {

--- a/web/src/fleet/health.ts
+++ b/web/src/fleet/health.ts
@@ -95,11 +95,14 @@ export function deriveHealth(
  * Server-side fleet health aggregate returned by GET /api/v1/fleet/health.
  * Counts are tenant-scoped and classified by the same degradation rule as
  * DegradedHeartbeatAge on the controller (5 min stale heartbeat).
+ * hidden is always present (non-suppressible): the operator must always see
+ * that concealment is in effect (Issue #2918).
  */
 export interface FleetHealth {
   healthy: number
   degraded: number
   unreachable: number
+  hidden: number
 }
 
 /**
@@ -125,6 +128,7 @@ export async function fetchFleetHealth(): Promise<FleetHealth> {
     healthy: rec['healthy'] as number,
     degraded: rec['degraded'] as number,
     unreachable: rec['unreachable'] as number,
+    hidden: typeof rec?.['hidden'] === 'number' ? (rec['hidden'] as number) : 0,
   }
 }
 

--- a/web/src/fleet/useStewards.ts
+++ b/web/src/fleet/useStewards.ts
@@ -38,6 +38,7 @@ function parseSteward(value: unknown): Steward | null {
   if (typeof record.status === 'string') steward.status = record.status
   if (typeof record.last_seen === 'string') steward.last_seen = record.last_seen
   if (typeof record.version === 'string') steward.version = record.version
+  if (typeof record.hidden === 'boolean') steward.hidden = record.hidden
   if (typeof record.dna === 'object' && record.dna !== null) {
     const dna = record.dna as Record<string, unknown>
     let attributes: Record<string, string> = {}
@@ -94,7 +95,7 @@ interface FetchOutcome {
   fetchedAtMs: number
 }
 
-export function useStewards(limit: number, offset: number, selector = ''): UseStewardsResult {
+export function useStewards(limit: number, offset: number, selector = '', includeHidden = false): UseStewardsResult {
   const { scope, rootPath, registerObservedPath } = useTenantScope()
   const [attempt, setAttempt] = useState(0)
   const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
@@ -115,7 +116,7 @@ export function useStewards(limit: number, offset: number, selector = ''): UseSt
 
   // Loading is derived, not set: the view is loading whenever the latest
   // outcome doesn't answer the current request key.
-  const key = `${limit}:${offset}:${effectiveSelector}:${attempt}`
+  const key = `${limit}:${offset}:${effectiveSelector}:${String(includeHidden)}:${attempt}`
 
   useEffect(() => {
     let cancelled = false
@@ -126,6 +127,11 @@ export function useStewards(limit: number, offset: number, selector = ''): UseSt
     const selectorTrimmed = effectiveSelector.trim()
     if (selectorTrimmed !== '') {
       params.set('q', selectorTrimmed)
+    }
+    // Issue #2918: pass include_hidden and include_quarantined when the toggle is on.
+    if (includeHidden) {
+      params.set('include_hidden', 'true')
+      params.set('include_quarantined', 'true')
     }
     apiFetch(`/api/v1/stewards?${params.toString()}`)
       .then(async (response) => {
@@ -157,7 +163,7 @@ export function useStewards(limit: number, offset: number, selector = ''): UseSt
     return () => {
       cancelled = true
     }
-  }, [key, limit, offset, effectiveSelector, registerObservedPath])
+  }, [key, limit, offset, effectiveSelector, includeHidden, registerObservedPath])
 
   const current = outcome?.key === key ? outcome : null
   return {


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/v1/stewards/{id}/visibility` — reversible, tenant-scoped, `AssuranceBasic`-gated endpoint that hides/unhides a steward from the default fleet view. API keys are rejected (closes the concealment-under-compromised-key gap). Audited at `AuditSeverityMedium`.
- `GET /api/v1/stewards` now excludes hidden and quarantined stewards by default; `include_hidden=true` / `include_quarantined=true` re-include them.
- `GET /api/v1/fleet/health` excludes hidden stewards from tile counts and adds a **non-suppressible** `hidden` field — operators always see that concealment is in effect regardless of filter state (security: hidden ≠ invisible).
- Frontend: toolbar "Show hidden / quarantined" toggle, persistent "(N hidden)" indicator in the default view, per-row hide/unhide button that stops propagation so it doesn't open the drawer.

## Changes

- `features/controller/api/handlers_stewards.go` — `handleSetStewardVisibility` handler + `emitVisibilityAudit`; hidden/quarantine exclusion in `handleListStewards` unfiltered branch
- `features/controller/api/handlers_fleet.go` — hidden exclusion from tile counts + non-suppressible `hidden` field in `FleetHealthResponse`
- `features/controller/fleet/fleet.go` / `memory.go` — `Hidden bool` on `StewardResult`; propagated by `toStewardResult`
- `features/controller/server/server.go` — `Hidden` forwarded in `serverFleetStewardProvider.GetAllStewards`
- `features/controller/api/routes_stewards.go` — `PATCH /{id}/visibility` route
- `features/controller/api/permissions.go` / `assurance.go` — `steward:visibility` permission at `AssuranceBasic`
- `features/controller/api/types.go` — `Hidden bool` on `StewardInfo`
- `web/src/fleet/` — toggle, indicator, per-row button, `useStewards` params, `FleetHealth.hidden`
- `docs/api/rest-api.md` — query params table for `GET /api/v1/stewards`, `hidden` field in health response, new `PATCH /{id}/visibility` section
- Parity tests updated: `route_registry_test.go` golden table, `tier_enforcement_test.go` `strongAssuranceRouteTable`

## Test results

- `make test-agent-complete` passed (all pre-commit, fast comprehensive, production-critical, frontend checks)
- 8 new backend tests for `handleSetStewardVisibility` (happy path, reversibility, cross-tenant 404, audit emitted, nil-store 503, invalid ID 400, AssuranceMachine rejected, list exclusion)
- 2 new backend tests for fleet health hidden count (excluded from buckets, non-suppressible)
- 5 new `FleetTable.test.tsx` tests (visibility button render, hide/unhide label, stopPropagation)
- 7 new `FleetOverview.test.tsx` tests (toggle render, include_hidden param, hidden count indicator, hidden tile)
- Adversarial story-review workflow: passed in 2 rounds (1 code-review fix round)

## Security

- `steward:visibility` requires `AssuranceBasic` — web sessions and cfg Bearer pass; bare API keys get `403`. Closes the concealment-under-API-key gap from the threat model.
- `emitVisibilityAudit` uses `AuditSeverityMedium` — concealment-capable action appears in the audit trail, above the Low bucket for benign toggles.
- Hidden count is non-suppressible in the fleet health response — a compromised principal cannot hide stewards and simultaneously erase the evidence from the tile aggregate.
- Tenant isolation: cross-tenant visibility changes return `404` (not `403`) to avoid existence disclosure.

Fixes #2918

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>