### PR TITLE
web/auth: passkey-only first-passkey enrollment via single-use magic link (Issue #2966)

### DIFF
--- a/docs/architecture/decisions/021-identity-assurance-levels.md
+++ b/docs/architecture/decisions/021-identity-assurance-levels.md
@@ -697,6 +697,33 @@ Two invariants enforce Decisions 3 and 4 on that mint path:
   its own tenant subtree, so a tenant-scoped web admin cannot obtain an enrollment
   bearer token for another tenant's account or grant itself a root-scoped one.
 
+**Implementation reference — enrollment link redemption (Issue #2966):** The browser
+side of Decision 2 ("redemption via magic link") and Decisions 5–6 (confinement and
+CAS) is implemented in Story #2966.
+
+- **Redemption endpoints** — `POST /api/v1/web/passkey/enroll/begin` and `.../finish`
+  are registered on the base router (no `authenticationMiddleware`; the token is the
+  credential) with the `authDefense` middleware for DoS protection. They take the raw
+  token in the `X-Enrollment-Token` header; account resolution is fully token-driven
+  (`getWebAccountByEnrollmentToken`). No caller-supplied username or path variable is
+  consulted — eliminating cross-account credential injection.
+- **Single-use gate** — `passkeyEnrollSessions.LoadAndDelete(tokenHash)` makes the
+  in-flight ceremony atomically consume the session; a second concurrent finish call
+  sees no session and gets `NO_ACTIVE_ENROLLMENT`.
+- **CAS precondition at finish** — after WebAuthn verification succeeds, the handler
+  reloads the account from the durable store (`loadWebAccountFromStore`) and rejects
+  the request with `ALREADY_ENROLLED` if any credential is already present, enforcing
+  the zero-authenticator precondition under concurrent access.
+- **Token consumed on success** — `EnrollmentLinkRevoked = true` is persisted
+  immediately; subsequent begin calls with the same token get `TOKEN_INVALID`.
+- **Confinement middleware** — `enrollmentConfinementMiddleware` is added to the `/api/v1`
+  subrouter (runs after authentication, before `requirePermission`). It blocks every
+  request from a cookie-authenticated session whose `AuthenticatorCount` is ≤ 0 with
+  `403 ENROLLMENT_REQUIRED`. mTLS admin and API-key principals are never blocked
+  (their `cookieAuth` context key is false).
+- **`webauthn:register` (add-to-existing) stays at `AssuranceStrong`.** The enrollment
+  redemption routes have no entry in `permissionAssurance`; they are fully public.
+
 Revocation is fail-closed: the durable record is written before the in-memory cache is
 updated, so a store failure leaves a still-revocable outstanding link rather than a
 cache that claims revoked while the persisted link stays live.

--- a/features/controller/api/handlers_web_accounts.go
+++ b/features/controller/api/handlers_web_accounts.go
@@ -358,6 +358,53 @@ func (s *Server) emitWebAccountAudit(ctx context.Context, action, tenantID, acti
 	}
 }
 
+// getWebAccountByEnrollmentToken finds the web account whose enrollment token hash
+// matches hash(rawToken). The scan is necessary because tokens identify accounts —
+// the lookup direction is token→account, not account→token. Cache is checked first;
+// if not found there, the durable store is scanned.
+//
+// Returns (nil, nil) when no account with the given token exists. The caller MUST
+// call verifyEnrollmentToken on the returned account to confirm validity, expiry, and
+// revocation status — the store lookup finds by hash only and does not check liveness.
+func (s *Server) getWebAccountByEnrollmentToken(ctx context.Context, rawToken string) (*webAccount, error) {
+	tokenHash := hashEnrollmentToken(rawToken)
+
+	// Check the in-memory cache first — the fresh handler path uses loadWebAccountFromStore
+	// for CAS purposes, but begin can use the cache for a fast validity check.
+	s.mu.RLock()
+	for _, acct := range s.webAccounts {
+		if acct != nil && acct.EnrollmentLinkHash == tokenHash {
+			s.mu.RUnlock()
+			return acct, nil
+		}
+	}
+	s.mu.RUnlock()
+
+	if s.secretStore == nil {
+		return nil, nil
+	}
+	// Cache miss: scan the store by token hash. Filtering by the hash directly avoids
+	// loading all accounts. An account with a consumed/expired token will still match
+	// here; the caller checks validity separately via verifyEnrollmentToken.
+	metas, err := s.secretStore.ListSecrets(ctx, &secretsif.SecretFilter{
+		Metadata: map[string]string{
+			secretsif.MetadataKeySecretType: webAccountSecretType,
+			"enrollment_link_hash":          tokenHash,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan accounts by enrollment token: %w", err)
+	}
+	if len(metas) == 0 {
+		return nil, nil
+	}
+	username := metas[0].Metadata["username"]
+	if username == "" {
+		return nil, fmt.Errorf("account matched by enrollment token is missing username metadata")
+	}
+	return s.loadWebAccountFromStore(ctx, username)
+}
+
 // --- enrollment magic link (Issue #2974) ---
 
 // hashEnrollmentToken returns the SHA-256 hex digest of a raw enrollment token.

--- a/features/controller/api/handlers_webauthn.go
+++ b/features/controller/api/handlers_webauthn.go
@@ -3,6 +3,7 @@
 //
 // Issue #2782: WebAuthn passkey / FIDO2 registration endpoints.
 // Issue #2783: WebAuthn credential list and revoke endpoints (cfg CLI bootstrap).
+// Issue #2966: first-passkey enrollment via single-use magic link (ADR-021 Amendment 1).
 //
 // Routes (register: webauthn:register permission, AssuranceStrong;
 //
@@ -21,6 +22,20 @@
 //		POST /api/v1/web/accounts/{username}/webauthn/revoke/{credential_id}
 //		     Removes a specific credential. credential_id is base64url-encoded.
 //
+// Enrollment routes (Issue #2966; no assurance requirement — token IS the credential;
+// registered on the BASE router, not under the authenticated api subrouter):
+//
+//	POST /api/v1/web/passkey/enroll/begin
+//	     Header: X-Enrollment-Token: <raw-hex-token>
+//	     Verifies the token, begins WebAuthn registration ceremony self-scoped to the
+//	     account the token identifies (never a caller-supplied username).
+//
+//	POST /api/v1/web/passkey/enroll/finish
+//	     Header: X-Enrollment-Token: <raw-hex-token>
+//	     Body: WebAuthn PublicKeyCredential JSON
+//	     Verifies WebAuthn response, enforces zero-credential CAS precondition, appends
+//	     credential, and atomically consumes the token. Token not reusable after this.
+//
 // Server-side verification enforces: challenge freshness (5-min TTL, server-stored),
 // single-use (session deleted on every finish attempt), origin match, RP-ID match,
 // and cryptographic attestation verification — all via the go-webauthn/webauthn
@@ -29,6 +44,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -39,7 +55,9 @@ import (
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // webAuthnPendingSession holds an in-progress WebAuthn registration ceremony state
@@ -569,6 +587,272 @@ func (s *Server) handleWebAuthnListCredentials(w http.ResponseWriter, r *http.Re
 		Username:    username,
 		Credentials: infos,
 	})
+}
+
+// enrollmentTokenHeader is the HTTP request header that carries the single-use
+// enrollment magic-link token for first-passkey enrollment (Issue #2966).
+// The raw token (hex-encoded, 160-bit) is presented here; the server computes
+// SHA-256 and compares in constant time against the stored hash.
+const enrollmentTokenHeader = "X-Enrollment-Token"
+
+// handlePasskeyEnrollBegin handles POST /api/v1/web/passkey/enroll/begin.
+//
+// The caller presents the raw enrollment token in X-Enrollment-Token. The server:
+//   1. Looks up the account by token hash (never by caller-supplied username).
+//   2. Verifies the token is unexpired and not revoked.
+//   3. Starts a WebAuthn registration ceremony scoped to that account.
+//   4. Stores the pending session keyed by tokenHash (not username) so the finish
+//      step can find it without trusting any caller-supplied identity.
+//
+// This route is on the BASE router (public) — the token IS the auth credential.
+func (s *Server) handlePasskeyEnrollBegin(w http.ResponseWriter, r *http.Request) {
+	wa := s.getWebAuthn()
+	if wa == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"WebAuthn not configured", "WEBAUTHN_NOT_CONFIGURED")
+		return
+	}
+
+	rawToken := r.Header.Get(enrollmentTokenHeader)
+	if rawToken == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			enrollmentTokenHeader+" header is required", "MISSING_ENROLLMENT_TOKEN")
+		return
+	}
+
+	// Resolve account by token — never by a caller-supplied path variable.
+	// This prevents the cross-account credential injection described in the issue.
+	acct, err := s.getWebAccountByEnrollmentToken(r.Context(), rawToken)
+	if err != nil {
+		s.logger.Error("Failed to look up account for enrollment begin",
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to look up account", "STORE_ERROR")
+		return
+	}
+	if acct == nil {
+		// No account with this token or token does not exist.
+		// Return the same error as invalid/expired to prevent account enumeration.
+		s.writeErrorResponse(w, http.StatusUnauthorized,
+			"Invalid or expired enrollment token", "TOKEN_INVALID")
+		return
+	}
+
+	if !verifyEnrollmentToken(acct, rawToken) {
+		s.writeErrorResponse(w, http.StatusUnauthorized,
+			"Invalid or expired enrollment token", "TOKEN_INVALID")
+		return
+	}
+
+	user := buildWebauthnUser(acct)
+
+	creation, sessionData, err := wa.BeginRegistration(user,
+		webauthn.WithAuthenticatorSelection(protocol.AuthenticatorSelection{
+			UserVerification: protocol.VerificationRequired,
+		}),
+		webauthn.WithExclusions(webauthn.Credentials(user.credentials).CredentialDescriptors()),
+	)
+	if err != nil {
+		s.logger.Error("WebAuthn BeginRegistration failed for enrollment",
+			"account_id", logging.SanitizeLogValue(acct.ID),
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to begin WebAuthn registration", "WEBAUTHN_BEGIN_ERROR")
+		return
+	}
+
+	// Key the ceremony by tokenHash, not username. This decouples the session lookup
+	// from any caller-supplied identity at finish time (self-scoping invariant).
+	tokenHash := hashEnrollmentToken(rawToken)
+	s.passkeyEnrollSessions.Store(tokenHash, &webAuthnPendingSession{
+		data:    *sessionData,
+		expires: time.Now().Add(webAuthnSessionTTL),
+	})
+
+	s.logger.Info("Passkey enrollment ceremony started",
+		"account_id", logging.SanitizeLogValue(acct.ID))
+
+	s.writeResponse(w, http.StatusOK, creation)
+}
+
+// handlePasskeyEnrollFinish handles POST /api/v1/web/passkey/enroll/finish.
+//
+// The caller presents X-Enrollment-Token and the WebAuthn registration response body.
+// The server:
+//  1. Loads and atomically deletes the pending ceremony (single-use enforcement).
+//  2. Verifies the WebAuthn response cryptographically.
+//  3. Reloads the account from the durable store (for CAS freshness).
+//  4. Under the CAS precondition: token still valid + zero registered credentials.
+//  5. Appends the credential, marks the token consumed, persists, audits.
+//
+// The LoadAndDelete on passkeyEnrollSessions is the primary concurrency gate: only one
+// finish request per ceremony can succeed (the second gets NO_ACTIVE_ENROLLMENT). The
+// store-fresh reload at step 3 guards against admin-mediated mutations between begin and
+// finish (TOCTOU hardening — ADR-021 Amendment 1 security property 3).
+func (s *Server) handlePasskeyEnrollFinish(w http.ResponseWriter, r *http.Request) {
+	wa := s.getWebAuthn()
+	if wa == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"WebAuthn not configured", "WEBAUTHN_NOT_CONFIGURED")
+		return
+	}
+
+	rawToken := r.Header.Get(enrollmentTokenHeader)
+	if rawToken == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			enrollmentTokenHeader+" header is required", "MISSING_ENROLLMENT_TOKEN")
+		return
+	}
+
+	tokenHash := hashEnrollmentToken(rawToken)
+
+	// LoadAndDelete is the single-use gate: only the first finish call succeeds.
+	rawSession, ok := s.passkeyEnrollSessions.LoadAndDelete(tokenHash)
+	if !ok {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"No active enrollment session — call begin first", "NO_ACTIVE_ENROLLMENT")
+		return
+	}
+	pending, ok := rawSession.(*webAuthnPendingSession)
+	if !ok {
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Invalid session state", "SESSION_STATE_ERROR")
+		return
+	}
+
+	if time.Now().After(pending.expires) {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Enrollment session expired — restart with begin", "SESSION_EXPIRED")
+		return
+	}
+
+	// Resolve account by token for WebAuthn user construction.
+	// We look up from cache here; CAS reload from store follows below.
+	acct, err := s.getWebAccountByEnrollmentToken(r.Context(), rawToken)
+	if err != nil {
+		s.logger.Error("Failed to look up account for enrollment finish",
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to look up account", "STORE_ERROR")
+		return
+	}
+	if acct == nil || !verifyEnrollmentToken(acct, rawToken) {
+		s.writeErrorResponse(w, http.StatusUnauthorized,
+			"Enrollment token is no longer valid", "TOKEN_INVALID")
+		return
+	}
+
+	user := buildWebauthnUser(acct)
+
+	// Full library-level WebAuthn verification (challenge, origin, RP-ID, attestation).
+	credential, err := wa.FinishRegistration(user, pending.data, r)
+	if err != nil {
+		s.logger.Warn("WebAuthn FinishRegistration verification failed for enrollment",
+			"account_id", logging.SanitizeLogValue(acct.ID),
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"WebAuthn verification failed", "WEBAUTHN_VERIFY_ERROR")
+		return
+	}
+
+	label := logging.SanitizeLogValue(r.URL.Query().Get("label"))
+
+	transports := make([]string, 0, len(credential.Transport))
+	for _, t := range credential.Transport {
+		transports = append(transports, string(t))
+	}
+	stored := WebAuthnCredential{
+		ID:             credential.ID,
+		PublicKey:      credential.PublicKey,
+		SignCount:      credential.Authenticator.SignCount,
+		Transport:      transports,
+		Label:          label,
+		RegisteredAt:   time.Now().UTC(),
+		BackupEligible: credential.Flags.BackupEligible,
+		BackupState:    credential.Flags.BackupState,
+	}
+
+	// CAS reload: re-read from the durable store (not cache) to detect any
+	// admin-mediated mutations that occurred between begin and finish.
+	// Combined with LoadAndDelete above, this closes the TOCTOU window.
+	freshAcct, freshErr := s.loadWebAccountFromStore(r.Context(), acct.Username)
+	if freshErr != nil {
+		s.logger.Error("CAS reload failed for enrollment finish",
+			"account_id", logging.SanitizeLogValue(acct.ID),
+			"error", logging.SanitizeLogValue(freshErr.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to verify account state", "STORE_ERROR")
+		return
+	}
+	if freshAcct == nil || !verifyEnrollmentToken(freshAcct, rawToken) {
+		// Token was revoked or expired by an admin between begin and finish.
+		s.writeErrorResponse(w, http.StatusGone,
+			"Enrollment token is no longer valid", "TOKEN_INVALID")
+		return
+	}
+	if len(freshAcct.Credentials) != 0 {
+		// Another finish raced ahead (impossible via this path due to LoadAndDelete, but
+		// guards against future code paths or direct-store mutations).
+		s.writeErrorResponse(w, http.StatusConflict,
+			"Account already has enrolled credentials", "ALREADY_ENROLLED")
+		return
+	}
+
+	// Precondition satisfied. Build updated account: append credential, consume token.
+	updatedAcct := *freshAcct
+	updatedAcct.Credentials = []WebAuthnCredential{stored}
+	updatedAcct.EnrollmentLinkRevoked = true
+
+	if err := s.persistWebAccount(r.Context(), &updatedAcct, ""); err != nil {
+		s.logger.Error("Failed to persist enrollment credential",
+			"account_id", logging.SanitizeLogValue(acct.ID),
+			"error", logging.SanitizeLogValue(err.Error()))
+		s.writeErrorResponse(w, http.StatusInternalServerError,
+			"Failed to persist credential", "STORE_ERROR")
+		return
+	}
+	s.cacheWebAccount(&updatedAcct)
+
+	// Audit: record account, credential ID, and delivery channel.
+	credIDStr := base64.RawURLEncoding.EncodeToString(stored.ID)
+	s.emitEnrollmentAudit(r.Context(), &updatedAcct, credIDStr)
+	s.logger.Info("First passkey enrolled via magic link",
+		"account_id", logging.SanitizeLogValue(updatedAcct.ID),
+		"username", logging.SanitizeLogValue(updatedAcct.Username))
+
+	s.writeResponse(w, http.StatusCreated, WebAuthnRegisterFinishResponse{
+		CredentialID: stored.ID,
+		Label:        stored.Label,
+		RegisteredAt: stored.RegisteredAt,
+	})
+}
+
+// emitEnrollmentAudit records a first-passkey enrollment audit event.
+func (s *Server) emitEnrollmentAudit(ctx context.Context, acct *webAccount, credentialID string) {
+	if s.auditManager == nil {
+		return
+	}
+	tenantID := acct.TenantID
+	if tenantID == "" {
+		tenantID = audit.SystemTenantID
+	}
+	b := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(business.AuditEventSystemAccess).
+		Action("web_account.passkey_enrolled").
+		User(acct.ID, business.AuditUserTypeHuman).
+		Resource("web-account", logging.SanitizeLogValue(acct.Username), "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityHigh).
+		Details(map[string]interface{}{
+			"credential_id":    logging.SanitizeLogValue(credentialID),
+			"delivery_channel": "magic_link",
+		})
+	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
+		s.logger.Warn("Failed to emit enrollment audit event",
+			"account_id", logging.SanitizeLogValue(acct.ID),
+			"error", logging.SanitizeLogValue(err.Error()))
+	}
 }
 
 // handleWebAuthnRevokeCredential handles

--- a/features/controller/api/handlers_webauthn_test.go
+++ b/features/controller/api/handlers_webauthn_test.go
@@ -32,6 +32,9 @@ import (
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"github.com/cfgis/cfgms/pkg/session"
 )
 
 // Test vectors from github.com/go-webauthn/webauthn@v0.17.0/protocol/credential_test.go.
@@ -700,6 +703,517 @@ func TestWebAuthnPresenceFinish(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		assert.Equal(t, "SESSION_EXPIRED", errCode(t, rec.Body.Bytes()))
 	})
+}
+
+// --- Issue #2966: first-passkey enrollment via magic link ---
+
+// setupEnrollServer creates a test server with a WebAuthn RP configured for the
+// supplied rpID/origins, pre-creates a web account for the given username, and
+// returns the server, username, and the raw enrollment magic-link token. The token
+// is minted by handleCreateWebAccount (which issues it for zero-cred accounts).
+func setupEnrollServer(t *testing.T, rpID string, rpOrigins []string, username string) (*Server, string, string) {
+	t.Helper()
+	server := setupTestServer(t)
+	wa, err := NewWebAuthnFromConfig(rpID, rpID, rpOrigins)
+	require.NoError(t, err)
+	server.SetWebAuthn(wa)
+
+	rec := postWebAccount(t, server, testAdminPrincipal(), WebAccountRequest{Username: username})
+	require.Equal(t, http.StatusCreated, rec.Code, "create account: %s", rec.Body.String())
+
+	var outer APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &outer))
+	raw := outer.Data.(map[string]interface{})
+	rawToken, _ := raw["enrollment_magic_link"].(string)
+	require.NotEmpty(t, rawToken, "enrollment magic link must be minted on account creation")
+	return server, username, rawToken
+}
+
+// doEnrollBegin calls handlePasskeyEnrollBegin directly with the supplied raw token.
+func doEnrollBegin(t *testing.T, server *Server, rawToken string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/web/passkey/enroll/begin", nil)
+	req.Header.Set(enrollmentTokenHeader, rawToken)
+	rec := httptest.NewRecorder()
+	server.handlePasskeyEnrollBegin(rec, req)
+	return rec
+}
+
+// doEnrollFinish calls handlePasskeyEnrollFinish directly with the supplied raw token and body.
+func doEnrollFinish(t *testing.T, server *Server, rawToken string, body *bytes.Reader) *httptest.ResponseRecorder {
+	t.Helper()
+	if body == nil {
+		body = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/web/passkey/enroll/finish", body)
+	req.Header.Set(enrollmentTokenHeader, rawToken)
+	rec := httptest.NewRecorder()
+	server.handlePasskeyEnrollFinish(rec, req)
+	return rec
+}
+
+// injectEnrollSession stores a pending enrollment session keyed by the token's hash,
+// bypassing the begin step — mirrors injectSession for the regular registration path.
+func injectEnrollSession(s *Server, rawToken string, sess webauthn.SessionData, ttl time.Duration) {
+	tokenHash := hashEnrollmentToken(rawToken)
+	s.passkeyEnrollSessions.Store(tokenHash, &webAuthnPendingSession{
+		data:    sess,
+		expires: time.Now().Add(ttl),
+	})
+}
+
+// TestPasskeyEnrollBegin tests the begin handler error paths and the happy path.
+func TestPasskeyEnrollBegin(t *testing.T) {
+	const username = "enroll-begin-user"
+	server, _, rawToken := setupEnrollServer(t, tvRPID, []string{tvOrigin}, username)
+
+	t.Run("NoWebAuthn", func(t *testing.T) {
+		noWaServer := setupTestServer(t)
+		rec := doEnrollBegin(t, noWaServer, rawToken)
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Equal(t, "WEBAUTHN_NOT_CONFIGURED", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("MissingToken", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/passkey/enroll/begin", nil)
+		rec := httptest.NewRecorder()
+		server.handlePasskeyEnrollBegin(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "MISSING_ENROLLMENT_TOKEN", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("InvalidToken", func(t *testing.T) {
+		rec := doEnrollBegin(t, server, "aabbccddeeff001122334455667788990011223344") // valid length, wrong value
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, "TOKEN_INVALID", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("ExpiredToken", func(t *testing.T) {
+		// Create a separate account and manually expire the enrollment link.
+		srv2, _, tok2 := setupEnrollServer(t, tvRPID, []string{tvOrigin}, "enroll-expired-user")
+		acct2, err := srv2.getWebAccount(context.Background(), "enroll-expired-user")
+		require.NoError(t, err)
+		// Backdate the expiry by an hour so the token is already expired.
+		acct2.EnrollmentLinkExpiresAt = acct2.EnrollmentLinkExpiresAt.Add(-73 * time.Hour)
+		require.NoError(t, srv2.persistWebAccount(context.Background(), acct2, "test"))
+		srv2.cacheWebAccount(acct2)
+
+		rec := doEnrollBegin(t, srv2, tok2)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, "TOKEN_INVALID", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("RevokedToken", func(t *testing.T) {
+		srv3, _, tok3 := setupEnrollServer(t, tvRPID, []string{tvOrigin}, "enroll-revoked-user")
+		acct3, err := srv3.getWebAccount(context.Background(), "enroll-revoked-user")
+		require.NoError(t, err)
+		acct3.EnrollmentLinkRevoked = true
+		require.NoError(t, srv3.persistWebAccount(context.Background(), acct3, "test"))
+		srv3.cacheWebAccount(acct3)
+
+		rec := doEnrollBegin(t, srv3, tok3)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, "TOKEN_INVALID", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		rec := doEnrollBegin(t, server, rawToken)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		// Verify the session is keyed by tokenHash, not by username.
+		tokenHash := hashEnrollmentToken(rawToken)
+		raw, loaded := server.passkeyEnrollSessions.Load(tokenHash)
+		require.True(t, loaded, "session must be stored under tokenHash after enroll begin")
+		pending, ok := raw.(*webAuthnPendingSession)
+		require.True(t, ok)
+		assert.False(t, time.Now().After(pending.expires), "session must not be expired")
+		assert.NotEmpty(t, pending.data.Challenge, "server-side session must carry a challenge")
+
+		// The session must NOT be stored under the username (self-scoping invariant).
+		_, usernameKeyed := server.passkeyEnrollSessions.Load(username)
+		assert.False(t, usernameKeyed, "session must be keyed by tokenHash, not username")
+	})
+}
+
+// TestPasskeyEnrollFinish tests the finish handler error paths and the happy path.
+func TestPasskeyEnrollFinish(t *testing.T) {
+	// --- W3C Level 3 §16.2 NoneES256 spec test vector (same as Finish_Success above) ---
+	const (
+		svRPID          = "example.org"
+		svOrigin        = "https://example.org"
+		svAttObjectHex  = "a363666d74646e6f6e656761747453746d74a068617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b559000000008446ccb9ab1db374750b2367ff6f3a1f0020f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4a5010203262001215820afefa16f97ca9b2d23eb86ccb64098d20db90856062eb249c33a9b672f26df61225820930a56b87a2fca66334b03458abf879717c12cc68ed73290af2e2664796b9220" //nolint:gosec
+		svClientDataHex = "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a22414d4d507434557878475453746e63647134313759447742466938767049612d7077386f4f755657345441222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a20426b5165446a646354427258426941774a544c453551227d"
+		svCredIDHex     = "f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4" //nolint:gosec
+		svChallengeHex  = "00c30fb78531c464d2b6771dab8d7b603c01162f2fa486bea70f283ae556e130"
+		svUsername      = "enroll-finish-user"
+	)
+
+	svAttObj, err := hex.DecodeString(svAttObjectHex)
+	require.NoError(t, err, "decode svAttObjectHex")
+	svCDJ, err := hex.DecodeString(svClientDataHex)
+	require.NoError(t, err, "decode svClientDataHex")
+	svCredIDBytes, err := hex.DecodeString(svCredIDHex)
+	require.NoError(t, err, "decode svCredIDHex")
+	svChallengeBytes, err := hex.DecodeString(svChallengeHex)
+	require.NoError(t, err, "decode svChallengeHex")
+	svCredIDStr := base64.RawURLEncoding.EncodeToString(svCredIDBytes)
+	svChallenge := base64.RawURLEncoding.EncodeToString(svChallengeBytes)
+
+	t.Run("NoWebAuthn", func(t *testing.T) {
+		noWaServer := setupTestServer(t)
+		rec := doEnrollFinish(t, noWaServer, "aabbccddeeff001122334455667788990011223344", nil)
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Equal(t, "WEBAUTHN_NOT_CONFIGURED", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("MissingToken", func(t *testing.T) {
+		srv, _, _ := setupEnrollServer(t, svRPID, []string{svOrigin}, "enroll-notoken-user")
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/web/passkey/enroll/finish", nil)
+		rec := httptest.NewRecorder()
+		srv.handlePasskeyEnrollFinish(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "MISSING_ENROLLMENT_TOKEN", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("NoActiveCeremony", func(t *testing.T) {
+		srv, _, rawToken := setupEnrollServer(t, svRPID, []string{svOrigin}, "enroll-noceremony-user")
+		// No begin call — no session in the map.
+		rec := doEnrollFinish(t, srv, rawToken, nil)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "NO_ACTIVE_ENROLLMENT", errCode(t, rec.Body.Bytes()))
+	})
+
+	// TestPasskeyEnrollFinish_ConcurrentRedeem: LoadAndDelete is atomic, so only the
+	// first finish call gets the session data. The second gets NO_ACTIVE_ENROLLMENT.
+	t.Run("ConcurrentRedeem_SecondFailsWithNoActiveCeremony", func(t *testing.T) {
+		srv, _, rawToken := setupEnrollServer(t, svRPID, []string{svOrigin}, "enroll-concurrent-user")
+		acct, err := srv.getWebAccount(context.Background(), "enroll-concurrent-user")
+		require.NoError(t, err)
+
+		sess := webauthn.SessionData{
+			Challenge:        svChallenge,
+			UserID:           []byte(acct.ID),
+			UserVerification: protocol.VerificationPreferred,
+			RelyingPartyID:   svRPID,
+			CredParams: []protocol.CredentialParameter{
+				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
+			},
+		}
+		injectEnrollSession(srv, rawToken, sess, 10*time.Minute)
+
+		// First finish: session is consumed (body is wrong, so WebAuthn verify fails
+		// with WEBAUTHN_VERIFY_ERROR — but the session is still deleted).
+		first := doEnrollFinish(t, srv, rawToken, bytes.NewReader(nil))
+		require.NotEqual(t, "NO_ACTIVE_ENROLLMENT", errCode(t, first.Body.Bytes()),
+			"first call must find the session (not return NO_ACTIVE_ENROLLMENT)")
+
+		// Second finish: session already consumed — must get NO_ACTIVE_ENROLLMENT.
+		second := doEnrollFinish(t, srv, rawToken, bytes.NewReader(nil))
+		assert.Equal(t, http.StatusBadRequest, second.Code)
+		assert.Equal(t, "NO_ACTIVE_ENROLLMENT", errCode(t, second.Body.Bytes()),
+			"second call must fail immediately because session was consumed by first")
+	})
+
+	t.Run("ExpiredSession", func(t *testing.T) {
+		srv, _, rawToken := setupEnrollServer(t, svRPID, []string{svOrigin}, "enroll-expiredsession-user")
+		acct, err := srv.getWebAccount(context.Background(), "enroll-expiredsession-user")
+		require.NoError(t, err)
+
+		sess := webauthn.SessionData{
+			Challenge:      svChallenge,
+			UserID:         []byte(acct.ID),
+			RelyingPartyID: svRPID,
+		}
+		injectEnrollSession(srv, rawToken, sess, -1*time.Second) // already expired
+		rec := doEnrollFinish(t, srv, rawToken, bytes.NewReader(nil))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "SESSION_EXPIRED", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("TokenInvalidAtFinish", func(t *testing.T) {
+		// Token is revoked between begin and finish: CAS check at finish rejects it.
+		srv, _, rawToken := setupEnrollServer(t, svRPID, []string{svOrigin}, "enroll-tokeninvalid-user")
+		acct, err := srv.getWebAccount(context.Background(), "enroll-tokeninvalid-user")
+		require.NoError(t, err)
+
+		sess := webauthn.SessionData{
+			Challenge:      svChallenge,
+			UserID:         []byte(acct.ID),
+			RelyingPartyID: svRPID,
+			CredParams: []protocol.CredentialParameter{
+				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
+			},
+		}
+		injectEnrollSession(srv, rawToken, sess, 10*time.Minute)
+
+		// Revoke the token (simulating admin action between begin and finish).
+		acct.EnrollmentLinkRevoked = true
+		require.NoError(t, srv.persistWebAccount(context.Background(), acct, "test-admin"))
+		srv.cacheWebAccount(acct)
+
+		// Finish should fail with TOKEN_INVALID.
+		// verifyEnrollmentToken runs before wa.FinishRegistration, so the result
+		// is determinate: 401 TOKEN_INVALID, not a WebAuthn verification error.
+		rec := doEnrollFinish(t, srv, rawToken,
+			finishBody(t, svCredIDStr,
+				base64.RawURLEncoding.EncodeToString(svCDJ),
+				base64.RawURLEncoding.EncodeToString(svAttObj)))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code,
+			"revoked token must produce 401 before WebAuthn verification is reached")
+		assert.Equal(t, "TOKEN_INVALID", errCode(t, rec.Body.Bytes()),
+			"revoked token must return TOKEN_INVALID error code")
+	})
+
+	t.Run("AlreadyEnrolled_CASPreconditionAtFinish", func(t *testing.T) {
+		// A credential is added between begin and finish: CAS check at finish rejects it.
+		srv, _, rawToken := setupEnrollServer(t, svRPID, []string{svOrigin}, "enroll-cas-user")
+		acct, err := srv.getWebAccount(context.Background(), "enroll-cas-user")
+		require.NoError(t, err)
+
+		sess := webauthn.SessionData{
+			Challenge:        svChallenge,
+			UserID:           []byte(acct.ID),
+			UserVerification: protocol.VerificationPreferred,
+			RelyingPartyID:   svRPID,
+			CredParams: []protocol.CredentialParameter{
+				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
+			},
+		}
+		injectEnrollSession(srv, rawToken, sess, 10*time.Minute)
+
+		// Inject a credential directly (simulating another path adding a credential).
+		injectCredential(t, srv, acct.Username, []byte("injected-credential"))
+
+		// The finish should be rejected by the CAS check: account now has credentials.
+		// WebAuthn verification passes first (server is configured for svRPID/svOrigin);
+		// the CAS store-reload then finds the injected credential and returns 409.
+		rec := doEnrollFinish(t, srv, rawToken,
+			finishBody(t, svCredIDStr,
+				base64.RawURLEncoding.EncodeToString(svCDJ),
+				base64.RawURLEncoding.EncodeToString(svAttObj)))
+		assert.Equal(t, http.StatusConflict, rec.Code,
+			"CAS precondition must fire 409 when credentials exist in the store at finish time")
+		assert.Equal(t, "ALREADY_ENROLLED", errCode(t, rec.Body.Bytes()),
+			"CAS precondition must return ALREADY_ENROLLED error code")
+	})
+
+	// Success test: uses the W3C Level 3 §16.2 NoneES256 spec vector.
+	t.Run("Success_FirstPasskeyPersisted", func(t *testing.T) {
+		srv, _, rawToken := setupEnrollServer(t, svRPID, []string{svOrigin}, svUsername)
+		acct, err := srv.getWebAccount(context.Background(), svUsername)
+		require.NoError(t, err)
+
+		sess := webauthn.SessionData{
+			Challenge:        svChallenge,
+			UserID:           []byte(acct.ID),
+			UserVerification: protocol.VerificationPreferred,
+			RelyingPartyID:   svRPID,
+			CredParams: []protocol.CredentialParameter{
+				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
+			},
+		}
+		injectEnrollSession(srv, rawToken, sess, 10*time.Minute)
+
+		body := finishBody(t, svCredIDStr,
+			base64.RawURLEncoding.EncodeToString(svCDJ),
+			base64.RawURLEncoding.EncodeToString(svAttObj))
+		rec := doEnrollFinish(t, srv, rawToken, body)
+		require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+		// Credential must be persisted.
+		updated, err := srv.getWebAccount(context.Background(), svUsername)
+		require.NoError(t, err)
+		require.Len(t, updated.Credentials, 1, "exactly one credential after enrollment")
+		assert.Equal(t, svCredIDBytes, updated.Credentials[0].ID,
+			"persisted credential ID must match the spec vector")
+
+		// Enrollment token must be consumed (revoked).
+		assert.True(t, updated.EnrollmentLinkRevoked,
+			"enrollment token must be marked as consumed after successful enrollment")
+
+		// Token must no longer be usable for a second enrollment begin.
+		rec2 := doEnrollBegin(t, srv, rawToken)
+		assert.Equal(t, http.StatusUnauthorized, rec2.Code,
+			"token must be unusable after enrollment (single-use)")
+
+		// Audit event must have been written.
+		require.NoError(t, srv.auditManager.Flush(context.Background()))
+		entries, err := srv.auditManager.QueryEntries(context.Background(),
+			&business.AuditFilter{Actions: []string{"web_account.passkey_enrolled"}})
+		require.NoError(t, err)
+		require.NotEmpty(t, entries, "web_account.passkey_enrolled audit entry must be written on success")
+		e := entries[0]
+		assert.Equal(t, "web_account.passkey_enrolled", e.Action)
+		assert.Equal(t, svUsername, e.ResourceID)
+	})
+}
+
+// TestPasskeyEnroll_SelfScopedToTokenAccount verifies that the enrollment handlers
+// resolve the target account from the TOKEN, not from any caller-supplied identifier.
+// This is the core fix for the cross-account credential injection vulnerability.
+func TestPasskeyEnroll_SelfScopedToTokenAccount(t *testing.T) {
+	// Create two separate accounts: A and B, each with their own enrollment token.
+	server := setupTestServer(t)
+	wa, err := NewWebAuthnFromConfig(tvRPID, tvRPID, []string{tvOrigin})
+	require.NoError(t, err)
+	server.SetWebAuthn(wa)
+
+	recA := postWebAccount(t, server, testAdminPrincipal(), WebAccountRequest{Username: "enroll-account-a"})
+	require.Equal(t, http.StatusCreated, recA.Code)
+	var outerA APIResponse
+	require.NoError(t, json.Unmarshal(recA.Body.Bytes(), &outerA))
+	tokenA := outerA.Data.(map[string]interface{})["enrollment_magic_link"].(string)
+
+	recB := postWebAccount(t, server, testAdminPrincipal(), WebAccountRequest{Username: "enroll-account-b"})
+	require.Equal(t, http.StatusCreated, recB.Code)
+	var outerB APIResponse
+	require.NoError(t, json.Unmarshal(recB.Body.Bytes(), &outerB))
+	tokenB := outerB.Data.(map[string]interface{})["enrollment_magic_link"].(string)
+
+	// Call begin with account A's token: the ceremony is set up for account A.
+	recBegin := doEnrollBegin(t, server, tokenA)
+	require.Equal(t, http.StatusOK, recBegin.Code)
+
+	// The session is keyed by tokenA's hash — not by username "enroll-account-b".
+	hashA := hashEnrollmentToken(tokenA)
+	_, loadedByHashA := server.passkeyEnrollSessions.Load(hashA)
+	assert.True(t, loadedByHashA, "session must be stored under account-A's token hash")
+
+	// Account B's token hash must NOT have a session (its begin was never called).
+	hashB := hashEnrollmentToken(tokenB)
+	_, loadedByHashB := server.passkeyEnrollSessions.Load(hashB)
+	assert.False(t, loadedByHashB, "account-B's token hash must not have a session")
+
+	// Using account B's token on finish with account A's active session must fail:
+	// no session exists under tokenB's hash.
+	recFinish := doEnrollFinish(t, server, tokenB, nil)
+	assert.Equal(t, http.StatusBadRequest, recFinish.Code)
+	assert.Equal(t, "NO_ACTIVE_ENROLLMENT", errCode(t, recFinish.Body.Bytes()),
+		"presenting account-B's token when only account-A has an active session must fail")
+}
+
+// TestEnrollmentConfinement tests the enrollmentConfinementMiddleware server-side gate.
+// AC: a zero-passkey cookie-auth session is refused all api routes; once enrolled (>0
+// passkeys), the same request passes the confinement check.
+func TestEnrollmentConfinement(t *testing.T) {
+	server := setupTestServer(t)
+
+	// A handler that always succeeds — we only test whether confinement blocks it.
+	successHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	withCookieSession := func(req *http.Request, count int) *http.Request {
+		ctx := context.WithValue(req.Context(), cookieAuthContextKey, true)
+		ctx = context.WithValue(ctx, principalContextKey, &Principal{
+			ID:                 "web-session-user",
+			Assurance:          session.AssuranceBasic,
+			AuthenticatorCount: count,
+		})
+		return req.WithContext(ctx)
+	}
+
+	t.Run("ZeroPasskeys_Blocked", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/web/accounts", nil)
+		req = withCookieSession(req, 0)
+		rec := httptest.NewRecorder()
+		server.enrollmentConfinementMiddleware(successHandler).ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Equal(t, "ENROLLMENT_REQUIRED", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("NegativeAuthenticatorCount_Blocked", func(t *testing.T) {
+		// -1 means account load failed; fail-closed.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/web/accounts", nil)
+		req = withCookieSession(req, -1)
+		rec := httptest.NewRecorder()
+		server.enrollmentConfinementMiddleware(successHandler).ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Equal(t, "ENROLLMENT_REQUIRED", errCode(t, rec.Body.Bytes()))
+	})
+
+	t.Run("OnePasskey_Allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/web/accounts", nil)
+		req = withCookieSession(req, 1)
+		rec := httptest.NewRecorder()
+		server.enrollmentConfinementMiddleware(successHandler).ServeHTTP(rec, req)
+		// Confinement passes; the handler is reached.
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"one passkey enrolled: confinement must allow the request")
+	})
+
+	t.Run("mTLSAdmin_NotBlockedByConfinement", func(t *testing.T) {
+		// mTLS principal: cookieAuth is false → confinement does not apply.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/web/accounts", nil)
+		ctx := context.WithValue(req.Context(), cookieAuthContextKey, false)
+		ctx = context.WithValue(ctx, principalContextKey, &Principal{
+			ID:                 "mtls-admin",
+			Assurance:          session.AssuranceStrong,
+			AuthenticatorCount: 0, // default zero for non-web-session principals
+		})
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+		server.enrollmentConfinementMiddleware(successHandler).ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"mTLS admin (cookieAuth=false) must not be blocked even with AuthenticatorCount=0")
+	})
+
+	t.Run("NoCookieAuth_NotBlocked", func(t *testing.T) {
+		// Request with no cookie auth context at all.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/web/accounts", nil)
+		rec := httptest.NewRecorder()
+		server.enrollmentConfinementMiddleware(successHandler).ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"no cookie auth context must pass through confinement")
+	})
+}
+
+// TestPasskeyEnroll_TokenHashing verifies that the enrollment token is never stored
+// or compared in plaintext — the implementation must use hashEnrollmentToken (SHA-256)
+// and constant-time compare (via verifyEnrollmentToken).
+func TestPasskeyEnroll_TokenHashing(t *testing.T) {
+	server := setupTestServer(t)
+	wa, err := NewWebAuthnFromConfig(tvRPID, tvRPID, []string{tvOrigin})
+	require.NoError(t, err)
+	server.SetWebAuthn(wa)
+
+	rec := postWebAccount(t, server, testAdminPrincipal(), WebAccountRequest{Username: "token-hash-user"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var outer APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &outer))
+	rawToken := outer.Data.(map[string]interface{})["enrollment_magic_link"].(string)
+
+	// The stored hash must differ from the raw token.
+	acct, err := server.getWebAccount(context.Background(), "token-hash-user")
+	require.NoError(t, err)
+	assert.NotEqual(t, rawToken, acct.EnrollmentLinkHash,
+		"stored hash must not equal the raw token (must be hashed)")
+
+	// The hash must equal SHA-256(rawToken).
+	expectedHash := hashEnrollmentToken(rawToken)
+	assert.Equal(t, expectedHash, acct.EnrollmentLinkHash,
+		"stored hash must be SHA-256 of the raw token")
+
+	// The passkeyEnrollSessions sync.Map key (after begin) must be the token hash.
+	recBegin := doEnrollBegin(t, server, rawToken)
+	require.Equal(t, http.StatusOK, recBegin.Code)
+
+	_, byHash := server.passkeyEnrollSessions.Load(hashEnrollmentToken(rawToken))
+	assert.True(t, byHash, "session must be stored under the token hash, not the raw token")
+
+	_, byRaw := server.passkeyEnrollSessions.Load(rawToken)
+	assert.False(t, byRaw, "session must NOT be stored under the raw token")
+}
+
+// TestWebAuthnRegisterStaysAtAssuranceStrong verifies that the existing
+// webauthn:register (add-to-existing) permission is NOT lowered by Issue #2966.
+// The enrollment redemption routes are separate and have no entry in permissionAssurance.
+func TestWebAuthnRegisterStaysAtAssuranceStrong(t *testing.T) {
+	req, ok := permissionAssurance["webauthn:register"]
+	require.True(t, ok, "webauthn:register must remain in permissionAssurance")
+	assert.Equal(t, session.AssuranceStrong, req.Min,
+		"webauthn:register must stay at AssuranceStrong (Issue #2966 must not lower it)")
 }
 
 // TestWebAuthnTOTPSeparation confirms that the WebAuthn registration code and the

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -664,6 +664,37 @@ var tenantCrossingRemedyPermissions = map[string]bool{
 	"tenant:crossing-grant":       true,
 }
 
+// enrollmentConfinementMiddleware blocks cookie-authenticated web sessions whose
+// principal has zero enrolled passkeys (AuthenticatorCount == 0) from all api routes.
+//
+// A zero-passkey session can ONLY redeem a first-passkey enrollment link; that redemption
+// path is on the BASE router (/api/v1/web/passkey/enroll/begin|finish), not the api
+// subrouter, so this middleware does not apply to it — by construction.
+//
+// mTLS admin and API-key principals are not cookie-authenticated (cookieAuthContextKey
+// is false), so they pass through regardless of AuthenticatorCount. AuthenticatorCount==-1
+// (account-load failure) is also blocked: fail-closed is safer than fail-open when the
+// session's enrollable state cannot be determined.
+//
+// This middleware MUST run BEFORE requirePermission (added earlier in the chain) so
+// that confinement is enforced even when the principal holds the required permission.
+func (s *Server) enrollmentConfinementMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookieAuth, _ := r.Context().Value(cookieAuthContextKey).(bool)
+		if cookieAuth {
+			principal, _ := r.Context().Value(principalContextKey).(*Principal)
+			if principal != nil && principal.AuthenticatorCount <= 0 {
+				// Zero or unknown authenticator count on a cookie-auth session.
+				s.writeErrorResponse(w, http.StatusForbidden,
+					"Account has no passkey enrolled — redeem your enrollment link first",
+					"ENROLLMENT_REQUIRED")
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // requirePermission creates middleware that enforces specific permission requirements.
 // Human administrator principals carry nil Permissions and are implicitly
 // authorized; web accounts carry an explicit (possibly empty) permission slice.

--- a/features/controller/api/route_registry_test.go
+++ b/features/controller/api/route_registry_test.go
@@ -242,6 +242,8 @@ var goldenRouteTable = []string{
 	"POST /api/v1/web/accounts/{username}/webauthn/register/finish",
 	"POST /api/v1/web/accounts/{username}/webauthn/revoke/{credential_id}",
 	"POST /api/v1/web/logout",
+	"POST /api/v1/web/passkey/enroll/begin",
+	"POST /api/v1/web/passkey/enroll/finish",
 	"POST /api/v1/web/passkey/login/begin",
 	"POST /api/v1/web/passkey/login/finish",
 	"POST /api/v1/webauthn/elevate/begin",

--- a/features/controller/api/route_security_manifest_test.go
+++ b/features/controller/api/route_security_manifest_test.go
@@ -37,6 +37,8 @@ var publicRouteSecurityPolicies = map[string]routeSecurityPolicy{
 	"POST /api/v1/stewards/{device_id}/refresh/complete":              publicWritePolicy("device proof-of-possession", "refresh.complete"),
 	"OPTIONS /api/v1/stewards/{device_id}/refresh/complete":           publicReadPolicy("none", "CORS preflight"),
 	"GET /api/v1/web/csrf":                                            publicReadPolicy("none", "pre-session CSRF issuance"),
+	"POST /api/v1/web/passkey/enroll/begin":                           publicWritePolicy("enrollment magic-link token (single-use, TTL-bounded)", "web.passkey.enroll.begin"),
+	"POST /api/v1/web/passkey/enroll/finish":                          publicWritePolicy("enrollment magic-link token plus WebAuthn attestation", "web.passkey.enroll.finish"),
 	"POST /api/v1/web/passkey/login/begin":                            publicWritePolicy("pre-session CSRF plus passkey ceremony", "web.passkey.login.begin"),
 	"POST /api/v1/web/passkey/login/finish":                           publicWritePolicy("passkey assertion plus ceremony cookie", "web.passkey.login.finish"),
 	"POST /api/v1/web/logout":                                         publicWritePolicy("web session plus session CSRF", "web.logout"),

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -157,6 +157,7 @@ type Server struct {
 	webAuthnElevateThrottle        sync.Map                              // Issue #2965: per-session/per-IP failed elevation throttle; key="session:<id>"|"ip:<ip>", value=*elevateThrottleRecord
 	passkeyLoginSessions           sync.Map                              // Issue #2993: pending passkey login ceremonies; key=ceremonyID, value=*passkeyLoginSession
 	passkeyLoginThrottle           sync.Map                              // Issue #2993: per-account/per-IP failed login throttle; key="account:<username>"|"ip:<ip>", value=*elevateThrottleRecord
+	passkeyEnrollSessions          sync.Map                              // Issue #2966: first-passkey enrollment ceremonies; key=tokenHash, value=*webAuthnPendingSession
 	telemetryHandler               http.Handler                          // Issue #2765: telemetry fan-out WebSocket handler
 	egConfigstoreWriter            egConfigstoreIngestor                 // Issue #2879: desired-state entity-graph internal writer (nil = disabled)
 	egProvider                     egReadProvider                        // Issue #2880: entity graph read API
@@ -479,7 +480,10 @@ func (s *Server) setupRouter() {
 	// requireTier(TierAny) removed: it was a no-op passthrough (Issue #2780 migrates to assurance-based enforcement).
 	api.Use(s.validationMiddleware)
 	api.Use(s.csrfMiddleware) // Issue #2493: session-bound CSRF for unsafe cookie-auth methods
-	s.apiRouter = api         // saved so Set* methods can lazy-register routes after construction
+	// Issue #2966: enrollment confinement — a cookie-authenticated session with zero enrolled
+	// passkeys is refused all api routes; first-passkey enrollment is on the base router.
+	api.Use(s.enrollmentConfinementMiddleware)
+	s.apiRouter = api // saved so Set* methods can lazy-register routes after construction
 
 	// --- Tier 0 (TierPublic) — no authentication required ---
 	//   GET  /api/v1/health
@@ -582,6 +586,15 @@ func (s *Server) setupRouter() {
 		s.authDefense.Middleware(http.HandlerFunc(s.handlePasskeyLoginBegin))).Methods("POST")
 	s.router.Handle("/api/v1/web/passkey/login/finish",
 		s.authDefense.Middleware(http.HandlerFunc(s.handlePasskeyLoginFinish))).Methods("POST")
+
+	// First-passkey enrollment routes (Issue #2966: ADR-021 Amendment 1).
+	// Registered on the BASE router (public pattern): the enrollment token is the bearer
+	// credential; no web session is required. Self-scoped to the account the token identifies —
+	// never to a caller-supplied {username}. Token is passed via X-Enrollment-Token header.
+	s.router.Handle("/api/v1/web/passkey/enroll/begin",
+		s.authDefense.Middleware(http.HandlerFunc(s.handlePasskeyEnrollBegin))).Methods("POST")
+	s.router.Handle("/api/v1/web/passkey/enroll/finish",
+		s.authDefense.Middleware(http.HandlerFunc(s.handlePasskeyEnrollFinish))).Methods("POST")
 
 	// Installer package download — public, no auth required (Issue #1704).
 	// Assembles a per-platform tar.gz on the fly. The download URL is the distribution mechanism.


### PR DESCRIPTION
## Summary

- **Enrollment redemption endpoints** (`POST /api/v1/web/passkey/enroll/begin|finish`) on the base router — token is the credential, no web session required
- **Self-scoped account resolution**: account identified exclusively by the `X-Enrollment-Token` header; no caller-supplied username/path variable consulted, eliminating cross-account injection
- **Single-use gate**: `passkeyEnrollSessions.LoadAndDelete(tokenHash)` is atomic — a concurrent second finish gets `NO_ACTIVE_ENROLLMENT`
- **CAS precondition at finish**: `loadWebAccountFromStore` fresh reload detects any credentials added between begin and finish; returns `409 ALREADY_ENROLLED`
- **Confinement middleware**: `enrollmentConfinementMiddleware` blocks every `cookieAuth=true` session with `AuthenticatorCount<=0` before `requirePermission`; mTLS/API-key principals (cookieAuth=false) pass unconditionally
- **`webauthn:register` (add-to-existing) unchanged** at `AssuranceStrong`; enrollment routes have no `permissionAssurance` entry

## Test plan

- [x] `TestPasskeyEnrollBegin` — no WebAuthn, missing/invalid/expired/revoked token, success (session keyed by tokenHash not username)
- [x] `TestPasskeyEnrollFinish` — no WebAuthn, missing token, no active ceremony, concurrent redeem (second gets `NO_ACTIVE_ENROLLMENT`), expired session, token-revoked-at-finish (`401 TOKEN_INVALID`), already-enrolled CAS (`409 ALREADY_ENROLLED` with real WebAuthn verification passing), success (W3C spec vector, credential persisted, token consumed, audit event written)
- [x] `TestPasskeyEnroll_SelfScopedToTokenAccount` — account-B's token cannot redeem account-A's active session
- [x] `TestEnrollmentConfinement` — zero passkeys blocked (403 `ENROLLMENT_REQUIRED`), negative count blocked, one passkey allowed, mTLS admin not blocked, no-cookie-auth not blocked
- [x] `TestPasskeyEnroll_TokenHashing` — raw token ≠ stored hash; stored hash = SHA-256(rawToken); session keyed by hash not raw
- [x] `TestWebAuthnRegisterStaysAtAssuranceStrong` — `webauthn:register` still at `AssuranceStrong`
- [x] Route table and security manifest updated; all CI-required route tests pass
- [x] `make lint-log-injection` pass — all new error values sanitized
- [x] `make check-architecture` pass — no central provider violations
- [x] `make test` pass (216 tests, 0 failures)
- [x] Race detector clean on enrollment test suite

Closes #2966

🤖 Generated with [Claude Code](https://claude.com/claude-code)